### PR TITLE
kanarenshu: 0.1.1 -> 0.1.4

### DIFF
--- a/pkgs/by-name/ka/kanarenshu/package.nix
+++ b/pkgs/by-name/ka/kanarenshu/package.nix
@@ -7,14 +7,14 @@
 
 buildGoModule (finalAttrs: {
   pname = "kanarenshu";
-  version = "0.1.1";
+  version = "0.1.4";
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "nuixyz";
     repo = "kanarenshu";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ea3wDS5AsXXFvhff3RoYj1HTcVrUq3Cd4Vjz80R2seI=";
+    hash = "sha256-ROpZXGvleciJf+B3KVSIcsSES9+mtdLhcPFtGBpEmqY=";
   };
 
   vendorHash = "sha256-ES9+l6aDY8Y38yi4ufw2bpBPCW58L2oSlfXzh1TWGRE=";


### PR DESCRIPTION
Diff: https://github.com/nuixyz/kanarenshu/compare/v0.1.1...v0.1.4

Changelog: https://github.com/nuixyz/kanarenshu/releases/tag/v0.1.4


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
