### PR TITLE
kiesel: 0.2.0 -> 0.3.0

### DIFF
--- a/pkgs/by-name/ki/kiesel/deps.nix
+++ b/pkgs/by-name/ki/kiesel/deps.nix
@@ -16,6 +16,14 @@ linkFarm "zig-packages" [
     };
   }
   {
+    name = "N-V-__8AALjnOQBiCk4NffYgEewZ5v9qlLlDyXO22FIyzNdf";
+    path = fetchgit {
+      url = "https://github.com/boa-dev/temporal";
+      tag = "v0.2.4";
+      hash = "sha256-0JhYANVsVvNC0OZe1E6WzGc+pH9j7Z9SGCmhk8TQanU=";
+    };
+  }
+  {
     name = "N-V-__8AAMFkNQCMS3QG2Q2vrQ1urnQq0PqKINS-iRDs1Xqc";
     path = fetchzip {
       url = "https://musl.libc.org/releases/musl-1.2.6.tar.gz";
@@ -31,14 +39,6 @@ linkFarm "zig-packages" [
     };
   }
   {
-    name = "N-V-__8AAPLKOQDfJ5TYhiiy_6a_dZqUmo9K4e8Xhjfup3fd";
-    path = fetchgit {
-      url = "https://github.com/boa-dev/temporal";
-      tag = "v0.2.3";
-      hash = "sha256-wD4pTVgQZrGONgSTDm9Eq3fo3Ez7aIC0/n4Rqgksad4=";
-    };
-  }
-  {
     name = "args-0.0.0-CiLiqmvgAADyJmrzcQTP9IOYNvTzR_KGrg3ZNNsH2Qv0";
     path = fetchgit {
       url = "https://github.com/ikskuh/zig-args";
@@ -47,19 +47,19 @@ linkFarm "zig-packages" [
     };
   }
   {
-    name = "bdwgc-8.3.0-8obE-IejLwCX53s54D3b3nIqlsMLiZ0ZtAF8nMvffTtR";
+    name = "bdwgc-8.3.0-8obE-Ky9LwD3G-0Hn12vdf3OhUGaCJxSUSlVxn-ScMJC";
     path = fetchgit {
       url = "https://github.com/bdwgc/bdwgc";
-      rev = "ea69934ed214cfb4e38d2a0176cc392af8055a83";
-      hash = "sha256-wippr/ilU5cf+2D6T+kXUDZC0r353wCYyad7Y0hQvdM=";
+      rev = "af6f40bf3ce6ea916d487e10eee9dd4691ed4a07";
+      hash = "sha256-x3nzPFXmsFdtZy8IGAF6F0boDRf0o3g14IZm1PRSp5U=";
     };
   }
   {
-    name = "bdwgc_zig-0.1.0-ffcEgVh8AAAhDLt3oykzvhRx_WDGdHCoqmswDTnmei6b";
+    name = "bdwgc_zig-0.1.0-ffcEgYd6AAA_rlVpPv9GN2Olt2DCBle_4Ageca2NDNUy";
     path = fetchgit {
       url = "https://github.com/bdwgc/bdwgc-zig";
-      rev = "1cfcd9ea8947e172f20b028fbc52e778632fa407";
-      hash = "sha256-bTjPgn44QAgWAjiLqP3S5CK9os7L1cex+TXgzKU2dHY=";
+      rev = "81e92063debddd226f3a660cee43665a04c926f3";
+      hash = "sha256-RZz4b9BcrLhxjkRTYI7RVbIIXXKyS1ZSIIo3hkzYjO0=";
     };
   }
   {
@@ -71,11 +71,11 @@ linkFarm "zig-packages" [
     };
   }
   {
-    name = "icu4zig-0.1.0-IT7GrJalAgC00wqxu8c6JBs8A580wS-QrXBE7FJ1ZVaz";
+    name = "icu4zig-0.1.0-IT7GrO3IAgCsmavpCdZXvoJFn4MCxFYJ7vVkQyH5BfrW";
     path = fetchgit {
       url = "https://codeberg.org/linus/icu4zig";
-      rev = "13caca132022c0acd9a0c04356ebf7d758340b8a";
-      hash = "sha256-fz1YnPDDEIJVxlmxUfYq3ydksu739cT6aNK5W9N1RbA=";
+      rev = "2e207c2db48a938453d6fe518fa30b76691a407a";
+      hash = "sha256-SsVKpMiv5YMTo/dsvRV8r6U2WOX3OFvolu/s2zVWu/k=";
     };
   }
   {

--- a/pkgs/by-name/ki/kiesel/package.nix
+++ b/pkgs/by-name/ki/kiesel/package.nix
@@ -14,18 +14,18 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "kiesel";
-  version = "0.2.0";
+  version = "0.3.0";
 
   src = fetchFromCodeberg {
     owner = "kiesel-js";
     repo = "kiesel";
     tag = finalAttrs.version;
-    hash = "sha256-bddGd3LPmVV8wwoVHYJJKoHS6ssYyU1hQBTGJBQJPgc=";
+    hash = "sha256-X5KpobHnqU8LR+odxeoPyVQbWLO8Yq1Tys7gNQu8/tI=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     src = "${finalAttrs.src}/pkg/zement";
-    hash = "sha256-SOp8UW0iKniXwzEGGtzX5rFAdVQKDHoEvCupquusvmo=";
+    hash = "sha256-YjbrKfkmhBxRxqg8mllK7eEsZwkFYMWL+z7u1PtjEYw=";
   };
   cargoRoot = "pkg/zement";
   deps = callPackage ./deps.nix { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
