### PR TITLE
python3Packages.ocrmypdf: 17.8.0 -> 17.8.1

### DIFF
--- a/pkgs/development/python-modules/ocrmypdf/default.nix
+++ b/pkgs/development/python-modules/ocrmypdf/default.nix
@@ -32,7 +32,7 @@
 
 buildPythonPackage rec {
   pname = "ocrmypdf";
-  version = "17.8.0";
+  version = "17.8.1";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     postFetch = ''
       rm "$out/.git_archival.txt"
     '';
-    hash = "sha256-E6SheIepSXQPxTCf6/vWeGpUs0x7VO+h86JhtSxK6e0=";
+    hash = "sha256-+KDn/x1BNqteodwhdr9QKzZ8/j5/wkzwQ+cWxOzz63g=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/ocrmypdf/default.nix
+++ b/pkgs/development/python-modules/ocrmypdf/default.nix
@@ -30,7 +30,7 @@
   installShellFiles,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "ocrmypdf";
   version = "17.8.1";
   pyproject = true;
@@ -38,7 +38,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "ocrmypdf";
     repo = "OCRmyPDF";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     # The content of .git_archival.txt is substituted upon tarball creation,
     # which creates indeterminism if master no longer points to the tag.
     # See https://github.com/ocrmypdf/OCRmyPDF/issues/841
@@ -107,7 +107,7 @@ buildPythonPackage rec {
     maintainers = with lib.maintainers; [
       dotlambda
     ];
-    changelog = "https://github.com/ocrmypdf/OCRmyPDF/blob/${src.tag}/docs/releasenotes/version17.md";
+    changelog = "https://github.com/ocrmypdf/OCRmyPDF/blob/${finalAttrs.src.tag}/docs/releasenotes/version17.md";
     mainProgram = "ocrmypdf";
   };
-}
+})

--- a/pkgs/development/python-modules/ocrmypdf/paths.patch
+++ b/pkgs/development/python-modules/ocrmypdf/paths.patch
@@ -1,5 +1,5 @@
 diff --git a/src/ocrmypdf/_exec/ghostscript.py b/src/ocrmypdf/_exec/ghostscript.py
-index 5afd6e17..0db47849 100644
+index bcee06fe..cc81c161 100644
 --- a/src/ocrmypdf/_exec/ghostscript.py
 +++ b/src/ocrmypdf/_exec/ghostscript.py
 @@ -36,7 +36,7 @@ COLOR_CONVERSION_STRATEGIES = frozenset(
@@ -12,7 +12,7 @@ index 5afd6e17..0db47849 100644
  
  log = logging.getLogger(__name__)
 diff --git a/src/ocrmypdf/_exec/jbig2enc.py b/src/ocrmypdf/_exec/jbig2enc.py
-index 9f107a07..469aed48 100644
+index b44a72ec..5858de31 100644
 --- a/src/ocrmypdf/_exec/jbig2enc.py
 +++ b/src/ocrmypdf/_exec/jbig2enc.py
 @@ -13,7 +13,7 @@ from ocrmypdf._exec._probe import ToolProbe
@@ -30,11 +30,11 @@ index 9f107a07..469aed48 100644
  def convert_single(cwd, infile, outfile, threshold):
 -    args = ['jbig2', '--pdf', '-t', str(threshold), infile]
 +    args = ['@jbig2@', '--pdf', '-t', str(threshold), infile]
-     with open(outfile, 'wb') as fstdout:
+     with outfile.open('wb') as fstdout:
          proc = run(args, cwd=cwd, stdout=fstdout, stderr=PIPE)
      proc.check_returncode()
 diff --git a/src/ocrmypdf/_exec/pngquant.py b/src/ocrmypdf/_exec/pngquant.py
-index 94bcdbf0..c0ae0fa3 100644
+index 5550ca06..a7718be2 100644
 --- a/src/ocrmypdf/_exec/pngquant.py
 +++ b/src/ocrmypdf/_exec/pngquant.py
 @@ -11,7 +11,7 @@ from subprocess import PIPE
@@ -48,7 +48,7 @@ index 94bcdbf0..c0ae0fa3 100644
  
 @@ -27,7 +27,7 @@ def quantize(input_file: Path, output_file: Path, quality_min: int, quality_max:
      """
-     with open(input_file, 'rb') as input_stream:
+     with input_file.open('rb') as input_stream:
          args = [
 -            'pngquant',
 +            '@pngquant@',
@@ -56,7 +56,7 @@ index 94bcdbf0..c0ae0fa3 100644
              '--skip-if-larger',
              '--quality',
 diff --git a/src/ocrmypdf/_exec/tesseract.py b/src/ocrmypdf/_exec/tesseract.py
-index 861f2d50..010ef6a6 100644
+index 0ff118b0..e36a2e31 100644
 --- a/src/ocrmypdf/_exec/tesseract.py
 +++ b/src/ocrmypdf/_exec/tesseract.py
 @@ -117,7 +117,7 @@ class TesseractVersion(Version):


### PR DESCRIPTION
Diff: https://github.com/ocrmypdf/OCRmyPDF/compare/v17.8.0...v17.8.1

Changelog: https://github.com/ocrmypdf/OCRmyPDF/blob/v17.8.1/docs/releasenotes/version17.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
