### PR TITLE
python3Packages.mwclient: 0.11.0 -> 0.11.0-unstable-2026-04-08 (and adopt)

### DIFF
--- a/pkgs/development/python-modules/mwclient/default.nix
+++ b/pkgs/development/python-modules/mwclient/default.nix
@@ -47,6 +47,6 @@ buildPythonPackage rec {
     description = "Python client library to the MediaWiki API";
     license = lib.licenses.mit;
     homepage = "https://github.com/mwclient/mwclient";
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.klea ];
   };
 }

--- a/pkgs/development/python-modules/mwclient/default.nix
+++ b/pkgs/development/python-modules/mwclient/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   hatchling,
   mock,
+  nix-update-script,
   pytest-cov-stub,
   pytestCheckHook,
   requests,
@@ -12,7 +13,7 @@
   six,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   version = "0.11.0-unstable-2026-05-15";
   pname = "mwclient";
   pyproject = true;
@@ -21,10 +22,10 @@ buildPythonPackage rec {
     owner = "mwclient";
     repo = "mwclient";
     rev = "87113730b1f41d8160057621bfd90ad88428f602";
-    sha256 = "sha256-R2erz4oo6111haxlc9zhpgWhihFjMT2Mg/kdWERzcp4=";
+    hash = "sha256-R2erz4oo6111haxlc9zhpgWhihFjMT2Mg/kdWERzcp4=";
   };
 
-  propagatedBuildInputs = [
+  dependencies = [
     requests
     requests-oauthlib
     six
@@ -43,10 +44,14 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "mwclient" ];
 
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
   meta = {
     description = "Python client library to the MediaWiki API";
     license = lib.licenses.mit;
     homepage = "https://github.com/mwclient/mwclient";
     maintainers = [ lib.maintainers.klea ];
   };
-}
+})

--- a/pkgs/development/python-modules/mwclient/default.nix
+++ b/pkgs/development/python-modules/mwclient/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  hatchling,
   mock,
   pytest-cov-stub,
   pytestCheckHook,
@@ -12,21 +13,25 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.11.0";
+  version = "0.11.0-unstable-2026-05-15";
   pname = "mwclient";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mwclient";
     repo = "mwclient";
-    tag = "v${version}";
-    sha256 = "sha256-qnWVQEG1Ri0z4RYmmG/fxYrlIFFf/6PnP5Dnv0cZb5I=";
+    rev = "87113730b1f41d8160057621bfd90ad88428f602";
+    sha256 = "sha256-R2erz4oo6111haxlc9zhpgWhihFjMT2Mg/kdWERzcp4=";
   };
 
   propagatedBuildInputs = [
     requests
     requests-oauthlib
     six
+  ];
+
+  build-system = [
+    hatchling
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
It seems even though upstream [fixed the issue 2 years ago](https://github.com/mwclient/mwclient/commit/96ca94a17328d5ee3e3ffbe74b5f0d49fd9cb7f6), and seem to be an active project, they don't seem to be making releases, so patch the derivation so checks don't fail.

- Is it a good idea to ask them to make a release, or should we configure the update script to make unstable updates?
- I have been told to possibly make these changes as a patch instead, what advantages would that have?
- Why does it need to be in `preCheck`, since when I tried with it in `postPatch` it seemed to fail the test.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
