### PR TITLE
cosmic-ext-applet-mare-player: init at 0.3.0

### DIFF
--- a/pkgs/by-name/co/cosmic-ext-applet-mare-player/package.nix
+++ b/pkgs/by-name/co/cosmic-ext-applet-mare-player/package.nix
@@ -1,0 +1,89 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  libcosmicAppHook,
+  just,
+  pkg-config,
+  dbus,
+  glib,
+  glib-networking,
+  gst_all_1,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cosmic-ext-applet-mare-player";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "glima";
+    repo = "mare-player";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-oxaL1dLNq2B6Vn6ZzztWG20pAjLTdWtIiOSkCMo31YQ=";
+  };
+
+  cargoHash = "sha256-R87TNV0Fn6VIsIdotjnpS9KYPeD5QuhHVaBS2c1dSt8=";
+
+  separateDebugInfo = true;
+  __structuredAttrs = true;
+
+  # The install requires the mare-video-window workspace member.
+  cargoBuildFlags = [ "--workspace" ];
+  cargoTestFlags = [ "--workspace" ];
+
+  # These tests fail in the Nix build environment for some reason.
+  checkFlags = [
+    "--skip=image_cache::tests"
+    "--skip=language_loader::language_loader_current_language_is_english_fallback"
+  ];
+
+  nativeBuildInputs = [
+    just
+    pkg-config
+    libcosmicAppHook
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    dbus
+    glib
+    glib-networking
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-libav
+  ];
+
+  dontUseJustBuild = true;
+  dontUseJustCheck = true;
+
+  justFlags = [
+    "--set"
+    "prefix"
+    (placeholder "out")
+    "--set"
+    "cargo-target-dir"
+    "target/${stdenv.hostPlatform.rust.cargoShortTarget}"
+  ];
+
+  preFixup = ''
+    libcosmicAppWrapperArgs+=(
+      --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0"
+      --prefix GIO_EXTRA_MODULES : "${glib-networking}/lib/gio/modules"
+    )
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://github.com/glima/mare-player";
+    description = "COSMIC desktop applet for TIDAL music streaming";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nyabinary ];
+    platforms = lib.platforms.linux;
+    mainProgram = "cosmic-applet-mare";
+  };
+})


### PR DESCRIPTION
<!--

^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Adds https://github.com/glima/mare-player :3
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
