### PR TITLE
jank: init at 0.1.0

### DIFF
--- a/pkgs/by-name/ja/jank/package.nix
+++ b/pkgs/by-name/ja/jank/package.nix
@@ -29,7 +29,7 @@ let
   zstd-src = fetchFromGitHub {
     owner = "facebook";
     repo = "zstd";
-    rev = "v1.5.7";
+    tag = "v1.5.7";
     hash = "sha256-tNFWIT9ydfozB8dWcmTMuZLCQmQudTFJIkSr0aG7S44=";
   };
 in

--- a/pkgs/by-name/ja/jank/package.nix
+++ b/pkgs/by-name/ja/jank/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   fetchFromGitHub,
-  # Use LLVM 22 since it's the first LLVM version has all of jank's required changes upstreamed. Few performance regressions expected to be fixed in LLVM 23
+  # Use LLVM 22 since it's the first LLVM version that has all of jank's required changes upstreamed. Few performance regressions expected to be fixed in LLVM 23
   llvmPackages_22,
   cmake,
   ninja,
@@ -85,7 +85,7 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     "-DFETCHCONTENT_SOURCE_DIR_LIBDWARF=${libdwarf-lite-src}"
     "-DFETCHCONTENT_SOURCE_DIR_ZSTD=${zstd-src}"
     (lib.cmakeBool "jank_unity_build" true)
-    (lib.cmakeBool "jank_test" finalAttrs.doCheck) 
+    (lib.cmakeBool "jank_test" finalAttrs.doCheck)
   ];
 
   # This runs as a bash script just before CMake configures the project

--- a/pkgs/by-name/ja/jank/package.nix
+++ b/pkgs/by-name/ja/jank/package.nix
@@ -37,16 +37,13 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
   pname = "jank";
   version = "0.1.0";
 
-  # add these two lines to satisfy nix tests, and remember to nix fmt before commit
   __structuredAttrs = true;
   strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "jank-lang";
     repo = "jank";
-    # rev = "86cd33b8edb7504209719f43391a185b84211a0c";
     rev = "7d185b25dacce7950bf7194830aad90c5b1bb6aa";
-    # hash = lib.fakeHash;
     hash = "sha256-og8BVjFAQwlS2M9js6+5lk6VMZXLuySH+eC5pLvmA8I=";
     fetchSubmodules = true;
 
@@ -74,7 +71,6 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     patchShebangs ./compiler+runtime/bin/ar-merge
   '';
-  # new pkgs must fortify to satisfy nixpkgs tests
   hardeningDisable = [ "fortify" ];
 
   cmakeBuildDir = "compiler+runtime/build";
@@ -88,13 +84,11 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "jank_test" finalAttrs.doCheck)
   ];
 
-  # This runs as a bash script just before CMake configures the project
   preConfigure = ''
     local cxxFlags="$(cat ${llvmPackages.clang}/nix-support/cc-cflags) $(cat ${llvmPackages.clang}/nix-support/libc-crt1-cflags)"
 
     local linkerFlags="$(cat ${llvmPackages.clang}/nix-support/cc-ldflags) -Wl,-rpath,${llvmPackages.stdenv.cc.libc}/lib -L${lib.getLib llvmPackages.libllvm}/lib -L${lib.getLib bzip2}/lib -L${lib.getLib openssl}/lib -L${lib.getLib zlib}/lib -L${lib.getLib zstd}/lib -L${lib.getLib libedit}/lib -L${lib.getLib libxml2}/lib"
 
-    # Append to the array created by structuredAttrs
     cmakeFlags+=(
       "-DCMAKE_CXX_FLAGS=$cxxFlags"
       "-DCMAKE_EXE_LINKER_FLAGS=$linkerFlags"

--- a/pkgs/by-name/ja/jank/package.nix
+++ b/pkgs/by-name/ja/jank/package.nix
@@ -82,6 +82,7 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     "-DFETCHCONTENT_SOURCE_DIR_ZSTD=${zstd-src}"
     (lib.cmakeBool "jank_unity_build" true)
     (lib.cmakeBool "jank_test" finalAttrs.doCheck)
+    (lib.cmakeBool "jank_force_phase_2" true)
   ];
 
   preConfigure = ''

--- a/pkgs/by-name/ja/jank/package.nix
+++ b/pkgs/by-name/ja/jank/package.nix
@@ -85,8 +85,7 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     "-DFETCHCONTENT_SOURCE_DIR_LIBDWARF=${libdwarf-lite-src}"
     "-DFETCHCONTENT_SOURCE_DIR_ZSTD=${zstd-src}"
     (lib.cmakeBool "jank_unity_build" true)
