### PR TITLE
freecad: remove thumbnailer absolute path patch

### DIFF
--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -138,12 +138,6 @@ freecad-utils.makeCustomizable (
         "--prefix PYTHONPATH : ${python3Packages.makePythonPath pythonDeps}"
       ];
 
-    postInstall = ''
-      substituteInPlace $out/share/thumbnailers/FreeCAD.thumbnailer \
-        --replace-fail "TryExec=freecad-thumbnailer" "TryExec=$out/bin/freecad-thumbnailer" \
-        --replace-fail "Exec=freecad-thumbnailer" "Exec=$out/bin/freecad-thumbnailer"
-    '';
-
     postFixup = ''
       mv $out/share/doc $out
       ln -s $out/doc $out/share/doc


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Removes the change made in https://github.com/NixOS/nixpkgs/commit/92a25dea79392ac11794c498ab68dfa7bd136d14. Building it already produces a `FreeCAD.thumbnailer` using absolute paths:

```
[Thumbnailer Entry]
TryExec=/nix/store/hbm1w76vhp917m18bb3addvmz2as6z73-freecad-1.1.1/bin/freecad-thumbnailer
Exec=/nix/store/hbm1w76vhp917m18bb3addvmz2as6z73-freecad-1.1.1/bin/freecad-thumbnailer -s %s %i %o
MimeType=application/x-extension-fcstd;
```

Fixes: #542724

NOTE: requires #537721 for fixing vtk in order to build

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
