### PR TITLE
isponsorblocktv: 2.6.1 -> 2.10.0

### DIFF
--- a/pkgs/by-name/is/isponsorblocktv/package.nix
+++ b/pkgs/by-name/is/isponsorblocktv/package.nix
@@ -1,29 +1,20 @@
 {
   fetchFromGitHub,
-  fetchpatch,
   lib,
   python3Packages,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "isponsorblocktv";
-  version = "2.6.1";
+  version = "2.10.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "dmunozv04";
     repo = "iSponsorBlockTV";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-AGjLehhGYz8FyojSFmSYKLCkHAExtpQiukQnTNt1YoY=";
+    hash = "sha256-DxSrvUT1Ga8XwbPTZxMY4ZUBL4Tnhy9ZD0iuT+8NweE=";
   };
-
-  patches = [
-    # Port iSponsorBlockTV to pyytlounge v3
-    (fetchpatch {
-      url = "https://github.com/ameertaweel/iSponsorBlockTV/commit/1809ca5a0d561bc9326a51e82118f290423ed3e6.patch";
-      hash = "sha256-v5YXfKUPTzpZPIkVSQF2VUe9EvclAH+kJyiiyUEe/HM=";
-    })
-  ];
 
   build-system = with python3Packages; [
     hatchling
@@ -34,6 +25,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     aiohttp
     appdirs
     async-cache
+    pychromecast
     pyytlounge
     rich-click
     rich
@@ -41,6 +33,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     textual-slider
     textual
     xmltodict
+    zeroconf
   ];
 
   # all dependencies are pinned to exact version numbers


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: https://github.com/dmunozv04/iSponsorBlockTV/releases

## Things done

Removed the pyytlounge patch because upstream now currently uses 3.2.0 (https://github.com/dmunozv04/iSponsorBlockTV/blob/d657386e5855a6dcd0ad5a97f7288ae6ec0cec4b/requirements.txt#L4).

Added required dependencies.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
