### PR TITLE
pacu: 1.6.2 -> 1.7.0, drop sqlalchemy v1.4

### DIFF
--- a/pkgs/by-name/pa/pacu/package.nix
+++ b/pkgs/by-name/pa/pacu/package.nix
@@ -5,39 +5,32 @@
   python3,
 }:
 
-let
-  python = python3.override {
-    self = python;
-    packageOverrides = self: super: { sqlalchemy = super.sqlalchemy_1_4; };
-  };
-in
-python.pkgs.buildPythonApplication (finalAttrs: {
+python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "pacu";
-  version = "1.6.2";
+  version = "1.7.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "RhinoSecurityLabs";
     repo = "pacu";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Hrks6mvvmmdCMxprB/SPlkfcSu6uyoEVtb0eUD3CALo=";
+    hash = "sha256-sW2ZfrlZiK29ON9TJLAg/YHnhM8ZtWBGCiAEQ5FIWHA=";
   };
 
   pythonRelaxDeps = [
     "dsnap"
-    "sqlalchemy-utils"
-    "sqlalchemy"
+    "botocore" # constrained in https://github.com/RhinoSecurityLabs/pacu/pull/498 to fix moto issues (mocking)
     "pycognito"
     "qrcode"
     "urllib3"
   ];
 
-  build-system = with python.pkgs; [ poetry-core ];
+  build-system = with python3.pkgs; [ poetry-core ];
 
   dependencies = [
     awscli
   ]
-  ++ (with python.pkgs; [
+  ++ (with python3.pkgs; [
     awscli
     boto3
     botocore
@@ -57,7 +50,7 @@ python.pkgs.buildPythonApplication (finalAttrs: {
     urllib3
   ]);
 
-  nativeCheckInputs = with python.pkgs; [
+  nativeCheckInputs = with python3.pkgs; [
     moto
     pytestCheckHook
   ];


### PR DESCRIPTION
This version supports sqlalchemy v2

* https://github.com/RhinoSecurityLabs/pacu/blob/v1.7.0/pyproject.toml#L19-L20
* https://github.com/RhinoSecurityLabs/pacu/pull/513
* part of https://github.com/NixOS/nixpkgs/issues/541099#issuecomment-4952333266


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
