### PR TITLE
gostringsynth: init at 0-unstable-2022-03-10

### DIFF
--- a/pkgs/by-name/go/gostringsynth/package.nix
+++ b/pkgs/by-name/go/gostringsynth/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+  pkg-config,
+  portaudio,
+}:
+buildGoModule (finalAttrs: {
+  pname = "gostringsynth";
+  version = "0-unstable-2022-03-10";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "crnbaker";
+    repo = "gostringsynth";
+    rev = "17a3ff88f78d8d2a5059c96294afb1470a4e09a6";
+    hash = "sha256-YtKUCNPIulmzuEt+9lG8LtJJADCcGGoszXSSSwWFjNI=";
+  };
+
+  vendorHash = "sha256-5PvlF03kWn0gLmh+XfFMBOg8x/oLDPuwa++MVA1+OQs=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    portaudio
+  ];
+
+  meta = {
+    description = "Real-time, polyphonic physical-modelling synthesizer that simulates the vibration of strings";
+    homepage = "https://github.com/crnbaker/gostringsynth";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ulysseszhan ];
+    mainProgram = "gostringsynth";
+  };
+})


### PR DESCRIPTION
[gostringsynth](https://github.com/crnbaker/gostringsynth) is a real-time, polyphonic physical-modelling synthesizer that simulates the vibration of strings using the finite-difference time-domain method.

ALSA seems to output a bunch of errors that pollutes the UI on my machine, but the program can be used as usual.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
