### PR TITLE
voxtype: add OSD frontends, fix PATH wrapping, enable upstream features

### DIFF
--- a/pkgs/by-name/vo/voxtype/package.nix
+++ b/pkgs/by-name/vo/voxtype/package.nix
@@ -17,10 +17,12 @@
   alsa-lib,
   dotool,
   libnotify,
+  libxkbcommon,
   openssl,
   pciutils,
   wl-clipboard,
   wtype,
+  ydotool,
   which,
   xclip,
   xdotool,
@@ -32,11 +34,13 @@
   shaderc,
   vulkan-headers,
   vulkan-loader,
+  wayland,
 
   onnxSupport ? false,
   onnxruntime,
 
   osdGtk4Support ? false,
+  osdNativeSupport ? false,
 
   wrapGAppsHook4,
   gtk4-layer-shell,
@@ -46,6 +50,7 @@
     dotool
     wl-clipboard
     wtype
+    ydotool
   ],
 
   x11Support ? stdenv.hostPlatform.isLinux,
@@ -78,9 +83,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
       "paraformer"
       "dolphin"
       "omnilingual"
+      "cohere"
+      "onnx-load-dynamic"
     ]
     ++ lib.optionals osdGtk4Support [
       "osd-gtk4"
+    ]
+    ++ lib.optionals osdNativeSupport [
+      "osd-native"
     ];
 
   nativeBuildInputs = [
@@ -113,6 +123,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ]
   ++ lib.optionals osdGtk4Support [
     gtk4-layer-shell
+  ]
+  ++ lib.optionals osdNativeSupport [
+    libxkbcommon
   ];
 
   env = {
@@ -161,6 +174,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
         --set ORT_DYLIB_PATH "${lib.getLib onnxruntime}/lib/libonnxruntime.so" \
         --prefix LD_LIBRARY_PATH : "${lib.getLib onnxruntime}/lib"
       ''}
+  ''
+  + lib.optionalString osdNativeSupport ''
+    wrapProgram $out/bin/voxtype-osd-native \
+      --prefix LD_LIBRARY_PATH : "${
+        lib.makeLibraryPath [
+          vulkan-loader
+          wayland
+        ]
+      }"
   ''
   + lib.optionalString installManPages ''
     installManPage target/debug/build/voxtype-*/out/man/*

--- a/pkgs/by-name/vo/voxtype/package.nix
+++ b/pkgs/by-name/vo/voxtype/package.nix
@@ -36,6 +36,11 @@
   onnxSupport ? false,
   onnxruntime,
 
+  osdGtk4Support ? false,
+
+  wrapGAppsHook4,
+  gtk4-layer-shell,
+
   waylandSupport ? stdenv.hostPlatform.isLinux,
   waylandRuntimePackages ? [
     dotool
@@ -73,6 +78,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
       "paraformer"
       "dolphin"
       "omnilingual"
+    ]
+    ++ lib.optionals osdGtk4Support [
+      "osd-gtk4"
     ];
 
   nativeBuildInputs = [
@@ -87,6 +95,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     shaderc
     vulkan-headers
     vulkan-loader
+  ]
+  ++ lib.optionals osdGtk4Support [
+    wrapGAppsHook4
   ];
 
   buildInputs = [
@@ -99,6 +110,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ]
   ++ lib.optionals onnxSupport [
     onnxruntime
+  ]
+  ++ lib.optionals osdGtk4Support [
+    gtk4-layer-shell
   ];
 
   env = {
@@ -128,6 +142,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       $out/share/voxtype/default-config.toml
 
     wrapProgram $out/bin/voxtype \
+      --prefix PATH : "$out/bin" \
       --prefix PATH : ${
         (lib.makeBinPath (
           [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3003,8 +3003,14 @@ with pkgs;
   vimpager = callPackage ../tools/misc/vimpager { };
   vimpager-latest = callPackage ../tools/misc/vimpager/latest.nix { };
 
-  voxtype-vulkan = callPackage ../by-name/vo/voxtype/package.nix { vulkanSupport = true; };
-  voxtype-onnx = callPackage ../by-name/vo/voxtype/package.nix { onnxSupport = true; };
+  voxtype-vulkan = callPackage ../by-name/vo/voxtype/package.nix {
+    vulkanSupport = true;
+    osdGtk4Support = true;
+  };
+  voxtype-onnx = callPackage ../by-name/vo/voxtype/package.nix {
+    onnxSupport = true;
+    osdGtk4Support = true;
+  };
 
   openconnectPackages = {
     inherit openconnect openconnect_openssl;


### PR DESCRIPTION
Fix the voxtype-onnx OSD binary lookup (Resolves #533080) and add feature parity with upstream v0.7.5

The daemon spawns `voxtype-osd`, which searches `PATH` for the GTK4/native frontend binary.  `wrapProgram` was replacing `PATH` with only the listed runtime deps, excluding `$out/bin`, so the daemon couldn't find its own binaries.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
