### PR TITLE
nixos/isponsorblocktv: init module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1285,6 +1285,7 @@
   ./services/networking/iscsi/initiator.nix
   ./services/networking/iscsi/root-initiator.nix
   ./services/networking/iscsi/target.nix
+  ./services/networking/isponsorblocktv.nix
   ./services/networking/ivpn.nix
   ./services/networking/iwd.nix
   ./services/networking/jibri/default.nix

--- a/nixos/modules/services/networking/isponsorblocktv.nix
+++ b/nixos/modules/services/networking/isponsorblocktv.nix
@@ -1,0 +1,140 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.services.networking.isponsorblocktv;
+  systemd-run = lib.getExe' pkgs.systemd "systemd-run";
+  isponsorblocktv-pkg = lib.getExe cfg.package;
+  isponsorblocktv-setup = ''
+    exec ${systemd-run} \
+      --pty \
+      --wait \
+      --unit=isponsorblocktv-setup \
+      --description="iSponsorBlockTV CLI configurator" \
+      --property=User=isponsorblocktv \
+      --property=Group=isponsorblocktv \
+      --property=WorkingDirectory=/var/lib/isponsorblocktv \
+      --property=StateDirectory=isponsorblocktv \
+      --property=StateDirectoryMode=0700 \
+      --property=ReadWritePaths=/var/lib/isponsorblocktv \
+      --property=ProtectSystem=strict \
+      --property=ProtectHome=yes \
+      --property=PrivateTmp=yes \
+      --property=PrivateDevices=yes \
+      --property=NoNewPrivileges=yes \
+      --property=CapabilityBoundingSet= \
+      --property=AmbientCapabilities= \
+      --property=SystemCallFilter=@system-service \
+      --property=SystemCallArchitectures=native \
+      --property=ProtectKernelTunables=yes \
+      --property=ProtectKernelModules=yes \
+      --property=ProtectKernelLogs=yes \
+      --property=ProtectClock=yes \
+      --property=ProtectControlGroups=yes \
+      --property=RestrictNamespaces=yes \
+      --property=LockPersonality=yes \
+      --property=MemoryDenyWriteExecute=yes \
+      --property=RestrictRealtime=yes \
+      --property=RestrictSUIDSGID=yes \
+      --property=RemoveIPC=yes \
+      --property=UMask=0066 \
+      --property=RestrictAddressFamilies=AF_INET \
+      --property=RestrictAddressFamilies=AF_INET6 \
+      --property=Conflicts=isponsorblocktv.service \
+      -- \
+      ${isponsorblocktv-pkg} --setup --data /var/lib/isponsorblocktv
+  '';
+in
+{
+  options.services.networking.isponsorblocktv = {
+    enable = lib.mkEnableOption "isponsorblocktv";
+    package = lib.mkPackageOption pkgs "isponsorblocktv" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      cfg.package
+      (pkgs.writeShellScriptBin "isponsorblocktv-setup" isponsorblocktv-setup)
+    ];
+
+    users.users.isponsorblocktv = {
+      isSystemUser = true;
+      group = "isponsorblocktv";
+      description = "iSponsorBlockTV service account";
+    };
+
+    users.groups.isponsorblocktv = { };
+
+    systemd.services.isponsorblocktv = {
+      description = "iSponsorBlockTV - SponsorBlock client for YouTube TV";
+      documentation = [ "https://github.com/dmunozv04/iSponsorBlockTV" ];
+
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      unitConfig.ConditionPathExists = "/var/lib/isponsorblocktv/config.json";
+
+      serviceConfig = {
+        ExecStart = "${isponsorblocktv-pkg} --data /var/lib/isponsorblocktv";
+        WorkingDirectory = "/var/lib/isponsorblocktv";
+
+        User = "isponsorblocktv";
+        Group = "isponsorblocktv";
+
+        StateDirectory = "isponsorblocktv"; # /var/lib/isponsorblocktv
+        StateDirectoryMode = "0700";
+        RuntimeDirectory = "isponsorblocktv"; # /run/isponsorblocktv
+        RuntimeDirectoryMode = "0700";
+
+        Restart = "always";
+        RestartSec = "10s";
+        StartLimitBurst = 5;
+        StartLimitIntervalSec = "120s";
+
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ReadWritePaths = [ "/var/lib/isponsorblocktv" ];
+
+        NoNewPrivileges = true;
+        CapabilityBoundingSet = "";
+        AmbientCapabilities = "";
+
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+          "~@raw-io"
+          "~@reboot"
+          "~@swap"
+          "~@obsolete"
+        ];
+        SystemCallArchitectures = "native";
+
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        RestrictNamespaces = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        RemoveIPC = true;
+        UMask = "0066";
+
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ gaelj ];
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Tested on the Diaries of a CEO channel, I got none of the annoying stuff.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
