### PR TITLE
freeciv21: init at 3.2-dev.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12772,6 +12772,11 @@
     matrix = "@me:jel.gay";
     name = "jel";
   };
+  jeltsch = {
+    name = "Wolfgang Jeltsch";
+    github = "jeltsch";
+    githubId = 5949153;
+  };
   jemand771 = {
     email = "willy@jemand771.net";
     github = "jemand771";

--- a/pkgs/by-name/fr/freeciv21/package.nix
+++ b/pkgs/by-name/fr/freeciv21/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  gettext,
+  readline,
+  python3,
+  lua5_3,
+  sqlite,
+  SDL2_mixer,
+  libertinus,
+  qt6,
+  kdePackages,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "freeciv21";
+  version = "3.2-dev.3";
+  src = fetchFromGitHub {
+    owner = "longturn";
+    repo = "freeciv21";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-n6NLf1EtCpPV+29TvcNk+Hl+UyjM7NHwdBaMLPq7IfY=";
+  };
+  strictDeps = true;
+  __structuredAttrs = true;
+  nativeBuildInputs = [
+    cmake
+    ninja
+    python3
+    qt6.wrapQtAppsHook
+  ];
+  buildInputs = [
+    gettext
+    readline
+    lua5_3
+    sqlite
+    SDL2_mixer
+    libertinus
+    qt6.qtbase
+    qt6.qtsvg
+    qt6.qtmultimedia
+    kdePackages.karchive
+  ];
+  configurePhase = ''
+    runHook preConfigure
+    cmake -B build -G Ninja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DFREECIV_DOWNLOAD_FONTS=0 \
+      -DCMAKE_INSTALL_PREFIX=$out
+    runHook postConfigure
+  '';
+  buildPhase = ''
+    runHook preBuild
+    cmake --build build
+    runHook postBuild
+  '';
+  installPhase = ''
+    runHook preInstall
+    cmake --install build
+    ln -s ${libertinus}/share/fonts $out/share
+    runHook postInstall
+  '';
+  meta = {
+    description = "Empire-building strategy game";
+    longDescription = ''
+      Freeciv21 is a turn-based, empire-building strategy game in which
+      each player becomes the leader of a civilization. You build
+      cities, develop infrastructure, wage wars, and more, thereby
+      competing or collaborating with leaders of other nations. The game
+      begins at the dawn of history and stretches into the space age.
+
+      Freeciv21 is rooted in the well-known game Freeciv and extends it
+      for more fun, with a revived focus on competitive multiplayer
+      environments. Players can choose from over 500 nations and can
+      play against the computer or against other people in an active
+      online community.
+    '';
+    homepage = "https://github.com/longturn/freeciv21";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ jeltsch ];
+    mainProgram = "freeciv21-client";
+  };
+})


### PR DESCRIPTION
This contribution adds the `freeciv21` package. [Freeciv21](https://github.com/longturn/freeciv21) is a fork of the well-known Freeciv, with a revived focus on competitive multiplayer environments. It is the game software of choice of [the Longturn community](https://longturn.net/).

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
