### PR TITLE
stash-clipboard: create symlinks, allow setting serviceArguments

### DIFF
--- a/nixos/modules/services/misc/stash-clipboard.nix
+++ b/nixos/modules/services/misc/stash-clipboard.nix
@@ -26,7 +26,18 @@ in
       type = types.listOf types.str;
       default = [ ];
       example = [ "--max-items 10" ];
-      description = "A list of arguments to pass to stash watch.";
+      description = ''
+        A list of arguments which are passed to `stash`. For a list of available arguments, run `stash --help`.
+      '';
+    };
+
+    serviceArguments = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "--persist" ];
+      description = ''
+        A list of arguments which are passed to `stash watch`. For a list of available arguments, run `stash watch --help`.
+      '';
     };
 
     filterFile = mkOption {
@@ -61,7 +72,7 @@ in
         wantedBy = [ "graphical-session.target" ];
         after = [ "graphical-session.target" ];
         serviceConfig = {
-          ExecStart = "${getExe cfg.package} ${concatStringsSep " " cfg.arguments} watch";
+          ExecStart = "${getExe cfg.package} ${concatStringsSep " " cfg.arguments} watch ${concatStringsSep " " cfg.serviceArguments}";
           LoadCredential = mkIf (cfg.filterFile != "") "clipboard_filter:${cfg.filterFile}";
         };
         environment = mkIf (cfg.excludedApps != [ ]) {

--- a/pkgs/by-name/st/stash-clipboard/package.nix
+++ b/pkgs/by-name/st/stash-clipboard/package.nix
@@ -3,6 +3,7 @@
   rustPlatform,
   fetchFromGitHub,
   nix-update-script,
+  createSymlinks ? true,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "stash-clipboard";
@@ -18,6 +19,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-iXL3G1H8tNS1oPAoEvvx7qwWUef95NBU3dwlEe+34zw=";
 
   __structuredAttrs = true;
+
+  postInstall = lib.optionalString createSymlinks ''
+    mkdir -p $out
+    for bin in stash-copy stash-paste wl-copy wl-paste; do
+      ln -sf $out/bin/stash $out/bin/$bin
+    done
+  '';
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
there are a seperate set of arguments that go before and after `watch`. Therefore we must allow configuring both. Add the new `serviceArguments` option to allow that.

When the `stash` binary is symlinked to `wl-copy`, `wl-paste`, `stash-copy` and `stash-paste`, its behaviour changes to match. Enable these symlinks by default as `wl-copy` and `wl-paste` should be drop in replacements for `wl-clipboard`. Users who don't wish to use them can disable the option. I think this is a sensible default as previously the clipboard would not function correctly in many apps without these binaries.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
