### PR TITLE
sqlitebiter: init at 0.36.3

### DIFF
--- a/pkgs/by-name/sq/sqlitebiter/package.nix
+++ b/pkgs/by-name/sq/sqlitebiter/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "sqlitebiter";
+  version = "0.36.3";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "thombashi";
+    repo = "sqlitebiter";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-u/CDQP66r10c2fwIhaam9aBrz1BC7g+g9IjlZ70qsrE=";
+  };
+
+  postPatch = ''
+    substituteInPlace requirements/requirements.txt \
+      --replace-fail "path>=13,<17" "path>=13"
+    substituteInPlace sqlitebiter/__main__.py \
+      --replace-fail ".isfile()" ".is_file()" \
+      --replace-fail ".isdir()" ".is_dir()"
+    substituteInPlace sqlitebiter/converter/_file.py \
+      --replace-fail ".isfile()" ".is_file()" \
+      --replace-fail "file_path.ext" "file_path.suffix"
+
+    # Remove pytest plugin options that require pytest-discord/pytest-md-report
+    substituteInPlace pyproject.toml \
+      --replace-fail "md_report = true" "" \
+      --replace-fail "md_report_verbose = 0" "" \
+      --replace-fail "md_report_color = \"auto\"" "" \
+      --replace-fail "discord_verbose = 1" ""
+  '';
+
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies =
+    with python3Packages;
+    [
+      appconfigpy
+      click
+      envinfopy
+      loguru
+      msgfy
+      nbformat
+      path
+      pathvalidate
+      pytablereader
+      retryrequests
+      simplesqlite
+      tcolorpy
+      typepy
+    ]
+    ++ pytablereader.optional-dependencies.excel
+    ++ pytablereader.optional-dependencies.md;
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+    pytablewriter
+    responses
+    sqliteschema
+    xlsxwriter
+  ];
+
+  pythonImportsCheck = [ "sqlitebiter" ];
+
+  meta = {
+    description = "CLI tool to convert various data formats to SQLite database files";
+    homepage = "https://github.com/thombashi/sqlitebiter";
+    changelog = "https://github.com/thombashi/sqlitebiter/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yajo ];
+  };
+})

--- a/pkgs/development/python-modules/appconfigpy/default.nix
+++ b/pkgs/development/python-modules/appconfigpy/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  loguru,
+}:
+
+buildPythonPackage rec {
+  pname = "appconfigpy";
+  version = "2.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "thombashi";
+    repo = "appconfigpy";
+    tag = "v${version}";
+    hash = "sha256-qXnS5NOILWvmGhTzOOBcLivhs7Y9vY72xinr3l7MZHA=";
+  };
+
+  build-system = [ setuptools ];
+
+  optional-dependencies = {
+    logging = [ loguru ];
+  };
+
+  pythonImportsCheck = [ "appconfigpy" ];
+
+  meta = {
+    description = "Python library to manage configuration files";
+    homepage = "https://github.com/thombashi/appconfigpy";
+    changelog = "https://github.com/thombashi/appconfigpy/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yajo ];
+  };
+}

--- a/pkgs/development/python-modules/envinfopy/default.nix
+++ b/pkgs/development/python-modules/envinfopy/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "envinfopy";
+  version = "0.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "thombashi";
+    repo = "envinfopy";
+    tag = "v${version}";
+    hash = "sha256-0T73lnQOMOX6jPMUHvtpTt8eTmJqZn2rOQ6bNKG3eno=";
+  };
+
+  build-system = [ setuptools ];
+
+  # envinfopy has no required runtime dependencies
+
+  pythonImportsCheck = [ "envinfopy" ];
+
+  meta = {
+    description = "Python library to get basic environment information";
+    homepage = "https://github.com/thombashi/envinfopy";
+    changelog = "https://github.com/thombashi/envinfopy/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yajo ];
+  };
+}

--- a/pkgs/development/python-modules/excelrd/default.nix
+++ b/pkgs/development/python-modules/excelrd/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "excelrd";
+  version = "3.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "thombashi";
+    repo = "excelrd";
+    tag = "v${version}";
+    hash = "sha256-PqAzijzNzejyNoIVHKx0NUHwt6KRMIcRrNCvSimxBlQ=";
+  };
+
+  build-system = [ setuptools ];
+
+  # excelrd has no required runtime dependencies
+
+  pythonImportsCheck = [ "excelrd" ];
+
+  meta = {
+    description = "Fork of xlrd with support for .xlsb files";
+    homepage = "https://github.com/thombashi/excelrd";
+    changelog = "https://github.com/thombashi/excelrd/releases/tag/v${version}";
+    license = lib.licenses.bsdOriginal;
+    maintainers = with lib.maintainers; [ yajo ];
+  };
+}

--- a/pkgs/development/python-modules/msgfy/default.nix
+++ b/pkgs/development/python-modules/msgfy/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "msgfy";
+  version = "0.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "thombashi";
+    repo = "msgfy";
+    tag = "v${version}";
+    hash = "sha256-wTUq44gx4lMwL5txg6/bCWIULPEFm8B/oUxkZIFb8JE=";
+  };
+
+  build-system = [ setuptools ];
+
+  # msgfy has no runtime dependencies
+
+  pythonImportsCheck = [ "msgfy" ];
+
+  meta = {
+    description = "Python library to convert exception objects to messages";
+    homepage = "https://github.com/thombashi/msgfy";
+    changelog = "https://github.com/thombashi/msgfy/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yajo ];
+  };
+}

