### PR TITLE
pdf-mcp: init at 1.21.0

### DIFF
--- a/pkgs/by-name/pd/pdf-mcp/package.nix
+++ b/pkgs/by-name/pd/pdf-mcp/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  tesseract,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "pdf-mcp";
+  version = "1.21.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "jztan";
+    repo = "pdf-mcp";
+    tag = "v${version}";
+    hash = "sha256-/CuVdfkJkc95JkZZZMA5euvdysdPObRcww+zImhCY5M=";
+  };
+
+  build-system = [ python3Packages.hatchling ];
+
+  pythonRelaxDeps = [
+    "click"
+    "joserfc"
+    "mcp"
+    "pydantic-settings"
+  ];
+
+  dependencies = with python3Packages; [
+    click
+    fastmcp
+    httpx
+    joserfc
+    numpy
+    pydantic
+    pydantic-settings
+    pymupdf
+  ];
+
+  makeWrapperArgs = [
+    "--prefix"
+    "PATH"
+    ":"
+    (lib.makeBinPath [ tesseract ])
+    "--set-default"
+    "TESSDATA_PREFIX"
+    "${tesseract}/share/tessdata"
+  ];
+
+  pythonImportsCheck = [ "pdf_mcp" ];
+
+  nativeCheckInputs = [
+    tesseract
+  ]
+  ++ (with python3Packages; [
+    pytestCheckHook
+    pytest-asyncio
+    pillow
+  ]);
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  # needs LLM API
+  disabledTestPaths = [
+    "tests/test_eval_coherence.py"
+    "tests/test_release.py"
+    "tests/test_demo_sample_pdf.py"
+  ];
+
+  # needs networking
+  disabledTests = [ "test_rejects_text_html_content_type" ];
+
+  pytestFlags = [
+    "-m"
+    "not slow"
+    "--ignore-glob=*/test_benchmark_*.py"
+  ];
+
+  meta = {
+    description = "MCP server that lets AI agents work through large PDFs without overflowing their context";
+    homepage = "https://github.com/jztan/pdf-mcp";
+    changelog = "https://github.com/jztan/pdf-mcp/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ derdennisop ];
+    mainProgram = "pdf-mcp";
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
