### PR TITLE
protobuf_{21,25,27,29,30,31}: fix 32-bit build

### DIFF
--- a/pkgs/development/libraries/protobuf/generic.nix
+++ b/pkgs/development/libraries/protobuf/generic.nix
@@ -90,6 +90,14 @@ stdenv.mkDerivation (finalAttrs: {
       substituteInPlace src/google/protobuf/testing/googletest.cc \
         --replace-fail 'tmpnam(b)' '"'$TMPDIR'/foo"'
     ''
+    # Adapt https://github.com/protocolbuffers/protobuf/pull/22412 for various
+    # older versions. sed -z spans newlines, so this can capture and replace
+    # the full multiline #if macro.
+    + lib.optionalString (lib.versionOlder version "32") ''
+      sed -zi 's/\(#if \w*(clang::musttail)\)[^\n]*\(\\\n[^\n]*\)*/'\
+      '\1 \&\& (defined(__aarch64__) || defined(__x86_64__) || defined(_M_X64))/' \
+        src/google/protobuf/port_def.inc
+    ''
     # Keep the sentinel macro non-retained for GCC 15+ to match generated
     # extension objects in linker arrays and avoid section type conflicts.
     + lib.optionalString (lib.versionAtLeast version "34") ''


### PR DESCRIPTION
`pkgsi686Linux.protobuf_21`, etc. broke sometime between the previous release and 26.05.

The build error is https://github.com/protocolbuffers/protobuf/issues/22367, for which there is a [simple upstream patch](https://github.com/protocolbuffers/protobuf/commit/719f3037032b2e952afe7fc49152cc4be38fa7a3) present in versions 32+, but unfortunately that patch doesn't apply cleanly to any of these older version numbers. Worse, the affected lines have changed from version to version. So rather than vendoring several near-identical patches into Nixpkgs to cover all of the affected versions, I wrote a bit of one-size-fits-all sed. Hopefully it isn't too distasteful.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
