### PR TITLE
p4c: fix build

### DIFF
--- a/pkgs/development/compilers/p4c/default.nix
+++ b/pkgs/development/compilers/p4c/default.nix
@@ -23,6 +23,8 @@
   enableP4Tests ? true,
   enableGTests ? true,
   enableMultithreading ? false,
+  makeFontsConf,
+  dejavu_fonts,
 }:
 let
   toCMakeBoolean = v: if v then "ON" else "OFF";
@@ -39,6 +41,10 @@ stdenv.mkDerivation (finalAttrs: {
     fetchSubmodules = true;
   };
 
+  FONTCONFIG_FILE = makeFontsConf {
+    fontDirectories = [ dejavu_fonts ];
+  };
+
   patches = [
     # Fix gcc-13 build:
     #   https://github.com/p4lang/p4c/pull/4084
@@ -47,11 +53,18 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/p4lang/p4c/commit/6756816100b7c51e3bf717ec55114a8e8575ba1d.patch";
       hash = "sha256-wWM1qjgQCNMPdrhQF38jzFgODUsAcaHTajdbV7L3y8o=";
     })
+    ./gcc-15.patch
   ];
 
   postFetch = ''
     rm -rf backends/ebpf/runtime/contrib/libbpf
     rm -rf control-plane/p4runtime
+  '';
+
+  # Fixes fontconfig errors.
+  # Mentioned in https://discourse.nixos.org/t/fontconfig-error-no-writable-cache-directories/34447
+  preConfigure = ''
+    export XDG_CACHE_HOME="$TMPDIR/cache"
   '';
 
   cmakeFlags = [

--- a/pkgs/development/compilers/p4c/gcc-15.patch
+++ b/pkgs/development/compilers/p4c/gcc-15.patch
@@ -1,0 +1,12 @@
+diff --git a/lib/log.cpp b/lib/log.cpp
+index c85962822..7b1bc1ae7 100644
+--- a/lib/log.cpp
++++ b/lib/log.cpp
+@@ -22,6 +22,7 @@ limitations under the License.
+ #define NOGC_ARGS
+ #endif /* HAVE_LIBGC */
+ 
++#include <cstdint>
+ #include <cstring>
+ #include <fstream>  // IWYU pragma: keep
+ #include <iomanip>


### PR DESCRIPTION
Add the missing `<cstdint>` header (patch code from #542616) required by GCC 15 and set the right environment variables to fix the fontconfig error.

Closes https://github.com/NixOS/nixpkgs/issues/542520

Built succesfully on the nixtbuild.net servers (My laptop wouldn't handle the memory required for the build)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
