### PR TITLE
Scenedetect 0.7

### DIFF
--- a/pkgs/by-name/dv/dvr-scan/package.nix
+++ b/pkgs/by-name/dv/dvr-scan/package.nix
@@ -27,7 +27,10 @@ python3Packages.buildPythonApplication rec {
     opencv-contrib-python
     pillow
     platformdirs
-    scenedetect
+    # dvr-scan 1.8.2 is incompatible with scenedetect 0.7 (breaking API change);
+    # upstream's 0.7 support only lands in the unreleased 2.0 branch. Pin to 0.6
+    # until a compatible dvr-scan release is available.
+    scenedetect_0_6
     screeninfo
     tqdm
 

--- a/pkgs/development/python-modules/scenedetect/0.6.nix
+++ b/pkgs/development/python-modules/scenedetect/0.6.nix
@@ -1,0 +1,77 @@
+# scenedetect 0.7 is a breaking API change. dvr-scan 1.8.2 (the latest release) is
+# only compatible with the 0.6 series; upstream migrated to scenedetect 0.7 on the
+# unreleased 2.0 branch. This pin keeps dvr-scan building until dvr-scan 2.0 is
+# released, at which point this file and the scenedetect_0_6 alias can be removed.
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  av,
+  click,
+  numpy,
+  pytestCheckHook,
+  opencv-python,
+  platformdirs,
+  tqdm,
+  versionCheckHook,
+}:
+let
+  testsResources = fetchFromGitHub {
+    owner = "Breakthrough";
+    repo = "PySceneDetect";
+    rev = "94389267a344785643980a2e0bb18179dcca01d3";
+    hash = "sha256-7ws7F7CkEJAa0PgfMEOwnpF4Xl2BQCn9+qFQb5MMlZ0=";
+  };
+in
+buildPythonPackage (finalAttrs: {
+  pname = "scenedetect";
+  version = "0.6.7.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Breakthrough";
+    repo = "PySceneDetect";
+    tag = "v${finalAttrs.version}-release";
+    hash = "sha256-bLR04wn4O23fHC12ZvWwDI7gLGvMhm+YnBOy4zYMPSM=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  pythonRelaxDeps = [
+    "click"
+  ];
+  dependencies = [
+    av
+    click
+    numpy
+    opencv-python
+    platformdirs
+    tqdm
+  ];
+
+  pythonImportsCheck = [ "scenedetect" ];
+
+  preCheck = ''
+    cp -r ${testsResources}/tests/resources tests/
+    chmod -R +w tests/resources
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    versionCheckHook
+  ];
+
+  versionCheckProgramArg = "version";
+
+  meta = {
+    description = "Python and OpenCV-based scene cut/transition detection program & library";
+    homepage = "https://www.scenedetect.com";
+    changelog = "https://github.com/Breakthrough/PySceneDetect/releases/tag/${finalAttrs.src.tag}";
+    mainProgram = "scenedetect";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ DataHearth ];
+  };
+})

--- a/pkgs/development/python-modules/scenedetect/default.nix
+++ b/pkgs/development/python-modules/scenedetect/default.nix
@@ -16,29 +16,26 @@ let
   testsResources = fetchFromGitHub {
     owner = "Breakthrough";
     repo = "PySceneDetect";
-    rev = "94389267a344785643980a2e0bb18179dcca01d3";
-    hash = "sha256-7ws7F7CkEJAa0PgfMEOwnpF4Xl2BQCn9+qFQb5MMlZ0=";
+    rev = "a1f226e2f4ec2f8cabb8aa4ac74d5c9d238dec6b";
+    hash = "sha256-7Xp2RsFhswumRzWy+oQPj//u16cygUw5V1Lg5Gs9NZI=";
   };
 in
 buildPythonPackage (finalAttrs: {
   pname = "scenedetect";
-  version = "0.6.7.1";
+  version = "0.7";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Breakthrough";
     repo = "PySceneDetect";
     tag = "v${finalAttrs.version}-release";
-    hash = "sha256-bLR04wn4O23fHC12ZvWwDI7gLGvMhm+YnBOy4zYMPSM=";
+    hash = "sha256-LvxnbPBWoHGrIWjRVR4aqxCKXeVe17xIbkhAagNa7J4=";
   };
 
   build-system = [
     setuptools
   ];
 
-  pythonRelaxDeps = [
-    "click"
-  ];
   dependencies = [
     av
     click
@@ -54,6 +51,11 @@ buildPythonPackage (finalAttrs: {
     cp -r ${testsResources}/tests/resources tests/
     chmod -R +w tests/resources
   '';
+
+  disabledTests = [
+    # Requires the optional MoviePy backend, which is not packaged here.
+    "test_cli_moviepy_accepts_frame_rate_override"
+  ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18169,6 +18169,10 @@ self: super: with self; {
 
   scenedetect = callPackage ../development/python-modules/scenedetect { };
 
+  # Kept for dvr-scan, which is not yet compatible with scenedetect 0.7. Remove
+  # once dvr-scan is updated to a release that supports scenedetect 0.7.
+  scenedetect_0_6 = callPackage ../development/python-modules/scenedetect/0.6.nix { };
+
   schedula = callPackage ../development/python-modules/schedula { };
 
   schedule = callPackage ../development/python-modules/schedule { };


### PR DESCRIPTION
## Description

Updates `scenedetect` from 0.6.7.1 to 0.7.

Since 0.7 is a breaking API change and the current `dvr-scan` release (1.8.2) only supports the 0.6 series, `dvr-scan` is pinned to a new `scenedetect_0_6` package until a compatible `dvr-scan` release is available. Upstream's scenedetect 0.7 support currently lives only in the unreleased `dvr-scan` 2.0 branch, so `scenedetect_0_6` and `pkgs/development/python-modules/scenedetect/0.6.nix` should be removed once that lands.

Closes #542823

### AI disclosure

Prepared with assistance from Claude Code (Claude Opus 4.8). I reviewed all changes; correctness was verified by building `python3Packages.scenedetect`, `python3Packages.scenedetect_0_6`, and `dvr-scan` and running their test suites — including a `nix-build --check` rebuild of `dvr-scan` to confirm its tests pass against the pinned scenedetect 0.6. The commits carry `Assisted-by:` trailers per the automation/AI policy.

## Things done



- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and &#34;core&#34; functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
