### PR TITLE
 zfstools: add gem dependency which is no longer in ruby per default

### DIFF
--- a/pkgs/by-name/zf/zfstools/Gemfile
+++ b/pkgs/by-name/zf/zfstools/Gemfile
@@ -1,0 +1,3 @@
+source "http://rubygems.org"
+
+gem "getoptlong"

--- a/pkgs/by-name/zf/zfstools/Gemfile.lock
+++ b/pkgs/by-name/zf/zfstools/Gemfile.lock
@@ -1,0 +1,14 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    getoptlong (0.2.1)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  getoptlong
+
+BUNDLED WITH
+   2.6.9

--- a/pkgs/by-name/zf/zfstools/gemset.nix
+++ b/pkgs/by-name/zf/zfstools/gemset.nix
@@ -1,0 +1,12 @@
+{
+  getoptlong = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "http://rubygems.org" ];
+      sha256 = "198vy9dxyzibqdbw9jg8p2ljj9iknkyiqlyl229vz55rjxrz08zx";
+      type = "gem";
+    };
+    version = "0.2.1";
+  };
+}

--- a/pkgs/by-name/zf/zfstools/package.nix
+++ b/pkgs/by-name/zf/zfstools/package.nix
@@ -1,12 +1,18 @@
 {
   lib,
+  bundlerEnv,
   stdenv,
   fetchFromGitHub,
-  ruby,
   zfs,
   freebsd,
   makeWrapper,
 }:
+let
+  rubyEnv = bundlerEnv {
+    name = "zfstools-gems";
+    gemdir = ./.;
+  };
+in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "zfstools";
@@ -19,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-z8umKWn8vUb2lLattbtSn4BCHD0W92hRvuL2uvrgm5o=";
   };
 
-  buildInputs = [ ruby ];
+  buildInputs = [ rubyEnv.wrappedRuby ];
   nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''

--- a/pkgs/by-name/zf/zfstools/package.nix
+++ b/pkgs/by-name/zf/zfstools/package.nix
@@ -13,10 +13,10 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.3.6";
 
   src = fetchFromGitHub {
-    sha256 = "16lvw3xbmxp2pr8nixqn7lf4504zaaxvbbdnjkv4dggwd4lsdjyg";
-    rev = "v${finalAttrs.version}";
-    repo = "zfstools";
     owner = "bdrewery";
+    repo = "zfstools";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-z8umKWn8vUb2lLattbtSn4BCHD0W92hRvuL2uvrgm5o=";
   };
 
   buildInputs = [ ruby ];
@@ -36,9 +36,8 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    inherit (finalAttrs) version;
-    inherit (finalAttrs.src.meta) homepage;
     description = "OpenSolaris-compatible auto-snapshotting script for ZFS";
+    homepage = "https://github.com/bdrewery/zfstools";
     longDescription = ''
       zfstools is an OpenSolaris-like and compatible auto snapshotting script
       for ZFS, which also supports auto snapshotting mysql databases.


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
