### PR TITLE
 pdns: enable darwin builds 

### DIFF
--- a/pkgs/by-name/pd/pdns/package.nix
+++ b/pkgs/by-name/pd/pdns/package.nix
@@ -48,8 +48,10 @@ stdenv.mkDerivation (finalAttrs: {
     curl
     unixodbc
     openssl
-    systemd
     lmdb
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    systemd
     tinycdb
   ];
 
@@ -61,26 +63,28 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.enableFeature true "reproducible")
     (lib.enableFeature true "tools")
     (lib.enableFeature true "ixfrdist")
-    (lib.enableFeature true "systemd")
+    (lib.enableFeature stdenv.hostPlatform.isLinux "systemd")
     (lib.withFeature true "libsodium")
     (lib.withFeature true "sqlite3")
     (lib.withFeatureAs true "libcrypto" (lib.getDev openssl))
     (lib.withFeatureAs true "modules" "")
     (lib.withFeatureAs true "dynmodules" (
-      lib.concatStringsSep " " [
-        "bind"
-        "geoip"
-        "gmysql"
-        "godbc"
-        "gpgsql"
-        "gsqlite3"
-        "ldap"
-        "lmdb"
-        "lua2"
-        "pipe"
-        "remote"
-        "tinydns"
-      ]
+      lib.concatStringsSep " " (
+        [
+          "bind"
+          "geoip"
+          "gmysql"
+          "godbc"
+          "gpgsql"
+          "gsqlite3"
+          "ldap"
+          "lmdb"
+          "lua2"
+          "pipe"
+          "remote"
+        ]
+        ++ lib.optional stdenv.hostPlatform.isLinux "tinydns"
+      )
     ))
     "--with-boost=${boost.dev}"
     "sysconfdir=/etc/pdns"
@@ -105,7 +109,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Authoritative DNS server";
     homepage = "https://www.powerdns.com";
     platforms = lib.platforms.unix;
-    broken = stdenv.hostPlatform.isDarwin;
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [
       mic92


### PR DESCRIPTION
Conditionally skip Linux-only dependencies on Darwin
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`. 
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
