### PR TITLE
nixos/sonarr: add local PostgreSQL provisioning

### DIFF
--- a/nixos/modules/services/misc/servarr/radarr.nix
+++ b/nixos/modules/services/misc/servarr/radarr.nix
@@ -31,6 +31,8 @@ in
 
       environmentFiles = servarr.mkServarrEnvironmentFiles "radarr";
 
+      database.createLocally = servarr.mkServarrPostgresqlOption "Radarr";
+
       user = lib.mkOption {
         type = lib.types.str;
         default = "radarr";
@@ -45,77 +47,85 @@ in
     };
   };
 
-  config = lib.mkIf cfg.enable {
-    systemd.tmpfiles.settings."10-radarr".${cfg.dataDir}.d = {
-      inherit (cfg) user group;
-      mode = "0700";
-    };
-
-    systemd.services.radarr = {
-      description = "Radarr";
-      after = [ "network.target" ];
-      wantedBy = [ "multi-user.target" ];
-      environment = servarr.mkServarrSettingsEnvVars "RADARR" cfg.settings;
-
-      serviceConfig = {
-        Type = "simple";
-        User = cfg.user;
-        Group = cfg.group;
-        EnvironmentFile = cfg.environmentFiles;
-        ExecStart = "${cfg.package}/bin/Radarr -nobrowser -data='${cfg.dataDir}'";
-        Restart = "on-failure";
-
-        # Hardening
-        CapabilityBoundingSet = "";
-        NoNewPrivileges = true;
-        ProtectHome = true;
-        ProtectClock = true;
-        ProtectKernelLogs = true;
-        PrivateTmp = true;
-        PrivateDevices = true;
-        PrivateUsers = true;
-        ProtectKernelTunables = true;
-        ProtectKernelModules = true;
-        ProtectControlGroups = true;
-        RestrictSUIDSGID = true;
-        RemoveIPC = true;
-        UMask = "0022";
-        ProtectHostname = true;
-        ProtectProc = "invisible";
-        RestrictAddressFamilies = [
-          "AF_INET"
-          "AF_INET6"
-          "AF_UNIX"
-        ];
-        RestrictNamespaces = true;
-        RestrictRealtime = true;
-        LockPersonality = true;
-        SystemCallArchitectures = "native";
-        SystemCallFilter = [
-          "@system-service"
-          "~@privileged"
-          "~@debug"
-          "~@mount"
-          "@chown"
-        ];
+  config = lib.mkMerge [
+    (lib.mkIf cfg.enable {
+      systemd.tmpfiles.settings."10-radarr".${cfg.dataDir}.d = {
+        inherit (cfg) user group;
+        mode = "0700";
       };
-      unitConfig.RequiresMountsFor = [ cfg.dataDir ];
-    };
 
-    networking.firewall = lib.mkIf cfg.openFirewall {
-      allowedTCPPorts = [ cfg.settings.server.port ];
-    };
+      systemd.services.radarr = {
+        description = "Radarr";
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+        environment = servarr.mkServarrSettingsEnvVars "RADARR" cfg.settings;
 
-    users.users = lib.mkIf (cfg.user == "radarr") {
-      radarr = {
-        group = cfg.group;
-        home = cfg.dataDir;
-        uid = config.ids.uids.radarr;
+        serviceConfig = {
+          Type = "simple";
+          User = cfg.user;
+          Group = cfg.group;
+          EnvironmentFile = cfg.environmentFiles;
+          ExecStart = "${cfg.package}/bin/Radarr -nobrowser -data='${cfg.dataDir}'";
+          Restart = "on-failure";
+
+          # Hardening
+          CapabilityBoundingSet = "";
+          NoNewPrivileges = true;
+          ProtectHome = true;
+          ProtectClock = true;
+          ProtectKernelLogs = true;
+          PrivateTmp = true;
+          PrivateDevices = true;
+          PrivateUsers = true;
+          ProtectKernelTunables = true;
+          ProtectKernelModules = true;
+          ProtectControlGroups = true;
+          RestrictSUIDSGID = true;
+          RemoveIPC = true;
+          UMask = "0022";
+          ProtectHostname = true;
+          ProtectProc = "invisible";
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+            "AF_UNIX"
+          ];
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          LockPersonality = true;
+          SystemCallArchitectures = "native";
+          SystemCallFilter = [
+            "@system-service"
+            "~@privileged"
+            "~@debug"
+            "~@mount"
+            "@chown"
+          ];
+        };
+        unitConfig.RequiresMountsFor = [ cfg.dataDir ];
       };
-    };
 
-    users.groups = lib.mkIf (cfg.group == "radarr") {
-      radarr.gid = config.ids.gids.radarr;
-    };
-  };
+      networking.firewall = lib.mkIf cfg.openFirewall {
+        allowedTCPPorts = [ cfg.settings.server.port ];
+      };
+
+      users.users = lib.mkIf (cfg.user == "radarr") {
+        radarr = {
+          group = cfg.group;
+          home = cfg.dataDir;
+          uid = config.ids.uids.radarr;
+        };
+      };
+
+      users.groups = lib.mkIf (cfg.group == "radarr") {
+        radarr.gid = config.ids.gids.radarr;
+      };
+    })
+    (servarr.mkServarrPostgresqlConfig {
+      inherit cfg;
+      name = "radarr";
+      postgresqlPort = config.services.postgresql.settings.port;
+      user = cfg.user;
+    })
+  ];
 }

