### PR TITLE
phira{,-unwrapped,-free}: 0.7.1 -> 0.8.0; add update script

### DIFF
--- a/pkgs/by-name/ph/phira-unwrapped/package.nix
+++ b/pkgs/by-name/ph/phira-unwrapped/package.nix
@@ -14,7 +14,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "phira-unwrapped";
-  version = "0.7.1";
+  version = "0.8.0";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "TeamFlos";
     repo = "phira";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-bn1vRxL4O32Txna3RqafOzXISziDiL//S8NwiIK5c4M=";
+    hash = "sha256-/ziX3rkHs38BKNQU8Q9NJC51ArJbs/HBSKN7BIozCBY=";
   };
 
   nativeBuildInputs = [
@@ -54,7 +54,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     ./assets.patch
   ];
 
-  cargoHash = "sha256-a+bQ5d9n18jrsgnqygBlMKWlu7KPU5tbQQSXRXE5zWY=";
+  cargoHash = "sha256-R4JljAElhxT88Ar1cvBlv0qSquyrvia7Rbygr9NSxwY=";
 
   # The developer put assets necessary for this test in gitignore, so it cannot run.
   checkFlags = [ "--skip=test_parse_chart" ];
@@ -73,6 +73,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   postInstall = ''
     install -Dm644 assets/icon.png $out/share/icons/hicolor/128x128/apps/phira.png
   '';
+
+  passthru.updateScript = ./update.sh;
 
   meta = {
     description = "Rhythm game with custom charts and multiplayer";

--- a/pkgs/by-name/ph/phira-unwrapped/update.sh
+++ b/pkgs/by-name/ph/phira-unwrapped/update.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -p nix-update nix gnused -i bash
+
+set -euo pipefail
+
+old_version="$(nix-instantiate --eval --raw -A phira-unwrapped.version)"
+nix-update phira-unwrapped
+version="$(nix-instantiate --eval --raw -A phira-unwrapped.version)"
+if [[ "$old_version" == "$version" ]]; then
+  exit 0
+fi
+
+file="$(nix-instantiate --eval --raw -A phira.meta.position | cut -d : -f 1)"
+hash="$(nix-prefetch-url --unpack "https://github.com/TeamFlos/phira/releases/download/v$version/Phira-windows-x86_64-v$version.zip")"
+hash="$(nix-hash --to-sri --type sha256 "$hash")"
+sed -i "s|hash = \".*\";|hash = \"$hash\";|" "$file"

--- a/pkgs/by-name/ph/phira/package.nix
+++ b/pkgs/by-name/ph/phira/package.nix
@@ -12,7 +12,7 @@
   # A derivation or a path that contains a dir `assets`.
   overrideAssets ? fetchzip {
     url = "https://github.com/TeamFlos/phira/releases/download/v${phira-unwrapped.version}/Phira-windows-x86_64-v${phira-unwrapped.version}.zip";
-    hash = "sha256-p0+o7q42caHqVWnHtgknYaCIJemG/9fNKF7pqTnRGE4=";
+    hash = "sha256-1/FBg1i8O83yusEAFlXiYWyabv04n1qkXwLgWaw8sTc=";
     stripRoot = false;
     meta.license = lib.licenses.unfree;
   },
@@ -54,6 +54,9 @@ symlinkJoin {
 
   passthru.assets = overrideAssets;
 
-  meta = phira-unwrapped.meta;
+  meta = phira-unwrapped.meta // {
+    # trick meta.position
+    description = phira-unwrapped.meta.description;
+  };
 
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
