### PR TITLE
flatpak-builder: fix building with svg icons

### DIFF
--- a/pkgs/development/tools/flatpak-builder/default.nix
+++ b/pkgs/development/tools/flatpak-builder/default.nix
@@ -14,6 +14,9 @@
   xmlto,
   meson,
   ninja,
+  gnome,
+  librsvg,
+  makeWrapper,
 
   acl,
   appstream,
@@ -42,6 +45,11 @@
   attr,
 }:
 
+let
+  gdkPixbufLoadersCache = gnome._gdkPixbufCacheBuilder_DO_NOT_USE {
+    extraLoaders = [ librsvg ];
+  };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "flatpak-builder";
   version = "1.4.4";
@@ -95,6 +103,7 @@ stdenv.mkDerivation (finalAttrs: {
     libxslt
     pkg-config
     xmlto
+    makeWrapper
   ];
 
   buildInputs = [
@@ -132,6 +141,7 @@ stdenv.mkDerivation (finalAttrs: {
       for file in ${installed_testdir}/{test-builder.sh,test-builder-python.sh,test-builder-deprecated.sh}; do
         patchShebangs $file
       done
+      wrapProgram $out/bin/flatpak-builder --set GDK_PIXBUF_MODULE_FILE ${gdkPixbufLoadersCache}
     '';
 
   passthru = {


### PR DESCRIPTION
As described in #480303, flatpak-builder fails when `librsvg` is not available for `gdk-pixbuf`.
Therefore, I just wrap `flatpak-builder` with a module file, which has `librsvg` included.
I had the same error message and found the mentioned issue after quit a long time of googling with no result.

Fixes #480303

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