--- a/nixos/modules/services/misc/servarr/settings-options.nix
+++ b/nixos/modules/services/misc/servarr/settings-options.nix
@@ -72,6 +72,66 @@
       '';
     };
 
+  mkServarrPostgresqlOption =
+    name:
+    lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to automatically create local PostgreSQL databases for ${name}.
+        The service connects through the local Unix socket using peer
+        authentication.
+      '';
+    };
+
+  mkServarrPostgresqlConfig =
+    {
+      cfg,
+      name,
+      postgresqlPort,
+      user,
+    }:
+    let
+      mainDb = "${name}-main";
+      logDb = "${name}-log";
+      localPostgresql = cfg.enable && cfg.database.createLocally;
+    in
+    lib.mkIf localPostgresql {
+      assertions = [
+        {
+          assertion = builtins.match "[a-zA-Z_][a-zA-Z0-9_-]*" user != null;
+          message = "services.${name}.user must be a valid PostgreSQL role name when database.createLocally is true.";
+        }
+      ];
+
+      services.postgresql = {
+        enable = true;
+        ensureDatabases = [
+          mainDb
+          logDb
+        ];
+        ensureUsers = [ { name = user; } ];
+      };
+
+      services.${name}.settings.postgres = {
+        host = "/run/postgresql";
+        port = postgresqlPort;
+        inherit user mainDb logDb;
+      };
+
+      systemd.services = {
+        postgresql-setup.postStart = lib.mkAfter ''
+          psql -tAc 'ALTER DATABASE "${mainDb}" OWNER TO "${user}";'
+          psql -tAc 'ALTER DATABASE "${logDb}" OWNER TO "${user}";'
+        '';
+
+        ${name} = {
+          after = [ "postgresql.target" ];
+          requires = [ "postgresql.target" ];
+        };
+      };
+    };
+
   mkServarrSettingsEnvVars =
     name: settings:
     lib.pipe settings [

--- a/nixos/modules/services/misc/servarr/sonarr.nix
+++ b/nixos/modules/services/misc/servarr/sonarr.nix
@@ -35,6 +35,8 @@ in
 
       environmentFiles = servarr.mkServarrEnvironmentFiles "sonarr";
 
+      database.createLocally = servarr.mkServarrPostgresqlOption "Sonarr";
+
       settings = servarr.mkServarrSettingsOptions "sonarr" 8989;
 
       user = lib.mkOption {
@@ -69,78 +71,86 @@ in
     };
   };
 
