### PR TITLE
mautrix-telegram: fix crash and unbreak default-python build

### DIFF
--- a/pkgs/by-name/ma/mautrix-telegram/0002-use-importlib-resources.patch
+++ b/pkgs/by-name/ma/mautrix-telegram/0002-use-importlib-resources.patch
@@ -1,0 +1,36 @@
+diff --git a/mautrix_telegram/web/public/__init__.py b/mautrix_telegram/web/public/__init__.py
+index cde3735..d911779 100644
+--- a/mautrix_telegram/web/public/__init__.py
++++ b/mautrix_telegram/web/public/__init__.py
+@@ -23,7 +23,7 @@ import time
+ 
+ from aiohttp import web
+ from mako.template import Template
+-import pkg_resources
++from importlib.resources import files
+ 
+ from mautrix.types import UserID
+ from mautrix.util.signed_token import sign_token, verify_token
+@@ -45,11 +45,11 @@ class PublicBridgeWebsite(AuthAPI):
+         self.secret_key = "".join(random.choices(string.ascii_lowercase + string.digits, k=64))
+ 
+         self.login = Template(
+-            pkg_resources.resource_string("mautrix_telegram", "web/public/login.html.mako")
++            files("mautrix_telegram").joinpath("web/public/login.html.mako").read_bytes()
+         )
+ 
+         self.mx_login = Template(
+-            pkg_resources.resource_string("mautrix_telegram", "web/public/matrix-login.html.mako")
++            files("mautrix_telegram").joinpath("web/public/matrix-login.html.mako").read_bytes()
+         )
+ 
+         self.app = web.Application(loop=loop)
+@@ -58,7 +58,7 @@ class PublicBridgeWebsite(AuthAPI):
+         self.app.router.add_route("GET", "/matrix-login", self.get_matrix_login)
+         self.app.router.add_route("POST", "/matrix-login", self.post_matrix_login)
+         self.app.router.add_static(
+-            "/", pkg_resources.resource_filename("mautrix_telegram", "web/public/")
++            "/", str(files("mautrix_telegram").joinpath("web/public/"))
+         )
+ 
+     def make_token(self, mxid: str, endpoint: str = "/login", expires_in: int = 900) -> str:

--- a/pkgs/by-name/ma/mautrix-telegram/package.nix
+++ b/pkgs/by-name/ma/mautrix-telegram/package.nix
@@ -3,24 +3,43 @@
   fetchPypi,
   fetchFromGitHub,
   python3,
+  openssl,
 
   withE2BE ? true,
 }:
 
 let
-  tulir-telethon = python3.pkgs.telethon.overrideAttrs (
-    finalAttrs: previousAttrs: {
-      version = "1.99.0a6";
-      pname = "tulir_telethon";
-      src = fetchFromGitHub {
-        owner = "tulir";
-        repo = "Telethon";
-        tag = "v${finalAttrs.version}";
-        hash = "sha256-ulnA+xKbZDOTzXYmF9oBWNBNhgxSiF+mKx1ijoCyo/w=";
-      };
-      dontUsePytestCheck = true;
-    }
-  );
+  # tulir-telethon is a fork of telethon used only by mautrix-telegram. It is
+  # built standalone rather than via telethon.overrideAttrs so it does not
+  # inherit telethon's `disabled = pythonAtLeast "3.14"` (which exists only
+  # because telethon's *tests* fail on 3.14). This fork skips the test suite.
+  #
+  # Kept as a local let binding rather than a top-level package: the upstream
+  # Python version is EOL (being rewritten in Go), so splitting it out would
+  # only add maintenance surface for code that will soon be replaced.
+  tulir-telethon = python3.pkgs.buildPythonPackage {
+    pname = "tulir_telethon";
+    version = "1.99.0a6";
+    pyproject = true;
+    src = fetchFromGitHub {
+      owner = "tulir";
+      repo = "Telethon";
+      tag = "v1.99.0a6";
+      hash = "sha256-ulnA+xKbZDOTzXYmF9oBWNBNhgxSiF+mKx1ijoCyo/w=";
+    };
+    postPatch = ''
+      substituteInPlace telethon/crypto/libssl.py --replace-fail \
+        "ctypes.util.find_library('ssl')" "'${lib.getLib openssl}/lib/libssl.so'"
+    '';
+    build-system = [
+      python3.pkgs.setuptools
+    ];
+    dependencies = with python3.pkgs; [
+      pyaes
+      rsa
+    ];
+    dontUsePytestCheck = true;
+  };
 in
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "mautrix-telegram";
@@ -36,7 +55,10 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   build-system = with python3.pkgs; [ setuptools ];
 
-  patches = [ ./0001-Re-add-entrypoint.patch ];
+  patches = [
+    ./0001-Re-add-entrypoint.patch
+    ./0002-use-importlib-resources.patch
+  ];
 
   pythonRelaxDeps = [
     "mautrix"


### PR DESCRIPTION
<!--
^ mautrix-telegram is currently broken on master due to two independent
issues. This PR fixes both:

1. setuptools 81+ removed `pkg_resources`, so 0.15.3 crashes on startup
   with ModuleNotFoundError. The upstream Python version is unmaintained
   (rewritten in Go), so pkg_resources is replaced with the stdlib
   importlib.resources.

2. Default python3 is now 3.14, but telethon is disabled on 3.14 (only
   because telethon's *tests* fail). tulir-telethon inherited the disable
   via telethon.overrideAttrs, breaking the default build. It is now built
   standalone, so it's unaffected by telethon's test-only disable (this
   fork already skips the test suite). ^
-->

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests]
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test]
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files: `mautrix-telegram --help`
      exits 0 (previously crashed at import). Built and verified with the
      **default python3 (3.14)**.
- [x] Fits [CONTRIBUTING.md].
- [x] Follows the [automation/AI policy] — commit carries an `Assisted-by:` trailer.

## Notes for reviewers

- **Verified in production**: the equivalent change was deployed on a home
  server (NixOS, default python3.14) and confirmed working — Telegram
  message bridging operates normally.
- `overrideAttrs { disabled = false; }` does *not* work, since `disabled` is
  baked into `drvPath` via `extendDerivation`; the fork must be built
  standalone.
- `setuptools` was intentionally left in `dependencies` (no longer needed for
  `pkg_resources`, but harmless) to keep the change minimal.

---

*This PR description was drafted with LLM assistance (opencode / glm-5.2) and reviewed by the submitter.*
