### PR TITLE
nixos/regreet: fix docs for `services.greetd` config

### DIFF
--- a/nixos/modules/programs/regreet.nix
+++ b/nixos/modules/programs/regreet.nix
@@ -15,14 +15,13 @@ in
       description = ''
         Enable ReGreet, a clean and customizable greeter for greetd.
 
-        To use ReGreet, {option}`services.greetd` has to be enabled and
-        {option}`services.greetd.settings.default_session` should contain the
-        appropriate configuration to launch
-        {option}`config.programs.regreet.package`. For examples, see the
-        [ReGreet Readme](https://github.com/rharish101/ReGreet#set-as-default-session).
+        By default enables {option}`services.greetd` and configures a
+        {command}`default_session` to launch ReGreet using the
+        {command}`cage` compositor.
 
-        A minimal configuration that launches ReGreet in {command}`cage` is
-        enabled by this module by default.
+        See the
+        [ReGreet Readme](https://github.com/rharish101/ReGreet#set-as-default-session)
+        for other examples.
       '';
     };
 
@@ -48,8 +47,8 @@ in
         [ "-s" "-d" "-m" "last" ]
       '';
       description = ''
-        Additional arguments to be passed to
-        [cage](https://github.com/cage-kiosk/cage).
+        Arguments to be passed to [cage](https://github.com/cage-kiosk/cage)
+        when using it as the default compositor.
       '';
     };
 


### PR DESCRIPTION
This touches only the docs for `programs.regreet` to make them more accurate and comprehensible.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
