### PR TITLE
writers: separate `writeNu`'s shebang from script contents

### DIFF
--- a/pkgs/build-support/writers/scripts.nix
+++ b/pkgs/build-support/writers/scripts.nix
@@ -877,12 +877,16 @@ rec {
   */
   writeNu =
     name: argsOrScript:
+    # Separate the shebang from doc comments attached to `main`.
     if lib.isAttrs argsOrScript && !lib.isDerivation argsOrScript then
+      script:
       makeScriptWriter (
         argsOrScript // { interpreter = "${lib.getExe pkgs.nushell} --no-config-file"; }
-      ) name
+      ) name "\n${script}"
     else
-      makeScriptWriter { interpreter = "${lib.getExe pkgs.nushell} --no-config-file"; } name argsOrScript;
+      makeScriptWriter {
+        interpreter = "${lib.getExe pkgs.nushell} --no-config-file";
+      } name "\n${argsOrScript}";
 
   /**
     Like writeScriptBin but the first line is a shebang to nu

--- a/pkgs/build-support/writers/test.nix
+++ b/pkgs/build-support/writers/test.nix
@@ -254,6 +254,23 @@ recurseIntoAttrs {
       ''
     );
 
+    nuDocComment =
+      let
+        script = writeNu "test-writers-nushell-doc-comment" ''
+          # Doc comment example
+          def main [] {}
+        '';
+      in
+      runCommand "test-writers-nushell-doc-comment" { } ''
+        ${script} --help > help
+        grep -F "Doc comment example" help
+        if grep -F "#!" help; then
+          echo "shebang included in Nushell doc comment" >&2
+          exit 1
+        fi
+        touch $out
+      '';
+
     babashka = expectSuccess (
       writeBabashka "test-writers-babashka" { } ''
         (println "success")


### PR DESCRIPTION
# Summary

Nushell scripts can attach documentation comments to their `main` function, similarly to Rust:

```nu
# Doc comment example
def main [] {}
```

These comments are displayed by `--help` and related commands.

Until now, `writeNu` placed the script contents directly after the generated shebang. A script beginning with a doc
comment therefore produced a file like this:

```nu
#!/nix/store/…/bin/nu
# Doc comment example
def main [] {}
```

Because both lines begin with `#` and there is no blank line separating them, Nushell interprets the shebang as part of
the doc comment attached to `main`. As a result, the shebang unexpectedly appears in the command's help output.

Users can work around this by manually starting their Nix string with an extra newline:

```nix
pkgs.writers.writeNu "hello" ''

# Doc comment example
def main [] {}
''
```

However, the significance of that leading newline is not obvious. It looks like incidental whitespace that someone may
reasonably remove later.

This change makes `writeNu` always insert a blank line after the shebang, for both its direct and options-based forms.
This keeps the shebang separate from any documentation attached to `main` without requiring callers to know about the
Nushell parsing quirk.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
