### PR TITLE
claude-code: 2.1.211 -> 2.1.212

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,22 +21,22 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-JswgBhADhoEUug2h1ZZ7OtFjFUVgCxiqIaWCYCMf+Sw=";
+          hash = "sha256-pPgl7MTzkBqZ/KatgAme7F6w873GLxZ1ZTYfkXzD4kw=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-+TBwLHUsPx+TiFP+5Gg59Yii76IERNbBQT3RLidogSo=";
+          hash = "sha256-gnaECK1yMNatDn/ZJ6od8wBQYMlJJ/Q49Z+Ur4SxWU8=";
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-Xglh5yLP4QoeMxqqUUAJyuyehN9hdDookhjwU6znRX4=";
+          hash = "sha256-g0DEP2f+ooEgYz8TFUYTMoVV83HGR2eK2dL5MWa92F8=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.211";
+      version = "2.1.212";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.211",
-  "commit": "17a4b6d7b2ee1936b95e595054c7e7d38fddafb7",
-  "buildDate": "2026-07-15T16:42:49Z",
+  "version": "2.1.212",
+  "commit": "8b2783a8f907ce5c5ad1241ecdbab0ff3301c617",
+  "buildDate": "2026-07-16T16:50:33Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "5a728a76198b6eca7f3c7cdbff43bab44b77b48c2108f7a3107d889773382629",
-      "size": 242445680
+      "checksum": "09ecba2ab2df9b6ee5b0695e26f65dea60fb3b6af3d3542ee09f466838d1e574",
+      "size": 244530512
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "33049eb14cf4702b992b7eda41ec077fc6e76539f7fd046e6d32538757235da4",
-      "size": 251966736
+      "checksum": "7681a0634c89fa4474e53c0c794e992944aebf3409a7a2b87ea9f9b0194ea341",
+      "size": 254080272
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "1fff7e8f947c07b19d10b1fbf714b7e547e9536253b9b58230d8adbc4624f867",
-      "size": 258849520
+      "checksum": "66e88634a8573a002702e6a9de0d80cb9bb7c9072f9e6f4486778539057dfd3c",
+      "size": 260946672
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "8272c8a474ac9ea1bc35f19b9f7c7e7dc4dc4eb6d5ad3e484b19335ac72446b2",
-      "size": 262023992
+      "checksum": "044a88cf3a5180776617fd3da1238dcbf9141ddec449a39cf7d2af1ac78e684e",
+      "size": 264096568
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "ca094a85ea464b2ebec2ecfcc9e2c056573d4ca95ebe12ffae2c7dccb722e17b",
-      "size": 252097720
+      "checksum": "6996b65fc90aa1e0b8f80824df77295d93fa43b12388915a762b58fd982a1d16",
+      "size": 254194872
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "c99bd7934ac841d5be6ee7d3644cb63bccef2cd495c6c1bb982a1b1deac1b466",
-      "size": 256680320
+      "checksum": "a17757970a1f7ef0c47a31ea8fa40798fd7796854ba9422e1a4175f3f149de2c",
+      "size": 258756992
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "3d8509ae7de11d77dbdc711aa320fc6d5064ce795464a8670696611b57093caf",
-      "size": 253293728
+      "checksum": "fe639693fd7e9a881c799867711abb7666dec2a5fefbaba41af6a09e71bcbefa",
+      "size": 255334560
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "a0f9bab0dbdda9b43a8765d54e329e44484d9dd7d4f40cf31db6eee27a2da41c",
-      "size": 247643808
+      "checksum": "adaa6e3dadb8016755ccd1907a5f249c1bc9bdb6c71d3f7dcea7d5db8f72d0a5",
+      "size": 249684640
     }
   },
   "sdkCompat": {


### PR DESCRIPTION
Update claude-code and vscode-extensions.anthropic.claude-code to 2.1.212.

https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md

> [!NOTE]
> Prepared with the assistance of Claude Code (Claude Opus 4.8). Version and hash bumps were produced by the standard `maintainers/scripts/update.nix` script; the change was built locally and validated across arches via `nixpkgs-review`, and reviewed by a human (@markus1189) before being marked ready.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
