### PR TITLE
[Backport release-26.05] chromium,chromedriver: 150.0.7871.124 -> 150.0.7871.128

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,10 +1,10 @@
 {
   "chromium": {
-    "version": "150.0.7871.124",
+    "version": "150.0.7871.128",
     "chromedriver": {
-      "version": "150.0.7871.125",
-      "hash_darwin": "sha256-HJTBS6eRmAsxrn7WW4hCxMCXdzn+1PYz1W0uZHJ38yk=",
-      "hash_darwin_aarch64": "sha256-VCgkc6MeMPbt0F2ZVTJNn9yJbSYNhy1zr8KzPVaVi0I="
+      "version": "150.0.7871.129",
+      "hash_darwin": "sha256-jeDZ/6nFKOc9XyAA1marZ/KVaxsQPznTP1/UhXoDapY=",
+      "hash_darwin_aarch64": "sha256-CtfrqG/AeXCg7Sl6LoidM+OhYvBWkRJoAxv3g68wqUw="
     },
     "deps": {
       "depot_tools": {
@@ -21,8 +21,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "9261fd0a595ac4964ea84e6bd4a025c1173a2ffa",
-        "hash": "sha256-YKkZfxFZ7mitD6YqJZW+NQByq71UVb0jCFIBXj0SyzU=",
+        "rev": "81891e5ca708047763816c778216799ef14c66cb",
+        "hash": "sha256-lGHZZ2xIih+TaH145CZwEwyXsM1ZQWwqXsIQjWQ/jvk=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -827,8 +827,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "209c9cea0db17d8caf23e9d2c7de08c351609744",
-        "hash": "sha256-3jUyRERu1r+Fl2uSAaRchV2L99XLp8XO9DHctk0lMjY="
+        "rev": "2b2f69158528fdd9d86b778cfcc2d0a1c4f8c59f",
+        "hash": "sha256-bqzCZSpKdXgKv3O1I7ck1PEXCa/2jBT7hpBEKW0LgTA="
       },
       "src/agents/shared": {
         "url": "https://chromium.googlesource.com/chromium/agents.git",


### PR DESCRIPTION
Manual backport of #542734 because of https://github.com/NixOS/nixpkgs/pull/541166#discussion_r3599248819

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests] (`nixosTests.chromium`).
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
