### PR TITLE
treewide: fix eval on unsupported systems

### DIFF
--- a/pkgs/by-name/bo/boundary/package.nix
+++ b/pkgs/by-name/bo/boundary/package.nix
@@ -71,7 +71,11 @@ stdenv.mkDerivation rec {
       jk
       techknowlogick
     ];
-    platforms = lib.platforms.unix;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
     mainProgram = "boundary";
   };
 }

--- a/pkgs/by-name/db/dbeaver-bin/package.nix
+++ b/pkgs/by-name/db/dbeaver-bin/package.nix
@@ -142,7 +142,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     '';
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.asl20;
-    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
     maintainers = with lib.maintainers; [
       gepbird
       mkg20001

--- a/pkgs/by-name/go/goose-cli/package.nix
+++ b/pkgs/by-name/go/goose-cli/package.nix
@@ -191,6 +191,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
       miniharinn
       caniko
     ];
-    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
   };
 })

--- a/pkgs/by-name/li/livekit-libwebrtc/package.nix
+++ b/pkgs/by-name/li/livekit-libwebrtc/package.nix
@@ -49,7 +49,7 @@ let
     "aarch64" = "arm64";
   };
   cpuName = stdenv.hostPlatform.parsed.cpu.name;
-  gnArch = platformMap."${cpuName}" or (throw "unsupported arch ${cpuName}");
+  gnArch = platformMap."${cpuName}" or "unsupported";
   gnOs =
     if stdenv.hostPlatform.isLinux then
       "linux"
@@ -352,6 +352,8 @@ stdenv.mkDerivation {
       WeetHet
       niklaskorz
     ];
-    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    platforms = lib.intersectLists (lib.platforms.linux ++ lib.platforms.darwin) (
+      lib.platforms.x86 ++ lib.platforms.aarch64 ++ lib.platforms.arm
+    );
   };
 }

--- a/pkgs/by-name/or/oracle-instantclient/package.nix
+++ b/pkgs/by-name/or/oracle-instantclient/package.nix
@@ -17,7 +17,7 @@ assert odbcSupport -> unixodbc != null;
 let
   inherit (lib) optional optionalString;
 
-  throwSystem = throw "Unsupported system: ${stdenv.hostPlatform.system}";
+  throwSystem = "unsupported";
 
   # assemble list of components
   components = [

--- a/pkgs/by-name/po/polyglot/package.nix
+++ b/pkgs/by-name/po/polyglot/package.nix
@@ -79,7 +79,10 @@ maven.buildMavenPackage rec {
     changelog = "https://github.com/DraqueT/PolyGlot/releases/tag/v${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ noodlez1232 ];
-    platforms = lib.platforms.linux;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
     mainProgram = "PolyGlot";
   };
 }

--- a/pkgs/by-name/ro/router/package.nix
+++ b/pkgs/by-name/ro/router/package.nix
@@ -53,6 +53,11 @@ rustPlatform.buildRustPackage rec {
     description = "Configurable, high-performance routing runtime for Apollo Federation";
     homepage = "https://www.apollographql.com/docs/router/";
     license = lib.licenses.elastic20;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
     maintainers = [ lib.maintainers.bbigras ];
   };
 }

--- a/pkgs/by-name/sl/slack/package.nix
+++ b/pkgs/by-name/sl/slack/package.nix
@@ -34,5 +34,5 @@ let
 in
 callPackage (if stdenvNoCC.hostPlatform.isDarwin then ./darwin.nix else ./linux.nix) {
   inherit pname passthru meta;
-  inherit (sources.${system} or (throw "Unsupported system: ${system}")) version src;
+  inherit (sources.${system} or sources.x86_64-linux) version src;
 }

--- a/pkgs/by-name/sp/spacetimedb/package.nix
+++ b/pkgs/by-name/sp/spacetimedb/package.nix
@@ -86,6 +86,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
     description = "Full-featured relational database system that lets you run your application logic inside the database";
     homepage = "https://github.com/clockworklabs/SpacetimeDB";
     license = lib.licenses.bsl11;

--- a/pkgs/development/compilers/zulu/common.nix
+++ b/pkgs/development/compilers/zulu/common.nix
@@ -32,16 +32,14 @@
   ffmpeg,
 }:
 let
-  dist =
-    dists.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+  dist = dists.${stdenv.hostPlatform.system} or (builtins.head (builtins.attrValues dists));
 
   arch =
     {
       "aarch64" = "aarch64";
       "x86_64" = "x64";
     }
-    .${stdenv.hostPlatform.parsed.cpu.name}
-      or (throw "Unsupported architecture: ${stdenv.hostPlatform.parsed.cpu.name}");
+    .${stdenv.hostPlatform.parsed.cpu.name} or "unsupported";
 
   platform =
     {

--- a/pkgs/development/python-modules/jaxlib/bin.nix
+++ b/pkgs/development/python-modules/jaxlib/bin.nix
@@ -129,5 +129,11 @@ buildPythonPackage {
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ samuela ];
+    platforms = [
+      "i686-linux"
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
   };
 }


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
