### PR TITLE
jimtcl: 0.82 -> 0.84

### DIFF
--- a/pkgs/by-name/ji/jimtcl/package.nix
+++ b/pkgs/by-name/ji/jimtcl/package.nix
@@ -19,13 +19,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "jimtcl";
-  version = "0.82";
+  version = "0.84";
 
   src = fetchFromGitHub {
     owner = "msteveb";
     repo = "jimtcl";
     rev = finalAttrs.version;
-    sha256 = "sha256-CDjjrxpoTbLESAbCiCjQ8+E/oJP87gDv9SedQOzH3QY=";
+    sha256 = "sha256-MvsC82PMmh7PP1sXNwZRNDNFU7r5LWRA6YqvuvZ9yZE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/op/openocd/package.nix
+++ b/pkgs/by-name/op/openocd/package.nix
@@ -17,9 +17,18 @@
   extraHardwareSupport ? [ ],
 }:
 let
-
   isWindows = stdenv.hostPlatform.isWindows;
   notWindows = !isWindows;
+
+  # OpenOCD needs JimTcl 0.82 and fails to build with the latest version (0.84).
+  # When updating OpenOCD, check which JimTcl version its jimtcl submodule uses.
+  jimtcl_0_82 = jimtcl.overrideAttrs (oldAttrs: rec {
+    version = "0.82";
+    src = oldAttrs.src.override {
+      rev = version;
+      sha256 = "sha256-CDjjrxpoTbLESAbCiCjQ8+E/oJP87gDv9SedQOzH3QY=";
+    };
+  });
 
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -40,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals notWindows [
     hidapi
-    jimtcl
+    jimtcl_0_82
     libftdi1
     libjaylink
   ]


### PR DESCRIPTION
- supersedes https://github.com/NixOS/nixpkgs/pull/542717
- make openocd stay at jimtcl 0.82 because of build failures (this PR does not cause a rebuild for openocd and its forks)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
