### PR TITLE
python3Packages.modal: 1.4.2 -> 1.5.2, modernize

### DIFF
--- a/pkgs/by-name/mo/modal/package.nix
+++ b/pkgs/by-name/mo/modal/package.nix
@@ -1,0 +1,1 @@
+{ python3Packages }: with python3Packages; toPythonApplication modal

--- a/pkgs/development/python-modules/modal/default.nix
+++ b/pkgs/development/python-modules/modal/default.nix
@@ -34,18 +34,21 @@
   types-toml,
   typing-extensions,
   watchfiles,
+  versionCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "modal";
-  version = "1.4.2";
+  version = "1.5.2";
   pyproject = true;
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "modal-labs";
     repo = "modal-client";
     tag = "py/v${finalAttrs.version}";
-    hash = "sha256-MXaiei2hUBwI9qlB7HZtWbnrsZq/iLnZgqIejn2ZgX8=";
+    hash = "sha256-YWSf5xsap5zfy1KbAyamFmjEIe7qpRcj6TfuWf/Tu68=";
   };
   sourceRoot = "${finalAttrs.src.name}/py";
 
@@ -105,6 +108,7 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
     python-dotenv
     six
+    versionCheckHook
   ];
 
   disabledTestPaths = [
@@ -127,6 +131,15 @@ buildPythonPackage (finalAttrs: {
   disabledTests = [
     # Non-deterministic
     "test_queue_blocking_put"
+
+    # try to hit modal servers
+    "test_blob_upload_uses_proxy"
+    "test_grpc_control_plane_uses_prox"
+    "test_grpc_task_command_router_uses_proxy"
+    "test_socks5_proxy_via_all_proxy"
+
+    # flaky
+    "test_process_fork"
   ];
 
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
