### PR TITLE
nixos/opentabletdriver: Match OTD Upstream systemd environment checks

### DIFF
--- a/nixos/modules/hardware/opentabletdriver.nix
+++ b/nixos/modules/hardware/opentabletdriver.nix
@@ -61,16 +61,27 @@ in
       wantedBy = [ "graphical-session.target" ];
       partOf = [ "graphical-session.target" ];
 
+      unitConfig = {
+        After = "graphical-session.target";
+        ConditionEnvironment = [
+          "|WAYLAND_DISPLAY"
+          "|DISPLAY"
+        ];
+      };
+
       serviceConfig = {
         Type = "simple";
-        # workaround for https://github.com/NixOS/nixpkgs/issues/469340
-        ExecStartPre = pkgs.writeShellScript "disable-for-gdm-greeter" ''
-          if [[ "$USER" = "gdm-greeter"* ]]; then
+        # workaround for https://github.com/NixOS/nixpkgs/issues/469340 and
+        # https://github.com/OpenTabletDriver/OpenTabletDriver/issues/4885
+        ExecStartPre = pkgs.writeShellScript "poll-for-non-gdm-greeter-display" ''
+          if [[ "$USER" = "gdm-greeter"* \
+              || ( "$${XDG_SESSION_TYPE}" = wayland && -z "$${WAYLAND_DISPLAY}" ) ]]; then
             exit 1
           fi
         '';
         ExecStart = lib.getExe' cfg.package "otd-daemon";
         Restart = "on-failure";
+        RestartSec = 3;
       };
     };
   };


### PR DESCRIPTION
OTD requires WAYLAND_DISPLAY or DISPLAY to be set, otherwise it assumes x11 which, on a WAYLAND display configuration, leads to segfaults on OTD start up. Enforce an ordering so that we wait until the session has initted before doing anything.

Upstream has both a check for these environment variables, as well as enforces a RestartSec=3 to prevent immediate restarts.

Additionally, it's theoretically possible for DISPLAY to be set before WAYLAND_DISPLAY, causing segmentation faults on wayland set ups, so add an explicit polling condition for that in the ExecStartPre script.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. (specifically `nix-build -A nixosTests.opentabletdriver`)
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant. **(Maybe? It fixes a bug/changes module behaviour)**
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy]. **(No GenAI was used in the analysis or writing of this PR.)**

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Fixes #543101 