### PR TITLE
python3Packages.paho-mqtt: use upstream patch for generating SSL certs

### DIFF
--- a/pkgs/development/python-modules/paho-mqtt/default.nix
+++ b/pkgs/development/python-modules/paho-mqtt/default.nix
@@ -3,9 +3,11 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   hatchling,
   openssl,
   pytestCheckHook,
+  writableTmpDirAsHomeHook,
 }:
 
 let
@@ -28,10 +30,13 @@ buildPythonPackage rec {
     hash = "sha256-VMq+WTW+njK34QUUTE6fR2j2OmHxVzR0wrC92zYb1rY=";
   };
 
-  postPatch = ''
-    substituteInPlace tests/ssl/gen.sh \
-      --replace-fail "c_rehash certs" "#c_rehash certs"
-  '';
+  patches = [
+    (fetchpatch {
+      name = "generate-ssl-certs-in-a-test-fixture.patch";
+      url = "https://github.com/eclipse-paho/paho.mqtt.python/pull/931.diff";
+      hash = "sha256-A7rWwpR4PnCi77F1VqsQKHBxHNrdeHgmVM6BGMeUpjs=";
+    })
+  ];
 
   build-system = [
     hatchling
@@ -40,6 +45,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     openssl
     pytestCheckHook
+    writableTmpDirAsHomeHook
   ];
 
   __darwinAllowLocalNetworking = true;
@@ -51,10 +57,6 @@ buildPythonPackage rec {
 
     # paho.mqtt not in top-level dir to get caught by this
     export PYTHONPATH=".:$PYTHONPATH"
-
-    pushd tests/ssl
-    HOME="$(mktemp -d)" ./gen.sh
-    popd
   '';
 
   disabledTests = [


### PR DESCRIPTION
@vcunat @BlastboomStrice @jaredmontoya Does this fix the build failure on your end?
related: https://github.com/NixOS/nixpkgs/pull/541855, https://github.com/NixOS/nixpkgs/issues/542586

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
