### PR TITLE
linuxPackages.nxp-pn5xx: 0.4-unstable-2025-02-08 -> 0-unstable-2026-07-16, nixos/nfc-nci: cleanup module loading

### DIFF
--- a/nixos/modules/hardware/nfc-nci.nix
+++ b/nixos/modules/hardware/nfc-nci.nix
@@ -181,10 +181,6 @@ in
       config.boot.kernelPackages.nxp-pn5xx
     ];
 
-    boot.kernelModules = [
-      "nxp-pn5xx"
-    ];
-
     # libnfc-nci calls sched_setscheduler via pthread_setschedparam, which would be blocked by upstream SystemCallFilter=~@resources
     systemd.services.pcscd.serviceConfig.SystemCallFilter = lib.mkIf cfg.enableIFD [
       "sched_setscheduler"

--- a/pkgs/os-specific/linux/nxp-pn5xx/default.nix
+++ b/pkgs/os-specific/linux/nxp-pn5xx/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nxp-pn5xx";
-  version = "0.4-unstable-2025-02-08-${kernel.version}";
+  version = "0-unstable-2026-07-16-${kernel.version}";
 
   src = fetchFromGitHub {
     owner = "jr64";
     repo = "nxp-pn5xx";
-    rev = "07411e0ce3445e7dcb970df1837f0ad74b7b0a7a";
-    hash = "sha256-jVkcvURFlihKW2vFvAaqzKdtexPXywRa2LkPkIhmdeU=";
+    rev = "6ebc3ce2000dc0ba82bd2f47eb01e69b8ba2dbd0";
+    hash = "sha256-rll9NyWZaHFTUIR/jnzZtO3D0Za/i1O+qT6fyvKcYTc=";
   };
 
   nativeBuildInputs = [ udevCheckHook ] ++ kernel.moduleBuildDependencies;


### PR DESCRIPTION
This PR updates the NXP NFC kernel module `nxp-pn5xx` to its most recent version, which brings support for Linux 7.1 .

In addition, a redundant  `boot.kernelModules` has been removed from nixos/nfc-nci , since the kernel module is automatically loaded (from `boot.extraModulePackages`) via ACPI device name matching.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
