### PR TITLE
glasgow: print error message in case of firmware mismatch

### DIFF
--- a/pkgs/by-name/gl/glasgow/package.nix
+++ b/pkgs/by-name/gl/glasgow/package.nix
@@ -91,7 +91,11 @@ pythonPackages.buildPythonApplication rec {
       firmware/glasgow.ihex firmware/glasgow.ihex
 
     # Ensure the compiled firmware is exactly the same as the one shipped in the repo.
-    cmp -s firmware/glasgow.ihex software/glasgow/hardware/firmware.ihex
+    if ! cmp -s firmware/glasgow.ihex software/glasgow/hardware/firmware.ihex; then
+      echo >&2 "Firmware doesn't reproduce!"
+      diff -u software/glasgow/hardware/firmware.ihex firmware/glasgow.ihex
+      exit 1
+    fi
 
     cd software
     export PDM_BUILD_SCM_VERSION="${pdmVersion}"


### PR DESCRIPTION
If the firmware doesn't reproduce, this currently fails without any error message.

Instead, print a proper error, and a diff with the desired firmware image.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
