### PR TITLE
systemtap-unwrapped: enable __structuredAttrs, strictDeps

### DIFF
--- a/pkgs/by-name/sy/systemtap-unwrapped/package.nix
+++ b/pkgs/by-name/sy/systemtap-unwrapped/package.nix
@@ -8,11 +8,15 @@
   cpio,
   elfutils,
   python3,
+  bashNonInteractive,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "systemtap";
   version = "5.4";
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchgit {
     url = "git://sourceware.org/git/systemtap.git";
@@ -30,14 +34,15 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     pkg-config
     cpio
+    gettext
     python3
     python3.pkgs.setuptools
   ];
   buildInputs = [
     boost
     elfutils
-    gettext
     python3
+    bashNonInteractive
   ];
   enableParallelBuilding = true;
 


### PR DESCRIPTION
#178468 

## Things done

Checked output is equivalent using diffoscope

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test