### PR TITLE
kdePackages.kate: split KWrite into a separate output

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -65,6 +65,8 @@
   Deployments running the server and worker in the same network namespace must also set at least the worker
   `AUTHENTIK_LISTEN__HTTP` address so that the server and worker do not bind to the same address.
 
+- `kdePackages.kate` no longer installs KWrite. KWrite is now available separately as `kdePackages.kwrite`.
+
 - `services.alps` has been rewritten, see [upstream repository](https://github.com/migadu/alps) for configuration.
 
 - Support for the legacy U‐Boot image format has been removed from the initrd generators, as it is deprecated upstream and no longer used by any platform in Nixpkgs.

--- a/nixos/modules/services/desktop-managers/plasma6.nix
+++ b/nixos/modules/services/desktop-managers/plasma6.nix
@@ -159,6 +159,7 @@ in
           gwenview
           okular
           kate
+          kwrite
           ktexteditor # provides elevated actions for kate
           khelpcenter
           dolphin

--- a/pkgs/kde/default.nix
+++ b/pkgs/kde/default.nix
@@ -65,6 +65,17 @@ let
         # Alias to match metadata
         kquickimageeditor = self.kquickimageedit;
 
+        kwrite = lib.extendDerivation true {
+          pname = "kwrite";
+          name = "kwrite-${self.kate.version}";
+          meta = self.kate.meta // {
+            description = "Text Editor";
+            homepage = "https://apps.kde.org/kwrite/";
+            mainProgram = "kwrite";
+            outputsToInstall = [ "kwrite" ];
+          };
+        } self.kate.kwrite;
+
         selenium-webdriver-at-spi = null; # Used for integration tests that we don't run, stub
 
         alpaka = self.callPackage ./misc/alpaka { };

--- a/pkgs/kde/gear/kate/default.nix
+++ b/pkgs/kde/gear/kate/default.nix
@@ -1,4 +1,25 @@
 { mkKdeDerivation }:
 mkKdeDerivation {
   pname = "kate";
+
+  outputs = [
+    "out"
+    "kwrite"
+    "dev"
+    "devtools"
+  ];
+
+  postInstall = ''
+    moveToOutput bin/kwrite "$kwrite"
+    moveToOutput share/applications/org.kde.kwrite.desktop "$kwrite"
+    moveToOutput share/metainfo/org.kde.kwrite.appdata.xml "$kwrite"
+    moveToOutput "share/icons/hicolor/*/apps/kwrite.*" "$kwrite"
+  '';
+
+  # Keep KWrite documentation out of the Kate output
+  postFixup = ''
+    moveToOutput "share/doc/HTML/*/kwrite" "$kwrite"
+  '';
+
+  meta.mainProgram = "kate";
 }


### PR DESCRIPTION
This adds a dedicated kwrite output to the existing kate derivation and exposes it as `kdePackages.kwrite`, so both editors can be installed independently.

`services.desktopManager.plasma6` gains kwrite in optionalPackages, so Plasma 6 users keep both editors exactly as before.

Also added a release note to indicate kdePackages.kate no longer provides kwrite.

Closes #511733

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at passthru.tests.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran nixpkgs-review on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in ./result/bin/.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test