### PR TITLE
lumen: 2.31.0 -> 2.32.0

### DIFF
--- a/pkgs/by-name/lu/lumen/package.nix
+++ b/pkgs/by-name/lu/lumen/package.nix
@@ -7,11 +7,12 @@
   openssl,
   fzf,
   mdcat,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "lumen";
-  version = "2.31.0";
+  version = "2.32.0";
 
   __structuredAttrs = true;
 
@@ -19,10 +20,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "jnsahaj";
     repo = "lumen";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-RoOCBwmBIOu17h0cB/t69lw1NWGl6chwAEgK4QixsPs=";
+    hash = "sha256-wTkg7NGCCON1P422q5/76rodIBqDeWIY07J4pRo8Q8k=";
   };
 
-  cargoHash = "sha256-RKSFbsqeR+m/VLs1qu6Ln4bZ9prYj5vUoemuLpSe5+M=";
+  cargoHash = "sha256-ZXw7KEvf1sUHWIM5R4Th2SmekTX6rGXznAq3mtcf3Zo=";
 
   strictDeps = true;
 
@@ -50,6 +51,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--skip=vcs::git::tests::test_get_merge_base_returns_ancestor"
     "--skip=vcs::git::tests::test_working_copy_parent_ref_returns_head"
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Fast terminal diff viewer and code review TUI";


### PR DESCRIPTION
Diff: https://github.com/jnsahaj/lumen/compare/v2.31.0...v2.32.0

Changelog: https://github.com/jnsahaj/lumen/releases/tag/v2.32.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
