### PR TITLE
packetry: add desktop entry and icon

### DIFF
--- a/pkgs/by-name/pa/packetry/package.nix
+++ b/pkgs/by-name/pa/packetry/package.nix
@@ -1,12 +1,16 @@
 {
   fetchFromGitHub,
   lib,
+  stdenv,
   rustPlatform,
   gtk4,
   pkg-config,
   pango,
   wrapGAppsHook4,
   versionCheckHook,
+  copyDesktopItems,
+  makeDesktopItem,
+  desktopToDarwinBundle,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -25,7 +29,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeBuildInputs = [
     pkg-config
     wrapGAppsHook4
-  ];
+    copyDesktopItems
+  ]
+  ++ lib.optional stdenv.hostPlatform.isDarwin desktopToDarwinBundle;
 
   buildInputs = [
     gtk4
@@ -41,9 +47,23 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
 
+  desktopItems = [
+    (makeDesktopItem {
+      name = "packetry";
+      desktopName = "Packetry";
+      comment = finalAttrs.meta.description;
+      exec = "packetry";
+      icon = "packetry";
+      categories = [ "Utility" ];
+    })
+  ];
+
   # packetry-cli is only necessary on windows https://github.com/greatscottgadgets/packetry/pull/154
   postInstall = ''
     rm $out/bin/packetry-cli
+
+    install -Dm644 appimage/dist/icon.png \
+      $out/share/icons/hicolor/512x512/apps/packetry.png
   '';
 
   meta = {


### PR DESCRIPTION
add desktop entry with icon and desktopToDarwinBundle.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
