### PR TITLE
cosense-cli: init at 1.10.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5558,6 +5558,12 @@
     githubId = 6487079;
     name = "Dane Rieber";
   };
+  conao3 = {
+    email = "conao3@gmail.com";
+    github = "conao3";
+    githubId = 4703128;
+    name = "Naoya Yamashita";
+  };
   conduktorbot = {
     email = "automation@conduktor.io";
     github = "conduktorbot";

--- a/pkgs/by-name/co/cosense-cli/package.nix
+++ b/pkgs/by-name/co/cosense-cli/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nodejs_24,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "cosense-cli";
+  version = "1.10.0";
+
+  src = fetchFromGitHub {
+    owner = "helpfeel";
+    repo = "cosense-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-kYEZ67NVgx2Rbn8m99a7xxDcjCzS4NtyvZK6o2d4ak4=";
+  };
+
+  nodejs = nodejs_24;
+
+  npmDepsHash = "sha256-VSpiCxgMTqU0p72x1rGgRokijZD/b5w4HPnlv3d2Tlw=";
+
+  __structuredAttrs = true;
+
+  dontNpmBuild = true;
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI for reading, searching, and editing Cosense (formerly Scrapbox) pages";
+    homepage = "https://github.com/helpfeel/cosense-cli";
+    changelog = "https://github.com/helpfeel/cosense-cli/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ conao3 ];
+    mainProgram = "cosense";
+  };
+})


### PR DESCRIPTION
## Description

Add [cosense-cli](https://github.com/helpfeel/cosense-cli), a CLI tool for reading, searching, and editing [Cosense](https://cosen.se/) (formerly Scrapbox) pages. It is designed for use as an Agent Skill for AI assistants.

Built with `buildNpmPackage` using Node.js 24 (as required by the upstream `engines` field).

## Things done

- [x] Built on `aarch64-darwin`
- [x] `nix-build -A cosense-cli` succeeds
- [x] Version check passes (`cosense --version` outputs `cosense v1.10.0`)
- [x] Added myself (`conao3`) to `maintainers/maintainer-list.nix`
- [x] Set up `nix-update-script` for automated updates