### PR TITLE
coqPackages.coq-lsp: include `pet-server` and wrap all binaries

### DIFF
--- a/pkgs/development/coq-modules/coq-lsp/default.nix
+++ b/pkgs/development/coq-modules/coq-lsp/default.nix
@@ -65,13 +65,17 @@
 
   installPhase = ''
     runHook preInstall
-    dune install -p ${pname} --prefix=$out --libdir $OCAMLFIND_DESTDIR
-    wrapProgram $out/bin/coq-lsp --prefix OCAMLPATH : $OCAMLFIND_DESTDIR --prefix OCAMLPATH : $OCAMLPATH
+    dune install --prefix=$out --libdir $OCAMLFIND_DESTDIR
+    for bin in $out/bin/*; do
+      wrapProgram "$bin" --prefix OCAMLPATH : $OCAMLFIND_DESTDIR --prefix OCAMLPATH : $OCAMLPATH
+    done
     runHook postInstall
   '';
 
   propagatedBuildInputs = with coq.ocamlPackages; [
     dune-build-info
+    logs
+    lwt
     menhir
     result
     uri


### PR DESCRIPTION
Adding `lwt` and `logs` to `propagatedBuildInputs` makes the build emit the `pet-server` binary, too.

All binaries are now wrapped to have `OCAMLPATH` available.

`-p ${pname}` removed as it has no effect.

---

Unblocks @remix7531's #542647 by providing `pet-server`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
