### PR TITLE
nixos/release-combined: tests.shadow moved to tests.shadow.login

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -201,7 +201,7 @@ rec {
         (onFullSupported "nixos.tests.printing-socket")
         (onFullSupported "nixos.tests.proxy")
         (onFullSupported "nixos.tests.sddm.default")
-        (onFullSupported "nixos.tests.shadow")
+        (onFullSupported "nixos.tests.shadow.login")
         (onFullSupported "nixos.tests.simple-container")
         (onFullSupported "nixos.tests.simple-vm")
         (onFullSupported "nixos.tests.sway")


### PR DESCRIPTION
This unblocks eval after the move in commit
963c03f40c7d945fa88ae0862fef0a490e21083c

_The usual checklist doesn't apply here really._

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
