### PR TITLE
stdenv: fix replaceStdenv evaluation

### DIFF
--- a/pkgs/stdenv/custom/default.nix
+++ b/pkgs/stdenv/custom/default.nix
@@ -16,6 +16,7 @@ let
       crossSystem
       overlays
       ;
+    crossOverlays = [ ];
     # Remove config.replaceStdenv to ensure termination.
     config = removeAttrs config [ "replaceStdenv" ];
   };

--- a/pkgs/test/top-level/default.nix
+++ b/pkgs/test/top-level/default.nix
@@ -83,6 +83,23 @@ lib.recurseIntoAttrs {
     assert appended.makeWrapper ? __spliced;
     pkgs.emptyFile;
 
+  replaceStdenv =
+    let
+      replacedPkgs = nixpkgsFun {
+        localSystem = {
+          inherit (pkgs.stdenv.buildPlatform) system;
+        };
+        config.replaceStdenv =
+          { pkgs }:
+          pkgs.stdenv
+          // {
+            wasReplaced = true;
+          };
+      };
+    in
+    assert replacedPkgs.stdenv.wasReplaced;
+    pkgs.emptyFile;
+
   massRebuildVariantComposition =
     let
       variants = [


### PR DESCRIPTION
Pass an explicit empty `crossOverlays` list when the custom stdenv bootstrap recursively imports `pkgs/stdenv`. This caller was missed in #528635  when the argument became required, breaking `config.replaceStdenv` evaluation.

Add a top-level regression test that verifies the replacement stdenv is applied without weakening the required internal interface.

Fixes #542759 

Assisted-by: codex with gpt-5.6-sol-high

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

