### PR TITLE
bandcampsync: init at 0.8.0

### DIFF
--- a/pkgs/by-name/ba/bandcampsync/package.nix
+++ b/pkgs/by-name/ba/bandcampsync/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonApplication (finalAttrs: {
+  pname = "bandcampsync";
+  version = "0.8.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "meeb";
+    repo = "bandcampsync";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-j370Kn95CQuGjwOoFMXNNQZ5odlR/0uiw02hN/UVAb8=";
+  };
+
+  build-system = with python3.pkgs; [ setuptools ];
+
+  dependencies = with python3.pkgs; [
+    beautifulsoup4
+    curl-cffi
+  ];
+
+  pythonImportsCheck = [ "bandcampsync" ];
+
+  meta = {
+    description = "Download your Bandcamp purchases automatically";
+    homepage = "https://github.com/meeb/bandcampsync";
+    changelog = "https://github.com/meeb/bandcampsync/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.haylin ];
+    mainProgram = "bandcampsync";
+  };
+})


### PR DESCRIPTION
There already is bandcamp-collection-downloader, but it doesn't support as much and is slower.
## Things done
packaged for nix, and tested by downloading my library.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].