### PR TITLE
npc: init at 1.0.0

### DIFF
--- a/pkgs/by-name/np/npc/package.nix
+++ b/pkgs/by-name/np/npc/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  git,
+  nix,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "npc";
+  version = "1.0.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "samestep";
+    repo = "npc";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-qgg1WwxcpqxmK+xchIWbGQ/EXUJdYje9++CziTFnmtA=";
+  };
+
+  cargoHash = "sha256-cxkVBKqFmlHjUrmx2jbGmGgrrZLpVmi/o6HzDKckudQ=";
+
+  env = {
+    GIT_BIN = lib.getExe git;
+    NIX_BIN = lib.getExe nix;
+  };
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Nixpkgs channel history CLI";
+    homepage = "https://github.com/samestep/npc";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      samestep
+      me-and
+    ];
+  };
+})


### PR DESCRIPTION
[npc](https://github.com/samestep/npc) is an MIT-licensed tool for working with Nix channels and channel histories.  In particular, it provides an `npc bisect` command that provides similar function to `git bisect` but only considering commits that have actually been pointed to by a relevant Nixpkgs release branch.

@samestep I've added you as a maintainer, since you're the author, but you obviously get to opt out!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