-  config = lib.mkIf cfg.enable {
-    systemd.services.sonarr = {
-      description = "Sonarr";
-      after = [ "network.target" ];
-      wantedBy = [ "multi-user.target" ];
-      environment = servarr.mkServarrSettingsEnvVars "SONARR" cfg.settings;
-      serviceConfig = {
-        Type = "simple";
-        User = cfg.user;
-        Group = cfg.group;
-        EnvironmentFile = cfg.environmentFiles;
-        ExecStart = utils.escapeSystemdExecArgs [
-          (lib.getExe cfg.package)
-          "-nobrowser"
-          "-data=${cfg.dataDir}"
-        ];
-        Restart = "on-failure";
+  config = lib.mkMerge [
+    (lib.mkIf cfg.enable {
+      systemd.services.sonarr = {
+        description = "Sonarr";
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+        environment = servarr.mkServarrSettingsEnvVars "SONARR" cfg.settings;
+        serviceConfig = {
+          Type = "simple";
+          User = cfg.user;
+          Group = cfg.group;
+          EnvironmentFile = cfg.environmentFiles;
+          ExecStart = utils.escapeSystemdExecArgs [
+            (lib.getExe cfg.package)
+            "-nobrowser"
+            "-data=${cfg.dataDir}"
+          ];
+          Restart = "on-failure";
 
-        # Hardening
-        CapabilityBoundingSet = "";
-        NoNewPrivileges = true;
-        ProtectHome = true;
-        ProtectClock = true;
-        ProtectKernelLogs = true;
-        PrivateTmp = true;
-        PrivateDevices = true;
-        PrivateUsers = true;
-        ProtectKernelTunables = true;
-        ProtectKernelModules = true;
-        ProtectControlGroups = true;
-        RestrictSUIDSGID = true;
-        RemoveIPC = true;
-        UMask = "0022";
-        ProtectHostname = true;
-        ProtectProc = "invisible";
-        RestrictAddressFamilies = [
-          "AF_INET"
-          "AF_INET6"
-          "AF_UNIX"
-        ];
-        RestrictNamespaces = true;
-        RestrictRealtime = true;
-        LockPersonality = true;
-        SystemCallArchitectures = "native";
-        SystemCallFilter = [
-          "@system-service"
-          "~@privileged"
-          "~@debug"
-          "~@mount"
-          "@chown"
-        ];
-      }
-      // lib.optionalAttrs (cfg.dataDir == "/var/lib/sonarr/.config/NzbDrone") {
-        StateDirectory = "sonarr";
+          # Hardening
+          CapabilityBoundingSet = "";
+          NoNewPrivileges = true;
+          ProtectHome = true;
+          ProtectClock = true;
+          ProtectKernelLogs = true;
+          PrivateTmp = true;
+          PrivateDevices = true;
+          PrivateUsers = true;
+          ProtectKernelTunables = true;
+          ProtectKernelModules = true;
+          ProtectControlGroups = true;
+          RestrictSUIDSGID = true;
+          RemoveIPC = true;
+          UMask = "0022";
+          ProtectHostname = true;
+          ProtectProc = "invisible";
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+            "AF_UNIX"
+          ];
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          LockPersonality = true;
+          SystemCallArchitectures = "native";
+          SystemCallFilter = [
+            "@system-service"
+            "~@privileged"
+            "~@debug"
+            "~@mount"
+            "@chown"
+          ];
+        }
+        // lib.optionalAttrs (cfg.dataDir == "/var/lib/sonarr/.config/NzbDrone") {
+          StateDirectory = "sonarr";
+        };
+        unitConfig.RequiresMountsFor = [ cfg.dataDir ];
       };
-      unitConfig.RequiresMountsFor = [ cfg.dataDir ];
-    };
 
-    networking.firewall = lib.mkIf cfg.openFirewall {
-      allowedTCPPorts = [ cfg.settings.server.port ];
-    };
-
-    users.users = lib.mkIf (cfg.user == "sonarr") {
-      sonarr = {
-        group = cfg.group;
-        home = cfg.dataDir;
-        uid = config.ids.uids.sonarr;
+      networking.firewall = lib.mkIf cfg.openFirewall {
+        allowedTCPPorts = [ cfg.settings.server.port ];
       };
-    };
 
-    users.groups = lib.mkIf (cfg.group == "sonarr") {
-      sonarr.gid = config.ids.gids.sonarr;
-    };
-  };
+      users.users = lib.mkIf (cfg.user == "sonarr") {
+        sonarr = {
+          group = cfg.group;
+          home = cfg.dataDir;
+          uid = config.ids.uids.sonarr;
+        };
+      };
+
+      users.groups = lib.mkIf (cfg.group == "sonarr") {
+        sonarr.gid = config.ids.gids.sonarr;
+      };
+    })
+    (servarr.mkServarrPostgresqlConfig {
+      inherit cfg;
+      name = "sonarr";
+      postgresqlPort = config.services.postgresql.settings.port;
+      user = cfg.user;
+    })
+  ];
 }

--- a/nixos/tests/radarr.nix
+++ b/nixos/tests/radarr.nix
@@ -4,15 +4,42 @@
   name = "radarr";
   meta.maintainers = [ ];
 
-  nodes.machine =
-    { pkgs, ... }:
-    {
-      services.radarr.enable = true;
+  nodes = {
+    machine =
+      { pkgs, ... }:
+      {
+        services.radarr.enable = true;
+      };
+
+    postgres = {
+      services.radarr = {
+        enable = true;
+        database.createLocally = true;
+      };
     };
+  };
 
   testScript = ''
     machine.wait_for_unit("radarr.service")
     machine.wait_for_open_port(7878)
     machine.succeed("curl --fail http://localhost:7878/")
+
+    with subtest("PostgreSQL databases survive a restart"):
+        postgres.wait_for_unit("postgresql.target")
+        postgres.wait_for_unit("radarr.service")
+        postgres.wait_for_open_port(7878)
+        postgres.succeed(
+            "test \"$(sudo -u postgres psql -tAc \"select datdba::regrole::text from pg_database where datname = 'radarr-main'\")\" = radarr",
+            "test \"$(sudo -u postgres psql -tAc \"select datdba::regrole::text from pg_database where datname = 'radarr-log'\")\" = radarr",
+            "test \"$(sudo -u postgres psql -tAc \"select count(*) from pg_tables where schemaname = 'public'\" radarr-main)\" -gt 0",
+            "test \"$(sudo -u postgres psql -tAc \"select count(*) from pg_tables where schemaname = 'public'\" radarr-log)\" -gt 0",
+            "test ! -e /var/lib/radarr/.config/Radarr/radarr.db",
+            "test ! -e /var/lib/radarr/.config/Radarr/logs.db",
+            "curl --fail http://localhost:7878/",
+        )
+        postgres.succeed("systemctl restart radarr.service")
+        postgres.wait_for_unit("radarr.service")
+        postgres.wait_for_open_port(7878)
+        postgres.succeed("curl --fail http://localhost:7878/")
   '';
 }

