### PR TITLE
nixosTests.optee: adjust ram and kernel offsets, explicitly load optee

### DIFF
--- a/nixos/tests/optee.nix
+++ b/nixos/tests/optee.nix
@@ -4,7 +4,6 @@
 
   meta = {
     maintainers = with lib.maintainers; [ jmbaur ];
-    broken = pkgs.stdenv.hostPlatform.isAarch64;
   };
 
   nodes.machine =
@@ -17,7 +16,8 @@
       uboot = ubootQemuAarch64.overrideAttrs (old: {
         postPatch = (old.postPatch or "") + ''
           substituteInPlace board/emulation/qemu-arm/qemu-arm.env \
-            --replace-fail "ramdisk_addr_r=0x44000000" "ramdisk_addr_r=0x46000000"
+            --replace-fail "kernel_addr_r=0x40400000" "kernel_addr_r=0x50000000" \
+            --replace-fail "ramdisk_addr_r=0x44000000" "ramdisk_addr_r=0x58000000"
         '';
       });
 
@@ -53,6 +53,7 @@
 
       # VM boots up via qfw
       boot.loader.grub.enable = false;
+      boot.kernelModules = [ "optee" ];
 
       services.tee-supplicant = {
         enable = true;


### PR DESCRIPTION
The PR performs the following:
1. The previous u-boot addresses overlapped with OP-TEE and thus the kernel/initramfs were getting clobbered. Moving them to the experimentally determined addresses keeps them separate.
2. Explicitly include the `optee` kernel module which was no longer being included by default.
3. Unmarks the broken test with the above fixes.

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
