### PR TITLE
sidplayfp: Fix linking on Darwin

### DIFF
--- a/pkgs/by-name/si/sidplayfp/package.nix
+++ b/pkgs/by-name/si/sidplayfp/package.nix
@@ -70,7 +70,11 @@ stdenv.mkDerivation (finalAttrs: {
           lib.optionals miniaudioNeedsPkgconfigs [
             "$(pkg-config --libs ${toString miniaudioPkgconfigs})"
           ]
-          ++ lib.optionals coreaudioSupport [ "-framework CoreAudio" ]
+          ++ lib.optionals coreaudioSupport [
+            "-framework CoreFoundation"
+            "-framework CoreAudio"
+            "-framework AudioToolbox"
+          ]
         )
       }"
   '';


### PR DESCRIPTION
https://hydra.nixos.org/build/337985363/log

```
Undefined symbols for architecture arm64:
  "_AudioComponentFindNext", referenced from:
      _ma_context_init__coreaudio in osaudio_miniaudio.o
  "_AudioComponentInstanceDispose", referenced from:
      _ma_context_init__coreaudio in osaudio_miniaudio.o
  "_AudioComponentInstanceNew", referenced from:
      _ma_context_init__coreaudio in osaudio_miniaudio.o
  "_AudioOutputUnitStart", referenced from:
      _ma_context_init__coreaudio in osaudio_miniaudio.o
  "_AudioOutputUnitStop", referenced from:
      _ma_context_init__coreaudio in osaudio_miniaudio.o
  "_AudioUnitAddPropertyListener", referenced from:
      _ma_context_init__coreaudio in osaudio_miniaudio.o
  "_AudioUnitGetProperty", referenced from:
      _ma_context_init__coreaudio in osaudio_miniaudio.o
  "_AudioUnitGetPropertyInfo", referenced from:
      _ma_context_init__coreaudio in osaudio_miniaudio.o
  "_AudioUnitInitialize", referenced from:
      _ma_context_init__coreaudio in osaudio_miniaudio.o
  "_AudioUnitRender", referenced from:
      _ma_context_init__coreaudio in osaudio_miniaudio.o
  "_AudioUnitSetProperty", referenced from:
      _ma_context_init__coreaudio in osaudio_miniaudio.o
  "_CFRelease", referenced from:
      _ma_context_init__coreaudio in osaudio_miniaudio.o
  "_CFStringGetCString", referenced from:
      _ma_context_init__coreaudio in osaudio_miniaudio.o
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (no-op)
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
