### PR TITLE
nixos/test-driver: stop OCR after matching text

### DIFF
--- a/nixos/lib/test-driver/src/test_driver/machine/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/machine/__init__.py
@@ -26,6 +26,7 @@ from test_driver.efi import EfiVariable, EfiVars
 from test_driver.errors import MachineError, RequestedAssertionFailed
 from test_driver.logger import AbstractLogger
 from test_driver.machine.ocr import (
+    iter_ocr_variants,
     perform_ocr_on_screenshot,
     perform_ocr_variants_on_screenshot,
 )
@@ -1162,10 +1163,16 @@ class QemuMachine(BaseMachine):
         """
 
         def screen_matches(last_try: bool) -> bool:
-            variants = self.get_screen_text_variants()
-            for text in variants:
-                if re.search(regex, text) is not None:
-                    return True
+            variants: list[str] = []
+            retry_delays = () if last_try else (1, 2, 4)
+            with iter_ocr_variants(
+                screenshot_cb=self._managed_screenshot,
+                retry_delays=retry_delays,
+            ) as results:
+                for text in results:
+                    variants.append(text)
+                    if re.search(regex, text) is not None:
+                        return True
 
             if last_try:
                 self.log(f"Last OCR attempt failed. Text was: {variants}")

--- a/nixos/lib/test-driver/src/test_driver/machine/ocr.py
+++ b/nixos/lib/test-driver/src/test_driver/machine/ocr.py
@@ -1,7 +1,16 @@
 import os
 import shutil
 import subprocess
-from concurrent.futures import Future, ThreadPoolExecutor
+import threading
+from collections.abc import Callable, Iterable, Iterator
+from concurrent.futures import (
+    FIRST_COMPLETED,
+    CancelledError,
+    Future,
+    ThreadPoolExecutor,
+    wait,
+)
+from contextlib import AbstractContextManager, ExitStack, nullcontext
 from pathlib import Path
 
 from test_driver.errors import MachineError
@@ -23,32 +32,194 @@ def perform_ocr_variants_on_screenshot(
     that can lead to more words being detected.
     Returns a string with words for each variant.
     """
