### PR TITLE
woxi: init at 0.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -611,6 +611,11 @@
       { fingerprint = "CE85 54F7 B9BC AC0D D648  5661 AB5F C04C 3C94 443F"; }
     ];
   };
+  ad-si = {
+    name = "Adrian Sieber";
+    github = "ad-si";
+    githubId = 36796532;
+  };
   ad030 = {
     name = "Alex Dam";
     github = "ad030";

--- a/pkgs/by-name/wo/woxi/package.nix
+++ b/pkgs/by-name/wo/woxi/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  rustPlatform,
+  fetchCrate,
+  nix-update-script,
+  versionCheckHook,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "woxi";
+  version = "0.3.0";
+
+  __structuredAttrs = true;
+
+  src = fetchCrate {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-gw2pudFKAFJ6MXzpqg7p5pHPhmQMTPH6hjlEPK6wr60=";
+  };
+
+  cargoHash = "sha256-mNA54ukwF6vsbm3sZnlfTENU/Hl2JAXfcZyDfj7LjY4=";
+
+  # The test suite compares Woxi's output against the proprietary
+  # `wolframscript` engine, which is unavailable in the sandbox.
+  doCheck = false;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Interpreter for a subset of the Wolfram Language";
+    homepage = "https://github.com/ad-si/Woxi";
+    changelog = "https://github.com/ad-si/Woxi/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.agpl3Plus;
+    mainProgram = "woxi";
+    maintainers = with lib.maintainers; [
+      ad-si
+      Dietr1ch
+    ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Description

Adds [Woxi](https://github.com/ad-si/Woxi), an interpreter for a subset of the Wolfram Language written in Rust. It provides a `woxi` CLI that evaluates Wolfram Language expressions (a symbolic computer-algebra system).

Built from the crates.io release with `fetchCrate` + `buildRustPackage`. The upstream test suite is disabled (`doCheck = false`) because it diff-tests output against the proprietary `wolframscript` engine, which is unavailable in the sandbox; a `versionCheckHook` install check exercises the built binary instead.

Also adds `ad-si` (the upstream author) to the maintainer list, as the package maintainer.

## Things done

- Built the package locally (`nix-build -A woxi`) on `aarch64-darwin`; the `versionCheckHook` install check passes (`woxi --version` → `woxi 0.3.0`) and `woxi eval 'Integrate[x^2, x]'` returns `x^3/3`.
- Formatted with `nixfmt` (RFC style); the expression evaluates with `nix-instantiate -A woxi`.
- Built on platform(s):
  - [x] aarch64-darwin
  - [ ] x86_64-darwin
  - [ ] x86_64-linux
  - [ ] aarch64-linux
- [x] `meta.description` is set and follows [the requirements](https://nixos.org/manual/nixpkgs/unstable/#var-meta-description).
- [x] `meta.license` fits the upstream license (`AGPL-3.0-or-later` → `lib.licenses.agpl3Plus`).
- [x] `meta.maintainers` is set.
- [x] Package uses the `pkgs/by-name` structure.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
