### PR TITLE
rocq-mcp: init at 0.3.1-unstable-2026-07-21; python3Packages.pytanque: init at 0.2.2

### DIFF
--- a/pkgs/by-name/ro/rocq-mcp/package.nix
+++ b/pkgs/by-name/ro/rocq-mcp/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  coqPackages,
+}:
+
+let
+  # Test data for TestMiniF2FSample; the test reads it via MINIF2F_WORKSPACE.
+  minif2f = fetchFromGitHub {
+    owner = "LLM4Rocq";
+    repo = "miniF2F-rocq";
+    rev = "d9480b5e4711a4a8e8334dad3ef2e72c2ec0efdd";
+    hash = "sha256-3wMOF7gJ/UgPjbnnwlG3ky0MSCbBEUEOc8qT4fl67JU=";
+  };
+in
+
+python3Packages.buildPythonApplication {
+  pname = "rocq-mcp";
+  version = "0.3.1-unstable-2026-07-21";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "LLM4Rocq";
+    repo = "rocq-mcp";
+    rev = "5a6afcd78e442ab022b6e66c13f66cfb3a9297c9";
+    hash = "sha256-zBN3lSawh9l9dZsb0PT+Pw3Yx2aSSarPzA4zTXCLYvA=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    fastmcp
+    psutil
+    pytanque
+  ];
+
+  nativeCheckInputs = [
+    # coqc (coq) and pet/pet-server (coq-lsp) let the full compile/interactive
+    # suite run, not just the mock-backed unit tests.
+    coqPackages.coq
+    coqPackages.coq-lsp
+    python3Packages.pytestCheckHook
+    python3Packages.pytest-asyncio
+  ];
+
+  # The Rocq stdlib is a separate library since Rocq 9.0. As a checkInput, the
+  # coq setup hook adds it to ROCQPATH so `From Stdlib Require Import ...`
+  # resolves for both coqc and pet.
+  checkInputs = [ coqPackages.stdlib ];
+
+  env.MINIF2F_WORKSPACE = "${minif2f}";
+
+  pythonImportsCheck = [ "rocq_mcp" ];
+
+  meta = {
+    description = "MCP server for Rocq/Coq proof development";
+    homepage = "https://github.com/LLM4Rocq/rocq-mcp";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ remix7531 ];
+    mainProgram = "rocq-mcp";
+  };
+}

--- a/pkgs/development/python-modules/pytanque/default.nix
+++ b/pkgs/development/python-modules/pytanque/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  requests,
+  typing-extensions,
+
+  # tests
+  coqPackages,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pytanque";
+  version = "0.2.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "LLM4Rocq";
+    repo = "pytanque";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-1Hae21BuMdE6MjRdiBO7fcsuS4HzahOdLLhynAUox3I=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    requests
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [
+    # coq-lsp provides the pet and pet-server binaries the tests drive.
+    coqPackages.coq-lsp
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pytanque" ];
+
+  meta = {
+    description = "Python client for the Petanque JSON-RPC interface to coq-lsp";
+    homepage = "https://github.com/LLM4Rocq/pytanque";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ remix7531 ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15996,6 +15996,8 @@ self: super: with self; {
 
   pytankerkoenig = callPackage ../development/python-modules/pytankerkoenig { };
 
+  pytanque = callPackage ../development/python-modules/pytanque { };
+
   pytap2 = callPackage ../development/python-modules/pytap2 { };
 
   pytapo = callPackage ../development/python-modules/pytapo { };


### PR DESCRIPTION
Adds two new packages enabling the Rocq MCP toolchain, plus the `coq-lsp` change they depend on:

- `python3Packages.pytanque` (0.2.2): Python client for the Petanque JSON-RPC interface to coq-lsp. Upstream: https://github.com/LLM4Rocq/pytanque
- `rocq-mcp` (0.3.1-unstable-2026-07-21): MCP (Model Context Protocol) server for Rocq/Coq proof development, built on FastMCP. Upstream: https://github.com/LLM4Rocq/rocq-mcp

`rocq-mcp` is pinned to `main` at `5a6afcd`. Upstream self-versions this as `0.3.1` in `pyproject.toml` but has not yet cut a git tag for the 0.3.x series (the newest tag is `0.2.0`), so it is packaged as an `unstable` snapshot per the nixpkgs convention. It requires `fastmcp >= 3.1` and `psutil`, both available in nixpkgs.

Both packages run their upstream test suites in the sandbox rather than disabling them: `rocq-mcp` reports 1187 passed / 0 skipped, and `pytanque` runs its stdio tests against a real `pet`.

## Review follow-ups

- **The suggested `fetchpatch2` for [LLM4Rocq/rocq-mcp#32](https://github.com/LLM4Rocq/rocq-mcp/pull/32) is no longer needed.** That PR has since merged upstream, and `src.rev` is now pinned to the merge commit (`5a6afcd`) itself, so the fix is already in the source. This also resolves @SuperSandro2000's point that an unmerged upstream PR would have to be vendored.
- **`MINIF2F_WORKSPACE` is wired to a pinned `miniF2F-rocq` checkout**, so `TestMiniF2FSample` is no longer skipped for want of a workspace.
- Rebased onto current `master`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## Disclosure

Per the [automation/AI policy]: the package derivations were prepared with assistance from Claude Code (Claude Opus 4.8, and Claude Opus 5). I always review everything I submit. I reviewed the packaging and build-tested it myself before opening this PR, and I'm accountable for the contribution. Commits carry an `Assisted-by:` trailer accordingly.