### PR TITLE
gecode: 6.2.0 → 6.4.0

### DIFF
--- a/pkgs/by-name/ge/gecode/package.nix
+++ b/pkgs/by-name/ge/gecode/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   bison,
+  cmake,
   flex,
   perl,
   gmp,
@@ -13,19 +14,20 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gecode";
-  version = "6.3.0";
+  version = "6.4.0";
 
   src = fetchFromGitHub {
     owner = "Gecode";
     repo = "gecode";
     tag = "release-${finalAttrs.version}";
-    hash = "sha256-i1geBYMO+edZJekKe/zO+kkgd/S4jSiSZnDLfSRlXwc=";
+    hash = "sha256-WhMN7QC+VQfvHUV1LLaW7I7fG++/fznh1ZDUY/Q8zD8=";
   };
 
   enableParallelBuilding = true;
   dontWrapQtApps = true;
   nativeBuildInputs = [
     bison
+    cmake
     flex
   ];
   buildInputs = [

--- a/pkgs/by-name/ge/gecode/package.nix
+++ b/pkgs/by-name/ge/gecode/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   bison,
   flex,
   perl,
@@ -12,25 +11,16 @@
   enableGist ? true,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gecode";
-  version = "6.2.0";
+  version = "6.3.0";
 
   src = fetchFromGitHub {
     owner = "Gecode";
     repo = "gecode";
-    rev = "release-${version}";
-    sha256 = "0b1cq0c810j1xr2x9y9996p894571sdxng5h74py17c6nr8c6dmk";
+    tag = "release-${finalAttrs.version}";
+    hash = "sha256-i1geBYMO+edZJekKe/zO+kkgd/S4jSiSZnDLfSRlXwc=";
   };
-
-  patches = [
-    # https://github.com/Gecode/gecode/pull/74
-    (fetchpatch {
-      name = "fix-const-weights-clang.patch";
-      url = "https://github.com/Gecode/gecode/commit/c810c96b1ce5d3692e93439f76c4fa7d3daf9fbb.patch";
-      sha256 = "0270msm22q5g5sqbdh8kmrihlxnnxqrxszk9a49hdxd72736p4fc";
-    })
-  ];
 
   enableParallelBuilding = true;
   dontWrapQtApps = true;
@@ -52,4 +42,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.all;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/by-name/mi/minizinc/package.nix
+++ b/pkgs/by-name/mi/minizinc/package.nix
@@ -13,22 +13,6 @@
   zlib,
 }:
 
-let
-  gecode_6_3_0 = gecode.overrideAttrs (_: {
-    version = "6.3.0";
-    src = fetchFromGitHub {
-      owner = "gecode";
-      repo = "gecode";
-      rev = "f7f0d7c273d6844698f01cec8229ebe0b66a016a";
-      hash = "sha256-skf2JEtNkRqEwfHb44WjDGedSygxVuqUixskTozi/5k=";
-    };
-    patches = [ ];
-  });
-in
-let
-  gecode = gecode_6_3_0;
-in
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "minizinc";
   version = "2.9.7";


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
