### PR TITLE
bitburner: init at 3.0.1

### DIFF
--- a/pkgs/by-name/bi/bitburner/electron.nix
+++ b/pkgs/by-name/bi/bitburner/electron.nix
@@ -1,0 +1,21 @@
+{
+  src,
+  version,
+
+  buildNpmPackage,
+}:
+
+buildNpmPackage {
+  pname = "bitburner-electron";
+  inherit version;
+
+  src = src + "/electron";
+  npmDepsHash = "sha256-esWF/kNXcs2BVXsHvlnQRv9CACf+/UBs79A03EV7Zps=";
+
+  dontNpmBuild = true;
+
+  installPhase = ''
+    mkdir $out
+    cp -r . $out
+  '';
+}

--- a/pkgs/by-name/bi/bitburner/package.nix
+++ b/pkgs/by-name/bi/bitburner/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  buildNpmPackage,
+  callPackage,
+  electron,
+  fetchFromGitHub,
+  makeWrapper,
+  nix-update-script,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "bitburner";
+  version = "3.0.1";
+
+  src = fetchFromGitHub {
+    owner = "bitburner-official";
+    repo = "bitburner-src";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6S3UWDNmpCvkfMscncb+Ca3GTwCiF8cugs30Og5DT6c=";
+  };
+
+  npmDepsHash = "sha256-zQQ1PV5NhzD1LJVXUmW6hW479JfZ5qWTnjxfSIz/XVA=";
+
+  __structuredAttrs = true;
+
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  postPatch = ''
+    substituteInPlace webpack.config.js \
+      --replace-fail 'require("child_process").execSync("git rev-parse --short HEAD").toString().trim();' '"${finalAttrs.src.tag}"'
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/bitburner
+    cp -r .app/* $out/share/bitburner
+    cp -r ${finalAttrs.passthru.electron}/* $out/share/bitburner
+
+    makeWrapper ${lib.getExe electron} $out/bin/bitburner \
+      --add-flags $out/share/bitburner \
+      --inherit-argv0
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    electron = callPackage ./electron.nix { inherit (finalAttrs) src version; };
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--subpackage"
+        "electron"
+      ];
+    };
+  };
+
+  meta = {
+    description = "Programming-based incremental game that revolves around hacking and cyberpunk themes";
+    homepage = "https://github.com/bitburner-official/bitburner-src";
+    changelog = "https://github.com/bitburner-official/bitburner-src/releases/tag/${finalAttrs.src.tag}";
+    license =
+      with lib.licenses;
+      AND [
+        asl20
+        commons-clause
+      ];
+    maintainers = with lib.maintainers; [ ilkecan ];
+    platforms = lib.platforms.linux;
+    mainProgram = "bitburner";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/bitburner-official/bitburner-src

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 542677`
Commit: `3d386635a1525ed01ae84d849033b12351c2c831`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>bitburner</li>
  </ul>
</details>
