### PR TITLE
porting-advisor-for-graviton: init at 1.1.1

### DIFF
--- a/pkgs/by-name/po/porting-advisor-for-graviton/package.nix
+++ b/pkgs/by-name/po/porting-advisor-for-graviton/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3,
+  versionCheckHook,
+}:
+
+let
+  inherit (python3.pkgs)
+    buildPythonApplication
+    jinja2
+    packaging
+    progressbar33
+    xlsxwriter
+    ;
+in
+buildPythonApplication (finalAttrs: {
+  pname = "porting-advisor-for-graviton";
+  version = "1.1.1";
+  format = "other"; # Only has a requirements.txt
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "aws";
+    repo = "porting-advisor-for-graviton";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-73XZXy9hCRFGHGAxjThLE5mAptQZpr1G/t1v2Fx3Bpg=";
+  };
+
+  dependencies = [
+    jinja2
+    packaging
+    progressbar33
+    xlsxwriter
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp src/porting-advisor.py $out/bin/porting-advisor-graviton
+    chmod +x $out/bin/porting-advisor-graviton
+
+    # Install the advisor Python package
+    mkdir -p $out/${python3.sitePackages}
+    cp -r src/advisor $out/${python3.sitePackages}/
+
+    runHook postInstall
+  '';
+
+  # This automatically wraps Python programs with the right environment
+  postFixup = ''
+    wrapPythonPrograms
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    description = "AWS Porting Advisor for Graviton helps customers assess and prepare their applications for migration to AWS Graviton processors";
+    homepage = "https://github.com/aws/porting-advisor-for-graviton";
+    changelog = "https://github.com/aws/porting-advisor-for-graviton/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jherland ];
+    mainProgram = "porting-advisor-graviton";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
