### PR TITLE
scenefx: 0.4.1 -> 0.5

### DIFF
--- a/pkgs/by-name/ma/mango/package.nix
+++ b/pkgs/by-name/ma/mango/package.nix
@@ -18,7 +18,7 @@
   enableXWayland ? true,
   meson,
   ninja,
-  scenefx,
+  scenefx_0_4,
   wlroots_0_19,
   libGL,
 }:
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     wayland
     wayland-protocols
     wlroots_0_19
-    scenefx
+    scenefx_0_4
     libGL
   ]
   ++ lib.optionals enableXWayland [

--- a/pkgs/by-name/sc/scenefx/0_4.nix
+++ b/pkgs/by-name/sc/scenefx/0_4.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  wlroots_0_19,
+  scdoc,
+  pkg-config,
+  wayland,
+  libdrm,
+  libxkbcommon,
+  pixman,
+  wayland-protocols,
+  libGL,
+  libgbm,
+  libxcb,
+  libxcb-wm,
+  validatePkgConfig,
+  testers,
+  wayland-scanner,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "scenefx";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "wlrfx";
+    repo = "scenefx";
+    tag = finalAttrs.version;
+    hash = "sha256-XD5EcquaHBg5spsN06fPHAjVCb1vOMM7oxmjZZ/PxIE=";
+  };
+
+  strictDeps = true;
+
+  depsBuildBuild = [ pkg-config ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    scdoc
+    validatePkgConfig
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    libdrm
+    libGL
+    libxkbcommon
+    libgbm
+    libxcb
+    libxcb-wm
+    pixman
+    wayland
+    wayland-protocols
+    wlroots_0_19
+  ];
+
+  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+
+  meta = {
+    description = "Drop-in replacement for the wlroots scene API that allows wayland compositors to render surfaces with eye-candy effects";
+    homepage = "https://github.com/wlrfx/scenefx";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    mainProgram = "scenefx";
+    pkgConfigModules = [ "scenefx" ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/sc/scenefx/package.nix
+++ b/pkgs/by-name/sc/scenefx/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   meson,
   ninja,
-  wlroots_0_19,
+  wlroots_0_20,
   scdoc,
   pkg-config,
   wayland,
@@ -13,6 +13,7 @@
   pixman,
   wayland-protocols,
   libGL,
+  lcms2,
   libgbm,
   libxcb,
   libxcb-wm,
@@ -23,13 +24,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "scenefx";
-  version = "0.4.1";
+  version = "0.5";
 
   src = fetchFromGitHub {
     owner = "wlrfx";
     repo = "scenefx";
     tag = finalAttrs.version;
-    hash = "sha256-XD5EcquaHBg5spsN06fPHAjVCb1vOMM7oxmjZZ/PxIE=";
+    hash = "sha256-vUjLG6eubEhJJVa9LPygIcVmNoHwYbSUTJcWEcbxnU4=";
   };
 
   strictDeps = true;
@@ -51,11 +52,12 @@ stdenv.mkDerivation (finalAttrs: {
     libxkbcommon
     libgbm
     libxcb
+    lcms2
     libxcb-wm
     pixman
     wayland
     wayland-protocols
-    wlroots_0_19
+    wlroots_0_20
   ];
 
   passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;

--- a/pkgs/by-name/sw/swayfx-unwrapped/package.nix
+++ b/pkgs/by-name/sw/swayfx-unwrapped/package.nix
@@ -22,7 +22,7 @@
   json_c,
   libevdev,
   scdoc,
-  scenefx,
+  scenefx_0_4,
   wayland-scanner,
   libxcb-wm,
   wlroots_0_19,
@@ -96,7 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
     libxkbcommon
     pango
     pcre2
-    scenefx
+    scenefx_0_4
     wayland
     wayland-protocols
     (wlroots_0_19.override { inherit (finalAttrs) enableXWayland; })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6677,6 +6677,13 @@ with pkgs;
   SDL = sdl12-compat;
   SDL2 = sdl2-compat;
 
+  inherit
+    ({
+      scenefx_0_4 = callPackage ../by-name/sc/scenefx/0_4.nix { };
+    })
+    scenefx_0_4
+    ;
+
   sev-snp-measure = with python3Packages; toPythonApplication sev-snp-measure;
 
   graphite2 = callPackage ../development/libraries/silgraphite/graphite2.nix { };


### PR DESCRIPTION
Update from 0.4.1 to 0.5

Changelog: https://github.com/wlrfx/scenefx/releases/tag/0.5

Needed for upcoming mango update #542954 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
