### PR TITLE
[staging] mbedtls: 3.6.6 -> 3.6.7, mbedtls_4: 4.1.0 -> 4.2.0

### DIFF
--- a/pkgs/by-name/mb/mbedtls/4.nix
+++ b/pkgs/by-name/mb/mbedtls/4.nix
@@ -5,8 +5,8 @@
 }:
 
 callPackage ./generic.nix {
-  version = "4.1.0";
-  hash = "sha256-TA1uka13So8URttw+JJVdKIL+IonkhIQSc0IfraXpIM=";
+  version = "4.2.0";
+  hash = "sha256-Xz5W5zYPNlASPyc1/Sz2O1LONdxpUkg1hgzKdax/3ag=";
 
   patches = [
     # Fixes the build with GCC 14 on aarch64.

--- a/pkgs/by-name/mb/mbedtls/package.nix
+++ b/pkgs/by-name/mb/mbedtls/package.nix
@@ -6,8 +6,8 @@
 }:
 
 callPackage ./generic.nix {
-  version = "3.6.6";
-  hash = "sha256-+PW41/c8M/Yz0EVWM4Gt4HTNBMUTU5MayaKVZ+upLIo=";
+  version = "3.6.7";
+  hash = "sha256-t1ZPeFA3ftKaEIaXQ7RXZEsiOAYK4KSSm55SFr9g17A=";
 
   patches = [
     # Fixes the build with GCC 14 on aarch64.


### PR DESCRIPTION
https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.7
https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-4.2.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