-    (lib.cmakeBool "jank_test" finalAttrs.doCheck)
-    # (lib.cmakeBool "jank_force_phase_2" true) # This phase 2 force should only be needed if we're not using CMAKE_BUILD_TYPE=Release. 
+    (lib.cmakeBool "jank_test" finalAttrs.doCheck) 
   ];
 
   # This runs as a bash script just before CMake configures the project

--- a/pkgs/by-name/ja/jank/package.nix
+++ b/pkgs/by-name/ja/jank/package.nix
@@ -86,7 +86,7 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     "-DFETCHCONTENT_SOURCE_DIR_ZSTD=${zstd-src}"
     (lib.cmakeBool "jank_unity_build" true)
     (lib.cmakeBool "jank_test" finalAttrs.doCheck)
-    (lib.cmakeBool "jank_force_phase_2" true)
+    # (lib.cmakeBool "jank_force_phase_2" true) # This phase 2 force should only be needed if we're not using CMAKE_BUILD_TYPE=Release. 
   ];
 
   # This runs as a bash script just before CMake configures the project

--- a/pkgs/by-name/ja/jank/package.nix
+++ b/pkgs/by-name/ja/jank/package.nix
@@ -1,0 +1,125 @@
+{
+  lib,
+  fetchFromGitHub,
+  llvmPackages_22,
+  cmake,
+  ninja,
+  git,
+  bzip2,
+  openssl,
+  zstd,
+  zlib,
+  libedit,
+  libxml2,
+  boost,
+  glibcLocales,
+}:
+
+let
+  llvmPackages = llvmPackages_22;
+
+  libdwarf-lite-src = fetchFromGitHub {
+    owner = "jeremy-rifkin";
+    repo = "libdwarf-lite";
+    rev = "5e71a74491dddc231664bbcd6a8cf8a8643918e9";
+    hash = "sha256-qHikjAG5xuuHquqqKGuiDHXVZSlg/MbNp9JNSAKM/Hs=";
+  };
+
+  zstd-src = fetchFromGitHub {
+    owner = "facebook";
+    repo = "zstd";
+    rev = "v1.5.7";
+    hash = "sha256-tNFWIT9ydfozB8dWcmTMuZLCQmQudTFJIkSr0aG7S44=";
+  };
+in
+llvmPackages.stdenv.mkDerivation (finalAttrs: {
+  pname = "jank";
+  version = "unstable-0.1-alpha-2026-05-22";
+
+  # add these two lines to satisfy nix tests, and remember to nix fmt before commit
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "jank-lang";
+    repo = "jank";
+    # rev = "86cd33b8edb7504209719f43391a185b84211a0c";
+    rev = "7d185b25dacce7950bf7194830aad90c5b1bb6aa";
+    # hash = lib.fakeHash;
+    hash = "sha256-og8BVjFAQwlS2M9js6+5lk6VMZXLuySH+eC5pLvmA8I=";
+    fetchSubmodules = true;
+
+  };
+
+  nativeBuildInputs = [
+    llvmPackages.clang
+    llvmPackages.libclang.dev
+    cmake
+    git
+    ninja
+    glibcLocales
+  ];
+
+  buildInputs = [
+    llvmPackages.libllvm.dev
+    bzip2
+    openssl
+    zstd
+    libedit
+    libxml2
+    boost
+  ];
+
+  postPatch = ''
+    patchShebangs ./compiler+runtime/bin/ar-merge
+  '';
+  # new pkgs must fortify to satisfy nixpkgs tests
+  hardeningDisable = [ "fortify" ];
+
+  cmakeBuildDir = "compiler+runtime/build";
+  cmakeDir = "..";
+
+  cmakeFlags = [
+    "-DCMAKE_SKIP_RPATH=ON"
+    "-DFETCHCONTENT_SOURCE_DIR_LIBDWARF=${libdwarf-lite-src}"
+    "-DFETCHCONTENT_SOURCE_DIR_ZSTD=${zstd-src}"
+    (lib.cmakeBool "jank_unity_build" true)
+    (lib.cmakeBool "jank_test" finalAttrs.doCheck)
+    (lib.cmakeBool "jank_force_phase_2" true)
+  ];
+
+  # This runs as a bash script just before CMake configures the project
+  preConfigure = ''
+    local cxxFlags="$(cat ${llvmPackages.clang}/nix-support/cc-cflags) $(cat ${llvmPackages.clang}/nix-support/libc-crt1-cflags)"
+
+    local linkerFlags="$(cat ${llvmPackages.clang}/nix-support/cc-ldflags) -Wl,-rpath,${llvmPackages.stdenv.cc.libc}/lib -L${lib.getLib llvmPackages.libllvm}/lib -L${lib.getLib bzip2}/lib -L${lib.getLib openssl}/lib -L${lib.getLib zlib}/lib -L${lib.getLib zstd}/lib -L${lib.getLib libedit}/lib -L${lib.getLib libxml2}/lib"
+
+    # Append to the array created by structuredAttrs
+    cmakeFlags+=(
+      "-DCMAKE_CXX_FLAGS=$cxxFlags"
+      "-DCMAKE_EXE_LINKER_FLAGS=$linkerFlags"
+      "-DCMAKE_SHARED_LINKER_FLAGS=$linkerFlags"
+      "-DCMAKE_MODULE_LINKER_FLAGS=$linkerFlags"
+    )
+  '';
+
+  env = {
+    LC_ALL = "C.UTF-8";
+  };
+
+  doCheck = true;
+  checkPhase = ''
+    pushd ..
+    ./build/jank-test
+    popd
+  '';
+
+  meta = with lib; {
+    description = "The native Clojure dialect hosted on LLVM with seamless C++ interop";
+    homepage = "https://jank-lang.org";
+    license = licenses.mpl20;
+    maintainers = [ ];
+    platforms = platforms.linux ++ platforms.darwin;
+    mainProgram = "jank";
+  };
+})