--- a/pkgs/development/python-modules/pytablereader/default.nix
+++ b/pkgs/development/python-modules/pytablereader/default.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  beautifulsoup4,
+  dataproperty,
+  excelrd,
+  jsonschema,
+  markdown,
+  mbstrdecoder,
+  path,
+  pathvalidate,
+  retryrequests,
+  simplesqlite,
+  tabledata,
+  typepy,
+}:
+
+buildPythonPackage rec {
+  pname = "pytablereader";
+  version = "0.31.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "thombashi";
+    repo = "pytablereader";
+    tag = "v${version}";
+    hash = "sha256-SxYP6JT7r9udUFh6ZADvKmMMnvFcStFx8qelK8pmsZ0=";
+  };
+
+  build-system = [ setuptools ];
+
+  postPatch = ''
+    substituteInPlace requirements/requirements.txt \
+      --replace-fail "path>=13,<17" "path>=13"
+  '';
+
+  dependencies = [
+    beautifulsoup4
+    dataproperty
+    jsonschema
+    mbstrdecoder
+    path
+    pathvalidate
+    tabledata
+    typepy
+  ];
+
+  optional-dependencies = {
+    excel = [ excelrd ];
+    md = [ markdown ];
+    sqlite = [ simplesqlite ];
+    url = [ retryrequests ];
+  };
+
+  pythonImportsCheck = [ "pytablereader" ];
+
+  meta = {
+    description = "Python library to load tabular data from various data formats";
+    homepage = "https://github.com/thombashi/pytablereader";
+    changelog = "https://github.com/thombashi/pytablereader/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yajo ];
+  };
+}

--- a/pkgs/development/python-modules/retryrequests/default.nix
+++ b/pkgs/development/python-modules/retryrequests/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  requests,
+}:
+
+buildPythonPackage rec {
+  pname = "retryrequests";
+  version = "0.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "thombashi";
+    repo = "retryrequests";
+    tag = "v${version}";
+    hash = "sha256-bla17VebkQlga6K+yGAd+XUxXz0Oh4Kem4i6tq29QxQ=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ requests ];
+
+  pythonImportsCheck = [ "retryrequests" ];
+
+  meta = {
+    description = "Python library that extends requests to retry on failures";
+    homepage = "https://github.com/thombashi/retryrequests";
+    changelog = "https://github.com/thombashi/retryrequests/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yajo ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17696,6 +17696,8 @@ self: super: with self; {
 
   retrying = callPackage ../development/python-modules/retrying { };
 
+  retryrequests = callPackage ../development/python-modules/retryrequests { };
+
   returns = callPackage ../development/python-modules/returns { };
 
   reuse = callPackage ../development/python-modules/reuse { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1215,6 +1215,8 @@ self: super: with self; {
 
   app-model = callPackage ../development/python-modules/app-model { };
 
+  appconfigpy = callPackage ../development/python-modules/appconfigpy { };
+
   appdirs = callPackage ../development/python-modules/appdirs { };
 
   appimage = callPackage ../development/python-modules/appimage { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10902,6 +10902,8 @@ self: super: with self; {
 
   msg-parser = callPackage ../development/python-modules/msg-parser { };
 
+  msgfy = callPackage ../development/python-modules/msgfy { };
+
   msgpack = callPackage ../development/python-modules/msgpack { };
 
   msgpack-numpy = callPackage ../development/python-modules/msgpack-numpy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5640,6 +5640,8 @@ self: super: with self; {
     inherit (pkgs) example-robot-data;
   };
 
+  excelrd = callPackage ../development/python-modules/excelrd { };
+
   exceptiongroup = callPackage ../development/python-modules/exceptiongroup { };
 
   exchangelib = callPackage ../development/python-modules/exchangelib { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16000,6 +16000,8 @@ self: super: with self; {
 
   pytabix = callPackage ../development/python-modules/pytabix { };
 
+  pytablereader = callPackage ../development/python-modules/pytablereader { };
+
   pytablewriter = callPackage ../development/python-modules/pytablewriter { };
 
   pytaglib = callPackage ../development/python-modules/pytaglib { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5486,6 +5486,8 @@ self: super: with self; {
 
   env-canada = callPackage ../development/python-modules/env-canada { };
 
+  envinfopy = callPackage ../development/python-modules/envinfopy { };
+
   environ-config = callPackage ../development/python-modules/environ-config { };
 
   environmental-override = callPackage ../development/python-modules/environmental-override { };


### PR DESCRIPTION
## Description

**sqlitebiter**: CLI tool to convert various data formats (CSV, Excel, JSON, Markdown, etc.) to SQLite database files.

Also introduces its 6 Python dependency packages: `msgfy`, `retryrequests`, `appconfigpy`, `envinfopy`, `excelrd`, and `pytablereader`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests in nixos/tests.
  - [ ] Package tests at passthru.tests.
  - [ ] Tests in lib/tests or pkgs/test for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.
- [x] Follows the automation/AI policy.

**AI disclosure**: This PR was produced with the assistance of `opencode` powered by `opencode/deepseek-v4-flash-free`. Every commit includes the required `Assisted-by:` trailer. All changes were manually reviewed and verified before submission.