### PR TITLE
forgejo: 15.0.5 -> 16.0.0

### DIFF
--- a/pkgs/by-name/fo/forgejo/generic.nix
+++ b/pkgs/by-name/fo/forgejo/generic.nix
@@ -12,6 +12,7 @@
   bash,
   brotli,
   buildGoModule,
+  coreutils,
   fetchpatch,
   forgejo,
   git,
@@ -79,6 +80,9 @@ buildGoModule rec {
     git
     openssh
     writableTmpDirAsHomeHook
+  ]
+  ++ lib.optionals (lib.versionAtLeast version "16") [
+    coreutils
   ];
 
   patches = [
@@ -116,6 +120,23 @@ buildGoModule rec {
 
     # TestRunHookPrePostReceive (cmd/hook_test.go) needs .git to pass
     git init
+  ''
+  # Unlike NixOS, the Nix build sandbox has no /usr/bin/env and we
+  # can't just create it, so Forgejo trying to execute git hooks
+  # that have #!/usr/bin/env as shebang fails with:
+  #
+  #  To /build/repos44353414/user2/repo1.wiki.git
+  #   ! [remote rejected] fda09356fb8b1da00546f764933f9dacda1b44ea -> master (pre-receive hook declined)
+  #  error: failed to push some refs to '/build/repos44353414/user2/repo1.wiki.git'
+  #   - remote: fatal: cannot exec '/build/appdata2719412950/home/hooks/pre-receive': No such file or directory
+  #
+  # We also can't just call patchShebangs because the hooks are
+  # created just in time by the test suite. Patching the source of
+  # the hooks after go build but before go test is oddly enough
+  # the least invasive hack to have those tests pass.
+  + lib.optionalString (lib.versionAtLeast version "16") ''
+    substituteInPlace modules/git/hook_generate.go \
+      --replace-fail "#!/usr/bin/env" "#!${lib.getExe' coreutils "env"}"
   '';
 
   checkFlags =
@@ -124,6 +145,11 @@ buildGoModule rec {
         "TestPassword" # requires network: api.pwnedpasswords.com
         "TestCaptcha" # requires network: hcaptcha.com
         "TestDNSUpdate" # requires network: release.forgejo.org
+      ]
+      ++ lib.optionals (lib.versionAtLeast version "16") [
+        "TestMigrateRepository" # requires network: codeberg.org
+      ]
+      ++ [
         "TestMigrateWhiteBlocklist" # requires network: gitlab.com (DNS)
         "TestURLAllowedSSH/Pushmirror_URL" # requires network git.gay (DNS)
         "TestBleveDeleteIssue" # Known Flake-y https://github.com/NixOS/nixpkgs/issues/509878

--- a/pkgs/by-name/fo/forgejo/lts.nix
+++ b/pkgs/by-name/fo/forgejo/lts.nix
@@ -1,1 +1,11 @@
-package.nix
+import ./generic.nix {
+  version = "15.0.5";
+  hash = "sha256-S+x/YEfQrYIzHLnZ7LDLnkMYVN3TajwS7SHydM8uMPQ=";
+  npmDepsHash = "sha256-BZSYjEsjUqMYWu3EUP+K35hqSOniv8Y6ek5bEC2vTPg=";
+  vendorHash = "sha256-00QiJ8W76FdG96fmsIRLkaYlMQTZoIRmRd/qYGyPuig=";
+  lts = true;
+  nixUpdateExtraArgs = [
+    "--override-filename"
+    "pkgs/by-name/fo/forgejo/lts.nix"
+  ];
+}

--- a/pkgs/by-name/fo/forgejo/package.nix
+++ b/pkgs/by-name/fo/forgejo/package.nix
@@ -1,9 +1,9 @@
 import ./generic.nix {
-  version = "15.0.5";
-  hash = "sha256-S+x/YEfQrYIzHLnZ7LDLnkMYVN3TajwS7SHydM8uMPQ=";
-  npmDepsHash = "sha256-BZSYjEsjUqMYWu3EUP+K35hqSOniv8Y6ek5bEC2vTPg=";
-  vendorHash = "sha256-00QiJ8W76FdG96fmsIRLkaYlMQTZoIRmRd/qYGyPuig=";
-  lts = true;
+  version = "16.0.0";
+  hash = "sha256-BZawFbrtcxftX4/Yk32aoVRQ6Kg+k1FhN9IoH6dxvVY=";
+  npmDepsHash = "sha256-UhivpUqNJvc3zHxdRVAWT9x68jG1KnQa8yS4KkL2W5g=";
+  vendorHash = "sha256-cb6f7ZX3pG95EEZotGXn6+YUJN59SFNVHFTejFJ6y28=";
+  lts = false;
   nixUpdateExtraArgs = [
     "--override-filename"
     "pkgs/by-name/fo/forgejo/package.nix"


### PR DESCRIPTION
https://forgejo.org/2026-07-release-v16-0/

https://codeberg.org/forgejo/forgejo/milestone/70071

Closes #542602

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