--- a/pkgs/by-name/ja/jank/package.nix
+++ b/pkgs/by-name/ja/jank/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  # Use LLVM 22 since it's the first LLVM version has all of jank's required changes upstreamed. Few performance regressions expected to be fixed in LLVM 23
   llvmPackages_22,
   cmake,
   ninja,

--- a/pkgs/by-name/ja/jank/package.nix
+++ b/pkgs/by-name/ja/jank/package.nix
@@ -35,7 +35,7 @@ let
 in
 llvmPackages.stdenv.mkDerivation (finalAttrs: {
   pname = "jank";
-  version = "unstable-0.1-alpha-2026-05-22";
+  version = "0.1.0";
 
   # add these two lines to satisfy nix tests, and remember to nix fmt before commit
   __structuredAttrs = true;

--- a/pkgs/by-name/ja/jank/package.nix
+++ b/pkgs/by-name/ja/jank/package.nix
@@ -107,6 +107,7 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     pushd ..
     ./build/jank-test
     popd
+    runHook postCheck
   '';
 
   meta = with lib; {


### PR DESCRIPTION
New package that successfully builds on NixOS into the result folder with working REPL.

Confirm the package works with strictDeps and structuredAttrs. Also works on MacOS on an M2 chip.

Additionally, used built-in health check:
```
~/Documents/jj/nixpkgs> ./result/bin/jank check-health
─ system ───────────────────────────────────────────────────────────────────────────────────────────
─ ✅ operating system: linux
─ ✅ default triple: x86_64-unknown-linux-gnu

─ jank install ─────────────────────────────────────────────────────────────────────────────────────
─ ✅ jank version: jank-0.1-alpha
─ ✅ jank resource dir: ../lib/jank/0.1
─ ✅ jank resolved resource dir: /nix/store/1k4l445gqbyqfwqgy3y1bnw92irr373r-jank-unstable-0.1-alpha-2026-05-22/bin/../lib/jank/0.1 (found)
─ ✅ jank user cache dir: /home/arik/.cache/jank/x86_64-unknown-linux-gnu-59ca8112712f2aff60d4783cd69118342d54e3049479948477b3f76a069525ba (not found)

─ clang install ────────────────────────────────────────────────────────────────────────────────────
─ ✅ configured clang path: /nix/store/5vnqv7z65pp1wqlbhmfjb8hgz3zapzly-clang-wrapper-22.1.5/bin/clang++ (found)
─ ✅ configured clang resource dir: /nix/store/5vnqv7z65pp1wqlbhmfjb8hgz3zapzly-clang-wrapper-22.1.5/resource-root (found)

─ jank runtime ─────────────────────────────────────────────────────────────────────────────────────
Note: Looks like your first run with these flags. Building pre-compiled header… done!
─ ✅ jank runtime initialized
─ ✅ jank pch path: /home/arik/.cache/jank/x86_64-unknown-linux-gnu-59ca8112712f2aff60d4783cd69118342d54e3049479948477b3f76a069525ba (found)
─ ✅ jank can jit compile c++
─ ✅ jank can aot compile working binaries

─ support ──────────────────────────────────────────────────────────────────────────────────────────
If you're having issues with jank, please either ask the jank community on the Clojurians Slack or report the issue on Github.
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ✅  ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ✅ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ✅ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ✅ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ✅ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
