### PR TITLE
python3Packages.pyworld: fix build without pkg_resources

### DIFF
--- a/pkgs/development/python-modules/pyworld/default.nix
+++ b/pkgs/development/python-modules/pyworld/default.nix
@@ -2,23 +2,37 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  numpy,
+
   cython,
+  numpy,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "pyworld";
   version = "0.3.5";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-G5PlPN22eg5PqjTWz5GaxsZi/rHIwO2QHXG1las5aqM=";
   };
 
-  nativeBuildInputs = [ cython ];
+  # remove dependency on pkg_resources
+  # See: https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder/pull/99
+  postPatch = ''
+    substituteInPlace pyworld/__init__.py \
+      --replace-fail "import pkg_resources" "import importlib.metadata" \
+      --replace-fail "pkg_resources.get_distribution('pyworld').version" "importlib.metadata.version('pyworld')"
+  '';
 
-  propagatedBuildInputs = [ numpy ];
+  build-system = [
+    cython
+    numpy
+    setuptools
+  ];
+
+  dependencies = [ numpy ];
 
   pythonImportsCheck = [ "pyworld" ];
 


### PR DESCRIPTION
Also, start using `pyproject = true` and new dependency list naming.

I could use a patch file for this change, but each patched line has a simple equivalent with `importlib.metadata`, so I didn't end up using a separate patch file.

`voicevox` depends on `pyworld`, so this would be good to have working.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
