### PR TITLE
golink: 1.0.0 -> 1.0.0-unstable-2026-07-03

### DIFF
--- a/pkgs/by-name/go/golink/package.nix
+++ b/pkgs/by-name/go/golink/package.nix
@@ -1,22 +1,22 @@
 {
-  git,
   lib,
   buildGoModule,
   fetchFromGitHub,
+  unstableGitUpdater,
 }:
 
-buildGoModule rec {
+buildGoModule {
   pname = "golink";
-  version = "1.0.0";
+  version = "1.0.0-unstable-2026-07-03";
 
   src = fetchFromGitHub {
     owner = "tailscale";
     repo = "golink";
-    tag = "v${version}";
-    hash = "sha256-cIml0ewF5j2cQySLHkMmV1rl7cVH8wuoPFeFDCARi1A=";
+    rev = "30223ca66c2dad29356b6266254e1bf4af921f28";
+    hash = "sha256-hp886p94NHA8u3021horHFf6tGa8x8gWdeNA1XnQZ6E=";
   };
 
-  vendorHash = "sha256-QIAkmqXWH3X2dIoWyVcqFXVHBwzyv1dNPfdkzD5LuSE=";
+  vendorHash = "sha256-7Ykb2YPrHwwBrWuufFwGTT9mQFzIRkiBiNlLvqpr+wo=";
 
   overrideModAttrs = old: {
     # netdb.go allows /etc/protocols and /etc/services to not exist and happily proceeds, but it panic()s if they exist but return permission denied.
@@ -29,6 +29,8 @@ buildGoModule rec {
     "-s"
     "-w"
   ];
+
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = {
     description = "Private shortlink service for tailnets";


### PR DESCRIPTION
the v1.0.0 tag is stuck on tailscale v1.78 (main has v1.96), which current headscale rejects (minimum client version v1.80), so golink from nixpkgs silently fails to join headscale tailnets, while appearing healthy. upstream develops on main and has not tagged since 2025-01. added an update script so the package tracks main going forward.

built on x86_64-linux and running in production against headscale 0.29.2. the darwin-sandbox-fix.patch was verified to still apply against the new vendored modernc libc, and vendorHash was derived against current master.

supersedes #542670, where i intended to fix a format check failure via a --depth 1 clone + force-push, lesson learned that that's not a good idea :D

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
