### PR TITLE
glasgow: 0-unstable-2025-12-22 -> 0-unstable-2025-07-25

### DIFF
--- a/pkgs/by-name/gl/glasgow/package.nix
+++ b/pkgs/by-name/gl/glasgow/package.nix
@@ -1,33 +1,16 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchFromGitHub,
-  fetchPypi,
-  sdcc,
-  yosys,
   icestorm,
   nextpnr,
+  sdcc,
+  yosys,
 }:
 
-let
-  # glasgow uses importlib_resources' open_text(), removed in 7.x; pin it to 6.x.
-  pythonPackages = python3.pkgs.overrideScope (
-    final: prev: {
-      importlib-resources = prev.importlib-resources.overridePythonAttrs (old: rec {
-        version = "6.5.2";
-        src = fetchPypi {
-          pname = "importlib_resources";
-          inherit version;
-          hash = "sha256-GF+Hre9bzCiESdmPtPugfOp4vANkVd1ExfxKL+eP7Sw=";
-        };
-        doCheck = false;
-      });
-    }
-  );
-in
-pythonPackages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "glasgow";
-  version = "0-unstable-2025-12-22";
+  version = "0-unstable-2025-07-25";
   # Similar to `pdm show`, but without the commit counter
   pdmVersion =
     let
@@ -35,17 +18,17 @@ pythonPackages.buildPythonApplication rec {
       rev = lib.substring 0 7 src.rev;
     in
     "${tag}.1.dev0+g${rev}";
-  # The latest commit ID touching the `firmware` directory, before a "deploy firmware" commit.
-  # Differs from rev!
-  firmwareGitRev = "8b5afc70";
+  # Usually the latest commit ID touching the `firmware` directory. Differs from src/rev!
+  # Run `git log -1 --abbrev=8 --pretty=%h HEAD .` inside the firmware/fx2 dir.
+  firmwareGitRev = "12b5cfb3";
 
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "GlasgowEmbedded";
     repo = "glasgow";
-    rev = "ccee116d8b59f25ed0874d152f6b9f9974b185f1";
-    hash = "sha256-2fF0lPfRtpci76q4fEhWAwLBXP0kfIP3dH5z8u/+yd8=";
+    rev = "c424688ff0d7faee49198bbdb2a34b1026534350";
+    hash = "sha256-0pVQg3FSBQ8A4eLnAxFdicOiCvAYmKwHnSoLGx1MLxM=";
   };
 
   nativeBuildInputs = [
@@ -53,13 +36,14 @@ pythonPackages.buildPythonApplication rec {
   ];
 
   build-system = [
-    pythonPackages.pdm-backend
+    python3Packages.pdm-backend
   ];
 
-  dependencies = with pythonPackages; [
+  dependencies = with python3Packages; [
     aiohttp
     amaranth
     cobs
+    enum-tools
     fx2
     importlib-resources
     libusb1
@@ -67,11 +51,12 @@ pythonPackages.buildPythonApplication rec {
     platformdirs
     pyvcd
     typing-extensions
+    tqdm
   ];
 
   nativeCheckInputs = [
     # pytestCheckHook discovers way less tests
-    pythonPackages.unittestCheckHook
+    python3Packages.unittestCheckHook
     icestorm
     nextpnr
     yosys
@@ -84,16 +69,16 @@ pythonPackages.buildPythonApplication rec {
   __darwinAllowLocalNetworking = true;
 
   preBuild = ''
-    make -C firmware GIT_REV_SHORT=${firmwareGitRev} LIBFX2=${pythonPackages.fx2}/share/libfx2
+    make -C firmware/fx2 GIT_TREE_DIRTY=0 GIT_REV_SHORT=${firmwareGitRev} LIBFX2=${python3Packages.fx2}/share/libfx2
 
     # Normalize the .ihex file, see ./software/deploy-firmware.sh.
-    ${pythonPackages.python.withPackages (p: [ p.fx2 ])}/bin/python firmware/normalize.py \
-      firmware/glasgow.ihex firmware/glasgow.ihex
+    ${python3Packages.python.withPackages (p: [ p.fx2 ])}/bin/python firmware/fx2/normalize.py \
+      firmware/fx2/build/firmware.ihex firmware/fx2/glasgow.ihex
 
     # Ensure the compiled firmware is exactly the same as the one shipped in the repo.
-    if ! cmp -s firmware/glasgow.ihex software/glasgow/hardware/firmware.ihex; then
+    if ! cmp -s firmware/fx2/glasgow.ihex software/glasgow/hardware/firmware-fx2.ihex; then
       echo >&2 "Firmware doesn't reproduce!"
-      diff -u software/glasgow/hardware/firmware.ihex firmware/glasgow.ihex
+      diff -u software/glasgow/hardware/firmware-fx2.ihex firmware/fx2/glasgow.ihex
       exit 1
     fi
 

--- a/pkgs/development/python-modules/enum-tools/default.nix
+++ b/pkgs/development/python-modules/enum-tools/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pygments,
+  whey,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "enum-tools";
+  version = "0.13.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "enum_tools";
+    inherit (finalAttrs) version;
+    hash = "sha256-DRMzXjYdMA3A+P2CyM+ZUUFyRvlnYUT17hdh62kCKOs=";
+  };
+
+  build-system = [
+    whey
+  ];
+
+  dependencies = [
+    pygments
+  ];
+
+  pythonImportsCheck = [ "enum_tools" ];
+
+  meta = {
+    description = "Tools to expand Python's enum module";
+    homepage = "https://github.com/domdfcoding/enum_tools";
+    license = lib.licenses.lgpl3;
+    maintainers = [ ];
+  };
+})

--- a/pkgs/development/python-modules/fx2/default.nix
+++ b/pkgs/development/python-modules/fx2/default.nix
@@ -1,23 +1,23 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
+  fetchFromCodeberg,
   sdcc,
   libusb1,
   setuptools-scm,
   crcmod,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "fx2";
-  version = "0.14";
+  version = "0.16";
   format = "setuptools";
 
-  src = fetchFromGitHub {
+  src = fetchFromCodeberg {
     owner = "GlasgowEmbedded";
     repo = "libfx2";
-    rev = "v${version}";
-    hash = "sha256-uMgf1VL3yvkLUfRlBn9NKcerfHfcFg9yEgHGWmwyh8I=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0AHFjb3dhkr3VVFHFNB/gpQKcqh0oGST1NoeZhdtT6o=";
   };
 
   nativeBuildInputs = [
@@ -47,8 +47,8 @@ buildPythonPackage rec {
   meta = {
     description = "Chip support package for Cypress EZ-USB FX2 series microcontrollers";
     mainProgram = "fx2tool";
-    homepage = "https://github.com/GlasgowEmbedded/libfx2";
+    homepage = "https://codeberg.org/GlasgowEmbedded/libfx2";
     license = lib.licenses.bsd0;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5465,6 +5465,8 @@ self: super: with self; {
 
   enturclient = callPackage ../development/python-modules/enturclient { };
 
+  enum-tools = callPackage ../development/python-modules/enum-tools { };
+
   env-canada = callPackage ../development/python-modules/env-canada { };
 
   environ-config = callPackage ../development/python-modules/environ-config { };


### PR DESCRIPTION
Removing the `importlib-resources` override introduced in #542220, as upstream now works with `importlib-resources` (https://github.com/GlasgowEmbedded/glasgow/pull/1196).

The GIT_TREE_DIRTY logic caused the firmware to not reproduce, fix for that landed in https://github.com/GlasgowEmbedded/glasgow/pull/1205changes/13d841b21d76130585dc187c88cbe2b6ac1c1078.

Location of the firmware changed, it's now in `firmware/fx2` instead of `firmware/`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
