### PR TITLE
nls-cli: init at 0.8.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4795,6 +4795,12 @@
     githubId = 543423;
     name = "Alex Wied";
   };
+  Cesatorii = {
+    email = "cesatorii.alt@protonmail.com";
+    name = "Cesatorii";
+    github = "Cesatorii";
+    githubId = 90511595;
+  };
   cfouche = {
     email = "chaddai.fouche@gmail.com";
     github = "Chaddai";

--- a/pkgs/by-name/nl/nls-cli/package.nix
+++ b/pkgs/by-name/nl/nls-cli/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "nls-cli";
+  version = "0.8.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "nolight132";
+    repo = "nls";
+    rev = "v${version}";
+    hash = "sha256-kY/57F/k2Geei3WPC49HwDJl7B8frNiQugP04wHw50A=";
+  };
+
+  proxyVendor = true;
+  vendorHash = "sha256-LgheQyb3W8wkqZT3fR9BWFHzh1U4I42AJktc292f6sc=";
+
+  subPackages = [ "cmd/nls" ];
+
+  meta = {
+    description = "nls: a pretty ls alternative with Git status and directory sizes";
+    homepage = "https://github.com/nolight132/nls";
+    license = lib.licenses.mit;
+    mainProgram = "nls";
+    maintainers = [ lib.maintainers.Cesatorii ];
+  };
+}


### PR DESCRIPTION
nls is a neo-ls: a modern file listing command built around beautiful tables, compatibility in pipes and scripts, and useful defaults like directory sizes without slowing normal usage.

The original GitHub link of neo-ls is this: https://github.com/nolight132/nls

This cli tool was added with the confirmation of the author, Pavel Olizko.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