--- a/nixos/tests/sonarr.nix
+++ b/nixos/tests/sonarr.nix
@@ -40,6 +40,12 @@
         postgres.succeed("systemctl restart sonarr.service")
         postgres.wait_for_unit("sonarr.service")
         postgres.wait_for_open_port(8989)
-        postgres.succeed("curl --fail http://localhost:8989/")
+        postgres.succeed(
+            "test \"$(sudo -u postgres psql -tAc "
+            "\"select count(*) from pg_tables where schemaname = 'public'\" sonarr-main)\" -gt 0",
+            "test \"$(sudo -u postgres psql -tAc "
+            "\"select count(*) from pg_tables where schemaname = 'public'\" sonarr-log)\" -gt 0",
+            "curl --fail http://localhost:8989/",
+        )
   '';
 }

--- a/nixos/tests/sonarr.nix
+++ b/nixos/tests/sonarr.nix
@@ -4,15 +4,42 @@
   name = "sonarr";
   meta.maintainers = [ ];
 
-  nodes.machine =
-    { pkgs, ... }:
-    {
-      services.sonarr.enable = true;
+  nodes = {
+    machine =
+      { pkgs, ... }:
+      {
+        services.sonarr.enable = true;
+      };
+
+    postgres = {
+      services.sonarr = {
+        enable = true;
+        database.createLocally = true;
+      };
     };
+  };
 
   testScript = ''
     machine.wait_for_unit("sonarr.service")
     machine.wait_for_open_port(8989)
     machine.succeed("curl --fail http://localhost:8989/")
+
+    with subtest("PostgreSQL databases survive a restart"):
+        postgres.wait_for_unit("postgresql.target")
+        postgres.wait_for_unit("sonarr.service")
+        postgres.wait_for_open_port(8989)
+        postgres.succeed(
+            "test \"$(sudo -u postgres psql -tAc \"select datdba::regrole::text from pg_database where datname = 'sonarr-main'\")\" = sonarr",
+            "test \"$(sudo -u postgres psql -tAc \"select datdba::regrole::text from pg_database where datname = 'sonarr-log'\")\" = sonarr",
+            "test \"$(sudo -u postgres psql -tAc \"select count(*) from pg_tables where schemaname = 'public'\" sonarr-main)\" -gt 0",
+            "test \"$(sudo -u postgres psql -tAc \"select count(*) from pg_tables where schemaname = 'public'\" sonarr-log)\" -gt 0",
+            "test ! -e /var/lib/sonarr/.config/NzbDrone/sonarr.db",
+            "test ! -e /var/lib/sonarr/.config/NzbDrone/logs.db",
+            "curl --fail http://localhost:8989/",
+        )
+        postgres.succeed("systemctl restart sonarr.service")
+        postgres.wait_for_unit("sonarr.service")
+        postgres.wait_for_open_port(8989)
+        postgres.succeed("curl --fail http://localhost:8989/")
   '';
 }


### PR DESCRIPTION
Add an opt-in `services.sonarr.database.createLocally` mode that provisions the `sonarr-main` and `sonarr-log` PostgreSQL databases required by upstream. Sonarr connects over the Unix socket with peer authentication, so no database password is placed in the Nix store. SQLite remains the default.

The NixOS test verifies both database owners and schemas, absence of SQLite files, the web UI, and rechecks the PostgreSQL schemas after restart.

This is stacked on #542534, which introduces the private shared Servarr helper. Only the final Sonarr commit is specific to this PR; the parent commit will drop out once #542534 merges.

This change was implemented with assistance from OpenAI Codex (GPT-5). The draft remains pending responsible human review under the nixpkgs automation/AI policy.

The updated branch passes the Sonarr NixOS test and `nixpkgs-vet` at `ea8abc3fa36e`. A [new multi-platform `nixpkgs-review`](https://github.com/caniko/nixpkgs-review-gha/actions/runs/29595541416) passed on aarch64-linux, x86_64-linux, aarch64-darwin, and x86_64-darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test



