### PR TITLE
python3Packages.cmdline: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/cmdline/default.nix
+++ b/pkgs/development/python-modules/cmdline/default.nix
@@ -2,22 +2,25 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   pyyaml,
 }:
 
 buildPythonPackage rec {
   pname = "cmdline";
   version = "0.2.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "7cf6af53549892b2218c2f56a199dff54a733be5c5515c0fd626812070b0a86a";
   };
 
+  build-system = [ setuptools ];
+
   # No tests, https://github.com/rca/cmdline/issues/1
   doCheck = false;
-  propagatedBuildInputs = [ pyyaml ];
+  dependencies = [ pyyaml ];
 
   meta = {
     description = "Utilities for consistent command line tools";

--- a/pkgs/development/python-modules/cmdline/default.nix
+++ b/pkgs/development/python-modules/cmdline/default.nix
@@ -6,14 +6,16 @@
   pyyaml,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "cmdline";
   version = "0.2.0";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "7cf6af53549892b2218c2f56a199dff54a733be5c5515c0fd626812070b0a86a";
+    inherit (finalAttrs) pname version;
+    hash = "sha256-fPavU1SYkrIhjC9WoZnf9UpzO+XFUVwP1iaBIHCwqGo=";
   };
 
   build-system = [ setuptools ];
@@ -22,9 +24,11 @@ buildPythonPackage rec {
   doCheck = false;
   dependencies = [ pyyaml ];
 
+  pythonImportsCheck = [ "cmdline" ];
+
   meta = {
     description = "Utilities for consistent command line tools";
     homepage = "https://github.com/rca/cmdline";
     license = lib.licenses.asl20;
   };
-}
+})


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
