### PR TITLE
nixos/man-db: create empty cache output

### DIFF
--- a/nixos/modules/misc/man-db.nix
+++ b/nixos/modules/misc/man-db.nix
@@ -89,6 +89,7 @@ in
                     preferLocalBuild = true;
                   }
                   ''
+                    mkdir -p "$out"
                     echo "MANDB_MAP ${cfg.manualPages}/share/man $out" > man.conf
                     mandb -C man.conf -pscq
                   ''

--- a/nixos/tests/man.nix
+++ b/nixos/tests/man.nix
@@ -7,6 +7,10 @@ let
 
   machineNames = map machineSafe manImplementations;
 
+  emptyManualPages = pkgs.runCommand "empty-man-pages" { } ''
+    mkdir -p "$out/share/man"
+  '';
+
   makeConfig = useImpl: {
     # Note: mandoc currently can't index symlinked section directories.
     # So if a man section comes from one package exclusively (e. g.
@@ -47,11 +51,26 @@ in
       name = machineSafe i;
       value = makeConfig i;
     }) manImplementations
+    ++ [
+      {
+        name = "empty_man_db_cache";
+        value.documentation.man = {
+          enable = true;
+          cache.enable = true;
+          man-db.manualPages = emptyManualPages;
+        };
+      }
+    ]
   );
 
   testScript = ''
     import re
     start_all()
+
+    with subtest("Test empty build-time man-db cache"):
+      empty_man_db_cache.succeed(
+        "test -d $(grep '^MANDB_MAP ' /etc/man_db.conf | cut -d' ' -f3)"
+      )
 
     def match_man_k(page, section, haystack):
       """


### PR DESCRIPTION
Ensure the build-time man-db cache derivation always creates its output directory. This path is selected by setting `documentation.man.cache.enable = true` while `documentation.man.cache.generateAtRuntime = false` (the default). `mandb` does not create its target directory when there are no manual pages to index, causing the NixOS build to fail because the derivation has no output.

Add coverage for an empty manual-page set to the existing `nixosTests.man` test.

Closes #542629

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
