### PR TITLE
clickhouse-sqlalchemy: init at 0.3.2

### DIFF
--- a/pkgs/development/python-modules/clickhouse-sqlalchemy/default.nix
+++ b/pkgs/development/python-modules/clickhouse-sqlalchemy/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  sqlalchemy,
+  requests,
+  clickhouse-driver,
+  nix-update-script,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "clickhouse-sqlalchemy";
+  version = "0.3.2";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-Jn86mh0NGG65mkGJWmhJItMRJc6iFwLNfcc68czdEOc=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  # asynch is not packaged in nixpkgs; drop it from install_requires
+  # and disable the corresponding sqlalchemy dialect entry point.
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail "'asynch>=0.2.2'," "" \
+      --replace-fail "('.asynch', 'asynch.base:ClickHouseDialect_asynch')," ""
+  '';
+
+  dependencies = [
+    sqlalchemy
+    requests
+    clickhouse-driver
+  ];
+
+  pythonImportsCheck = [
+    "clickhouse_sqlalchemy"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Simple ClickHouse SQLAlchemy Dialect";
+    homepage = "https://pypi.org/project/clickhouse-sqlalchemy";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jlesquembre ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2957,6 +2957,8 @@ self: super: with self; {
 
   clickhouse-driver = callPackage ../development/python-modules/clickhouse-driver { };
 
+  clickhouse-sqlalchemy = callPackage ../development/python-modules/clickhouse-sqlalchemy { };
+
   cliff = callPackage ../development/python-modules/cliff { };
 
   clifford = callPackage ../development/python-modules/clifford { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Depends on https://github.com/NixOS/nixpkgs/pull/536995

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
