### PR TITLE
gonemaster: init at 1.6.0

### DIFF
--- a/pkgs/by-name/go/gonemaster/package.nix
+++ b/pkgs/by-name/go/gonemaster/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitea,
+  testers,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "gonemaster";
+  version = "1.6.0";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "pawal";
+    repo = "gonemaster";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-ufoyusyQY5jm9zbs75ukehLgOt73Q5w6f2AAa/PqnO0=";
+  };
+
+  vendorHash = "sha256-ASrTpOUURL0bEPrUVsidrj0SMrDamNHvW6M2cjl6brI=";
+
+  __structuredAttrs = true;
+
+  subPackages = [
+    "cmd/gonemaster"
+    "cmd/gonemaster-server"
+    "cmd/gonemaster-client"
+    "cmd/gonemaster-nagios"
+    "cmd/gonemaster-mcp"
+  ];
+
+  # Disable the embedded web UIs in gonemaster-server (requires npm/Node).
+  tags = [ "nogui" ];
+
+  # Tests require network access for live DNS queries.
+  doCheck = false;
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    version = "v${finalAttrs.version}";
+  };
+
+  meta = {
+    description = "Go implementation of the Zonemaster DNS test engine";
+    homepage = "https://codeberg.org/pawal/gonemaster";
+    changelog = "https://codeberg.org/pawal/gonemaster/src/tag/v${finalAttrs.version}/Changelog";
+    license = lib.licenses.bsd2;
+    mainProgram = "gonemaster";
+    maintainers = with lib.maintainers; [ tomfitzhenry ];
+  };
+})


### PR DESCRIPTION
DNS delegation health checker with scoring, cohort analysis, and monitoring.

https://codeberg.org/pawal/gonemaster

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
