### PR TITLE
alot: 0.11 -> 0.12

### DIFF
--- a/pkgs/by-name/al/alot/package.nix
+++ b/pkgs/by-name/al/alot/package.nix
@@ -12,7 +12,7 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "alot";
-  version = "0.11";
+  version = "0.12";
   pyproject = true;
 
   outputs = [
@@ -25,8 +25,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
   src = fetchFromGitHub {
     owner = "pazz";
     repo = "alot";
-    tag = finalAttrs.version;
-    hash = "sha256-mXaRzl7260uxio/BQ36BCBxgKhl1r0Rc6PwFZA8qNqc=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-x2o/VfIeDIWsv0JS0FBWVHEjNaktx1/MjhDnqQSe/IY=";
   };
 
   postPatch = ''
@@ -58,31 +58,29 @@ python3Packages.buildPythonApplication (finalAttrs: {
     gnupg
     notmuch
     procps
-  ]
-  ++ (with python3Packages; [
-    pytestCheckHook
-    mock
-  ]);
-
-  postBuild = lib.optionalString withManpage [
-    "make -C docs man"
+    python3Packages.pytestCheckHook
   ];
 
-  disabledTests = [
-    # Some twisted tests need internet access
-    "test_env_set"
-    "test_no_spawn_no_stdin_attached"
-    # DatabaseLockedError
-    "test_save_named_query"
-  ];
+  postBuild =
+    let
+      docPythonPath = python3Packages.makePythonPath (
+        with python3Packages;
+        [
+          notmuch2
+          standard-mailcap
+        ]
+      );
+    in
+    lib.optionalString withManpage ''
+      PYTHONPATH="$PWD:${docPythonPath}" make -C docs man
+    '';
 
   postInstall =
     let
       completionPython = python3.withPackages (ps: [ ps.configobj ]);
     in
     lib.optionalString withManpage ''
-      mkdir -p $out/man
-      cp -r docs/build/man $out/man
+      install -Dm644 docs/build/man/alot.1 -t $man/share/man/man1
     ''
     + ''
       mkdir -p $out/share/{applications,alot}


### PR DESCRIPTION
- Updates to [latest version](https://github.com/pazz/alot/compare/v0.11...v0.12)
- Also fixes build, which is broken on master

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test