-    if shutil.which("tesseract") is None:
-        raise MachineError("OCR requested but `tesseract` is not available")
-
-    # Tesseract runs parallel on up to 4 cores.
-    # Docs suggest to run it with OMP_THREAD_LIMIT=1 for hundreds of parallel
-    # runs. Our average test run is somewhere inbetween.
-    # https://github.com/tesseract-ocr/tesseract/issues/3109
-    nix_cores: str | None = os.environ.get("NIX_BUILD_CORES")
-    cores: int = os.cpu_count() or 1 if nix_cores is None else int(nix_cores)
-    workers: int = max(1, int(cores / 4))
-
-    with ThreadPoolExecutor(max_workers=workers) as e:
-        # The idea here is to let the first tesseract call run on the raw image
-        # while the other two are preprocessed + tesseracted in parallel
-        future_results: list[Future] = [e.submit(_run_tesseract, screenshot_path)]
-        if variants:
-
-            def tesseract_processed(inverted: bool) -> str:
-                return _run_tesseract(_preprocess_screenshot(screenshot_path, inverted))
-
-            future_results.append(e.submit(tesseract_processed, False))
-            future_results.append(e.submit(tesseract_processed, True))
-        return [future.result() for future in future_results]
+    with iter_ocr_variants(
+        screenshot_cb=lambda: nullcontext(screenshot_path),
+        include_processed_variants=variants,
+    ) as results:
+        return list(results)
 
 
-def _run_tesseract(image: Path) -> str:
+class _CommandRunner:
+    def __init__(self) -> None:
+        self._cancelled = threading.Event()
+        self._lock = threading.Lock()
+        self._processes: set[subprocess.Popen[bytes]] = set()
+
+    def run(self, args: list[str | Path]) -> tuple[int, bytes, bytes]:
+        with self._lock:
+            if self._cancelled.is_set():
+                raise CancelledError
+            process = subprocess.Popen(
+                args,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            self._processes.add(process)
+
+        try:
+            stdout, stderr = process.communicate()
+        finally:
+            with self._lock:
+                self._processes.discard(process)
+
+        assert process.returncode is not None
+        return process.returncode, stdout, stderr
+
+    def delay(self, seconds: float) -> None:
+        if self._cancelled.wait(seconds):
+            raise CancelledError
+
+    def check_cancelled(self) -> None:
+        if self._cancelled.is_set():
+            raise CancelledError
+
+    def cancel(self) -> None:
+        with self._lock:
+            self._cancelled.set()
+            processes = tuple(self._processes)
+
+        for process in processes:
+            try:
+                process.kill()
+            except ProcessLookupError:
+                pass
+
+
+ScreenshotCallback = Callable[[], AbstractContextManager[Path]]
+
+
+class OcrResultStream:
+    def __init__(
+        self,
+        screenshot_cb: ScreenshotCallback,
+        include_processed_variants: bool = True,
+        *,
+        retry_delays: Iterable[float] = (),
+    ) -> None:
+        self._screenshot_cb = screenshot_cb
+        self._include_processed_variants = include_processed_variants
+        self._retry_delays = tuple(retry_delays)
+        self._runner = _CommandRunner()
+        self._screenshot_lock = threading.Lock()
+        self._exit_stack = ExitStack()
+        self._executor: ThreadPoolExecutor | None = None
+        self._futures: set[Future[str]] = set()
+        self._ready: list[str] = []
+        self._closed = False
+
+    def __enter__(self) -> "OcrResultStream":
+        if shutil.which("tesseract") is None:
+            raise MachineError("OCR requested but `tesseract` is not available")
+
+        # Tesseract runs parallel on up to 4 cores.
+        # Docs suggest OMP_THREAD_LIMIT=1 for hundreds of parallel runs. Our
+        # average test run is somewhere inbetween.
+        # https://github.com/tesseract-ocr/tesseract/issues/3109
+        nix_cores: str | None = os.environ.get("NIX_BUILD_CORES")
+        cores: int = os.cpu_count() or 1 if nix_cores is None else int(nix_cores)
+        workers: int = max(1, int(cores / 4)) + len(self._retry_delays)
+
+        def tesseract_delayed(delay: float) -> str:
+            self._runner.delay(delay)
+            # Machine command channels are not safe for concurrent use.
+            with self._screenshot_lock:
+                self._runner.check_cancelled()
+                with self._screenshot_cb() as delayed_screenshot_path:
+                    return _run_tesseract(self._runner, delayed_screenshot_path)
+
+        def tesseract_processed(screenshot_path: Path, inverted: bool) -> str:
+            processed = _preprocess_screenshot(self._runner, screenshot_path, inverted)
+            return _run_tesseract(self._runner, processed)
+
+        try:
+            screenshot_path = self._exit_stack.enter_context(self._screenshot_cb())
+            self._executor = ThreadPoolExecutor(max_workers=workers)
+            self._futures.add(
+                self._executor.submit(_run_tesseract, self._runner, screenshot_path)
+            )
+
+            # Start delayed screenshots before the processed variants. Each
+            # delayed job gets an executor slot so it cannot be queued behind
+            # a slow image conversion.
+            for delay in self._retry_delays:
+                self._futures.add(self._executor.submit(tesseract_delayed, delay))
+
+            if self._include_processed_variants:
+                self._futures.add(
+                    self._executor.submit(tesseract_processed, screenshot_path, False)
+                )
+                self._futures.add(
+                    self._executor.submit(tesseract_processed, screenshot_path, True)
+                )
+        except BaseException:
+            self.close()
+            raise
+
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.close()
+
+    def __iter__(self) -> Iterator[str]:
+        return self
+
+    def __next__(self) -> str:
+        result = self.next_result()
+        if result is None:
+            raise StopIteration
+        return result
+
+    def next_result(self, timeout: float | None = None) -> str | None:
+        """Return the next completed OCR result, or None after a timeout."""
+        if self._ready:
+            return self._ready.pop()
+        if not self._futures:
+            return None
+
+        completed, self._futures = wait(
+            self._futures,
+            timeout=timeout,
+            return_when=FIRST_COMPLETED,
+        )
+        self._ready.extend(future.result() for future in completed)
+        if self._ready:
+            return self._ready.pop()
+        return None
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+
+        self._runner.cancel()
+        for future in self._futures:
+            future.cancel()
+        try:
+            if self._executor is not None:
+                self._executor.shutdown(wait=True, cancel_futures=True)
+        finally:
+            self._exit_stack.close()
+
+
+def iter_ocr_variants(
+    screenshot_cb: ScreenshotCallback,
+    include_processed_variants: bool = True,
+    *,
+    retry_delays: Iterable[float] = (),
+) -> OcrResultStream:
+    """
+    Take a screenshot and return OCR interpretations as they become available.
+    Take fresh screenshots for raw OCR after each retry delay. Closing the
+    result stream cancels unfinished work.
+    """
+    return OcrResultStream(
+        screenshot_cb,
+        include_processed_variants,
+        retry_delays=retry_delays,
+    )
+
+
+def _run_tesseract(runner: _CommandRunner, image: Path) -> str:
     # tesseract --help-oem
     # OCR Engine modes (OEM):
     #  0|tesseract_only          Legacy engine only.
@@ -57,7 +228,7 @@ def _run_tesseract(image: Path) -> str:
     #  3|default                 Default, based on what is available.
     ocr_engine_mode = 2
 
-    ret = subprocess.run(
+    returncode, stdout, _stderr = runner.run(
         [
             "tesseract",
             image,
@@ -68,15 +239,16 @@ def _run_tesseract(image: Path) -> str:
             "debug_file=/dev/null",
             "--psm",
             "11",
-        ],
-        capture_output=True,
+        ]
     )
-    if ret.returncode != 0:
-        raise MachineError(f"OCR failed with exit code {ret.returncode}")
-    return ret.stdout.decode("utf-8")
+    if returncode != 0:
+        raise MachineError(f"OCR failed with exit code {returncode}")
+    return stdout.decode("utf-8")
 
 
-def _preprocess_screenshot(screenshot_path: Path, negate: bool = False) -> Path:
+def _preprocess_screenshot(
+    runner: _CommandRunner, screenshot_path: Path, negate: bool = False
+) -> Path:
     if shutil.which("magick") is None:
         raise MachineError("OCR requested but `magick` is not available")
 
@@ -112,14 +284,13 @@ def _preprocess_screenshot(screenshot_path: Path, negate: bool = False) -> Path:
         "1x65535",
     ]
 
