### PR TITLE
nixos/technitium-dns-server: set WorkingDirectory on systemd service

### DIFF
--- a/nixos/modules/services/networking/technitium-dns-server.nix
+++ b/nixos/modules/services/networking/technitium-dns-server.nix
@@ -66,6 +66,7 @@ in
 
         StateDirectory = "technitium-dns-server";
         LogsDirectory = "technitium";
+        WorkingDirectory = "%S/technitium-dns-server";
 
         Restart = "always";
         RestartSec = 10;


### PR DESCRIPTION
I recently ran into an issue where Technitium was showing unusually high CPU usage despite essentially no query load (~0.24 qps). htop showed one thread in Technitium's thread pool rotating through high utilization with a lot of time spent in syscalls. Running `strace -c` for a few seconds on the process showed >600k `getdents64` and 2.8M `newfstatat` calls, which felt way out of proportion to what the server should be doing.

I checked which paths the offending file descriptors pointed at (`/proc/<tid>/fd/*`) and found they resolved to `/` and `/nix` — so whatever was doing the enumerating seems like it was walking from the filesystem root rather than Technitium's state/config directory.
The service definition doesn't set `WorkingDirectory`, so systemd defaults it to `/`. I added `WorkingDirectory = "%S/technitium-dns-server"` (matching the existing `StateDirectory`) to the service config, and CPU usage dropped to near-idle on every machine I tested this on.

Regardless of the exact mechanism, explicitly setting `WorkingDirectory` to the state directory seems like a correctness win — services probably shouldn't implicitly run with `/` as their working directory.

(Sonnet 5 used to proofread/cleanup my PR summary)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
