### PR TITLE
ccusage: 20.0.6 -> 20.0.17

### DIFF
--- a/pkgs/by-name/cc/ccusage/package.nix
+++ b/pkgs/by-name/cc/ccusage/package.nix
@@ -8,22 +8,27 @@
   apple-sdk_15,
   libiconv,
   versionCheckHook,
-  nix-update-script,
+  nix-update,
+  writeShellApplication,
+  curl,
   runCommand,
   jq,
 }:
 
 let
-  # ccusage embeds the LiteLLM model-pricing table at build time. Its build
-  # script otherwise downloads this file from the network, which fails in the
-  # sandbox. Upstream pins the data via a flake input and points
-  # CCUSAGE_PRICING_JSON_PATH at it; mirror that exact revision here so the
-  # build is offline and reproducible (see package.nix + flake.lock in the
-  # upstream repo at tag v20.0.6). Bump this revision together with the package
-  # version; nix-update only refreshes the src and cargo hashes.
+  # ccusage embeds the LiteLLM model-pricing table at build time instead of
+  # downloading it (the Nix sandbox has no network). Upstream pins the exact
+  # data revision via its flake.lock and points CCUSAGE_PRICING_JSON_PATH at it;
+  # we mirror that revision here so the build is offline, reproducible, and
+  # byte-identical to what upstream ships.
+  #
+  # Both values below are kept in sync with the package version by
+  # passthru.updateScript — do not edit them by hand.
+  litellmPricingRev = "f27df8d516802ce4c1b32973992154fe83b851cf";
+  litellmPricingHash = "sha256-zJa6H2EwP9s+hMVs78Y+hwo4UX1dHRtvX5J3MdGh5aI=";
   litellmPricing = fetchurl {
-    url = "https://raw.githubusercontent.com/BerriAI/litellm/f27df8d516802ce4c1b32973992154fe83b851cf/model_prices_and_context_window.json";
-    hash = "sha256-zJa6H2EwP9s+hMVs78Y+hwo4UX1dHRtvX5J3MdGh5aI=";
+    url = "https://raw.githubusercontent.com/BerriAI/litellm/${litellmPricingRev}/model_prices_and_context_window.json";
+    hash = litellmPricingHash;
   };
 in
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -72,7 +77,40 @@ rustPlatform.buildRustPackage (finalAttrs: {
   doInstallCheck = true;
 
   passthru = {
-    updateScript = nix-update-script { };
+    # Plain nix-update only refreshes version + src/cargo hashes; it can't know
+    # about the LiteLLM pricing pin above. This wrapper bumps the package as
+    # usual, then reads the litellm revision that ccusage locks at the new tag
+    # and rewrites litellmPricingRev/litellmPricingHash to match, so automated
+    # (r-ryantm) bumps stay complete instead of shipping stale pricing data.
+    updateScript = lib.getExe (writeShellApplication {
+      name = "ccusage-update";
+      runtimeInputs = [
+        curl
+        jq
+        nix-update
+      ];
+      text = ''
+        set -euo pipefail
+
+        attr="''${UPDATE_NIX_ATTR_PATH:-ccusage}"
+
+        nix-update "$attr"
+
+        version=$(nix-instantiate --eval --raw -A "$attr.version")
+        rev=$(curl --fail --silent --show-error --location \
+          "https://raw.githubusercontent.com/ccusage/ccusage/v''${version}/flake.lock" \
+          | jq --raw-output '.nodes.litellm.locked.rev')
+        hash=$(nix-prefetch-url --type sha256 \
+          "https://raw.githubusercontent.com/BerriAI/litellm/''${rev}/model_prices_and_context_window.json" \
+          | xargs nix --extra-experimental-features nix-command hash convert --hash-algo sha256 --to sri)
+
+        file=$(nix-instantiate --eval --raw -A "$attr.meta.position" | sed -re 's/:[0-9]+$//')
+        sed -i \
+          -e "s|litellmPricingRev = \"[0-9a-f]*\"|litellmPricingRev = \"''${rev}\"|" \
+          -e "s|litellmPricingHash = \"sha256-[^\"]*\"|litellmPricingHash = \"''${hash}\"|" \
+          "$file"
+      '';
+    });
 
     tests = {
       # With no agent data on disk, ccusage must still emit a valid, empty JSON

--- a/pkgs/by-name/cc/ccusage/package.nix
+++ b/pkgs/by-name/cc/ccusage/package.nix
@@ -24,8 +24,8 @@ let
   #
   # Both values below are kept in sync with the package version by
   # passthru.updateScript — do not edit them by hand.
-  litellmPricingRev = "f27df8d516802ce4c1b32973992154fe83b851cf";
-  litellmPricingHash = "sha256-zJa6H2EwP9s+hMVs78Y+hwo4UX1dHRtvX5J3MdGh5aI=";
+  litellmPricingRev = "49ca04d8c3ddea336237ce6f3082dbc26d19e944";
+  litellmPricingHash = "sha256-rkUyugxdoD7WlPN//6BQpl4OJQuBbc20db7gt7exqpc=";
   litellmPricing = fetchurl {
     url = "https://raw.githubusercontent.com/BerriAI/litellm/${litellmPricingRev}/model_prices_and_context_window.json";
     hash = litellmPricingHash;
@@ -33,20 +33,20 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ccusage";
-  version = "20.0.6";
+  version = "20.0.17";
 
   src = fetchFromGitHub {
     owner = "ccusage";
     repo = "ccusage";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-uf/FlPprxx4jh74YwjmYMtoIHpTkKrWTLetbNoYiFv4=";
+    hash = "sha256-486iLPRqQVRnKVbVT93D08RTRzd6/h503ckB//24nho=";
   };
 
   # The Cargo workspace lives in rust/, not at the repo root.
   cargoRoot = "rust";
   buildAndTestSubdir = "rust";
 
-  cargoHash = "sha256-izA2Gs5nPmt0zn6/e1xM80vyyQHYKGEUDpUFRpyFiB8=";
+  cargoHash = "sha256-23l/BCCGcZ1i5mFBC6Q+FE7sQRHnPLbU4QoQe7TfoiQ=";
 
   __structuredAttrs = true;
   strictDeps = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
