### PR TITLE
nimble: 0.20.1 -> 0.24.1

### DIFF
--- a/pkgs/by-name/ni/nimble/package.nix
+++ b/pkgs/by-name/ni/nimble/package.nix
@@ -1,48 +1,54 @@
 {
   lib,
-  buildNimPackage,
   fetchFromGitHub,
-  nim,
-  openssl,
+  buildNimPackage,
   makeWrapper,
-
   nix-update-script,
+
+  openssl,
+  nim,
+  useSystemNim ? true,
 }:
+buildNimPackage (finalAttrs: {
 
-buildNimPackage (
-  final: prev: {
-    pname = "nimble";
-    version = "0.20.1";
+  pname = "nimble";
+  version = "0.24.1";
 
-    src = fetchFromGitHub {
-      owner = "nim-lang";
-      repo = "nimble";
-      rev = "v${final.version}";
-      hash = "sha256-DV/cheAoG0UviYEYqfaonhrAl4MgjDwFqbbKx7jUnKE=";
-      fetchSubmodules = true;
-    };
+  src = fetchFromGitHub {
+    owner = "nim-lang";
+    repo = "nimble";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-39d9EsS0opz6vQzSE91gBRQbaTPeebVQLf/QdJoaD8o=";
+    fetchSubmodules = true;
+  };
 
-    nativeBuildInputs = [ makeWrapper ];
-    buildInputs = [ openssl ];
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ openssl ];
 
-    nimFlags = [ "--define:git_revision_override=${final.src.rev}" ];
+  nimFlags = [ "--define:git_revision_override=${finalAttrs.src.tag}" ];
 
-    doCheck = false; # it works on their machine
+  doCheck = false; # it works on their machine
 
-    postInstall = ''
-      wrapProgram $out/bin/nimble \
-        --suffix PATH : ${lib.makeBinPath [ nim ]}
-    '';
+  postInstall =
+    let
+      wrapperFlags = lib.concatStringsSep " " (
+        [ "--suffix PATH : ${lib.makeBinPath [ nim ]}" ]
+        ++ lib.optionals useSystemNim [
+          "--add-flag \"--nim:${lib.getExe nim}\""
+          "--add-flag '--useSystemNim'"
+        ]
+      );
+    in
+    "wrapProgram $out/bin/nimble ${wrapperFlags}";
 
-    passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script { };
 
-    meta = {
-      description = "Package manager for the Nim programming language";
-      homepage = "https://github.com/nim-lang/nimble";
-      changelog = "https://github.com/nim-lang/nimble/releases/tag/v${final.version}";
-      license = lib.licenses.bsd3;
-      mainProgram = "nimble";
-      teams = [ lib.teams.nim ];
-    };
-  }
-)
+  meta = {
+    description = "Package manager for the Nim programming language";
+    homepage = "https://github.com/nim-lang/nimble";
+    changelog = "https://github.com/nim-lang/nimble/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.bsd3;
+    mainProgram = "nimble";
+    teams = [ lib.teams.nim ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Upgrade nimble to 0.24.1.

Additionally, introduces an opt-out override (`useSystemNim`) to ensure the `nixpkgs` owned `nimble` is not relying on release binaries fetched by `nimble`. 

[Release Notes](https://github.com/nim-lang/nimble/releases/tag/v0.24.1)


Closes #497074

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
