### PR TITLE
[Backport release-26.05] schildi-revenge: 26.06.06 -> 26.07.13

### DIFF
--- a/pkgs/by-name/sc/schildi-revenge/deps.json
+++ b/pkgs/by-name/sc/schildi-revenge/deps.json
@@ -1,344 +1,1385 @@
 {
  "!comment": "This is a nixpkgs Gradle dependency lockfile. For more details, refer to the Gradle section in the nixpkgs manual.",
  "!version": 1,
- "https://dl.google.com/dl/android/maven2/androidx": {
-  "annotation#annotation-jvm/1.9.1": {
+ "https://dl.google.com/dl/android/maven2": {
+  "androidx/activity#activity-compose/1.10.1": {
+   "module": "sha256-HtE6UO27iFlidR4by1uKQgeiDLeA6iSP+mU6qz+xD+k=",
+   "pom": "sha256-5k22txJvtRI5S8PPQzKjiCgAnaqN1W7L5sDHMAshJ/U="
+  },
+  "androidx/activity#activity-ktx/1.10.1": {
+   "module": "sha256-fBg4lRiaJ/16pZ/c9QKfpk+tKOnTkSmpyzDkC15CZ64=",
+   "pom": "sha256-QhNJDkzitXUOREUkbf6d5PZlXCEjwEp5qCSMyIk+K/Q="
+  },
+  "androidx/activity#activity-ktx/1.7.0": {
+   "module": "sha256-9AAacJtvcTKyKl4Xwk+Lips8RipZjeOw8WzFekNEurY=",
+   "pom": "sha256-cEmjrk2pyvNQojMroLECJd7ovohU1gioN76X0ipxk8g="
+  },
+  "androidx/activity#activity/1.10.1": {
+   "module": "sha256-iTtzpLFtGcAzhnWtC5+lEi2cacRPYRhxvYxAfTviOmg=",
+   "pom": "sha256-CuTeiIl09c75gmYJAOwyoz8QlodQ23r6lDja7Bg/FOc="
+  },
+  "androidx/activity#activity/1.7.0": {
+   "module": "sha256-KnRrASaoqy9XbnFn8aeFtFLvfumXq9l57gxaKcNvbqY=",
+   "pom": "sha256-7eFnck23n8fFLPAv4JeZtFqUpTHX8CaFp4M3vAYsA5s="
+  },
+  "androidx/activity/activity-compose/1.10.1/activity-compose-1.10.1": {
+   "aar": "sha256-+JrxsmzMg0Y0OHyFfC3U9GVNN2UIkAOcUnwv7QfbamE="
+  },
+  "androidx/activity/activity-ktx/1.10.1/activity-ktx-1.10.1": {
+   "aar": "sha256-85b1jb13LAZbhzaWt0o9TQh1VLN2YoDmO0myXbtTqxY="
+  },
+  "androidx/activity/activity-ktx/1.7.0/activity-ktx-1.7.0": {
+   "aar": "sha256-/OMX1hoi8SlntHW/y4DIndpm5BiXXokOpwPLdOErWxE="
+  },
+  "androidx/activity/activity/1.10.1/activity-1.10.1": {
+   "aar": "sha256-titSjJF96b5Jfrb4iDAZfCDp0hJnw5FsYTSS5e6DfU0="
+  },
+  "androidx/activity/activity/1.7.0/activity-1.7.0": {
+   "aar": "sha256-5EsgMiczhxVpgpEsWR734t1IW6Cy5om1KLWkLycaTyc="
+  },
+  "androidx/annotation#annotation-experimental/1.4.0": {
+   "module": "sha256-WTDqfyH8ttDesroydIoO98j9LEI4SGBYK6fNIN65A3k=",
+   "pom": "sha256-QdK52Hn8kiGs2o6HPsfSaxU7m44EdwrHlJHgV2uu8Dg="
+  },
+  "androidx/annotation#annotation-experimental/1.4.1": {
+   "module": "sha256-KsL3EG4S8mNCW0pN/ICYlEf7iVZ1/pAthnWap0/RK30=",
+   "pom": "sha256-/leyKEF/TXxneQPcYftKfPmT1gNJneJtjYET5HfMTxs="
+  },
+  "androidx/annotation#annotation-jvm/1.10.0": {
+   "jar": "sha256-3dBy3btVMXjiBVF853ey8Fqp5BKYLZ7LTu3HTxIS9pc=",
+   "module": "sha256-Qq/KN0GUJz5AZ7k3z8RHvTyMT9RB9B1E+VQFDf1hBt0=",
+   "pom": "sha256-XuzgkDtIEKodqFQU3EwnRgRth4pUOqEt1PH+dBcfdQY="
+  },
+  "androidx/annotation#annotation-jvm/1.8.1": {
+   "module": "sha256-yVnjsM3HXBXv4BYF+laqefAz45I44VBji4+r3mqhIaA=",
+   "pom": "sha256-1JIDczqm+uBGw6PeTnlu7TR1lXVUhqZCc5iYRHWXULQ="
+  },
+  "androidx/annotation#annotation-jvm/1.9.1": {
    "jar": "sha256-HjQ5F+vye6lv5NxSscrX/TK3OPvGNVu2zVs7MF1yEtA=",
    "module": "sha256-A/tlkXfIYY5HQlklwRvJHzhHA+omwmW+myXNeSkrURw=",
    "pom": "sha256-ibmcIY1gAZMWtQqreYFnB7whaWyJagMOGxrgOJYby44="
   },
-  "annotation#annotation/1.9.1": {
+  "androidx/annotation#annotation/1.10.0": {
+   "module": "sha256-Wy1Dh/OE5ZE6SuyXmiDs4Tu1zpkryQqWLeof7qf6iek=",
+   "pom": "sha256-iA979LNdBgdGy+8xnUoFK0vYJrtxtAUA5VMZch/6TnY="
+  },
+  "androidx/annotation#annotation/1.8.1": {
+   "module": "sha256-5jhuha/dhlBE4hZXXkk+05pjpjJb2SU3miFCnDlByLU=",
+   "pom": "sha256-txIll07Ah+uWwl72gZ9VscIvUw6FykRrpzX7Zu0E/1w="
+  },
+  "androidx/annotation#annotation/1.9.1": {
    "jar": "sha256-ODIq+nNFw34pxl7IhSF4rhwm4jCWoGNNB6SjiTkx9Yw=",
    "module": "sha256-8gSwW3KKl1YXGLxxYkLkfGKcAIWoDudPylPU1ji8vj8=",
    "pom": "sha256-xzOIHC4X1ffIZhzAKpFZyxYLeyCUon1ZORbIfT4lBjY="
   },
-  "arch/core#core-common/2.2.0": {
+  "androidx/annotation/annotation-experimental/1.4.0/annotation-experimental-1.4.0": {
+   "aar": "sha256-xut+Z2AR7GWzJCg3PUUN69/EUXnE+LOnUhdPuHwXsIo="
+  },
+  "androidx/annotation/annotation-experimental/1.4.1/annotation-experimental-1.4.1": {
+   "aar": "sha256-a9THx0dvgmDNO9u4EYNYPpP8n3kMJ96n3DFBgcv4eqA="
+  },
+  "androidx/appcompat#appcompat-resources/1.7.1": {
+   "module": "sha256-FjzF4PJJQz3bABb70BGrjeB88j4H5hjHRkRojibNGOg=",
+   "pom": "sha256-L6+SLow9cG8p2GKz+7OqE0dwXCHG6uGFhtK7H3Nm6gE="
+  },
+  "androidx/appcompat/appcompat-resources/1.7.1/appcompat-resources-1.7.1": {
+   "aar": "sha256-ji2zEiTKU7EIx4TaKzYZWQYnFtQWshDP7z1aOCgwbfA="
+  },
+  "androidx/arch/core#core-common/2.1.0": {
+   "pom": "sha256-g7uzlg6qvGAKw2bJTLWUFORBUyodaqk4iwuL/6zlzwE="
+  },
+  "androidx/arch/core#core-common/2.2.0": {
    "jar": "sha256-ZTCKBrHADuGGy54ZMhOD8EO5k4E/FSLEf0o+MwO9ukE=",
    "module": "sha256-7fQgDP3C2UYjIlLJnl3LnGG7kJ61RQsmE9HU/cl0uYE=",
    "pom": "sha256-HhfUr41kJb4qafivTWVKh+BFYlmp7vFUKGm8sCNUfig="
   },
-  "collection#collection-jvm/1.5.0": {
+  "androidx/arch/core#core-runtime/2.2.0": {
+   "module": "sha256-qLF1E5SeXbbJYBwwvhnflTdi3Yd1EvHiz8+ugdJECUQ=",
+   "pom": "sha256-D5U3BlmBQNnYc1zdWusfo1kz9OLzHAvz64GgU6TIwaU="
+  },
+  "androidx/arch/core/core-runtime/2.2.0/core-runtime-2.2.0": {
+   "aar": "sha256-ob5eDKorB2I4Yq9q4hs6sHGBIyRRhNDjDeqBtT+ZCkc="
+  },
+  "androidx/autofill#autofill/1.0.0": {
+   "pom": "sha256-Nner6tXU4Gz3bLrLlUFR4FF3nCJ0SURR+0JON1qp5FA="
+  },
+  "androidx/autofill/autofill/1.0.0/autofill-1.0.0": {
+   "aar": "sha256-yUaPVuBQBuoVGkJsVJV80Hmbi4OledKEbdIgYfM+Xs0="
+  },
+  "androidx/collection#collection-jvm/1.5.0": {
    "jar": "sha256-cLNZJOS6vN/6N9Dlde4DnFai2XEjNCYkxItgMjNwQ0E=",
    "module": "sha256-3eheKSUJIxtUcbsJG1dQmdT0MWHrKB6HOFA4oBYQcuY=",
    "pom": "sha256-EcQVhk00AvYdQm5nIQFY3OGwRoBBJSaplPGCPs08s4g="
   },
-  "collection#collection/1.5.0": {
+  "androidx/collection#collection-ktx/1.5.0": {
+   "jar": "sha256-k5tKhpdkDnfYPk6LTEqdGPgTAZjFlhGUr43Z253Hw1M=",
+   "module": "sha256-QiiJTiXux+FzKbIGunLoqtJVvFNQGNxirMXv87XHqqU=",
+   "pom": "sha256-mD+NBjDQctW/zRZqSYrHIT86RKmMCQUQBM6WQp2GfOo="
+  },
+  "androidx/collection#collection/1.1.0": {
+   "pom": "sha256-Z+kGbKSs/cbjzFCCk8MboDmAV/8Rjk9wseGBPJo0VtE="
+  },
+  "androidx/collection#collection/1.4.2": {
+   "module": "sha256-AybSz1rb5ZIxKBDKH3HGwMww91PEPwfHQCNht4ineEw=",
+   "pom": "sha256-TyYVoXrqz+EraCmCFKGfKhnGjGbVkAdb27+2WevOK38="
+  },
+  "androidx/collection#collection/1.5.0": {
    "jar": "sha256-9f+49GHEtdbyiDoscEeXd3OzHVsj7wMMBXUUwMns60c=",
    "module": "sha256-v+t72E8/fdp71ztnCdSh9h9aN/hDcouuCKBn49+aCu8=",
    "pom": "sha256-LWXI0LNtS0+q3ESv+breI9hx1xWe7fKz8C2AKzS3elc="
   },
-  "compose/runtime#runtime-annotation-jvm/1.10.5": {
-   "jar": "sha256-+J3ai81zh20PwWVohEsr15RD7nymKBCHTSXH3Ko5S9Y=",
-   "module": "sha256-tjv/82rZJ/SUVGt0m3o2Ox324fobKSyXihkr7fTv6EQ=",
-   "pom": "sha256-DJECRC6QE5BNF+fZNHyNvKRjSt6Met9yVGwOe6ei/F8="
+  "androidx/compose/animation#animation-android/1.11.2": {
+   "module": "sha256-rvYyphtOF/+CyYGvVpzAK8G/d7J8roSwbkzbQIpdWxQ=",
+   "pom": "sha256-ka56+it4dejAYu0ZtCpYNRWl2SwtGpkjXkrPLPXlmXo="
   },
-  "compose/runtime#runtime-annotation-jvm/1.9.0": {
-   "jar": "sha256-mJstoov1unlmwIyi2z9IpgfmhOSrT/DegOnNXsZjwHY=",
-   "module": "sha256-BwRUw9jx/YX9sCztcMXdVbnJUGqfHJYwmVrWtUhbweY=",
-   "pom": "sha256-kTdIOF0hz/MrNeJZUR7w4mo4lt9+4P8Sv2rGEOreq2A="
+  "androidx/compose/animation#animation-core-android/1.11.2": {
+   "module": "sha256-YbXCv2BYgWKSiJ+Hd7XcyCMWTVMlTeY6AJaT5JQxwc4=",
+   "pom": "sha256-QP/GOWTB3xrvpY3nG2AJHXVC3maRqGMjmLlRYqqWnWE="
   },
-  "compose/runtime#runtime-annotation-jvm/1.9.4": {
-   "jar": "sha256-mJstoov1unlmwIyi2z9IpgfmhOSrT/DegOnNXsZjwHY=",
-   "module": "sha256-cdTwQFv/4v7dHZuLZJ63DhuW0HBnQLVjhhhMEhZiALk=",
-   "pom": "sha256-OMb8W3u9UXzgpBSKwe+P1E+GoMLOHmlkm/FXhWDPLpY="
+  "androidx/compose/animation#animation-core/1.11.2": {
+   "module": "sha256-wnW8zE4K0YIJhM/Ttq2uSbwuVFD0lmlvdM9cf+zCdq4=",
+   "pom": "sha256-EOhVmCPzhXxcJGQ7vHvbgnMHN1GQbAPTVX7FSEfh8hY="
   },
-  "compose/runtime#runtime-annotation/1.10.5": {
-   "jar": "sha256-XUzoJpn1AaDI4eZyZY8fgIlTTgaYm/JTvfqxHixzBZU=",
-   "module": "sha256-VYNtTRHcFC32bcSxz/XoMXiyN5jbwAQUyhYZOBNkeFE=",
-   "pom": "sha256-9gQoKGzJ35GwfaC8gQvnBRtkts7o3ZVM4gD9nbBVs6E="
+  "androidx/compose/animation#animation/1.11.2": {
+   "module": "sha256-NIsbeSIlgiOhe2dj71cysAepvZmk1Db5FP0xLImOdco=",
+   "pom": "sha256-yQ+2AszF2+TiDodBHAJbDeK4Qtk9CT+c4vk2alqd5+s="
   },
-  "compose/runtime#runtime-annotation/1.9.0": {
-   "module": "sha256-aI/PepDHx6su4gF+reuc2inzWuF+aq3sct/QdA8C5iQ=",
-   "pom": "sha256-0Vin/5qk2CFOCF+dXHndAAKjLRgWoCOqn6omucRtg6c="
+  "androidx/compose/animation/animation-android/1.11.2/animation-android-1.11.2": {
+   "aar": "sha256-e6ziQR7qXFoXcW9FnRmuK609uOFd+ik/4SWAbvdBai0="
   },
-  "compose/runtime#runtime-annotation/1.9.4": {
-   "module": "sha256-JmaBc8UooQ3RpzXY0LF6q10ujJYWlTg72PHUSPCHws0=",
-   "pom": "sha256-zrmsMOstfKN8qXafyC3CFsEkeSHLC3eKW2q6YuVbhqI="
+  "androidx/compose/animation/animation-core-android/1.11.2/animation-core-android-1.11.2": {
+   "aar": "sha256-pkgiwzFpSbgFCz9hqIeJGUsEn2X0RPjYubthg8KL9kc="
   },
-  "compose/runtime#runtime-desktop/1.10.5": {
-   "jar": "sha256-sZWGBUL2Et4FErVKdTU+D21YgV8MlTCgO8Ww5zRHSCk=",
-   "module": "sha256-dAYUqXRffpcEq2deze7GeSljSAPNxdIhsjIAHGaiBmI=",
-   "pom": "sha256-ijTm+Hv20HzRPXJaCdf/e9Ox0KNzKalD9ANKyJv6a94="
+  "androidx/compose/foundation#foundation-android/1.11.2": {
+   "module": "sha256-6qKCVahAhxe2LrCmHNMktpSJHkaJwR2AwJQ3PeRR7Lw=",
+   "pom": "sha256-qGjpTc8wdLw5IRAdoOYXECahq3SEBi1QlL/wT0zeI98="
   },
-  "compose/runtime#runtime-desktop/1.9.0": {
-   "jar": "sha256-rmV+QzL7cvobQ3zlyqSGxrSl4XWIqu8CZ6qSkYu6dFg=",
-   "module": "sha256-vVE7iwcDHUB2Y2i/ILOSanNAU3lGxuhXJK1pknOn+g8=",
-   "pom": "sha256-4ybvc2sUSnnTBXjuMcSiY0F1U5tcMyZPBcmrxvpl0fo="
+  "androidx/compose/foundation#foundation-layout-android/1.11.2": {
+   "module": "sha256-8BPcZmNCnMK87mPKttpncqLfwhJkMaM9Q9F9whCbXHA=",
+   "pom": "sha256-28ffCVZJwys9W1in+wku8DCnbgq3pQse5P5r8BhiEFo="
   },
-  "compose/runtime#runtime-desktop/1.9.4": {
-   "jar": "sha256-tWObLfBAhyh7WIbUfbHveRwnnBB07mKEgXJu2Qz/A+c=",
-   "module": "sha256-9NbvOvLHfjiA2GuAEzw8S2XhAaQTzYhks8FCZW8NZT8=",
-   "pom": "sha256-auYydwtkdmu36sMLZF+AarEk9kLOiFKKg4xsfOXtUkk="
+  "androidx/compose/foundation#foundation-layout/1.11.2": {
+   "module": "sha256-n1XOaelLqzL2iXElv3m+JEUTd7pJaiEfeZND2UCTU8c=",
+   "pom": "sha256-nCt+th0bOOiOWlGkQ/pmOHFZXyHFQxbFwuq1+kE6Bzs="
   },
-  "compose/runtime#runtime-retain-desktop/1.10.5": {
-   "jar": "sha256-Rj7pwek9G5E0WL/syW0SijV0qAL0HIyXgdcyDDtV7Ys=",
-   "module": "sha256-vdwnS3pYT/sW5EvEwnnxErsY9O6it4DfdNkC6/hLumw=",
-   "pom": "sha256-tHAngJ/qZQmY2Jm8NEKnS808DnBJQ/rYufkHd0lEoK0="
+  "androidx/compose/foundation#foundation/1.11.2": {
+   "module": "sha256-QoD2r41VMyT1tdKBNaDBrQB9/EtMjQWrv4IzpiyURZ4=",
+   "pom": "sha256-BORtqkQ7iBqL9F6k+UkU06KwRt8iJSnE3Dzias2AO+4="
   },
-  "compose/runtime#runtime-retain/1.10.5": {
-   "jar": "sha256-rxY11W6En8ruAC2dqeHeZsy3FULLodGWdkRBGU3BVEM=",
-   "module": "sha256-gCOC/hCAMjMXl6ZFBKpN4Hjk7WtHUytVepzWMGEeO10=",
-   "pom": "sha256-AKXSE6cZrSVhpJbmr56y1jku9O2riTdo/zYyolZv8zM="
+  "androidx/compose/foundation/foundation-android/1.11.2/foundation-android-1.11.2": {
+   "aar": "sha256-oGJMM9ysSVxBiC/X6ERdEnK9FgrDiToopmzhT5T+3UU="
   },
-  "compose/runtime#runtime-saveable-desktop/1.10.5": {
-   "jar": "sha256-7yTiTMjJw7mHEAf731ie2aquz5WXmma3SEgG+fDiTZE=",
-   "module": "sha256-+pRBxpkgZazdTbMuBwtQHZDtW0m56OV6j7gkruBser8=",
-   "pom": "sha256-iRqrmg0pxbsMXMX00ff+OJmkvjCa5UK2+kZjHA/zfiQ="
+  "androidx/compose/foundation/foundation-layout-android/1.11.2/foundation-layout-android-1.11.2": {
+   "aar": "sha256-Pp7jmd6n+4M03Otv7fXiD34vYZcZ9o6gVv7RFmVR7Ug="
   },
-  "compose/runtime#runtime-saveable-desktop/1.9.4": {
-   "jar": "sha256-35kHo+Zyw/qdp+iAMTZ5zbB+gKfzFB9UrB7IFJ0MW+Y=",
-   "module": "sha256-BwrIv4Rv7/f5a+6uF++WBCvgs10uNdwOPHOv2aXLM4A=",
-   "pom": "sha256-t2I5gDlhPCa1EgSoOGyWicjr8lWD1DiXiG/IQew7aeU="
+  "androidx/compose/material#material-icons-core-android/1.7.6": {
+   "module": "sha256-eietGojQmSEqfhomiis0BXeFUrAtAgvl8Gprn2o+yUI=",
+   "pom": "sha256-DyMnhhbx+raN5Ipg2UQGjelGROS3JucFqIHB53gJj9Q="
   },
-  "compose/runtime#runtime-saveable/1.10.5": {
-   "jar": "sha256-+ivj7IPEsSm8t6mxXOH8sNHXYzTn7dt7jzXOmt97CBE=",
-   "module": "sha256-bgFdVYIl2LhxzwZy0YYfVuQCrCfNV6ib7xV2KayxMZs=",
-   "pom": "sha256-tKcjpST7DEAunfM29gPk+gKDWDTgH3FunEU/6H6IodA="
+  "androidx/compose/material#material-icons-core/1.7.6": {
+   "module": "sha256-sRuDHpv+L6ZMeSiVb5/otZT4uPQLQliwmEAGKz9Wsr8=",
+   "pom": "sha256-itunFh4OocV1LwuYYW7lKi2Jm5qgYHzzUA+lQyquXEo="
   },
-  "compose/runtime#runtime-saveable/1.9.4": {
-   "module": "sha256-exsm2uetyGKjS/vYPgoS5x3uI41Bp7pd42bOBVzaKPU=",
-   "pom": "sha256-I8fdOoHs474rqLTm7osX/Nkg3nRpADkkBW1Wltb9RP8="
+  "androidx/compose/material#material-icons-extended-android/1.7.6": {
+   "module": "sha256-YGlqfsGPzoI3DMbiFqT56yFgMth8q0A0LjNKdHI+vas=",
+   "pom": "sha256-JdIXQwTDF55rO/3YzjzpXJCpLEvUro4Me5QeWBeEAGA="
   },
-  "compose/runtime#runtime/1.10.5": {
-   "jar": "sha256-OTRR9TXSGU2ljqSzu9oNoJu8DeHQQVF2q+AdVnZKDOM=",
-   "module": "sha256-zw9E6oolRaUAMppCTFO/WRCIfUn/+yECLdAVYJbr35Q=",
-   "pom": "sha256-YYG0edX3JMzZfHHu6sXY4XHK6BJaz5wGV7SvWdRdjwk="
+  "androidx/compose/material#material-icons-extended/1.7.6": {
+   "module": "sha256-7NczNuE23rRe267g3qEPelSQHh54FcS9FicJeXmJN4M=",
+   "pom": "sha256-rFSvA/qAXWNsC/pFi+Fqw1mL+7NtvsGA9loGGFA/o70="
   },
-  "compose/runtime#runtime/1.9.0": {
-   "module": "sha256-sR6bZBtlR39obhm0mdqkNbr0INE7t56Y2wXsAYktsi4=",
-   "pom": "sha256-0vrrNhehR8vOsH6B2tI8+wHi/QiJ3hO5kJWQChpe030="
+  "androidx/compose/material#material-ripple-android/1.9.3": {
+   "module": "sha256-E7KTlP/fTKvl0ykB28khwaVNVolsS0LQIjGSosNQsOc=",
+   "pom": "sha256-vez15umfjUgjj/TZKH++ZqhxTfPbEVt92OE2gY493VM="
   },
-  "compose/runtime#runtime/1.9.4": {
-   "module": "sha256-f5pbcCKwprlNXD5LAOYS4Zbw2pkV1qs8Sd8dItFbb1o=",
-   "pom": "sha256-eVGpmylFQxFVtvqEwUoJh6pQXBevj6xvOz/zVQ9xcYw="
+  "androidx/compose/material#material-ripple/1.9.3": {
+   "module": "sha256-5F/QpN9hdGLtrfkiBoiZNXk/vhwHlY89WFa6OYZAM5U=",
+   "pom": "sha256-jzXiBWbwG9TL3ETMza5U9qWTiPsj4NDiPa4/ZkB2j1A="
   },
-  "datastore#datastore-core-jvm/1.2.1": {
+  "androidx/compose/material/material-icons-core-android/1.7.6/material-icons-core-android-1.7.6": {
+   "aar": "sha256-SNGCBRI2sd/sgpszv00/0G0DwodtUyII4/dJAVnWXEY="
+  },
+  "androidx/compose/material/material-icons-extended-android/1.7.6/material-icons-extended-android-1.7.6": {
+   "aar": "sha256-B+l+UvNdeJ70ddnGh+XKRsxU+aDUr44dypKsJfshRQw="
+  },
+  "androidx/compose/material/material-ripple-android/1.9.3/material-ripple-android-1.9.3": {
+   "aar": "sha256-gWH+Pr737PP0ClO3tpMIUHuxCwI7P9x7WO+zFxNohHk="
+  },
+  "androidx/compose/material3#material3-android/1.4.0": {
+   "module": "sha256-/M1qjQ0z/PfDJ3vEPrRSxzgD7GIFl8gdvEp54pCnGpc=",
+   "pom": "sha256-zANiZTJAcIoBDeUP7oyviEphD7sQtgE+hmlNd8Q/68c="
+  },
+  "androidx/compose/material3#material3/1.4.0": {
+   "module": "sha256-dXCB0Sja+IAcHdmsxDH6UmnmVrKKCkkK6YzO5o6cNFI=",
+   "pom": "sha256-ZytDH1nI4KhSJpCy9G8beWZxBjiJPGDDHF8Z+EctYsw="
+  },
+  "androidx/compose/material3/material3-android/1.4.0/material3-android-1.4.0": {
+   "aar": "sha256-Ojfos23zgi/h5gWfD5+v2ogAOIhgR3YkrBuUIsQYo24="
+  },
+  "androidx/compose/runtime#runtime-android/1.11.2": {
+   "module": "sha256-uIZvUklXzYGh7ecfjemeyfQ1WfM4ELcYp/gNb9vCSgY=",
+   "pom": "sha256-5hPA+jb5BoVtWGyVHaItONXvk0Fa0rcqibHIagHaouY="
+  },
+  "androidx/compose/runtime#runtime-annotation-android/1.11.2": {
+   "module": "sha256-O6eGZLUOkrOgJeFqThKfjTYmcwmznVufNfHRDNyxZyE=",
+   "pom": "sha256-/5hwEFAR3UYq3yB59k+9pHgUOm+5UN1iIui69Q1lFCQ="
+  },
+  "androidx/compose/runtime#runtime-annotation-jvm/1.11.0-rc01": {
+   "jar": "sha256-4oaoUgcJ173GZIHCcmYMKo0msSdA92ECVDzkVwQ3A5Y=",
+   "module": "sha256-JJMFQNItrRK1aVpERxiOx5N/eKYqVKRapnPK2ftwRlI=",
+   "pom": "sha256-wshTQYcZD+NmeWky/a0PL6PqPjYIj+5Qp5AvyXIdSB8="
+  },
+  "androidx/compose/runtime#runtime-annotation-jvm/1.11.2": {
+   "jar": "sha256-4oaoUgcJ173GZIHCcmYMKo0msSdA92ECVDzkVwQ3A5Y=",
+   "module": "sha256-mAOREpmtfxBJH7AM7QZ3H0dLv7UNLLk0sExeV79pFZA=",
+   "pom": "sha256-Wn8tmNFKL4YHDqKdhJDiYpn0jwhQtpG3lU0293kQ5T8="
+  },
+  "androidx/compose/runtime#runtime-annotation/1.11.0-rc01": {
+   "jar": "sha256-GQ42On8pUXlPW08JhtpFTzmkJbh3mbLVksKniXLRdd8=",
+   "module": "sha256-pnylTwY8OPboC3lNrvVJNVUVS69V6xil3z7n7ct4N0A=",
+   "pom": "sha256-/V+nj8Fb55Ttiaikhp5CdiQqpGjc7FI4SSpB41QDhzc="
+  },
+  "androidx/compose/runtime#runtime-annotation/1.11.2": {
+   "jar": "sha256-GQ42On8pUXlPW08JhtpFTzmkJbh3mbLVksKniXLRdd8=",
+   "module": "sha256-NhSpP6QePns7dSfjf64wXhswojyyKF+s428wXbuC9Fk=",
+   "pom": "sha256-Smd2+thKJeT9sP3AaLiAilcuXMDpvscSsilMHjmsCTY="
+  },
+  "androidx/compose/runtime#runtime-desktop/1.11.0-rc01": {
+   "jar": "sha256-UMm1xchPpj0MKqcTGjxvVbM9FrUhFXWWReQ3D0yZhY8=",
+   "module": "sha256-WuLpf5rVMLT9FWxbJzjII9glpQFdP1kHjnt7sMikYYY=",
+   "pom": "sha256-xUBbjIh6dBleBjsbR9Wd5uq4cwUIJrIQzASS0N6RMN8="
+  },
+  "androidx/compose/runtime#runtime-desktop/1.11.2": {
+   "jar": "sha256-aVUa7o+SEUkhgW89mqpmBiEE2yKO1XEKZmb3rb36/jw=",
+   "module": "sha256-b5bQGrIJuGKdS8crPLYqzT/hKshtjg/0349RsopLKkQ=",
+   "pom": "sha256-EtXDwmN11h2Sv/Bn09S8gJ5H3KE/I9H2BuVUcBJ80Do="
+  },
+  "androidx/compose/runtime#runtime-retain-android/1.11.2": {
+   "module": "sha256-vtZ9MEQZVvLYzsnEL6R+CaLrX4jfipp6BngVRYj73CU=",
+   "pom": "sha256-UtQgmPUe90hJOfieLT7sEJ2pnk3Lo56bxjxWJtuJaWI="
+  },
+  "androidx/compose/runtime#runtime-retain-desktop/1.11.0-rc01": {
+   "jar": "sha256-m35ip98zPDPv+eGm1sJQik2P5LekN3gHVTj+PaS8RIU=",
+   "module": "sha256-rYhJPsh9RcM4BOFBSWvvuRUqyDP6A3pPjiIHPyxQz1k=",
+   "pom": "sha256-wB6g2unzf3ouoBbiMFgR+0Uw3FdKCVymkX3CdRmzD8Y="
+  },
+  "androidx/compose/runtime#runtime-retain-desktop/1.11.2": {
+   "jar": "sha256-m35ip98zPDPv+eGm1sJQik2P5LekN3gHVTj+PaS8RIU=",
+   "module": "sha256-jnF2lFlOIuU+IBhrzSS9g6J/QcAQP1sr3LPsRXNCQn0=",
+   "pom": "sha256-x7EjehNSlhZPkgt+FUwmSyv9rQVSVQBDdhV4cA6jNdA="
+  },
+  "androidx/compose/runtime#runtime-retain/1.11.0-rc01": {
+   "jar": "sha256-o2qxCWSG9aiFkeqG9u1S8RLD+E8b+cM0PcGS00EOhCo=",
+   "module": "sha256-d7+iDvl5cCm/1OeY+q7OmWf3OAqfnEADlwKLCWBT5uQ=",
+   "pom": "sha256-lUVDAEJaV/dC7d4G2YRGBzNIcxC/GZZajaIS8S2yukM="
+  },
+  "androidx/compose/runtime#runtime-retain/1.11.2": {
+   "jar": "sha256-o2qxCWSG9aiFkeqG9u1S8RLD+E8b+cM0PcGS00EOhCo=",
+   "module": "sha256-zetoCiKgEn2QY9hj1syYoi6BIXIeGHCZYdU9EpytGHI=",
+   "pom": "sha256-H9Opc9dmUGpvO9tc80BY7xISKV3219XNeSPWtkXPoZw="
+  },
+  "androidx/compose/runtime#runtime-saveable-android/1.11.2": {
+   "module": "sha256-5XXpLh42zQlNK5P+9azh21RI80Oh+Ie3dRKs5jwLxFk=",
+   "pom": "sha256-Ed+YtJ8khupdibdMifKqKpcPV2x9jhTUnhu/zGkVTko="
+  },
+  "androidx/compose/runtime#runtime-saveable-android/1.7.0": {
+   "module": "sha256-FPU88sgBBcde61vxmQRDmtXfpDJ93ZRIKdy3KDraCWA=",
+   "pom": "sha256-NB5w5ZLSQyjAvfAz9nk5Wz1r6Ps/T/hh2GBkvUrZw3E="
+  },
+  "androidx/compose/runtime#runtime-saveable-desktop/1.11.0-rc01": {
+   "jar": "sha256-saF+bCJt67Qsoif1gEWdnZ3qYtQqqOaF71bNfOdwsaE=",
+   "module": "sha256-LlNO/IXS7Of611IBgz2SAnWXq7jU+EyOQs8vrJLPlCE=",
+   "pom": "sha256-OwnxBF1mzdZ9aIA3eS53NkRbN9YXHv1slz6wRMbuQXA="
+  },
+  "androidx/compose/runtime#runtime-saveable-desktop/1.11.2": {
+   "jar": "sha256-saF+bCJt67Qsoif1gEWdnZ3qYtQqqOaF71bNfOdwsaE=",
+   "module": "sha256-qRjbULEcx/dEJhf9My0a3Ut72bIqIOpMfYHfAeZNe1g=",
+   "pom": "sha256-nUKDfFDNQ3n/5QKT55cT1APh4+73w4HEES6XX24TtDk="
+  },
+  "androidx/compose/runtime#runtime-saveable/1.11.0-rc01": {
+   "jar": "sha256-16wwfVhrLKq/C97ElJohyPSaZT+miOZi2fSn6y2UdW4=",
+   "module": "sha256-fHZc5oTwYER/CkeFgB4Nz0GWATkAAx7a4VQKGJ/SvhQ=",
+   "pom": "sha256-vl2THwygv0IJwVJODwJ81FXvFZe8l/U6tSGe4Sam2JU="
+  },
+  "androidx/compose/runtime#runtime-saveable/1.11.2": {
+   "jar": "sha256-16wwfVhrLKq/C97ElJohyPSaZT+miOZi2fSn6y2UdW4=",
+   "module": "sha256-L0uS8+cbpnQ5rVI2sge9WWYmzNVb7nDYEfLU1+CApk0=",
+   "pom": "sha256-70hZYCbjOYhPNdacUpiMQqyWb0vINRa/X3zyEyh8oic="
+  },
+  "androidx/compose/runtime#runtime-saveable/1.7.0": {
+   "module": "sha256-V096AtKqST7Zo0pfOFZyJm6XS77qNQMnRU6gCL3S7Zc=",
+   "pom": "sha256-UG3TGS4UUkxsHClvNFl7hGoyZPqtF820AuHszCJNDko="
+  },
+  "androidx/compose/runtime#runtime/1.11.0-rc01": {
+   "jar": "sha256-iOf2l5HyKyfudkmfYMltbJ335UGYVnwgqjlW8J5Lti0=",
+   "module": "sha256-9qoW/UKCWGMRau0MFAqIPj7KRSjihhCRTnqhFCIaMXE=",
+   "pom": "sha256-kQ9SBuUzbh/ekzZH/n/oxA/uWZ8CO47JZtfoxSzgWFg="
+  },
+  "androidx/compose/runtime#runtime/1.11.2": {
+   "jar": "sha256-EjyO2UUlDPUP+610tYV8s32u9aU/hTeHC1VFJbNkExw=",
+   "module": "sha256-aLriuaUArmOAm45H/xSZcnvBSkJASOBVMum55WOqoG0=",
+   "pom": "sha256-Zqsry2Myf6uC84jtBvgW/CIyfhdSEaibFIPN5CmLgAo="
+  },
+  "androidx/compose/runtime#runtime/1.7.0": {
+   "module": "sha256-e5NRsP9t+SdtAtQPEnZa5Vv1xt+4/430x338oTj7n8E=",
+   "pom": "sha256-eUHY/NaDVXGG0vU8gXPDX3GqrJ1OZI6a6x7cS5L702E="
+  },
+  "androidx/compose/runtime/runtime-android/1.11.2/runtime-android-1.11.2": {
+   "aar": "sha256-VzMcZArTPx9h4NdtTgq9Y3tF2vqzdGfVB1jsH9R7svQ="
+  },
+  "androidx/compose/runtime/runtime-annotation-android/1.11.2/runtime-annotation-android-1.11.2": {
+   "aar": "sha256-zb1/i+pEFepW6YUpUKiV2hW6WVBrC5F7HiHlYHpCmEQ="
+  },
+  "androidx/compose/runtime/runtime-retain-android/1.11.2/runtime-retain-android-1.11.2": {
+   "aar": "sha256-KER9kKSgtHZTwRiK4nL/pnhMoIRf/xknv0r9zwlsE68="
+  },
+  "androidx/compose/runtime/runtime-saveable-android/1.11.2/runtime-saveable-android-1.11.2": {
+   "aar": "sha256-GBLtZHvDWvl+pX/HcSKnGuGen61p82I+hu40G1rwhGQ="
+  },
+  "androidx/compose/ui#ui-android/1.11.2": {
+   "module": "sha256-tWCMOOd+ggHbUGo5J+xTsS+FpB/wRk7DOCFwO4Q8iRA=",
+   "pom": "sha256-6jSe3GeeEu6DDpuu1SIUGta7CN1wf3zlomIdlObKdYo="
+  },
+  "androidx/compose/ui#ui-geometry-android/1.11.2": {
+   "module": "sha256-gO3OmMisRWcQX6GdGoFQCuZ/jx0DfcqYC2BtcQboWZ0=",
+   "pom": "sha256-QoQD2hnDC0WZgJBLSRtRx21/cbDx6Fhb0sggXQvXpWQ="
+  },
+  "androidx/compose/ui#ui-geometry/1.0.1": {
+   "module": "sha256-4v6ktWj/k+NAvEsYyKPCqbr98+EhDZ7TADbB2YiL42k=",
+   "pom": "sha256-a8eueqmlaUSxbzq4pWXDMtMHt5ZHH2wPUepXvtq7wgg="
+  },
+  "androidx/compose/ui#ui-geometry/1.11.2": {
+   "module": "sha256-qHu7vhOvVrnAxRTSX/uLzNxBn1jrOsdFtEsvCDXPO2o=",
+   "pom": "sha256-eAxENP5NXBdpeoeUq1vaDHYW8jc5xf9jmqOZbXFyyy0="
+  },
+  "androidx/compose/ui#ui-graphics-android/1.11.2": {
+   "module": "sha256-uSR/yfnXL4lNlzrJWmWUrGOusO4fTY4/T1A5nNKUZO0=",
+   "pom": "sha256-LzD4OVaihZV9X6lEWNupgty3irCXK+4hzkwWLxB+X10="
+  },
+  "androidx/compose/ui#ui-graphics/1.0.1": {
+   "module": "sha256-rZzkDe7HIbiYjEOrhH2APQC+6Ixnz8g43uVlaR8125U=",
+   "pom": "sha256-GONZWSUbahn/IUhSZDDJtpPpDm2Zv6ebCEm9lJ1e5VY="
+  },
+  "androidx/compose/ui#ui-graphics/1.11.2": {
+   "module": "sha256-MPXuHUeVRAJD05zRyFq9+vdCXqphF9P3aArPZm//Mm8=",
+   "pom": "sha256-SKX6uAEwRVKaC5qQ7ZC7ECwvDXdV74sJsyYqysJ7is8="
+  },
+  "androidx/compose/ui#ui-text-android/1.11.2": {
+   "module": "sha256-v5zD85CE+CHP5zlfa37nFinhvvK3nNWgRu+SUPtIQcQ=",
+   "pom": "sha256-t2KaGzJ5hE7LoMvWBZIlkzhoLlyzyKn1H4GvkcG1rbA="
+  },
+  "androidx/compose/ui#ui-text/1.0.1": {
+   "module": "sha256-Q6HslNPOzF870g8cU1UasDoLpyivGHGnS/I5xBh5Xxs=",
+   "pom": "sha256-sclCzOWe1DTUcgZ7yUk4f7XLxgJ/dAsCWQzrjggKgbw="
+  },
+  "androidx/compose/ui#ui-text/1.11.2": {
+   "module": "sha256-ERBLV++3cXI4sR2rotbwkOTPN4G/y5UvecnUW7nf+zw=",
+   "pom": "sha256-7poQVrUiXJVHPvAeCuadTLvLwnzknWH49mMoy3k+qcQ="
+  },
+  "androidx/compose/ui#ui-tooling-preview-android/1.11.2": {
+   "module": "sha256-hI4gQNaXrIIs5zCUu5GBvqX1Q1ppc4bxeTpJ/qKKIUo=",
+   "pom": "sha256-Bg+sIq7AbyFzp1wDY4QGT4dxVUwKPal+ToJaIzzmvE8="
+  },
+  "androidx/compose/ui#ui-tooling-preview/1.11.2": {
+   "module": "sha256-onXe5206hFJnbBcFhttxPBtiN3tefWC2+qidCrTJwKk=",
+   "pom": "sha256-OpFj1r4dkFmHXbSi/4tFyXS3P8DGdIR8TQr4NsMXPS8="
+  },
+  "androidx/compose/ui#ui-unit-android/1.11.2": {
+   "module": "sha256-+MOr+zOmIeyyr/WUvk/VNPudJ4dcAFZXUlsKHn1EhGw=",
+   "pom": "sha256-2a93abw9zmQ7Rzo9Cvdjs/95YdNdhsNukTV/9yLDZKQ="
+  },
+  "androidx/compose/ui#ui-unit/1.0.1": {
+   "module": "sha256-PbEuW0fW9tqR7Ub+uQL+URKCyEbk7xr/u5FHefprEII=",
+   "pom": "sha256-jrCYEDVgGvGhTFv4p/Ae99S0702VciEhxhF/o9CO7lk="
+  },
+  "androidx/compose/ui#ui-unit/1.11.2": {
+   "module": "sha256-ncKF5czk992PHR6m0rLT4p6NzdFXmJ+0PKCPjOl9CKw=",
+   "pom": "sha256-Sf7dpUF8Ud6ry9pbGFE69y2ozsCAKx7LIYrB8Al3gOc="
+  },
+  "androidx/compose/ui#ui-util-android/1.11.2": {
+   "module": "sha256-wVDIfflEGEAJYh0PVVTSEc4BgE31pL7RA14FMREYYt0=",
+   "pom": "sha256-J4aoJKYHeLClXr3iNtPKtUsCPi8NjlLNYy6dQWWpLMI="
+  },
+  "androidx/compose/ui#ui-util/1.11.2": {
+   "module": "sha256-Y9rfTGMmKeB+RoKW7mFJdrtIUbhQKS32umBu8RAe1aE=",
+   "pom": "sha256-L8IPFsnoXf3qsUl6S+EcRL370DazNVRjtSV2nJRtdmE="
+  },
+  "androidx/compose/ui#ui/1.0.1": {
+   "module": "sha256-VwMaasm2DltWeS6/XN5uFoEv9WbtkZDL0YiwC0bBN3k=",
+   "pom": "sha256-IfZaw0n3m8YNhGbQ64DNBj8YUvRMrKShyfN8GandvWY="
+  },
+  "androidx/compose/ui#ui/1.11.2": {
+   "module": "sha256-7WT/sFlotqW6seWh5QqwPVnHzb1GLvbS7AMRBecupmA=",
+   "pom": "sha256-Twps2Hz8SXdQmdKc+OV+I+vEemKhiHvZqyeuk4+cUUw="
+  },
+  "androidx/compose/ui/ui-android/1.11.2/ui-android-1.11.2": {
+   "aar": "sha256-oNf5MK8sp3XOXg5VyD8oo2w7mzXuBHUZDD/wYvaWJXI="
+  },
+  "androidx/compose/ui/ui-geometry-android/1.11.2/ui-geometry-android-1.11.2": {
+   "aar": "sha256-OoOW3zx4L45XU07058gbnMuIm8/89yDoTHyi3RAOLdo="
+  },
+  "androidx/compose/ui/ui-geometry/1.0.1/ui-geometry-1.0.1": {
+   "aar": "sha256-BNzqed4K+DR/RRe+wgV41CQK5e5AGRAgygfXo45kADM="
+  },
+  "androidx/compose/ui/ui-graphics-android/1.11.2/ui-graphics-android-1.11.2": {
+   "aar": "sha256-XFEHfa2KchbnuPL5YNKoLQioMhKf/mn/Bz2P5LozexI="
+  },
+  "androidx/compose/ui/ui-graphics/1.0.1/ui-graphics-1.0.1": {
+   "aar": "sha256-a39dDJREg+o5Cz1tqEOOemngz+MQvRbDxeeKwAFbFmM="
+  },
+  "androidx/compose/ui/ui-text-android/1.11.2/ui-text-android-1.11.2": {
+   "aar": "sha256-459edu1nB9iu3z2EZzbGHxG+/eBVBNGL4D+es5urBvA="
+  },
+  "androidx/compose/ui/ui-text/1.0.1/ui-text-1.0.1": {
+   "aar": "sha256-8na0A/uVvaKfyDoz/3F1kWYuosdp/DTCB37EYLZfDaA="
+  },
+  "androidx/compose/ui/ui-tooling-preview-android/1.11.2/ui-tooling-preview-android-1.11.2": {
+   "aar": "sha256-g8oLra9Vr1htelF5emu3URnC38kdePWB8DMxefF/lEA="
+  },
+  "androidx/compose/ui/ui-unit-android/1.11.2/ui-unit-android-1.11.2": {
+   "aar": "sha256-zfpoLRccipMJY3XiNupZmHOcCbk/cv1x6v8JkBGhaKY="
+  },
+  "androidx/compose/ui/ui-unit/1.0.1/ui-unit-1.0.1": {
+   "aar": "sha256-dbE+KhXaijGs912BxCd/8oILG/WCkbRoisVSAM3BgHI="
+  },
+  "androidx/compose/ui/ui-util-android/1.11.2/ui-util-android-1.11.2": {
+   "aar": "sha256-Bsz698i8HF9uomMjPEfVhbWl5Rr7opw9IUlZb1RiJZc="
+  },
+  "androidx/compose/ui/ui/1.0.1/ui-1.0.1": {
+   "aar": "sha256-GUPapKNBKGG5or3Bp8jC/wXZuBkcHT5W67Ij0utKhSY="
+  },
+  "androidx/concurrent#concurrent-futures/1.0.0": {
+   "pom": "sha256-RQW5peMKlBi1mprWcCw+QZOupuaRo9A88iDHZArQg+I="
+  },
+  "androidx/concurrent#concurrent-futures/1.1.0": {
+   "jar": "sha256-DOBnxRSg0QSdG+vfcJ40TtMmb+l0QnVoKTfNyxMzTp4=",
+   "module": "sha256-d2OaCwUeIlELrZOv/OoOvXge8SS/m3YhqVdJk3vPzf0=",
+   "pom": "sha256-dIo0610T0Z0Yet7K6oJmf97V8bC5imVeE+0uSos9iuY="
+  },
+  "androidx/core#core-ktx/1.13.0": {
+   "module": "sha256-o+agaS4F/VnmrDgHFe1ysyXGJaNidkbGnRCL3N3EJg8=",
+   "pom": "sha256-fPbU+y9hq0kkIyuS1lgLZd+RA8BDfNrmDOFDiMNzEhA="
+  },
+  "androidx/core#core-ktx/1.13.1": {
+   "module": "sha256-q1MLBOL75zIFSEiZo75WyQlohz60lvxS5ep1ltkQNdE=",
+   "pom": "sha256-Mcw0W4xs3SBG3PZ4ct+KjLT0TqDK3k34AALKp+O3GAk="
+  },
+  "androidx/core#core-ktx/1.16.0": {
+   "module": "sha256-ifuSyhJ1lM3NEcXvtasOjrI0ZrxBuN91eVFNL+9uEoE=",
+   "pom": "sha256-RmDPtgbtiYKLo+EPebKYCf+2d+5dI0b+m8sD38S5tkU="
+  },
+  "androidx/core#core-viewtree/1.0.0": {
+   "module": "sha256-EThs+kbLv922pAWfFDVMAGkc9l09Y8NhiBioMybvPH8=",
+   "pom": "sha256-1PLtEXb6jFYSuA90yVKoeZFCqe02AioaI4/eWxQFgNk="
+  },
+  "androidx/core#core/1.13.0": {
+   "module": "sha256-Lg5uXBIFt0YqDFw+MrWMLlJUNYEu2JlGx75nN0k7UeM=",
+   "pom": "sha256-RQLk7YtZEiAhrJocExLiMm5LD0P37Lu8m1Dud0KVdNQ="
+  },
+  "androidx/core#core/1.13.1": {
+   "module": "sha256-KhCXm7s7zXslt/Zkq06bAW+r8hdKJnaLZ34S5L6kx8Q=",
+   "pom": "sha256-Unq/pajWr3SLN+HAFi0WM6LV6kOHsCBai0NrYhS6HPY="
+  },
+  "androidx/core#core/1.16.0": {
+   "module": "sha256-SrSjsLwWZOOixg3saZr2NXeOFcbuNzlxaQlI8HPdch4=",
+   "pom": "sha256-B0l0oVUCIa96qF3taQPD2Eyb3t+ea0/zsMtHEym1rHc="
+  },
+  "androidx/core/core-ktx/1.13.0/core-ktx-1.13.0": {
+   "aar": "sha256-WcVOYSnpJhxtgQ+O6kpu4vSZTYFisc2fyIychMkqzPw="
+  },
+  "androidx/core/core-ktx/1.16.0/core-ktx-1.16.0": {
+   "aar": "sha256-F2bb2C9koS3NNZ7LbxXzzzXbTWbSKWGnxRsv/GRoMUw="
+  },
+  "androidx/core/core-viewtree/1.0.0/core-viewtree-1.0.0": {
+   "aar": "sha256-3BtnjVjrzyv6FYe+aP+CZpTOPSISUbnvMNTUs2KX5t4="
+  },
+  "androidx/core/core/1.13.0/core-1.13.0": {
+   "aar": "sha256-G5bI6xDEtAKD/dbpqnT//wX65PFdVPYbpp1Rf80URpU="
+  },
+  "androidx/core/core/1.16.0/core-1.16.0": {
+   "aar": "sha256-a/A9OdvjdErM4ifTtpc3TDYlquECX77IrZ/XvVi85DE="
+  },
+  "androidx/customview#customview-poolingcontainer/1.0.0": {
+   "module": "sha256-kDA01RUt0uAWKxRo6iWiLhyjhABrPSgtWhQ8x2AyGgE=",
+   "pom": "sha256-n6YhlsTE55tqWNuziowCK++NshmJ19ri2g9vW2Yompw="
+  },
+  "androidx/customview/customview-poolingcontainer/1.0.0/customview-poolingcontainer-1.0.0": {
+   "aar": "sha256-NYQQL8Sb85nFbjt75L/hIADEYRIyDNjPhcwKj5Pz51I="
+  },
+  "androidx/databinding#databinding-common/8.13.2": {
+   "jar": "sha256-Zsq4JjnawPbCQzRkwJOwdNYIxLuIfsOKm4vErJgSZzI=",
+   "pom": "sha256-HRsskeiTEHht7ncOkSby+iDtEuPmF+Q5yiif9d85E7E="
+  },
+  "androidx/databinding#databinding-compiler-common/8.13.2": {
+   "jar": "sha256-osP/8MOaxyxMIcQVAXBmwmPv4XDYrrnTOaPsp8DXnx4=",
+   "pom": "sha256-b+dyhf/5yqYWJqP8b/Y1JUj4GQosdDS+kh7P70a+o+s="
+  },
+  "androidx/datastore#datastore-core-android/1.2.1": {
+   "module": "sha256-bQdjAukJZcxR2STEtnplqfqRvd59EHvFeco6IhVQhtU=",
+   "pom": "sha256-w/79rLpSc2DXs1Zane9mZ1MANJbOkOOYrasWfNfGME8="
+  },
+  "androidx/datastore#datastore-core-jvm/1.2.1": {
    "jar": "sha256-3S0ID8FusL6h4C5VUdQ0lvueUXeFXFtyxqr24WqxxcE=",
    "module": "sha256-n5XebiGnr+uq44H79ZKtcX0PipLdfhVISq3z6SUaSoY=",
    "pom": "sha256-/HfBwerbtG10A85wFKe7JbQ55JuHr1OW24NF5OjQHUg="
   },
-  "datastore#datastore-core-okio-jvm/1.2.1": {
+  "androidx/datastore#datastore-core-okio-jvm/1.2.1": {
    "jar": "sha256-et5iOaZ2dINPVyRCjncsQXYintML4lOsflIIKikH7gU=",
    "module": "sha256-h1PfOHGdyVNabVODRmi5E30+EWcQghuya3h6hcn8v8o=",
    "pom": "sha256-9jvfHz3Gn4wQi57GB8QznRIVm9lbamqtNKNAriG1N+s="
   },
-  "datastore#datastore-core-okio/1.2.1": {
+  "androidx/datastore#datastore-core-okio/1.2.1": {
    "jar": "sha256-qqFaAMdoj/Xobp6fbCj4fexa/plcRVA18lEBTSmMNMY=",
    "module": "sha256-Uio4O9pYJQuWCKnOZ2L8oPVL6aOPlEay0uJhwsnOsqg=",
    "pom": "sha256-l6IMy9DxVBo743GsqYmHKPZS/hpYg/9SuUg8YSvS5yg="
   },
-  "datastore#datastore-core/1.2.1": {
+  "androidx/datastore#datastore-core/1.2.1": {
    "jar": "sha256-724F4UniVvNgr6IJhajKUtjhGXBlfqKSpvu1cT95R9o=",
    "module": "sha256-PsuQuyXi5OZ09U4VSWSZINGzHPOcjKLCyREV6Pivje0=",
    "pom": "sha256-xQ8uSECCuGNRBn74OB07ApFTWjzbnlIgiRBZMPhNI7M="
   },
-  "datastore#datastore-preferences-core-jvm/1.2.1": {
+  "androidx/datastore#datastore-preferences-core-android/1.2.1": {
+   "module": "sha256-HjuwBxdFtHOiaOJLoiPE2vhn0OQJQGiRFvy4h3DKnZ8=",
+   "pom": "sha256-Y7r+U4pEUmkdWtfcZ4MYeegV5Ml822vzzHr8mBSpYbc="
+  },
+  "androidx/datastore#datastore-preferences-core-jvm/1.2.1": {
    "jar": "sha256-vINQxaOCo/aCYBSG9UUdYSLV/YwVr6Maznsi+pgAXqY=",
    "module": "sha256-yO1zm8SUsu88iTP+qBqItqpgNfEu/7R0BAdmYQ//hE0=",
    "pom": "sha256-I7MC9Tjee7D+DuOTnTBXQVB0rMzb3iubCbi2nOpxuns="
   },
-  "datastore#datastore-preferences-core/1.2.1": {
+  "androidx/datastore#datastore-preferences-core/1.2.1": {
    "jar": "sha256-/mJsICueo7bqzo2q6w5pL6XYL1Vx0sA3Wo3RT508ymY=",
    "module": "sha256-RhuLV+aHzDFW7/tPrayde7XadyMm7mo0hE61nrCR2Yw=",
    "pom": "sha256-lGmC5zev6Fn5A5+6GFdcodTx520Yghu3M9O0C0LeCvk="
   },
-  "datastore#datastore-preferences-external-protobuf/1.2.1": {
+  "androidx/datastore#datastore-preferences-external-protobuf/1.2.1": {
    "jar": "sha256-Twm6f8oqBzpcVSeptjdYK5PiYsK2qJl3xYTSjOqDjrw=",
    "module": "sha256-AJRV3Ob24zyLPvmkSFn3u+o51JBKUjqibFtmYOAyZrI=",
    "pom": "sha256-f3iN+Yvsc2EbIW+0vqYl2RMwBUIit4nnYmoUb4b7Iyc="
   },
-  "datastore#datastore-preferences-proto/1.2.1": {
+  "androidx/datastore#datastore-preferences-proto/1.2.1": {
    "jar": "sha256-2bvZT3jppskzCO7Sa4p+1GsfEooZwoL+NvloBOnXwYQ=",
    "module": "sha256-XrEsUlySObPJ6F2WsXea3Qy4ZrD7AC+MBvWyh6DvkbQ=",
    "pom": "sha256-4vhhHTXgwleKQzM84/5eHLXlFo3XNDgQ0QrLZIhWbQY="
   },
-  "lifecycle#lifecycle-common-jvm/2.10.0": {
+  "androidx/datastore/datastore-core-android/1.2.1/datastore-core-android-1.2.1": {
+   "aar": "sha256-Q17a17yx+7GipG3nvk1trymUebMyjr91fr3+AoEMvdg="
+  },
+  "androidx/datastore/datastore-preferences-core-android/1.2.1/datastore-preferences-core-android-1.2.1": {
+   "aar": "sha256-SMIjXldvsBX4YXJuee6UdJSON9ox0siHwW6+tGgXBZ8="
+  },
+  "androidx/documentfile#documentfile/1.0.0": {
+   "pom": "sha256-ATKIqTF6VScGzmJfskST6CIyiFKSI+xXjPhVpa6cFuU="
+  },
+  "androidx/documentfile/documentfile/1.0.0/documentfile-1.0.0": {
+   "aar": "sha256-hloGHvL60WUi+EM1NrjUcgjEb/fHdFGX36HutIGGlIc="
+  },
+  "androidx/dynamicanimation#dynamicanimation/1.0.0": {
+   "pom": "sha256-RM4i7mINKPFzAbzGCtSbabfQWWwqh7BUrR4/6se0qJg="
+  },
+  "androidx/dynamicanimation/dynamicanimation/1.0.0/dynamicanimation-1.0.0": {
+   "aar": "sha256-zgBRYsIpvzCNLVsS+2ytCHQGnLvqzO5jqBk70I1A3gQ="
+  },
+  "androidx/emoji2#emoji2/1.2.0": {
+   "module": "sha256-nRmWzKA3d7qh8nzRVTHbmDpjPa43uQ+FvVNQGstWaZ0=",
+   "pom": "sha256-+vWVXSybCbupLlFWnyuShBne0FtclknARTySXH2mI2A="
+  },
+  "androidx/emoji2#emoji2/1.3.0": {
+   "module": "sha256-3chR7bpl/RWnobw60YZI4vcy3VrY7zYCIkvOBkf1tNE=",
+   "pom": "sha256-FOu+qCNPATIRll/dCLQu6QfOAHWvMhAYyMKGXC5dsOs="
+  },
+  "androidx/emoji2#emoji2/1.4.0": {
+   "module": "sha256-kr4WzMt1f4B73dkvH8qVoDioEMzKBRxBScEWgkeJVLg=",
+   "pom": "sha256-H2ciFIT30SYOtuK0kM1OcEa/XLU2J215+XKtPxmLR00="
+  },
+  "androidx/emoji2/emoji2/1.4.0/emoji2-1.4.0": {
+   "aar": "sha256-Qz/r00NKRWZxdsdqZPPyBcpjNaa1RMW11X8lo4o3UkI="
+  },
+  "androidx/exifinterface#exifinterface/1.4.2": {
+   "module": "sha256-Y2UWXrWqzHAKNLFlCikQ6gHr2BmCG4mvdon6QSdPsAs=",
+   "pom": "sha256-sRwHY/MJTShmRBK30zFrtdGnhYEPt7T+XzVs1cvNFyU="
+  },
+  "androidx/exifinterface/exifinterface/1.4.2/exifinterface-1.4.2": {
+   "aar": "sha256-a7K2hoKiAjxV81+UFET/6gFXlHsGHk/XYGupNeLndCU="
+  },
+  "androidx/graphics#graphics-path/1.0.1": {
+   "module": "sha256-P2/H6W+KH9IQRdp/LjMq71KKofVrZFX7jyUEOq+g4bg=",
+   "pom": "sha256-hm+zV8cUb192eK1E5LxsKCPVaN784e0oBbtsiZYGsig="
+  },
+  "androidx/graphics/graphics-path/1.0.1/graphics-path-1.0.1": {
+   "aar": "sha256-jKQDK215s1HwtZrUtYDt27lCPhZS98lYgwaH8e7i7AM="
+  },
+  "androidx/interpolator#interpolator/1.0.0": {
+   "pom": "sha256-DdwHzDlpn0js2eyJS1gwwPCeIugpWSlO3zchciTIi3s="
+  },
+  "androidx/interpolator/interpolator/1.0.0/interpolator-1.0.0": {
+   "aar": "sha256-MxkxNaZP4h+iw17sZojxp25RJgbA/IPcG2ieN63Xcyo="
+  },
+  "androidx/legacy#legacy-support-core-utils/1.0.0": {
+   "pom": "sha256-j9CTAIs+58BuUseNoq+YCntHtpuWf6kdrXr0ZvegCjg="
+  },
+  "androidx/legacy/legacy-support-core-utils/1.0.0/legacy-support-core-utils-1.0.0": {
+   "aar": "sha256-p+3PAdW1KzA0BzAnvEd1t4pHZLtiAruR1hyCmt2N0cc="
+  },
+  "androidx/lifecycle#lifecycle-common-java8/2.10.0": {
+   "jar": "sha256-SX3YTeny/UYyTyX5o68DLToj0IfoevUVxLGUNfbWplE=",
+   "module": "sha256-RTKPdawHejY4HcU9aMBSiLoZgTfKvEH91NJNxEfu3bo=",
+   "pom": "sha256-r6pdhRk6axCKJfb6iorj57KwsrK3z1NZf3K8tPWUJxg="
+  },
+  "androidx/lifecycle#lifecycle-common-java8/2.6.1": {
+   "module": "sha256-G+sLn/+2MKAF3sodNYPSrL7IaF1t6AmjpuDkM/QYtsM=",
+   "pom": "sha256-HeG0opB9T5Oym6QzmvRluaJOHA/2p0ks8d/N+AJdRew="
+  },
+  "androidx/lifecycle#lifecycle-common-jvm/2.10.0": {
    "jar": "sha256-FZQwgth7zXiDA5j6N38sixJkPeKQ0JBu2OSaLTNd21Q=",
    "module": "sha256-k9kBazr9A2OaQH9RoRnVyk2umI3jdsOA8OUd2diOaG0=",
    "pom": "sha256-ygYrmrsCmLDUCuEMLRygbUEp9fYO/cXoxExsKzN10Vs="
   },
-  "lifecycle#lifecycle-common-jvm/2.9.2": {
-   "jar": "sha256-N9ibIQHwdKxsJgkX2rsYVgdkXuIAqjAYx8W95w7c8YQ=",
-   "module": "sha256-cjad+SZiA6QqezjE5J9n5ueWL55I4ihiftfvRmsFFIE=",
-   "pom": "sha256-jQ3Ks2SXw0q09G3Hm+cCWsQDWdDUK/SL1pqaa6FzQnI="
-  },
-  "lifecycle#lifecycle-common-jvm/2.9.4": {
+  "androidx/lifecycle#lifecycle-common-jvm/2.9.4": {
    "jar": "sha256-N9ibIQHwdKxsJgkX2rsYVgdkXuIAqjAYx8W95w7c8YQ=",
    "module": "sha256-HRg385QrM+owqiMB/c6iY5QIoP1v1DaMIkePqBU6678=",
    "pom": "sha256-MXNemVOq7qtOB/z/pMarNRn5CzMcSx2oFz35EWB9OQY="
   },
-  "lifecycle#lifecycle-common/2.10.0": {
+  "androidx/lifecycle#lifecycle-common/2.10.0": {
    "jar": "sha256-nTqZgAlbdp3rTzKPfzJUObGIFHEk1m3ELt1V4+e+6jc=",
    "module": "sha256-XRJHse373J3e3L5SXJ0mKVZ7HFOMt6nGIM0EShJLXHM=",
    "pom": "sha256-EAT03wURixPCqQmEa63GZkbtJ3lEcGpgTk3YKE1TVIs="
   },
-  "lifecycle#lifecycle-common/2.9.2": {
+  "androidx/lifecycle#lifecycle-common/2.6.1": {
+   "module": "sha256-k3R6kUXLNrxxAF9Zjt4y4rEUmt5aFuYrDklpNFvGLYU=",
+   "pom": "sha256-PmaDDVn65S4QMLS+ckseV3rIFNJzNf34GnEoPcCCnxo="
+  },
+  "androidx/lifecycle#lifecycle-common/2.6.2": {
+   "module": "sha256-D6fyj1z/ikBqT3hwskPLDW16fCD6p6K+yv9ZB64S+cw=",
+   "pom": "sha256-VzBM2sTaKJpuzdBzjhax2IWPHvjp+r4tZaljcZ/YHbo="
+  },
+  "androidx/lifecycle#lifecycle-common/2.9.2": {
    "module": "sha256-SDP4jjmhvSZO1eoYciAj6+UedLGaBBEkaqPXQOFukIE=",
    "pom": "sha256-bLkiyxFc6PYeffjRkl4tHTDvPP0I2G7Tl66qc32V+S8="
   },
-  "lifecycle#lifecycle-common/2.9.4": {
+  "androidx/lifecycle#lifecycle-common/2.9.4": {
+   "jar": "sha256-x6boNdoHEtFe/q4Nct+R5mMQQt9Pzw+cIM7KdAY4xoU=",
    "module": "sha256-xXi9dV6kbXp3gRMJo1OVOOLX+4agX8KtgcZV7Pff96Q=",
    "pom": "sha256-DjoMh5jSb0kjhVCj3E1r1GXUm4K8t1nKPEY6MWAOchw="
   },
-  "lifecycle#lifecycle-runtime-compose-desktop/2.10.0": {
+  "androidx/lifecycle#lifecycle-livedata-core-ktx/2.10.0": {
+   "module": "sha256-KyigMgHzB3sq4+KFP5g5RK/fUYsCk5rPyf6eX8q4cnU=",
+   "pom": "sha256-2YIILDJ57rnBh9mJdmXKmpDTRD812txokmH0snxy2aw="
+  },
+  "androidx/lifecycle#lifecycle-livedata-core-ktx/2.9.4": {
+   "module": "sha256-CpQOeeJWzH++xp2Os1NirHlZmrSyGrSEarpkuklgoZI=",
+   "pom": "sha256-yiBzrEbTZBB/302DLFtynmEM3H0S5zbZFRtaURm+gLk="
+  },
+  "androidx/lifecycle#lifecycle-livedata-core/2.10.0": {
+   "module": "sha256-HYO9XzzMEpjtolue0SjowYf4MOfzr40ClL5oirsDw10=",
+   "pom": "sha256-S+1ekc0qfAFVgyC2oXbbuGf8o8TGl9uUjiA75F+RDWQ="
+  },
+  "androidx/lifecycle#lifecycle-livedata-core/2.9.4": {
+   "module": "sha256-3uYGVquxlNoCjZO5vWUrSxZM2rNaAAtHXWMwPF0AmUs=",
+   "pom": "sha256-zsEWEUjj9sS31ROqmJcp6EqO6UcfDEfANHiz+zxJ6iE="
+  },
+  "androidx/lifecycle#lifecycle-livedata/2.10.0": {
+   "module": "sha256-Om1HOzEEyYNQHeSIPWunaE3IMzDEYO+Vg5CoJlsHgxA=",
+   "pom": "sha256-trk2hsVaHKjsIOfYSl/jQSZ+XaxuOQ+xzKOYODER6wg="
+  },
+  "androidx/lifecycle#lifecycle-livedata/2.9.4": {
+   "module": "sha256-moFToHri7di3kZo0rZGVhHAF6u1p+j5QYGNiCKcowxI=",
+   "pom": "sha256-JPi5RFSZEqtoOqcOYdMrXhqoPC8fnULwno7aMjd2CrE="
+  },
+  "androidx/lifecycle#lifecycle-process/2.10.0": {
+   "module": "sha256-xorsfMHQ0Z9RMo59KMkdz7SsjhqYQ8/WGB4aqUrhnJs=",
+   "pom": "sha256-osMGIyCHP5rCne0dnKSiQVUpwuRWjVO18rgT7FKtxmQ="
+  },
+  "androidx/lifecycle#lifecycle-process/2.4.1": {
+   "module": "sha256-46rj7QS0dE/zFFLpj9KZ4639KNO1cjZh2WeLkvoJzrQ=",
+   "pom": "sha256-2n4uEMrn12JaCuRUAXoSV0nheRoTnC13feka3YlBCvU="
+  },
+  "androidx/lifecycle#lifecycle-process/2.9.2": {
+   "module": "sha256-sLST7Nw14vme9f3lNAYMPQqe70YGocxMeMY+p5Nje0U=",
+   "pom": "sha256-Q0y5BeqcHXkoyHKoXddkfoh0WfdYo+mPIoExXu8f0yk="
+  },
+  "androidx/lifecycle#lifecycle-process/2.9.4": {
+   "module": "sha256-981QUbrLP0uOx9xArGNCph7qEUdZLdqfNkokz4gsfds=",
+   "pom": "sha256-XqxaCicThHf0Dwqg50nNB/v1WA1KmtxtLVnbZMrEmxA="
+  },
+  "androidx/lifecycle#lifecycle-runtime-android/2.10.0": {
+   "module": "sha256-dJtuekQikUWB4HldnUj7T5bao/7pd0dCH/QjSGAYX0c=",
+   "pom": "sha256-6X7gHa9vTcy5AL23Zyuqta08fCXEVJH9zPXroztur/8="
+  },
+  "androidx/lifecycle#lifecycle-runtime-android/2.9.4": {
+   "module": "sha256-x4iOhQxA/QWfssHsW/RuiDE+m11RUhM8OFoar7hDP0c=",
+   "pom": "sha256-Jx5UAJ/fOizVq0FOignmr0JRtj1ISkLFMKuGiXSl6h8="
+  },
+  "androidx/lifecycle#lifecycle-runtime-compose-android/2.10.0": {
+   "module": "sha256-pZT365OTD+9SwsuxlPj0GyWQZ5+eZq7DNZVMRRosCPg=",
+   "pom": "sha256-gHgw76JxMGSShrAGHJcq2dwLGmHRv8LXGi6N33H2K8U="
+  },
+  "androidx/lifecycle#lifecycle-runtime-compose-android/2.9.4": {
+   "module": "sha256-4Ieiwr3+NgSXM5M1ulHbzdFQPAp8n0+ChdtwI+BClDk=",
+   "pom": "sha256-p6Bzx9sQl0Ynuog/ZIo0/oBT9QwpTZGS4YPJAdrqjGU="
+  },
+  "androidx/lifecycle#lifecycle-runtime-compose-desktop/2.10.0": {
    "jar": "sha256-TSM+7sxuJ2mnZEKDDF/RiEBXw20M4nRRZxk6EMyJdvg=",
    "module": "sha256-JXsLxt9zrYYOazeLlIkIZ5ZMdDDanIhKZfZnz+XL3BA=",
    "pom": "sha256-DVXZUfjn5VGIMZwhP4lx37pZ2Re2ZYhSe5ZUcCc7u1Y="
   },
-  "lifecycle#lifecycle-runtime-compose-desktop/2.9.4": {
+  "androidx/lifecycle#lifecycle-runtime-compose-desktop/2.9.4": {
    "jar": "sha256-0lwIPfk9pxihh2oyk70V99x6gR6ZhzWUO85ZBoOleDU=",
    "module": "sha256-xANG1Q0gglWZKxsFPINcljYxhBtw34tvxp8kUpmI3MU=",
    "pom": "sha256-EHpGt+Pp/+28BWd4Ler5/3ZztYgdDFX72Bsv49r9CHQ="
   },
-  "lifecycle#lifecycle-runtime-compose/2.10.0": {
+  "androidx/lifecycle#lifecycle-runtime-compose/2.10.0": {
    "jar": "sha256-wFuz86yHG28cdomAuFGtBWRZ8pKuxV7HbOzHF4GB7fc=",
    "module": "sha256-YyuoWyQ6BAT28zrW58mW97qaQvN32whHNK56MY6qbsg=",
    "pom": "sha256-D3kM4VGREBDVN80gRSZ1AX/yX9/x+1zfSZvzoFrULKo="
   },
-  "lifecycle#lifecycle-runtime-compose/2.9.4": {
+  "androidx/lifecycle#lifecycle-runtime-compose/2.9.4": {
+   "jar": "sha256-iDVBasWaI/cVLrDyF72rdCo3fphUYjB2OcErr8FAjkE=",
    "module": "sha256-J9hk9AyjC5Z7hdqsa5F7va6mN9Y+EjlIyVBFwhvlhIM=",
    "pom": "sha256-DvP7KPibgLkMeK1ro0UWTVWQiJ7jRZsCfyZpWTYpFXU="
   },
-  "lifecycle#lifecycle-runtime-desktop/2.10.0": {
+  "androidx/lifecycle#lifecycle-runtime-desktop/2.10.0": {
    "jar": "sha256-b3C3b7eiYvR7mTF8IyccKKia0YQAVHtL/vvS7wRQD5A=",
    "module": "sha256-Lu74CEz2cSnhmSJ6P6us+FBvV/ruywqrD3ZdXE5ZBAo=",
    "pom": "sha256-SQEy3ZcZUnyYf6pBMkaax+QcJXub5DU/Kc2rFcVS568="
   },
-  "lifecycle#lifecycle-runtime-desktop/2.9.2": {
-   "jar": "sha256-L7SfdtECF5L7NZ4KkkbBUJ8vW1VfCkZZHSTVjetovVw=",
-   "module": "sha256-LlSqpZmBsgH4wWFd8SOPcCXy/z82H+FNwOcJJhaJOu4=",
-   "pom": "sha256-mSJ0JPvUDXx17N+uiOXDVuDEuWVAtKui88RAyFnOU1s="
-  },
-  "lifecycle#lifecycle-runtime-desktop/2.9.4": {
+  "androidx/lifecycle#lifecycle-runtime-desktop/2.9.4": {
    "jar": "sha256-L7SfdtECF5L7NZ4KkkbBUJ8vW1VfCkZZHSTVjetovVw=",
    "module": "sha256-+VLq6Qa8BiePYEGvs8EzPp1rAL5DeIV7zWahulg2eQk=",
    "pom": "sha256-+yriSTRTAzy/Kzp0qh36Z8/bwYmlTRkJg9/RVQLQtuc="
   },
-  "lifecycle#lifecycle-runtime/2.10.0": {
+  "androidx/lifecycle#lifecycle-runtime-ktx-android/2.10.0": {
+   "module": "sha256-mAob4UbK+harOxaAmR3eFLIHeksT1bMUJ8uY3Ikw8ks=",
+   "pom": "sha256-XBomndDwrOh/IoMog7iYvXtCUtaofwTBc0fYPjEoZg4="
+  },
+  "androidx/lifecycle#lifecycle-runtime-ktx-android/2.9.4": {
+   "module": "sha256-aiBw6dkkO9O11aEIudtVg7zEx0KzLvtF/jP0lCnrcZM=",
+   "pom": "sha256-eKrOefvO2OuMF+CwKy1VvpkG+92gU+amF+5uWV/KzhQ="
+  },
+  "androidx/lifecycle#lifecycle-runtime-ktx/2.10.0": {
+   "jar": "sha256-XXTR6cRdU4qvxIsjE+WY7/m0oTv+6fLz13b1J01c3iI=",
+   "module": "sha256-VW8VlXN2hYtuOrwI+z31ZupetAZxSSUxlL8qBJYG204=",
+   "pom": "sha256-BgrRdTOB56+deluJgp85Tvb9R/d+MbpMgSRivDe9phg="
+  },
+  "androidx/lifecycle#lifecycle-runtime-ktx/2.6.1": {
+   "module": "sha256-OYVPMsmwEPZS9OUEHKTOBpgdy2lUEowejhzALmOrGF8=",
+   "pom": "sha256-UF6EiRwSTXiwivfASJMOzc09FpDlBFNZoftGrmzybro="
+  },
+  "androidx/lifecycle#lifecycle-runtime-ktx/2.9.2": {
+   "module": "sha256-/edqfOymbbSbEwD6rX0iIHYGJAWSJpCeq7/tHvTNeKQ=",
+   "pom": "sha256-d/i5UFhMLiAK1hUNRrLK8Cqu7CZuv172Xnzl0aa+FQc="
+  },
+  "androidx/lifecycle#lifecycle-runtime-ktx/2.9.4": {
+   "module": "sha256-BeV4jgAF06oz4tZaXctRvasGCUolTBNbggMW1kkxq8c=",
+   "pom": "sha256-CvaMzSgqP5jYMvORtmVQmNR28Z2R9A+QnTxpWBShHKs="
+  },
+  "androidx/lifecycle#lifecycle-runtime/2.10.0": {
    "jar": "sha256-2UTSBKRQ7QGjLv/M+0gyv51kYAkLcXqIoBM4HSBKtjk=",
    "module": "sha256-2oBfoBekrM4T9QFGmnWj8wYkjuvFj1vMKAGbABXfumU=",
    "pom": "sha256-Sote7FTV7N8JnqU7Lk6fJNspZ+pdOTCXtqbFSe1pMI0="
   },
-  "lifecycle#lifecycle-runtime/2.9.2": {
-   "module": "sha256-Tt2F+xoXbKfoOxW0dltc7hqTSqMX5BcQ+grBM0HXODo=",
-   "pom": "sha256-C7WGx+arw98w0Xnqn72uhnREwnmoF6IQHAzJQ/ks79w="
+  "androidx/lifecycle#lifecycle-runtime/2.6.1": {
+   "module": "sha256-pMuwGkLQcEe9jYcAF8lqGwt7RnMyDoa2YxehO+LsEMc=",
+   "pom": "sha256-QecdAD1DfxadToraWcsZgvG0e30lwjAQuPyB1SinQNU="
   },
-  "lifecycle#lifecycle-runtime/2.9.4": {
+  "androidx/lifecycle#lifecycle-runtime/2.6.2": {
+   "module": "sha256-6gExhGq+H+nepZrG3+Hw+52LbWAMnv+aH9StXuXny8c=",
+   "pom": "sha256-gXUlVUbipfUQhl+ErOaAZglUcwJAsZBdkXW0NFvtqXc="
+  },
+  "androidx/lifecycle#lifecycle-runtime/2.9.4": {
+   "jar": "sha256-ulZtD0bcAcIWl3jScjh4ns66oAZVZC4Cwk5Og+fcWQU=",
    "module": "sha256-3LxbW1BmboQlinS/2OUUkYxZOk/87wwDWFYqAvvYDFg=",
    "pom": "sha256-1helGd2zajCCE/W5r5kWOwo6NznOA4G2yND6aBRhOgg="
   },
-  "lifecycle#lifecycle-viewmodel-desktop/2.10.0": {
+  "androidx/lifecycle#lifecycle-viewmodel-android/2.10.0": {
+   "module": "sha256-BrB6B64Xx1kqMMUzw9RqEl/LG+8JbX5hNOJCDbJGTQo=",
+   "pom": "sha256-CqFxpQ9QqFyQaHrYLc038xr90b/SRjwhXRMilg5R4ig="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-android/2.9.4": {
+   "module": "sha256-tjes3YqrU0iXRmGDCHSnRWusNB9DoLKBgnzGsPz8c8E=",
+   "pom": "sha256-lmC1otgP/g8OW0+ZO1gdFZcqjBSq5ReEtgl7yXvgN54="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-compose-android/2.10.0": {
+   "module": "sha256-VSolTWLF2aqDC9edophyCCUeHIGv2Tw8K/+wJtQvRco=",
+   "pom": "sha256-NjOHpx8PMSUXUUvs2aQB7IWJ+8uNCTShysPF8F6wDIo="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-compose/2.10.0": {
+   "module": "sha256-J8EDbQHMgtAUKwTg1NfbPJkQBHKlkr6vdYvC6GWfLuc=",
+   "pom": "sha256-SAtwtmyTWh9JJ0LvWuFt+XTXtJV6AR8nlQAgctXtUlk="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-desktop/2.10.0": {
    "jar": "sha256-58hqXlxm/UH9PMnJrTGimXEQsaY4DEQbo/e2sLBw4ys=",
    "module": "sha256-zaMZ18njJgKFmnK+gcACblbReX75umfpFz6QXT90d08=",
    "pom": "sha256-z5W8pQ/AIStIWGre/gQ9VF+B+/YeNF8LeR6tlrLnNuE="
   },
-  "lifecycle#lifecycle-viewmodel-desktop/2.9.2": {
-   "jar": "sha256-mPgWvmhpQHyH1GBYdW+XeA+mxs9hrNupchb0E3Ma8V0=",
-   "module": "sha256-EDoC/VlNnhlqMQF7rZ69in05EOKKt5Shi2CvS4F18s8=",
-   "pom": "sha256-AZqq8EgWPVXoTyiQpYWpVQGn1KqbbhSByOWPcXsvDJ0="
-  },
-  "lifecycle#lifecycle-viewmodel-desktop/2.9.4": {
+  "androidx/lifecycle#lifecycle-viewmodel-desktop/2.9.4": {
    "jar": "sha256-mPgWvmhpQHyH1GBYdW+XeA+mxs9hrNupchb0E3Ma8V0=",
    "module": "sha256-73aG2pDJWnP0A+vKyHzwbNdR5JGecf4gqRFFm8tIT1s=",
    "pom": "sha256-sLwaHSilS9d4oSYQRI0o/tYDh3gfHNWa+r40sdA0XSs="
   },
-  "lifecycle#lifecycle-viewmodel-savedstate-desktop/2.10.0": {
+  "androidx/lifecycle#lifecycle-viewmodel-ktx/2.10.0": {
+   "module": "sha256-g3v92Eju/vd1RPoonb/0xChoDdmCBkHq24Qcx6dMg/k=",
+   "pom": "sha256-4TnbsaAM4Iqu2GVXqpaO7HFR1tSzBMMk4uVyJ1qs2Qg="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-ktx/2.6.1": {
+   "module": "sha256-pREPhXiLwWffn+j74IAE3cXF3ZsVy3N2zurvAl/Mqvg=",
+   "pom": "sha256-D0XiJCYK980beeN8VfnSPf+U/UExbtn2ACU/rM/0wc8="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-ktx/2.9.2": {
+   "module": "sha256-y4SLtnJXBWOSmoa6bINhgfSoqIQrE4+mdo6+AS9YJeY=",
+   "pom": "sha256-kVzYQ90QvT1aPgrNUQ99tZN/8U9oHb6GrePjBORoMGU="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-ktx/2.9.4": {
+   "module": "sha256-VjHv6reX95oa26XfZLLwzKVOCLQodW33YwyyO5AJimc=",
+   "pom": "sha256-DM0OnTYa1ptqclOrTtISSjvU+/mzOONsFDGzxe57x5Q="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-savedstate-android/2.10.0": {
+   "module": "sha256-lJ0qhitrWEzuka9wqeAXvbEX0iW7RgltqUJKFyjKeek=",
+   "pom": "sha256-X81Cm6V+Hd4bQ4U05Twj1idNI04zx0iWP2+qn4GTPIc="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-savedstate-android/2.9.4": {
+   "module": "sha256-v2TEw89a1f5db9Dgd4fsaAVMwib59nDgWvXvnaZ8JZM=",
+   "pom": "sha256-NKuEkea2MRI85ffwrgbfojjCEdzz5xAz7WFlb51HcYw="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-savedstate-desktop/2.10.0": {
    "jar": "sha256-kpRFl4QqaXYj0HRtcZ2K86y59MeA2mEQYvpg2ZOUTSw=",
    "module": "sha256-Wbc2f72Ct0pgUykaEnQ8rAws8f6WkpN4xR2Cv4/pqV0=",
    "pom": "sha256-i2wwG0UvOIUsD9VRfFFDl2uwLDaSHb+F3TDYiz9gOAE="
   },
-  "lifecycle#lifecycle-viewmodel-savedstate-desktop/2.9.2": {
-   "jar": "sha256-PgtE4lFOr91pONVFfZ9G5HhQd8RdO0NktcI8TcuT79M=",
-   "module": "sha256-lIcA/BG62P5o4na+85NOzf889H12tSMRrtMMunDB3Dw=",
-   "pom": "sha256-SB3uYNMEYo+2QdsKJ3dGBi4D0eIIefF5AgLQaydM6ws="
-  },
-  "lifecycle#lifecycle-viewmodel-savedstate-desktop/2.9.4": {
+  "androidx/lifecycle#lifecycle-viewmodel-savedstate-desktop/2.9.4": {
    "jar": "sha256-PgtE4lFOr91pONVFfZ9G5HhQd8RdO0NktcI8TcuT79M=",
    "module": "sha256-Zz9dNS3D2hsaNY5aMO9+FjIZs6HXA27hjJNQxT8F8rE=",
    "pom": "sha256-MV7u84MhWBlbUY4+zOEEWkqSmexIP1YYh2BuVf9qHLk="
   },
-  "lifecycle#lifecycle-viewmodel-savedstate/2.10.0": {
+  "androidx/lifecycle#lifecycle-viewmodel-savedstate/2.10.0": {
    "jar": "sha256-sYFE6RxHgLOwWUMlYFPX1NzMRbFTBm1fX/zhg5qgURs=",
    "module": "sha256-UIV3gePd+OOZBeTkpXowSWwkX5kB0bfT8XOCOCGINH0=",
    "pom": "sha256-WWVv/K4eDhRwQ7DW2JlmpflnUvBSkev6AoQG7ZRETdE="
   },
-  "lifecycle#lifecycle-viewmodel-savedstate/2.9.2": {
-   "module": "sha256-wXhdcTP8/hFpz0tPbxgER3wdpv/XmtVg9M7brfFsHo4=",
-   "pom": "sha256-8no6SPJjUb0t4pEq7j9zarJufDfXj4fz9VR18piHIKc="
-  },
-  "lifecycle#lifecycle-viewmodel-savedstate/2.9.4": {
+  "androidx/lifecycle#lifecycle-viewmodel-savedstate/2.9.4": {
+   "jar": "sha256-wMw+Mfw1hIbZbwJw3+Kw9E+YXwyrDvp3OipWfVX3YaU=",
    "module": "sha256-Q4nMoKmoAace/664j4nwoD2Zwivgk8U5qcD5w5YpVBY=",
    "pom": "sha256-aRK1XHRcV57G/L6wBl1aF9i18G3QpYeIA31B5A21AgI="
   },
-  "lifecycle#lifecycle-viewmodel/2.10.0": {
+  "androidx/lifecycle#lifecycle-viewmodel/2.10.0": {
    "jar": "sha256-UIvzKEdXFp/Ff0K4S+8LhTjJOvK9C+xbo+/pPUWlv3k=",
    "module": "sha256-T9cd9zMkXEbkuI6FtKkLgsmvSjWe8x8r3yUPk6AsdFI=",
    "pom": "sha256-HYYK/wylmNSOjoPaP05naQeEmFdKGNO4iewrjECQsZg="
   },
-  "lifecycle#lifecycle-viewmodel/2.9.2": {
-   "module": "sha256-uBT8ApPfHqN+GfIGrRg3A/+bslTdbarvXl59H4V/4Yw=",
-   "pom": "sha256-qsFQVEEJtWQoOeo5u2P7e5B6jSK3wXEWmD7YpaI0unw="
+  "androidx/lifecycle#lifecycle-viewmodel/2.6.1": {
+   "module": "sha256-K0BvrqXBLyuN9LemCTH4RmSPLh9NeDYeGY0RhPGaR5c=",
+   "pom": "sha256-3C6OZdtT0hZZon7ZO5Zt7jNsHC6OhyhhZ3OJqZuLkTQ="
   },
-  "lifecycle#lifecycle-viewmodel/2.9.4": {
+  "androidx/lifecycle#lifecycle-viewmodel/2.9.4": {
+   "jar": "sha256-VBDN/cPyW8y1pNvYEhpdN2sTeQQc7Gsdol+ZZ8oJ8Bk=",
    "module": "sha256-lk1p1rh3KW6Lead7uCbvX7GGrsqnoaf/d2+yJQyZMAY=",
    "pom": "sha256-BU22+S2SMBA7OsqLDavMDWPeJuRA/5jrWxmiVV0+sDc="
   },
-  "navigationevent#navigationevent-desktop/1.0.2": {
+  "androidx/lifecycle/lifecycle-livedata-core-ktx/2.10.0/lifecycle-livedata-core-ktx-2.10.0": {
+   "aar": "sha256-XxhCl0mhg+GReNhmWuQr97YxC1A1iung4MxFKv1uC8M="
+  },
+  "androidx/lifecycle/lifecycle-livedata-core-ktx/2.9.4/lifecycle-livedata-core-ktx-2.9.4": {
+   "aar": "sha256-9Vt6jUM+m4FjFUzKpC+ivlXHDNHt5e7qUhpLS4hN1P4="
+  },
+  "androidx/lifecycle/lifecycle-livedata-core/2.10.0/lifecycle-livedata-core-2.10.0": {
+   "aar": "sha256-Et1hqYQ8zrtFR9Pr4vbQMMqPaYjSL4+tGcCvk7SpfpU="
+  },
+  "androidx/lifecycle/lifecycle-livedata-core/2.9.4/lifecycle-livedata-core-2.9.4": {
+   "aar": "sha256-6oZvDDedH5KDeZQBCrWsCl1UmdurUh78cbO8K0l9a6Q="
+  },
+  "androidx/lifecycle/lifecycle-livedata/2.10.0/lifecycle-livedata-2.10.0": {
+   "aar": "sha256-PowAn8iNocUuTtBagSadWsm9QFBG8wAwf146F+IBpt8="
+  },
+  "androidx/lifecycle/lifecycle-livedata/2.9.4/lifecycle-livedata-2.9.4": {
+   "aar": "sha256-8kDCyUqW1KXq5dN5wqhYnUJqM7mJ2Drp8OAfaVAsAYE="
+  },
+  "androidx/lifecycle/lifecycle-process/2.10.0/lifecycle-process-2.10.0": {
+   "aar": "sha256-ELtbsSdz3KEdg0PAFM/RfftAln1uzjfo8V0E2M6wd1w="
+  },
+  "androidx/lifecycle/lifecycle-process/2.9.4/lifecycle-process-2.9.4": {
+   "aar": "sha256-R4S40IPCEeB22RFb+hc39+D2K1U+gBz1DKpEAONKldY="
+  },
+  "androidx/lifecycle/lifecycle-runtime-android/2.10.0/lifecycle-runtime-android-2.10.0": {
+   "aar": "sha256-IZOhVz1iPzeyDH0n0aj5A6cvZRzG8y5XlPhd2nRP7nU="
+  },
+  "androidx/lifecycle/lifecycle-runtime-android/2.9.4/lifecycle-runtime-android-2.9.4": {
+   "aar": "sha256-hvFqEzDrI2ALqQ0DNLPh2zjTowyLHvzZLKIaqFr6gXM="
+  },
+  "androidx/lifecycle/lifecycle-runtime-compose-android/2.10.0/lifecycle-runtime-compose-android-2.10.0": {
+   "aar": "sha256-RumW1SaClZb220YmFpqWfwVv3nEDUH/1lrzRd7c8NnU="
+  },
+  "androidx/lifecycle/lifecycle-runtime-compose-android/2.9.4/lifecycle-runtime-compose-android-2.9.4": {
+   "aar": "sha256-toA/kGqJ/YXHffND3Urus0kSXKeeEtVdaNTPQvQiMfY="
+  },
+  "androidx/lifecycle/lifecycle-runtime-ktx-android/2.10.0/lifecycle-runtime-ktx-android-2.10.0": {
+   "aar": "sha256-hxiDcDM5+HKE0jLLQ24xfG9K9WEtkrQ/J8axO5IQn6c="
+  },
+  "androidx/lifecycle/lifecycle-runtime-ktx-android/2.9.4/lifecycle-runtime-ktx-android-2.9.4": {
+   "aar": "sha256-lwGZye0awT1iCqjef4q7wozoBlPDzjKNCsLxUnK1bhs="
+  },
+  "androidx/lifecycle/lifecycle-viewmodel-android/2.10.0/lifecycle-viewmodel-android-2.10.0": {
+   "aar": "sha256-kwMocDACfKC4z5inSN3rEh7Bv6ExLABpQo5HZburzng="
+  },
+  "androidx/lifecycle/lifecycle-viewmodel-android/2.9.4/lifecycle-viewmodel-android-2.9.4": {
+   "aar": "sha256-SyNrLlBNtcpdCTNP7wWqjNwx7jWkM8OqTQQg76lhMzI="
+  },
+  "androidx/lifecycle/lifecycle-viewmodel-compose-android/2.10.0/lifecycle-viewmodel-compose-android-2.10.0": {
+   "aar": "sha256-IlkE5UrVFUdoYwRx4Qi5jhQ8Jh3wwIOA/0PqfoMtrX4="
+  },
+  "androidx/lifecycle/lifecycle-viewmodel-ktx/2.10.0/lifecycle-viewmodel-ktx-2.10.0": {
+   "aar": "sha256-VClayGtniG3AYT449iHFMZldBmIAX8dj40DhmpCZT4Q="
+  },
+  "androidx/lifecycle/lifecycle-viewmodel-ktx/2.9.4/lifecycle-viewmodel-ktx-2.9.4": {
+   "aar": "sha256-t9WLuGu44szGB9H4Vw5xSBD3z7P+ujfTdf8WRjg0NaE="
+  },
+  "androidx/lifecycle/lifecycle-viewmodel-savedstate-android/2.10.0/lifecycle-viewmodel-savedstate-android-2.10.0": {
+   "aar": "sha256-GUBCOfpYQyLC+B6WWeFivAEbdG0p3JUKEdJgYk2DIl4="
+  },
+  "androidx/lifecycle/lifecycle-viewmodel-savedstate-android/2.9.4/lifecycle-viewmodel-savedstate-android-2.9.4": {
+   "aar": "sha256-B5RBxD+j/46noC3zsS7sSDw+V1g/gyz6/2Y3UFJ8FCE="
+  },
+  "androidx/lifecycle/lifecycle-viewmodel/2.10.0/lifecycle-viewmodel-2.10.0": {
+   "aar": "sha256-S4Cc+etzI9IAUE6Vkh/rd3/wgCFcrbgjd0LV7Qult5I="
+  },
+  "androidx/lifecycle/lifecycle-viewmodel/2.9.4/lifecycle-viewmodel-2.9.4": {
+   "aar": "sha256-yrQEsF1frtIJEEoq7xTAy7MWq5+r5KjwN7BD5dL0NDU="
+  },
+  "androidx/loader#loader/1.0.0": {
+   "pom": "sha256-yXjVUICLR0NKpJpjFkEQpQtVsLzGFgqTouN9URDfjF4="
+  },
+  "androidx/loader/loader/1.0.0/loader-1.0.0": {
+   "aar": "sha256-Efc1yztVxFjUcL7Z4lJUN1tRi0sbrWkmeDpwJtsPUCU="
+  },
+  "androidx/localbroadcastmanager#localbroadcastmanager/1.0.0": {
+   "pom": "sha256-oAAEH1ofeSg8UXXhu2DPNoN4D0Acap00++l1ElP6b/k="
+  },
+  "androidx/localbroadcastmanager/localbroadcastmanager/1.0.0/localbroadcastmanager-1.0.0": {
+   "aar": "sha256-5xwyjO71xKfXby2G3xtl1l/irPhosaTv2Eo/NDNhhtg="
+  },
+  "androidx/navigationevent#navigationevent-desktop/1.0.1": {
    "jar": "sha256-Q97rV3T9c3+pReCaR/k7bxpQjRf6yPO2XxyGPn99BmA=",
-   "module": "sha256-GKJKvO+qQwHquqLVD8DiEABPmzRv4KZGYNlQGfNcU7E=",
-   "pom": "sha256-fy3dXDpWBCuV6pFFabqJpq5eP3KnBEpLF3OwQb/OGs8="
+   "module": "sha256-kJ46U7h2B1HXmu9YZfS/SRoWCV2eGvvfueSKxovR/Gg=",
+   "pom": "sha256-MluouGydEyyXeA53cbo8k51iLIfAxYcHlen0OCmd93E="
   },
-  "navigationevent#navigationevent/1.0.2": {
+  "androidx/navigationevent#navigationevent/1.0.1": {
    "jar": "sha256-PXBoRNxJYGyxqjzX1rJ/R/GA38TG1Le4DqR4/4jcvZM=",
-   "module": "sha256-hA2TsFuCeQbhZfcXoDeKDszN6z4NEUkOoU1atbEIJic=",
-   "pom": "sha256-GwQqB6oi1U8GaFw38JPepPJtnvrlsgEDlLDGWE6IgUM="
+   "module": "sha256-NrRI1xJsSW2bEryrKNzWguxI7IP6x+VizS5LZSeB7xE=",
+   "pom": "sha256-h9uD3BBM9BeKnov3Wy44nbkXa1iDoTuNeiqEEGkG99k="
   },
-  "savedstate#savedstate-compose-desktop/1.3.3": {
-   "jar": "sha256-SpR4em5bz+FDOQpPJzfUQl0uqGfys0qEfebNo8bMxYo=",
-   "module": "sha256-BqAgEkeEflkwPk/7RoyUGcYUcI9Wh4fgq9WpLG2trUA=",
-   "pom": "sha256-N8EU329XwI5xm1T4pK4DzIS1y3ODNiRIxULQmZ5XQTM="
+  "androidx/print#print/1.0.0": {
+   "pom": "sha256-YkgsBZSEG+4ku5lqu2y3syCmo7d9yp8KC6T+O+VTCqc="
   },
-  "savedstate#savedstate-compose-desktop/1.4.0": {
+  "androidx/print/print/1.0.0/print-1.0.0": {
+   "aar": "sha256-HVx/MTWhu6Zh/Dc/1y4R6wpK27M5Z4eCbdjkGQ1dnt0="
+  },
+  "androidx/profileinstaller#profileinstaller/1.3.0": {
+   "module": "sha256-oW/lEeWZwgQtoSK+CVaa7NP0+QytN+8IvQu8ORGMksg=",
+   "pom": "sha256-EsvAHIpa5LQSyvPFoGYszSgALe3P8dvmwqs2Zb6fdYw="
+  },
+  "androidx/profileinstaller#profileinstaller/1.4.0": {
+   "module": "sha256-Ob+ZeijY7tLLMZgZ9vNSobo6eLnJeQBPvgXia499Fgs=",
+   "pom": "sha256-1f45mBo7S3w5WFEw2gv8k4NQVMg0pDjT5j4GXl94vlU="
+  },
+  "androidx/profileinstaller#profileinstaller/1.4.1": {
+   "module": "sha256-bxHPZeS/hESZXMc+WqP4GwgtZucgwFkrxfyA0/c4UPc=",
+   "pom": "sha256-bd5DgntAU15AU9HFLUsiekEVVsKJ5lQAyaHMYeK0HOM="
+  },
+  "androidx/profileinstaller/profileinstaller/1.4.0/profileinstaller-1.4.0": {
+   "aar": "sha256-1QIUH8zpAkMPYrZ0wyrs0PdSYufuLNFcdK22F80TEwo="
+  },
+  "androidx/profileinstaller/profileinstaller/1.4.1/profileinstaller-1.4.1": {
+   "aar": "sha256-tRn5MX3tHiwcKZMDjAaS4w2jJsqZCX2TMf8tOlhhpCg="
+  },
+  "androidx/savedstate#savedstate-android/1.4.0": {
+   "module": "sha256-AGJRTcuAwup+BBH6i+VFUIU7q3v2sb8UwlF8Lvh0/1A=",
+   "pom": "sha256-tEshW0zOJMpktfqlj/Rj9LkavAKvlbpAWt5IiCj093k="
+  },
+  "androidx/savedstate#savedstate-compose-android/1.4.0": {
+   "module": "sha256-K+jHU6B8kgzy9dY9Zuh0P7CKkz0EwCt6OIt3tm/KhI8=",
+   "pom": "sha256-3hmDHau4Sk0OEg6G3OsIz2LAhga12Z6RqPjmtKRliIM="
+  },
+  "androidx/savedstate#savedstate-compose-desktop/1.4.0": {
    "jar": "sha256-wCqYsMKzXN3iRcC/5uf/RTx7bQal64aB0lt/VLh06kg=",
    "module": "sha256-gI/3I6FTrM4WBImlvEtYyh1wM/6EqQYPUtF9sifqpM0=",
    "pom": "sha256-U+fXiRm8heHIjh5rDinQrjvGaT16jsVzGnJQRMdhdGE="
   },
-  "savedstate#savedstate-compose/1.3.3": {
-   "module": "sha256-BYxm9HOvIVVCltHOG+aNXV4FLt8GmOlYPENhqng4VEE=",
-   "pom": "sha256-4/ZHRdP91KBJQwX1Q0RbW5iYOnSLDnJMIuMkKtAZy+I="
-  },
-  "savedstate#savedstate-compose/1.4.0": {
+  "androidx/savedstate#savedstate-compose/1.4.0": {
    "jar": "sha256-hk0ggwlx+wjC7Q/E+QKwX9AuOO8wvLZaQ7DJkQqsOIw=",
    "module": "sha256-cnUhGQGgfuOXPkCjRV6K0SlV0dI03CSJ+Ghvz8gguKg=",
    "pom": "sha256-sV9HtCWFRCybap1BavwweCxp2/mldgosNxdfACTw0X4="
   },
-  "savedstate#savedstate-desktop/1.3.1": {
-   "jar": "sha256-xciQYrqEArj4ZX79VNsf8ZL5HKlfrlnDtBj7xHfD4+o=",
-   "module": "sha256-ojpT27hho7dWpXwBrJXnD6zUEC9SbAIFFR8fJ+YeoaE=",
-   "pom": "sha256-kEAj2DEYw/jOLa5imbljIWCRTOjsZf7MS2lnZOTsPlU="
-  },
-  "savedstate#savedstate-desktop/1.3.3": {
-   "jar": "sha256-xciQYrqEArj4ZX79VNsf8ZL5HKlfrlnDtBj7xHfD4+o=",
-   "module": "sha256-lF88cTqx84ltshbRmfkkRBRTlh7iu9dLtHrokZ2691k=",
-   "pom": "sha256-LY28tvROMSS4n/WUGmZ9HRSLkOViPkfb9Rw5ve0L4j4="
-  },
-  "savedstate#savedstate-desktop/1.4.0": {
+  "androidx/savedstate#savedstate-desktop/1.4.0": {
    "jar": "sha256-6WXtegEb6DonGsfYIkmndjaEee46KweUjDRFtR1kCFY=",
    "module": "sha256-5z8s+IGOzjR9i13/mQ0Ntjmn37j8yF7uyyYYOD9+zvc=",
    "pom": "sha256-jxFKQnNTWta9y+0Zhs/dmNlV6804oyqP7k7n3I4hH14="
   },
-  "savedstate#savedstate/1.3.1": {
-   "module": "sha256-f0RPZf6XnogYNnLa1arxvTn5HYDKyXFtPYTgZkyVkz4=",
-   "pom": "sha256-GhLo7FM8a1UtSX37R/rRo5zQuZY5e3S5YDeo4breW1k="
+  "androidx/savedstate#savedstate-ktx/1.2.1": {
+   "module": "sha256-lDWRhLK6UcD0mKK5BV03s3IjHvm8xUpJcqyZ8DA6//E=",
+   "pom": "sha256-0JVTIR9nA7Ga79YI1gB8dxMtJ6KBVWqOaJ2Sdk7CfTs="
   },
-  "savedstate#savedstate/1.3.3": {
-   "module": "sha256-qeIZivqGIswgPVx697gdUa8YVoM2Pv2xK5TnV2oNdP8=",
-   "pom": "sha256-arxTGFGx2bQG9tuXdMKWNT5rFN0oF60YFGPux//jO2Q="
+  "androidx/savedstate#savedstate-ktx/1.3.1": {
+   "module": "sha256-WQB9jTPPFm/f0am/Vsz9IS6YIsBLOnQZZvrOWRhhBlU=",
+   "pom": "sha256-FM7JH3Pd5NTHoR7GYLbF0IPd3zDvQSz2oXQ9wQpipbg="
   },
-  "savedstate#savedstate/1.4.0": {
+  "androidx/savedstate#savedstate-ktx/1.4.0": {
+   "module": "sha256-fPhogSIKpZTErRaF69DylePZe5wP3DGygwD0MYpQRag=",
+   "pom": "sha256-sIWvfMS7KX7Q8lyoXTYpYTqyU8C1MmhMbPd8Ku50ccU="
+  },
+  "androidx/savedstate#savedstate/1.2.1": {
+   "module": "sha256-W7ZW/HYNnjmWtTUWDLtBBgM8n3NukInm706wxml4UGY=",
+   "pom": "sha256-DTO8KF3x4S8ieA8WJKbws46iphgbCVXsZkHK9iDFDL8="
+  },
+  "androidx/savedstate#savedstate/1.4.0": {
    "jar": "sha256-CYWWyN+6K+9EvgN/PT+JzdARWHUF7YL6Yl8qg6ItZBU=",
    "module": "sha256-oPKsWgdgY/DIE891pG37eAvVpaLIZ3JAvKhVFVTaj9I=",
    "pom": "sha256-0raKLQzHbyPOvG1Oqbvy1j+1Nv/ZTgVRStnabF9TBJI="
+  },
+  "androidx/savedstate/savedstate-android/1.4.0/savedstate-android-1.4.0": {
+   "aar": "sha256-FlbOYs0jPUiL271C5TO4CyJDW3ppCsrm2+cwI5JRLBQ="
+  },
+  "androidx/savedstate/savedstate-compose-android/1.4.0/savedstate-compose-android-1.4.0": {
+   "aar": "sha256-DwrjAy1sbuqDTuIheciXYWDQnYQdMOR/U/VrGzQ4d0s="
+  },
+  "androidx/savedstate/savedstate-ktx/1.4.0/savedstate-ktx-1.4.0": {
+   "aar": "sha256-I1k5OURrxaFUoeNf3dh7gvGeKt8HIgfxFb8pqLQxwdM="
+  },
+  "androidx/startup#startup-runtime/1.0.0": {
+   "module": "sha256-QO/8oNbuH94yvClol+VOu8xM9KopsMUxA2y9KoJKPCQ=",
+   "pom": "sha256-GQtlQlHxEEUvZ/ahPXZuj+4IEfB+bwsPd9WJBiJqy6g="
+  },
+  "androidx/startup#startup-runtime/1.1.1": {
+   "module": "sha256-z9ls9kUMbitpdZiSRymtmgSVxaT89Ovufi+BsH5BWGU=",
+   "pom": "sha256-9BFLXGhZuxvDyvKBy21vJZmPp/cpLGTOrqdKkyEOdGs="
+  },
+  "androidx/startup/startup-runtime/1.1.1/startup-runtime-1.1.1": {
+   "aar": "sha256-4KYymjcSYv5MRQNytw/a8zt2nvaRcJRyN4fPzolrHdM="
+  },
+  "androidx/tracing#tracing/1.0.0": {
+   "module": "sha256-/Ish6+X6OnyW7gmLzc0A8HfrznPyQ/qFjisGcWFfddg=",
+   "pom": "sha256-zQKZqQ1HINePHPtf91BfTbwacNBf4j/Z9NS3fqWcoF4="
+  },
+  "androidx/tracing#tracing/1.2.0": {
+   "module": "sha256-0NjUhra9MyBtvz8abRZ+m0PCaOpjwzIciGsVQ60F7OM=",
+   "pom": "sha256-80vsTrWIcdMQApATdxCKqh6/53+m2IK4uGIAsVjibqE="
+  },
+  "androidx/tracing/tracing/1.2.0/tracing-1.2.0": {
+   "aar": "sha256-b6qQOQ0f2/Ctuamb+Z3me5TGxvNa6pUQWTqdF5c3NqI="
+  },
+  "androidx/transition#transition/1.6.0": {
+   "module": "sha256-x2PDdv1tOeUUd8kCsxXljKKh9H1LCZy5n0mhSL1hxWA=",
+   "pom": "sha256-Bw13lQEAce3vvvlLjJ1aLKxctfOxosXlWFRkOBd8jvg="
+  },
+  "androidx/transition/transition/1.6.0/transition-1.6.0": {
+   "aar": "sha256-JIxF4SVNMRgdIEewsBOU8JouU5pdnom3c9U8YsloYPY="
+  },
+  "androidx/vectordrawable#vectordrawable-animated/1.2.0": {
+   "module": "sha256-sTOjPAE0wIDnBSyixhK/R/cmeHOnT1i9JVmzZ3HmbJY=",
+   "pom": "sha256-JkHJmjkZ8MIDkkDHyH9U+Hn3PNoEQA9DeFl3PMTqRAU="
+  },
+  "androidx/vectordrawable#vectordrawable/1.2.0": {
+   "module": "sha256-UTX1gPnNQVF9j4h/zEO3V2BwO+33DoT2FkcOMHN3Edw=",
+   "pom": "sha256-lKPqq257kyBFtoovbul/BHHWvV05V3WhiSLilv1FMwY="
+  },
+  "androidx/vectordrawable/vectordrawable-animated/1.2.0/vectordrawable-animated-1.2.0": {
+   "aar": "sha256-oHC90EIioEB5Tl6fpLd41XX3uPToTQbZo47E1Zl3Cmk="
+  },
+  "androidx/vectordrawable/vectordrawable/1.2.0/vectordrawable-1.2.0": {
+   "aar": "sha256-T0S5SBetJm7YZBsLj6tObQOJAqYoQLtlKEcyIuHNz8k="
+  },
+  "androidx/versionedparcelable#versionedparcelable/1.1.1": {
+   "pom": "sha256-X1HmWHPKYS3jg4+pDS7pW40EDv0xucOQoZv5TWFc2y8="
+  },
+  "androidx/versionedparcelable/versionedparcelable/1.1.1/versionedparcelable-1.1.1": {
+   "aar": "sha256-V+jZMmDRjVuQB8nu08ZK0VnekMhgnr/HSjR8vVFFNaQ="
+  },
+  "androidx/window#window-core-android/1.5.0": {
+   "module": "sha256-W9gYaGgDvzwDf2Gg6Wr0RB6ISqik2RBi0q1Xh2+Re1A=",
+   "pom": "sha256-RjxQsiqWnGJ069t7X1a6HqHd41LpZ58KC6kPOXHbzVc="
+  },
+  "androidx/window#window-core/1.5.0": {
+   "module": "sha256-WVYE8FWhJQjsPHdPLZDF5WQUumJGx1QXLZyVyKAOwE8=",
+   "pom": "sha256-44ow/pqcy1dVMbJl/sjiMge9qYGJd6rklfP+dLnJ4fM="
+  },
+  "androidx/window#window/1.5.0": {
+   "module": "sha256-isXSdy6XyVfd3LyxwRmCKdSv5XzfXs1es81DagUZB0M=",
+   "pom": "sha256-1PIrmRppYA4v/Da0KsGZYm/ZbV8WSMO+7M013gb8w1E="
+  },
+  "androidx/window/window-core-android/1.5.0/window-core-android-1.5.0": {
+   "aar": "sha256-0NUNsHVhlKbUmmatja/ReyS0xfvYN5N1BW4uub3+ryI="
+  },
+  "androidx/window/window/1.5.0/window-1.5.0": {
+   "aar": "sha256-XeLUiqV4QC9G3rUpSpVc7mLwx9jBhA72Jvx6+4q+Ivk="
+  },
+  "com/android#signflinger/8.13.2": {
+   "jar": "sha256-wdyixoNjTuGilCmPnHF5V4r2qG4IC9xA+WGRW8XIFC8=",
+   "pom": "sha256-CfafQNTgDVIHLrDdB6xnaugjEyeaYIUw043RSAD1X8Q="
+  },
+  "com/android#zipflinger/8.13.2": {
+   "jar": "sha256-BwYAacNeRp18NDq8FfHWNivBNWuBv0YlOduIpT7WU/E=",
+   "pom": "sha256-4u7Td4LaTYx5nUxLc3w1rYjTkS9RNs/f4sAUzNQLNQw="
+  },
+  "com/android/application#com.android.application.gradle.plugin/8.13.2": {
+   "pom": "sha256-1FkMwEiO+6eC+zfRPlKBKTL37/8QIi7SqWt1IL/aoq8="
+  },
+  "com/android/databinding#baseLibrary/8.13.2": {
+   "jar": "sha256-eUETcJ2rIbBsJis3lec8twj7rK5hcV80Nh4a9iN6GHA=",
+   "pom": "sha256-3/d3DxXM6F4bqoYuCUeh9ubuxNZJcLuz7MevDcFKbRw="
+  },
+  "com/android/library#com.android.library.gradle.plugin/8.13.2": {
+   "pom": "sha256-xYVT/MkO41ec7v/K6WH0rEciskhUkhr6rJt6ZomG670="
+  },
+  "com/android/tools#annotations/31.13.2": {
+   "jar": "sha256-O0u5YgwX0Z5b2RrBmICAVTVztMO3Of3ZJBb0Ly2vPng=",
+   "pom": "sha256-63PyFYFKl68he6cabGhZ+xx+V7E8XWzNmVneLJdCR1U="
+  },
+  "com/android/tools#common/31.13.2": {
+   "jar": "sha256-1OvhcR3gz1CcTVYiRWJLohqxR5RLzd5jUb+26NrM+CY=",
+   "pom": "sha256-JhPXZpT9SkW7xosWXBRTfVtUadvqbap32cMuj4VCFHM="
+  },
+  "com/android/tools#desugar_jdk_libs/2.1.5": {
+   "jar": "sha256-2ARL764JV4G5qAvx+qku3DA4LXXUN0dnhMG/mRWYqXY=",
+   "pom": "sha256-LhlYgPFdRUXI1gstLKxSIBzPmNt6Kdsld61YJqkw/Mo="
+  },
+  "com/android/tools#desugar_jdk_libs_configuration/2.1.5": {
+   "jar": "sha256-e8kFGzoewZgGMR3Laqm5un75wiyqb0gQ2lW94oX7d3A=",
+   "pom": "sha256-sgmXNbk5BdbwG1LhNtE2QoDNanLG5+o74nSmxncD8rQ="
+  },
+  "com/android/tools#dvlib/31.13.2": {
+   "jar": "sha256-488/3JR3iN7o1bqnbLcqZlcRdLxHQe3w47q5enypDhs=",
+   "pom": "sha256-HKqrkCIWAyLLMQfz/p4VuBXr0391aLxklStZCi3c5wY="
+  },
+  "com/android/tools#repository/31.13.2": {
+   "jar": "sha256-6VCbMNCI6JmUj4yw1zKTwe/S4fEh/Mu+JdUztki5P6E=",
+   "pom": "sha256-7+6KWA6sdHjIrvnTC85aQydT0m2UCl2VP/SCzkE8Zjo="
+  },
+  "com/android/tools#sdk-common/31.13.2": {
+   "jar": "sha256-jP35nW8XaJ5907zxg01zT23Rxk2MQ5BGMsZdVGlWWTQ=",
+   "pom": "sha256-ezPXPdQoR7BPWaUeqrcbNFLA1pn3xpZZFSuDhjzJDMQ="
+  },
+  "com/android/tools#sdklib/31.13.2": {
+   "jar": "sha256-3vmw5/ROVK3ThcrBcVSDck+CfxZlEevAwQMZdCqoCGU=",
+   "pom": "sha256-/saYRrZwqz267yBnul+YKa77gEd8n3aA+Q9Ka+NpWlg="
+  },
+  "com/android/tools/analytics-library#crash/31.13.2": {
+   "jar": "sha256-zKl6wpoTKb0xCj6DK25X9GIn5QGqUpwApj3yF8XX30E=",
+   "pom": "sha256-+Rdh8nEZmwiOhbYjLgWYM+EU9WoT8RpVeVx2/rljZpM="
+  },
+  "com/android/tools/analytics-library#protos/31.13.2": {
+   "jar": "sha256-st7SCol/upZJ7+sYui/AYu455QDU63EgRcsONLQ7Xvs=",
+   "pom": "sha256-h+Vtxrwei3h2ACBQiqMn14SubOmq3mwenHpPPyZSXOA="
+  },
+  "com/android/tools/analytics-library#shared/31.13.2": {
+   "jar": "sha256-dUNYFvICt6PITZyvMSqJViWiRJkfj8UtBEYjnjrimpw=",
+   "pom": "sha256-iosZjZfS6noBpq5TxyRwfWa6N6BATLmCNJzs5F9VDHg="
+  },
+  "com/android/tools/analytics-library#tracker/31.13.2": {
+   "jar": "sha256-G2ZRS/KRUkIu6KGbmOAgDZLrCj0oBI60hXVk6aHHuFs=",
+   "pom": "sha256-fyfJXcqu/ZLc7ss35hsam3AUHs7oaiENnFf0bK5Pkck="
+  },
+  "com/android/tools/build#aapt2-proto/8.13.2-14304508": {
+   "jar": "sha256-ps2oLVCOw7MlqeN/ePn6hFVv80DPQ7sjxiew8550bw4=",
+   "module": "sha256-fVtyhfR2yCAI8NOfUGsLjFPxsCa9Yk163GiCFr6Opb4=",
+   "pom": "sha256-+f1XBgvd7CGC3Mk1dBbpk5DUq4t4YWVLZ7cqdOCQ/6U="
+  },
+  "com/android/tools/build#aaptcompiler/8.13.2": {
+   "jar": "sha256-9vZwbTt6Jh4kKCDaXIVRI9PCNzgVnKNybgw05IK4B3A=",
+   "module": "sha256-DjumtDrZj6aRMd4di2xqdUGzr3FEPctdUqLP/CVY7ms=",
+   "pom": "sha256-sQ/OQPXnkalYeGlI/NanTEc7yHTLScuYpnePGBz3MeQ="
+  },
+  "com/android/tools/build#apksig/8.13.2": {
+   "jar": "sha256-wHDtE5RinXRkGqCQb2Cy/6Hud+Y2ah+TQ39ZcXsa64k=",
+   "pom": "sha256-Ij3tgmjn8O6d8BCdgEnO1hR0tevYSMLToIiTKixcyCM="
+  },
+  "com/android/tools/build#apkzlib/8.13.2": {
+   "jar": "sha256-KQkclFclL5l93+r7M91lo3OtRYQBKPlFgy2Or9kRhWE=",
+   "pom": "sha256-szSNoCWwi1M/Lm45E4aS6gsaiZVd3D4bjbF5alUxRtQ="
+  },
+  "com/android/tools/build#builder-model/8.13.2": {
+   "jar": "sha256-rl6VUVqzSNNKNb6D7TFcX7fowGZ+GG9OFWxl36omFf4=",
+   "module": "sha256-WuEdekCFfhpLC8an9CGCVclhabcBFTX5owt3tfbjJ6E=",
+   "pom": "sha256-TyWfQx/NK5q6MxCW8Q+Xq0ttX+kn32N+yy08+Vw8/eA="
+  },
+  "com/android/tools/build#builder-test-api/8.13.2": {
+   "jar": "sha256-PP7QuuwufQ5kVm9oCKAO9eBRrXb8T7qdRk0Ro8L5hqk=",
+   "module": "sha256-T3Lzqf0+n1FsNs76xpeNzAQEliELjPrX0pVMg7ug6ZA=",
+   "pom": "sha256-E1tr6DkVxZFu6TBTxUTaQb0Avc8Y6wjEsNT8SsnLyb8="
+  },
+  "com/android/tools/build#builder/8.13.2": {
+   "jar": "sha256-fTk/hVMSDH16hpyzPEJ5qtlIWYZ3P2Ovl68I6i4f83o=",
+   "module": "sha256-SooQjeXwQUKmdXhhoKV6KYuTa3t/f5xbkeXKqafv2pA=",
+   "pom": "sha256-Gqs99HpacMRsGOT6BuNjrVf3UPtGDHHvFl9xqHb3hyY="
+  },
+  "com/android/tools/build#bundletool/1.18.1": {
+   "jar": "sha256-pzNBp5RavLDmuJccexsoAb12UAZEfKDSQ3pCYNVyzqw=",
+   "pom": "sha256-XE33suMfF/IOS429YqK3hloJpJof0pMaNZ/TlOy5taU="
+  },
+  "com/android/tools/build#gradle-api/8.13.2": {
+   "jar": "sha256-qNzcbxM49wVfaxvCZTF+FNZYM+bH9yshAsVWjh3015I=",
+   "module": "sha256-G+ABgWcGZoc80BKOnexu6ZzSriB7q5CezBH/DPcpvF0=",
+   "pom": "sha256-B6fxsnM2mtT8EjpMy0f7Hg2WixGjjHPNRchTPWTOx4s="
+  },
+  "com/android/tools/build#gradle-common-api/8.13.2": {
+   "jar": "sha256-/N6AX81XOa7WB6nNwyUxb0IvoFpG4UCikdLyTso6Wf4=",
+   "module": "sha256-nm7c2Vn27YeiJzuF3g9O+sJufNy/S9ako/TgXI5+fBw=",
+   "pom": "sha256-DTY2ikCNkKt/cEhkHezZ6ALoIZdYV1651CGKRmNlUVg="
+  },
+  "com/android/tools/build#gradle-settings-api/8.13.2": {
+   "jar": "sha256-NwQ4vPd4LYxbQHNwNlsEe/Bj+Zp3ReH18YUxgzmNB6Y=",
+   "module": "sha256-5crHmMEyNO6kOtsITFyBwgrRw2zEtbV/OSLZH07AJNY=",
+   "pom": "sha256-iJlOxc2yOO23vY51Rx2NCXkvtSUEa3hBNabN6+DUwz8="
+  },
+  "com/android/tools/build#gradle/8.13.2": {
+   "jar": "sha256-5JT3znXKbBq/8wHUpwsY/dPWr4VYdfT4UIK7dgjwQd4=",
+   "module": "sha256-CqwL7hpPxlzWmmeIVIp+IdJGJQyFgBfhHjvyMWPLdac=",
+   "pom": "sha256-/H7bqTxbkc5yZ/p7/cH6SUIu/GM6wnmjY+AusP0pvK0="
+  },
+  "com/android/tools/build#manifest-merger/31.13.2": {
+   "jar": "sha256-QNJfWUDC5Qv34Y4yX3+7nIbPRdtahdHO+O+YVAQieh8=",
+   "module": "sha256-S9nUffB7eBdKcvqpJCOTWvKdF8mJaoS2WLkh9vGpI0g=",
+   "pom": "sha256-cEzxt4bSDIBGo7Ml/DKQ+pgulwlfZK0hmHzz7jN53bI="
+  },
+  "com/android/tools/build#transform-api/2.0.0-deprecated-use-gradle-api": {
+   "jar": "sha256-TeSj0F4cU0wtueRYi/NAgrsr0jLYq7lyfEMCkM4iV0A=",
+   "pom": "sha256-fGLzhW6KvKHXkleSXybBJmhpP12VkEBWu6yIYFz9hXU="
+  },
+  "com/android/tools/build/jetifier#jetifier-core/1.0.0-beta10": {
+   "jar": "sha256-Jqu0oTkn2QYhacUEyelP6A6a46T3tauIdasAdTapH14=",
+   "module": "sha256-8JF1iaQtJ2Fj8QBAq1hC6RiD3L2x1Iv9Hx/Kpywcp7c=",
+   "pom": "sha256-XJ1C5rfjXU2NAuCjIs8maTs+w2QrEHyPC+WnIdRaDG0="
+  },
+  "com/android/tools/build/jetifier#jetifier-processor/1.0.0-beta10": {
+   "jar": "sha256-xQZ6e5KCN6EnGl6ctXEOn4C0lzKTlFvFHjpMhk6kv+0=",
+   "module": "sha256-NsJVdrGZk982AXBSjMYrckbDd3bWFYFUpnzfj8LVjhM=",
+   "pom": "sha256-M7F/OWmJQEpJF0dIVpvI7fTjmmKkKjXOk9ylwOS6CEI="
+  },
+  "com/android/tools/ddms#ddmlib/31.13.2": {
+   "jar": "sha256-g5lX+WEQBxPqDu1iioaEzDmqR5Yxw2JJeT5t9+DNY9g=",
+   "pom": "sha256-mohLOgztXxl+011f8o3UQIJK62qMQh/GgnbrgZIq0MA="
+  },
+  "com/android/tools/emulator#proto/31.13.2": {
+   "jar": "sha256-t3+BzAdR15OT7EsusEb5ENIavNdgi1sPWh7+obMkO0g=",
+   "pom": "sha256-NPBZInrVOOvI7RkjRJDO1YpuKUhFpyy6sRTrV6MRNWo="
+  },
+  "com/android/tools/layoutlib#layoutlib-api/31.13.2": {
+   "jar": "sha256-0GvGUCR2MqSk5llrhzEgGfRekAJnxUdsR6W/puP9MTI=",
+   "pom": "sha256-ttE1l7KS5SNcEe3gBH/c5wjtnwreawOcXwJ3C6jWEFM="
+  },
+  "com/android/tools/lint#lint-model/31.13.2": {
+   "jar": "sha256-nuVdj9ACc27ZXul/sF9N964B9Pl29zj7837Kt5Xlkxk=",
+   "pom": "sha256-kmFkH147W3zkzc07dddGebywrMb65cyAh99QGJOVm4E="
+  },
+  "com/android/tools/lint#lint-typedef-remover/31.13.2": {
+   "jar": "sha256-Sjujur/Xnm/Ge872R/tOz+r1m0gbEI98LrpNHFxt6o4=",
+   "pom": "sha256-VSFuggl5u3yVA/fqPBApj3xBj/O8cvsp+v7VQdn45CE="
+  },
+  "com/android/tools/utp#android-device-provider-ddmlib-proto/31.13.2": {
+   "jar": "sha256-BHrs3WbhBhN/d6UsRC8bg9t9boSWiZgAJR8gbH853mU=",
+   "pom": "sha256-QRYjc/qmac/XQQEHfsKc8oUiLpMbqInFPmD/YOz2Yx4="
+  },
+  "com/android/tools/utp#android-device-provider-ddmlib/31.13.2": {
+   "jar": "sha256-sW6/71tjsDuAPq0KXhlO404N02HB4ZFVfZmPAVNHRP8=",
+   "module": "sha256-FXRXBPuVGjYpsaJjWsbiEIWw9uYyWWbUdyXlDDpfrFs=",
+   "pom": "sha256-0+eBcTpLa9BjVD3ktUfc3DtADzM/uSHo64fOyXihxc4="
+  },
+  "com/android/tools/utp#android-device-provider-profile-proto/31.13.2": {
+   "jar": "sha256-PnsJj24+yuMbb3kJw0O07AmqGNion0G/kgd7pLBW9FM=",
+   "pom": "sha256-1VV0td2msIt2qxCpJklZNMfdwQ9hfTNud5tgO1Vem6I="
+  },
+  "com/android/tools/utp#android-device-provider-profile/31.13.2": {
+   "jar": "sha256-lWDCWFnJwVx3FEy7WDcLrTlIguzDFp/V5Ym31OUuhm8=",
+   "module": "sha256-fM5ga+y1hTIhypALdUDQ5su4we1MKt8LBu45w20OTek=",
+   "pom": "sha256-smVzfBte/3zXQm9ii2gr4a79CsR1oRk/0eQIQOEj9Nc="
+  },
+  "com/android/tools/utp#android-test-plugin-host-additional-test-output-proto/31.13.2": {
+   "jar": "sha256-a6fmrCII10wbtfHRRkq6/GpF2HELIEVaLcAq34cmvIM=",
+   "pom": "sha256-ryqLvOmjdsDe9Kryh6GdzoUgLxJ7UjJC/+H4BB4U3yg="
+  },
+  "com/android/tools/utp#android-test-plugin-host-additional-test-output/31.13.2": {
+   "jar": "sha256-+q5CoWz3bXUptZsbmk2/nLG+3KWBGOuoJP3bgxLcdlU=",
+   "module": "sha256-sKPFs1jWtiZ0SOtqv+r2rQJasfB8s7ZQr1L9cCut/AU=",
+   "pom": "sha256-NGdCkqoA/jQOWfcLoOYplspdjKRkns2gsqTGjvOwTzg="
+  },
+  "com/android/tools/utp#android-test-plugin-host-apk-installer-proto/31.13.2": {
+   "jar": "sha256-TythBULpGjWjlrBDaKeEA25CuHhwIUYFULmjSVu4JFs=",
+   "pom": "sha256-qL1ZxNO6Howe4EJm9q8qRtKonyCeXllrFjdZwb1IDyo="
+  },
+  "com/android/tools/utp#android-test-plugin-host-apk-installer/31.13.2": {
+   "jar": "sha256-lJxvZRIhKdPs1ZsImYYOjiTpaCzsHACNHxGlzJM2b2Q=",
+   "module": "sha256-rklFwRAtyPUwdfYeuooPZmx0N//r4rn7FnGWjMRUcxM=",
+   "pom": "sha256-bXJmUtjrmRGvrvVsYdgwhw0Nc/f2FIz+OdMHHS96owk="
+  },
+  "com/android/tools/utp#android-test-plugin-host-coverage-proto/31.13.2": {
+   "jar": "sha256-+oZxmj3F3kZffgwCMYRBTCf4/VOjT9VXKJwL9t80AkQ=",
+   "pom": "sha256-5W3OG2cA6f1KG5tPXK2q0IZNOYLuZJM5IrXU4MCKp0U="
+  },
+  "com/android/tools/utp#android-test-plugin-host-coverage/31.13.2": {
+   "jar": "sha256-SZOpUEnlLE0xR+nE38aWzFp2r4MDpCBrtgwr+rxWOuk=",
+   "module": "sha256-2vHyeSUp3ETOxol/l/yEXbqmP+wtaTnJfifC/upNs/Y=",
+   "pom": "sha256-KZZUgBQenSuZYfNzTD+5rdkKS63o11oHur7udP6OnQ0="
+  },
+  "com/android/tools/utp#android-test-plugin-host-device-info-proto/31.13.2": {
+   "jar": "sha256-loOsdkinpBvpoTSfaYFZKUT2JxZImMPIkloL7t6LuLs=",
+   "pom": "sha256-KtC5oodv9I1QsPQIPQfj2/1Dp8Gn1sjRcKn0+uyTlR4="
+  },
+  "com/android/tools/utp#android-test-plugin-host-device-info/31.13.2": {
+   "jar": "sha256-pTufdk2AvtKeDy4O5iV23Am4c4Zgi7Yu8UU9Ay+XaWg=",
+   "module": "sha256-bBIiuD/k1MxYT29EGfak6Vcj3KpFPHoyRp/yTAgJ4qA=",
+   "pom": "sha256-O3fGvofJKUpgp6jiqEo/Sa0jIJy7fIG7WF3lRySXSzY="
+  },
+  "com/android/tools/utp#android-test-plugin-host-emulator-control-proto/31.13.2": {
+   "jar": "sha256-pPNKrg+f+gJtv3FRQ23XrlO+y3JiK0DyxHnKyJQ9kxk=",
+   "pom": "sha256-jxTna0jka6UmSo+PpNmPgIWrZUxPF1p+BPQPrGAZ15Q="
+  },
+  "com/android/tools/utp#android-test-plugin-host-emulator-control/31.13.2": {
+   "jar": "sha256-cwIsKid57qz7/OZ92nz7sh47PPVhClTjX8MNj8yGCTA=",
+   "module": "sha256-AZYRJVaOGMsxJEbw4cTt/TZp/IqQxFn/UFcp7+Lgc84=",
+   "pom": "sha256-dUbsbfAjTkabNh4PLA/Lr2N4BEX4VOsqxMJ2sHyZ8o4="
+  },
+  "com/android/tools/utp#android-test-plugin-host-logcat-proto/31.13.2": {
+   "jar": "sha256-wfbrus2tVZtu/k6qKVYVUrMxVjlfBpzZcD/aCcRi3qY=",
+   "pom": "sha256-/zDRtJGIKYz5JqMKkU21ZWm+AuRFqm0DVlIHUKyYxag="
+  },
+  "com/android/tools/utp#android-test-plugin-host-logcat/31.13.2": {
+   "jar": "sha256-9Vm3xUTimsNUczmAXF6Y2TjionZGkddOur6zbh/KD7o=",
+   "module": "sha256-3z0on/um/yj6iHVGJHfZEfAJzAlMfKVZc7lrMdoCaek=",
+   "pom": "sha256-La4mMDSObLGhRR4gJCAjk9RWErRUZmdxn6msE9gfglE="
+  },
+  "com/android/tools/utp#android-test-plugin-result-listener-gradle-proto/31.13.2": {
+   "jar": "sha256-1Cm5MS3/oFAzgdHuGxipmb2QHnRWYSsvtIxqXVosr4g=",
+   "pom": "sha256-NURycXV95NFmjrHctNobh2pLlEQHYky9661bHttESPo="
+  },
+  "com/android/tools/utp#android-test-plugin-result-listener-gradle/31.13.2": {
+   "jar": "sha256-9e057Np3aEcwsmFtES1p+S9Qnj1sOIKKvGqGPvd/4OU=",
+   "module": "sha256-aJrPHlaZS/50AVIYvYlZXVf+wUFXxc5mocdcfgEfiJ8=",
+   "pom": "sha256-aWdAHML+nRizUOPlQuf2l45UxA4UDLEbgrDPEDmkv9k="
+  },
+  "com/android/tools/utp#utp-common/31.13.2": {
+   "jar": "sha256-zeZ4pksTBBzdLMna0WhZkKHQkPsE/12iJh/3WoNZgQY=",
+   "pom": "sha256-su8omyDL3HUwfnQc8RXaFVRZ4aWLXQwuCh/aPK0TtnE="
+  },
+  "com/google/testing/platform#android-device-provider-local/0.0.9-alpha03": {
+   "jar": "sha256-ZnpNNbu6h9PIb1GA36Uh/b16TvXGDZSRVLAwHz4jLhs=",
+   "pom": "sha256-kTs67pWnFYGkCQOLHMonPOg10/K48qtaYAu+12nqbf0="
+  },
+  "com/google/testing/platform#android-driver-instrumentation/0.0.9-alpha03": {
+   "jar": "sha256-UHxjLsfbd7yymbVRnVmxTMYkOqxUF2fGMv2+3cYiawc=",
+   "pom": "sha256-AtXBStCZWXGhCIGQdacXXRAHa9cVJ3LO00QrsZxMG1M="
+  },
+  "com/google/testing/platform#android-test-plugin/0.0.9-alpha03": {
+   "jar": "sha256-1st+Em9DMDcZC808O5BLGbqELUaxew/SfDjMTM7L7JA=",
+   "pom": "sha256-qCucEMqqjl0fPNtjhHqbA6yXOKUlswmrcNTRZh7f6iI="
+  },
+  "com/google/testing/platform#core-proto/0.0.9-alpha03": {
+   "jar": "sha256-0AHrDMu/yMueqhk6NY5jcSl0Y5d1ZHvpSasjLCsptAc=",
+   "pom": "sha256-O7RSgN8d0clrmgFySmFFZrfWDTNFP81SwsdB+ZmcOk4="
+  },
+  "com/google/testing/platform#core/0.0.9-alpha03": {
+   "jar": "sha256-bhgG0BXEFllvU6RaMQDiV0PDE6bj/E9S8k6LJX8sgs4=",
+   "pom": "sha256-nwPalZsyYcweuciIa/iu1vXWC7lbjYY4vtVUQ65iDCo="
+  },
+  "com/google/testing/platform#launcher/0.0.9-alpha03": {
+   "jar": "sha256-ABL5gKBZoMTCFtDx0AFoZ6sx64B54/j4efHwK3vjpuc=",
+   "pom": "sha256-GLgPNKXp+hpe7CJQ/XHlRl8utLTQnhgZQOOPG24GRFI="
   }
  },
  "https://plugins.gradle.org/m2": {
@@ -349,6 +1390,14 @@
   },
   "com/github/ben-manes/versions#com.github.ben-manes.versions.gradle.plugin/0.54.0": {
    "pom": "sha256-o07zaR8ZggeMe8ef2fuJojK3xzxFpYuBEVH+m/dgb+I="
+  },
+  "com/github/jk1#gradle-license-report/3.1.2": {
+   "jar": "sha256-usYblgjaDRDRS+dHknUJ1xkjxQXLFunIBatR53gv2jg=",
+   "module": "sha256-g/wB/sH7gX2Zk3PDolzmr7HVCDGY28D9LOJwgdF6rBM=",
+   "pom": "sha256-PdcOs3qnhw3Lu3FhPsrJsQCf0gu5bZ6qnYbyyiUCGvc="
+  },
+  "com/github/jk1/dependency-license-report#com.github.jk1.dependency-license-report.gradle.plugin/3.1.2": {
+   "pom": "sha256-DtyZC8qthXD2Ek0T89Mzmyc8EUdsl9r0kiBNEKh9WMA="
   },
   "com/google/code/gson#gson-parent/2.8.9": {
    "pom": "sha256-sW4CbmNCfBlyrQ/GhwPsN5sVduQRuknDL6mjGrC7z/s="
@@ -494,6 +1543,10 @@
   }
  },
  "https://repo.maven.apache.org/maven2": {
+  "ca/gosyer#kotlin-multiplatform-appdirs-android/2.0.0": {
+   "module": "sha256-oqK2yFh9N35RSspPrOx2goRjJ3RdrxKOEisyLhdwYX8=",
+   "pom": "sha256-aQ7Rh42CH7HmVnVme7LzSXiMyRRb+HQn+2S+Y3raBfE="
+  },
   "ca/gosyer#kotlin-multiplatform-appdirs-jvm/2.0.0": {
    "jar": "sha256-9W8QSfNyX4LKLkFSVGpM0+g5pUN9Gktr1zoLpp9oQ3M=",
    "module": "sha256-3LnXloRopOXkX0gYiTTXm+MaEYoebg5bsJ5BiVttPSk=",
@@ -503,6 +1556,25 @@
    "jar": "sha256-xaWXTFVJ9veueA2lkSrHEYPVAEe0LUA7/OS5LFci9c4=",
    "module": "sha256-yGECuuKG8zdIIe+H9FO50b3XCQQ4fRWHI6FgyvTtHis=",
    "pom": "sha256-wzXWGRFakyrtcWEKbIAQIssts+vXeWpBf0rgwFyzCAM="
+  },
+  "ca/gosyer/kotlin-multiplatform-appdirs-android/2.0.0/kotlin-multiplatform-appdirs-android-2.0.0": {
+   "aar": "sha256-uRGCzwx3t9BqwAtvlc+v28rT09uaZr8xuxKTC0b09KM="
+  },
+  "co/touchlab#kermit-android-debug/2.1.0": {
+   "module": "sha256-PTX96AWuxv0Wqm5CsaLzDGgvvOx3Tm12YRbe8tzQE6s=",
+   "pom": "sha256-NYv9620vxczOcluG9tEeMDUUf3P+EQi0kqJq7hnFJlg="
+  },
+  "co/touchlab#kermit-android/2.1.0": {
+   "module": "sha256-NcVcObKiKiIqskFvYAKZyJ1Yw7wRX/xi+OAJ3u5prCk=",
+   "pom": "sha256-QEC1Js97SAg4Uk4WoTQvdnG6uMaHDeWlJ3L1NR1RbVo="
+  },
+  "co/touchlab#kermit-core-android-debug/2.1.0": {
+   "module": "sha256-SmbpuYMCzXPSUgVgpFtC+1AuRIcnc6ifqSKBYsM2+3w=",
+   "pom": "sha256-buAIP6qf7d/O/w7lVuxFgaMd5Aiu3i1GPjrfLbQuESo="
+  },
+  "co/touchlab#kermit-core-android/2.1.0": {
+   "module": "sha256-X+k/0c82jnuRGBwi6pdh0DFSVgRafEcG41gdJWFRPUQ=",
+   "pom": "sha256-hYBZ6LfjBzx6TORAcgoZ8bXNJ6YVB12jTnC1jX8mg0M="
   },
   "co/touchlab#kermit-core-jvm/2.1.0": {
    "jar": "sha256-o7+Kg6Q1Pz3UcpMjsojt0bfwR0x9MlHhYbJBodBwVDo=",
@@ -524,12 +1596,25 @@
    "module": "sha256-j5+C8LO6FjpyFoyjtNDIreZjiYWlSHCmrmxVSiVoDMc=",
    "pom": "sha256-LttgVDFR0D1gnKQZd/mAyiPCauXJZUdfBIEsCDsWLFI="
   },
+  "co/touchlab/kermit-android-debug/2.1.0/kermit-android-debug-2.1.0": {
+   "aar": "sha256-/CXcJ5JOmeNNvcKUN2yFDwZ4L8SQ3lySEnY57bqVUa4="
+  },
+  "co/touchlab/kermit-android/2.1.0/kermit-android-2.1.0": {
+   "aar": "sha256-smFeJdqT8yKlaNKldAB8q4CZOjAAbmlzi8g5+Z5aQBE="
+  },
+  "co/touchlab/kermit-core-android-debug/2.1.0/kermit-core-android-debug-2.1.0": {
+   "aar": "sha256-Bw6RvhVuf/SIXPPXBc4h1B8czxC9cPv3oIFu5wFsSA8="
+  },
+  "co/touchlab/kermit-core-android/2.1.0/kermit-core-android-2.1.0": {
+   "aar": "sha256-4d5az3Azn+MG4UEZMLnLZPswa8EYMJ9n4MMXYHFzc4c="
+  },
   "com/akuleshov7#ktoml-core-jvm/0.7.1": {
    "jar": "sha256-wiy2Ye78deMAB6GwjTfE6ToVf386lQpHglFjLAr2BQ0=",
    "module": "sha256-nk20aBr+n8zryNDKpAaVKLW8ersNrDPrPOOkpd34XCw=",
    "pom": "sha256-bMHKxVFmEEVu3rqjgc21VgMU0VI0TUmD8vkMwoD1iLc="
   },
   "com/akuleshov7#ktoml-core/0.7.1": {
+   "jar": "sha256-ysG1EkRpNnrJBlYATheeFmG3PaFlIhlP3NMnR7P4sjc=",
    "module": "sha256-hRT4XEby1I04dPmzkG/JOIIHPDfb9tFx7+smenVd0mw=",
    "pom": "sha256-7gHJjNR9lVtZmKbK68N8H+SouOI1crHufEylupSd22w="
   },
@@ -627,26 +1712,240 @@
    "pom": "sha256-2Eq7+TR9M3sx+jAO1yMQ31QCxmGhgDp0sOjkNnb4WWA="
   },
   "com/github/skydoves#compose-stable-marker/1.0.7": {
+   "jar": "sha256-5qqgcUK5pe0tl6pzwbLot02bunA6foOyW1eXTv0jgXg=",
    "module": "sha256-m8NxIK0ge/t3eqykNy1UMYiUR7QwkTMgxG2tUHuoPm4=",
    "pom": "sha256-G3+FZj1NbgIXTUdklUmV1lmefruAviob6/6wNeJIP4U="
   },
+  "com/google/accompanist#accompanist-drawablepainter/0.37.3": {
+   "module": "sha256-M/O1/0mKSsp0U3Nccx7zo+X3FBkdEjKijeg/dtNC1VY=",
+   "pom": "sha256-ambPsAooHoQHAXIlSRPvIKN/W4QR0i69BLyAWnHk0t8="
+  },
+  "com/google/accompanist/accompanist-drawablepainter/0.37.3/accompanist-drawablepainter-0.37.3": {
+   "aar": "sha256-BFPExU7D7xOuGLgzAPHSoHixypLTo3gUN1FmMOO4UN8="
+  },
+  "com/google/android#annotations/4.1.1.4": {
+   "jar": "sha256-unNOHoTAnWFa9qCdMwNLTwRC+Hct7BIO+zdthqVlrhU=",
+   "pom": "sha256-5LtUdTw2onoOXXAVSlA0/t2P6sQoIpUDS/1IPWx6rng="
+  },
+  "com/google/api/grpc#proto-google-common-protos/2.17.0": {
+   "jar": "sha256-TvH+DDJ/wVIdHXU7CxxKh1pUvRTr3tOv/wyjlTILbqk=",
+   "pom": "sha256-PwKBU6WFxZ9Viz5Dp8mAmmAai7XpEGHWxlj/+iTLjiY="
+  },
+  "com/google/api/grpc#proto-google-common-protos/2.48.0": {
+   "jar": "sha256-Q+x4B0WaqkAS6Dihvk7y1ZDPIzMF2mCvW1TwjsjPIwI=",
+   "pom": "sha256-ReuSeyJoX8Eb+rac5q07Q59y2Bajp95GvSP07Rm/icM="
+  },
+  "com/google/auto#auto-common/1.2.1": {
+   "jar": "sha256-9D8p/ipuuvBLJZjN7sMqTjRtSalATpkPX8GcGfOijQ4=",
+   "pom": "sha256-E7S1AGKUn4sTQ5J8WBU207sFG4r+pQmqb5AvTeKLwbI="
+  },
+  "com/google/auto#auto-parent/6": {
+   "pom": "sha256-BfdAxmSBZdsAz2GN1WwgDEcl41jm1U9YU+C+wVc06go="
+  },
+  "com/google/auto/service#auto-service-aggregator/1.1.1": {
+   "pom": "sha256-4tw+JjpdsMyBcvsuubzSMqzs/clugXED6rPI2fGQDGo="
+  },
+  "com/google/auto/service#auto-service-annotations/1.1.1": {
+   "jar": "sha256-Fqdt0AomUFaER/XW46niyAnZpCNn1WtFIVz7iXMfTSQ=",
+   "pom": "sha256-Fln9CiXOqfqav7GN6517GAzOOs6rFv+eYlRhVn5Eot8="
+  },
+  "com/google/auto/service#auto-service/1.1.1": {
+   "jar": "sha256-H0j0UVA+Yj2rp9ntNozKD4Hh44FWU6RWARPhLAEp69U=",
+   "pom": "sha256-DFPC+HlJs76PHIxnu3bAjtT0vrjbqkdcMrpZPUYXYxc="
+  },
+  "com/google/auto/value#auto-value-annotations/1.6.2": {
+   "jar": "sha256-tIsE3bpA6KwzvwNvBvxDmV/FCEvZS9qs6AfOJ9O+o/s=",
+   "pom": "sha256-HHbNRi/JbnqpbccM6C8NVAY9bfFts1ycfZzA0amdP/8="
+  },
+  "com/google/auto/value#auto-value-parent/1.6.2": {
+   "pom": "sha256-J7ZAyCF59c/2IAnAtyAz2bxg9g6ZAqZoAidLf+N/yBw="
+  },
+  "com/google/code/findbugs#jsr305/3.0.2": {
+   "jar": "sha256-dmrSoHg/JoeWLIrXTO7MOKKLn3Ki0IXuQ4t4E+ko0Mc=",
+   "pom": "sha256-GYidvfGyVLJgGl7mRbgUepdGRIgil2hMeYr+XWPXjf4="
+  },
+  "com/google/code/gson#gson-parent/2.10.1": {
+   "pom": "sha256-QkjgiCQmxhUYI4XWCGw+8yYudplXGJ4pMGKAuFSCuDM="
+  },
   "com/google/code/gson#gson-parent/2.11.0": {
    "pom": "sha256-issfO3Km8CaRasBzW62aqwKT1Sftt7NlMn3vE6k2e3o="
+  },
+  "com/google/code/gson#gson-parent/2.8.9": {
+   "pom": "sha256-sW4CbmNCfBlyrQ/GhwPsN5sVduQRuknDL6mjGrC7z/s="
+  },
+  "com/google/code/gson#gson/2.10.1": {
+   "jar": "sha256-QkHBSncnw0/uplB+yAExij1KkPBw5FJWgQefuU7kxZM=",
+   "pom": "sha256-0rEVY09cCF20ucn/wmWOieIx/b++IkISGhzZXU2Ujdc="
   },
   "com/google/code/gson#gson/2.11.0": {
    "jar": "sha256-V5KNblpu3rKr03cKj5W6RNzkXzsjt6ncKzCcWBVSp4s=",
    "pom": "sha256-wOVHvqmYiI5uJcWIapDnYicryItSdTQ90sBd7Wyi42A="
   },
+  "com/google/code/gson#gson/2.8.9": {
+   "jar": "sha256-05mSkYVd5JXJTHQ3YbirUXbP6r4oGlqw2OjUUyb9cD4=",
+   "pom": "sha256-r97W5qaQ+/OtSuZa2jl/CpCl9jCzA9G3QbnJeSb91N4="
+  },
+  "com/google/crypto/tink#tink/1.7.0": {
+   "jar": "sha256-iJcKRWoIukxmsBsj5YRsoQlcwU5Uy0g2Pl0uFaEwcwg=",
+   "pom": "sha256-Ku41I3FfjyzRCyYDyNGeVhrHWDELfiyYU5RtLF57S/c="
+  },
+  "com/google/dagger#dagger/2.28.3": {
+   "jar": "sha256-8d0j+K40qOkTZnI5kerQ1kmdGj6RY85VDCALAtdqhys=",
+   "pom": "sha256-JlupWajhPDoGEz8EtTkWnBAY2v/U0z9TxFOrTLOG9XA="
+  },
+  "com/google/dagger#dagger/2.48": {
+   "jar": "sha256-H6Im0rSgLMgJUPpNSaSiNcyOztSZtYH8NYpVRGqD9Xk=",
+   "pom": "sha256-df10hXPlgHWxMG9/rhnPWwLAsIUJCPdlExsJKhFWqUQ="
+  },
+  "com/google/errorprone#error_prone_annotations/2.18.0": {
+   "pom": "sha256-kgE1eX3MpZF7WlwBdkKljTQKTNG80S9W+JKlZjvXvdw="
+  },
+  "com/google/errorprone#error_prone_annotations/2.23.0": {
+   "jar": "sha256-7G858Gi2/5rDI8aOKLkpn4wKgMpRLcyx1KcPQKw+wFQ=",
+   "pom": "sha256-1auxfyMbY78Ak1j6ZAKBt0SBDLlYflmUl3g0lZwH29g="
+  },
   "com/google/errorprone#error_prone_annotations/2.27.0": {
-   "jar": "sha256-JMkjNyxY410LnxagKJKbua7cd1IYZ8J08r0HNd9bofU=",
    "pom": "sha256-TKWjXWEjXhZUmsNG0eNFUc3w/ifoSqV+A8vrJV6k5do="
+  },
+  "com/google/errorprone#error_prone_annotations/2.28.0": {
+   "jar": "sha256-8/yKOgpAIHBqNzsA5/V8JRLdJtH4PSjH04do+GgrIx4=",
+   "pom": "sha256-DOkJ8TpWgUhHbl7iAPOA+Yx1ugiXGq8V2ylet3WY7zo="
+  },
+  "com/google/errorprone#error_prone_annotations/2.3.1": {
+   "pom": "sha256-PtzmtxG6No7+Frm3qssCFPvWSEFMublllTouftiagZo="
+  },
+  "com/google/errorprone#error_prone_annotations/2.30.0": {
+   "jar": "sha256-FE86771uJ9rsVdN1OyxrE8Gv2vDPBIFs21ZFiO2S8b0=",
+   "pom": "sha256-9xOEnCOzSVPoVFZdzoqnlcrgwUFmEbcgwhRhMix5X4Y="
+  },
+  "com/google/errorprone#error_prone_parent/2.18.0": {
+   "pom": "sha256-R/Iumce/RmOR3vFvg3eYXl07pvW7z2WFNkSAVRPhX60="
+  },
+  "com/google/errorprone#error_prone_parent/2.23.0": {
+   "pom": "sha256-9UcKSzEE/jCfvpSoDRbDxU0g90j0xd5PaKQoaI8wy9Q="
   },
   "com/google/errorprone#error_prone_parent/2.27.0": {
    "pom": "sha256-+oGCnQSVWd9pJ/nJpv1rvQn4tQ5tRzaucsgwC2w9dlQ="
   },
+  "com/google/errorprone#error_prone_parent/2.28.0": {
+   "pom": "sha256-rM79u1QWzvX80t3DfbTx/LNKIZPMGlXf5ZcKExs+doM="
+  },
+  "com/google/errorprone#error_prone_parent/2.3.1": {
+   "pom": "sha256-dnUl2agRKc0IGWg4KYAzYye+QWKx4iUaGCkR2qczwSM="
+  },
+  "com/google/errorprone#error_prone_parent/2.30.0": {
+   "pom": "sha256-Xog0zMDl7Qxy8wbCULUY5q0Q0HWpt7kQz2lcuh7gKi0="
+  },
+  "com/google/flatbuffers#flatbuffers-java/1.12.0": {
+   "jar": "sha256-P4wIi03QSphYch8uFiUIyU2w3Yb5YeMG7mPvLtqHG/c=",
+   "pom": "sha256-yyJrr1RiYHcPIegVKmqoi6FSMNc591DfSA8qZo1D4Os="
+  },
+  "com/google/guava#failureaccess/1.0.1": {
+   "jar": "sha256-oXHuTHNN0tqDfksWvp30Zhr6typBra8x64Tf2vk2yiY=",
+   "pom": "sha256-6WBCznj+y6DaK+lkUilHyHtAopG1/TzWcqQ0kkEDxLk="
+  },
+  "com/google/guava#failureaccess/1.0.2": {
+   "jar": "sha256-io+Bz5s1nj9t+mkaHndphcBh7y8iPJssgHU+G0WOgGQ=",
+   "pom": "sha256-GevG9L207bs9B7bumU+Ea1TvKVWCqbVjRxn/qfMdA7I="
+  },
+  "com/google/guava#guava-parent/26.0-android": {
+   "pom": "sha256-+GmKtGypls6InBr8jKTyXrisawNNyJjUWDdCNgAWzAQ="
+  },
+  "com/google/guava#guava-parent/32.0.1-jre": {
+   "pom": "sha256-Q+0ONrNT9B5et1zXVmZ8ni35fO8G6xYGaWcVih0DTSo="
+  },
+  "com/google/guava#guava-parent/33.3.1-jre": {
+   "pom": "sha256-VUQdsn6Iad/v4FMFm99Hi9x+lVhWQr85HwAjNF/VYoc="
+  },
+  "com/google/guava#guava/32.0.1-jre": {
+   "jar": "sha256-vX+iJ1kfuFCWd9DREiz5UVjzuKn0VlP1goHYefbcSMU=",
+   "pom": "sha256-QsJX9/c203ezGv7u6XirJtcwzXCvYN3nZi4YI1LiSCo="
+  },
+  "com/google/guava#guava/33.3.1-jre": {
+   "jar": "sha256-S/Dixa+ORSXJbo/eF6T3MH+X+EePEcTI41oOMpiuTpA=",
+   "module": "sha256-QYWMhHU/2WprfFESL8zvOVWMkcwIJk4IUGvPIODmNzM=",
+   "pom": "sha256-MTtn/BPrOwY07acVoSKZcfXem4GIvCgHYoFbg6J18ZM="
+  },
+  "com/google/guava#listenablefuture/1.0": {
+   "jar": "sha256-5K12B+XAR3xviQ7yaknLjRu03/tlC6tFAq/uZGROMGk=",
+   "pom": "sha256-U4c8rya8HtilZ+psk5qyqqP0el4y1creld31CA0jI4o="
+  },
+  "com/google/guava#listenablefuture/9999.0-empty-to-avoid-conflict-with-guava": {
+   "jar": "sha256-s3KgN9QjCqV/vv/e8w/WEj+cDC24XQrO0AyRuXTzP5k=",
+   "pom": "sha256-GNSx2yYVPU5VB5zh92ux/gXNuGLvmVSojLzE/zi4Z5s="
+  },
+  "com/google/j2objc#j2objc-annotations/2.8": {
+   "jar": "sha256-8CqV+hpele2z7YWf0Pt99wnRIaNSkO/4t03OKrf01u0=",
+   "pom": "sha256-N/h3mLGDhRE8kYv6nhJ2/lBzXvj6hJtYAMUZ1U2/Efg="
+  },
+  "com/google/j2objc#j2objc-annotations/3.0.0": {
+   "jar": "sha256-iCQVc0Z93KRP/U10qgTCu/0Rv3wX4MNCyUyd56cKfGQ=",
+   "pom": "sha256-I7PQOeForYndEUaY5t1744P0osV3uId9gsc6ZRXnShc="
+  },
+  "com/google/jimfs#jimfs-parent/1.1": {
+   "pom": "sha256-xxVVdR5X4O+RKHDorJYlrnglAqalucGcz4OyqX2LJr0="
+  },
+  "com/google/jimfs#jimfs/1.1": {
+   "jar": "sha256-xIKOKNfAqTCvk4dRCzutp9qlwE18Jadce4sIHxwlfd0=",
+   "pom": "sha256-76huXNki8XtHL9/K5XI02NSsPhSLYlBzffzkVK96ekQ="
+  },
+  "com/google/protobuf#protobuf-bom/3.22.3": {
+   "pom": "sha256-E6Mt+53m/Bw8P3r1Pk1cd/130rR2uuOLdLdYHN7i5lU="
+  },
+  "com/google/protobuf#protobuf-bom/3.24.4": {
+   "pom": "sha256-BOz9UsUN8Hp1VR+bCeDvMGMO5CN9CRyg7KceW/t4zOU="
+  },
+  "com/google/protobuf#protobuf-bom/3.25.5": {
+   "pom": "sha256-CA4phBcyOLUOBkwiav/7sbAjNSApXHkKf9PWrkWT8GM="
+  },
+  "com/google/protobuf#protobuf-java-util/3.22.3": {
+   "jar": "sha256-xhX3aHncXDA+TfW5Smr6OVNAWMdUXbLUg/2V2fY8i/4=",
+   "pom": "sha256-tEcBsGoGSGXsm1YUqT6eKPrdfU38S0YPIcgZ71Pb4tY="
+  },
+  "com/google/protobuf#protobuf-java-util/3.24.4": {
+   "jar": "sha256-EzySniz+OZChBdGOrMxJEistL7SStCDvAtXZ+Tfq67g=",
+   "pom": "sha256-nwzsJ21NnVpD1uKcwrAk5GgEyThqlvpSfu/Xv3SI5/A="
+  },
+  "com/google/protobuf#protobuf-java-util/3.25.5": {
+   "jar": "sha256-2sxYssPS+o1L3cGsuIHnjWz3wTfdeLwdZ/aspzJDao0=",
+   "pom": "sha256-oJ0ZDqpqeWFrxfS1QE6UsMq1WYA6mMigkMQJmWL0H5I="
+  },
+  "com/google/protobuf#protobuf-java/3.24.4": {
+   "jar": "sha256-5WVVIr4apcwfLwkqoDawRFFX8pSSju3xMyrJOMe2loY=",
+   "pom": "sha256-OUEiHKZXgZ3evZX+i3QPRwr3q/MEYLE+ocmrefEPq5E="
+  },
+  "com/google/protobuf#protobuf-java/3.25.5": {
+   "jar": "sha256-hUAkf62eBrrvqPtF6zE4AtAZ9IXxQwDg+da1Vu2I51M=",
+   "pom": "sha256-51IDIVeno5vpvjeGaEB1RSpGzVhrKGWr0z5wdWikyK8="
+  },
+  "com/google/protobuf#protobuf-kotlin/3.24.4": {
+   "jar": "sha256-UIyhPZe1D1QE6qN+tEk8sHiEFi63lxv5JNj4A9TCG7Q=",
+   "pom": "sha256-O7Hm75SmpDa9L/Zq8N1gPCPtOilDsvuJn4PZ+Hktcqk="
+  },
+  "com/google/protobuf#protobuf-parent/3.22.3": {
+   "pom": "sha256-OZEz1/b1eTTddsSxjoY0j0JFMhCNr0oByPgguGZfCSk="
+  },
+  "com/google/protobuf#protobuf-parent/3.24.4": {
+   "pom": "sha256-+37AUFh2/bnseVEKztLR6wTDuM/GkLWJBJdXypgcrbM="
+  },
+  "com/google/protobuf#protobuf-parent/3.25.5": {
+   "pom": "sha256-ZMwOOtboX1rsj53Pk0HRN56VJTZP9T4j4W2NWCRnPvc="
+  },
   "com/googlecode/htmlcompressor#htmlcompressor/1.5.2": {
    "jar": "sha256-psxeXeBb7nQgj9MHj8H66uVPdK1wzlbqX0k2TFbSw4M=",
    "pom": "sha256-rmmOFrwcgawzZd0SaTETtZAB1Yf83mGBKJytHBhPTs0="
+  },
+  "com/googlecode/juniversalchardet#juniversalchardet/1.0.3": {
+   "jar": "sha256-dXv+kGGTuLZR553CbNZ9a1XQdwos37A4FZFQT3edSnY=",
+   "pom": "sha256-eEY5mzXHzWQqmzoADD4tYtBOs3pFR7aTPMixi8wvCGs="
+  },
+  "com/squareup#javapoet/1.10.0": {
+   "jar": "sha256-IO9LguQ/98ZSKBohMTzzuUEJJGet0/pzUJwm9pae/as=",
+   "pom": "sha256-FpA0CiIiefLLrfNz6Igm+iD388w+wCUvNoGP7TJwGrE="
+  },
+  "com/squareup#javawriter/2.5.0": {
+   "jar": "sha256-/PsJ+w6gqpfTz+fqeSOYCBNI5GjxJrNgPLOAPyQBl/A=",
+   "pom": "sha256-4avX8RFs9eDFmUdpPiGJII7JQpayozlMlZ41EdOZp7A="
   },
   "com/squareup/moshi#moshi-kotlin/1.12.0": {
    "jar": "sha256-HENsB8FZzRrwMrt5NRpIqY5/eBrIB8/4tXEamZtWZt8=",
@@ -663,10 +1962,10 @@
    "module": "sha256-YH4iD/ghW5Kdgpu/VPMyiU8UWbTXlZea6vy8wc6lTPM=",
    "pom": "sha256-fHNwQKlBlSLnxQzAJ0FqcP58dinlKyGZNa3mtBGcfTg="
   },
-  "com/squareup/okio#okio-jvm/3.16.4": {
-   "jar": "sha256-IZa5k800272Rnn4B9XpHgbWL7oD4YQYWPih8IDQ6lqc=",
-   "module": "sha256-kAjVopVKBoxoSCdPbuvf9IsUpw28aT0zAuCMVwzKAy8=",
-   "pom": "sha256-ZnePTQWXvOY/kewADFdcwCmzIB990JLLgIh1FVs+hqE="
+  "com/squareup/okio#okio-jvm/3.17.0": {
+   "jar": "sha256-OxPcw+FXMEfC1Qf8T3/LC7DLzZ05XaIdIOCUBuLNanM=",
+   "module": "sha256-1GF9DfcfIC5ymUcYSOYl9PNtf6ZNRsNQP3Cs9IIaRd4=",
+   "pom": "sha256-5ORCN6ZvQJG8D1sdWiu+IorAFKs8D5GM1vwCujGZkDA="
   },
   "com/squareup/okio#okio-jvm/3.6.0": {
    "jar": "sha256-Z1Q/Bzb8QirpJ+0OUEuYvF4mn9oNNQBXkzfLcT2ihBI=",
@@ -674,21 +1973,63 @@
    "pom": "sha256-YbTXxRWgiU/62SX9cFJiDBQlqGQz/TURO1+rDeiQpX8="
   },
   "com/squareup/okio#okio-jvm/3.9.1": {
+   "jar": "sha256-/m/pE3j5v6ewjDhkgozkGABc8orMoS6IR+tlxWXDdQA=",
    "module": "sha256-sK+pGSxC18Rj3jjWMlk2xpAdnjtxSXNf/RihHfMQNKs=",
    "pom": "sha256-VXZInO8kBTNoAPxt6VhUU18zVxpO/lpa0OybmwkNIdU="
   },
-  "com/squareup/okio#okio/3.16.4": {
-   "jar": "sha256-yZZPOUxM0yt5vzOK+/ovIpciHu4IMReHBhzqVfh91g4=",
-   "module": "sha256-yEQahybbGk+dTzngaOu0LfalnWR+MqnGHBW1OQ7VklI=",
-   "pom": "sha256-CPvpfh4ugVoUyvFv9ayHCFEb713ec51gwHE5UYdtomM="
+  "com/squareup/okio#okio/3.17.0": {
+   "jar": "sha256-iSiY/xOwz9pfC/aJ6zO3wAyFOyUx/NT+IP5TAtN5gdg=",
+   "module": "sha256-PYeNuf/U6VnDD5qDZqiMItAB6bMkN419vu2YVo5+xVk=",
+   "pom": "sha256-FbSDHoT1ylLdN8HW4XCaKQfi6bwqnD6hPyggMd4MATU="
   },
   "com/squareup/okio#okio/3.6.0": {
    "module": "sha256-akesUDZOZZhFlAH7hvm2z832N7mzowRbHMM8v0xAghg=",
    "pom": "sha256-rrO3CiTBA+0MVFQfNfXFEdJ85gyuN2pZbX1lNpf4zJU="
   },
   "com/squareup/okio#okio/3.9.1": {
+   "jar": "sha256-mcjrvEmV8p3ViwXXVYP8yLlX2yHu64xdiXM/DTSVWJc=",
    "module": "sha256-m5C0J0pa1gLdV01tS0iQNmOy3ppgufw0AiSCk9hD4SE=",
    "pom": "sha256-06DDd+epr8zbsCqrXgUNwhL/2pQNvUcOo5cSpDQt8I4="
+  },
+  "com/sun/activation#all/1.2.0": {
+   "pom": "sha256-HYUY46x1MqEE5Pe+d97zfJguUwcjxr2z1ncIzOKwwsQ="
+  },
+  "com/sun/activation#all/1.2.1": {
+   "pom": "sha256-NgiDv2RIbs7xYbjygvZQNTbdGmcNU6Coccj7IBcOZ5U="
+  },
+  "com/sun/activation#javax.activation/1.2.0": {
+   "jar": "sha256-mTMCsWzXBW8h53nMV30XWoELtJAO9zzY+/K1D5KLqc4=",
+   "pom": "sha256-+Hm26UWFTGkAsNvuHIOE16s95+FX/XrISTdAXEFtKl4="
+  },
+  "com/sun/istack#istack-commons-runtime/3.0.8": {
+   "jar": "sha256-T/q7Br5FSgXkOY4gx3+itjCNS4jfvvfKMKdrW31VBe8=",
+   "pom": "sha256-wuAU00y4TtKH0GSYbEXDBaQSQiinM37M9sQh0U1wjxw="
+  },
+  "com/sun/istack#istack-commons/3.0.8": {
+   "pom": "sha256-oPBRfoUS8PvMe4KVwS9lZqPQwthtZVY53GYu+MDH6+U="
+  },
+  "com/sun/xml/bind#jaxb-bom-ext/2.3.2": {
+   "pom": "sha256-Gn3sKyfn4FV0TNuM8bkN70/Uc6zRuATv8JgTk1iVm9c="
+  },
+  "com/sun/xml/bind/mvn#jaxb-parent/2.3.2": {
+   "pom": "sha256-IN1tw0q3VJrEDaHYLpIiLsQ0etDsDLEY72xXA77VOhg="
+  },
+  "com/sun/xml/bind/mvn#jaxb-runtime-parent/2.3.2": {
+   "pom": "sha256-sk+NUfGEpovBuG1IwOPP7+shpE7eHF9zA8WK4EiFM+w="
+  },
+  "com/sun/xml/bind/mvn#jaxb-txw-parent/2.3.2": {
+   "pom": "sha256-tV0++psVj0g6MOkseMy2APkzFHM9CJ66m3RDbwGzFKQ="
+  },
+  "com/sun/xml/fastinfoset#FastInfoset/1.2.16": {
+   "jar": "sha256-BW86HhRECfIe0Wr8JoBfWOmiHz/OFUPELUAHGdJQxRE=",
+   "pom": "sha256-4UfSWKtuZpH3BZmpUkAObmx1WPjJwCjb4b4jF4MI6DA="
+  },
+  "com/sun/xml/fastinfoset#fastinfoset-project/1.2.16": {
+   "pom": "sha256-kFgkJa3B9AtBNi2vuVFzkxIlrKpeeWINXmvVL2Rikro="
+  },
+  "com/vanniktech#blurhash-android/0.3.0": {
+   "module": "sha256-1a1640mCYGf1M7DgLrfKkhvoHpJEaQYXNMT6YtjYJg0=",
+   "pom": "sha256-NcviEiaV6br3iglVQI4XXwRd8fJ1SmZetaBJGRy+Oxw="
   },
   "com/vanniktech#blurhash-jvm/0.3.0": {
    "jar": "sha256-VIpmuA/kdWi86xPcmpr9oR4MVBVkRRN4B684HPRaob4=",
@@ -700,92 +2041,156 @@
    "module": "sha256-bSIprgvwr8Ch/+IEd6qTpNOI5EAabcr5azls8CDwjy0=",
    "pom": "sha256-kLK8EYcBgB/7DW0LrSCKyBRkHzcSPd2utfINHTd+6rA="
   },
+  "com/vanniktech/blurhash-android/0.3.0/blurhash-android-0.3.0": {
+   "aar": "sha256-Mw7O8WpwCX1++g+JB2qJzYGObZ0LaIQg0+dwXLUpbjE="
+  },
+  "commons-codec#commons-codec/1.11": {
+   "jar": "sha256-5ZnVMY6Xqkj0ITaikn5t+k6Igd/w5sjjEJ3bv/Ude30=",
+   "pom": "sha256-wecUDR3qj981KLwePFRErAtUEpcxH0X5gGwhPsPumhA="
+  },
+  "commons-io#commons-io/2.16.1": {
+   "jar": "sha256-9B97qs1xaJZEes6XWGIfYsHGsKkdiazuSI2ib8R3yE8=",
+   "pom": "sha256-V3fSkiUceJXASkxXAVaD7Ds1OhJIbJs+cXjpsLPDj/8="
+  },
+  "commons-logging#commons-logging/1.2": {
+   "jar": "sha256-2t3qHqC+D1aXirMAa4rJKDSv7vvZt+TmMW/KV98PpjY=",
+   "pom": "sha256-yRq1qlcNhvb9B8wVjsa8LFAIBAKXLukXn+JBAHOfuyA="
+  },
   "de/jangassen#jfa/1.2.0": {
    "jar": "sha256-8cwY8VldRBroOc2hRlwIsefbRrcsHX87NzIK4WQexys=",
    "pom": "sha256-tNgod+BwsV0dTmdrQV9qVCnw4i3U75gX2F5MWcU7yr8="
   },
-  "dev/zacsweers/metro#compiler/0.13.2": {
-   "jar": "sha256-IdUz86KNprcAl56j/gpWJAs9wgNfd6vXCdtjcuMAOhc=",
-   "module": "sha256-7vq4/l8cA0F1g0Kjha9JSHspskHKaPKl0IAIvQ3fhl0=",
-   "pom": "sha256-qi4IrMz+X212avx56aVPMd+G/gdY5BzmKW2GjJPi3SU="
+  "dev/zacsweers/metro#compiler/1.1.1": {
+   "jar": "sha256-MdND/GKbblD01JYxka2yau894e+iXYElBo596UheoSI=",
+   "module": "sha256-ddGfsqptq5lmPw8q3FAvy3yV3REOC+uYJZy7K8DQZks=",
+   "pom": "sha256-O2EQQfLfXlHKuw/Qyefz1u8HjR9oj2T7jeQ7i7zU5DQ="
   },
-  "dev/zacsweers/metro#dev.zacsweers.metro.gradle.plugin/0.13.2": {
-   "pom": "sha256-k2fumkPqfEGebbXa6Z+lo/ROV5NzDKY9rJkKIwztQOE="
+  "dev/zacsweers/metro#dev.zacsweers.metro.gradle.plugin/1.1.1": {
+   "pom": "sha256-HhMABm4TrgyLsUbMF/WzanV1zi0mSbU3t/+u5Sfxl7E="
   },
-  "dev/zacsweers/metro#gradle-plugin/0.13.2": {
-   "jar": "sha256-myYSaPXbrs7SgCyMZCah4kW4dRptO5j0ZigHFbwM1JM=",
-   "module": "sha256-5LShS1g4/Az5XPu/MVxRC2xNW5Svs1Yo/CrlxW0HAF8=",
-   "pom": "sha256-JhsorfMb1vnqusRTad35BwuSYQYVkdxlzeLzX4n0kGc="
+  "dev/zacsweers/metro#gradle-plugin/1.1.1": {
+   "jar": "sha256-mVgHMfSr7Hn8dGxCnQVMCXWiLHEZDXjvQguMDg18PuY=",
+   "module": "sha256-dnkR5xlz+f7fNRx2etacST+4hYO2E4ivTN6sJSAToEg=",
+   "pom": "sha256-DMa65DhfdVTon9W2pKjm98x5llcjCdX6h8jDpuppNNo="
   },
-  "dev/zacsweers/metro#runtime-jvm/0.13.2": {
-   "jar": "sha256-SGAYoNiyUJZTNovmq66J2VdPTMpDezLj8YCbDQQ71mc=",
-   "module": "sha256-AZfrajH8w+OZBjTJ9RF9ugRqwx5YO6ihBLuzRou6Y4A=",
-   "pom": "sha256-EscU+yycpYo7TLkic95F1FoFJ5yq/1UqJM4tQNsHPMI="
+  "dev/zacsweers/metro#runtime-jvm/1.1.1": {
+   "jar": "sha256-NFnWGIxNw8ycjgZ+I7gfO6Thll3tLXvG6L2CfSSy2LE=",
+   "module": "sha256-6VwmWgY+1Qbs7I4GXoZR1WMRDc9tYfOXcaQodrIk7Uc=",
+   "pom": "sha256-/Z9ZjxIc0SKldm5tCCEL01iDD/59+qw7vUahwkj69Hg="
   },
-  "dev/zacsweers/metro#runtime/0.13.2": {
-   "jar": "sha256-C+8WXCyr/5OO8KeZuG0ydEvoEq1VYxEwwWpDDW+p0z8=",
-   "module": "sha256-cMGrnK9MhwYUglD1vz11+aJSPMmTTR6gxAeB9LEabQs=",
-   "pom": "sha256-4bXRNr0avav92i/PAjWUEQJkylaKDgwDugqqUKvEBhk="
+  "dev/zacsweers/metro#runtime/1.1.1": {
+   "jar": "sha256-gZ/YKrOMEwFadi4jrHl1Z43h6IXBqvoRg+ESHGFosrw=",
+   "module": "sha256-d40CCk+mbG5vSblbLq4cErulW9nSuh0cKAwgSVrEMPM=",
+   "pom": "sha256-E+C5YR2XHcDzQFgtSGZ6L7bR/dyaGdtP/UOwvI2rlnc="
   },
-  "io/coil-kt/coil3#coil-compose-core-jvm/3.4.0": {
-   "jar": "sha256-UZpHGiZB7VJW052oUbF4qv8yfJ+iNQYi+utE7rGO05c=",
-   "module": "sha256-DHLibYVA/HN8kFHGhAVQhlM/UTmgcnutc3PWF4knYAg=",
-   "pom": "sha256-jtWVHvZARZs7JFnHxROoqAPg9n4FbZmMZEWJfgwKoLA="
+  "io/coil-kt/coil3#coil-android/3.5.0-beta01": {
+   "module": "sha256-mxFKXy6ESgYWIUBygotIP1bWG7pGoy7OyIs2RBDsJNY=",
+   "pom": "sha256-I+DBB588BtBF+IF+PyniToim64WVwYKUKmIH6/M3z90="
   },
-  "io/coil-kt/coil3#coil-compose-core/3.4.0": {
-   "jar": "sha256-xgS7FINNhN25VhbBQhMnNSkXyMFMtt8Wdi8fUv562KU=",
-   "module": "sha256-gJP4IwYSR/QTuhN1bF1kCpbXXqjldeHbVNuv0zCF5go=",
-   "pom": "sha256-Bi62HyYVqqmh82FTzVBVA7Z3Xc2ZxHTDAQ8t7+R4TDw="
+  "io/coil-kt/coil3#coil-compose-android/3.5.0-beta01": {
+   "module": "sha256-bo/nHPP2mxlJXIm65SnuUWiA26CBW4ObETul6FPO3CA=",
+   "pom": "sha256-H/E3U2s0HvBWq8zfxT+4DphHq5N1Wu78kHIDjczkKKw="
   },
-  "io/coil-kt/coil3#coil-compose-jvm/3.4.0": {
-   "jar": "sha256-HYlXkAM5FpVebMW4NXX5YozHN6KaVUhNfDzC86az7WU=",
-   "module": "sha256-6wKPSFt5vp9FXa/dnvnSROYCAhMn3Gk5feu9APpThYA=",
-   "pom": "sha256-qBb2n8Bu8PIG7xXGyrAde8L8nOp5Eikf1+izVYIELxo="
+  "io/coil-kt/coil3#coil-compose-core-android/3.5.0-beta01": {
+   "module": "sha256-T4aXsdYY0GTN8xwmixkwBd0uEKVbangFZrxpi3njHgw=",
+   "pom": "sha256-7aTvfZX5fJq81pn3TdYZvurl53toBSYkhaVy2ebVzfw="
   },
-  "io/coil-kt/coil3#coil-compose/3.4.0": {
-   "jar": "sha256-Iz+ZBSm9Ijm6AAockpas3oRMDQFyUGaQw6m6t8ZXByU=",
-   "module": "sha256-gUi96Mu3cTaN6vsPXopXMOjdqnuZd9K/Sa6oW9SZ5f8=",
-   "pom": "sha256-SHmLQ9l293aYHAgR54N279S/jf/aAzvUnh9BLgsHi18="
+  "io/coil-kt/coil3#coil-compose-core-jvm/3.5.0-beta01": {
+   "jar": "sha256-1bggBh9BiCqQEFw6SNkDuyUktQq4Go+UBA3Eevj6qgw=",
+   "module": "sha256-zVJuXqo+bABuVTeD63YbhDQjkjR/KAY88vQIjcnOA0A=",
+   "pom": "sha256-rNxSvLVZq9EoHGB8R+UAbLv6PFzHenxaugkoJxdWMYU="
   },
-  "io/coil-kt/coil3#coil-core-jvm/3.4.0": {
-   "jar": "sha256-VcqK14GHwpuZ4eJ9ZL1TSiXPU+ooz3hs1iIESiKqNXE=",
-   "module": "sha256-QubYdwaCSraBNwvlpF1hSbKJNb4rHJ1hEWIbSOYLVdI=",
-   "pom": "sha256-J/jri/iHdHvY3BTRifkdB4DLE8tkx5Emai5wDHoM3ME="
+  "io/coil-kt/coil3#coil-compose-core/3.5.0-beta01": {
+   "jar": "sha256-3rpZ/T6+xD+OKMtNpu3h3Q9YC8ha8ZZPrsbmgixFph0=",
+   "module": "sha256-b0Nd6a280k3/3gVk5/sEXYkbRfG5rCO3zbziZpfhZOs=",
+   "pom": "sha256-v1yuxq2mNdhXu+/BYbk9Tiw56hiz0EPKQteb6plCBcI="
   },
-  "io/coil-kt/coil3#coil-core/3.4.0": {
-   "jar": "sha256-ovFt0ldTnOQQ1G1W5lV6P8l/f1BPe/AVXPI4g234AfA=",
-   "module": "sha256-6iHg7xC2TxMmH8L6aAIU3tSJTjvp+YUy7fsUi1q8Hjc=",
-   "pom": "sha256-cFLwQJso91rDHXBWHDzsHwAMOm4GuITKz36N64nYnj4="
+  "io/coil-kt/coil3#coil-compose-jvm/3.5.0-beta01": {
+   "jar": "sha256-hEC1U8TWZ9Tqa4ocJdv+hXhl6h++7LHrmWX4Z/fRlus=",
+   "module": "sha256-dX1DXViMW4hbaHqyqzd3K6Upd5dzAOYoXC5L7muThTc=",
+   "pom": "sha256-HyIdVlQdF1TTCmLvR1hpxpfcKp9xU+c2GYEmMY/x4Ow="
   },
-  "io/coil-kt/coil3#coil-jvm/3.4.0": {
+  "io/coil-kt/coil3#coil-compose/3.5.0-beta01": {
+   "jar": "sha256-HW23bMsvhgjr/XGmRLFXlQ7+U1ALEzvcyO60iu5w6uM=",
+   "module": "sha256-ToGXqXT0kwOJhH9/KYq08tnXKcpuoF/lX4b+t+CyByo=",
+   "pom": "sha256-t6YNifKhjJE91ps6qjUHRo0AIbRBILgd/zetl7n6PCI="
+  },
+  "io/coil-kt/coil3#coil-core-android/3.5.0-beta01": {
+   "module": "sha256-YzK9ZD+e6SksOcyrF3g/AszoOy4mfzePyPZ1N2FEgpM=",
+   "pom": "sha256-SX2zjcIQwvOy3H5UZfMGX/2izxHZ/AZ1ymwAPNJRH+o="
+  },
+  "io/coil-kt/coil3#coil-core-jvm/3.5.0-beta01": {
+   "jar": "sha256-p12Kp4UF9dNaTpxrBUxvWMMZQmIvLlyz9sVAKQO90oc=",
+   "module": "sha256-cDAPYSpXzEI3fLUXzChFIzY5kh/WJXUYh0A4onEDvZo=",
+   "pom": "sha256-meZ54pjrIfRZf2Ne25JSsfWFACxecyesYj3FE9udRNY="
+  },
+  "io/coil-kt/coil3#coil-core/3.5.0-beta01": {
+   "jar": "sha256-11MYayv1c8q7UGRu4/AivT1ZrCc8kaRwzGZdGFxwloA=",
+   "module": "sha256-aPn/xzlxCbW0vYmDbfY7CP80pI7mW64NCRxprbUvSW0=",
+   "pom": "sha256-XacP9kPOGyJeYbxuS1SWPl/i+UoBYlPeJ8RW6/xWavk="
+  },
+  "io/coil-kt/coil3#coil-gif/3.5.0-beta01": {
+   "module": "sha256-00qJ6/w7MoGnSfCCIxo3Cl/3Q+Qw0nw26XU/vBZHqPo=",
+   "pom": "sha256-k/vcQcIbLApBXw0KWhuDP/Wn8aN0eg1BcQ52Vr+cWXc="
+  },
+  "io/coil-kt/coil3#coil-jvm/3.5.0-beta01": {
    "jar": "sha256-FuRMFYG9fFczMNTIMUU9gdLKUGWtgZxFyuj/lkExepQ=",
-   "module": "sha256-29d1JoWn9q6dRZp8XGRUIcOc+R82E20DJdrk+6ssOWU=",
-   "pom": "sha256-hwcuI9DzN6vjUFVaW535RMfVn3735cW9meWIGr5BASc="
+   "module": "sha256-yeTTr2pkjU73aXVOCIk/jtQNqwUh7n9+aohRT52yoQY=",
+   "pom": "sha256-ixtB8PEPMIUR0r96/u46KmooBcB6dMfi13K/UMOUSFU="
   },
-  "io/coil-kt/coil3#coil-network-core-jvm/3.4.0": {
-   "jar": "sha256-pendnwlGa9qldwAiBk+9nAHP1nIpo1aLFmSpep0TG/8=",
-   "module": "sha256-0PBWjEA2kr76N0ardL4Zhpju247VS5A3JyYTYPKrgeY=",
-   "pom": "sha256-x+h8S7FnrR7QHy6ma+7UU0GrApk/Jzg2Uv57rHBA07w="
+  "io/coil-kt/coil3#coil-network-core-android/3.5.0-beta01": {
+   "module": "sha256-PZfCUTC2+kjxl/bj8R/RA4Rif3P/hu1yaRi1rcJV6p8=",
+   "pom": "sha256-x98DK2vfpJBBIvMCX6Wuufn5njmgixlZna0y47pPIf4="
   },
-  "io/coil-kt/coil3#coil-network-core/3.4.0": {
-   "jar": "sha256-UvW4cp8b2QIjmvL3kzz7DHYRLwEO6GYH1EdnAJwrqyQ=",
-   "module": "sha256-HwXhOXxUXmlg9rIsBbP+S0uxWAk+5Zc+n5qu69sCSHU=",
-   "pom": "sha256-98udG+JA0nNXljQLujPmAV9QLxrla6eZXrL4gNCP5io="
+  "io/coil-kt/coil3#coil-network-core-jvm/3.5.0-beta01": {
+   "jar": "sha256-FXEFoZjH0aZDC7ANpPfIXWhxfbpZOOuREmrsURg9B5Q=",
+   "module": "sha256-3WyJ/F6rgLIVqTzMehdzvxWCWN+5vzLlzUlzVXC+H8Y=",
+   "pom": "sha256-O+W2gdZA7BQfWYtOQTEYWinYk7Khwaniaf+je+c//Yo="
   },
-  "io/coil-kt/coil3#coil-network-okhttp-jvm/3.4.0": {
-   "jar": "sha256-lpMYS6Nfve4MrGRNR1FBB2rXieNJ2SEmx63bx7ib3Cs=",
-   "module": "sha256-ANWexH86+CoVVLTaGpLmzcvWxrO6pgyQpfGQRFsakM4=",
-   "pom": "sha256-SgqzKTsP/0a3H3DvLTY4tsqvUXaRiJRBbO5qSS7jdsc="
+  "io/coil-kt/coil3#coil-network-core/3.5.0-beta01": {
+   "jar": "sha256-irMBKkLATfMmmw1MzoLTYLzc6PyIKy2Mc+ZGbcO0G5o=",
+   "module": "sha256-EdegVJkMBY5O5XrPhgc4GNCS88gsRzzj4/bkl15zw6M=",
+   "pom": "sha256-le7vs3offwSGSLB8h3RJKI87KUXp7M1zKEERSjKKotI="
   },
-  "io/coil-kt/coil3#coil-network-okhttp/3.4.0": {
+  "io/coil-kt/coil3#coil-network-okhttp-android/3.5.0-beta01": {
+   "module": "sha256-4WIYVlAJNJisD/qxQ7+eZPNIlBKubM4Wv4BLpJrC0xU=",
+   "pom": "sha256-xlr1aGiYw72NiXnhZWy/K9G3wLIxXwK1kNNeLk1dNQo="
+  },
+  "io/coil-kt/coil3#coil-network-okhttp-jvm/3.5.0-beta01": {
+   "jar": "sha256-wtJ1Oc/OHgyPiTQsSvPrxG2TtJlUP3MD2z4/OS9iAhY=",
+   "module": "sha256-YLRVEMmdUA+N7xrPN9AmpSe0lc/bhzYVrIhdm7iiLmk=",
+   "pom": "sha256-XseMXREdINV7/neMg2e3woD5Zx7EXLic9WXwYOleSf0="
+  },
+  "io/coil-kt/coil3#coil-network-okhttp/3.5.0-beta01": {
    "jar": "sha256-mUDHZn3QbRihsY0j0ktKlXvXEFif66VLUNlhiEUtHpY=",
-   "module": "sha256-2ob7y0O0kO8ZTUCr78U+bJd1Y8czkwGnaCFff16RvwU=",
-   "pom": "sha256-PLlSeecJZr5qjK4HdZcjKS8p28XbLX3c4K4oMV4a2GQ="
+   "module": "sha256-KwxxNAeN+iGBEapuqzQFbQy8vYzOf1k64YwPy0lXbk0=",
+   "pom": "sha256-gay9LyJJtLkzXC8650pAsNHInjls1XPOPiK7dmZVwGk="
   },
-  "io/coil-kt/coil3#coil/3.4.0": {
-   "jar": "sha256-gzU2f+hZSf1wwIaVbiEL3ZPj0o6+diXnjpkLUbBzq/8=",
-   "module": "sha256-0yJb8IXYbZ1kkfEDMEQ24MR7fnvOttkQicqZTvAjg3M=",
-   "pom": "sha256-ehSZzkBhq7uO5z7s7o+cjLpccy1kmMTVXDkrXkeefpY="
+  "io/coil-kt/coil3#coil/3.5.0-beta01": {
+   "jar": "sha256-fhq+PVgs1+kxFetX5ryjpCLDjtKHXRHnqfOfF1sJYF8=",
+   "module": "sha256-Y6u/NcatELbrNBNh0sgKcVJAqIrbu59JjywVhCCAdnk=",
+   "pom": "sha256-3zQRrqSTGs/PiqV8kLDjh3scJA+2K2hA3E51LY/TFDQ="
+  },
+  "io/coil-kt/coil3/coil-android/3.5.0-beta01/coil-android-3.5.0-beta01": {
+   "aar": "sha256-4eCvVI1KilNZAiHDBzZzka0GtCYZ3wQuJ8mwAjV1tX0="
+  },
+  "io/coil-kt/coil3/coil-compose-android/3.5.0-beta01/coil-compose-android-3.5.0-beta01": {
+   "aar": "sha256-qgzc8LzqR8hBTvTG20ZNNi+L/8plKD6xNqXtKE+CuNk="
+  },
+  "io/coil-kt/coil3/coil-compose-core-android/3.5.0-beta01/coil-compose-core-android-3.5.0-beta01": {
+   "aar": "sha256-h9pmGwUI0ZxjStzP/liPttoLC1/PUuC7HQAbjBC3jVE="
+  },
+  "io/coil-kt/coil3/coil-core-android/3.5.0-beta01/coil-core-android-3.5.0-beta01": {
+   "aar": "sha256-hjoM21bp6l17l7YBo+DVFqytKSaRmY5eNqAWx3eo9+s="
+  },
+  "io/coil-kt/coil3/coil-gif/3.5.0-beta01/coil-gif-3.5.0-beta01": {
+   "aar": "sha256-80lx4EcIaExv9Hgsn+6T+bVwUVzY5v/6OJPUIvhOZYU="
+  },
+  "io/coil-kt/coil3/coil-network-core-android/3.5.0-beta01/coil-network-core-android-3.5.0-beta01": {
+   "aar": "sha256-1bEVcTQ18ScKzBw9LuTUIdyDvOSRhIW/g4if+fkDcO4="
+  },
+  "io/coil-kt/coil3/coil-network-okhttp-android/3.5.0-beta01/coil-network-okhttp-android-3.5.0-beta01": {
+   "aar": "sha256-NDon7OByAjAPDmobjWI+U1PAU2aYRP76skFrGtzKdgE="
   },
   "io/github/java-diff-utils#java-diff-utils-parent/4.12": {
    "pom": "sha256-2BHPnxGMwsrRMMlCetVcF01MCm8aAKwa4cm8vsXESxk="
@@ -793,6 +2198,10 @@
   "io/github/java-diff-utils#java-diff-utils/4.12": {
    "jar": "sha256-mZCiA5d49rTMlHkBQcKGiGTqzuBiDGxFlFESGpAc1bU=",
    "pom": "sha256-wm4JftyOxoBdExmBfSPU5JbMEBXMVdxSAhEtj2qRZfw="
+  },
+  "io/github/kdroidfilter#androidcontextprovider/1.0.1": {
+   "module": "sha256-Yr0DpoiTACCwevVi8YDE5HAZRvhjx++mITlp3IHKWDg=",
+   "pom": "sha256-XESpbotbhEnKaAf2WDeod9P6waERqw+xKW37aTFk8D8="
   },
   "io/github/kdroidfilter#composenativetray-jvm/1.3.0": {
    "jar": "sha256-9WFazSLSGP8smuRttNoUHImIuhz1UvP5QWDiTki6zis=",
@@ -834,6 +2243,10 @@
    "module": "sha256-MESuVblJgO2rT4HMqbFFQ+g8h0B1g96dtAHZuMdbOaU=",
    "pom": "sha256-ppnWzCJ3L+KybcWm/y+brDpIsHTVLfsjmrKRisVtTsw="
   },
+  "io/github/kdroidfilter#platformtools.core-android/0.7.5": {
+   "module": "sha256-KpEP5zXN61K8NxeuYJsKjehjClV8GHeBr9rzmQnmN/w=",
+   "pom": "sha256-4mESu4kE7J+4yEk2MpVFn9LqyqnEhk+bvrSgmOva93Y="
+  },
   "io/github/kdroidfilter#platformtools.core-jvm/0.7.5": {
    "jar": "sha256-9JW3mMkkbWaJ1rmImJcK8u+geEYBK2UfgQ+UBn35ihs=",
    "module": "sha256-CSgA7Vb/8ZxyuIBo4Y7YNhFCkUaHSj3GeVS7nuYWzaY=",
@@ -843,6 +2256,10 @@
    "jar": "sha256-reaoCgAWiypY8gdevCv+myB3p4MqZbg7zJjnmcLz+68=",
    "module": "sha256-ITmBJcYIYR/zTyU2TGQ+r0fTpTgwe8F+XKDH+fzAvr8=",
    "pom": "sha256-aerg3Dk7+0G8E5nm7hfKSqHWIs4LoFnLkgzNaf//uNw="
+  },
+  "io/github/kdroidfilter#platformtools.darkmodedetector-android/0.7.5": {
+   "module": "sha256-1s892+2kwMrt9/8tqBhG5oAT5ebTfWJ2RsdcxZbqYik=",
+   "pom": "sha256-JH9IMdvNE0vNAxpCdKxR/jCdWTn5DGsGZMM1dkXbFSI="
   },
   "io/github/kdroidfilter#platformtools.darkmodedetector-jvm/0.7.5": {
    "jar": "sha256-iJW3nq/QvLgQynu/0Oog76P4OsQMG74qwwB2Nt4DISg=",
@@ -854,139 +2271,338 @@
    "module": "sha256-kibzxBq0koDI2ICOdnCGJkvK6Wa2HjjhoZ/Z6DjS+d4=",
    "pom": "sha256-aOCPC4VPlpixFzpkVstualPzc65tzLv3XL/ag0TiRwA="
   },
-  "io/ktor#ktor-client-core-jvm/3.4.3": {
-   "jar": "sha256-85Jh6JTfw5LHOnyeTNnzpvIFOadSSdi5xMJJuAD9+PA=",
-   "module": "sha256-kBoGXtZEzRzJQNy40jS1nE28Q5md96Q752G2XVwWbMM=",
-   "pom": "sha256-nuva7qpaGilELP/LjGuARFMxOhfyzdc4lGTp1jd371Y="
+  "io/github/kdroidfilter/androidcontextprovider/1.0.1/androidcontextprovider-1.0.1": {
+   "aar": "sha256-zDyE78B5I2BHuxmhxeY2qCZolf/3xAOpyKsQUegFF6U="
   },
-  "io/ktor#ktor-client-core/3.4.3": {
-   "jar": "sha256-EVePpxQnYKfAjFglRs03SCsjaExmjGlpMvbBhwtvwJ8=",
-   "module": "sha256-nJaxhi3Dnw9oM9nALH3liAbWfZ3MYlBO4r7obaGSMB4=",
-   "pom": "sha256-f8THD5i9nQtzAQ+GRCNLXoi6xt1pRIgftFbFO+FT4n0="
+  "io/github/kdroidfilter/platformtools.core-android/0.7.5/platformtools.core-android-0.7.5": {
+   "aar": "sha256-ScFRBvn1+2x8GkvDsJsifOa8/fJ7wtBO5kWPfiom8tI="
   },
-  "io/ktor#ktor-events-jvm/3.4.3": {
-   "jar": "sha256-DwShuDgBMaFOlwW/HcvJ3yMvEkFTP8W40avYMHR93KQ=",
-   "module": "sha256-eeEIV/SWgUg1Pei+2HDfZqifPr8d6K4LaM9ff2T2+Gg=",
-   "pom": "sha256-9UhK45rMTWxivK2R+LbzroYqxrxoaemh8s8bo+7jalA="
+  "io/github/kdroidfilter/platformtools.darkmodedetector-android/0.7.5/platformtools.darkmodedetector-android-0.7.5": {
+   "aar": "sha256-WS8N3Brt8GS7/LoEKjia5M416c6QAeh/f/5LTNvwNKc="
   },
-  "io/ktor#ktor-events/3.4.3": {
-   "jar": "sha256-AXH8Y+I+z47LsUcn42ohjtCQ13AmIaQGZjDmRa/DKnA=",
-   "module": "sha256-iFOMVNRUJlYsI/dtPg0Xh5dQu2dJla0gERa4UrAIhdU=",
-   "pom": "sha256-AMiqw04HLRxxjWn5e7Xaejg0YvaNiOoMHFp+3kd95+k="
+  "io/grpc#grpc-api/1.57.2": {
+   "jar": "sha256-QrcuZXLAhAVaw84D5u/kM+sF72ILPa9RNqQ1n8csw+E=",
+   "pom": "sha256-x99FUaZPAoKnZugJUU1COEUKdCkFX5x3GIgdFqMQoCY="
   },
-  "io/ktor#ktor-http-cio-jvm/3.4.3": {
-   "jar": "sha256-8ElYQSa29Nouk9fUMzYpYxLiqI1dUmPx0dJPG41m/zo=",
-   "module": "sha256-ySfYy+G12KCFyJRlS4rLwJoHkn0cGhxjW1VtN+NBTFQ=",
-   "pom": "sha256-JZ9NsLXMSaR1c0v3hIehFaGS6S/AmJHhHhlhqmiaDwM="
+  "io/grpc#grpc-api/1.69.1": {
+   "jar": "sha256-qNPW3McfOrYT1miEIoK0iL3ZPT6ZoO9dyn7ub6c0woM=",
+   "pom": "sha256-vq8uR11cRdBjTU0yS/hNsqjWqSkilx5vfcJ+hRxCkH8="
   },
-  "io/ktor#ktor-http-cio/3.4.3": {
-   "jar": "sha256-MlFo99aA+JBzl/87TR+WiNzJILJYyHSpE+OzRfJBYJk=",
-   "module": "sha256-bJGF/f35izzYbLpwez4NoUr7ihTePe20hccafwPMyuU=",
-   "pom": "sha256-62gfWQOGEvNs8oXWt6bpyuWDBCTwrPmaAWUUu8nYjp8="
+  "io/grpc#grpc-context/1.27.2": {
+   "pom": "sha256-DyErFOvYNMvtm9iGml1snBeY7OtRLH/MKNqJ9vik7dg="
   },
-  "io/ktor#ktor-http-jvm/3.4.3": {
-   "jar": "sha256-sxNMLGxJvMl0ekJCeNByPtuiSiU7NkUOq8x/pWLirak=",
-   "module": "sha256-gq5sIoutescyEwStMduZdvPP0zOPOazWtPNIKEAkvpo=",
-   "pom": "sha256-wdL9ezT+PT/mFSZXkZJvIBeAwfUHJk1uodKk3AHdmsU="
+  "io/grpc#grpc-context/1.57.2": {
+   "jar": "sha256-m4rIjZzvKBna/+1729LyJoAjfUgsbGcf4C022j8IzwA=",
+   "pom": "sha256-iSf3fWOB4kSHaCcIGWpspyg2i4/XzrsQT9kyS2sSSRc="
   },
-  "io/ktor#ktor-http/3.4.3": {
-   "jar": "sha256-dELHB5CPgs4lZkz6B3CYx6l+qeuTbMKivhT6kp0XieE=",
-   "module": "sha256-N0VSChyPVCRmCovRJ34JlqH/Ehp1aVJmqR7PEti5/iM=",
-   "pom": "sha256-TRz1iMxd+vLlf1+yrnMjxA3pY22q2/5lLofqmPW8VkM="
+  "io/grpc#grpc-context/1.69.1": {
+   "jar": "sha256-Re+VuMFYqLW906y2e55oLvJUFLsUj0iOyEdDirZHFdQ=",
+   "pom": "sha256-beKbzqslob0L4R7qhGjQ4/HAxHbQpTMhW0/eHIKEtXA="
   },
-  "io/ktor#ktor-io-jvm/3.4.3": {
-   "jar": "sha256-RdpGKS4cKwWAxIfrp2fX28tQRg3y1uiTf0PoddkrRN8=",
-   "module": "sha256-nc98up0ZHkVwxE1EP5TWCyhJiIkc40feWWBXocNsppE=",
-   "pom": "sha256-LtT6ft1CHFIGV2/wlOXwHodDjonSYqVOZZmSMlKGCWk="
+  "io/grpc#grpc-core/1.57.2": {
+   "jar": "sha256-WhAHCr/rSWbsTVgJYdzE5/afqDqyUkL5LBdl77B7hgY=",
+   "pom": "sha256-CpcgGv4Xh08DX4ol/7lwZ45Jqt8pksfZfG/5+x1dohE="
   },
-  "io/ktor#ktor-io/3.4.3": {
-   "jar": "sha256-bi8Bu1BC9U6yPX1vrm9S3FoD9rH3o2agu+m2606aiC0=",
-   "module": "sha256-//2lHn3hMeIpcl+0IVMSi++p5rkRNAmxD4gZ0ehhdi0=",
-   "pom": "sha256-vqyeo/zmS0cuMVI2afPLIX0xnqs8qd5LHq26ZBZV1Jo="
+  "io/grpc#grpc-core/1.69.1": {
+   "jar": "sha256-UTUsra7L+aSkqkLZP28fxyjx/QGwUWgDg+0J5WMf+9A=",
+   "pom": "sha256-loCY9KhFG7zT17iMaoq1t6dO+A397npgUvNS//eDssU="
   },
-  "io/ktor#ktor-network-jvm/3.4.3": {
-   "jar": "sha256-pro+Kta7OKI7CPCO3DLjpgBArZUsbDqeCIctXZbdi0U=",
-   "module": "sha256-3wYcaZ9FR9LhGCepP0+I/lEfDK6/hXNOAU32gIkiqKA=",
-   "pom": "sha256-T8kNVYjgG5tXc+5MG6C9r80a1mLksHtXWLBMTR38FZU="
+  "io/grpc#grpc-inprocess/1.69.1": {
+   "jar": "sha256-t8asDjq/S41YJhDWMteUF7w9qBJU4aS89/Aejbe9Ve8=",
+   "pom": "sha256-/rswpc8jgjfQdaOSPok5khg9rxcaHrQ0rPEyEUpff4o="
   },
-  "io/ktor#ktor-network/3.4.3": {
-   "module": "sha256-Mo0KmmgMefqIDSvcGGBNuOB3U2sT/lb2KM/ILbRWAxw=",
-   "pom": "sha256-9HGimig98gDhJT/vCsw+yOMPGtSyFLFvWnQJy6zzZko="
+  "io/grpc#grpc-netty/1.57.2": {
+   "jar": "sha256-mAnUwQyU0R57KUbN61sohL4goJUQKJVE83Vp8CyHeiE=",
+   "pom": "sha256-ixIWHPKqz785j7Wvw7DXOiGvIGulDD2Pe/T2xLN16/g="
   },
-  "io/ktor#ktor-serialization-jvm/3.4.3": {
-   "jar": "sha256-WH37qUYnL2W0El/QpoJCxC2E3jn/wrguN7q/N+QtaRk=",
-   "module": "sha256-1tWshNysj1H91xB5cm0Wec8XSUxIF9VEfmY68pGgIMU=",
-   "pom": "sha256-23rkKbgpGlRXi4djqD0LJItBM64l6HjibDUGIHbluCo="
+  "io/grpc#grpc-netty/1.69.1": {
+   "jar": "sha256-Uqhu1m94kz6D0aP7cWKtFmdIlWTEVWNmt6NXnHAkpEc=",
+   "pom": "sha256-jwZlDMkUKMxRMRG/676r95mUGF1yREsC5d+so4vkNxQ="
   },
-  "io/ktor#ktor-serialization/3.4.3": {
-   "jar": "sha256-tgY1K6fiKrmbRZjH3UGrk64P8YhvD4/93ZmnmBsyVA0=",
-   "module": "sha256-T+4wl1yw6S4NYqMkioF0sfB7uI62DF1laKNRJedWCPs=",
-   "pom": "sha256-4upPJ0roD+p5VYJDWkOJ1cmH15Uanb5aYJsUMWrmFGw="
+  "io/grpc#grpc-protobuf-lite/1.57.2": {
+   "jar": "sha256-/EkX3F1BmsgQ+z8nUjwU514f5QNyFU+rKTJCFe5qlVo=",
+   "pom": "sha256-YHeMHqQHo7oKfw8J3wmegnInjoq8KYIsnPUOGgUvG3U="
   },
-  "io/ktor#ktor-sse-jvm/3.4.3": {
-   "jar": "sha256-qQaybsUziQFskuniSunXmXbj5YJncT0Muajyaj8/aQc=",
-   "module": "sha256-GAzZFl4HYVhbtTmjRTR9zKw8hqE8dMRnL0ytITfoGsw=",
-   "pom": "sha256-clI40vwgtKittZB6vTOQcUa2LJJG3UFp8Tp4pikskaA="
+  "io/grpc#grpc-protobuf-lite/1.69.1": {
+   "jar": "sha256-wp+Q+t88diD5NZokPAZ92FtzvXZbKPPZXfkQrC0zFVU=",
+   "pom": "sha256-Jj8fhE11bBXbX6uIaZZeM3IrP0/pB/4ciFqQ4EZGFzE="
   },
-  "io/ktor#ktor-sse/3.4.3": {
-   "jar": "sha256-CyJmwH4hDhfrJAsttWPnvpqcnC96WFdOqqZZOgtlX+0=",
-   "module": "sha256-44dTyTiU/6SGb2ftjhDjd9xwCdJPdsJ3aIsu6dEsTMs=",
-   "pom": "sha256-iZfzk4e1n8qxvvFcfuQ7eymDJOs5U+MXOfDJ7hDDn4Q="
+  "io/grpc#grpc-protobuf/1.57.2": {
+   "jar": "sha256-MWMNip6fCKlZhiAV4wpIY5CL42gMOmhvTB8I0v/q9wY=",
+   "pom": "sha256-xeIpKAIFOXfwRhCxcEhKmh6mrxVBwUSyfRiECsVE+p0="
   },
-  "io/ktor#ktor-utils-jvm/3.4.3": {
-   "jar": "sha256-5Iuc5Rhw9BDHq1wEDI5tAmlIJ+v9/ForhPCGrQSbtWE=",
-   "module": "sha256-OxfQWvPm0mTnYqh9wor5ipRcvXIJtqbu0/KrXIH5Xx4=",
-   "pom": "sha256-M0ozEdk/iJ0R9D4Mt5/jq8TZjaYVTTt/z7oXbbmDS6w="
+  "io/grpc#grpc-protobuf/1.69.1": {
+   "jar": "sha256-TFLvlI+4mHo7qn1GujYre/MH3TxR8pJBzVxZg5igEN8=",
+   "pom": "sha256-v0ynbSrORNlpRxT7zz/XKcmO8uWGOrkgpIPAUqIvRCM="
   },
-  "io/ktor#ktor-utils/3.4.3": {
-   "jar": "sha256-YiCmt/pEy7dKg9Q4vtPpR7ou7VwQxoyeUA8fUv8wsXc=",
-   "module": "sha256-NRoL9TGXRIj0tH82hNfiMJK4+epGwWDw7TCl89NQgQE=",
-   "pom": "sha256-nKnA3GjHIk2iLx4uM7LvPmXLBOtL8SaJwZcLX3JIzbs="
+  "io/grpc#grpc-services/1.57.2": {
+   "jar": "sha256-BXpDumR4M3VqsvhRusgKO5+NzgJvwawfF9TzFWSPQXI=",
+   "pom": "sha256-dHYBoDpYoYl5gZrFLO/8WGuPnGprQi4XI/Mmr0iBPrk="
   },
-  "io/ktor#ktor-websocket-serialization-jvm/3.4.3": {
-   "jar": "sha256-2ZmnuQs9mtLvDRF8Ss5isQvXrBNFzRxqdoCkP/++DtA=",
-   "module": "sha256-aA7NoHNJxf+3FzVwVRd7fehIpu690bXIhvlzzzpwgDg=",
-   "pom": "sha256-uFOTESsUbe6LlrdxuoyiCjY9bmtO8W5T1ZP1bgXPcnU="
+  "io/grpc#grpc-stub/1.57.2": {
+   "jar": "sha256-hNKvEnGRaPdjdfKv39brUTOoZe26kkTUDmuWjjrd4dM=",
+   "pom": "sha256-IVnmFKh5R3XrmOLhyFg0q05ZEb4cSnXHFjqZPpyJK6w="
   },
-  "io/ktor#ktor-websocket-serialization/3.4.3": {
-   "jar": "sha256-PRUs4CTMJjFuJEU3HPhPr+JiECQc13vF58hD17/n0z8=",
-   "module": "sha256-13WjyEC6DDt9WOtQZ33kG0OtZbBsrVlBAhF+XlxRXZc=",
-   "pom": "sha256-QSPdZhKyV50uomw1TwhNJyxDkZw0ansWvUNedYK4hNA="
+  "io/grpc#grpc-stub/1.69.1": {
+   "jar": "sha256-45xjJz1TBS6+n2ONiumBdnNexWcyjZoXCSzdtvI5uMI=",
+   "pom": "sha256-9a2BV+xA2KI0djKWXWoD0YpIrUYl8y62SzenpHDOU7s="
   },
-  "io/ktor#ktor-websockets-jvm/3.4.3": {
-   "jar": "sha256-7S+/uB0wKc8FpirHttRbOKhzoC+O5gsErmU0btUpnuQ=",
-   "module": "sha256-eXohs+3Xxgs6GiMKYbEfkoEAJVD9LwCnmB73XUblJkc=",
-   "pom": "sha256-k2UZSibMt2zh5QG+UngqZRULt0XdzUibgcFHwL6r44U="
+  "io/grpc#grpc-util/1.69.1": {
+   "jar": "sha256-3Vl71nXqoELz41eGSNkFDIE8RZXF3mhp753btEkAYDE=",
+   "pom": "sha256-0g00aMt01WvlXtPUb2PKOO5LygkY2arXJ3pEj24HpbQ="
   },
-  "io/ktor#ktor-websockets/3.4.3": {
-   "jar": "sha256-DlDrexsDI2CHmF/v+VmXsayEcuge4IoLzpRTnWL3ibc=",
-   "module": "sha256-xTwREBNT5YY31k9EevyRPGVUHbgDOeB+q7PeWiGD8BI=",
-   "pom": "sha256-UWoi9aLNpSqE9e4WFcfKtvKABy9GqYNY5bRjS2zh/mQ="
+  "io/ktor#ktor-client-core-jvm/3.5.0": {
+   "jar": "sha256-VPHR8goaFXYdC0RaisGyb4WVOsNf4id2N3xbQWb7N34=",
+   "module": "sha256-M9wLAQXnJM5N3l37qyIws/FE+4czdSqHWXOQJ/q7YE0=",
+   "pom": "sha256-uN/og5qZl25LOIg+MEepXWbpjCICinGZvSuWtItGQmk="
+  },
+  "io/ktor#ktor-client-core/3.5.0": {
+   "jar": "sha256-MZOSBfhiEFwvY0YnKrtVSRRaFbRgJf5o3xrT6bXErPY=",
+   "module": "sha256-vSX44EwJcZ7txWV5aW5xjZxhLVypZMDp3oEVtCSwO/Y=",
+   "pom": "sha256-bihc2pmG1VOcBJNCwqftMRY1MYRKt/3JJQCwBSe9NHg="
+  },
+  "io/ktor#ktor-events-jvm/3.5.0": {
+   "jar": "sha256-jUm530dFrH4hOGTdQkmwmLTr0VZviwCHuL+3rM4CS1Q=",
+   "module": "sha256-VsG1N4ALdcgks1iZ+pBOkhjk5N9sGVi0j4FQXPLf1Kw=",
+   "pom": "sha256-pHpoFsDiyVauryyEiaxAxKGupz1fblmlvCyXVEkkHkI="
+  },
+  "io/ktor#ktor-events/3.5.0": {
+   "jar": "sha256-y2t/GV/ZyDsXJxL7E2i7me5gHCM66+/7nt8XK2oQKkA=",
+   "module": "sha256-TgRkCpmobTazws8DxgNvhflbqbr1WQG6PBwR9XalVL0=",
+   "pom": "sha256-3tNQHKZZ/2hVayAfsiMfA2k/YgQ2pV3cu5t1xJPFfS4="
+  },
+  "io/ktor#ktor-http-cio-jvm/3.5.0": {
+   "jar": "sha256-j+H7Hlz5hJ74XAnqjxmrXXom90ZEEBytSZBMakkVR1s=",
+   "module": "sha256-Wd2hYUh8kz7gJbzdlrO3XpkrUAtvsfbkj6AUiMWGG+I=",
+   "pom": "sha256-fCxaKuXskgIU3hcoryjJnoicm37cOTnRjvoORroduao="
+  },
+  "io/ktor#ktor-http-cio/3.5.0": {
+   "jar": "sha256-z+ZRVd4Smrx6O5bfYsizebK7Tj83ER+IQ8Fb8O+1Qc8=",
+   "module": "sha256-7fcPLn3Y5aGTqZ5NPdRaYw5DVCVAZNPk8ob2VIvHyec=",
+   "pom": "sha256-CL/Hjmc5tOE8F1/vRzI+wQaGN0Fh3U4Ug1isrlBAIzM="
+  },
+  "io/ktor#ktor-http-jvm/3.5.0": {
+   "jar": "sha256-K6usNV3jZMRzsnsGDRyBD8L4PtbkSCLqvGw/Rq3xVaM=",
+   "module": "sha256-cH+4Jd5xPg8hcp4K1tQYSZC4PPtaYceUC55Ooaugx44=",
+   "pom": "sha256-9v8xXUJu/ovnQCiUykxI30j8xeM0TxJJnShri+q6Mmc="
+  },
+  "io/ktor#ktor-http/3.5.0": {
+   "jar": "sha256-Hf1GUk4bvz7XtPUjdlTYcY+RGGRYgoQlX7bLcv2FsnU=",
+   "module": "sha256-VkIoS3asAW2DnBwoySXAbiq09tFt+nN6H/iJZfHZN9Q=",
+   "pom": "sha256-OrhYDEYAvqGhTA9pgm1n5hHzEnhbsIpGRaZ91BAojkA="
+  },
+  "io/ktor#ktor-io-jvm/3.5.0": {
+   "jar": "sha256-yp+UQ0eSBP6XoAvVO8Pe5bBRTBoIjp3x4OTUzPxgXlE=",
+   "module": "sha256-/QxmE+yCfPCdICdT5sZj57OT92awmNPhAbUCtnfb26g=",
+   "pom": "sha256-xQyDA/OG6CX+fmdxIq4rnaAbJhr6Ph9woWwIiHcmbMU="
+  },
+  "io/ktor#ktor-io/3.5.0": {
+   "jar": "sha256-slbt/JjznwD8Ysjq1HCsrce7tuYoiJoOMcYX+a37kdM=",
+   "module": "sha256-y2FR4vesZcJwKLFt7jMqTbvMwVMFgM/T/o9PKwyKc0c=",
+   "pom": "sha256-biSVDcRyz1+8qGoFeC0ujT4QSi9kWPOb3d3m0bescrU="
+  },
+  "io/ktor#ktor-network-jvm/3.5.0": {
+   "jar": "sha256-IBWJCI8PIZom0S4B58TlszWP0okHXBt5nRXECEccGYU=",
+   "module": "sha256-Riu72moAj0JA7m2DHgUWgupy86GIvgbEE+a69pIHMt4=",
+   "pom": "sha256-9GIDluO2+pTy+F4KQasERQV8naRT4QJjASkDm+dLrZo="
+  },
+  "io/ktor#ktor-network/3.5.0": {
+   "module": "sha256-XodNKhs4VuDiisLzG+ACVCLTm/kX1lx7b9SGL4zipKs=",
+   "pom": "sha256-Ow70GRGvz0G0o4Rvch1GRWVZ0tE5h5QJuqgr0bRC1Y0="
+  },
+  "io/ktor#ktor-serialization-jvm/3.5.0": {
+   "jar": "sha256-0Ivvxng8T+n1wIV5mzLqcCf94eXQinrveVQTpjPGhjw=",
+   "module": "sha256-1DKnY8QrF4xkffgkVo1IT40yQb/fqYVaAhScI5eB02U=",
+   "pom": "sha256-NebJO0lWpFB2d54X4P5lzWBnuwa/Zg/C+KbHzuwWreY="
+  },
+  "io/ktor#ktor-serialization/3.5.0": {
+   "jar": "sha256-/SrvFQlzPKSOhMeVPMdy52gWhCiVyTc6ctQqzPbBDlY=",
+   "module": "sha256-OPh4TdgVNYCecVoeMGxq88/TCW5N0IQbsTggOTuHQWo=",
+   "pom": "sha256-X8Lm5Daq0RuqQ4GowROk0wzQbmfU62ushXpFIs41q0Q="
+  },
+  "io/ktor#ktor-sse-jvm/3.5.0": {
+   "jar": "sha256-lBhxZYxcm+1dFxKbB0chDphrCKV6R4+EzdmivNigCIQ=",
+   "module": "sha256-V7KFlTRixcTdg+oqatrF/hiEDxUVb3VUjGOSGPSGvns=",
+   "pom": "sha256-ZLF7TIWcMQKgCf2IMkFw7zNx2Oz95PpAIMuHj1lm2Kg="
+  },
+  "io/ktor#ktor-sse/3.5.0": {
+   "jar": "sha256-H0g43bfVfoS905E69LQGJ2Yqvbyi+6iSG4Z/GmLQv10=",
+   "module": "sha256-6Usv/TfLarDOwXQKxr+bE4PosmzLkIgMcAEh6xMpxgk=",
+   "pom": "sha256-wahVhBWICx1OHJ87tkivI+AzQiw8grjQqLNnk3nUCp8="
+  },
+  "io/ktor#ktor-utils-jvm/3.5.0": {
+   "jar": "sha256-IUIA8HSv6dS5FdNHOXtcH3aPvdEOrXGS6K39Zi3Upy8=",
+   "module": "sha256-lr8SZTPTjLiz8WkRw2mAwts+dGxkh4KIADoLbhk4WuM=",
+   "pom": "sha256-We88Ni2DBk8LBkx5SKzjixmfZxcYPgqtCOnoJ5Kbh2s="
+  },
+  "io/ktor#ktor-utils/3.5.0": {
+   "jar": "sha256-1syTBOx3QJllHiDG0y3kpn9t04FvkefJllN4PJKQ9Xo=",
+   "module": "sha256-KSPNpVwBptcAWoYPW4/9CHLucEuLKNFM6QWl6ma7qsg=",
+   "pom": "sha256-JJKBcvdfDHkHSo+9rgL0KNR2E/Dz9asyonz2mRHCDS4="
+  },
+  "io/ktor#ktor-websocket-serialization-jvm/3.5.0": {
+   "jar": "sha256-z5MerkR9y+dgKIkd0YW2ReEbbHoQhyv83k/kCoLTs0I=",
+   "module": "sha256-6D00HGh91ohvvbVie9stNXOGI8Iuth+ZY4lmF/O48bM=",
+   "pom": "sha256-Ib4S+MPSfGr5cxV9w2ruXETAKHi8aK+LdbXSSzXKkuI="
+  },
+  "io/ktor#ktor-websocket-serialization/3.5.0": {
+   "jar": "sha256-t0VVWddBP5wLMIiSCfgkQBokNNj1zF6grTiLSFQ7dTs=",
+   "module": "sha256-dZVABH5cT1DbmSd9ECsY+ItHAZ/mhKoti5QTYtw+fCg=",
+   "pom": "sha256-14Oaz68+KwRzJkmakT4JDSQJjP6fWs+9sIFub8Svx/s="
+  },
+  "io/ktor#ktor-websockets-jvm/3.5.0": {
+   "jar": "sha256-7Ae0veE6PDrWFp1ix1owj9ERZ+q0qhqpuqJIRww5fOE=",
+   "module": "sha256-dl5OdlQONxCYC/z2xoQorvyypk4tq8R2JlkG73yIxOE=",
+   "pom": "sha256-oIc0oBdVRrwjZKFuQ6e5LjXxmmW9q9QTyLXB9dOhTyU="
+  },
+  "io/ktor#ktor-websockets/3.5.0": {
+   "jar": "sha256-3vZ9V1vRQtHXXk8XWHlW9IPAlWJYapzAL5KaLyEcIEQ=",
+   "module": "sha256-kvvRwTkxxVqWGB8fM4CyiKpWiLPHdgtGzBN+4DybY80=",
+   "pom": "sha256-WhVJDgXGmEzUgY1OoHlzxnoz1TtUayJXOVdon5ytwcA="
   },
   "io/netty#netty-bom/4.2.12.Final": {
    "pom": "sha256-Sx6sh5HJMaM9ni+4wINDJVLPh0adtBm30kNBeONPBww="
   },
-  "io/sellmair#evas-compose-jvm/1.3.0": {
-   "jar": "sha256-z0ANDakJZF+G1zUrr8Fll3ucyZ0KsPhm3Kj21x9D6oA=",
-   "module": "sha256-lPSPBmrTfJEdo1KiBwagvGctskRFg1qSc2gZ1H4gs+A=",
-   "pom": "sha256-a4ZqTh4vonYspaHatax8JWooP5jHa60GraVo/w1yl0Q="
+  "io/netty#netty-buffer/4.1.110.Final": {
+   "jar": "sha256-RtdOeRJarMBVwx8YFS/cXUpWmqjWAJEgPQuqgzlzrDw=",
+   "pom": "sha256-cQrBnMAc2A32vpo/qtPCIrShoy9LVRN74HtgmdXaNWI="
   },
-  "io/sellmair#evas-compose/1.3.0": {
-   "module": "sha256-tPb3Xfgpkqbcqtc37O0Q3xxlwrSEoLIghFPZDiom1e8=",
-   "pom": "sha256-ZJgX/ZaAWkx5mbqTvXk5t3lMYCQaDbm1suBAUGsExfM="
+  "io/netty#netty-buffer/4.1.93.Final": {
+   "jar": "sha256-AHx9nDeN8C05BWfQ1931Qv/dsCG3MT2/UCOSET/6uwg=",
+   "pom": "sha256-g/vFTitzuG1Vsgj2GNGioVaRDsFG9+zldWUAe3UK3Xg="
   },
-  "io/sellmair#evas-jvm/1.3.0": {
-   "jar": "sha256-tjgzqY9CQUFitnTfPDi9G3AHiHJuYXM91Mz9gAb9w7Q=",
-   "module": "sha256-+GZCZ4GOhqRjyLLHux+R/Be7BfGxOlFbmvW2tw/9fyA=",
-   "pom": "sha256-FkeNhw1UmbLDzmAnDYLJR2DYswHDvcU1AM4U98SHgA8="
+  "io/netty#netty-codec-http/4.1.110.Final": {
+   "jar": "sha256-3A1q9QVGMKcP8O81TyCqem5Gc4yfxWNu09T+d+OL1I0=",
+   "pom": "sha256-Ua6ZCvFKMh2209aIS5F7fUNj62Dd3A8Uk7GAIaFC560="
   },
-  "io/sellmair#evas/1.3.0": {
-   "module": "sha256-IookviLFssr0kQ6Zi+W3nXKaYVzObAQYNBfByxE5XkI=",
-   "pom": "sha256-dNeLQjL3wIqiktIuxRH2KMhPAa7YMbNTT/DHGplDiTg="
+  "io/netty#netty-codec-http/4.1.93.Final": {
+   "jar": "sha256-2s94znirLSlXAyXbTNJFHqWJY5gH3pWIGg+nFVqea1U=",
+   "pom": "sha256-o9r/8HG20oToBj2WhD3iu4PPO4iergzJ4K22SlejG4I="
+  },
+  "io/netty#netty-codec-http2/4.1.110.Final": {
+   "jar": "sha256-tUbHVEWkh7t7zVqUd5yuzOM1gs974xuLOfwOZbHuJvw=",
+   "pom": "sha256-KdL2wmw8yp/oOTZxcH/o75w+MQIKLf4GuCxCZJnCWDc="
+  },
+  "io/netty#netty-codec-http2/4.1.93.Final": {
+   "jar": "sha256-2WzAkEWhNBxtR0lDUqomO4e3L7HS6p7KFhqnOCC/6Ls=",
+   "pom": "sha256-CEQztC1UH3rEtZKH3SUyhc/aOj1l3nLnNou37D02cnE="
+  },
+  "io/netty#netty-codec-socks/4.1.110.Final": {
+   "jar": "sha256-l2BSo8m7KAvG2Z86KeZARnfPlYw94FsgUJPTjABriAw=",
+   "pom": "sha256-/+V7MWGR3U+WvuZsVwnBPL207KsIXAEMjbDGqoCav2w="
+  },
+  "io/netty#netty-codec-socks/4.1.93.Final": {
+   "jar": "sha256-DqR7W6I8odqOuRRsj8dVwScUFGM7Hivizh33ZLoP/yo=",
+   "pom": "sha256-jNgW7ZkalGBBurTLJL2cjkHuBpJRJRHy2DzvU462Bdc="
+  },
+  "io/netty#netty-codec/4.1.110.Final": {
+   "jar": "sha256-nszOmo2Ce7jOhPnDGD/sWL0clqUQEM9xEpd0YDSvNwE=",
+   "pom": "sha256-qAa7U2uzI2Zbr/fNEiPysnKi1HF6tPmxI2EIbarl3z4="
+  },
+  "io/netty#netty-codec/4.1.93.Final": {
+   "jar": "sha256-mQw3gWjcY2TG/1aXAfTy8SL//omYs+GJ66TE2GjtEIQ=",
+   "pom": "sha256-Gc3tJnoHDf8avJ0Cm1UvrSYqzBq6XGxnsiePyhE6Jqs="
+  },
+  "io/netty#netty-common/4.1.110.Final": {
+   "jar": "sha256-mFHsZlSLng1BFkzpiUPN1LvjBfaN29JOrlLkUBoNexo=",
+   "pom": "sha256-fUF/UzUwTa4eoIoGWGA4yD/orYTB01uqFe0RkhzveSA="
+  },
+  "io/netty#netty-common/4.1.93.Final": {
+   "jar": "sha256-RDuzFlmfsW47rrovtYiBgU1/8LevF2/nbjgHGm6G+MA=",
+   "pom": "sha256-QtiDsT6zjKv1SWFkYsXzMfUzO/DI/JIVdE+DwBgKT2s="
+  },
+  "io/netty#netty-handler-proxy/4.1.110.Final": {
+   "jar": "sha256-rVSrT+nEfvPnI9cSURJttT6NtUOHGtuer8lERlOe/1I=",
+   "pom": "sha256-xhPLTn4G9C76MduNiyoznti/QfAMRtONCQmkwGxlbc8="
+  },
+  "io/netty#netty-handler-proxy/4.1.93.Final": {
+   "jar": "sha256-KsX3+++gtz73g4iQaTRNVRVQWhSyMDvmk8UALEht8rQ=",
+   "pom": "sha256-bcUNoOZ/WXgSh0+B6qRUBPfQdrgZnqkIiTKoXBthAkU="
+  },
+  "io/netty#netty-handler/4.1.110.Final": {
+   "jar": "sha256-1aCNfeNkkS5ChZaN5NTM4/AdpLsEjVxpN+Xyrx+OFIo=",
+   "pom": "sha256-TUPBPRT1Y1oviw1QlNejHFCe4PUsck66DvMM/+PqFVU="
+  },
+  "io/netty#netty-handler/4.1.93.Final": {
+   "jar": "sha256-Tl9WOuFO1xM4GBbVgvX8/QYVrvspIDSGzft4LYoAoCs=",
+   "pom": "sha256-hKFSXKwLR1nvrvKZekf+Gbm1ZC+Sc/oP1YoudsegWf4="
+  },
+  "io/netty#netty-parent/4.1.110.Final": {
+   "pom": "sha256-aFra83Nmb8FUJ8gQ+K/zpP4ZSpfH7XS2nQfFSPDULxw="
+  },
+  "io/netty#netty-parent/4.1.93.Final": {
+   "pom": "sha256-sQnLdvN1/tuKnvdaxYBjFw3rfqLd0CT0Zv723GXN/O4="
+  },
+  "io/netty#netty-resolver/4.1.110.Final": {
+   "jar": "sha256-oum0rnyqkvxb10fhHR3sINgbGPwAlZVUMCJErFxWznA=",
+   "pom": "sha256-ZV80GS6MdhizxaeeSI5NqjXe9BsNFtRfo2Ujw7TJ9kE="
+  },
+  "io/netty#netty-resolver/4.1.93.Final": {
+   "jar": "sha256-5Zdwtm6Bgi5dERrE5UTX6wxUPgooX1JijlOUGs2O11k=",
+   "pom": "sha256-WzUMPJHp5V0py+aM/k7yEWzB8DKGd+v59hW6twgsefQ="
+  },
+  "io/netty#netty-transport-native-unix-common/4.1.110.Final": {
+   "jar": "sha256-UXF7t0cRQZUDkMZxOkSf2xBU0H5gc37n3acIN5bN7kg=",
+   "pom": "sha256-6hjOBMmpesDFH045exhSKf2VmX6QsRM5rc98UZRtU9g="
+  },
+  "io/netty#netty-transport-native-unix-common/4.1.93.Final": {
+   "jar": "sha256-d0FlocTbqssX+cGtZms1aaallxWugo58PUdwP0eaU+c=",
+   "pom": "sha256-Fbwltn/wpJJysnDvK4z/1iAFfKFssp3/etVmGtyirhI="
+  },
+  "io/netty#netty-transport/4.1.110.Final": {
+   "jar": "sha256-pC3Wg5DKFLT/LUBiiglsdkhbStt8GWAtUokyGgZp5wQ=",
+   "pom": "sha256-MPXaDnZG8YQNYy+IYVyLnYIFSZ1oVZucRUezsEoGg80="
+  },
+  "io/netty#netty-transport/4.1.93.Final": {
+   "jar": "sha256-paeAGbwc1D28PHt83TgBkSyibR9Jj7VgUU/uSXhkupY=",
+   "pom": "sha256-DdYqDrPLHqABpNBCbk9cCN8ccNkmVnW/+lxYNhNCLUM="
+  },
+  "io/opencensus#opencensus-api/0.31.0": {
+   "jar": "sha256-cCulXXjznVUZXc8EH9+qt6dJCprEUBNUJIftnk06TSM=",
+   "pom": "sha256-m0eVkefD4KtFOB+gQ6kWV4Fb3Yw1k68BDHrDb0yQWRk="
+  },
+  "io/opencensus#opencensus-proto/0.2.0": {
+   "jar": "sha256-DBktRR6d106Ychsn0C8OK2vKRLUVY7Xavy4hH3o+vxM=",
+   "pom": "sha256-twh5B5IPyKgVNGhrLxorMxEnr5fwFau9s3hqUfP6HlI="
+  },
+  "io/perfmark#perfmark-api/0.26.0": {
+   "jar": "sha256-t9I+k6NFN84zJwgmmg0UBHiKW14ZSegvVTX85Rs+qVs=",
+   "module": "sha256-MdgyMyR0zkgVD1uuADNDMZE28zav0QdqKJApMZ4+qXo=",
+   "pom": "sha256-ft7khhbhe2Epfq46gutIOoXlbSVnkpN4qkbzCpUDIto="
+  },
+  "io/perfmark#perfmark-api/0.27.0": {
+   "jar": "sha256-x7R4UD7FJOVd8ZtCTUbSfIporrgBZk+t1PBptx9S0PY=",
+   "module": "sha256-n2xOamK43v0UFzrNt9spPQhjU7Ikkj7vYpP1gWGJPMo=",
+   "pom": "sha256-IsF1wsGCNmdjDITnMiV2f1lwSS2ObL/7gaZXXbpHLSY="
+  },
+  "jakarta/activation#jakarta.activation-api/1.2.1": {
+   "jar": "sha256-iwoPUvqLBcVDGSGgY+2GbvqkHa3y46fuPhlh8rDZZFs=",
+   "pom": "sha256-QlhcsH3afyOqBOteCUAGGUSiRqZ609FpQvvlaf8DzTE="
+  },
+  "jakarta/xml/bind#jakarta.xml.bind-api-parent/2.3.2": {
+   "pom": "sha256-FaVbfVN8n5lwrq0o0q+XwFn2X/YQL3a70p8SR92Kbfs="
+  },
+  "jakarta/xml/bind#jakarta.xml.bind-api/2.3.2": {
+   "jar": "sha256-aRVjBAeb3u2fwK47OTifGbPMS6REO8gFCJlTlOrXQuo=",
+   "pom": "sha256-tTeziNurTMBpC50vsMdBJNZyUxc0VnrPblMTDqsTGtY="
+  },
+  "javax/annotation#javax.annotation-api/1.3.2": {
+   "jar": "sha256-4EulGVvNVV3JVlD3zGFNFR5LzVLSmhC4qiGX86uJq5s=",
+   "pom": "sha256-RqSiUcpAbnjkhT16K66DKChEpJkoUUOe6aHyNxbwa5c="
+  },
+  "javax/inject#javax.inject/1": {
+   "jar": "sha256-kcdwRKUMSBY2wy2Rb9ickRinIZU5BFLIEGUID5V95/8=",
+   "pom": "sha256-lD4SsQBieARjj6KFgFoKt4imgCZlMeZQkh6/5GIai/o="
   },
   "junit#junit/4.13.2": {
    "jar": "sha256-jklbY0Rp1k+4rPo0laBly6zIoP/1XOHjEAe+TBbcV9M=",
    "pom": "sha256-Vptpd+5GA8llwcRsMFj6bpaSkbAWDraWTdCSzYnq3ZQ="
+  },
+  "net/java#jvnet-parent/1": {
+   "pom": "sha256-KBRAgRJo5l2eJms8yJgpfiFOBPCXQNA4bO60qJI9Y78="
+  },
+  "net/java#jvnet-parent/3": {
+   "pom": "sha256-MPV4nvo53b+WCVqto/wSYMRWH68vcUaGcXyy3FBJR1o="
   },
   "net/java/dev/jna#jna-jpms/5.18.1": {
    "jar": "sha256-RKxmAoCCMvPelQp9Dum4xrmec3M7aUYeZDV2YHvnTbY=",
@@ -1004,6 +2620,10 @@
    "jar": "sha256-rRTBsexPQ9OWIxIZ36Y16/go9zjqyfiQ6hvAd5WJLZo=",
    "pom": "sha256-OdU4qVmaRHR3CDiGXtQs+j5rPRMIbLHld7i7QxSNGmU="
   },
+  "net/java/dev/jna#jna-platform/5.6.0": {
+   "jar": "sha256-ns6ovysbOZY5OdGLcEZO72DFCP7Ygg+dyroMNVGOq/c=",
+   "pom": "sha256-G+s1y0GE5skGp+Murr2FLdPaCiY5YumRNKuUWDI5Tig="
+  },
   "net/java/dev/jna#jna/5.17.0": {
    "jar": "sha256-s6lAjnxR4I7w47/MCPRD9uwPYZG6jNfBjVPSsi5b28A=",
    "pom": "sha256-UBoP8F2EpK0Q9t4lvpT0k5i3CjG+jzoO2fTGtE++/uQ="
@@ -1012,6 +2632,145 @@
    "jar": "sha256-JgxLHiKx254RDuRBxPE84RX4QfpIxB14dQmGIUs5VVc=",
    "pom": "sha256-mLYq5v8oDXR/s1n8QuSP7RE9Rbw3Kagj3DC4MIqAZkU="
   },
+  "net/java/dev/jna#jna/5.6.0": {
+   "jar": "sha256-VVfiNaiqL5dm1dxgnWeUjyqIMsLXls6p7x1svgs7fq8=",
+   "pom": "sha256-X+gbAlWXjyRhbTexBgi3lJil8wc+HZsgONhzaoMfJgg="
+  },
+  "net/java/dev/jna/jna/5.18.1/jna-5.18.1": {
+   "aar": "sha256-fwU+PsmeFN1xJZyCwcigJzjWShPDEiayrMFw8wYJUeA="
+  },
+  "net/sf/jopt-simple#jopt-simple/4.9": {
+   "jar": "sha256-JsWFbpVLX4ZNt28TuGkZtZxu7Pn9kwuWuqiIRia68vU=",
+   "pom": "sha256-evfi2LJLR5jwTCt9okyfvRt1V7TgF8IFRIFWWRYHkJI="
+  },
+  "net/sf/kxml#kxml2/2.3.0": {
+   "jar": "sha256-8mTdn3mh/eEM5ezFMiHv8kvkyTMcgwt9UvLwintjPeI=",
+   "pom": "sha256-Mc5gb06VGJNimbsNJ8l4+mHhhf0d58mHT+lZpT40poU="
+  },
+  "org/apache#apache/13": {
+   "pom": "sha256-/1E9sDYf1BI3vvR4SWi8FarkeNTsCpSW+BEHLMrzhB0="
+  },
+  "org/apache#apache/18": {
+   "pom": "sha256-eDEwcoX9R1u8NrIK4454gvEcMVOx1ZMPhS1E7ajzPBc="
+  },
+  "org/apache#apache/21": {
+   "pom": "sha256-rxDBCNoBTxfK+se1KytLWjocGCZfoq+XoyXZFDU3s4A="
+  },
+  "org/apache#apache/23": {
+   "pom": "sha256-vBBiTgYj82V3+sVjnKKTbTJA7RUvttjVM6tNJwVDSRw="
+  },
+  "org/apache#apache/31": {
+   "pom": "sha256-VV0MnqppwEKv+SSSe5OB6PgXQTbTVe6tRFIkRS5ikcw="
+  },
+  "org/apache/commons#commons-compress/1.21": {
+   "jar": "sha256-auz9VFlyillWAc+gcljRMZcv/Dm0kutIvdWWV3ovJEo=",
+   "pom": "sha256-Z1uwI8m+7d4yMpSZebl0Kl/qlGKApVobRi1Mp4AQiM0="
+  },
+  "org/apache/commons#commons-parent/34": {
+   "pom": "sha256-Oi5p0G1kHR87KTEm3J4uTqZWO/jDbIfgq2+kKS0Et5w="
+  },
+  "org/apache/commons#commons-parent/42": {
+   "pom": "sha256-zTE0lMZwtIPsJWlyrxaYszDlmPgHACNU63ZUefYEsJw="
+  },
+  "org/apache/commons#commons-parent/52": {
+   "pom": "sha256-ddvo806Y5MP/QtquSi+etMvNO18QR9VEYKzpBtu0UC4="
+  },
+  "org/apache/commons#commons-parent/69": {
+   "pom": "sha256-1Q2pw5vcqCPWGNG0oDtz8ZZJf8uGFv0NpyfIYjWSqbs="
+  },
+  "org/apache/httpcomponents#httpclient/4.5.14": {
+   "jar": "sha256-yLx+HFGm1M5y9A0uu6vxxLaL/nbnMhBLBDgbSTR46dY=",
+   "pom": "sha256-8YNVr0z4CopO8E69dCpH6Qp+rwgMclsgldvE/F2977c="
+  },
+  "org/apache/httpcomponents#httpcomponents-client/4.5.14": {
+   "pom": "sha256-W60d5PEBRHZZ+J0ImGjMutZKaMxQPS1lQQtR9pBKoGE="
+  },
+  "org/apache/httpcomponents#httpcomponents-client/4.5.6": {
+   "pom": "sha256-sEK0HyOR7bANNff05Qmu0hI2SMHSRs5Y0Pe5Bcn+H3M="
+  },
+  "org/apache/httpcomponents#httpcomponents-core/4.4.16": {
+   "pom": "sha256-8tdaLC1COtGFOb8hZW1W+IpAkZRKZi/K8VnVrig9t/c="
+  },
+  "org/apache/httpcomponents#httpcomponents-parent/10": {
+   "pom": "sha256-yq+WfZSvshdT82CCxghiBr0fSIJf9ZaTLM66crZdOfo="
+  },
+  "org/apache/httpcomponents#httpcomponents-parent/11": {
+   "pom": "sha256-qQH4exFcVQcMfuQ+//Y+IOewLTCvJEOuKSvx9OUy06o="
+  },
+  "org/apache/httpcomponents#httpcore/4.4.16": {
+   "jar": "sha256-bJs90UKgncRo4jrTmq1vdaDyuFElEERp8CblKkdORk8=",
+   "pom": "sha256-PLrYSbNdrP5s7DGtraLGI8AmwyYRQbDSbux+OZxs1/o="
+  },
+  "org/apache/httpcomponents#httpmime/4.5.6": {
+   "jar": "sha256-CysRAsGNPH4Fp3IUubdQGm9gVhdK5WBODiVndu2nVT4=",
+   "pom": "sha256-37/W/+KnhMqYF8RjZap/ileDILgFveOdb1WgsJ2KqMo="
+  },
+  "org/bitbucket/b_c#jose4j/0.9.5": {
+   "jar": "sha256-gI+zFm8+Z9rZgRwzECmrFoEkL9Urc1vD8z8oEWf8xy4=",
+   "pom": "sha256-utAkGAobRpy9lOXy2xKEG8rFRD2VRWB/Zzz95nfB2HI="
+  },
+  "org/bouncycastle#bcpkix-jdk18on/1.79": {
+   "jar": "sha256-NjmiTd+bpLfroGWbRHcOkeuoFkIYiOVx8oWq3v5TLNY=",
+   "pom": "sha256-NeSfQTTeKsMmw6UKJXYsu021bzgC+j9zDMhbZTrQmHs="
+  },
+  "org/bouncycastle#bcprov-jdk18on/1.79": {
+   "jar": "sha256-DYHswxJFNrU5vOmqP+liG3+Eyc7jcbY1pbMceLeasdo=",
+   "pom": "sha256-2PGgaxSddG6dmN5U4veqmy62E/s1ymfYrjls6qxmHuQ="
+  },
+  "org/bouncycastle#bcutil-jdk18on/1.79": {
+   "jar": "sha256-xwuIraWJOMvC8AXUAykFQHi8+hFJ5v/APpJC62qyGDY=",
+   "pom": "sha256-4kwftM8WBUBaaYjp5NbksuH0OT/HOompRSrmJe4xHQI="
+  },
+  "org/checkerframework#checker-qual/2.5.8": {
+   "pom": "sha256-M6xqDxNBrpZkfH1EZfSqPST+l9Jpe87izq5vyLXvLDw="
+  },
+  "org/checkerframework#checker-qual/3.33.0": {
+   "jar": "sha256-4xYlW7/Nn+UNFlMUuFq7KzPLKmapPEkdtkjkmKgsLeE=",
+   "module": "sha256-6FIddWJdQScsdn0mKhU6wWPMUFtmZEou9wX6iUn/tOU=",
+   "pom": "sha256-9VqSICenj92LPqFaDYv+P+xqXOrDDIaqivpKW5sN9gM="
+  },
+  "org/checkerframework#checker-qual/3.43.0": {
+   "jar": "sha256-P7wumPBYVMPfFt+auqlVuRsVs+ysM2IyCO1kJGQO8PY=",
+   "module": "sha256-+BYzJyRauGJVMpSMcqkwVIzZfzTWw/6GD6auxaNNebQ=",
+   "pom": "sha256-kxO/U7Pv2KrKJm7qi5bjB5drZcCxZRDMbwIxn7rr7UM="
+  },
+  "org/codehaus/mojo#animal-sniffer-annotations/1.23": {
+   "jar": "sha256-n/5Sa/Q6Y0jp2LM7nNb1gKf17tDPBVkTAH7aJj3pdNA=",
+   "pom": "sha256-VhDbBrczZBrLx6DEioDEAGnbYnutBD+MfI16+09qPSc="
+  },
+  "org/codehaus/mojo#animal-sniffer-annotations/1.24": {
+   "jar": "sha256-xyDm5by+ay9I3tdaR7zNt2Pu3nnRQzAQLg01Lj2J7ZI=",
+   "pom": "sha256-iEhPYKatQjipf+us8rMz6eCMF4uPGAoFo+2/9KOKg24="
+  },
+  "org/codehaus/mojo#animal-sniffer-parent/1.23": {
+   "pom": "sha256-a38FSrhqh/jiWZ81gIsJiZIuhrbKsTmIAhzRJkCktAQ="
+  },
+  "org/codehaus/mojo#animal-sniffer-parent/1.24": {
+   "pom": "sha256-Sd2rQ8g2HcLvDB/4fLWQ+nIxcCq59i4m1RLcGKHxzQQ="
+  },
+  "org/codehaus/mojo#mojo-parent/74": {
+   "pom": "sha256-FHIyWhbwsb2r7SH6SDk3KWSURhApTOJoGyBZ7cZU8rM="
+  },
+  "org/codehaus/mojo#mojo-parent/84": {
+   "pom": "sha256-L+UQYYsvYPzV8vuCvEssLDRASNdPML5xn8uGgp7orDA="
+  },
+  "org/eclipse/ee4j#project/1.0.2": {
+   "pom": "sha256-dJWgenl+iOQ8O8GodCG9ix/FXjIpH6GOTjLYAx3chz8="
+  },
+  "org/eclipse/ee4j#project/1.0.5": {
+   "pom": "sha256-kWtHlNjYIgpZo/32pk2+eUrrIzleiIuBrjaptaLFkaY="
+  },
+  "org/glassfish/jaxb#jaxb-bom/2.3.2": {
+   "pom": "sha256-oQGLtUZ47Z9ayy96QITjhf9RAgH06dv1913GpnX2a+c="
+  },
+  "org/glassfish/jaxb#jaxb-runtime/2.3.2": {
+   "jar": "sha256-5uCh6J+2/3hieeagCC1c71LcLr5nBT0EGABzdlK0/Rs=",
+   "pom": "sha256-lEilrX+mimCD375PQsjIPggrkgKhBUAfxo6UTCZUizQ="
+  },
+  "org/glassfish/jaxb#txw2/2.3.2": {
+   "jar": "sha256-SmqfSDOI1GG4GqmijGhbi3TAWXmTvxiEsE7dvKlfSP4=",
+   "pom": "sha256-p53QAvsDgYP/KGomNb4uaMEDuH4OZHF9jUS/0Bf9M+o="
+  },
   "org/hamcrest#hamcrest-core/1.3": {
    "jar": "sha256-Zv3vkelzk0jfeglqo4SlaF9Oh1WEzOiThqekclHE2Ok=",
    "pom": "sha256-/eOGp5BRc6GxA95quCBydYS1DQ4yKC4nl3h8IKZP+pM="
@@ -1019,9 +2778,9 @@
   "org/hamcrest#hamcrest-parent/1.3": {
    "pom": "sha256-bVNflO+2Y722gsnyelAzU5RogAlkK6epZ3UEvBvkEps="
   },
-  "org/javassist#javassist/3.30.2-GA": {
-   "jar": "sha256-66NykJlLXkho86+Y/xE/YkSmsJk4XZrUaIEwfTywGq8=",
-   "pom": "sha256-QieFHLcOQ/c6zti//mkt465EEsSmLc3/BV5RPuPYAaM="
+  "org/jdom#jdom2/2.0.6": {
+   "jar": "sha256-E0XxG6YG0VYD1nQFUajCGUfAIVZAdw7GcnH+eL6pfPU=",
+   "pom": "sha256-R7I6ef4za3QbgkNMbgSdaBZSVuQF51wQkh/XL6imXY0="
   },
   "org/jetbrains#annotations/13.0": {
    "jar": "sha256-rOKhDcji1f00kl7KwD5JiLLA+FFlDJS4zvSbob0RFHg=",
@@ -1036,11 +2795,8 @@
    "module": "sha256-Zg7q/+b69J/qIIOkNCqAsbhNK/yXYx9tfmeLSFsZm5o=",
    "pom": "sha256-4Fs07/GcQaRQesMEW7ngiVmInyRoRzuV1nhuhCjHgLQ="
   },
-  "org/jetbrains/androidx/lifecycle#lifecycle-common/2.9.4": {
-   "module": "sha256-S/WE5uBMORPf6cIMGIKiKZ3N3gMgR9YxpqsAZSpRnTM=",
-   "pom": "sha256-DRDzDh37izhO+dnYN5kDd+pecAijEujpEINo++ZR67g="
-  },
   "org/jetbrains/androidx/lifecycle#lifecycle-common/2.9.6": {
+   "jar": "sha256-shoUn+KMzMfs43tVCY0QAnq6PS4Nsx0S083JB97SNoo=",
    "module": "sha256-gF5FIbAzeYEISMesMUzzyVT8jS3zSlsJEcRW1Djc2iY=",
    "pom": "sha256-0yUq74s29h2gYJD4T+URQCGCA0Tq0dZAw3NXohkYVBk="
   },
@@ -1048,11 +2804,6 @@
    "jar": "sha256-McPEtt6jjweMRoKd7ixDq7or+HV7fuig9mDzEhc2SJg=",
    "module": "sha256-FKEs03MDhyfssw91RF+H5sqf9DzwFcZm0HLr3U7PHBs=",
    "pom": "sha256-R/Y3Vq9c4hBRByM0+oBYjAPBZNo3HSTLTO362OGyglU="
-  },
-  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose-desktop/2.9.4": {
-   "jar": "sha256-oHi0QUV+wOEAB9zRY/+fLAQ3+bNfvJ7Gzq2C+OmFiU0=",
-   "module": "sha256-bzhY5UrLXgDNt5WBB1XNOo0YvhH5CA5Kq9NOW8fkAmk=",
-   "pom": "sha256-o4T7ZoTUHnwBpKhmOERe+s/bHJ2dzEwi5JIBV8T9Odc="
   },
   "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose-desktop/2.9.6": {
    "jar": "sha256-McPEtt6jjweMRoKd7ixDq7or+HV7fuig9mDzEhc2SJg=",
@@ -1064,11 +2815,8 @@
    "module": "sha256-wsBsS6GmDvmIlIX2+lFVslfH6GTJo+tvN0M84N7xhvs=",
    "pom": "sha256-NaXwX5/pggJulEwaYuXV7Sp10zsOhJvwchSasMXYAxo="
   },
-  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose/2.9.4": {
-   "module": "sha256-FOsoP3X55Qs7gDCWEi5xO7YX8LZkWntNkUYReBLzmzQ=",
-   "pom": "sha256-nTn31/uWEshmNaR9lkulaMrU+K6LD6JpwvNXUR4mC4E="
-  },
   "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose/2.9.6": {
+   "jar": "sha256-rbdbK4nWjzONlCC4sk3ZulNohypPxw4yKCwvoPGToPw=",
    "module": "sha256-gAMMZAio8gsZVXh+GmE8tp8Fh26vW5GF++FZSAwPZyE=",
    "pom": "sha256-OFjDsK0gsHhobakHitFk7MbF5Y8wlvLS5vpmznPHg98="
   },
@@ -1077,11 +2825,8 @@
    "module": "sha256-9HuN0p6QQBl8OpMYzGkzHYOUwj7iYVLwO9IEe71NgAI=",
    "pom": "sha256-t2ghIp9UPorV8uaFgF5r4FE/sV7UHvS94IDTtezoYiU="
   },
-  "org/jetbrains/androidx/lifecycle#lifecycle-runtime/2.9.4": {
-   "module": "sha256-bu2+0UiG5BVzBDUROa1LtNTvkBxn3AKyJ+6Yvkr2EXs=",
-   "pom": "sha256-maX6xqZWgAhsFHQuww5ChGeEiEOVfgUhKzfW+qhbBaw="
-  },
   "org/jetbrains/androidx/lifecycle#lifecycle-runtime/2.9.6": {
+   "jar": "sha256-ndWDtwkTbgqv5g4bkCSb9jvIDNe6bgZBznShqzYTxk8=",
    "module": "sha256-LSN78RA5ccVpZ6GVMbwI8QBuSZOoQxmpL04V+w+Qyhs=",
    "pom": "sha256-8ju8dgqLqe3xr4gbY7h84LcUMFl8DhLtXq9YJ2DTjnw="
   },
@@ -1100,11 +2845,8 @@
    "module": "sha256-r4zVML1zj+GsH+Dg/IYhnyToE4yN4/lMGFzuwvqly/o=",
    "pom": "sha256-eZav2khVeVAQN+XFXVwE7omQ7RT2Y+T9PtN72jfaSZg="
   },
-  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-savedstate/2.9.4": {
-   "module": "sha256-BenXVkAXdWgEeEwxXpZxqASZXa3EHaolt/8g3OWJm2Q=",
-   "pom": "sha256-7bq4xQVmwkGOjCZUXViG+sbkExhgn4Xarhd1t/jM9FQ="
-  },
   "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-savedstate/2.9.6": {
+   "jar": "sha256-dCOTmMsfIKgROze5PTCfH1dJShT3DWV4ZI6LsIP4D10=",
    "module": "sha256-rQ264j3Z3KujqV0dCCwb+0xASxe7kySQ9ASayTgl3E8=",
    "pom": "sha256-hC0AC7vnoGloZw6B/tCSr3gLhtbjCLaqGo+QwjsrZ2w="
   },
@@ -1113,344 +2855,230 @@
    "module": "sha256-BeXmNx8kIzertlVRuq29uDTDF4auOuhH+BKSd1w9RcY=",
    "pom": "sha256-EF3rS+RhEND7iGT0o0Qr/b1Cw90jEUCzrOa5dMkZoXA="
   },
-  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel/2.9.4": {
-   "module": "sha256-RQ5l1bXN5cWq6WwHPkOmA8k3xawekl2V1gX2zAmivoc=",
-   "pom": "sha256-jx+k87JIILrduKGJmb9NkMnF93g0BmL2lfYSrHOK09s="
-  },
   "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel/2.9.6": {
+   "jar": "sha256-ns0rxhNl+0+j9vKEq6khSNv9PRrKOGYq1UvOysKrVUY=",
    "module": "sha256-JMv8NlN1knXknL9Wl748L+fEpqHByk+CWAWk82EbYJU=",
    "pom": "sha256-oJpT4rFQ+ZKfyN33sZ0qhl1K8TRGnYFx5aiFhEA/zsM="
-  },
-  "org/jetbrains/androidx/savedstate#savedstate-compose-desktop/1.3.4": {
-   "jar": "sha256-UijQcyEoARdHyNVvZRVlBaCy0psADTmMbxl5vA70IRM=",
-   "module": "sha256-HMfdieaRvibyXww3A/+4qDCwl6v6vFRakNf6JOKkRec=",
-   "pom": "sha256-NbzmQ7VvI5UgjooZhxZkW0vCkLz6yXlaWv/8j/k3BmM="
   },
   "org/jetbrains/androidx/savedstate#savedstate-compose-desktop/1.3.6": {
    "jar": "sha256-Dz0EXF/X4TAatsOM0HeAZ7BITPOaysEjO+cacjpqgHU=",
    "module": "sha256-krjcB5kBhmwbUgx1DDHghRtQSZUkfa3yu1HPcLgO9pg=",
    "pom": "sha256-RJsKGtrBUXq3EzFIQN2vUqy/hz6shWCDsuLSGBPP0J8="
   },
-  "org/jetbrains/androidx/savedstate#savedstate-compose/1.3.4": {
-   "module": "sha256-A46PL+QVpysSdcURVYa94PKM445mUZqTaO2wvZMePTc=",
-   "pom": "sha256-WeXvwinjf4pQWaElb5mp1A1ayC2ms9YhQSNqyou8R50="
-  },
   "org/jetbrains/androidx/savedstate#savedstate-compose/1.3.6": {
    "jar": "sha256-Ybi1HQS02ZLo4bYYrUzxFzJDAeSSrQagWPyWzfhht4A=",
    "module": "sha256-r8PlvURgTqnKYQwjQFoJa0CJ1izTRnl9M5/14sig5bQ=",
    "pom": "sha256-uUeSNGwy0j9Md1UYlfi80RSbtbgPuncxu60qoR07zIc="
-  },
-  "org/jetbrains/androidx/savedstate#savedstate/1.3.4": {
-   "module": "sha256-nx47jPrw+5xq1VqY6u7M/fO6p3lTj0JynWSeQGWLd5A=",
-   "pom": "sha256-31rG2m1h5s9MeWq3dLxDiMztC4h8B50q5VbpwZrcYgo="
   },
   "org/jetbrains/androidx/savedstate#savedstate/1.3.6": {
    "jar": "sha256-B0GnUJQJeMfosWBfEXvmLjmf1Xp2Jasa6AooosoPNBU=",
    "module": "sha256-5Z+aDYcs4zt44W18XqY2lgRuYXKTSozo1Cdyawd5GTQ=",
    "pom": "sha256-+01/UV0FOzQ9G+gAao4Ehw3SFbi1L89/DJvIv+7WgMY="
   },
-  "org/jetbrains/compose#compose-gradle-plugin/1.10.3": {
-   "jar": "sha256-d48mgTMzNIhWDYG8zaVVA1uILv2eKCfWkcnGlJaPL2s=",
-   "module": "sha256-HwCtYh+cIyGWA2KtyrQrUq0ryIQ+8Qi56WfM03E2rfU=",
-   "pom": "sha256-5+ltaBasFiuUf4f3f9E1G52BMO9amENhClEF2qIyQ1M="
+  "org/jetbrains/compose#compose-gradle-plugin/1.11.1": {
+   "jar": "sha256-p4uEexWdXLcC0bYs+o8miX4A3coL2I4KVwNarvN0hqk=",
+   "module": "sha256-75q6+yrL5z/87yVmzsoI54hUZckPQO+RRJiRxS3FHHc=",
+   "pom": "sha256-tyr7g2O40X0i4s4hLZZqnPhSoOHkC/6EwYkRbgzHeUw="
   },
-  "org/jetbrains/compose#gradle-plugin-internal-jdk-version-probe/1.10.3": {
-   "jar": "sha256-k+cSRZy25+oodZxQdFuWufCpy9NuECpkUbpqMgLDRkM=",
-   "module": "sha256-MSf8sJgMd67/CVn8KKpeVITi1BA1yjueIpQguoLCLhY=",
-   "pom": "sha256-osvx2YU1apEBi21GF/QrNhs1Q01n675H3DArWbEt80A="
+  "org/jetbrains/compose#gradle-plugin-internal-jdk-version-probe/1.11.1": {
+   "jar": "sha256-wNLTPRbxdffJXv5W7gVMenf/ii2dpXFLvolDmbZIcpo=",
+   "module": "sha256-+0zIBUd6uqCMC2OcIMdldGVZ4HXGrNnu4X6AXRTkjnc=",
+   "pom": "sha256-2h+OFRyH5nAhrE/rBsQTWLHWfziNte/9b9dcz1d5mSk="
   },
-  "org/jetbrains/compose#org.jetbrains.compose.gradle.plugin/1.10.3": {
-   "pom": "sha256-0abWKYWWrm4rsGeAMbv4wl54KEBCalDJ4weoXLRXBsQ="
+  "org/jetbrains/compose#org.jetbrains.compose.gradle.plugin/1.11.1": {
+   "pom": "sha256-l0NsU/5PZQPKybETrkdAVuAE2UB4JfSgC+54Yitqm8w="
   },
-  "org/jetbrains/compose/animation#animation-core-desktop/1.10.3": {
-   "jar": "sha256-QcAiDdvFXLiX/rDVgWt0j5wRFiFx8SdDwEtQ0NhNtig=",
-   "module": "sha256-riRweG87PQrDeEJIz750J5XyILUhq9M/0Zh740fG5bc=",
-   "pom": "sha256-zdJX3Ppv5CRud5U41Fu3+pZ5Qgsc/bJcFMTWh3CsECw="
+  "org/jetbrains/compose/animation#animation-core-desktop/1.11.0-beta03": {
+   "jar": "sha256-Gzr40gYnsBEB2Cf3LibbrczI0hLA/8DAL/Km/JZ6bKg=",
+   "module": "sha256-dayy25cZPo48G46wRJnYupZ1wf2VqxCMWv/3ZRrUfY0=",
+   "pom": "sha256-EDNFH/5muRzTA9SPKwy1cJqfmtryCW9O/FPSCQuF0co="
   },
-  "org/jetbrains/compose/animation#animation-core-desktop/1.8.2": {
-   "module": "sha256-qxOVOtDhVv+Au9EXooS4EVYN46LMXQKvjWGDKM5xbIg=",
-   "pom": "sha256-5BZ9JA37PUEKkRee2wCWUkkSqkdZLOk/SqbirF0g6uY="
-  },
-  "org/jetbrains/compose/animation#animation-core-desktop/1.9.0": {
-   "jar": "sha256-ds9NCbUxL5qeRugKJwx2pxV6k4GUk/63B2+cjJhhBgU=",
-   "module": "sha256-HDYyn4gq6yRHC8JYRVpXevjwVGV+OeWjDsocxR9wBkE=",
-   "pom": "sha256-0AS32FEkDFzOaTFu02dVyOzygw2YpC16jsrytm8GOYI="
+  "org/jetbrains/compose/animation#animation-core-desktop/1.11.1": {
+   "jar": "sha256-Gzr40gYnsBEB2Cf3LibbrczI0hLA/8DAL/Km/JZ6bKg=",
+   "module": "sha256-RcYWgKu7S0Pjeu6AGADn+McNYQVsbhHNOAZhSiMEHmQ=",
+   "pom": "sha256-z3Gjr4mGYDoAyTVLm3Ql8zAfGfm4Q2C4xPsQCQ4NXW8="
   },
   "org/jetbrains/compose/animation#animation-core-desktop/1.9.1": {
    "module": "sha256-hgdAqi8Icj+Iq5y9pDwTI/0Dbvfdw11tURa0ZDnAROc=",
    "pom": "sha256-1VVL+PdDa479M8WdaENtV8T0woD2wK+oqBRDrGtGV78="
   },
-  "org/jetbrains/compose/animation#animation-core-desktop/1.9.3": {
-   "jar": "sha256-ds9NCbUxL5qeRugKJwx2pxV6k4GUk/63B2+cjJhhBgU=",
-   "module": "sha256-hNnSyX8aeeZyRZntDqAd1wQCURcArCGP9V79qZ6j2CE=",
-   "pom": "sha256-4y8Cfj983nDxLtkxt92SO9s6VuoYYKSZhmtAu3YEqiI="
+  "org/jetbrains/compose/animation#animation-core/1.11.0-beta03": {
+   "jar": "sha256-yVDtLCc6sA4VznLQTqo4AYiNXVXkM18C1NACkAnffXo=",
+   "module": "sha256-Lyg8tBqEJe4z+el2WvpqpXHe32uUCt75Me1iTUV2pyE=",
+   "pom": "sha256-mzS3KMEUniUwiVW/tsQiy+opZdI24udDU1ZxhzrIRag="
   },
-  "org/jetbrains/compose/animation#animation-core/1.10.3": {
-   "jar": "sha256-v8T0PWZFdawQ22FkkhL0U5L5aCR/lq6R4ac+S9CiBPM=",
-   "module": "sha256-XYUVJC/1g+Ia9MMP3hSIUjAXjcqk902VAMeoJidUAnw=",
-   "pom": "sha256-gRpNAdnxMxbtseUzmc3bgZ2f3y9HWvpm4iSZG/NPVes="
-  },
-  "org/jetbrains/compose/animation#animation-core/1.8.2": {
-   "module": "sha256-tRGby7/TKMDcD8yKRynXk6g3vz4naSP1bRCtvifGSMk=",
-   "pom": "sha256-RSX5/0gQEwHIPf84HI+Hre+IYuIAdmLUQwgDBG8tOkA="
-  },
-  "org/jetbrains/compose/animation#animation-core/1.9.0": {
-   "module": "sha256-AyvygPprM79S8/PKNEQe2Ing2RdH+2ly4IgcEhagAu0=",
-   "pom": "sha256-QL8NFIA7IHhDz87+sllqcj1m35hwN3wNiQRjt2XRHns="
+  "org/jetbrains/compose/animation#animation-core/1.11.1": {
+   "jar": "sha256-yVDtLCc6sA4VznLQTqo4AYiNXVXkM18C1NACkAnffXo=",
+   "module": "sha256-PNhXR4ESEdkz69mwnAZ47QoTdEJUTUWXfH+0y7xpYeg=",
+   "pom": "sha256-WZd8s6w6nSmzcDTmf7HB0OpggME41inpqaQ3XzlBvio="
   },
   "org/jetbrains/compose/animation#animation-core/1.9.1": {
    "module": "sha256-sLNcaXIN2EWqMr9DTUyMalYOE4elIAh0jvlGeJSOoyQ=",
    "pom": "sha256-u3hZBa0EmVIiHZzNxcJFY5ri9TfiEICldU/YZ0UhvK0="
   },
-  "org/jetbrains/compose/animation#animation-core/1.9.3": {
-   "module": "sha256-//2Jmf4MeqLGL+F2pGRbxxslH4+JK8fBwcbZFV6vLLI=",
-   "pom": "sha256-HxktalvHdmP3EGHKkbD+RaiwF56b5c52GInkx5ics9c="
+  "org/jetbrains/compose/animation#animation-desktop/1.11.0-beta03": {
+   "jar": "sha256-u0HGxVCkccaMURhcO7BFhIKk6APuB0vyFa3Igy4gB+E=",
+   "module": "sha256-F82Km0qkV2AvXmzcFhzCrb28Z2reZM7IJcivacRPUzM=",
+   "pom": "sha256-rME5ZlLRuMsUTMcbPf9bOpKvXyhnTPPnIQ9J3ReapsE="
   },
-  "org/jetbrains/compose/animation#animation-desktop/1.10.3": {
-   "jar": "sha256-GIHFV1RABV1UpnlBj3rX6GwDSXQziTYL7Q9qNq8WujQ=",
-   "module": "sha256-YY744ccvBoP4cbTZWyhl9kxjgI87ZUIKB+8O7wzF0Rc=",
-   "pom": "sha256-tBYhxRzPb9oueqO44E2D8egLz7SfBLDojVVLif38DMc="
+  "org/jetbrains/compose/animation#animation-desktop/1.11.1": {
+   "jar": "sha256-u0HGxVCkccaMURhcO7BFhIKk6APuB0vyFa3Igy4gB+E=",
+   "module": "sha256-Xspxyb3gALsU4gUE5VfMPUzoVZdEpiowMTTdCyImKsU=",
+   "pom": "sha256-1cmnfoKnK6vZ+nAcHGdj76d5LFvxdIo2QCT9r8ooOXo="
   },
-  "org/jetbrains/compose/animation#animation-desktop/1.9.0": {
-   "jar": "sha256-+LkLWR0fjCyLVHzd2uo3CpmJsLLHG0IDi2f9so8SC30=",
-   "module": "sha256-GZi9Zn+D8JNWo5xob3hS7RVvjCqNuJKVo6w56UYkukM=",
-   "pom": "sha256-cdJ8weEaTONaDDWYjPFMHqDlygRz9hm+3augjRl0v8Y="
+  "org/jetbrains/compose/animation#animation/1.11.0-beta03": {
+   "jar": "sha256-CzkZYHS7VWNHvRiSt32kT4nXysl4jRV70i5Ea2xwk64=",
+   "module": "sha256-1fsd1sWN0y1qhTqpqOCYP0Gp390nBEXCF0D5aWOwuYQ=",
+   "pom": "sha256-tktWrhGVzsdcUIPKOA2q6jLhheB/fa2m9prDdiNUXoo="
   },
-  "org/jetbrains/compose/animation#animation-desktop/1.9.3": {
-   "jar": "sha256-u8XhmPe4FZ+nFwr/LvvJxhJKbamn+quIiekiQio7Ils=",
-   "module": "sha256-W9cMeWQRQOm3sLdHlW8yj2tiayvu/unikOy/OkJQ28w=",
-   "pom": "sha256-L99kHu+ToKOvR4Aslk0Wagvx6GZvd8yVUjW77jXxf6s="
+  "org/jetbrains/compose/animation#animation/1.11.1": {
+   "jar": "sha256-CzkZYHS7VWNHvRiSt32kT4nXysl4jRV70i5Ea2xwk64=",
+   "module": "sha256-hddIC1HSPOPPHTVqZMIzXWdXZxVOXvlsfzLq+o8OsIs=",
+   "pom": "sha256-d50b/Qi0HKFp+g7M4fRQthYgM7eAZ0vlgRfhgBxRqz0="
   },
-  "org/jetbrains/compose/animation#animation/1.10.3": {
-   "jar": "sha256-wk2FqQJHt64x7m5du+xicV7QRoEqSIhhQq/YjVaD9GQ=",
-   "module": "sha256-1duqOn4R7nbqmSCDCb+5RxIG8fgvzCjoe/Aui0ulccc=",
-   "pom": "sha256-LHgtDl0eauEvaJ0A+P+RnGM828uaE4F9x/AParksMt4="
-  },
-  "org/jetbrains/compose/animation#animation/1.9.0": {
-   "module": "sha256-RiS7LSOr9KRgyluQd1oG53UoTk2gnYOYl5hpjgVDM1g=",
-   "pom": "sha256-zNUgtBuPHxNkX8e2txcG0ochLUQ26E5L4ETRKGtKlIE="
-  },
-  "org/jetbrains/compose/animation#animation/1.9.3": {
-   "module": "sha256-qj5kBl1T2z8KenRJ/2HKb5QfXzKKddHldItIZ/8ElTE=",
-   "pom": "sha256-BYvPS8fjYOus8vHvLRoQu1XP+7cIMzfD81ZRKt1iFTM="
-  },
-  "org/jetbrains/compose/annotation-internal#annotation/1.10.3": {
+  "org/jetbrains/compose/annotation-internal#annotation/1.10.0": {
    "jar": "sha256-WaDpt3s+H2HT4/Dfj5ntKhKxaN7YCeo55v117v+UvhI=",
-   "module": "sha256-aIUGFrD2Kg1aSQSAxpD0hWa3Jez019L1Jt6pAnA2Voc=",
-   "pom": "sha256-ax6PA960/1/orq5MHbElj8lGDDmlNPPQI36a7Xx72dw="
+   "module": "sha256-HL+uQT2AyKFYOzNP9XnvvC8oDLcj2RHA4kFEfzS142w=",
+   "pom": "sha256-f+e1+/Oz3SH1HP3NSVXqto9Aug/BnVd5irryB3dZtDA="
   },
-  "org/jetbrains/compose/annotation-internal#annotation/1.8.2": {
-   "module": "sha256-6tQ9Tmx0RuQ3H8KpGRhBKUJXKCApYhbsE/hAOj0w9Ww=",
-   "pom": "sha256-GSS3emTUqvyOwlr6mUXq2MRmTSJGrKmU0vq60CxbsDE="
+  "org/jetbrains/compose/annotation-internal#annotation/1.9.1": {
+   "module": "sha256-RsknnlfVlOv57yHCfGM8wgy86ypFIIMrlOgaejaJCpg=",
+   "pom": "sha256-im42jvSXI4fcZZrftOgJkK9mi4q6k/ZPwURQM7byuR4="
   },
-  "org/jetbrains/compose/annotation-internal#annotation/1.9.0": {
-   "module": "sha256-wuNy4DRqo8B0a94IDEAFIb0zdicuXVTBc2pkuji8dZc=",
-   "pom": "sha256-hOGFqg90Z7GfToFxQY0FRr2MpJMIfhPFXoUWeHoq/V4="
-  },
-  "org/jetbrains/compose/annotation-internal#annotation/1.9.3": {
-   "module": "sha256-XJA8onJ3P/ZifQO8vgh0IwV+kKYfYpNxyYupGQ04DDA=",
-   "pom": "sha256-zC5CIiLwOdJa9TeVsBO6syHZG7HothhYNuG4sWbo9wk="
-  },
-  "org/jetbrains/compose/collection-internal#collection/1.10.3": {
+  "org/jetbrains/compose/collection-internal#collection/1.10.0": {
    "jar": "sha256-NnuOooSW3AJFMaD+l1dt12hkuwZv+gm6IUH3PHm/PD0=",
-   "module": "sha256-mZ/hZJwmRHaT2+XQFKgQeE1qiYjShwAkp0ecMxa/jlA=",
-   "pom": "sha256-Y9pqUxNa3hS5UFwL4pVXObOwZGkw7J2F7j5DcmLSRa4="
+   "module": "sha256-C6k3s06FAnNf+ds1y0RpAs8RooVgyGqmSDNlu9/548I=",
+   "pom": "sha256-5FdZGCjqC+2jhllNlNsB49nX3XcypgY4eZrlkxzyNqM="
   },
-  "org/jetbrains/compose/collection-internal#collection/1.8.2": {
-   "module": "sha256-et7z8txM7WiKbJz7YNYGu2K0A2nvic2yr+l2NCiuoYk=",
-   "pom": "sha256-N3c+CKLm/WF2YfGpQp10mEiujF5xq+kXntswRzl+c+w="
+  "org/jetbrains/compose/collection-internal#collection/1.9.1": {
+   "module": "sha256-Zr648cP02SBn/9YViufb8WeZlOB1RM6NNMSpD3fZsfA=",
+   "pom": "sha256-Pt165cmCi3TPEev8QyhpdWSiDIcELs9u+/SbSJfaVMc="
   },
-  "org/jetbrains/compose/collection-internal#collection/1.9.0": {
-   "module": "sha256-gDAK5xf3KEo4h5SKEX94kRnvukfy0fZIiwCv0Mt0rx8=",
-   "pom": "sha256-boJ19whECuea8VxYRdIUy2liiMRyyokyV3q7VsER5ic="
+  "org/jetbrains/compose/components#components-resources-android/1.11.1": {
+   "module": "sha256-PWhXK+C5SgFvJ33zkg2StEn3J0RRiHB/CP87o/BLv10=",
+   "pom": "sha256-LZiynzZmuOviZ6Xw+vGfqb6ugP9i2R4IKHyZJYtvilQ="
   },
-  "org/jetbrains/compose/collection-internal#collection/1.9.3": {
-   "module": "sha256-DG395u8H/Lkr6q4j5SO4yLOBaYYd7HKyT3+urnVT6iA=",
-   "pom": "sha256-uMEk0N0L89C3jdKlGvWBtzsy20VZGtmbb/scmo9o1L4="
+  "org/jetbrains/compose/components#components-resources-desktop/1.11.1": {
+   "jar": "sha256-BeHK13yO3nkwrSEiO4GZMrcNetlp6/75fd8nL8GnvDk=",
+   "module": "sha256-wg/4XvLT1WWTJUY5RD+AXD3gGygz4nsWcZ35SwQzUXU=",
+   "pom": "sha256-B2F/aMr/i7Q5yzuD48EjjBSquPUmHsTDv7bPCE4Khzg="
   },
-  "org/jetbrains/compose/components#components-resources-desktop/1.10.3": {
-   "jar": "sha256-fbvgZoO++oEQtKySanQyt+LuRG7RVq31WtF+nIaK4OI=",
-   "module": "sha256-qpgF01LVAd0nUt742l2vAAsY7ZCRbbnzN6Jbp9VHZm0=",
-   "pom": "sha256-XAMcVL/tWAgj790GKivUGNZELOaKIaVcr0GSSVkf1HE="
+  "org/jetbrains/compose/components#components-resources/1.11.1": {
+   "jar": "sha256-arSpUPBmPXY85qZsNn2f5Ud2VT9skrzrbOXTKNtEWI4=",
+   "module": "sha256-FY0UPT9BXVsn8nHRP4waqwbfl3ZeCTfyMO8H3Z1L8zo=",
+   "pom": "sha256-cSuuPBIodvYHy1kelwhZtLfoCscNiahBgimEPY7fv/c="
   },
-  "org/jetbrains/compose/components#components-resources-desktop/1.9.0": {
-   "jar": "sha256-87jzMba7QxKnTtFte7NlRCfPpzcopYF63b/2TG533+w=",
-   "module": "sha256-OTHh694xwO+VJYKEJkOrT7yKQa3f8LMQN/y5HJnRjtE=",
-   "pom": "sha256-JiFTqaOp09D+2PS88PlLDk9Xzx31156V6JGGiUE3kA0="
+  "org/jetbrains/compose/components/components-resources-android/1.11.1/components-resources-android-1.11.1": {
+   "aar": "sha256-rf9g5bjEAWHNSfjfTD3i2ERlUoqCkf/tFZb2IMcFwTI="
   },
-  "org/jetbrains/compose/components#components-resources/1.10.3": {
-   "jar": "sha256-w8pVlHgcoFydarBZbX9OvcZKdE63TXvCwQ5Yxo1E65Q=",
-   "module": "sha256-0TjBrJkvJVO3GY8CNllHUXaOJfSxxPt/hWJ57axdEG8=",
-   "pom": "sha256-Ta/7HsxYuoCPrJ3aes4bp4/I2iApbOJfpKQS+wEo8WQ="
-  },
-  "org/jetbrains/compose/components#components-resources/1.9.0": {
-   "module": "sha256-O/zJJv65jlZXAEXvnMLXKH+swiWJNEQlTENGSEM42P0=",
-   "pom": "sha256-4UJBU1Q55uEIKLERKX1Ot/9QIR+JR81kx0nKck4BmmE="
-  },
-  "org/jetbrains/compose/desktop#desktop-jvm-linux-x64/1.10.3": {
-   "pom": "sha256-WmNhwRJxW+ojNImOII7IJkCGPVkih8KCi57fVtXXM6k="
-  },
-  "org/jetbrains/compose/desktop#desktop-jvm-linux-x64/1.9.0": {
-   "pom": "sha256-ikrzKPIGw40cwII7kzDaHHM/HAY2dIVgzPk8T6u9JcM="
+  "org/jetbrains/compose/desktop#desktop-jvm-linux-x64/1.11.1": {
+   "pom": "sha256-H9Q2XorYZZKgFLJ/TF0JdLiY5dVwjf2tFwon3D74u2A="
   },
   "org/jetbrains/compose/desktop#desktop-jvm-macos-arm64/1.9.0": {
    "pom": "sha256-JiGp36CoFnnMhSVjEflgjoMQj5zRlDvQa1F/fblo1kw="
   },
-  "org/jetbrains/compose/desktop#desktop-jvm/1.10.3": {
-   "jar": "sha256-/bY95Mm9xlcMU1XusPAT1GNe/9pCkHwtCErMd+CNT4o=",
-   "module": "sha256-oFaLOfMJVCZFJVaI77Qx3u4JUJ8jXQiMJROx08LDFn8=",
-   "pom": "sha256-ZkN5IyKyUh5VqkxvaqVDNax0FDUSO7Z/WJ6JsAZ6bRQ="
+  "org/jetbrains/compose/desktop#desktop-jvm/1.11.1": {
+   "jar": "sha256-nz0iHhrM1sfGSsKg18gFNTe8f0lZLETXK3ZkNN/OdEA=",
+   "module": "sha256-L1zMciy73iVgOeMSEsAm9zGL5IU9/MnF3U4fwtxgOMU=",
+   "pom": "sha256-lfOCogMYZh6K4DpAdHjqUKaRYI0nQtOnEPxqeR7O1yk="
   },
-  "org/jetbrains/compose/desktop#desktop-jvm/1.9.0": {
-   "jar": "sha256-winFLJW0xNc5hMiPQPhHXAfRPSkI003wKeQktroambI=",
-   "module": "sha256-XZKFY3U+ZqsA1zpMgxAoYUt5SubNnt3BykvxdziQ2Eo=",
-   "pom": "sha256-Fa1qgZfJUB2LTvKsCnkU7SOK4KSU+Gq5dYdlaYjticc="
+  "org/jetbrains/compose/desktop#desktop/1.11.1": {
+   "jar": "sha256-uF4VUMzSz46+U78IHMv7PWmvYaXzVbj8sRsuin96ohQ=",
+   "module": "sha256-91Hc17faBt+lcbSQJQ5+johwxpmegVieo4OjjrWb300=",
+   "pom": "sha256-DTBaW5mD5ygF1YrGVHuDn4SkwIbC5cN2JvBQgz0rwD8="
   },
-  "org/jetbrains/compose/desktop#desktop/1.10.3": {
-   "jar": "sha256-CJ4kQXv59sNO7Fcg7rssvMguooVezvkBM+sX4QedWGg=",
-   "module": "sha256-amqqVt4c3fe9rFlNfuh/bpnUiQ2kmT25Yf5cOirS3OE=",
-   "pom": "sha256-NPi89983+I9us/8gN+7v7sjNFvlxzt0sqmupEgMvI4I="
+  "org/jetbrains/compose/foundation#foundation-desktop/1.11.0-beta03": {
+   "jar": "sha256-ex5Udj63UU5Mp4YzYREt9/8qiv/egSHkPo3Cf8GrktE=",
+   "module": "sha256-VmzkCAMY5fTL/kgMYzhW9Gu6lPBSlIshiveOqKTlANw=",
+   "pom": "sha256-XYILp7WmvQfTAsGzjBf739ENwPebmTQb4AuqJmsF6Kg="
   },
-  "org/jetbrains/compose/desktop#desktop/1.9.0": {
-   "module": "sha256-kiCLVt2h9QQPgOmufi3pZ9az1UY2gorrwFYVBa6weLk=",
-   "pom": "sha256-6pFZD1PxYbxeT/rjAVVXsG7zGcLme+lPiHuDPGEIPw8="
+  "org/jetbrains/compose/foundation#foundation-desktop/1.11.1": {
+   "jar": "sha256-MmAWU2N+R8xEL6d8nl3ZWlV6BTOlMEulIAzHLFZfB0o=",
+   "module": "sha256-MYn6H3Eb30h5ewnt7DbxxEYDG21s/HiULXJY3wFH7bI=",
+   "pom": "sha256-OkA9BQm/hR0p7LqSdJW1wmn+sQCYXBcfdjWF7uIAtWk="
   },
-  "org/jetbrains/compose/foundation#foundation-desktop/1.10.3": {
-   "jar": "sha256-Opt7+ucvGpKoEj0ykLt9f2HZLlzeh3r1Nzw+XCys6ys=",
-   "module": "sha256-97MIb0lTebZoHD7744z3D9z8fK9UzGM79rPQlpSnUiE=",
-   "pom": "sha256-ljQ4YfNGEdQrKvHOq8L45W5NpyTjp1fXOIqHlwHic/E="
+  "org/jetbrains/compose/foundation#foundation-layout-desktop/1.11.0-beta03": {
+   "jar": "sha256-iJ/2np/rLzUYaKUOPyGw6wA0gck1t9XBLMjFWPFVGqY=",
+   "module": "sha256-Me/vBdRVthRszjUOlLKixYPn8koMSGiNRjA3oZFm76s=",
+   "pom": "sha256-Acx9MixEYurLgudM+OVbDAeJSJOmfp1/WC8BF+bIbQU="
   },
-  "org/jetbrains/compose/foundation#foundation-desktop/1.9.0": {
-   "jar": "sha256-CzobXwhb5sDOlTVKRzmzXp6oLgD3kEl8H1PHLqUTQvk=",
-   "module": "sha256-vpZlZzRb+0wg8vNOWSVdBKRhvAXF4fia/qyOrD9kqro=",
-   "pom": "sha256-Dy5t7Bgcjq7IznOIHLJIaC+c9Z+rl/iuDFevTBkGyNY="
+  "org/jetbrains/compose/foundation#foundation-layout-desktop/1.11.1": {
+   "jar": "sha256-15kptFUh3/DHfTGEQSAHs7lpV1XIsZM9X/nk8ek/oTE=",
+   "module": "sha256-0o6VTq2HvE4cIg0Tm8FJVUHBjdEWbK9U7cj+Au/OeVk=",
+   "pom": "sha256-eQO2y+HHwzMm1B+6pWm5G60IKPCTeQNArkzQERkqhe0="
   },
-  "org/jetbrains/compose/foundation#foundation-desktop/1.9.3": {
-   "jar": "sha256-08V6qBjAEjNAju7wc09RsLwWh7ceTPhj3fkrk6fMhhI=",
-   "module": "sha256-/nKrfJWvH+8AgrxOYWlG4VBQ3gZRA/UA1FSweqM4Tpg=",
-   "pom": "sha256-+HCWU6qwkonNNgeG8mwcJ8+UL5g9Xkj0GhGREzdC2AU="
+  "org/jetbrains/compose/foundation#foundation-layout/1.11.0-beta03": {
+   "jar": "sha256-sUYAI/yC0pioGhcNGPPnL+39QoRI0r5gUCPbFbg2xWo=",
+   "module": "sha256-tJfEXxA1kNcNo2cu6t2Zg6tsuFsFyxUG3hUx03YokKw=",
+   "pom": "sha256-+JMUlJ+eHNkat9VoJAP1E7N1shrauDcTEFq/8D31TQE="
   },
-  "org/jetbrains/compose/foundation#foundation-layout-desktop/1.10.3": {
-   "jar": "sha256-jY4ABiqDoUdAn0L5F5g5TDwiHSKHeVPv99CoF2e10Pw=",
-   "module": "sha256-NXX5ELMyQjwm+/DFQwPMeWQBmmH+yeC6OEyRiSgUF0k=",
-   "pom": "sha256-KftqG6ps/iBKzdfAlTytZ4PAPwecjt/5lDSwBXya9Rk="
+  "org/jetbrains/compose/foundation#foundation-layout/1.11.1": {
+   "jar": "sha256-sUYAI/yC0pioGhcNGPPnL+39QoRI0r5gUCPbFbg2xWo=",
+   "module": "sha256-QuPM5CdYs9tRHynzfhhoD0wsPKbY/Zr/Pbar2Z7BJQk=",
+   "pom": "sha256-1EJsKsBwAIzN/MPV/NGtBbC9xMu9+ysFRVWDnQHV9Kc="
   },
-  "org/jetbrains/compose/foundation#foundation-layout-desktop/1.8.2": {
-   "module": "sha256-FLYe6xVeaN7rIikWXb9OsXxYDoUZHVWAImCESRfwnrc=",
-   "pom": "sha256-Fed6HT2iHROf8shLGg6t+xGr5NZq+nMO47Tdbgm/9Yk="
+  "org/jetbrains/compose/foundation#foundation/1.11.0-beta03": {
+   "jar": "sha256-TSDNftbAbktx+pCa7iY3wVEyDzgmvarzLZt6VVZJM7I=",
+   "module": "sha256-j7CB2b1ZeLldP1JPOr3UHwaoGj40lbzRfiS8vzY3xWE=",
+   "pom": "sha256-2AxtwYrDqFx9D6M+dOdORh4w+UBwn/pzOsp+MhzsubM="
   },
-  "org/jetbrains/compose/foundation#foundation-layout-desktop/1.9.0": {
-   "jar": "sha256-WVDOHhAlmuIZikbhaB2Vnxa81k2LXQKJ4XxQhjrz+O0=",
-   "module": "sha256-5wXUw8YaJQC9BmkMhIGkjjl/PzyEaPEVYX1p6szzcTs=",
-   "pom": "sha256-KxoFyZeJ69iDa5wc73P09K6FUqWN5SvNu0iDlLy2ASM="
+  "org/jetbrains/compose/foundation#foundation/1.11.1": {
+   "jar": "sha256-TSDNftbAbktx+pCa7iY3wVEyDzgmvarzLZt6VVZJM7I=",
+   "module": "sha256-6/fS6fGq7hC1sUyJpTPIB/Di9YJl5mZlD3cq4eEM7JM=",
+   "pom": "sha256-M7AOmYx1WEw3v5OSfg45iXySV2LBNVoDl3T6+4Ly7dA="
   },
-  "org/jetbrains/compose/foundation#foundation-layout-desktop/1.9.3": {
-   "jar": "sha256-WVDOHhAlmuIZikbhaB2Vnxa81k2LXQKJ4XxQhjrz+O0=",
-   "module": "sha256-gtXkFCxeZpJWvZH2owJ7+crJKATmi9Rfdaj0dbysts4=",
-   "pom": "sha256-noSi2dPlxYmIFRKUkjFU1dyxh9oF1mM8Q8XtHD54Zgg="
-  },
-  "org/jetbrains/compose/foundation#foundation-layout/1.10.3": {
-   "jar": "sha256-XCmtk/BVfEeKvT/N/5wZXF6EvajJfwIu98WPSSMyFHU=",
-   "module": "sha256-gkovKnf9KkRJEfFeXQGELBpbJdOyYeDmJEvfoQ2Me1M=",
-   "pom": "sha256-v7wQ5yF+NgW+1e5f5G/kTFht7ZQRxo+50u4xaQ7MrkM="
-  },
-  "org/jetbrains/compose/foundation#foundation-layout/1.8.2": {
-   "module": "sha256-4ZO0QesgCnPcerN0hgMczkKibiznAPp53WsxZut6R5Q=",
-   "pom": "sha256-fWrcrn12qThawuLXFFl3HzGkFRLDgY+WLPm75d6nF1Q="
-  },
-  "org/jetbrains/compose/foundation#foundation-layout/1.9.0": {
-   "module": "sha256-YwrZaw97aT69sY9aXgKPZxaM4paL08yz8VflSqRjG7s=",
-   "pom": "sha256-Y0v0YLAjBNxJWl1pTxHeKYZeCdgHzZ7q1hPTxgXmkEc="
-  },
-  "org/jetbrains/compose/foundation#foundation-layout/1.9.3": {
-   "module": "sha256-BC1gYzk28D+86dvOi66DXG3mR/ZWaqtlUhmveApPB4o=",
-   "pom": "sha256-SGJ1Sxcpg8FGGKEesl328Sfx8gVXHKMa4CQ1NmDBbD0="
-  },
-  "org/jetbrains/compose/foundation#foundation/1.10.3": {
-   "jar": "sha256-4ZIu0qgQtBnlPztiGgnSJ4Ohu4U9b0J9qfMgEglxKx8=",
-   "module": "sha256-V66/3SNSe9U2Ix+hP28fFwP5I7RuTYeobXwW5T2x23c=",
-   "pom": "sha256-mHKS9jWEfIedR/5Og7/bmvcxVK6hb88+lz53+EdYkHA="
-  },
-  "org/jetbrains/compose/foundation#foundation/1.9.0": {
-   "module": "sha256-/6+3yasG25hJJDhAlTja6o9Y3Bydh0TsSgMCn6b4Ky0=",
-   "pom": "sha256-KdYEVx22XMXYrruz8VeeiDBr1SxG2dh203PpYauoQW8="
-  },
-  "org/jetbrains/compose/foundation#foundation/1.9.3": {
-   "module": "sha256-XMLCtU13nZlCjZcgjf9mclJe8PBY0b+3F7s8cNopVr4=",
-   "pom": "sha256-1uFzEB2DhAZQMlv2jdRpOdznvuXzPos6/j1fx3DgdEI="
-  },
-  "org/jetbrains/compose/hot-reload#hot-reload-agent/1.0.0": {
-   "jar": "sha256-MmtA0vfH40G4B2hGA7ji9XUMOdj5yfZ6ShjCJMjDGX0=",
-   "module": "sha256-WnI00tHPc0kArfE68JjMXNl9R4m1dM6hVF5b38U9J4A=",
-   "pom": "sha256-9idg8jL1hUnsbvIJUUCyeTjPVBPeJxjl5BJICFaRsTo="
-  },
-  "org/jetbrains/compose/hot-reload#hot-reload-analysis/1.0.0": {
-   "jar": "sha256-ubbR2SyC25+mVAgddK656uNlbh8U+T/EvMob1gWM7RU=",
-   "module": "sha256-mo+hE7NYpZLrGLOmePcjin4iFrHBhsdrVpYXvRx4FLo=",
-   "pom": "sha256-pZPc8QWIEVihx4CqVzcmgCYGP+4KRLNlbZxbXT/93h8="
-  },
-  "org/jetbrains/compose/hot-reload#hot-reload-annotations-jvm/1.0.0": {
+  "org/jetbrains/compose/hot-reload#hot-reload-annotations-jvm/1.1.1": {
    "jar": "sha256-9QbjmAxn+HbJUUvgIJW8rTvv969P3tu/WXlD2G3wcPM=",
-   "module": "sha256-V2zswUJwwpwX+cng/CEQecEo0MBPlAvMHdyP/A9HpYQ=",
-   "pom": "sha256-yKl2WannZXTliRSIwW0u8xMwzlTxynIgLrXiGstLKmc="
+   "module": "sha256-tzLbcqfMhTnByPNVYmMeq5aeADP3DU3mzYcXwS02bdI=",
+   "pom": "sha256-DT6Dj8VwSkIGkuTkxGFS0EmN/t9Mv9QnZqjnlBiJkW4="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-annotations/1.0.0": {
-   "jar": "sha256-3DgxgwlH4wbP7Dt/EKS5fN+VrMjntKMLnQUOaiOI6pU=",
-   "module": "sha256-kSBb9Jz0CWbbCc4CngfEUoRek7lzLpgOxcGjbt/z2WM=",
-   "pom": "sha256-3aWEn5RinN6jGfKxP9RUjIOw3EzJbOxSpxKf0FvNToI="
+  "org/jetbrains/compose/hot-reload#hot-reload-annotations/1.1.1": {
+   "jar": "sha256-FfTQYpKf6T46z2ri6laAfh0LKhWPmfiE3nva2vpvc5c=",
+   "module": "sha256-GzIidigY3IspcNtNmW9JALlqtg2ZGLO/BGdQYITYkQw=",
+   "pom": "sha256-4MJcqn8j1wZ+dQTsxY4OEK7eEzDWJk+iC17F9ZgORm8="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-core/1.0.0": {
-   "jar": "sha256-U0+7FSIvV1lLAzDPGTr0Q6cg7YouhXzFWHEwIrG0keA=",
-   "module": "sha256-IclZxt8H2/UDOPYsdFWvyPh1yDB5RFvK2BpPDglknoA=",
-   "pom": "sha256-s05XRwVr5YBCDQt4ahYc8gZfchGeAfCPiRTV3JvDB2s="
+  "org/jetbrains/compose/hot-reload#hot-reload-core/1.1.1": {
+   "jar": "sha256-DBLxjNb1mFr0Af8MOwMT4xaW8o6tsgBGgNoRx7AW1ps=",
+   "module": "sha256-EZ1rqh8S8A+yoh3ZX2kkD8UQ1qCH1FvPdB2gOnMkB3U=",
+   "pom": "sha256-F94xHE/mPK5mLl0PugrYdWWXRrkx0Pov+6C9HzRDEc0="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-devtools-api/1.0.0": {
-   "jar": "sha256-tXW6eZ2ynY1N5LK0aFhHxtKR4JpkfVstTM5D1v8c5cY=",
-   "module": "sha256-TgBuaOSX9omnvjg+MbmuqKBEoJCLtLavXltzAmdytNI=",
-   "pom": "sha256-3Ql9KAngMyEyvcYYBE+Iru3t++SVQ2uUgh8+JjzMI/s="
+  "org/jetbrains/compose/hot-reload#hot-reload-devtools-api/1.1.1": {
+   "jar": "sha256-X7Cqbk00kczz7GcdPLvx8rz88OBnbz4thWEs/ejfbVE=",
+   "module": "sha256-8iAegT/4RSdDHsV7j/q9dNQVV0TUZrucUhqPQHzdDFM=",
+   "pom": "sha256-M1JwjocZRXcOuwWb0ofxUOoO3xiMJVLJov+le5zvMPU="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-devtools/1.0.0": {
-   "jar": "sha256-aXlhIy7pOlRWq2EFTww12XnXsMnjcgK56kUMt6so1K8=",
-   "module": "sha256-FTy000ikm/fdBPAP1QNA6sr4Px+FK1+CWT2fvRqkp78=",
-   "pom": "sha256-HtbnvXf8IJLHuRXuOUbjLiGal0S0kgle8pZMny/jAnw="
+  "org/jetbrains/compose/hot-reload#hot-reload-gradle-plugin/1.1.1": {
+   "jar": "sha256-yErWizz55/HRj43qTlCXo86YYAIPpVA0JU8AnA3mndM=",
+   "module": "sha256-3rLhUP0khvjJMScGzQuIOfy5FqkKGihtQqn5JoWSlZs=",
+   "pom": "sha256-HzNyUqXvicvUGpsVOsmRRdK54K4u0mbGgEj0BUH8oGM="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-gradle-plugin/1.0.0": {
-   "jar": "sha256-NVGyox2E7Pla0UDP3FsEs7a1Br8VZhh63vm5GgXGawQ=",
-   "module": "sha256-BESHhjuIvcse0ymXqNij1sVogVgHfYUKmbNSihWuJWI=",
-   "pom": "sha256-KjpWO0MhAFxK+EbO3aCr2EA/avxtSdojD7q4EOrvB+k="
+  "org/jetbrains/compose/hot-reload#hot-reload-orchestration/1.1.1": {
+   "jar": "sha256-OJyfTOFdQIOjykh8+YIIWXxG4wn3DhXT2DXf4w/4mTk=",
+   "module": "sha256-zqLGhUYawKYlkdwPVxN5lbx/L0yWVhx+dh0vT8+0Q0E=",
+   "pom": "sha256-VzrjxEI1VHILRiii9ZWXH9d3r4c67Gfgor2SElu+JZg="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-orchestration/1.0.0": {
-   "jar": "sha256-nuw1Z76g9hI2An6AOOAD8BIAsOifEyydH6fDkByzS7I=",
-   "module": "sha256-0+mMw3hrwELMGWuFjctzdMODK4nKYakv17ywY4LIhyg=",
-   "pom": "sha256-ybUGOBTo1vIaeg09PKnfVnzz/oXj9kuQFiQzD8df8lo="
+  "org/jetbrains/compose/hot-reload#hot-reload-runtime-api-jvm/1.1.1": {
+   "jar": "sha256-AiGFq+fdw9i49lBnN/jFXKu+X8jUn+EoN3/3GEcl6vw=",
+   "module": "sha256-v3WtT4g84yZhqRttSMxcMLk10g7tGCAu3l8m4hddG+8=",
+   "pom": "sha256-D+FZhNuX0wiPA3CwQG0ON2GeawD7gNL/wklJWhO9Zhc="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-runtime-api-jvm/1.0.0": {
-   "jar": "sha256-456SOpwjDi5JyWmnuxs1M4s32+1erLLAOIkgto5uvDQ=",
-   "module": "sha256-tA3MSn42Q0jCXyE8IuTHFLRGhm1fNcn8iw9Aa2Vr21Q=",
-   "pom": "sha256-MJgt9tT/1aV0cKjAVceFOwxB76F+rl0pkAbpLz7pQ7I="
+  "org/jetbrains/compose/hot-reload#hot-reload-runtime-api/1.1.1": {
+   "jar": "sha256-DXwGz7KAihdDfKSLcuxjSljAmM9AhQdOALcc60fCmeQ=",
+   "module": "sha256-xMGOOQLn8bcY53511o1+PTr7KgDGYEFnpSdaGKkcK3M=",
+   "pom": "sha256-GOhkDldZzxqo5pcJmNTUZQBj+H877uBk4Sg8i4sreyU="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-runtime-api/1.0.0": {
-   "jar": "sha256-5M6NjBByySNtUkmu9DaPhKM1kr9wb1zDBk7HNObBatw=",
-   "module": "sha256-WFqlgVPJTyVhkXHMBy+CEVw5TYu+PsSa8KpUWHEgZjc=",
-   "pom": "sha256-3eyc3hN+JhsKtteccyrE7X9Ktk5xRTtqZ2wTsNnwbFY="
+  "org/jetbrains/compose/hot-reload#hot-reload-runtime-jvm/1.1.1": {
+   "jar": "sha256-9iQCE7NYXC82OI+MWXSqqVBw/QFxTkfqNbSPgob/70E=",
+   "module": "sha256-L0vVQf0Ofe0pESxWRwjHuhuVgGknUKy0uJVl7wtHX5U=",
+   "pom": "sha256-wcnX5pm7pTWgUtvw6sKXxn62zwN5X9AlUC8vnKHNA3s="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-runtime-jvm/1.0.0": {
-   "jar": "sha256-ehDmryszBytMfePjjI+Pq2VCr8UVz+8kLlOHj+x+EAI=",
-   "module": "sha256-z5SLFdUac4ebh8Zszk2JEyaTDdm9oRchZj1olHCDUmI=",
-   "pom": "sha256-UdKNSEj/eI45/WCFkJ/kEYH215u6xU92dJc8MNj92vc="
+  "org/jetbrains/compose/hot-reload#org.jetbrains.compose.hot-reload.gradle.plugin/1.1.1": {
+   "pom": "sha256-1MflNuUHav7FKqKagxvikzEz4dOY/TdHVttu5CP5Yd4="
   },
-  "org/jetbrains/compose/hot-reload#org.jetbrains.compose.hot-reload.gradle.plugin/1.0.0": {
-   "pom": "sha256-buCnhcd6o2l4sJSDyk0zJ68TS6ZjktF4Tr109dyD/NM="
-  },
-  "org/jetbrains/compose/material#material-desktop/1.10.3": {
-   "jar": "sha256-7kr6M6JBHgbPG+xolmd2f/uZH/AiaeBApO9k5245IRk=",
-   "module": "sha256-oHcuPnoXOyVEyrU0/XlYOi/wZA8VXM+cVW37+St6Uxs=",
-   "pom": "sha256-L3/X+0HcGuyjh8GZmv9K95xvYSiMBlfhl0eUF3VZoPM="
-  },
-  "org/jetbrains/compose/material#material-desktop/1.9.0": {
-   "jar": "sha256-WgTR4pWWAj/dXK/e20UQpKb6ZRIuhBm1ogSlFtyJR4c=",
-   "module": "sha256-TJ2trYhGh+FTYScKxPLbbAjX+xZQBm/bEJa5gBELA+0=",
-   "pom": "sha256-0+IE86ZZdTxVipwLnVnHoP4t+PmWHJdnMps6sxyFRqw="
+  "org/jetbrains/compose/material#material-desktop/1.11.1": {
+   "jar": "sha256-/NiBITYov1Cx4niSXbiS9VLCO9Y7x+25m5aHkMngl/g=",
+   "module": "sha256-eP9qdfrxc7Vef3T7jy78/lUf/yqcARZd4d7jXtkuPNw=",
+   "pom": "sha256-FHmRJK0j4aKzEb8bcDUhns561uU2w89JMnwMmc11fYk="
   },
   "org/jetbrains/compose/material#material-icons-core-desktop/1.7.3": {
    "jar": "sha256-vPbIU7bbL/FI0tOq07en6lTZP8e0Lgr9hA622vGhxoE=",
@@ -1472,389 +3100,269 @@
    "module": "sha256-sfqa12veAdmGn5uwxxKc0rByeU8jfgTRXj73yKZqSHI=",
    "pom": "sha256-3NyiJy7t6vlAZmO5s4zMl8cXnoWqHKeJMuxhIuVZlYw="
   },
-  "org/jetbrains/compose/material#material-ripple-desktop/1.10.3": {
-   "jar": "sha256-MldpehpYGI7D3DHzGGfxw4IJkAuH3xJh66yeahOH24M=",
-   "module": "sha256-pR3QR6gJYUVSE+M9RkwPbfuFYs1yUT5uHhm40Dky/ts=",
-   "pom": "sha256-cPnot28P5QBPa7xSCt74A6o6a3w5Wr8CEKxi/4sOqUI="
-  },
-  "org/jetbrains/compose/material#material-ripple-desktop/1.8.2": {
-   "module": "sha256-qonDHtpLPCdfECYdvgaC7a5j/N66IKNauEDsZIsQH7w=",
-   "pom": "sha256-TLDKRvyZMp5/EyBOXzVVjWKFl8f/LlpBFZKyPRiCmSs="
-  },
-  "org/jetbrains/compose/material#material-ripple-desktop/1.9.0": {
-   "jar": "sha256-JAfZ6Dxv2EuQsSPMeuYpH6ehi7QJOK0hD2deTIZCXIs=",
-   "module": "sha256-2zKNEcRG02g9UjTeSFKppIOPc7w2XCDglmFYre/lbAs=",
-   "pom": "sha256-KVdrVWPnpEioaL1EkUP4HGeC8yHC35pYERwvzdbZh9w="
+  "org/jetbrains/compose/material#material-ripple-desktop/1.11.1": {
+   "jar": "sha256-4k7Qp0BDhQjMg+s8sH3FXYOwouJfIz9I/8KgeCpy4Ac=",
+   "module": "sha256-VIlnE1bPlsJY+xLEmuYL33TtHYW3CxLpv+1ASkVLKhA=",
+   "pom": "sha256-9B1CZZeqEaa2HiYVkhzylupzSobj1mQnKTuAGzWMOZs="
   },
   "org/jetbrains/compose/material#material-ripple-desktop/1.9.1": {
    "module": "sha256-BlaiK1iKg5uADqwoWqPrTQNd89VSIccGxdNfpil+bYk=",
    "pom": "sha256-T5wpVlxWK/sQxbeoEGzHkuJZp2z3iJnemi71R4cADBM="
   },
-  "org/jetbrains/compose/material#material-ripple/1.10.3": {
-   "jar": "sha256-ce62zqnl/PPpPoRj4YjOseRIhxg6AgId0ML0JKWrHEo=",
-   "module": "sha256-WO35cU3AaVBDi8b89gCAtaSLq34IbsrQOHX5I+7CYp4=",
-   "pom": "sha256-c+E5j0QvD2h4PxOJIbmxBAis4y6Uv7h7H0YX0FiMwHo="
-  },
-  "org/jetbrains/compose/material#material-ripple/1.8.2": {
-   "module": "sha256-sPjhBmZdFZ5A5QpkLm/L4voyjv7tdZ073Js89SZ8nQk=",
-   "pom": "sha256-2Bnue2maiafpoGNneZA+WkB/M+IgBggHvkVGiFiMQqo="
-  },
-  "org/jetbrains/compose/material#material-ripple/1.9.0": {
-   "module": "sha256-WBIIy/NsxIRNry00g+nD3Dd2myRLnTdjDvhEx2fViss=",
-   "pom": "sha256-AXqwUq4lbqakhkdg6OQWCVHLKmEJXt7hiSW6XNOlE3U="
+  "org/jetbrains/compose/material#material-ripple/1.11.1": {
+   "jar": "sha256-aCKiJ1yYknuGNUbXdYUydrFZkhTkI02btHEHstpwdOM=",
+   "module": "sha256-4cXp8ji+k3PPrs17nYPvvpU/zFzheZYrr6PyIAWJIlg=",
+   "pom": "sha256-8S2WkwTwAJJVQoC6ah+0rpuZ9LAa5FjpI12aIEXXrJc="
   },
   "org/jetbrains/compose/material#material-ripple/1.9.1": {
    "jar": "sha256-KS0rP7u8wkuzJvP2QtrJqM1V4Y1bUYNlusbayiOlz3Q=",
    "module": "sha256-iY2+mg5iyco5GzdewaJ7SZZXQ7dKBq2F9ucQoLu0o9o=",
    "pom": "sha256-9S84Kui5GL5SNnYUELp9jdEuC2rJkjB5fFOyQLoaMeg="
   },
-  "org/jetbrains/compose/material#material/1.10.3": {
-   "jar": "sha256-LSEY93unibj6F5gDhWp64ex1P5/5ko70jyB3VAq4MgU=",
-   "module": "sha256-hUirZfmexDGhviU4aHlXl7pxYje0HOijrAHtc3pCqx8=",
-   "pom": "sha256-WHVX6+B9rZpj+5dUNl4GDp9OQrknZqMStPghVnEPEmY="
-  },
-  "org/jetbrains/compose/material#material/1.9.0": {
-   "module": "sha256-UyLG9xJ+ZTOuU8dQ+TmDz7ww6kiJTOc72bKqUIzby/g=",
-   "pom": "sha256-4sNTk4f+GRpSKz4DesH+9UYn5T2gpkgHr6Xbd/+rCKc="
-  },
-  "org/jetbrains/compose/material3#material3-desktop/1.8.2": {
-   "jar": "sha256-PgFota97rNusxB6dNv9PbTmouYn9Y7aOOzBftqTSq1g=",
-   "module": "sha256-00fR/8tIGIzQgLUdIaRbyTi7wRaKoFhXqmUvnujPoZY=",
-   "pom": "sha256-WdF4UbuYtEfu+CrRrR0TPSvNfAVqDlQ4SKcqqteSbH4="
+  "org/jetbrains/compose/material#material/1.11.1": {
+   "jar": "sha256-8pMkH9XVFXmeT3wbfOQrPghdIaSZoZVZH7Pq2UyZVXU=",
+   "module": "sha256-zRVOaYXpFUjuCLjIQBdJk3lFDotRHstXL1n4rMJASeQ=",
+   "pom": "sha256-L9p0J+ElR+kEUII0E6WGjo3SMSvmROY6pjPtojWn8WI="
   },
   "org/jetbrains/compose/material3#material3-desktop/1.9.0": {
    "jar": "sha256-ePB4ehxtIPmyRgo4f1Hs9VTiEdPIdLItZlMKVAOQuBE=",
    "module": "sha256-8k6gvUIXSQX9Mq+I84qKTRXYBlQ8qxiyT/5mnxjnWY0=",
    "pom": "sha256-2uS4gKerRfs4sPOijcOSbbWiOdGxfn6i5xY3+WMLtUw="
   },
-  "org/jetbrains/compose/material3#material3/1.8.2": {
-   "module": "sha256-ecEjW2d12MzzwJkrYDrBUPkMkmUyLAwg7rHCKTSCZVM=",
-   "pom": "sha256-BcrLqe9FofHCyT3MhTbmvl/p4Wo2s2PIqqpjraSZrWc="
-  },
   "org/jetbrains/compose/material3#material3/1.9.0": {
    "jar": "sha256-C+JrF0bluq5Dfb+CDa7+9+EHtkiEb5fntBHc0d5PZDM=",
    "module": "sha256-+np0XfkXBZHZjzdzMDvPU4KTE6z7Q8csGqT4+5m6RaQ=",
    "pom": "sha256-lyjwhwOCTgT6yPhOZuHn8obuQwiQ8yf/ix51Qx3fGto="
   },
-  "org/jetbrains/compose/runtime#runtime-desktop/1.10.3": {
-   "jar": "sha256-BfVXDAp+qK3db+lQenDyk++n8UUNi5sW3DyP7iHMYSc=",
-   "module": "sha256-AzcEvJYZP3j8+I8ZHWr+QThLXvohEKIb+sHSm78fKJA=",
-   "pom": "sha256-6XHhyRcUR2RQjFqRk98TVyU3eVTNemGrn0eSUCtufGA="
+  "org/jetbrains/compose/runtime#runtime-desktop/1.11.0-beta03": {
+   "jar": "sha256-vOssUG5CCZNL4BrA9FMysMEreIbuANw5DHu9+/WPQhc=",
+   "module": "sha256-8oK4GYgmtmdnQi3rdoCwW0S2XebRzccgUNWw0iW3Hnk=",
+   "pom": "sha256-vu8B5OdOsVfmWE5/8+Wkc14hAkHL//k0NRVObtFfFts="
   },
-  "org/jetbrains/compose/runtime#runtime-desktop/1.9.0": {
-   "jar": "sha256-BfVXDAp+qK3db+lQenDyk++n8UUNi5sW3DyP7iHMYSc=",
-   "module": "sha256-kszIipLLMPWv1OBsHU/jkKBCEDbOzUD7jL6ntnEp8Pc=",
-   "pom": "sha256-hRQIp7xApYgt3rUY0HU/c42x0birWJP3U1mmYfmArSk="
+  "org/jetbrains/compose/runtime#runtime-desktop/1.11.1": {
+   "jar": "sha256-vOssUG5CCZNL4BrA9FMysMEreIbuANw5DHu9+/WPQhc=",
+   "module": "sha256-IqGKlVggz4zIxmQPUf2+feRncV6suiXMU4aIPZQrzWo=",
+   "pom": "sha256-+B5PSD8GxVjXclg/KNig9bPrpZZw7phPluQOEf7lmOk="
   },
-  "org/jetbrains/compose/runtime#runtime-desktop/1.9.3": {
-   "jar": "sha256-BfVXDAp+qK3db+lQenDyk++n8UUNi5sW3DyP7iHMYSc=",
-   "module": "sha256-PTuLjN+aMF8bQuIKiUjw6NkHoyLbktmEmdCg4d18TyE=",
-   "pom": "sha256-r0eMxiql29JF+HIbQEpFZp7pk6zxaTXs7CGdq65uoZI="
+  "org/jetbrains/compose/runtime#runtime-saveable-desktop/1.11.0-beta03": {
+   "jar": "sha256-dpbBXdI94BQNgVDxEV9Z0qIRMx47qiQ/QYR0R36Ylxw=",
+   "module": "sha256-vcQ6n/CC1Lt9SFdIEAYs6zSu+um1J1CcQVgtmUR1W4s=",
+   "pom": "sha256-o8WlwM47B3ND4gZFPtQPZeBjiP3fZVqltiUM8wKAFnA="
   },
-  "org/jetbrains/compose/runtime#runtime-saveable-desktop/1.10.3": {
-   "jar": "sha256-63EytV3isJE3Nv3/RwUCKAPkVYEPAY7+zJ6zIwk2Ugo=",
-   "module": "sha256-JKUzujIzNXFcrGkEiFr8GQBMy/rbpZoFJcHFPI2kfwo=",
-   "pom": "sha256-D/UkSJQVoj7DPL88/+0k4uankfjwqvJNsQx/uGQylpE="
+  "org/jetbrains/compose/runtime#runtime-saveable-desktop/1.11.1": {
+   "jar": "sha256-dpbBXdI94BQNgVDxEV9Z0qIRMx47qiQ/QYR0R36Ylxw=",
+   "module": "sha256-nT3r1HAKUl7E4JspOOwX/mkw+AccE0/FTVqmiOkHB5Q=",
+   "pom": "sha256-90MTqloWvsPZAbjYKYHNKgci/dwqxqji5Psne/hTTOI="
   },
-  "org/jetbrains/compose/runtime#runtime-saveable-desktop/1.9.0": {
-   "jar": "sha256-lgpiL9h17cPFmPJpIQHm+STvePuvvpQR50nRhK+49i8=",
-   "module": "sha256-QT66RZ1ktkSR4mtYEPCXk5OX52278IvGKf2kYE+GR/w=",
-   "pom": "sha256-pIix1dT0+gTMEUVKX1YnmoDbgV5wv8poOu6gmovY0Wg="
+  "org/jetbrains/compose/runtime#runtime-saveable/1.11.0-beta03": {
+   "jar": "sha256-aZ+/dGYW6ifIkD9QuV04BZDB8Hw5VaI7fAvwual51A0=",
+   "module": "sha256-fLfCEhxH1b+klQI+rs89V0ZXiIio7MWae+O2k+JABw4=",
+   "pom": "sha256-cqHT9I2uI002RzEiBL2X5HClq0KqtlPA0zkwDJsf8sM="
   },
-  "org/jetbrains/compose/runtime#runtime-saveable-desktop/1.9.3": {
-   "jar": "sha256-63EytV3isJE3Nv3/RwUCKAPkVYEPAY7+zJ6zIwk2Ugo=",
-   "module": "sha256-G9YdH5y8eupNKWgKQnuusT4/7swkssYyusJI/TqHL/k=",
-   "pom": "sha256-0WllLahBVRQ34G/mvsJ04QodSziMT40nQuehJF0re9k="
+  "org/jetbrains/compose/runtime#runtime-saveable/1.11.1": {
+   "jar": "sha256-aZ+/dGYW6ifIkD9QuV04BZDB8Hw5VaI7fAvwual51A0=",
+   "module": "sha256-cG31drzu1+6WQLpyHHWZwitc5Il23mW+vYXFaSfGtaU=",
+   "pom": "sha256-oE+rRUIsu/z5rnu8/DT4dIpbIev067rua1NAOQE5TnY="
   },
-  "org/jetbrains/compose/runtime#runtime-saveable/1.10.3": {
-   "jar": "sha256-3R9FlRnD00QOtXjsQSrQaRnJ02ucF+XNs5jWv7CMIvs=",
-   "module": "sha256-T/wCzyHJTDjKgSBPIRJtYzKeYIiD5r2PIEMua+5M6CM=",
-   "pom": "sha256-48qngqK2ebBKlYcLpy7WZJKAfxYJUOtRLgrmjynqFUo="
+  "org/jetbrains/compose/runtime#runtime/1.11.0-beta03": {
+   "jar": "sha256-dJL4PPeRpyeIDFVcrCmLkd/S4MqSJK2vkiO9gj64wMw=",
+   "module": "sha256-ppHzsuiouhmW3QExhh20VLnBSdBNwtCoyMGjB1Fhuew=",
+   "pom": "sha256-2oRUH9Bi3rS7cag6EvyJOVSETNIZusNG9p/jiWfvHn0="
   },
-  "org/jetbrains/compose/runtime#runtime-saveable/1.9.0": {
-   "module": "sha256-vND9YwqwZNKdv3HahqLATVX1lXiM+doOB8G+YZdAQlI=",
-   "pom": "sha256-0TBzcL6/xy7vRmUgeBvnPskoxvHzur2HfozlRl47Xb0="
-  },
-  "org/jetbrains/compose/runtime#runtime-saveable/1.9.3": {
-   "module": "sha256-r8hC/ovdMqXOdBMrta6H9ziiCXUGkW0W4orbGIgFfpU=",
-   "pom": "sha256-8b9Fr9nQV0k5nvAqwnbC3LZWVz3USSdTD66/L7u7R7M="
-  },
-  "org/jetbrains/compose/runtime#runtime/1.10.3": {
-   "jar": "sha256-uj5+kVsZvOBaHnQzWlRijrzuRssjihu2hHrT+wRaVr0=",
-   "module": "sha256-Ma23If6jrpqbW5tS6gUY1+3NR/rricTBKuki2sFJcW0=",
-   "pom": "sha256-PzmzrJI8vG31+BwX9AYVdG3KL6DdxKIz9iawtvyhDOk="
-  },
-  "org/jetbrains/compose/runtime#runtime/1.9.0": {
-   "module": "sha256-FuTMFfw9DaBRlitd4t2codlJqQ6TBF4nOCvdozGjiqM=",
-   "pom": "sha256-NYdEukMSFIl1/n0TqPnnQV1BRTdTSkFG2YDJSIBrSQA="
+  "org/jetbrains/compose/runtime#runtime/1.11.1": {
+   "jar": "sha256-dJL4PPeRpyeIDFVcrCmLkd/S4MqSJK2vkiO9gj64wMw=",
+   "module": "sha256-K16b4y2ouXH+yhrdU/OfXGb/rKuBCzFfXmJzPe2wEF4=",
+   "pom": "sha256-ZiHJEdYlb9Em5YpDnSjnIWnD+XYJ2CGOeUbirgCf+Us="
   },
   "org/jetbrains/compose/runtime#runtime/1.9.3": {
    "module": "sha256-RoPOYaDjW2fnQuNTqNRlcXglAxwQgc+7+zojate9s9o=",
    "pom": "sha256-4yJMwKXBCThxJVp+fmcbXoXsxKLloEg1Q7o3Tc9awq4="
   },
-  "org/jetbrains/compose/ui#ui-backhandler-desktop/1.10.3": {
-   "jar": "sha256-G6v2j1oFy+G6jPk08OV1uw0LGEREUU5qp+wfgATJzjM=",
-   "module": "sha256-NLa5JVcTtJ2+Sb/Ny9qelSz80OnCJSBAi2I1PRN7+aE=",
-   "pom": "sha256-GckrfcqDBGLgeL8HGwQr1yRHrr5GCHbkac9nhq/h/Og="
+  "org/jetbrains/compose/ui#ui-backhandler-android-debug/1.9.1": {
+   "module": "sha256-19K/nVe3u0l2A4khAQPy49mvhs93P4IVgfffsTix3HM=",
+   "pom": "sha256-MddXn+UHZyPpN4ZrlXpEncv4TvYhYGlAUnmVTJRQcsk="
   },
-  "org/jetbrains/compose/ui#ui-backhandler-desktop/1.8.2": {
-   "module": "sha256-+oKZkW+3Mr9DcgP4srNf2cfIX64H4I6qh4bVYM4eo1w=",
-   "pom": "sha256-FyT0XKYO3FXhUT1ePE6xpveCcBRMREpO2aEB1Jxolpc="
+  "org/jetbrains/compose/ui#ui-backhandler-android/1.9.1": {
+   "module": "sha256-wm5ZfRh4NgAA2PZvCW4XTnsqEEIY0v/gfhrg2xMkW+8=",
+   "pom": "sha256-KJdxsgWQBooM6fHuSRonOoA+9ayDWUyKVQN+A94iQr8="
   },
-  "org/jetbrains/compose/ui#ui-backhandler-desktop/1.9.0": {
-   "jar": "sha256-N9Npc3xo770nsUuDXOKIzK5FaTzBUCy161gxo09Eo9A=",
-   "module": "sha256-9gHX8qF1m8UoF9XSmX62b7zXZWPAkHeWJzr/dTE0FAE=",
-   "pom": "sha256-qFojKagc8fJgF5STGQ9zxBByptHZJjn3MwFvCMJyAoQ="
+  "org/jetbrains/compose/ui#ui-backhandler-desktop/1.11.0-beta03": {
+   "jar": "sha256-AH+5qD+kBbi/4d2+/vPdkp3qK+QpU+ZRDORvhf9jXjA=",
+   "module": "sha256-st2Y3GD0GMpEgJVEPBABE8UHQU4R0fZTDPJAv8Cdq34=",
+   "pom": "sha256-ay4QcRVV5RVjKs11siDsbJ50qjHzKRpz6ajRNx9GGm4="
   },
-  "org/jetbrains/compose/ui#ui-backhandler-desktop/1.9.3": {
-   "jar": "sha256-N9Npc3xo770nsUuDXOKIzK5FaTzBUCy161gxo09Eo9A=",
-   "module": "sha256-dGExx/cfhC4n5QGSwyrcJeiH1EoLbCKVXP6787UpLPI=",
-   "pom": "sha256-wc4wH0ViEhDEOp9TSQ0itmQcRDVo+laE9LCzlKCt0iw="
+  "org/jetbrains/compose/ui#ui-backhandler-desktop/1.11.1": {
+   "jar": "sha256-AH+5qD+kBbi/4d2+/vPdkp3qK+QpU+ZRDORvhf9jXjA=",
+   "module": "sha256-0QGxD3yuXegOFJdTyNg7lRaSLm79BCJaM5wJvdrEVGk=",
+   "pom": "sha256-KopUqbkj11gjfd/ZXm57NxJ2gIYDJOWN0gjlqGGH+5Q="
   },
-  "org/jetbrains/compose/ui#ui-backhandler/1.10.3": {
-   "jar": "sha256-oyMxtIaU52eRz0Gx4WGUfs1zscw29iksG7vHPMQRd2s=",
-   "module": "sha256-eWIJfSsQmDZ+jNRpQQU9g3U0B+Ze84aASiyu96EckmY=",
-   "pom": "sha256-IzfSkg0+wW6/WGVPDlC4wWO3cTea5aVv1WtDOzEkdA0="
+  "org/jetbrains/compose/ui#ui-backhandler/1.11.0-beta03": {
+   "jar": "sha256-ni/S+T5C4kpwidSx1VIpp2f1G1MspEqDDpjknWrd6DQ=",
+   "module": "sha256-pUJEbcbYQXGTbmYbkeiVuO12/3EGqrQub1U9e5kUowI=",
+   "pom": "sha256-UBu8+9vWLgsqdhasNuIxG8NsBM8dM3Pk2eqALZEgtg0="
   },
-  "org/jetbrains/compose/ui#ui-backhandler/1.8.2": {
-   "module": "sha256-WR18EZK6Ag6G3DevzSi/QzFyT+bE+kfO2XWQkKrp6EU=",
-   "pom": "sha256-OfZ7iLon+G50hefUvexlDWzRkI66opCQKf7tMvxrjfI="
-  },
-  "org/jetbrains/compose/ui#ui-backhandler/1.9.0": {
-   "module": "sha256-P4hjF2qDOYRO2IuAerY9e6T/sE5FHQ2z3vOl5rike1w=",
-   "pom": "sha256-vQddtSeMju4iD5jf0PWJ1MQfVm4hcPGAPFB1e9q12+k="
+  "org/jetbrains/compose/ui#ui-backhandler/1.11.1": {
+   "jar": "sha256-ni/S+T5C4kpwidSx1VIpp2f1G1MspEqDDpjknWrd6DQ=",
+   "module": "sha256-TDymAUhUKkHYT5IkioExCUqgXOad7SLB4KkL5kIbGt4=",
+   "pom": "sha256-ro3VqyhA7HVN3PsFy4H4erLHf/NkFkA+7MWWr1PwDXQ="
   },
   "org/jetbrains/compose/ui#ui-backhandler/1.9.1": {
    "module": "sha256-Md+hhs1xs1XLG+eGB//VJW3Mg8/xFaJg6k1pdJIJJYI=",
    "pom": "sha256-jKkBhNsSyAgoKenTNle2BzBOI6o2nTbfy7sQjib+DuI="
   },
-  "org/jetbrains/compose/ui#ui-backhandler/1.9.3": {
-   "module": "sha256-dDCSIM9OhiXxSAUduWL3g+4E87ZCatgbEXKeaD8JcYE=",
-   "pom": "sha256-IRNOf+Gko/ke6PDfdCFGTa/zjLv32D1qx80oWvg+QjE="
+  "org/jetbrains/compose/ui#ui-desktop/1.11.0-beta03": {
+   "jar": "sha256-4X6Wgg+HXHKCVZwec/xE3hR2daQTEInVoOXUUJzck/0=",
+   "module": "sha256-KuTvIslxmIpC//n59gkez1naEgmMHDa19CSQgT+SX10=",
+   "pom": "sha256-VR+emWnI9fLOLHDLBdKPVQ55iabxhMleRk9bauK+NJo="
   },
-  "org/jetbrains/compose/ui#ui-desktop/1.10.3": {
-   "jar": "sha256-7IiHwDozP6N00LTEa7n7cAk3hX9AiOrqTEzA7INfdJg=",
-   "module": "sha256-QexVKoykIp1qXsMAxPIa2LVlzhBA1wRhfl0ktsMaOvE=",
-   "pom": "sha256-gtlnQ/oWPgzFcclgdyEGkmrWtR7j7zw88IGAF/MMouo="
+  "org/jetbrains/compose/ui#ui-desktop/1.11.1": {
+   "jar": "sha256-RC1KLw2VBURTtoGRME3KmVJn5y/Ny7wKY5l7/03N+Uk=",
+   "module": "sha256-J26MT45zVFyDgdA1SQcvu7hsO5j0fzqS5N3mO3hwGt4=",
+   "pom": "sha256-OBBx4nN56euSbGNATHbtIm+4+CEQ+PJkMANFYkzQwtQ="
   },
-  "org/jetbrains/compose/ui#ui-desktop/1.9.0": {
-   "jar": "sha256-c5clOZPo1RLGE7dyOeIOUFLaghj2sLZMzeLDexS1QNw=",
-   "module": "sha256-nShr23AMBOUQ6rfv8xcalPsS21In3UmIVjy2/JQAuCk=",
-   "pom": "sha256-N8qab9bThJ5l+UCCMjH05oycfYfAt19zSLSPIeU+NPw="
+  "org/jetbrains/compose/ui#ui-geometry-desktop/1.11.0-beta03": {
+   "jar": "sha256-rW1VV1cnCKzuvxqmJsWQDo/OYfBAptXZcbGtylhpq4w=",
+   "module": "sha256-7nOj5PCvwqleoDzoGQ24x2wT671Drj6TklydalfGzTE=",
+   "pom": "sha256-ZTY5x2xtRfUpFXrOe6cBbMjpD6FU2OyQjvkb4tqWZg8="
   },
-  "org/jetbrains/compose/ui#ui-desktop/1.9.3": {
-   "jar": "sha256-nJIUT23ylm1319Fmv4ktjF3ao1jAr47IJ2515CZgevQ=",
-   "module": "sha256-b7sxOjIcHw/GgZFKPgHUmydYgTTakLrXHrEsow0a5+0=",
-   "pom": "sha256-6ZxZIdDUmtwX6Xl4CPHoyT36g9Y09wef/nbT1XLGHB4="
+  "org/jetbrains/compose/ui#ui-geometry-desktop/1.11.1": {
+   "jar": "sha256-rW1VV1cnCKzuvxqmJsWQDo/OYfBAptXZcbGtylhpq4w=",
+   "module": "sha256-nkZ3Rd+KER895SD6pftnlFFEdTCrmbak58QnyEww0ig=",
+   "pom": "sha256-4TnWipls4mpydKoJrfPl9yGtjse0gnVzz7N6Bn8rMAs="
   },
-  "org/jetbrains/compose/ui#ui-geometry-desktop/1.10.3": {
-   "jar": "sha256-zb/avMrIq+8tm8BCDsDEvnqID20mstHMTiMXwNJS7ic=",
-   "module": "sha256-lgQU9dg6zOgoJoWEGcmyjj/x06R7vkEuMkXA5Y6OTjE=",
-   "pom": "sha256-SGFxRyZ0bKhvpFR5Sx+wx93SoWeVgrGlEPBmi3A4uLQ="
+  "org/jetbrains/compose/ui#ui-geometry/1.11.0-beta03": {
+   "jar": "sha256-+3sqZUb2gbwrjukuVlD83kKpHaBmnYG4g4VFISnj3eI=",
+   "module": "sha256-olopE+gEhIL/ohKUO1+CK/CjepWN4SEc7AG4a75IAO8=",
+   "pom": "sha256-OBu9zibKolLz+sAewF0yuJlDE0mYn9dQQCiMdgSI7MY="
   },
-  "org/jetbrains/compose/ui#ui-geometry-desktop/1.9.0": {
-   "jar": "sha256-3qD2dSTkNJY3yYXg+iIE/zVJIvOMZcyPgQZJ0Njp+uo=",
-   "module": "sha256-mZqXUb2oQ+LV/S6ZVq3Fd+FxVP5SrH6Q7LdaqTd+WUY=",
-   "pom": "sha256-ajUF56SiSisNnJqjxSFMQ5M0mQljcpLjvPjvjDR/9EM="
+  "org/jetbrains/compose/ui#ui-geometry/1.11.1": {
+   "jar": "sha256-+3sqZUb2gbwrjukuVlD83kKpHaBmnYG4g4VFISnj3eI=",
+   "module": "sha256-8frXRcmYYY5Tgm+iSVfYjhwKFueCs/ctNxYAA78MerQ=",
+   "pom": "sha256-uhc2rmi4+mQZMdUpkwXoPRCpzn0cZOWIbUyfou+AJEU="
   },
-  "org/jetbrains/compose/ui#ui-geometry-desktop/1.9.3": {
-   "jar": "sha256-3qD2dSTkNJY3yYXg+iIE/zVJIvOMZcyPgQZJ0Njp+uo=",
-   "module": "sha256-BR1eOV0OB305IVxbnXP3I+xEBjK2leBZD52i07kdnpk=",
-   "pom": "sha256-Vsnm4VvcVVQNaroiYKvRSwXw7AKbSeUvw/6EUkyAOqI="
+  "org/jetbrains/compose/ui#ui-graphics-desktop/1.11.0-beta03": {
+   "jar": "sha256-zpz6uzK04iaxG/sLU48FHu9McFAEkQzXf+KRkYnnyCo=",
+   "module": "sha256-XYAm9BcoLlhZ/01c4xnu32BMsizL+AZ+Mo8hnbEokiw=",
+   "pom": "sha256-b8ACQ2Kh20U+Af1u/RYUKEJGUZHDtWOrMjVwtE7C26o="
   },
-  "org/jetbrains/compose/ui#ui-geometry/1.10.3": {
-   "jar": "sha256-Fu6RG4s+UdacwImB2VcjoWgtV4/vr3+OilTVVVv4WSU=",
-   "module": "sha256-xH4Zjl1/zy+lNzDFORotQbkYnPbUy96nqc6lfwMaVLI=",
-   "pom": "sha256-59cSUyCMUcsEg4n9rXWoNHZ9NZmapWjP7FtPiOuuHK4="
+  "org/jetbrains/compose/ui#ui-graphics-desktop/1.11.1": {
+   "jar": "sha256-x9diDHjw5kBS8fKN9UqWmzbPSRjnlltWaHWFVWk0blk=",
+   "module": "sha256-eMKnTI0R9NfIxAE9ksmqkhML4wYloE7VvyK7UkziRcM=",
+   "pom": "sha256-sbg9CWCygnJssIXQPwsmx2CvmcQ1mgeuiIqmAOwZ+8U="
   },
-  "org/jetbrains/compose/ui#ui-geometry/1.9.0": {
-   "module": "sha256-MrCoE8bMfwFQv+MYCKP9uAm4g7Xp+yODOZ2OCbxzAvQ=",
-   "pom": "sha256-6D3wiP53lSdwbdxB5T6g/o+aE0fLCZ79FGskisUtbEc="
+  "org/jetbrains/compose/ui#ui-graphics/1.11.0-beta03": {
+   "jar": "sha256-txpnyyuomXi00QvmmykNVvltxuCfahAgR+8S+YFB+Kc=",
+   "module": "sha256-mYh8YwTbaYZyP1ghSQE/D1DGPGjl3r1rFa4KVaHxhCk=",
+   "pom": "sha256-zEM9waFzO+vESHmB5WxCeu2lbc1beO4ufZf4TOSEc2k="
   },
-  "org/jetbrains/compose/ui#ui-geometry/1.9.3": {
-   "module": "sha256-BjMaYYvV3QXSIEF7anPoQjtaluNNU4vZ9Cp80eVvl4M=",
-   "pom": "sha256-WBN7lJhIqew1/8/4sjM1kZTp19/c7GlpRY61KYllCYM="
-  },
-  "org/jetbrains/compose/ui#ui-graphics-desktop/1.10.3": {
-   "jar": "sha256-n6YENk3E3iPT+BAfL1lor6dC2EcQWl4sQbagqpEj8Rs=",
-   "module": "sha256-RFCY1FzyEXQXpn6X9Rtc7PUx6HxvYPF65DEjv92i+U0=",
-   "pom": "sha256-nFOUiy1/SAlltzXpSNgUjpl1lJ2+ILnBaZ3fDHFOPM4="
-  },
-  "org/jetbrains/compose/ui#ui-graphics-desktop/1.8.2": {
-   "module": "sha256-VKdWGvFbAenj1reymZfgvN5/VhMgTzwWaaYhBdZ5b4s=",
-   "pom": "sha256-Q8xiGyDTZPIimJ4bva2fkSoice/WjDX5SJlczGX6emo="
-  },
-  "org/jetbrains/compose/ui#ui-graphics-desktop/1.9.0": {
-   "jar": "sha256-D4vlJjaE3TrgPCPoIhoejmlypQjsmuzXd/iYR5jxUfg=",
-   "module": "sha256-zhOcM8R+fBaIL+Wg9x/ybsIgf0nbXkQs8dLsZjBYls8=",
-   "pom": "sha256-dnVmTZ/ahP6rPQ3AJn1nzNraBKiSlTzQsCY3BejgIsI="
-  },
-  "org/jetbrains/compose/ui#ui-graphics-desktop/1.9.3": {
-   "jar": "sha256-D4vlJjaE3TrgPCPoIhoejmlypQjsmuzXd/iYR5jxUfg=",
-   "module": "sha256-mTvTBodaBfZ31NpkMS0ryg+77/wTXstcr8HsORgVTho=",
-   "pom": "sha256-+OREs7Vl2nYYWQqdu8K9+EJFrtTSdhNjWfwEP7drSzc="
-  },
-  "org/jetbrains/compose/ui#ui-graphics/1.10.3": {
-   "jar": "sha256-F9QqULHO3TvO33td55ZYPt9z/SnNwgeVxeWA2x9/bgw=",
-   "module": "sha256-9828VRQnee5Xi8fP/n5xopYqaJFkXLnnbHu8h+Ie1/o=",
-   "pom": "sha256-O3KdDpbmdci9sYStwDrSU2nWlcarGhiToO5G1nQKExA="
-  },
-  "org/jetbrains/compose/ui#ui-graphics/1.8.2": {
-   "module": "sha256-ah9EbiXhhsXFXUOG42zKGnadejS0QSN6vWxmSrPrPiU=",
-   "pom": "sha256-x7BcaNcE2k5LXbxB9z2f17jwZRjHgjcQqHuohM20JU0="
-  },
-  "org/jetbrains/compose/ui#ui-graphics/1.9.0": {
-   "module": "sha256-Dvn6KFk5rYTtwfdsWt5TDFFg8GdE1PVnrZeGRui5AEY=",
-   "pom": "sha256-WTraj4T62MMvpRVLwqHpDRcjycZMCNhuvTfBsg80tp4="
+  "org/jetbrains/compose/ui#ui-graphics/1.11.1": {
+   "jar": "sha256-txpnyyuomXi00QvmmykNVvltxuCfahAgR+8S+YFB+Kc=",
+   "module": "sha256-26V/jt8uDPbelpKYFQXGi+Tnj+7yhS7c2s/JFfs68Sc=",
+   "pom": "sha256-d6XkNSQTllS293GgVBAofQEc7sjnq3roZCcE/Up5L2o="
   },
   "org/jetbrains/compose/ui#ui-graphics/1.9.1": {
    "module": "sha256-ttJkrI5cSN1PbxPZ/YGQeA8aOG5KEL2Qw7sFVlLUdAE=",
    "pom": "sha256-Fg1bjrRrnNaYMU32OM+sNDC5aC3fm1RAG3kWxjd7z6c="
   },
-  "org/jetbrains/compose/ui#ui-graphics/1.9.3": {
-   "module": "sha256-WZRUxCZS+cyjOPEzwWLfV8sOZ2EgroZFl0FrFHXmVyM=",
-   "pom": "sha256-kGv0hbcgzxNRbm4UTNyU/cVfIcF2UIfZeIWqXWWxrFA="
+  "org/jetbrains/compose/ui#ui-text-desktop/1.11.0-beta03": {
+   "jar": "sha256-wajOseh1xvG7LmfsqHePwEAn3WGPMaafiGNoy9017uw=",
+   "module": "sha256-EuEkZ75vI6v8ETW9ZK0jp0nh7z7zixrQ+XGf4IPfdyk=",
+   "pom": "sha256-AighDkf3GUAJU1iAE/VACFCsZqHNBbEGZ42PCHOA8eM="
   },
-  "org/jetbrains/compose/ui#ui-text-desktop/1.10.3": {
-   "jar": "sha256-+8pNuUW+KGuE91wMnHhCGEcL6++oMfc/CO37MpS2yOg=",
-   "module": "sha256-5gnsPt8KodhowgXbhOS4nqLaA4nCcrA0Ra7YrswPAY4=",
-   "pom": "sha256-Fd6V18ybuUy8U+g0DdryyEyq4hyID6NQ1YyYk1o+yBE="
+  "org/jetbrains/compose/ui#ui-text-desktop/1.11.1": {
+   "jar": "sha256-wajOseh1xvG7LmfsqHePwEAn3WGPMaafiGNoy9017uw=",
+   "module": "sha256-9scak1ko0uAWzsZveE52qtzUKhnXaKyBrXpFUXSgt1I=",
+   "pom": "sha256-hcEWmHvTA0hEYx1kLTP9goNcuZqc7J2bZ94s4wNDQNE="
   },
-  "org/jetbrains/compose/ui#ui-text-desktop/1.8.2": {
-   "module": "sha256-M/9uYPm7rQMunqnxIZir/MD5H0dLeclIh0NK//DE4xY=",
-   "pom": "sha256-rQhacC7enMbO4cCujRFRO1stHpu0BTJ52RjGvqZf5R0="
+  "org/jetbrains/compose/ui#ui-text/1.11.0-beta03": {
+   "jar": "sha256-XdkHaJyLQ6YQAFx/qGkYDCC2ozWhOnLM7Sw7w3di1ug=",
+   "module": "sha256-EJFByb8fbBTakvlbvuPKoDvbwTVJC44uv8VGzhkWS50=",
+   "pom": "sha256-KbvfF8yk+j4YokEW8GTX9AKu09BKnOmHe5tLC0MQ5X4="
   },
-  "org/jetbrains/compose/ui#ui-text-desktop/1.9.0": {
-   "jar": "sha256-M3cgBxAUajU1hOtz6/6t19ZBANNWuvW/hgh24Rgij0I=",
-   "module": "sha256-zVME5EaA/wXyqzYNOiRrCCIwhRfjAFfmYnBr15waBtk=",
-   "pom": "sha256-XEZdule7t8YccSEaS2jRBr/HRoguZBReio7Z3jwzix4="
-  },
-  "org/jetbrains/compose/ui#ui-text-desktop/1.9.3": {
-   "jar": "sha256-M3cgBxAUajU1hOtz6/6t19ZBANNWuvW/hgh24Rgij0I=",
-   "module": "sha256-UFCQKbJeoFDYbnL2wv9p3lp8j+INsjgkMs+0YVmam8A=",
-   "pom": "sha256-ltaW+gUBBy569mpdyzbuhhDyzDq0WOsCJviEuWD/ueA="
-  },
-  "org/jetbrains/compose/ui#ui-text/1.10.3": {
-   "jar": "sha256-tTfQs7sj7HlaGzVifeqpNwPP0HM7x7LcNGQV3wYkOpE=",
-   "module": "sha256-CPiJJvaVF0nsUM/1hDl4BqECAUznBWLmrje14JDCE/Y=",
-   "pom": "sha256-umj/mgjfC4sIdY/F4RQHd5CBhF2Sp3a1D2yleLqt0+c="
-  },
-  "org/jetbrains/compose/ui#ui-text/1.8.2": {
-   "module": "sha256-6MI81LMwHQAVpsgJYVty7dTJPCKarirtmfAVgJ6K56k=",
-   "pom": "sha256-gU42tOmeT+hYu07T+r4bYAfk85iqEbuFIuEKTqqgrNE="
-  },
-  "org/jetbrains/compose/ui#ui-text/1.9.0": {
-   "module": "sha256-oLAwD3XZxrvIN6sNSuRpo3WqoZwV/ZhY03BVJmJOsEc=",
-   "pom": "sha256-0l2bn0ISu2Xoqx4KsQaltKLVxIky3AAzeZ015cS+hwQ="
+  "org/jetbrains/compose/ui#ui-text/1.11.1": {
+   "jar": "sha256-XdkHaJyLQ6YQAFx/qGkYDCC2ozWhOnLM7Sw7w3di1ug=",
+   "module": "sha256-YymeOu/iaYtpeI/e/NDyz6C41ybk/Uxw0119qvexek0=",
+   "pom": "sha256-LoyJ7XELS9uTjWgqHFaY+ubFVMleMoRCAchw1mAEpNQ="
   },
   "org/jetbrains/compose/ui#ui-text/1.9.1": {
    "module": "sha256-lEvw4Xg0uVarRga3jgXG90MxqSVAcnYJ0Qq1cjd6F9k=",
    "pom": "sha256-jEFrj59tZfdBvaLWzwySOJjfJyA99Q2alHSiLNDhQig="
   },
-  "org/jetbrains/compose/ui#ui-text/1.9.3": {
-   "module": "sha256-ExDZIq34+r97g8qO6Z1bNCJnWSscNvjdANkDp/y8eUc=",
-   "pom": "sha256-7kAj5T1Z2i94hfKhuON4lhALRv/QHXrpQ9kqT10EmAo="
+  "org/jetbrains/compose/ui#ui-tooling-preview-desktop/1.11.1": {
+   "jar": "sha256-YNOpE+VQpAdiSNYhBc0Ki1xsgHzwnF3nLLr0KI3FKpA=",
+   "module": "sha256-EtH9xNyF1SIYoD3GzD4QHchll8+PW9APQvBYmUqHVXE=",
+   "pom": "sha256-tTgw2EyCDGaI3pFSDEL2l3dQ00gqJKLfOQWS86F3/9A="
   },
-  "org/jetbrains/compose/ui#ui-tooling-preview-desktop/1.10.3": {
-   "jar": "sha256-tfpvu+6l+JatKo53A71+tXTTobWrbUTb4KB1Nr1q9sQ=",
-   "module": "sha256-Bn2HL8VQfiVgupRjfTEUiVMrykfmHIa3R0FZ93SDHio=",
-   "pom": "sha256-1+SCuqTsTsJFzyvYs83q735LupSOU9C719SJXumMYb8="
+  "org/jetbrains/compose/ui#ui-tooling-preview/1.11.1": {
+   "jar": "sha256-LUfR7+TwgJksRPI+0u2ARq3O1XqneezIIW/8cA+qXjY=",
+   "module": "sha256-eI6dM0RECTpSX6AYmyTJak3yVxX5NhV11yxzuVAyttI=",
+   "pom": "sha256-n+vWaCE0Zl/E6ucbMa3AtpZcHO6nOaBH1PoovUdi06o="
   },
-  "org/jetbrains/compose/ui#ui-tooling-preview-desktop/1.9.0": {
-   "jar": "sha256-qyghEVDLh8RtZzfiyGyb9E2sZCqV7SbbLCAKDi2vJQ0=",
-   "module": "sha256-4tbglF3zQSeXbYCB7PrQm8Rja5mpceQbd1Z5xZXaWR4=",
-   "pom": "sha256-WhRl70I5MpG2qcNZ97Hkl///onhZKPDkvS8PI10diI0="
+  "org/jetbrains/compose/ui#ui-uikit/1.11.0-beta03": {
+   "jar": "sha256-axl+MetJAS/Qvc0HxVjrXVpXYkZoXpVBvD0rcTNa7ug=",
+   "module": "sha256-K5N3yyyrBbZ3nq9tVoLms1QKUTHXC64uAju1rvK5Cyo=",
+   "pom": "sha256-HVM/yiMbbHjNsm+U/TwdWKH1kzBuNIaBG+8vQujVk2U="
   },
-  "org/jetbrains/compose/ui#ui-tooling-preview/1.10.3": {
-   "jar": "sha256-YlyeD/k7ko5YYPEcUQiizVEXl7m0Om3MuznXydowUjM=",
-   "module": "sha256-eF5tJOCTxaLPQWCgX68MS5jC4myXWyduwIq6zpJEaAQ=",
-   "pom": "sha256-QfDdaCgaz0YMYwX0ybcp9t7xWBZsmPcHV7QCOxhg6g8="
+  "org/jetbrains/compose/ui#ui-uikit/1.11.1": {
+   "jar": "sha256-axl+MetJAS/Qvc0HxVjrXVpXYkZoXpVBvD0rcTNa7ug=",
+   "module": "sha256-ITx8vB7IvSEct1kZ2OIl1uZ4/hn+llLYJFL/6D1yvFI=",
+   "pom": "sha256-vCeDFBSpwqrywW6XwY4uG3U8cWBPf87lo8Ws19SUBJg="
   },
-  "org/jetbrains/compose/ui#ui-tooling-preview/1.9.0": {
-   "module": "sha256-qLznna0FAdzZ4hCg0TrDGpiYtn0fDfJoNJuwP/RYgM0=",
-   "pom": "sha256-3Sx+EPRlVAIyJVl4J+n4B79+UEq30vkjp6C8pEffiD0="
+  "org/jetbrains/compose/ui#ui-unit-desktop/1.11.0-beta03": {
+   "jar": "sha256-nJGGiwvZZ9ZPcm7cMZyJXjWYcaRO9+ddxp/wytRqwNo=",
+   "module": "sha256-Nnw06UVjeFSGYuGy9kEPc7A1+NZHwCrvmbsO8knlhwQ=",
+   "pom": "sha256-ZrSIAeOXKPUA7zE6Y1kXAnCzxsMv13TuoFHjY8ZIdwU="
   },
-  "org/jetbrains/compose/ui#ui-uikit/1.10.3": {
-   "jar": "sha256-GhOzmt860nZ/ln92S6Cg0u0qLQnu8xDyLSwDBNe9pss=",
-   "module": "sha256-+9+ULffd5/i7joGH1N33UVjQJcZ9RcJWtxKyN9o/dFw=",
-   "pom": "sha256-V+AYB3a8mq21KYxdlVEhooa122j6VOSEKdz9uHMCvGg="
+  "org/jetbrains/compose/ui#ui-unit-desktop/1.11.1": {
+   "jar": "sha256-nJGGiwvZZ9ZPcm7cMZyJXjWYcaRO9+ddxp/wytRqwNo=",
+   "module": "sha256-mmIUrNREcxfb9da5Xj7DopDK15Gca8W7p/n2ETT/LzY=",
+   "pom": "sha256-QWbnNxm2rjaMRwE8mTjZ032FOOmST2YhsxRj92gg83s="
   },
-  "org/jetbrains/compose/ui#ui-unit-desktop/1.10.3": {
-   "jar": "sha256-8PNDmSiz2RMvB8steoYJFpY3LryDVNFrSIMLbOFegWE=",
-   "module": "sha256-YK5I45ilQiP6fTG3IgkPicpZllR6Zw+nuCHM+4tqLPo=",
-   "pom": "sha256-kDqfw2cqSsSvdiNndU3GG9GGGJfzBwmOv4hs1Ue+bT8="
+  "org/jetbrains/compose/ui#ui-unit/1.11.0-beta03": {
+   "jar": "sha256-aoewfvoRvawJxaZZ9oLMjDc+DiwntHkWUwtzC0g9Jc4=",
+   "module": "sha256-r6wiakOeSfF5efbRj/LLM03yB4qWoG+VMR0Og4uOApw=",
+   "pom": "sha256-SnhCIaTl54XVT1I+RUAFPaMkJF58mE4iPGNEl/jM66c="
   },
-  "org/jetbrains/compose/ui#ui-unit-desktop/1.7.3": {
-   "module": "sha256-Tscp7nc71qd6x6bKCayPqPUFejgJjclUnYSm44ml7pw=",
-   "pom": "sha256-n/eV5ZtaFbFZMYar9pUyNlEbMkb6s9lAhURyUxTDcKs="
+  "org/jetbrains/compose/ui#ui-unit/1.11.1": {
+   "jar": "sha256-aoewfvoRvawJxaZZ9oLMjDc+DiwntHkWUwtzC0g9Jc4=",
+   "module": "sha256-zR8anUPkHHrlt9gVAEbd4BPjxlayx62fol4c3gI2gLg=",
+   "pom": "sha256-4CbxFkMTGn+jwtZzTgP4JX4+NS6eHxJpxDUh80EwiWs="
   },
-  "org/jetbrains/compose/ui#ui-unit-desktop/1.9.0": {
-   "jar": "sha256-EV99ATZ/4ddX9G8+WIJXzBLTmiIiprOXVIfKDuqGFuY=",
-   "module": "sha256-9LjQy4GaPPqID16h6LxxPe4439uRa8P1vdjd1Cp2TmY=",
-   "pom": "sha256-CwR/GlukxA3i2aels9nBgZ6rNW9kvNxUAqr8dvsiUwE="
+  "org/jetbrains/compose/ui#ui-util-desktop/1.11.0-beta03": {
+   "jar": "sha256-c9BJMKkfuaIETywZjsbj8dphaWzLWaKI0f8KFbqwju0=",
+   "module": "sha256-TVAepThaSn0SGYWhzoQMX0kOLAiil4GTUHejKKIfwOc=",
+   "pom": "sha256-2z6lgDJyeS96EJqX/A2NOqxmLQP6DQSQlCXA7kC1rP0="
   },
-  "org/jetbrains/compose/ui#ui-unit-desktop/1.9.3": {
-   "jar": "sha256-EV99ATZ/4ddX9G8+WIJXzBLTmiIiprOXVIfKDuqGFuY=",
-   "module": "sha256-U1s9qLc15uzRKRSAOfr/FKJHar0D+kFCTObt1f7GI6w=",
-   "pom": "sha256-h/R7VdAMyoj2UW6FqESUCfBf63fPszdnoq7vYhYDJRI="
+  "org/jetbrains/compose/ui#ui-util-desktop/1.11.1": {
+   "jar": "sha256-c9BJMKkfuaIETywZjsbj8dphaWzLWaKI0f8KFbqwju0=",
+   "module": "sha256-Y/eRvdSFrp2hu+mhKs192NlJRUi3rSxih7OCfgh99yM=",
+   "pom": "sha256-x1kLUwQm1IyRQ+KYivDfHuWzWuIPm5kjrILdiJw4L8w="
   },
-  "org/jetbrains/compose/ui#ui-unit/1.10.3": {
-   "jar": "sha256-khB/iX1tho/DPn5O3cPodMqa6yLYcSdkasjtK2drxHo=",
-   "module": "sha256-SJxKVMN8asZIn6hyu5GO9hkCQEdV6bBJ3LC3bLWBvUY=",
-   "pom": "sha256-YxwN1GEOak4O2ATvqRCf1FcfR//AHUa4T8nTI31ROXQ="
+  "org/jetbrains/compose/ui#ui-util/1.11.0-beta03": {
+   "jar": "sha256-zb1LEe9BZ7FIOHnExuxS0VLBtQfwyBdBuD+UNACoOvU=",
+   "module": "sha256-gn/7w7YxvAXdXY0D2z0Yh1+XHnNq6CrWoJFdlE2eTJU=",
+   "pom": "sha256-GyslM5cSbeSyHcleAspH9vDiXl/mtHOcVEse9hS9K5Q="
   },
-  "org/jetbrains/compose/ui#ui-unit/1.7.3": {
-   "module": "sha256-12BSTnbgmCj0oa3tvG89ZGZ+g4GP9A2G8MXOANlIrWg=",
-   "pom": "sha256-DA7+AYbpUYP+JYBBmDJNLy8xdwSEV0qQlrmLrAzZ/9E="
+  "org/jetbrains/compose/ui#ui-util/1.11.1": {
+   "jar": "sha256-zb1LEe9BZ7FIOHnExuxS0VLBtQfwyBdBuD+UNACoOvU=",
+   "module": "sha256-j488kSfdGBmN9aMoBH7vbum/UU9aMNo9MD8D52ryrQg=",
+   "pom": "sha256-adivGuv/w0tIRdaGyLuam1IJwDhhDFDDeBO6Az5dJhg="
   },
-  "org/jetbrains/compose/ui#ui-unit/1.9.0": {
-   "module": "sha256-swHbwckV5ClwaGLg09Q7DrG+0xkkd1Vns+7t2SH0g84=",
-   "pom": "sha256-xE2RKziWVTv7+ZXmf+uJZtpP1QNGm4j048Ea/KyS3HU="
+  "org/jetbrains/compose/ui#ui/1.11.0-beta03": {
+   "jar": "sha256-8Rl3lcLsw4Vp90iVrO+UaGkydD+vEjcteM0xY9GVj9s=",
+   "module": "sha256-dyfymNnS5zYkTMamtjeqjbHOLMLpFzNHgeSqgFuhfhc=",
+   "pom": "sha256-hRpdUDvAR5JKomYWUTCInuzTY4rXty8flov03x/TNbM="
   },
-  "org/jetbrains/compose/ui#ui-unit/1.9.3": {
-   "module": "sha256-+rgCJR75HGHb76FqSNupF/yVt9sJzQohLXn6XdRCgts=",
-   "pom": "sha256-SvveVAHDpEDevrSvcszIknHUA9uL0Osi41xUW2ZhT84="
+  "org/jetbrains/compose/ui#ui/1.11.1": {
+   "jar": "sha256-Plv/lbmorLcTPvj87ENDgvcHDRyLWsPc5soSyAKlJRY=",
+   "module": "sha256-jOjNcE6cjIFg87/k3Ks2hqSNJUzQTMoyBHDn6HKifdI=",
+   "pom": "sha256-XcGk1dMXvlIA7gRZYzaxb75Jl8MDNPwhzxvfn0xDETw="
   },
-  "org/jetbrains/compose/ui#ui-util-desktop/1.10.3": {
-   "jar": "sha256-e/yTqMrSl0zf1aLIF+MIPg48SO+Z5Nu6UeuYoUyS7S0=",
-   "module": "sha256-8IqyrOlYf+ysqau8JGl0ADCozk2vQ5Ia3vpUCjmmAnM=",
-   "pom": "sha256-UjW+9VVNVGNc5FXgzNKiUd9+aaqxNgH6OUUgsUqA69I="
+  "org/jetbrains/compose/ui/ui-backhandler-android-debug/1.9.1/ui-backhandler-android-debug-1.9.1": {
+   "aar": "sha256-27zWOMnruel/YfK/EwQI5Wxs5dAB3F9ecIRc4JNXySk="
   },
-  "org/jetbrains/compose/ui#ui-util-desktop/1.9.0": {
-   "jar": "sha256-nLACuJI3L6IDCX6hHSFz3z4nEPZAzPeK2NBfPprx9xY=",
-   "module": "sha256-SUw37O+HE6n4UoBX6BbaPW3UD/kRcMZfygX7MlStozI=",
-   "pom": "sha256-6jmJnKSbL2BgJpcaZsbJcLNcpcyDNzWBssu7JcFaPtA="
-  },
-  "org/jetbrains/compose/ui#ui-util-desktop/1.9.3": {
-   "jar": "sha256-nLACuJI3L6IDCX6hHSFz3z4nEPZAzPeK2NBfPprx9xY=",
-   "module": "sha256-ouuTFJGMuOIn404uuvSTcRsPSv8nwZ+zGrr43b+8SU0=",
-   "pom": "sha256-PdzaSnSoiB1TJHwCG4oLRtpP+nnw3ISfCouvbedXCSI="
-  },
-  "org/jetbrains/compose/ui#ui-util/1.10.3": {
-   "jar": "sha256-8K3Lk6F/J7VUgxQgfbiq+Y+u1i49stIsqYxJnqK8I+0=",
-   "module": "sha256-iZWbbG68oTMcl5ZJ+xe6Gn3jJzenPyEdPCQSALsW2CE=",
-   "pom": "sha256-8CmGm5gA/E5wFJYuah+OXp6G8A8LgL0dWAGjlDSxtIo="
-  },
-  "org/jetbrains/compose/ui#ui-util/1.9.0": {
-   "module": "sha256-y6I6SuhwblUOxPj3BW225t4Q7oGB9ZEYtUGyzTWrP/g=",
-   "pom": "sha256-FXiSH0ZOLYUd47smQi7VTeiet5Tz/3Ufu4HmqbOxLW0="
-  },
-  "org/jetbrains/compose/ui#ui-util/1.9.3": {
-   "module": "sha256-vzxx0r1FrCKQFidq+zp/V58XWAUuNsv00DA7E9nb6zA=",
-   "pom": "sha256-Qko43+7YsGYRZPE8YgfwrFMJ/0zU4oSxOqJ4tqRvUvY="
-  },
-  "org/jetbrains/compose/ui#ui/1.10.3": {
-   "jar": "sha256-rKMrBWibtBFqwQ7usoOlfQy36h782XYh1GQ/XLRP7Gw=",
-   "module": "sha256-DEQJwWJayTiBvTHszB6bViPGaU+9+mFM01AP+wa9qKY=",
-   "pom": "sha256-h1fPGlIoZBUdQBf8nSGttA5ke+HIdJhbOJYvLrN4ju4="
-  },
-  "org/jetbrains/compose/ui#ui/1.9.0": {
-   "module": "sha256-M6lOgXRyk5JvQ5FMDB0G1LFrSfTKwX1geTXHLjD8yEc=",
-   "pom": "sha256-Pd5Fl2AoE2rkmsrdr7O6oWT8wpTv6sGqjaoRI0EdPPI="
-  },
-  "org/jetbrains/compose/ui#ui/1.9.3": {
-   "module": "sha256-g6n1tIgz3apLwOxywHUn9kIUMehcuMtKYjHt18kIhDE=",
-   "pom": "sha256-1BliLw4IiJAwNstVd/dor/6jEbk4+KjHNhcTfM7sqs4="
+  "org/jetbrains/compose/ui/ui-backhandler-android/1.9.1/ui-backhandler-android-1.9.1": {
+   "aar": "sha256-j4830Osz9Zdgi8IPh1AhsdgNtvg1wTjNfO+Qk8etTCQ="
   },
   "org/jetbrains/intellij/deps#trove4j/1.0.20200330": {
    "jar": "sha256-xf1yW/+rUYRr88d9sTg8YKquv+G3/i8A0j/ht98KQ50=",
@@ -1874,6 +3382,10 @@
   },
   "org/jetbrains/kotlin#compose-compiler-gradle-plugin/2.3.21/gradle813": {
    "jar": "sha256-B5V8OelCS3WZSpThAZBKF5D6iSvJdlsh3rysg7g2fCM="
+  },
+  "org/jetbrains/kotlin#compose-group-mapping/2.3.21": {
+   "jar": "sha256-T8gpfrPkZr83vKgjrbZ/LQ9lHo11OOrsxsCBIYWAVfo=",
+   "pom": "sha256-Hn0hE+XDWTfhSPFBmobsIsIr0TnEKKb20tO2q5OFkRI="
   },
   "org/jetbrains/kotlin#fus-statistics-gradle-plugin/2.3.21": {
    "module": "sha256-jkdTFzSm1uiWG04P0a6GefvL0SRxPdLP5+mhLEe8c44=",
@@ -2012,9 +3524,21 @@
    "jar": "sha256-CA6LPO7rLvzlHQI4T14i/w2N8am7qUrpAV4wrCGhdJA=",
    "pom": "sha256-uRJdcl70/Xj8L0pLc1G/apS8G7OeZT9p+u4o2FgH8n0="
   },
+  "org/jetbrains/kotlin#kotlin-parcelize-compiler/2.3.21": {
+   "jar": "sha256-K9QfTCQAbJtVM5OshtMjqUuRqs50N71EeTJF+mY1eRk=",
+   "pom": "sha256-7jcD6PKafitwaBpM+ibj16EPMcqERCgbsFNuym21TVc="
+  },
+  "org/jetbrains/kotlin#kotlin-parcelize-runtime/2.3.21": {
+   "jar": "sha256-oh1fhUde+yfxfdl9GiidZIdPLd/bUI6khEd6TPGv6Wk=",
+   "pom": "sha256-Xy5Ehc/7o28EqsBV8qgwFREz2VB09fG1icVhCaS5tAc="
+  },
   "org/jetbrains/kotlin#kotlin-reflect/1.6.10": {
    "jar": "sha256-MnesECrheq0QpVq+x1/1aWyNEJeQOWQ0tJbnUIeFQgM=",
    "pom": "sha256-V5BVJCdKAK4CiqzMJyg/a8WSWpNKBGwcxdBsjuTW1ak="
+  },
+  "org/jetbrains/kotlin#kotlin-reflect/1.8.21": {
+   "jar": "sha256-imzVo88JKs7idM4sRE3Dbu/bYxV5hZ3U2FezMJpSnJE=",
+   "pom": "sha256-OdeNszIizbsythjHxSI9RFfMGXQoVtEWqFCQ5KlvYjo="
   },
   "org/jetbrains/kotlin#kotlin-reflect/2.0.21": {
    "jar": "sha256-OtL8rQwJ3cCSLeurRETWEhRLe0Zbdai7dYfiDd+v15k=",
@@ -2075,52 +3599,61 @@
   "org/jetbrains/kotlin#kotlin-serialization/2.3.21/gradle813": {
    "jar": "sha256-DhI+4919qUppjA+SqmDyRESVJKzeYu7KSjbixgcbM0U="
   },
+  "org/jetbrains/kotlin#kotlin-stdlib-common/1.8.21": {
+   "jar": "sha256-akTJ7MnXdU2elD+x41iMdNSj8Xhb5RB09J1sVyNoKnM=",
+   "pom": "sha256-4ZpVd8vOqJcolw21MzyCZMjGmuci7recv0HV8LDJrmU="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-common/1.9.0": {
+   "jar": "sha256-KDJ0IEvXwCB4nsRvj45yr0JE1/VQszkqV+XKAGrXqiw=",
+   "pom": "sha256-NmDTanD+s6vknxG5BjPkHTYnNXbwcbDhCdqbOg3wgqU="
+  },
   "org/jetbrains/kotlin#kotlin-stdlib-common/2.0.21": {
    "module": "sha256-b134r2M2AKa5z7D8x2SvPVEZ83Zndne5G2rugWsdMKs=",
    "pom": "sha256-X0As+413MZW5ZwUBJMnom1+EsXJGThiUkpeJv1xMLyk="
   },
-  "org/jetbrains/kotlin#kotlin-stdlib-common/2.1.21": {
-   "module": "sha256-pNj8FM7bN3mEOkf7zlIv0XPph1CRlk26wbjdeIT2wfk=",
-   "pom": "sha256-kk6Exb2AM5n2nFspYmsTKpSwBAL1X53lugGNyBHfo5M="
+  "org/jetbrains/kotlin#kotlin-stdlib-common/2.2.0": {
+   "module": "sha256-WPwNZk/Dpn5+a+n9vq7b0hLfo+Un90T4YeeSzacsDkc=",
+   "pom": "sha256-U3q0BzqEelm6dtmaZFqGCbU4L/pdJZGjVLL6MR9JlzM="
   },
   "org/jetbrains/kotlin#kotlin-stdlib-common/2.3.21": {
    "module": "sha256-atL1eJGlTZamkiES91jflXzhq4o9WlchXLdPo+EF4lU=",
    "pom": "sha256-3kz/N522KFN9r20aYfAqIL8YVIDxIMq0IU/uPcMzo+g="
   },
-  "org/jetbrains/kotlin#kotlin-stdlib-jdk7/1.8.0": {
-   "pom": "sha256-36lkSmrluJjuR1ux9X6DC6H3cK7mycFfgRKqOBGAGEo="
+  "org/jetbrains/kotlin#kotlin-stdlib-common/2.4.0": {
+   "module": "sha256-sDh/gRgDrxUU8aojhbRgw7gTxvQ861bPreavqiBpedg=",
+   "pom": "sha256-/RpljtvteICsPgoNvSCuGkbJh+QK9UTjprEQglu+/PU="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk7/1.8.20": {
+   "jar": "sha256-rx7EDDuVGv3MDCoBc8e4F2PFKBwtW6+/CoVEokxdzAw=",
+   "pom": "sha256-NiLRBleM3cwKnsIPjOgV9/Sf9UL2QCKNIUH8r4BhawY="
   },
   "org/jetbrains/kotlin#kotlin-stdlib-jdk7/1.8.21": {
    "jar": "sha256-M9FI2w4R3r0NkGd9KCQrztkH+cd3MAAP1ZeGcIkDnYY=",
    "pom": "sha256-m7EH1dXjkwvFl38AekPNILfSTZGxweUo6m7g8kjxTTY="
   },
-  "org/jetbrains/kotlin#kotlin-stdlib-jdk7/2.0.21": {
-   "jar": "sha256-cS9IB2Dt7uSKhDaea+ifarUjdUCLsso74U72Y/cr7jE=",
-   "pom": "sha256-TXE+dTi5Kh15cX6nHPHQI1eoThFFDEbLkuMgee40224="
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk7/2.2.0": {
+   "jar": "sha256-DRC8DUK4YF8jYpo/MeonwZzbyp3N9PU/bSLNY2aDbRg=",
+   "pom": "sha256-lcIYnDXve/xIlRwyrXCEeyHzgJ0m9dCnbiNXCHmYjDA="
   },
-  "org/jetbrains/kotlin#kotlin-stdlib-jdk7/2.1.21": {
-   "jar": "sha256-lmhGFy4QUstbNNezRkemR5mzP22oFlCfeCXFb1WJUjQ=",
-   "pom": "sha256-Dm8fi7CjxJxFYamSMAl0c4g/1bL121k5bQ5VGfJ2xDA="
-  },
-  "org/jetbrains/kotlin#kotlin-stdlib-jdk7/2.2.20": {
-   "jar": "sha256-O9Juy20Sl4xcTgtB92yf9VH6wqXmJoQnqdKgzfilrZE=",
-   "pom": "sha256-Cukeav/wZg79os8CjFvbnnoehn4Z3CyOuuiaglcUOOI="
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk8/1.8.20": {
+   "jar": "sha256-45i2eXdiJxi/GP+ZtznH2doGDzP7RYouJSAyIcFq8BA=",
+   "pom": "sha256-OkYiFKM26ZVod2lTGx43sMgdjhDJlJzV6nrh14A6AjI="
   },
   "org/jetbrains/kotlin#kotlin-stdlib-jdk8/1.8.21": {
    "jar": "sha256-PbdSowB08G7mxXmEqm8n2kT00rvH9UQmUfaYjxyyt9c=",
    "pom": "sha256-ODnXKNfDCaXDaLAnC0S08ceHj/XKXTKpogT6o0kUWdg="
   },
-  "org/jetbrains/kotlin#kotlin-stdlib-jdk8/2.0.21": {
-   "jar": "sha256-FcjArLMRSDwGjRaXUBllR0tw39gKx5WA7KOgPPUeSh0=",
-   "pom": "sha256-MQ1tXGVBPjEQuUAr2AdfyuP0vlGdH9kHMTahj+cnvFc="
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk8/2.2.0": {
+   "jar": "sha256-rcFmSNu881sNEOfsMBw110bRwv5GDGBqulnxKxF8+bA=",
+   "pom": "sha256-I00G/b3CncvAdEfijEomq6uVmdXD2qPZKjTmrt6iNqY="
   },
-  "org/jetbrains/kotlin#kotlin-stdlib-jdk8/2.1.21": {
-   "jar": "sha256-h7T5Vt4nQBRGIn5HSsejGs/w0KgIcWDFQojB5vRqZ+Y=",
-   "pom": "sha256-9KkWH2LpUq9Q/WKhomCB8413f+zWlH/YQD8UR/hmnao="
+  "org/jetbrains/kotlin#kotlin-stdlib/1.8.21": {
+   "jar": "sha256-BCoc0ayXbNz+XrY/HY4LC4kskkjhWmnIz7pJXVRupSo=",
+   "pom": "sha256-/gzZ4yGT5FMzP9Kx9XfmYvtavGkHECu5Z4F7wTEoD9c="
   },
-  "org/jetbrains/kotlin#kotlin-stdlib-jdk8/2.2.20": {
-   "jar": "sha256-wxQXeTXY3C7ah5UHEX8l1t5W9sV+3plBaxTNYiu54J0=",
-   "pom": "sha256-NditbBnaV6t00h7YHdxYSZt8GwAlEbXoUgANuwxYq64="
+  "org/jetbrains/kotlin#kotlin-stdlib/1.9.0": {
+   "jar": "sha256-Na7/vi21qkRgcs7lD87ki3+p4vxRyjfAzH19C8OdlS4=",
+   "pom": "sha256-N3UiY/Ysw+MlCFbiiO5Kc9QQLXJqd2JwNPlIBsjBCso="
   },
   "org/jetbrains/kotlin#kotlin-stdlib/2.0.21": {
    "jar": "sha256-8xzFPxBafkjAk2g7vVQ3Vh0SM5IFE3dLRwgFZBvtvAk=",
@@ -2135,6 +3668,11 @@
    "module": "sha256-DTc1BD1ot6WvtE0n3mX4Cp0rIIRicJwu27SP1bOVrYo=",
    "pom": "sha256-xVJAhso+SaZ5ht+P3M1mA3uvXzxaNYt2+d1gm+57tjg="
   },
+  "org/jetbrains/kotlin#kotlin-stdlib/2.2.0": {
+   "jar": "sha256-ZdEthaO4ZcFg25FHhRcSpksQ2t1osi7qIqlb+KhnDco=",
+   "module": "sha256-pbmP3NnbAX1ULhlyJdzuGNZYpW3h2yzEHhMZbWsXaaQ=",
+   "pom": "sha256-jDyCEAfBNBFVhzm589U4LrgVUds4lc/7iVYeVsD03BY="
+  },
   "org/jetbrains/kotlin#kotlin-stdlib/2.3.21": {
    "jar": "sha256-b2TqxzbblDTdaSW0pRi50dFxd2UjIMN5Fs+bo859fXo=",
    "module": "sha256-e06ksiQrsXektKu2PD89hXMx1A01hl42/MPbZm7BAXQ=",
@@ -2142,6 +3680,11 @@
   },
   "org/jetbrains/kotlin#kotlin-stdlib/2.3.21/all": {
    "jar": "sha256-IZeuB3iLCdA9Xz8qLVIHOFnjUkgbtv60M145EJMRYnA="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib/2.4.0": {
+   "jar": "sha256-zLFP+D+ryxFFi3mNvJgkdIzN/+7HnJq6eJ5u0c2oaxw=",
+   "module": "sha256-wkpH3L2Sldd29EO+Qdd6wkUwlgHtBTcR3uKwJUvgLbY=",
+   "pom": "sha256-gZT/eanuJKf6P3SmsXnAShhZ3ouYek8JgwVuWUUXId4="
   },
   "org/jetbrains/kotlin#kotlin-test-junit/2.3.21": {
    "jar": "sha256-VUc58oLqyhFIgq1+/82FI94mUettZRiWJEJREJkspM4=",
@@ -2181,22 +3724,44 @@
   "org/jetbrains/kotlin/plugin/compose#org.jetbrains.kotlin.plugin.compose.gradle.plugin/2.3.21": {
    "pom": "sha256-SecF24pUPn5ZxAyx4RYz2bw3NIv/5PEV8Zec34ifkig="
   },
+  "org/jetbrains/kotlin/plugin/parcelize#org.jetbrains.kotlin.plugin.parcelize.gradle.plugin/2.3.21": {
+   "pom": "sha256-KK59VS1Dtw4MZAgfAqu9IZa8qOElBe86H7+f9aJcF7Q="
+  },
   "org/jetbrains/kotlin/plugin/serialization#org.jetbrains.kotlin.plugin.serialization.gradle.plugin/2.3.21": {
    "pom": "sha256-yIhTYIUUX6NyHzlWQ7PIDLYim9iayrC4etXTYuOd7Gk="
   },
-  "org/jetbrains/kotlinx#atomicfu-jvm/0.23.2": {
-   "jar": "sha256-EB/0P/Vj/KFnr1remMO2m/VpAQ6rdFATuE2JVQNNOzw=",
-   "module": "sha256-9frJHDc6AJjlzK5iIeibtxoUkM9qiUnuNI1G7hyo06Y=",
-   "pom": "sha256-WTrWZUvtuP1m4DrQfQxIZ6x3WjgPTiYOFI6p26pTRU4="
+  "org/jetbrains/kotlinx#atomicfu-jvm/0.22.0": {
+   "jar": "sha256-LaBzcn86teVYTnTBLhFRnJCK4t+vausl3tQrZoIpeII=",
+   "module": "sha256-NQcPkjzmn4fG+Q5TBXIOJwRAm2miN0SSrEW+cAde5Jo=",
+   "pom": "sha256-CSM9N5NaKWh4/H6+92ECEmT64oBb+SZCAyi3y5DWelY="
   },
-  "org/jetbrains/kotlinx#atomicfu/0.23.2": {
-   "module": "sha256-UVMN4oSWehXiEcmFY8qdI1aJm4yzMXBFYLBkWt6sbcA=",
-   "pom": "sha256-QlA7zusRzeFIh3T7DE+chWM6juD6XSLTNyYMLfUKkrY="
+  "org/jetbrains/kotlinx#atomicfu-jvm/0.28.0": {
+   "jar": "sha256-OVduxGuDQS/3opCdJMzLupBADpH5qmeyUDCbwIcuz1I=",
+   "module": "sha256-NLYjr5wlyn8uUkBvEElcRub0EINdegWMYLo2kj1oljU=",
+   "pom": "sha256-3X+tXV1LIcqdsHiHULCZe6HbaILe2G5SEvXIP8UfrOw="
+  },
+  "org/jetbrains/kotlinx#atomicfu/0.22.0": {
+   "module": "sha256-XIdu9+HuB90wchxDtG6tjtojzisiJg5w+TPL4AToBgc=",
+   "pom": "sha256-lsP4fQNiioMRHD35NOgD134Q1hNCD3vE0wBZg4bI7zc="
+  },
+  "org/jetbrains/kotlinx#atomicfu/0.23.1": {
+   "jar": "sha256-fbhmDr5LkbtHjts2FsTjpQulnAfcpRfR4ShMA/6GrFc=",
+   "module": "sha256-Pokf5ja1UQgZIQD884saObzRwlM+I8Ri/AdkTur8sg8=",
+   "pom": "sha256-aIt5ABn0F87APmldZWexc7o7skGJVBZi8U/2ZEG1Pas="
   },
   "org/jetbrains/kotlinx#atomicfu/0.27.0": {
-   "jar": "sha256-oiN62Ro9NklP+yVW9MWYicgfeuO177RF0S7NCQs3xuk=",
    "module": "sha256-umecB1fjmeaKmfl9c4QosvtwB3F93/Dx3uuoYrr0RpA=",
    "pom": "sha256-e3Fbn9t9MTr8hRjV/Kv0LrSfzNbNf/RHNqEF6AmUBdg="
+  },
+  "org/jetbrains/kotlinx#atomicfu/0.28.0": {
+   "jar": "sha256-09oifhoGwZVcEQFM3vpZlpqwygUHqB6ooP0Fq2xNvJw=",
+   "module": "sha256-U1VoySkaPadwXEtAU16s7fhrJI31cKxSZpyQfUu4VYs=",
+   "pom": "sha256-yboB7z5omdQs8HDVm6OdVy/FhjvylscpqZciwGR99so="
+  },
+  "org/jetbrains/kotlinx#kotlinx-browser/0.5.0": {
+   "jar": "sha256-pZr+a8slswkUsKLQrp7Zunrc+vmRG3MkpaW9mBUK8QI=",
+   "module": "sha256-x4N0GbmT1yzN0Te0FRZzh7l0qfbKRFDn9JuBQ+Za86Y=",
+   "pom": "sha256-ufuiXryFRH9SF9NHBll2ahP8/h2MXe3LJC6iKKEPTek="
   },
   "org/jetbrains/kotlinx#kotlinx-collections-immutable-jvm/0.4.0": {
    "jar": "sha256-12cBStDJon0n0m/Tjnr6AwruDRQTOPEIeB/wLs8v2rU=",
@@ -2208,92 +3773,154 @@
    "module": "sha256-hcc5iv+JMuodhuYKsl/IsngaVsbrZIVfz/TcZaG3d6U=",
    "pom": "sha256-NPZcN43q2J+3yi0Sr4Pdg0A8uoXI7bOlxrxa1R/+90k="
   },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-android/1.11.0": {
+   "jar": "sha256-wssgbScBfH0b9f8Xl4c5dUPRN0jbq7DXI34VheCykEQ=",
+   "module": "sha256-e30d3fGIgX3qrXOOkuEfqlq9+TfIcSDN8DYQJWatS+M=",
+   "pom": "sha256-IkVnQg0+DtX+9A94n97UXf1RsWIxnijXfTyajexIIbg="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-android/1.6.4": {
+   "module": "sha256-aFFlWeb4SmIbl4PNiSpkYwzNeHWENYjds/BQFCXjPxU=",
+   "pom": "sha256-SffjJHTWQ5bs4sAU29wiBNZlz6j9c+aaahs/qxOBmLc="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-android/1.9.0": {
+   "jar": "sha256-vXg6zS+XOIRdWDgPRvRbXN6V0MsDAn1WclM4smv8TXI=",
+   "module": "sha256-ffHgTXfwzEEYkNmZqUSbDjvNTxWaRsMGCxECBMpgfUM=",
+   "pom": "sha256-voYCDNW5O4poykMYWgSbmwuqNF/Rvh/aoBT9rvktbnw="
+  },
   "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.10.2": {
    "pom": "sha256-+vDGU45T3cBJmmNmTY52PCFlgLLhjnIsy98bQxpq/iY="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.11.0": {
+   "pom": "sha256-9lhgvOWKK/rfBf3FFtODM0IfDjh/74fiREnAOUyA0lQ="
   },
   "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.6.4": {
    "pom": "sha256-qyYUhV+6ZqqKQlFNvj1aiEMV/+HtY/WTLnEKgAYkXOE="
   },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.7.3": {
+   "pom": "sha256-Tl0ZAOY3nvP1lw0EqPMFKa3IL4WejMEHwhzoFJ72ZsQ="
+  },
   "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.8.0": {
    "pom": "sha256-Ejnp2+E5fNWXE0KVayURvDrOe2QYQuQ3KgiNz6i5rVU="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.9.0": {
+   "pom": "sha256-vqVRHpAB8sWTq1CA3xMbIZq14ghcxZec5YPqzUlG/Xg="
   },
   "org/jetbrains/kotlinx#kotlinx-coroutines-core-jvm/1.10.2": {
    "jar": "sha256-XKF1s43zMf1kFVs1zYyuElH6nuNpcJs21C4KKIzM4/0=",
    "module": "sha256-6eSnS02/4PXr7tiNSfNUbD7DCJQZsg5SUEAxNcLGTFM=",
    "pom": "sha256-ZY9Xa5bIMuc4JAatsZfWTY4ul94Q6W36NwDez6KmDe8="
   },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core-jvm/1.11.0": {
+   "jar": "sha256-0ddaoB3/u00cUg5n5MTn9fYXRxjny0YyQSUD8vDmBPo=",
+   "module": "sha256-WyVWU61rHyHgxGEIYF8SnjqlbtlBSEnMn1tDZEFRdSg=",
+   "pom": "sha256-3VS5eqP6uR/CT13ykWwivpQpoznS9Ft/8JIzL2wZ3Dk="
+  },
   "org/jetbrains/kotlinx#kotlinx-coroutines-core-jvm/1.6.4": {
    "jar": "sha256-wkyLsnuzIMSpOHFQGn5eDGFgdjiQexl672dVE9TIIL4=",
    "module": "sha256-DZTIpBSD58Jwfr1pPhsTV6hBUpmM6FVQ67xUykMho6c=",
    "pom": "sha256-Cdlg+FkikDwuUuEmsX6fpQILQlxGnsYZRLPAGDVUciQ="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core-jvm/1.7.3": {
+   "jar": "sha256-GrOsw48+c1XE+dHsYhB6RvpzyJnzBw0FXl1Dc9/mfhI=",
+   "module": "sha256-NNbumbdqwGK1FVW0pwvhg0n+VWbaeaGQYU8XHIC2U44=",
+   "pom": "sha256-dThYdT3su7I5c0PiuHHwYvaXgS6UIuQcnuRqZrk+7jA="
   },
   "org/jetbrains/kotlinx#kotlinx-coroutines-core-jvm/1.8.0": {
    "jar": "sha256-mGCQahk3SQv187BtLw4Q70UeZblbJp8i2vaKPR9QZcU=",
    "module": "sha256-/2oi2kAECTh1HbCuIRd+dlF9vxJqdnlvVCZye/dsEig=",
    "pom": "sha256-pWM6vVNGfOuRYi2B8umCCAh3FF4LduG3V4hxVDSIXQs="
   },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core-jvm/1.9.0": {
+   "jar": "sha256-rYnCiSI15nDyItgZyz2BGIFDyxmgW1nfmImuQmn1xwo=",
+   "module": "sha256-syGomeQNPONFcHqiz9qZg60NzGn+p0qbi/kGoWwc+Kk=",
+   "pom": "sha256-GcSImUGzqgmL1XzGTwL5razGVNVxoSqVbeS1uxSMZJk="
+  },
   "org/jetbrains/kotlinx#kotlinx-coroutines-core/1.10.2": {
    "jar": "sha256-MZtlMAnUnHCYL5jfKcyE/HAlsJLLBXHI51MuOtQ2ba4=",
    "module": "sha256-j+JUF35xGnzRijwG2CQvzpRfQcLMoT3BmzOuQqVDUBY=",
    "pom": "sha256-UZ2lQACW80YqTa6AeDrQUEE9S8gex65T+udq7wzL7Uw="
   },
-  "org/jetbrains/kotlinx#kotlinx-coroutines-slf4j/1.10.2": {
-   "jar": "sha256-1l3uPK+m97+u/ttJP8aLXGOr51BzT7ivkvrHoNMQFFc=",
-   "module": "sha256-B7xJACLGWAQpQfUrFxwPXOBkvWxjUikEMDmS5BegRbs=",
-   "pom": "sha256-xHdj+siNuwlDhJ0W4RucBdReYDhMfNExBe5xD7TdX7M="
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core/1.11.0": {
+   "jar": "sha256-BOdzf7Fc9fOu2DqRFBpTA6CyrNiG9bvDXNvnka1j3+4=",
+   "module": "sha256-Hhl4XTRyi3Ul16d/8y6tRUfVHMekXUrETU3mCBabDA0=",
+   "pom": "sha256-QbbnjBsNEbyZ3nlTkN+eTs5k3BE/SC1uMI8bekIcHTA="
   },
-  "org/jetbrains/kotlinx#kotlinx-coroutines-swing/1.10.2": {
-   "jar": "sha256-Ar24XyDsCABEKav2iH6NDkDzq2N9dGL4F/D4q759HrU=",
-   "module": "sha256-kFK7SUS5FqUGX2GNfUb+EqTAxonQIbyYQ1v4l3WIsWQ=",
-   "pom": "sha256-zt+0Miu5cVkXrmmCCeoS3ziKuliVy7rRxWcith6EQ8A="
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core/1.6.4": {
+   "module": "sha256-pu7UoYNViOfIT817BHX86aezREyHDrx5e4i6ZMz0V2s=",
+   "pom": "sha256-E2tO24ekfhUlHwhC8xifoxl560q1Gs+0I5tL+NFtRYg="
   },
-  "org/jetbrains/kotlinx#kotlinx-coroutines-test-jvm/1.10.2": {
-   "jar": "sha256-WQpUn4wdtZDJ2YqKIEJKH1gaNBYqNp5qa9iEzn0209c=",
-   "module": "sha256-VrIIF8xRrYi9tZwBIWsJiXzU+mmNUXu0d9kqlyp6Gq8=",
-   "pom": "sha256-Y96yqGiry+JIjrzrqnXnMbLvIQQQO4FzjnY3/JolpfM="
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core/1.7.3": {
+   "module": "sha256-f7FiOWWU7CjhtqRBG0V5SadnD14SAZF2d04f1rlHG78=",
+   "pom": "sha256-7W6wOYcXA14p8cHWCk4927iYWPPbnge1etdZ03Ta6Ck="
   },
-  "org/jetbrains/kotlinx#kotlinx-coroutines-test/1.10.2": {
-   "module": "sha256-QiByzuO2n2jVsVA7tmUb54lGsEw5KEocwCbM6L3x+AY=",
-   "pom": "sha256-vyXI3w7J8+rHu+5Tm2AbYBm36Z9fPzAR4ugXixQHUNs="
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core/1.8.0": {
+   "module": "sha256-FE7s1TZd4+MNe0YibAWAUeOZVbXBieMfpMfP+5nWILo=",
+   "pom": "sha256-yglaS/iLR0+trOgzLBCXC3nLgBu/XfBHo5Ov4Ql28yE="
   },
-  "org/jetbrains/kotlinx#kotlinx-datetime-jvm/0.7.1": {
-   "jar": "sha256-O4uYZXya/zvn9rS1denz+5o6H0UqgB2g9DiQFzSs2t4=",
-   "module": "sha256-2iG17aY2QqSURWXCqMhEzkj17+c0cDrFkYKglBusino=",
-   "pom": "sha256-inUEl+cFy/5Ljqu2IN1MG4woTs6taqjmMKWXefQ4l10="
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core/1.9.0": {
+   "jar": "sha256-cInDPBRYZQIHYNPbyl5GNBM8w91/65Jugw9t5u3iisY=",
+   "module": "sha256-rVNANKlTtOEsvuuHTGat+LHKFN8V/g0uZUeqNOht/so=",
+   "pom": "sha256-dw8nk9BeKwJ7nHmZOOwdLU7xQc5YGceAwyw5lcrbCkc="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-slf4j/1.11.0": {
+   "jar": "sha256-EENHHn1fmWgN86BWz3ZiduD+M55IAw3qUD/ByUwzdD4=",
+   "module": "sha256-eJRlqAo7YbMcJwBZ9nF42iYEXcLd85sBtFQ6YCrc9wY=",
+   "pom": "sha256-IIUKKt51yo8Ax5gblNZZ8oqyah4nuGZuS4oxAu59I40="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-swing/1.11.0": {
+   "jar": "sha256-f2WP6VK1YXYRH6rYrCdSaJBGCJFdbHk3T6DID7KI+2A=",
+   "module": "sha256-I4V4NJwX/DTVylTRIi8v6VR+Yb6FgnRQ93kAFoeCcdo=",
+   "pom": "sha256-Xg1OSIf8gLFAcOMd62DIxY4lYRFvNro5rEuSAZP74Nk="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-test-jvm/1.11.0": {
+   "jar": "sha256-1PfucdpwivRxnc620yAMj53FFG6hqBLLYo7VPGQZb5Y=",
+   "module": "sha256-g1U1kqRGrfki3Gavt1ZaOwDFKVhwjCEMKE53YdMdD4Y=",
+   "pom": "sha256-hNEZMm3mSWuPIKmFq+M9GOLSYrDPIEUwWpHrxX+x9bY="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-test/1.11.0": {
+   "jar": "sha256-hWeg71jaDUNVtz9wg3HoT7Ob0o4HeIAEqHZONwbrd4A=",
+   "module": "sha256-uh54xTl6qTSnS555nSkOa3afYE2q2zBkD5Gub8r4HW0=",
+   "pom": "sha256-n+XNTGBseFzBT8RpLtHsbLQFPB9eZ/qLP6Ot8cca+ao="
   },
   "org/jetbrains/kotlinx#kotlinx-datetime-jvm/0.7.1-0.6.x-compat": {
    "jar": "sha256-z5zfezB0BEZXoagLwbtSgLWFRalnrH/kKxqjz5MwVxQ=",
    "module": "sha256-J/MbNeJ4XVidhYHTbJ+dZpK0S7Y3rBW2kcVGHdDF7Iw=",
    "pom": "sha256-HfcIy6EsD0qC/LdoyoPc9LgPrJ5i37QCvDYkhexE/PE="
   },
-  "org/jetbrains/kotlinx#kotlinx-datetime/0.7.1": {
-   "jar": "sha256-s9gJ0hpBtyrp3gsy3FqhlIV7F7Px7kEHv84zSE+gXQU=",
-   "module": "sha256-R0gD1qR3t8OV7otCw0zK52ZftdIx/bBa0I7TCFwk03o=",
-   "pom": "sha256-yiZ2PuBih00KtdOBzB0jBKjLm/VKUoI6wE7PA5oaMfw="
+  "org/jetbrains/kotlinx#kotlinx-datetime-jvm/0.8.0": {
+   "jar": "sha256-7kS1H4l3wvUdV1KZpPxngqs3AOukz8f61UjM7RVDk2o=",
+   "module": "sha256-X+Uto4d86+Pq52X53qh1gAmolNJEHN1uisb7pTjxcec=",
+   "pom": "sha256-ZqScb1N5kQZRonMqtzhY+IimhqVpybHL8vYAoDRYKCc="
   },
   "org/jetbrains/kotlinx#kotlinx-datetime/0.7.1-0.6.x-compat": {
+   "jar": "sha256-Mp/yxos4TqGgxNQNScdfMzu0pCItaQEX5j6jQCu2dIg=",
    "module": "sha256-Z9HcRg78U5nv5IcpK32V8vIY4kmAamOO/FxJrqptU+I=",
    "pom": "sha256-iBoHz8YixkJPjy675W0bZLzLqjqLs43i5MCbTpcR/8g="
   },
-  "org/jetbrains/kotlinx#kotlinx-io-bytestring-jvm/0.8.2": {
-   "jar": "sha256-PagF6dov88sRn3RNzRHeahjjKluTNRjxdBi6V5XPp3U=",
-   "module": "sha256-zLwAxm9EwR025LLI3him8gFK409V2vIarbRpXuB5qjs=",
-   "pom": "sha256-FRY1+uo9dZloCkuDrXiLcAAmFtXFdnSdh+RNgxM3iQU="
+  "org/jetbrains/kotlinx#kotlinx-datetime/0.8.0": {
+   "jar": "sha256-GLd/BOpHaSZ0lwfh7LujQ2oMUJg0eAYmVTdPHxGRd6M=",
+   "module": "sha256-NHk8CZGv1NbNDfhzfVw4D7hNoJcUfHDs7BodaLBszGM=",
+   "pom": "sha256-80wfr0blQG5y5jyzjqPkPujf7THCv0FmDBLyW0Z4tak="
   },
-  "org/jetbrains/kotlinx#kotlinx-io-bytestring/0.8.2": {
-   "jar": "sha256-g0mATPWbsOhVOZ0C972+oRBKQo4zd36XG/MdG70lDT8=",
-   "module": "sha256-Rr6OR2rNrlReNYRmWuWDzEqYr8YU6Ms9DGTI1Puvk7o=",
-   "pom": "sha256-VNISwY3EmqVjNq7MgqP2u09ibxRiS0xZ3WQQifP15e0="
+  "org/jetbrains/kotlinx#kotlinx-io-bytestring-jvm/0.9.0": {
+   "jar": "sha256-Q6jJ18VGBiLE/+fnyUQ3Nq8aaRgzFrUy3nipqvqGtjY=",
+   "module": "sha256-0RrPnfTLjwsBXNARZici1ySQwIiZhCJOpW3+TCc0rqQ=",
+   "pom": "sha256-jQD25Qd/O76Bod8yi+te79AIzI+B//5srNUm8BXcnoQ="
   },
-  "org/jetbrains/kotlinx#kotlinx-io-core-jvm/0.8.2": {
-   "jar": "sha256-YQdwzIVe3xxX2fzXxp/QQK9Xra+INFBfkYBd5oB4PRM=",
-   "module": "sha256-CwPCv3wseY6naj73f/gPOYVNOFhBsefR/jbFxQpRXd0=",
-   "pom": "sha256-4gGfv0x3cnzBGQLazKfnHBBtW/ALFBrnUqYZjakVscg="
+  "org/jetbrains/kotlinx#kotlinx-io-bytestring/0.9.0": {
+   "jar": "sha256-Siu1X59CjfC/p3WsVAZAzA5tYz7Gb1IM0hV7/hC+L0g=",
+   "module": "sha256-hhg+j506LZqCiIN4+tb5V1hhk1nkXfty7K9sCwcmOFA=",
+   "pom": "sha256-1DAvY5qQe0AlwH89LuQ+3KC369+2rtWA2k0gdjQLIGc="
   },
-  "org/jetbrains/kotlinx#kotlinx-io-core/0.8.2": {
-   "jar": "sha256-KAA+vl98bQrGW53+o0RziH498p991fkEpF2WxCELZ8I=",
-   "module": "sha256-5HEw0i3rmVYcjoMa96o4FP0ZjjMKCm0RbFIVN2j9ocE=",
-   "pom": "sha256-yXvIo+dC1U/J2Vp2EfeXDYVTrM4zvhdfGnyCEK5sGiQ="
+  "org/jetbrains/kotlinx#kotlinx-io-core-jvm/0.9.0": {
+   "jar": "sha256-M4hyFI+qSkSsyb+pE0OBPVF4To1H8AWtRAZkcpf4UEE=",
+   "module": "sha256-GtjQ5PgKNhxWevWqkEYHYp5TAN7hU6RnPmUX+HayFDY=",
+   "pom": "sha256-fLkR4mPRz0Lm1zY+1WAaYaxYgZdo1SB9+RsPaeIqbOg="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-core/0.9.0": {
+   "jar": "sha256-7yi18O49Zm/1B49uGwjAjRCj/ioWkUHfx2PeluqvvK0=",
+   "module": "sha256-+QJWEkHN4gRxfh6u368DBumKuZZ5rLemY6rqgfFaNiA=",
+   "pom": "sha256-rYa7iYQNaLA2Wz0hnRACStrUxkZOBBNsakKeG7do/qY="
   },
   "org/jetbrains/kotlinx#kotlinx-serialization-bom/1.10.0": {
    "pom": "sha256-Lpc+Tfw7xjjdLmg9qVncK5eSMpe/O49gx/8A1h6sOwc="
@@ -2329,6 +3956,7 @@
    "pom": "sha256-MTN3P7z5gip/Ol6FqxmUHme9KJv1/DGC2dtNHKuG6yI="
   },
   "org/jetbrains/kotlinx#kotlinx-serialization-core/1.7.3": {
+   "jar": "sha256-SFBoLg5ZdoYmlTMNhOuGmfHcXVCEn2JSY5lcyIvG83s=",
    "module": "sha256-OdCabgLfKzJVhECmTGKPnGBfroxPYJAyF5gzTIIXfmQ=",
    "pom": "sha256-MdERd2ua93fKFnED8tYfvuqjLa5t1mNZBrdtgni6VzA="
   },
@@ -2342,6 +3970,11 @@
    "module": "sha256-RM5rdW+TyQrD2nPzXtCrA29Dtz9X81Y8ysnhUvQRJy0=",
    "pom": "sha256-3G/845DzKNm8p0CmO5EJKv0J9Ec6HyqA131ks8W1BdM="
   },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-jvm/1.7.3": {
+   "jar": "sha256-sekThJntjSA3Xt2j8rHJXzEDoljv9q+e3F6gcQDyspw=",
+   "module": "sha256-D/cOITHypldYIvdhHAXig8SuCBczA/QQSUy0Eom9PvY=",
+   "pom": "sha256-0zRdKAgXvgfpwnrNYHPUleF73/VxxHADTglmQgeGp90="
+  },
   "org/jetbrains/kotlinx#kotlinx-serialization-json/1.10.0": {
    "module": "sha256-yfNeuGIPLTiZoFgoXEF3NciVbu0rGFO+2jrBPHeCuMc=",
    "pom": "sha256-+uXntE6iGb3qzoSlC/8y06x/bdGb5KjiRTbhgzxUoNY="
@@ -2350,6 +3983,11 @@
    "jar": "sha256-V3iMNxB/VfqYDvNsFX5w7O9XMVinYng7/TDtSCRBnoA=",
    "module": "sha256-kxa2Th0N4KjHQTS0YJFtz20Z5ieUG0xO62PgfpBxEa8=",
    "pom": "sha256-K9jF550v7oGDpF7YaQJOHXRXGTaWCxgSXWA7Bxj1NuM="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json/1.7.3": {
+   "jar": "sha256-qpP6PJY5LLE5WTE0Qw3C1RNn9Z1VPl43R+vYAHsmPxs=",
+   "module": "sha256-HPAiijWIcx1rrzvLvbCKMiUB9wQg1Q4pKrUB5V2Mz08=",
+   "pom": "sha256-BaiftqSvoKHUB51YgsrTSaF/4IqYv5a30A0GplUh3H0="
   },
   "org/jetbrains/kotlinx#kotlinx-serialization-protobuf/1.7.3": {
    "jar": "sha256-dMdtR+VdhmvBjZ7Yia45y859sLd95acgENqx8kR5NXc=",
@@ -2360,36 +3998,40 @@
    "jar": "sha256-ZX7efX+OF1yQmyPKoQ/NTUpREwT9k4qpzIRXtDeJUNU=",
    "pom": "sha256-/jziiqT0Ga0GcErRyoIzTQ6HFmfKWxE8UVfnUXzhMh4="
   },
-  "org/jetbrains/skiko#skiko-awt-runtime-linux-x64/0.9.22.2": {
-   "jar": "sha256-Szx19siqYLiDYsPf2Nc/hdkjc187Fb9nXEmBwm7+hdQ=",
-   "pom": "sha256-LmRnxRep8E1Z1YlRFkpMl/zMpRcs+/lXkNLF6AHzdt8="
+  "org/jetbrains/runtime#jbr-api/1.9.0": {
+   "jar": "sha256-fjcoTjO1swTuYXTcqpLblJslfMTImRyoZefa9RE9gnk=",
+   "pom": "sha256-M7lsUL7ccqirVffzfSN8X+MwugWvMRZHeKGpgP1N3E8="
   },
-  "org/jetbrains/skiko#skiko-awt-runtime-linux-x64/0.9.37.4": {
-   "jar": "sha256-7Hlt8TXZgLuxdA54n+hmioGE3yQ+TRw5mXdQMDx28Ts=",
-   "pom": "sha256-OdTTs4n7AZEljgICt7DeawkhBQm81haLJ3Slsk8u1qI="
+  "org/jetbrains/skiko#skiko-awt-runtime-linux-x64/0.144.6": {
+   "jar": "sha256-PtFr43PMu6f73Kms13R/8u09RBdkrAcKogaCyEdkpnE=",
+   "pom": "sha256-QnxTZkt/qBWscS6xKF/ZNrz2mxJE2vs0gqxm3+iSJhU="
+  },
+  "org/jetbrains/skiko#skiko-awt-runtime-macos-arm64/0.144.6": {
+   "jar": "sha256-rsN7ROjav03mIAaBRnaWVXSL45cb+GhhTl7GskCyrDU=",
+   "pom": "sha256-lL7LBJrdupIyi+3lgPP1V4sa0NAypqXWzGr/pj2Ko1Q="
   },
   "org/jetbrains/skiko#skiko-awt-runtime-macos-arm64/0.9.22.2": {
-   "jar": "sha256-iaMVIfr5mFu9SFjIYyg9HDjqXXjRd72zmqMgMoXy/QQ=",
    "pom": "sha256-sqCj8EKIL9aGPFpynw1S3TpVTWpxCYfW8PNVifDY3oY="
   },
-  "org/jetbrains/skiko#skiko-awt/0.9.22.2": {
-   "jar": "sha256-jMftbErik0zd9lAtF98w89HCNYmMggtQYrkw/qS51jw=",
-   "module": "sha256-LeiBcFkeTTs4BM1Mdr2I5XUGBjUyOyHCiXGqw9dkBk4=",
-   "pom": "sha256-GIPhVQyTdcCV4177wr2N/A1iBPddDw+KSBiRQwkzjeg="
+  "org/jetbrains/skiko#skiko-awt/0.144.5": {
+   "jar": "sha256-GeMozzmjOcDYDGSx6YbYI4B8391Eta0egJHEsDTy5S0=",
+   "module": "sha256-5omIIKF4zeZa1nb1xi92P615R/AA8U6DkATfr9VT4gI=",
+   "pom": "sha256-77/4J7kSusLfh23xkTpiyKhBVS+quOs9XoXCyik80YQ="
   },
-  "org/jetbrains/skiko#skiko-awt/0.9.37.4": {
-   "jar": "sha256-noWa65gmI/qxVrpmcceCVff14bczNPPeeTJED+1kVd8=",
-   "module": "sha256-GsTVhATzIPDdifbMoV+Bj048iehjiATfjgHtTYDFyHo=",
-   "pom": "sha256-jMcrhU+iv+z2j79TB66ZLxP+wxa6hQksYsiJswNopa8="
+  "org/jetbrains/skiko#skiko-awt/0.144.6": {
+   "jar": "sha256-V0IBIu0B/vBc20lBV2yY6mIlxSXzc4DCFqPARrK1Up0=",
+   "module": "sha256-+HxTqxf2SfK4U8c7UkTsyUMSimXTCRczRV5j3HXt1Gw=",
+   "pom": "sha256-hYumSDgVeq/Oe0lvNq3HPyLLjfk4W4Rw3G6UYp7Ckos="
   },
-  "org/jetbrains/skiko#skiko/0.9.22.2": {
-   "module": "sha256-++zojoxrB/L+lPgSKs9AfjnTsMFUzHf+OLZoPfNn9Ks=",
-   "pom": "sha256-FVBgFtv1/RvtYYDWpVe7dyeX1N2woKzKLu0OVkf69fw="
+  "org/jetbrains/skiko#skiko/0.144.5": {
+   "jar": "sha256-JwF75Q+DlQyJgm9TM/FkMYqcEfyA+CXTbyRL3cKTRvE=",
+   "module": "sha256-664bLBc2v4iUWHH8gkyRG8p4KA+x2CpVkiqoyfvCVs0=",
+   "pom": "sha256-oUr6OtK+4DmVwrXu5DtCHrPNhINUuMQJIlSMhVZ5k0o="
   },
-  "org/jetbrains/skiko#skiko/0.9.37.4": {
-   "jar": "sha256-cnPbKwiENaMKptPPRl8cgtCR4cU43r13F6OXirP4l9o=",
-   "module": "sha256-cCCSHsd+yhXxDs3xbMt1fOUToR9e1KKHPh3FYJ4EYok=",
-   "pom": "sha256-yGEgoPxWVhXsdLgBnP65EnsqzDAgpx+qn3DdUswmtBk="
+  "org/jetbrains/skiko#skiko/0.144.6": {
+   "jar": "sha256-JwF75Q+DlQyJgm9TM/FkMYqcEfyA+CXTbyRL3cKTRvE=",
+   "module": "sha256-WERq+5TVVDcMFmDrn7aM1G0X3jlfrSyClHcXvU8H0q0=",
+   "pom": "sha256-VMhrNiyMumSLoJ0bRgaqgamX1hK+dnMVKeqMWkA4xzE="
   },
   "org/jsoup#jsoup/1.22.2": {
    "jar": "sha256-WWeFmW08bfFvVEwjLRCpodiHg7KkdAz1JRy2FvK+cE0=",
@@ -2400,50 +4042,118 @@
    "module": "sha256-0wfKd6VOGKwe8artTlu+AUvS9J8p4dL4E+R8J4KDGVs=",
    "pom": "sha256-zauSmjuVIR9D0gkMXi0N/oRllg43i8MrNYQdqzJEM6Y="
   },
+  "org/junit#junit-bom/5.10.2": {
+   "module": "sha256-3iOxFLPkEZqP5usXvtWjhSgWaYus5nBxV51tkn67CAo=",
+   "pom": "sha256-Fp3ZBKSw9lIM/+ZYzGIpK/6fPBSpifqSEgckzeQ6mWg="
+  },
   "org/junit#junit-bom/5.13.4": {
    "module": "sha256-6Vkoj94bGwUNm8CC/HhniRKNpdKFMJFGj8pQQQS99AA=",
    "pom": "sha256-16CKmbJQLwu2jNTh+YTwv2kySqogi9D3M2bAP8NUikI="
   },
-  "org/kodein/emoji#emoji-kt-jvm/2.3.0": {
-   "jar": "sha256-IrKGuhvU9tEgGWuxOSwULIZ+mPcSEVeAlIPwFKJTEwM=",
-   "module": "sha256-U6FTLaPEZpYp4Wv7eJgRyzF6zP7obk9xQLVndFt+yYs=",
-   "pom": "sha256-aoUosnvwZ46PIEyCxyS9MdGoPpBaXzAZe3rKH4HLy8U="
+  "org/junit#junit-bom/5.9.2": {
+   "module": "sha256-qxN7pajjLJsGa/kSahx23VYUtyS6XAsCVJdyten0zx8=",
+   "pom": "sha256-LtB9ZYRRMfUzaoZHbJpAVrWdC1i5gVqzZ5uw82819wU="
   },
-  "org/kodein/emoji#emoji-kt/2.3.0": {
-   "jar": "sha256-ZIzPgkBjzdh1m/K6cnTiAvwi1LYr/S7Sr0itPRGZG3A=",
-   "module": "sha256-MNtVhttWit9Z9T3UrfKlD7DyKYbakUrrEFV7UYVfcRc=",
-   "pom": "sha256-eTDXZIhCKU7Ws7dBoXN6Q06DKRE4ZvcJ3m+wf3k4HnI="
+  "org/jvnet/staxex#stax-ex/1.8.1": {
+   "jar": "sha256-IFIlSQVunlCqNe8LRFouR6U9Br4LCpRn1wTiSD/7BJo=",
+   "pom": "sha256-j8hPNs5tps6MiTtlOBmaf2mmmgcG2bF6PuajoJRS7tY="
+  },
+  "org/kodein/emoji#emoji-kt-jvm/2.4.0": {
+   "jar": "sha256-jL2rOkWG0lnx6+ZGOy5xcp8lgjfPDgj2HRbTsnELPqI=",
+   "module": "sha256-/p9USod54adSeMfnwx/Xz1hD+oiVaAvpcFhCcjerF5k=",
+   "pom": "sha256-zqcDuPFZn7+anKB9V7ICkiIBgMw4bqKtZsvK3H3QZ2I="
+  },
+  "org/kodein/emoji#emoji-kt/2.4.0": {
+   "jar": "sha256-HIeMdjUt8RPRqLPckh0/r2Pg5oLsXy/Oq/yguvkL56A=",
+   "module": "sha256-hsBQw028DEH5wilvWN9qascAMhn99EHUpncrRNPyZyE=",
+   "pom": "sha256-Z36gCnKoilousQexig/VsSnPvFq9jUz1J/rfHQHpG3M="
   },
   "org/ow2#ow2/1.5.1": {
    "pom": "sha256-Mh3bt+5v5PU96mtM1tt0FU1r+kI5HB92OzYbn0hazwU="
+  },
+  "org/ow2/asm#asm-analysis/9.8": {
+   "jar": "sha256-5kBzL7zTxicZJaUE8SXjg4Roj037v5LIYi387g0J7bk=",
+   "pom": "sha256-xXR+JccuGwfVJjx1x4rWGmJt0kWPr8r8I/gdMlPuQu0="
+  },
+  "org/ow2/asm#asm-commons/9.8": {
+   "jar": "sha256-MwGhwctMWfzFKSZI2sHXxa7UwPBn376IhzuM3+d0BPQ=",
+   "pom": "sha256-95PnjwH3A3F9CUcuVs3yEv4piXDIguIRbo5Un7bRQMI="
   },
   "org/ow2/asm#asm-tree/9.8": {
    "jar": "sha256-FLeIDLfIXu0QHicQQy/D/7gydVMqaolNxMQJXUmtWfE=",
    "pom": "sha256-cUnn+qDhkSlvh5ru2SCciULTmPBpjSzKGpxijy4qj3c="
   },
+  "org/ow2/asm#asm-tree/9.9.1": {
+   "jar": "sha256-DzVVCWtyC4ILusqwtRVYm+4CAL7gmb2hTFYXOK6De6E=",
+   "pom": "sha256-Z/7kRrpRKHEwBzjw+Vb2GlAKhS9oYf9w8KPHvwwPpAU="
+  },
+  "org/ow2/asm#asm-util/9.8": {
+   "jar": "sha256-i6BGDsso/Q4pgOXz7zQzpROkV7wHf4GlO9x1tYegjRU=",
+   "pom": "sha256-JNCXDhceKRe4Oo8PBdUKHNtcguUIVVtS28ydM2HE8Ow="
+  },
   "org/ow2/asm#asm/9.8": {
    "jar": "sha256-h26raoPa7K1cpn65/KuwY8l7WuuM8fynqYns3hdSIFE=",
    "pom": "sha256-wTZ8O7OD12Gef3l+ON91E4hfLu8ErntZCPaCImV7W6o="
+  },
+  "org/ow2/asm#asm/9.9.1": {
+   "jar": "sha256-bzgoohXJIAWaXvovtVwjPWxU7FytypnOGxvdEAd8fd0=",
+   "pom": "sha256-rKaN7pui9s2Q/95yjv3H4+v89Z8/Qfv+JI0tAdW4Zq8="
+  },
+  "org/slf4j#slf4j-api/1.7.30": {
+   "jar": "sha256-zboHlk0btAoHYUhcax6ML4/Z6x0ZxTkorA1/lRAQXFc=",
+   "pom": "sha256-fgdHdR6bZ+Gdy1IG8E6iLMA9JQxCJCZALq3QNRPywxQ="
   },
   "org/slf4j#slf4j-api/2.0.17": {
    "jar": "sha256-e3UdlSBhlU1av+1xgcH2RdM2CRtnmJFZHWMynGIuuDI=",
    "pom": "sha256-FQxAKH987NwhuTgMqsmOkoxPM8Aj22s0jfHFrJdwJr8="
   },
+  "org/slf4j#slf4j-api/2.0.18": {
+   "jar": "sha256-RFCP0VdlAGiMeQsZCs3Rb+xPjHmj4LkAr9cFA88FX1U=",
+   "pom": "sha256-bCx/LAJ3TMK3thn70t94c82tKXGJJuRHVLh/cNHrQ8s="
+  },
   "org/slf4j#slf4j-bom/2.0.17": {
    "pom": "sha256-940ntkK0uIbrg5/BArXNn+fzDzdZn/5oGFvk4WCQMek="
+  },
+  "org/slf4j#slf4j-bom/2.0.18": {
+   "pom": "sha256-khmqtgFXUSbE5m4TMesrDGwXozCsTVoH480R1YCgwS0="
+  },
+  "org/slf4j#slf4j-parent/1.7.30": {
+   "pom": "sha256-EWR5VuSKDFv7OsM/bafoPzQQAraFfv0zWlBbaHvjS3U="
   },
   "org/slf4j#slf4j-parent/2.0.17": {
    "pom": "sha256-lc1x6FLf2ykSbli3uTnVfsKy5gJDkYUuC1Rd7ggrvzs="
   },
+  "org/slf4j#slf4j-parent/2.0.18": {
+   "pom": "sha256-CziWvtrSye2Wl+3L6h2gxUzSOKcjWDqBNYqDv7eC6fo="
+  },
   "org/sonatype/oss#oss-parent/7": {
    "pom": "sha256-tR+IZ8kranIkmVV/w6H96ne9+e9XRyL+kM5DailVlFQ="
+  },
+  "org/sonatype/oss#oss-parent/9": {
+   "pom": "sha256-+0AmX5glSCEv+C42LllzKyGH7G8NgBgohcFO8fmCgno="
+  },
+  "org/tensorflow#tensorflow-lite-metadata/0.2.0": {
+   "jar": "sha256-6fGLikHwF+kDPLDthciiuiMHKSzf4l6uNlkj56MdKnA=",
+   "pom": "sha256-D+MTJug7diLLzZx11GeykfAf/jzG4+dmUawFocHHo2A="
   }
  },
- "https://www.jitpack.io": {
-  "com/github/beeper/matrix-messageformat-compose#messageformat-jvm/10242add9dbeefe02c8d63e8392ffe5343becf93": {
-   "jar": "sha256-ckEsgRBqBAY9A6dQuw9nKtqFuN5n8FfCjUC7nhJa6Ho=",
-   "module": "sha256-LuZGtICVxnF4ynfHmbc7GW04Trm6/ge7eJJabMFfSEo=",
-   "pom": "sha256-PXECa+pwp7HvzEqJKWwntEFWTcZgWycta3sriIF8mFo="
+ "https://www.jitpack.io/com/github/beeper": {
+  "matrix-messageformat-compose#messageformat-android/5ac720dbe1a46f228df673cc2c554584731f932c": {
+   "module": "sha256-rgzSoj3H+Kt7ysCZ3I0jbYflLLj2giWHR81XGSSve8E=",
+   "pom": "sha256-5ULao2clDL2jQKAP/YkfNDdrMEJJgvHbZRpQMfFAheU="
+  },
+  "matrix-messageformat-compose#messageformat-jvm/5ac720dbe1a46f228df673cc2c554584731f932c": {
+   "jar": "sha256-XiHH93nwFIKa1kM6f3jhnohGGw2XRaZ7vNGt2QS8rfo=",
+   "module": "sha256-xFighI7x4M2UzBxhuUhqbY9/zMAH+9nbKnOmUxfCs5s=",
+   "pom": "sha256-Tgml1Kjr3pI9GWxuk+6llGmih5zkApnz2i/Ny4VTKUs="
+  },
+  "matrix-messageformat-compose#messageformat/5ac720dbe1a46f228df673cc2c554584731f932c": {
+   "jar": "sha256-swtSuuU+MpS8OiDuKQqxIvX8j/5M1+maux3D93XE8j0=",
+   "module": "sha256-dn5zinoZXu7Pm03e06QBSNOgKGAI6znPLC1p9qsVsX4=",
+   "pom": "sha256-2dxqevZRD0Uap1g3MFzRk+fLc0tUKqJsTVqmWICO3CQ="
+  },
+  "matrix-messageformat-compose/messageformat-android/5ac720dbe1a46f228df673cc2c554584731f932c/messageformat-android-5ac720dbe1a46f228df673cc2c554584731f932c": {
+   "aar": "sha256-oRcxncL4PiTd3Kb2OzTfgOoA+IHajXOBMnkgG+M2FLM="
   }
  }
 }

--- a/pkgs/by-name/sc/schildi-revenge/package.nix
+++ b/pkgs/by-name/sc/schildi-revenge/package.nix
@@ -14,20 +14,20 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "schildi-revenge";
-  version = "26.05.05";
+  version = "26.07.13";
 
   src = fetchFromGitHub {
     owner = "SchildiChat";
     repo = "schildi-revenge";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-B12OcryErrrFyKFweCFQWnbt/L8HvceAhBI51TlT3pg=";
+    hash = "sha256-1Akm57GxGtEymDbfq879uglxEoENp/g+aFUNM1O0qRo=";
     fetchSubmodules = true;
   };
 
   cargoRoot = "matrix-rust-sdk";
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src cargoRoot;
-    hash = "sha256-8HI7UtuO2eg3/Zb2PhX0jvTDaIOpCCY0EHkrsdzSEkc=";
+    hash = "sha256-TIpT2g00f99qTGPA+bBaEz4kj5BC1scEywv6oDCFlkQ=";
   };
 
   nativeBuildInputs = [
@@ -59,14 +59,14 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    BUILD_DIR="composeApp/build/compose/binaries/main-release/app/SchildiChatRevenge"
+    BUILD_DIR="composeApp/build/compose/binaries/main-release/app/schildichat-revenge"
 
     mkdir -p $out/share/{applications,icons/scalable}
     cp -r $BUILD_DIR/bin $out/bin
     cp -r $BUILD_DIR/lib $out/lib
 
     cp -r graphics/ic_launcher_foreground.svg $out/share/icons/scalable/ic_launcher.svg
-    cp -r launcher/SchildiChatRevenge.desktop $out/share/applications
+    cp -r launcher/schildichat-revenge.desktop $out/share/applications
 
     runHook postInstall
   '';
@@ -80,7 +80,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Matrix client for desktop written in Kotlin and using the Matrix Rust SDK";
-    mainProgram = "SchildiChatRevenge";
+    mainProgram = "schildichat-revenge";
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl3Only;
     homepage = "https://schildi.chat/revenge";


### PR DESCRIPTION
This update is Version [26.07.13](https://github.com/SchildiChat/schildi-revenge/releases/tag/v26.07.13).

Main Changes:
- Login via next-gen auth
- Sticker support, for stickers with stable spec identifiers
and more, which can be found in the changelogs linked above.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
