### PR TITLE
Speechd: add pipewire as audio output method

### DIFF
--- a/pkgs/by-name/sp/speechd/package.nix
+++ b/pkgs/by-name/sp/speechd/package.nix
@@ -3,9 +3,10 @@
   lib,
   replaceVars,
   pkg-config,
-  fetchurl,
+  fetchFromGitHub,
   fetchpatch,
   testers,
+  nix-update-script,
   python3Packages,
   gettext,
   itstool,
@@ -43,9 +44,11 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "speech-dispatcher";
   version = "0.12.1";
 
-  src = fetchurl {
-    url = "https://github.com/brailcom/speechd/releases/download/${finalAttrs.version}/speech-dispatcher-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-sUpSONKH0tzOTdQrvWbKZfoijn5oNwgmf3s0A297pLQ=";
+  src = fetchFromGitHub {
+    repo = "speechd";
+    owner = "brailcom";
+    tag = finalAttrs.version;
+    sha256 = "sha256-+DgbL5n4G5Hjwk5ymITwfVlSbBfI1hLjtcuRBZDGNTg=";
   };
 
   patches = [
@@ -153,6 +156,8 @@ stdenv.mkDerivation (finalAttrs: {
       '';
 
   enableParallelBuilding = true;
+
+  passthru.updateScript = nix-update-script { };
 
   passthru.tests.version = testers.testVersion {
     package = finalAttrs.finalPackage;

--- a/pkgs/by-name/sp/speechd/package.nix
+++ b/pkgs/by-name/sp/speechd/package.nix
@@ -134,7 +134,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = lib.optionalString withPico ''
-    substituteInPlace src/modules/pico.c --replace "/usr/share/pico/lang" "${picotts}/share/pico/lang"
+    substituteInPlace src/modules/pico.c \
+      --replace-fail "/usr/share/pico/lang" "${picotts}/share/pico/lang"
   '';
 
   installFlags = [

--- a/pkgs/by-name/sp/speechd/package.nix
+++ b/pkgs/by-name/sp/speechd/package.nix
@@ -25,6 +25,8 @@
   withAlsa ? false,
   alsa-lib,
   withOss ? false,
+  withPipewire ? false,
+  pipewire,
   withFlite ? true,
   flite,
   withEspeak ? true,
@@ -97,6 +99,9 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals withAlsa [
     alsa-lib
   ]
+  ++ lib.optionals withPipewire [
+    pipewire
+  ]
   ++ lib.optionals withEspeak [
     espeak
     sonic
@@ -116,9 +121,19 @@ stdenv.mkDerivation (finalAttrs: {
   configureFlags = [
     "--sysconfdir=/etc"
     # Audio method falls back from left to right.
-    "--with-default-audio-method=\"libao,pulse,alsa,oss\""
     "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
     "--with-systemduserunitdir=${placeholder "out"}/lib/systemd/user"
+  ]
+  ++ [
+    ''--with-default-audio-method="${
+      lib.concatStringsSep "," (
+        lib.optional withLibao "libao"
+        ++ lib.optional withPulse "pulse"
+        ++ lib.optional withAlsa "alsa"
+        ++ lib.optional withPipewire "pipewire"
+        ++ lib.optional withOss "oss"
+      )
+    }"''
   ]
   ++ lib.optionals withPulse [
     "--with-pulse"
@@ -131,6 +146,9 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals withOss [
     "--with-oss"
+  ]
+  ++ lib.optionals withPipewire [
+    "--with-pipewire"
   ]
   ++ lib.optionals withEspeak [
     "--with-espeak-ng"

--- a/pkgs/by-name/sp/speechd/package.nix
+++ b/pkgs/by-name/sp/speechd/package.nix
@@ -44,6 +44,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "speech-dispatcher";
   version = "0.12.1";
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   src = fetchFromGitHub {
     repo = "speechd";
     owner = "brailcom";

--- a/pkgs/by-name/sp/speechd/package.nix
+++ b/pkgs/by-name/sp/speechd/package.nix
@@ -5,6 +5,7 @@
   pkg-config,
   fetchurl,
   fetchpatch,
+  testers,
   python3Packages,
   gettext,
   itstool,
@@ -151,6 +152,10 @@ stdenv.mkDerivation (finalAttrs: {
       '';
 
   enableParallelBuilding = true;
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+  };
 
   meta = {
     description =


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

### Speechd
I modified the speechd package to
- Add version test
- Updated the `substituteInPlace` to use `replace-fail`
- Changed to fetchFromGitHub and added a updatescript
- Added `__structuredAttrs` and `strictDeps`
- Add Pipewire as and audio output module

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
