### PR TITLE
rc: fix build with "editline" library

### DIFF
--- a/pkgs/by-name/rc/rc/package.nix
+++ b/pkgs/by-name/rc/rc/package.nix
@@ -9,9 +9,11 @@
   ed,
   ncurses,
   readline,
+  editline,
   installShellFiles,
   historySupport ? true,
   readlineSupport ? true,
+  editlineSupport ? false,
   lineEditingLibrary ? if stdenv.hostPlatform.isDarwin then "null" else "readline",
 }:
 
@@ -25,10 +27,10 @@ assert lib.elem lineEditingLibrary [
 assert
   !(lib.elem lineEditingLibrary [
     "edit"
-    "editline"
     "vrl"
   ]); # broken
 assert (lineEditingLibrary == "readline") -> readlineSupport;
+assert (lineEditingLibrary == "editline") -> editlineSupport;
 stdenv.mkDerivation (finalAttrs: {
   pname = "rc";
   version = "unstable-2025-10-01";
@@ -61,9 +63,8 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     ncurses
   ]
-  ++ lib.optionals readlineSupport [
-    readline
-  ];
+  ++ lib.optional readlineSupport readline
+  ++ lib.optional editlineSupport editline;
 
   strictDeps = true;
 

--- a/pkgs/by-name/rc/rc/package.nix
+++ b/pkgs/by-name/rc/rc/package.nix
@@ -12,8 +12,7 @@
   installShellFiles,
   historySupport ? true,
   readlineSupport ? true,
-  lineEditingLibrary ?
-    if (stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isStatic) then "null" else "readline",
+  lineEditingLibrary ? if stdenv.hostPlatform.isDarwin then "null" else "readline",
 }:
 
 assert lib.elem lineEditingLibrary [
@@ -74,7 +73,9 @@ stdenv.mkDerivation (finalAttrs: {
     "MANPREFIX=${placeholder "man"}/share/man"
     "CPPFLAGS=\"-DSIGCLD=SIGCHLD\""
     "EDIT=${lineEditingLibrary}"
-  ];
+  ]
+  # Required to fix static build, harmless for dynamic builds.
+  ++ lib.optional (lineEditingLibrary == "readline") "LDLIBS=-lncurses";
 
   buildFlags = [
     "all"

--- a/pkgs/by-name/rc/rc/package.nix
+++ b/pkgs/by-name/rc/rc/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   fetchpatch2,
   pkgsStatic,
+  rc,
   byacc,
   ed,
   ncurses,
@@ -88,7 +89,21 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     shellPath = "/bin/rc";
-    tests.static = pkgsStatic.rc;
+    tests = {
+      static = pkgsStatic.rc;
+      readline = lib.optionalDrvAttr (!stdenv.hostPlatform.isDarwin) (
+        rc.override {
+          readlineSupport = true;
+          lineEditingLibrary = "readline";
+        }
+      );
+      editline = lib.optionalDrvAttr (!stdenv.hostPlatform.isDarwin) (
+        rc.override {
+          editlineSupport = true;
+          lineEditingLibrary = "editline";
+        }
+      );
+    };
   };
 
   meta = {


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
