### PR TITLE
rufin: 0.8.0 -> 0.9.0

### DIFF
--- a/pkgs/by-name/ru/rufin/package.nix
+++ b/pkgs/by-name/ru/rufin/package.nix
@@ -3,7 +3,7 @@
   fetchFromGitHub,
   rustPlatform,
   cacert,
-  gdk-pixbuf,
+  glib,
   gettext,
   gst_all_1,
   gtk4,
@@ -14,7 +14,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rufin";
-  version = "0.8.0";
+  version = "0.9.0";
 
   __structuredAttrs = true;
 
@@ -22,10 +22,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "screwys";
     repo = "Rufin";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-N2JM0sRg32lQhRhajwfla0SVhxBgEp5cVEetFOXBqKE=";
+    hash = "sha256-VYuM0SAAvoQ/H4dufgoPFNIYwwEjpctqiElrKPi5D+E=";
   };
 
-  cargoHash = "sha256-1KTEVLqlvgUO02hLnTbqjdfPS5z8Ra6qQG5s5H0S2fY=";
+  cargoHash = "sha256-a0VPqbw2rjOzRjYpk8NoI2mq9LxFd6BBJ/AmE3tyVR4=";
 
   strictDeps = true;
 
@@ -36,8 +36,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   buildInputs = [
-    gdk-pixbuf
-    gettext
+    glib
     gtk4
     libadwaita
   ]
@@ -75,7 +74,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     install -Dm644 -t "$out/share/icons/hicolor/64x64/apps" \
       data/icons/hicolor/64x64/apps/*.png
 
-    for po_file in locales/*.po; do
+    for po_file in crates/localization/locales/*.po; do
       if [ -f "$po_file" ]; then
         lang="$(basename "$po_file" .po)"
         mkdir -p "$out/share/locale/$lang/LC_MESSAGES"


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
