### PR TITLE
cargo: don't use bootrstrap cargo for shell completions

### DIFF
--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -80,9 +80,9 @@ rustPlatform.buildRustPackage.override
       if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
         ''
           installShellCompletion --cmd cargo \
-            --bash <(CARGO_COMPLETE=bash cargo) \
-            --fish <(CARGO_COMPLETE=fish cargo) \
-            --zsh <(CARGO_COMPLETE=zsh cargo)
+            --bash <(CARGO_COMPLETE=bash $out/bin/cargo) \
+            --fish <(CARGO_COMPLETE=fish $out/bin/cargo) \
+            --zsh <(CARGO_COMPLETE=zsh $out/bin/cargo)
         ''
       else
         ''


### PR DESCRIPTION
I've noticed that pulling cargo causes bootstrap cargo+rustc to be pulled as well. After some investigation, it turned out that shell completions for the final cargo were referring to bootstrap cargo, causing additional `640MiB` to be pulled.

Since the code responsible for generating completions (introduced in #469996) is gated behind `stdenv.buildPlatform.canExecute stdenv.hostPlatform`, I assume the intention was to use the built cargo binary, and not the bootstrap one for generation. However, without an absolute path, the latter would end up being picked.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
