### PR TITLE
treewide: don't install .pak files for wrapped Electron apps

### DIFF
--- a/pkgs/by-name/bi/bitwarden-desktop/package.nix
+++ b/pkgs/by-name/bi/bitwarden-desktop/package.nix
@@ -185,7 +185,7 @@ buildNpmPackage (finalAttrs: {
   ''
   + lib.optionalString stdenv.hostPlatform.isLinux ''
     mkdir -p $out/opt/Bitwarden
-    cp -r apps/desktop/dist/linux-*unpacked/{locales,resources{,.pak}} $out/opt/Bitwarden
+    cp -r apps/desktop/dist/*-unpacked/resources $out/opt/Bitwarden
 
     makeWrapper '${lib.getExe electron}' "$out/bin/bitwarden" \
       --run "ulimit -c 0" \

--- a/pkgs/by-name/bl/blockbench/package.nix
+++ b/pkgs/by-name/bl/blockbench/package.nix
@@ -70,7 +70,7 @@ buildNpmPackage rec {
   ''
   + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     mkdir -p $out/share/blockbench
-    cp -r dist-electron/*-unpacked/{locales,resources{,.pak}} $out/share/blockbench
+    cp -r dist-electron/*-unpacked/resources $out/share/blockbench
 
     for size in 16 32 48 64 128 256 512; do
       mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps

--- a/pkgs/by-name/br/breaktimer/package.nix
+++ b/pkgs/by-name/br/breaktimer/package.nix
@@ -76,10 +76,8 @@ buildNpmPackage rec {
     runHook preInstall
   ''
   + lib.optionalString stdenv.hostPlatform.isLinux ''
-    unpacked="release/linux-${lib.optionalString stdenv.hostPlatform.isAarch64 "arm64-"}unpacked"
-
     mkdir -p "$out/share/lib/breaktimer"
-    cp -r "$unpacked"/{locales,resources{,.pak}} "$out/share/lib/breaktimer"
+    cp -r release/*-unpacked/resources "$out/share/lib/breaktimer"
 
     makeWrapper '${lib.getExe electron}' "$out/bin/breaktimer" \
       --add-flags "$out/share/lib/breaktimer/resources/app.asar" \

--- a/pkgs/by-name/br/bruno/package.nix
+++ b/pkgs/by-name/br/bruno/package.nix
@@ -163,7 +163,7 @@ buildNpmPackage rec {
         ''
           mkdir -p $out/opt/bruno $out/bin
 
-          cp -r packages/bruno-electron/dist/linux*-unpacked/{locales,resources{,.pak}} $out/opt/bruno
+          cp -r packages/bruno-electron/dist/*-unpacked/resources $out/opt/bruno
 
           makeWrapper ${lib.getExe electron} $out/bin/bruno \
             --add-flags $out/opt/bruno/resources/app.asar \

--- a/pkgs/by-name/bs/bs-manager/package.nix
+++ b/pkgs/by-name/bs/bs-manager/package.nix
@@ -97,7 +97,7 @@ buildNpmPackage (finalAttrs: {
     done
 
     mkdir -p $out/share/bs-manager
-    cp -r release/build/*-unpacked/{locales,resources{,.pak}} $out/share/bs-manager
+    cp -r release/build/*-unpacked/resources $out/share/bs-manager
 
     makeWrapper ${lib.getExe electron} $out/bin/bs-manager \
       --set-default ELECTRON_FORCE_IS_PACKAGED 1 \

--- a/pkgs/by-name/ca/caprine/package.nix
+++ b/pkgs/by-name/ca/caprine/package.nix
@@ -46,7 +46,7 @@ buildNpmPackage rec {
 
     ${lib.optionalString stdenv.hostPlatform.isLinux ''
       mkdir -p $out/share/caprine
-      cp -r dist/*-unpacked/{locales,resources{,.pak}} $out/share/caprine
+      cp -r dist/*-unpacked/resources $out/share/caprine
 
       makeWrapper ${lib.getExe electron} $out/bin/caprine \
           --add-flags $out/share/caprine/resources/app.asar \

--- a/pkgs/by-name/ch/cheating-daddy/package.nix
+++ b/pkgs/by-name/ch/cheating-daddy/package.nix
@@ -84,7 +84,7 @@ buildNpmPackage (finalAttrs: {
     runHook preInstall
 
     mkdir -p $out/share/cheating-daddy
-    cp --recursive out/*/{locales,resources{,.pak}} $out/share/cheating-daddy
+    cp --recursive out/*/resources $out/share/cheating-daddy
     makeWrapper ${lib.getExe electron} $out/bin/cheating-daddy \
       --add-flags $out/share/cheating-daddy/resources/app.asar \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true --wayland-text-input-version=3}}" \

--- a/pkgs/by-name/de/deltachat-desktop/package.nix
+++ b/pkgs/by-name/de/deltachat-desktop/package.nix
@@ -112,7 +112,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     mkdir -p $out/opt/DeltaChat
-    cp -r packages/target-electron/dist/*-unpacked/{locales,resources{,.pak}} $out/opt/DeltaChat
+    cp -r packages/target-electron/dist/*-unpacked/resources $out/opt/DeltaChat
 
     makeWrapper ${lib.getExe electron} $out/bin/${finalAttrs.meta.mainProgram} \
       --add-flags $out/opt/DeltaChat/resources/app.asar \

--- a/pkgs/by-name/do/dopamine/package.nix
+++ b/pkgs/by-name/do/dopamine/package.nix
@@ -103,7 +103,7 @@ buildNpmPackage (finalAttrs: {
       else
         ''
           mkdir -p $out/share/dopamine
-          cp -r release/linux*unpacked/{locales,resources{,.pak}} $out/share/dopamine
+          cp -r release/*-unpacked/resources $out/share/dopamine
 
           makeWrapper ${lib.getExe electron} $out/bin/dopamine \
             --add-flags $out/share/dopamine/resources/app.asar \

--- a/pkgs/by-name/dr/drawio/package.nix
+++ b/pkgs/by-name/dr/drawio/package.nix
@@ -93,7 +93,7 @@ stdenv.mkDerivation (finalAttrs: {
   ''
   + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     mkdir -p "$out/share/lib/drawio"
-    cp -r dist/*-unpacked/{locales,resources{,.pak}} "$out/share/lib/drawio"
+    cp -r dist/*-unpacked/resources "$out/share/lib/drawio"
 
     install -Dm644 build/icon.svg "$out/share/icons/hicolor/scalable/apps/drawio.svg"
 

--- a/pkgs/by-name/fa/falkor/package.nix
+++ b/pkgs/by-name/fa/falkor/package.nix
@@ -30,7 +30,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     mkdir -p $out/share/falkor
     substituteInPlace $out/share/applications/falkor.desktop \
       --replace-fail "/opt/Falkor/" ""
-    mv opt/Falkor/{resources,resources.pak,locales} $out/share/falkor
+    mv opt/Falkor/resources $out/share/falkor
 
     makeWrapper ${lib.getExe electron} $out/bin/falkor \
       --argv0 "falkor" \

--- a/pkgs/by-name/fe/feishin/package.nix
+++ b/pkgs/by-name/fe/feishin/package.nix
@@ -105,10 +105,7 @@ buildNpmPackage {
   ''
   + lib.optionalString (stdenv.hostPlatform.isLinux && !webVersion) ''
     mkdir -p $out/share/feishin
-
-    pushd dist/*-unpacked/
-    cp -r locales resources{,.pak} $out/share/feishin
-    popd
+    cp -r dist/*-unpacked/resources $out/share/feishin
 
     # Code relies on checking app.isPackaged, which returns false if the executable is electron.
     # Set ELECTRON_FORCE_IS_PACKAGED=1.

--- a/pkgs/by-name/fi/filen-desktop/package.nix
+++ b/pkgs/by-name/fi/filen-desktop/package.nix
@@ -126,7 +126,7 @@ buildNpmPackage {
         ''
           # Copy built resources
           mkdir -p $out/share/${packageName}
-          cp -r prod/*-unpacked/{locales,resources{,.pak}} $out/share/${packageName}
+          cp -r prod/*-unpacked/resources $out/share/${packageName}
 
           # Create desktop icon
           mkdir -p $out/share/icons/hicolor/128x128/apps

--- a/pkgs/by-name/fo/folia-major/package.nix
+++ b/pkgs/by-name/fo/folia-major/package.nix
@@ -70,7 +70,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook preInstall
 
     mkdir -p $out/lib/folia-major
-    cp -r release/*-unpacked/{locales,resources{,.pak}} $out/lib/folia-major/
+    cp -r release/*-unpacked/resources $out/lib/folia-major/
 
     install -D build/icon.png $out/share/icons/hicolor/512x512/apps/folia-major.png
 

--- a/pkgs/by-name/fr/freetube/package.nix
+++ b/pkgs/by-name/fr/freetube/package.nix
@@ -66,7 +66,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   ''
   + lib.optionalString stdenvNoCC.hostPlatform.isLinux ''
     mkdir -p $out/share/freetube
-    cp -r build/*-unpacked/{locales,resources{,.pak}} -t $out/share/freetube
+    cp -r build/*-unpacked/resources -t $out/share/freetube
 
     makeWrapper ${lib.getExe electron} $out/bin/freetube \
       --add-flags "$out/share/freetube/resources/app.asar" \

--- a/pkgs/by-name/gi/gitify/package.nix
+++ b/pkgs/by-name/gi/gitify/package.nix
@@ -96,7 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
       else
         ''
           mkdir -p $out/share/gitify
-          cp -r dist/*-unpacked/{locales,resources{,.pak}} $out/share/gitify
+          cp -r dist/*-unpacked/resources $out/share/gitify
 
           mkdir -p $out/share/icons/hicolor/256x256/apps
           magick assets/images/app-icon.ico $out/share/icons/hicolor/256x256/apps/gitify.png

--- a/pkgs/by-name/go/goofcord/package.nix
+++ b/pkgs/by-name/go/goofcord/package.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     mkdir -p "$out/share/lib/goofcord"
-    cp -r ./dist/*-unpacked/{locales,resources{,.pak}} "$out/share/lib/goofcord"
+    cp -r ./dist/*-unpacked/resources "$out/share/lib/goofcord"
 
     install -Dm644 "assets/gf_icon.png" "$out/share/icons/hicolor/256x256/apps/goofcord.png"
 

--- a/pkgs/by-name/ht/httptoolkit/package.nix
+++ b/pkgs/by-name/ht/httptoolkit/package.nix
@@ -72,7 +72,7 @@ buildNpmPackage rec {
   ''
   + lib.optionalString stdenv.hostPlatform.isLinux ''
     mkdir -p $out/share/httptoolkit
-    cp -r dist/*-unpacked/{locales,resources{,.pak}} $out/share/httptoolkit
+    cp -r dist/*-unpacked/resources $out/share/httptoolkit
 
     ln -s ${httptoolkit-server} $out/share/httptoolkit/resources/httptoolkit-server
 

--- a/pkgs/by-name/iv/ivette/package.nix
+++ b/pkgs/by-name/iv/ivette/package.nix
@@ -87,7 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
   ''
   + lib.optionalString stdenv.hostPlatform.isLinux ''
     mkdir -p "$out/share/lib/ivette"
-    cp -r dist/*-unpacked/{locales,resources{,.pak}} "$out/share/lib/ivette"
+    cp -r dist/*-unpacked/resources "$out/share/lib/ivette"
 
     install -Dm444 static/icon.png $out/share/icons/hicolor/512x512/apps/ivette.png
 

--- a/pkgs/by-name/iv/ivpn-ui/package.nix
+++ b/pkgs/by-name/iv/ivpn-ui/package.nix
@@ -49,7 +49,7 @@ buildNpmPackage (finalAttrs: {
     runHook preInstall
 
     mkdir -p $out/share/ivpn-ui
-    cp -r dist/*-unpacked/{locales,resources{,.pak}} $out/share/ivpn-ui
+    cp -r dist/*-unpacked/resources $out/share/ivpn-ui
 
     install -Dm644 $src/ui/References/Linux/ui/ivpnicon.svg $out/share/icons/hicolor/scalable/apps/ivpn-ui.svg
 

--- a/pkgs/by-name/ji/jitsi-meet-electron/package.nix
+++ b/pkgs/by-name/ji/jitsi-meet-electron/package.nix
@@ -93,7 +93,7 @@ buildNpmPackage rec {
 
     ${lib.optionalString stdenv.hostPlatform.isLinux ''
       mkdir -p $out/share/jitsi-meet-electron
-      cp -r dist/*-unpacked/{locales,resources{,.pak}} $out/share/jitsi-meet-electron
+      cp -r dist/*-unpacked/resources $out/share/jitsi-meet-electron
 
       makeWrapper ${lib.getExe electron} $out/bin/jitsi-meet-electron \
           --add-flags $out/share/jitsi-meet-electron/resources/app.asar \

--- a/pkgs/by-name/ka/kando/package.nix
+++ b/pkgs/by-name/ka/kando/package.nix
@@ -106,7 +106,7 @@ buildNpmPackage.override { inherit nodejs; } rec {
 
     ${lib.optionalString stdenv.hostPlatform.isLinux ''
       mkdir -p $out/share/kando
-      cp -r out/*/{locales,resources{,.pak}} $out/share/kando
+      cp -r out/*/resources $out/share/kando
 
       install -Dm644 assets/icons/icon.svg $out/share/icons/hicolor/scalable/apps/kando.svg
 

--- a/pkgs/by-name/ko/koodo-reader/package.nix
+++ b/pkgs/by-name/ko/koodo-reader/package.nix
@@ -92,7 +92,7 @@ stdenv.mkDerivation (finalAttrs: {
       install -Dm644 ${./mime-types.xml} $out/share/mime/packages/koodo-reader.xml
 
       mkdir -p $out/share/lib/koodo-reader
-      cp -r dist/*-unpacked/{locales,resources{,.pak}} $out/share/lib/koodo-reader
+      cp -r dist/*-unpacked/resources $out/share/lib/koodo-reader
     ''}
 
     ${lib.optionalString stdenv.hostPlatform.isDarwin ''

--- a/pkgs/by-name/ko/kopia-ui/package.nix
+++ b/pkgs/by-name/ko/kopia-ui/package.nix
@@ -57,7 +57,7 @@ buildNpmPackage {
   installPhase = ''
     runHook preInstall
     mkdir -p $out/share/kopia
-    cp -r ../dist/kopia-ui/*-unpacked/{locales,resources{,.pak}} $out/share/kopia
+    cp -r ../dist/kopia-ui/*-unpacked/resources $out/share/kopia
     install -Dm644 $src/icons/kopia.svg $out/share/icons/hicolor/scalable/apps/kopia.svg
     makeWrapper ${lib.getExe electron} $out/bin/kopia-ui \
       --prefix PATH : ${lib.makeBinPath [ kopia ]} \

--- a/pkgs/by-name/ku/kuro/package.nix
+++ b/pkgs/by-name/ku/kuro/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
 
     # resources
     mkdir -p "$out/share/lib/kuro"
-    cp -r ./dist/*-unpacked/{locales,resources{,.pak}} "$out/share/lib/kuro"
+    cp -r ./dist/*-unpacked/resources "$out/share/lib/kuro"
 
     # icons
     magick static/Icon.png -resize 512x512 kuro.png # original icon is 1024x1024, which isn't supported by hicolor

--- a/pkgs/by-name/le/legcord/package.nix
+++ b/pkgs/by-name/le/legcord/package.nix
@@ -86,7 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     mkdir -p "$out/share/lib/legcord"
-    cp -r ./dist/*-unpacked/{locales,resources{,.pak}} "$out/share/lib/legcord"
+    cp -r ./dist/*-unpacked/resources "$out/share/lib/legcord"
 
     install -Dm644 "build/icon.png" "$out/share/icons/hicolor/256x256/apps/legcord.png"
 

--- a/pkgs/by-name/lo/logseq/package.nix
+++ b/pkgs/by-name/lo/logseq/package.nix
@@ -259,7 +259,7 @@ stdenv.mkDerivation (finalAttrs: {
     install -Dm644 static/icons/logseq.png "$out/share/icons/hicolor/512x512/apps/logseq.png"
 
     mkdir -p $out/share/logseq
-    cp -r static/out/*/{locales,resources{,.pak}} $out/share/logseq
+    cp -r static/out/*/resources $out/share/logseq
 
     makeWrapper ${lib.getExe electron} $out/bin/logseq \
         --add-flags $out/share/logseq/resources/app \

--- a/pkgs/by-name/lx/lx-music-desktop/package.nix
+++ b/pkgs/by-name/lx/lx-music-desktop/package.nix
@@ -104,7 +104,7 @@ buildNpmPackage (finalAttrs: {
     runHook preInstall
 
     mkdir -p "$out/opt/lx-music-desktop"
-    cp -r build/*-unpacked/{locales,resources{,.pak}} "$out/opt/lx-music-desktop"
+    cp -r build/*-unpacked/resources "$out/opt/lx-music-desktop"
     rm "$out/opt/lx-music-desktop/resources/app-update.yml"
 
     for size in 16 32 48 64 128 256 512; do

--- a/pkgs/by-name/ma/marktext/package.nix
+++ b/pkgs/by-name/ma/marktext/package.nix
@@ -149,7 +149,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     popd
 
-    cp -r build/*-unpacked/{locales,resources{,.pak}} $out/opt/marktext
+    cp -r build/*-unpacked/resources $out/opt/marktext
 
     makeWrapper ${lib.getExe electron} $out/bin/marktext \
       --add-flags $out/opt/marktext/resources/app.asar \

--- a/pkgs/by-name/mq/mqtt-explorer/package.nix
+++ b/pkgs/by-name/mq/mqtt-explorer/package.nix
@@ -107,7 +107,7 @@ stdenv.mkDerivation rec {
     ${lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
       mkdir -p "$out/share/mqtt-explorer"/{app,icons/hicolor}
 
-      cp -r build/*-unpacked/{locales,resources{,.pak}} "$out/share/mqtt-explorer/app"
+      cp -r build/*-unpacked/resources "$out/share/mqtt-explorer/app"
 
       for file in res/appx/Square44x44Logo.targetsize-*_altform-unplated.png; do
 

--- a/pkgs/by-name/ne/netron/package.nix
+++ b/pkgs/by-name/ne/netron/package.nix
@@ -54,12 +54,8 @@ buildNpmPackage (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    mkdir $out
-
-    pushd dist/linux-${lib.optionalString stdenv.hostPlatform.isAarch64 "arm64-"}unpacked
     mkdir -p $out/opt/netron
-    cp -r locales resources{,.pak} $out/opt/netron
-    popd
+    cp -r dist/*-unpacked/resources $out/opt/netron
 
     makeWrapper '${lib.getExe electron}' "$out/bin/netron" \
       --add-flags $out/opt/netron/resources/app.asar \

--- a/pkgs/by-name/op/openscreen/package.nix
+++ b/pkgs/by-name/op/openscreen/package.nix
@@ -77,7 +77,7 @@ buildNpmPackage (finalAttrs: {
 
     ${lib.optionalString stdenv.hostPlatform.isLinux ''
       mkdir -p $out/share/openscreen
-      cp -r release/*/*-unpacked/{locales,resources{,.pak}} $out/share/openscreen
+      cp -r release/*/*-unpacked/resources $out/share/openscreen
 
       makeWrapper ${lib.getExe electron} $out/bin/openscreen \
           --add-flags $out/share/openscreen/resources/app.asar \

--- a/pkgs/by-name/pe/pear-desktop/package.nix
+++ b/pkgs/by-name/pe/pear-desktop/package.nix
@@ -83,7 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
   ''
   + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     mkdir -p "$out/share/pear-desktop"
-    cp -r pack/*-unpacked/{locales,resources{,.pak}} "$out/share/pear-desktop"
+    cp -r pack/*-unpacked/resources "$out/share/pear-desktop"
 
     pushd assets/generated/icons/png
     for file in *.png; do

--- a/pkgs/by-name/pe/penpot-desktop/package.nix
+++ b/pkgs/by-name/pe/penpot-desktop/package.nix
@@ -63,12 +63,8 @@ buildNpmPackage rec {
   installPhase = ''
     runHook preInstall
 
-    mkdir $out
-
-    pushd dist/linux-${lib.optionalString stdenv.hostPlatform.isAarch64 "arm64-"}unpacked
     mkdir -p $out/opt/Penpot
-    cp -r locales resources{,.pak} $out/opt/Penpot
-    popd
+    cp -r dist/*-unpacked/resources $out/opt/Penpot
 
     makeWrapper '${lib.getExe electron}' "$out/bin/penpot-desktop" \
       --add-flags $out/opt/Penpot/resources/app.asar \

--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -143,7 +143,7 @@ stdenv.mkDerivation (finalAttrs: {
       ''
       + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
         mkdir -p "$out/share/lib/podman-desktop"
-        cp -r dist/*-unpacked/{locales,resources{,.pak}} "$out/share/lib/podman-desktop"
+        cp -r dist/*-unpacked/resources "$out/share/lib/podman-desktop"
 
         install -Dm644 buildResources/icon.svg "$out/share/icons/hicolor/scalable/apps/podman-desktop.svg"
 

--- a/pkgs/by-name/re/redisinsight/package.nix
+++ b/pkgs/by-name/re/redisinsight/package.nix
@@ -141,7 +141,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     mkdir -p "$out/share/redisinsight"/{app,defaults,static/plugins,static/resources/plugins}
 
-    cp -r release/*-unpacked/{locales,resources{,.pak}} "$out/share/redisinsight/app"
+    cp -r release/*-unpacked/resources "$out/share/redisinsight/app"
     mv "$out/share/redisinsight/app/resources/resources" "$out/share/redisinsight"
 
     # icons

--- a/pkgs/by-name/ri/ride/package.nix
+++ b/pkgs/by-name/ri/ride/package.nix
@@ -101,7 +101,7 @@ buildNpmPackage rec {
       install -Dm644 $src/D.svg $out/share/icons/hicolor/scalable/apps/ride.svg
 
       mkdir -p $out/share/ride
-      cp -r locales resources{,.pak} $out/share/ride
+      cp -r resources $out/share/ride
       makeShellWrapper ${lib.getExe electron} $out/bin/ride \
           --add-flags $out/share/ride/resources/app.asar \
           --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \

--- a/pkgs/by-name/rs/rstudio/package.nix
+++ b/pkgs/by-name/rs/rstudio/package.nix
@@ -351,7 +351,7 @@ stdenv.mkDerivation (finalAttrs: {
   + lib.optionalString (!server && stdenv.hostPlatform.isLinux) ''
     # remove unneeded electron files, since we'll wrap the app with our own electron
     shopt -s extglob
-    rm -r $out/lib/rstudio/!(locales|resources|resources.pak)
+    rm -r $out/lib/rstudio/!(resources)
 
     makeWrapper ${lib.getExe electron} "$out/bin/rstudio" \
       --add-flags "$out/lib/rstudio/resources/app/" \

--- a/pkgs/by-name/sh/shiru/package.nix
+++ b/pkgs/by-name/sh/shiru/package.nix
@@ -81,7 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
   ''
   + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     mkdir -p "$out/share/lib/shiru"
-    cp -r dist/*-unpacked/{locales,resources{,.pak}} "$out/share/lib/shiru"
+    cp -r dist/*-unpacked/resources "$out/share/lib/shiru"
 
     install -Dm644 buildResources/icon.png "$out/share/icons/hicolor/512x512/apps/shiru.png"
 

--- a/pkgs/by-name/sh/shogihome/package.nix
+++ b/pkgs/by-name/sh/shogihome/package.nix
@@ -93,7 +93,7 @@ buildNpmPackage (finalAttrs: {
   ''
   + lib.optionalString stdenv.hostPlatform.isLinux ''
     mkdir -p "$out/share/lib/shogihome"
-    cp -r dist/*-unpacked/{locales,resources{,.pak}} "$out/share/lib/shogihome"
+    cp -r dist/*-unpacked/resources "$out/share/lib/shogihome"
 
     install -Dm444 'docs/icon.svg' "$out/share/icons/hicolor/scalable/apps/shogihome.svg"
 

--- a/pkgs/by-name/si/siyuan/package.nix
+++ b/pkgs/by-name/si/siyuan/package.nix
@@ -143,7 +143,7 @@ stdenv.mkDerivation (finalAttrs: {
   + lib.optionalString isLinux ''
     mkdir -p $out/share/siyuan
 
-    cp -r build/*-unpacked/{locales,resources{,.pak}} $out/share/siyuan
+    cp -r build/*-unpacked/resources $out/share/siyuan
 
     makeWrapper ${lib.getExe electron} $out/bin/siyuan \
         --chdir $out/share/siyuan/resources \

--- a/pkgs/by-name/sl/slimevr/package.nix
+++ b/pkgs/by-name/sl/slimevr/package.nix
@@ -86,7 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     mkdir -p $out/share/slimevr
-    cp -r gui/dist/artifacts/*/*-unpacked/{locales,resources{,.pak}} $out/share/slimevr/
+    cp -r gui/dist/artifacts/*/*-unpacked/resources $out/share/slimevr/
     # `JAVA_HOME`, `JAVA_TOOL_OPTIONS`, and `--path` are so the GUI can
     # launch the server.
     makeWrapper ${lib.getExe electron} $out/bin/slimevr \

--- a/pkgs/by-name/sp/sparkle/package.nix
+++ b/pkgs/by-name/sp/sparkle/package.nix
@@ -89,7 +89,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook preInstall
 
     mkdir -p $out/lib/sparkle
-    cp -r dist/*-unpacked/{locales,resources{,.pak}} $out/lib/sparkle/
+    cp -r dist/*-unpacked/resources $out/lib/sparkle/
 
     install -D resources/icon.png $out/share/icons/hicolor/512x512/apps/sparkle.png
 

--- a/pkgs/by-name/sp/splayer/package.nix
+++ b/pkgs/by-name/sp/splayer/package.nix
@@ -123,7 +123,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     mkdir -p "$out/share/splayer"
-    cp -Pr --no-preserve=ownership dist/*-unpacked/{locales,resources{,.pak}} $out/share/splayer
+    cp -Pr --no-preserve=ownership dist/*-unpacked/resources $out/share/splayer
 
     _icon_sizes=(16x16 32x32 96x96 192x192 256x256 512x512)
     for _icons in "''${_icon_sizes[@]}";do

--- a/pkgs/by-name/st/stoat-desktop/package.nix
+++ b/pkgs/by-name/st/stoat-desktop/package.nix
@@ -118,7 +118,7 @@ stdenv.mkDerivation (finalAttrs: {
       find out/*/resources/app/node_modules -type f -executable -exec remove-references-to -t ${nodejs} '{}' \;
 
       mkdir -p "$out/share/stoat-desktop"
-      cp -r out/*/resources{,.pak} "$out/share/stoat-desktop"
+      cp -r out/*/resources "$out/share/stoat-desktop"
 
       makeWrapper ${lib.getExe electron} "$out/bin/stoat-desktop" \
         --add-flag $out/share/stoat-desktop/resources/app.asar \

--- a/pkgs/by-name/un/unofficial-homestuck-collection/package.nix
+++ b/pkgs/by-name/un/unofficial-homestuck-collection/package.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation (finalAttrs: {
     install -Dm644 build/dev.bambosh.UnofficialHomestuckCollection.metainfo.xml $out/share/metainfo/dev.bambosh.UnofficialHomestuckCollection.metainfo.xml
     install -Dm644 build/dev.bambosh.UnofficialHomestuckCollection.desktop $out/share/applications/dev.bambosh.UnofficialHomestuckCollection.desktop
     install  -d $out/bin $out/share/unofficial-homestuck-collection
-    cp -r dist_electron/*-unpacked/{locales,resources{,.pak}} $out/share/unofficial-homestuck-collection
+    cp -r dist_electron/*-unpacked/resources $out/share/unofficial-homestuck-collection
     makeWrapper ${lib.getExe electron} $out/bin/unofficial-homestuck-collection \
       --add-flags $out/share/unofficial-homestuck-collection/resources/app.asar \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \

--- a/pkgs/by-name/va/vacuum-tube/package.nix
+++ b/pkgs/by-name/va/vacuum-tube/package.nix
@@ -44,8 +44,8 @@ buildNpmPackage rec {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/opt
-    cp -r ./dist/*-unpacked $out/opt/VacuumTube
+    mkdir -p $out/opt/VacuumTube
+    cp -r ./dist/*-unpacked/resources $out/opt/VacuumTube
 
     for i in 16 32 48 64 256 512; do
       install -Dm644 "assets/icons/$i"x"$i.png" \

--- a/pkgs/by-name/vi/vikunja-desktop/package.nix
+++ b/pkgs/by-name/vi/vikunja-desktop/package.nix
@@ -95,7 +95,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     ${lib.optionalString stdenv.hostPlatform.isLinux ''
       mkdir -p "$out/share/lib/vikunja-desktop"
-      cp -r ./dist/*-unpacked/{locales,resources{,.pak}} "$out/share/lib/vikunja-desktop"
+      cp -r ./dist/*-unpacked/resources "$out/share/lib/vikunja-desktop"
       cp -r ./node_modules "$out/share/lib/vikunja-desktop/resources"
 
       install -Dm644 "build/icon.png" "$out/share/icons/hicolor/256x256/apps/vikunja-desktop.png"

--- a/pkgs/by-name/vo/voicevox/package.nix
+++ b/pkgs/by-name/vo/voicevox/package.nix
@@ -117,7 +117,7 @@ stdenv.mkDerivation (finalAttrs: {
       install -Dm644 public/icon.png $out/share/icons/hicolor/256x256/apps/voicevox.png
 
       mkdir -p $out/share/voicevox
-      cp -r dist_electron/*-unpacked/{locales,resources{,.pak}} $out/share/voicevox
+      cp -r dist_electron/*-unpacked/resources $out/share/voicevox
 
       makeWrapper ${lib.getExe electron} $out/bin/voicevox \
         --add-flags $out/share/voicevox/resources/app.asar \

--- a/pkgs/by-name/wh/whatsapp-electron/package.nix
+++ b/pkgs/by-name/wh/whatsapp-electron/package.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
     mkdir -p "$out/share/whatsapp-electron"
-    cp -r dist/*-unpacked/{locales,resources{,.pak}} "$out/share/whatsapp-electron"
+    cp -r dist/*-unpacked/resources "$out/share/whatsapp-electron"
 
     install -D assets/whatsapp-icon-512x512.png $out/share/icons/hicolor/512x512/apps/whatsapp.png
     install -D assets/whatsapp-icon-512x512.svg $out/share/icons/hicolor/scalable/apps/whatsapp.svg

--- a/pkgs/by-name/wi/wire-desktop/package.nix
+++ b/pkgs/by-name/wi/wire-desktop/package.nix
@@ -137,7 +137,7 @@ stdenv.mkDerivation (finalAttrs: {
   + lib.optionalString (stdenv.hostPlatform.isLinux) ''
 
     mkdir -p $out/share/wire-desktop
-    cp -r wrap/dist/linux-unpacked/{locales,resources{,.pak}} $out/share/wire-desktop
+    cp -r wrap/dist/*-unpacked/resources $out/share/wire-desktop
 
     makeWrapper ${lib.getExe electron} $out/bin/wire-desktop \
       --add-flags $out/share/wire-desktop/resources/app.asar \

--- a/pkgs/by-name/yt/ytmdesktop/package.nix
+++ b/pkgs/by-name/yt/ytmdesktop/package.nix
@@ -111,7 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
   + lib.optionalString stdenv.hostPlatform.isLinux ''
 
     mkdir -p "$out"/share/ytmdesktop
-    cp -r out/*/{locales,resources{,.pak}} "$out"/share/ytmdesktop
+    cp -r out/*/resources "$out"/share/ytmdesktop
 
     install -Dm644 src/assets/icons/ytmd.png "$out"/share/pixmaps/ytmdesktop.png
 

--- a/pkgs/tools/security/bitwarden-directory-connector/default.nix
+++ b/pkgs/tools/security/bitwarden-directory-connector/default.nix
@@ -81,7 +81,7 @@ in
         -c.npmRebuild=false
 
       mkdir -p $out/share/bitwarden-directory-connector $out/bin
-      cp -r dist/*-unpacked/{locales,resources{,.pak}} $out/share/bitwarden-directory-connector
+      cp -r dist/*-unpacked/resources $out/share/bitwarden-directory-connector
 
       makeWrapper ${lib.getExe electron} $out/bin/bitwarden-directory-connector \
         --add-flags $out/share/bitwarden-directory-connector/resources/app.asar \


### PR DESCRIPTION
In upstream electron/chromium sources `base::DIR_ASSETS` is being used as a prefix for both loading `resources.pak` `locales/*.pak` files.

resources.pak loading: https://github.com/electron/electron/blob/17cb7d49058d9892e126663890fab09bcc1d4fa7/shell/app/electron_main_delegate.cc#L145-L164

locales loading: https://github.com/chromium/chromium/blob/d06318639aa86ce112788574b79164de9f881a8a/ui/base/ui_base_paths.cc#L41-L43

`app.getPath("assets")` is a function that returns the current `base::DIR_ASSETS` value.
When running an electron app via wrapping it with the original electron binary, `app.getPath("assets")` returns the original electron's `/libexec/electron` directory.

So there is no reason to also copy the `locales` and `resources.pak` directory, since we're using the original files anyways.
Maybe in the past it was needed, but it shouldn't be needed now.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
