### PR TITLE
norgolith: 0.4.0 -> 1.3.1, norgolith-mcp: init at 1.1.0, norgolith-plugin-sdk: init at 1.1.1

### DIFF
--- a/pkgs/by-name/no/norgolith-mcp/package.nix
+++ b/pkgs/by-name/no/norgolith-mcp/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "norgolith-mcp";
+  version = "1.1.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "norgolith";
+    repo = "core";
+    tag = "norgolith-mcp-v${finalAttrs.version}";
+    hash = "sha256-YaJ+VMtEZksiGvEaDUVrvOxtV/qxTUSQGDLiEBQ8OP8=";
+  };
+
+  cargoHash = "sha256-dxWsMsOmTS5g8pKLw6Vtv5NyJtrRzkiPlBCq2WPRw/M=";
+
+  cargoRoot = "norgolith-mcp";
+  buildAndTestSubdir = "norgolith-mcp";
+
+  meta = {
+    description = "MCP (Model Context Protocol) server for Norgolith documentation";
+    homepage = "https://norgolith.dev";
+    changelog = "https://github.com/norgolith/core/releases/tag/norgolith-mcp-v${finalAttrs.version}";
+    license = lib.licenses.gpl2Only;
+    maintainers = [ lib.maintainers.Ladas552 ];
+    mainProgram = "norgolith-mcp";
+  };
+})

--- a/pkgs/by-name/no/norgolith-plugin-sdk/package.nix
+++ b/pkgs/by-name/no/norgolith-plugin-sdk/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "norgolith-plugin-sdk";
+  version = "1.1.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "norgolith";
+    repo = "core";
+    tag = "norgolith-plugin-sdk-v${finalAttrs.version}";
+    hash = "sha256-jL8Ajv3K70t1eXttqtrm9WoN9QRW6aucK380iJn3ACw=";
+  };
+
+  cargoHash = "sha256-KhsNCVZAFDWVlxTzkpTdDT6RqE9j+nejTj0botqywvM=";
+
+  cargoRoot = "sdk";
+  buildAndTestSubdir = "sdk";
+
+  meta = {
+    description = "SDK for building Norgolith plugins";
+    homepage = "https://norgolith.dev";
+    changelog = "https://github.com/norgolith/core/releases/tag/norgolith-plugin-sdk-v${finalAttrs.version}";
+    license = lib.licenses.gpl2Only;
+    maintainers = [ lib.maintainers.Ladas552 ];
+    mainProgram = "norgolith-plugin-sdk";
+  };
+})

--- a/pkgs/by-name/no/norgolith/package.nix
+++ b/pkgs/by-name/no/norgolith/package.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "norgolith";
-  version = "0.4.0";
+  version = "1.3.1";
 
   src = fetchFromGitHub {
     owner = "norgolith";
     repo = "core";
     tag = "norgolith-v${finalAttrs.version}";
-    hash = "sha256-K3Gg/8LKmxrHLzVUx4IF3nTxwl2PU7CrV5oZ8BwHo1U=";
+    hash = "sha256-R74IUEQ7XkeC/YeEhKTOTPwnhRwDh+nAbAOstc9PzFk=";
   };
 
-  cargoHash = "sha256-O3Sd0A9XhhtBUqwCDV2TVYAe9Q8Ir0j5YHX220AgTjc=";
+  cargoHash = "sha256-Zy8IhQq5Fdnv7CkkEFHV/wxedEAmd6OfKw7BWbRoA7w=";
 
   nativeBuildInputs = [
     pkg-config
@@ -32,6 +32,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   useNextest = true;
+  buildAndTestSubdir = "core";
 
   env = {
     LIBGIT2_NO_VENDOR = true;
@@ -42,10 +43,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "The monolithic Norg static site generator built with Rust";
-    homepage = "https://norgolith.amartin.beer";
-    changelog = "https://github.com/norgolith/core/releases/tag/v${finalAttrs.version}";
+    homepage = "https://norgolith.dev";
+    changelog = "https://github.com/norgolith/core/releases/tag/norgolith-v${finalAttrs.version}";
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [ Ladas552 ];
+    maintainers = [ lib.maintainers.Ladas552 ];
     mainProgram = "lith";
   };
 })


### PR DESCRIPTION
Updated the norgolith package to build properly and updates being caught by the bot after a repo had a refactor. 

As it is now a monorepo of several packages I also added them as separate packages. They pull from the same repository, but build different cargo.toml files.

New packages include an SDK for plugin developers and MCP for norgolith documentation

As per changelog: https://github.com/norgolith/core/releases/tag/norgolith-v1.0.0 , this update introduces breaking changes to templates, as it's now tera syntax v2. Please follow migration tutorial: https://norgolith.dev/docs/templating-migration/
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