-    ret = subprocess.run(
-        ["magick", "convert"] + magick_args + [screenshot_path, out_file],
-        capture_output=True,
+    returncode, stdout, stderr = runner.run(
+        ["magick", "convert"] + magick_args + [screenshot_path, out_file]
     )
 
-    if ret.returncode != 0:
+    if returncode != 0:
         raise MachineError(
-            f"Image processing failed with exit code {ret.returncode}, stdout: {ret.stdout.decode()}, stderr: {ret.stderr.decode()}"
+            f"Image processing failed with exit code {returncode}, stdout: {stdout.decode()}, stderr: {stderr.decode()}"
         )
 
     return out_file


### PR DESCRIPTION
wait_for_text() currently waits for every OCR variant before checking
whether any matches. A slow processed variant can therefore block a test
even when raw OCR already found the text.

Refactor OCR execution into a cancellable result stream while retaining
the existing list-returning helper. This allows to consume variant
results as they complete, bailing out on the first match.

Additionally, a screenshot can be taken before a UI update is rendered,
so also race raw OCR from fresh screenshots after 1, 2, and 4 seconds.
Cancellation interrupts the backoff waits and active OCR subprocesses.

In my testing, firefox_decrypt's QEMU test script fell from 462.26 to
25.16 seconds (18.4x faster). Its quit-dialog wait fell from 426.53 to
1.18 seconds (361x faster).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
