### PR TITLE
mbedtls: pick patch to fix 32-bit builds with GCC 15.3

### DIFF
--- a/pkgs/by-name/mb/mbedtls/fix-gcc153-32bit.patch
+++ b/pkgs/by-name/mb/mbedtls/fix-gcc153-32bit.patch
@@ -1,0 +1,14 @@
+diff --git a/library/common.h b/library/common.h
+index 1f59b32426..8c756bcb07 100644
+--- a/library/common.h
++++ b/library/common.h
+@@ -332,7 +332,8 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
+         uint32_t x = mbedtls_get_unaligned_uint32(a + i) ^ mbedtls_get_unaligned_uint32(b + i);
+         mbedtls_put_unaligned_uint32(r + i, x);
+     }
+-#if defined(__IAR_SYSTEMS_ICC__)
++#if defined(__IAR_SYSTEMS_ICC__) || \
++    (defined(MBEDTLS_COMPILER_IS_GCC) && MBEDTLS_GCC_VERSION >= 150300)
+     if (n % 4 == 0) {
+         return;
+     }

--- a/pkgs/by-name/mb/mbedtls/package.nix
+++ b/pkgs/by-name/mb/mbedtls/package.nix
@@ -1,4 +1,9 @@
-{ callPackage, fetchurl }:
+{
+  lib,
+  stdenv,
+  callPackage,
+  fetchurl,
+}:
 
 callPackage ./generic.nix {
   version = "3.6.6";
@@ -14,5 +19,10 @@ callPackage ./generic.nix {
       url = "https://raw.githubusercontent.com/openwrt/openwrt/52b6c9247997e51a97f13bb9e94749bc34e2d52e/package/libs/mbedtls/patches/100-fix-gcc14-build.patch";
       hash = "sha256-20bxGoUHkrOEungN3SamYKNgj95pM8IjbisNRh68Wlw=";
     })
+  ]
+  ++ lib.optionals stdenv.hostPlatform.is32bit [
+    # Fixes build with GCC 15.3 on 32-bit platforms.
+    # See: https://github.com/Mbed-TLS/mbedtls/pull/10793
+    ./fix-gcc153-32bit.patch
   ];
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
