### PR TITLE
[26.05] ntfs3g: 2026.2.25 -> 2026.7.7

### DIFF
--- a/pkgs/by-name/nt/ntfs3g/package.nix
+++ b/pkgs/by-name/nt/ntfs3g/package.nix
@@ -8,14 +8,13 @@
   mount,
   libuuid,
   kmod,
-  macfuse-stubs,
   crypto ? false,
   libgcrypt,
+  macfuse-stubs,
   gnutls,
-  fuse,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ntfs3g";
   version = "2026.2.25";
 
@@ -29,19 +28,19 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "tuxera";
     repo = "ntfs-3g";
-    rev = version;
-    sha256 = "sha256-uiVh87ExLXq94NVqR8MEg7Lrvamm6MrH+qP3Nosii5c=";
+    tag = finalAttrs.version;
+    hash = "sha256-uiVh87ExLXq94NVqR8MEg7Lrvamm6MrH+qP3Nosii5c=";
   };
 
   buildInputs = [
     gettext
     libuuid
-    fuse
   ]
   ++ lib.optionals crypto [
     gnutls
     libgcrypt
-  ];
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ macfuse-stubs ];
 
   # Note: libgcrypt is listed here non-optionally because its m4 macros are
   # being used in ntfs-3g's configure.ac.
@@ -65,12 +64,17 @@ stdenv.mkDerivation rec {
     "--enable-xattr-mappings"
     "--${if crypto then "enable" else "disable"}-crypto"
     "--enable-extras"
-    "--with-mount-helper=${mount}/bin/mount"
-    "--with-umount-helper=${mount}/bin/umount"
-    "--with-fuse=external"
+    "--with-mount-helper=${lib.getExe' mount "mount"}"
+    "--with-umount-helper=${lib.getExe' mount "umount"}"
+
+    # Use bundled FUSE as fuse2 is being deprecated
+    # https://github.com/tuxera/ntfs-3g/issues/54#issuecomment-3058178016
+    # Darwin doesn't support internal FUSE, so we use the external macFUSE stubs instead.
+    # https://github.com/tuxera/ntfs-3g/issues/8#issuecomment-920700418
+    "--with-fuse=${if stdenv.hostPlatform.isLinux then "internal" else "external"}"
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
-    "--with-modprobe-helper=${kmod}/bin/modprobe"
+    "--with-modprobe-helper=${lib.getExe' kmod "modprobe"}"
   ];
 
   postInstall = ''
@@ -83,7 +87,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://github.com/tuxera/ntfs-3g";
     description = "FUSE-based NTFS driver with full write support";
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.ryand56 ];
     mainProgram = "ntfs-3g";
     platforms = with lib.platforms; darwin ++ linux;
     license = with lib.licenses; [
@@ -91,4 +95,4 @@ stdenv.mkDerivation rec {
       lgpl2Plus # fuse-lite
     ];
   };
-}
+})

--- a/pkgs/by-name/nt/ntfs3g/package.nix
+++ b/pkgs/by-name/nt/ntfs3g/package.nix
@@ -16,7 +16,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ntfs3g";
-  version = "2026.2.25";
+  version = "2026.7.7";
 
   outputs = [
     "out"
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "tuxera";
     repo = "ntfs-3g";
     tag = finalAttrs.version;
-    hash = "sha256-uiVh87ExLXq94NVqR8MEg7Lrvamm6MrH+qP3Nosii5c=";
+    hash = "sha256-7Z3rMOHBwrWqkxeksic3+Z+WvwJy2ra9rRxGjESsd04=";
   };
 
   buildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
