### PR TITLE
flatpak: run Fish profile integration only in login shells

### DIFF
--- a/pkgs/by-name/fl/flatpak/fish-login-shell.patch
+++ b/pkgs/by-name/fl/flatpak/fish-login-shell.patch
@@ -1,0 +1,13 @@
+diff --git a/profile/flatpak.fish b/profile/flatpak.fish
+index ee15074b..9277bfc2 100644
+--- a/profile/flatpak.fish
++++ b/profile/flatpak.fish
+@@ -1,4 +1,7 @@
+-if type -q flatpak
++# Fish sources vendor configuration for every shell, including `fish -c`.
++# Descendants inherit XDG_DATA_DIRS, so only initialize it in a login shell
++# instead of invoking `flatpak --installations` for every Fish process.
++if status is-login; and type -q flatpak
+     # Fast-path: skip spawning `flatpak --installations` when the canonical
+     # user installation's exports/share is already present in $XDG_DATA_DIRS.
+     set -x --path XDG_DATA_DIRS $XDG_DATA_DIRS

--- a/pkgs/by-name/fl/flatpak/package.nix
+++ b/pkgs/by-name/fl/flatpak/package.nix
@@ -115,6 +115,12 @@ stdenv.mkDerivation (finalAttrs: {
     # https://github.com/NixOS/nixpkgs/issues/53441
     ./unset-env-vars.patch
 
+    # Flatpak installs flatpak.fish as vendor configuration, which Fish sources
+    # for every shell, including non-interactive `fish -c` processes. Restrict
+    # the integration to login shells: it only changes XDG_DATA_DIRS, which
+    # descendant shells inherit, and avoids repeatedly running Flatpak.
+    ./fish-login-shell.patch
+
     # The icon validator needs to access the gdk-pixbuf loaders in the Nix store
     # and cannot bind FHS paths since those are not available on NixOS.
     finalAttrs.passthru.icon-validator-patch


### PR DESCRIPTION
Hello. I had a misfortune of needing to install Flatpak and later noticed that opening a new tmux pane would sometimes print linker warnings such as:

```text
'g_io_module_load': .../gpaste-45.3/lib/libgpaste-2.so: undefined symbol: g_io_module_load
Failed to load module: .../gpaste-45.3/lib/libgpaste-2.so
```

Might be in part caused by some sandboxing I'm doing, but it doesn't seem reasonable for that thing to insert itself into every shell invocation just to insert its desktop icons do XDG dirs somewhere (IIUC).

I had clanker used to debug this and write a patch, but I'm a reasonable human being overseeing it.

Opening as a draft not to forget, will drive it for a day to see if I haven't broke something.

### Summary

Restrict Flatpak's Fish profile integration to login shells. This prevents non-login and non-interactive Fish processes from unnecessarily invoking `flatpak --installations` while preserving initialization for environments inherited from login shells.

### Details

Flatpak ships `profile/flatpak.fish` in its source tarball rather than nixpkgs, so add and apply a downstream patch. The patch documents that Fish sources vendor configuration for every process and guards the integration with `status is-login`; because the script only adjusts `XDG_DATA_DIRS`, descendant shells inherit the initialized value.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
