### PR TITLE
actual-server: fix build on Darwin

### DIFF
--- a/pkgs/by-name/ac/actual-server/package.nix
+++ b/pkgs/by-name/ac/actual-server/package.nix
@@ -93,6 +93,31 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Disable the install script for sharp to prevent it from trying to download binaries
     cat <<< $(${lib.getExe jq} '.dependenciesMeta."sharp".built = false' ./package.json) > ./package.json
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # Nix may rename `themes` to avoid a collision with `Themes` on
+    # case-insensitive Darwin filesystems.
+    themesDir=packages/component-library/src/themes
+    caseHackThemesDir=$(find packages/component-library/src -maxdepth 1 -type d -name 'themes~nix~case~hack~*' -print -quit)
+    if [ -n "$caseHackThemesDir" ]; then
+      themesDir=$caseHackThemesDir
+      if [ ! -e packages/component-library/src/themes ]; then
+        ln -s "$(basename "$caseHackThemesDir")" packages/component-library/src/themes
+      fi
+    fi
+
+    mkdir -p packages/desktop-client/src/style/themes
+    cp \
+      "$themesDir"/dark.css \
+      "$themesDir"/light.css \
+      "$themesDir"/midnight.css \
+      "$themesDir"/palette.css \
+      packages/desktop-client/src/style/themes/
+    substituteInPlace packages/desktop-client/src/style/theme.tsx \
+      --replace-fail "@actual-app/components/themes/dark.css?inline" "./themes/dark.css?inline" \
+      --replace-fail "@actual-app/components/themes/light.css?inline" "./themes/light.css?inline" \
+      --replace-fail "@actual-app/components/themes/midnight.css?inline" "./themes/midnight.css?inline" \
+      --replace-fail "@actual-app/components/themes/palette.css?inline" "./themes/palette.css?inline"
   '';
 
   buildPhase = ''


### PR DESCRIPTION
`actual-server` fails to build on case-insensitive Darwin filesystems. The
source contains both `Themes` and `themes`; Nix moves the latter to a
`~nix~case~hack~` path while unpacking. Consequently, Vite cannot resolve the
inline theme imports from `packages/desktop-client/src/style/theme.tsx`.

Restore the lower-case theme path during `postPatch`, copy the four imported
CSS files next to `theme.tsx`, and rewrite those imports to the local copies.
The workaround is Darwin-only, so Linux builds are unchanged.

This addresses the remaining build failure after [#506652](https://github.com/NixOS/nixpkgs/pull/506652) enabled Darwin support. I also checked open related nixpkgs work; [#506686](https://github.com/NixOS/nixpkgs/pull/506686) does not cover this failure.

AI assistance: Codex (GPT-5) was used to investigate, implement, and validate this change. The resulting one-file patch was reviewed before submission.

## Things done

- Built on platform:
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Ran `actual-server --help` from the built output.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
