### PR TITLE
socket-vmnet: init at 1.2.2; minikube: add socket_vmnet support

### DIFF
--- a/pkgs/by-name/mi/minikube/package.nix
+++ b/pkgs/by-name/mi/minikube/package.nix
@@ -9,6 +9,7 @@
   libvirt,
   withQemu ? false,
   qemu,
+  socket-vmnet,
   withVfkit ? false,
   vfkit,
   makeWrapper,
@@ -77,9 +78,15 @@ buildGoModule (finalAttrs: {
       --prefix PATH : ${
         lib.makeBinPath (
           lib.optionals withQemu [ qemu ]
-          ++ lib.optionals stdenv.hostPlatform.isLinux [ libvirt ]
+          ++ lib.optionals (withQemu && stdenv.hostPlatform.isDarwin) [ socket-vmnet ]
           ++ lib.optionals (withVfkit && stdenv.hostPlatform.isDarwin) [ vfkit ]
+          ++ lib.optionals stdenv.hostPlatform.isLinux [ libvirt ]
         )
+      } \
+      ${
+        lib.optionalString (
+          withQemu && stdenv.hostPlatform.isDarwin
+        ) ''--set MINIKUBE_SOCKET_VMNET_CLIENT_PATH "${lib.getExe' socket-vmnet "socket_vmnet_client"}"''
       } \
       ${lib.optionalString stdenv.hostPlatform.isLinux "--prefix LD_LIBRARY_PATH : ${
         lib.makeLibraryPath [ libvirt ]

--- a/pkgs/by-name/so/socket-vmnet/package.nix
+++ b/pkgs/by-name/so/socket-vmnet/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "socket-vmnet";
+  version = "1.2.2";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "lima-vm";
+    repo = "socket_vmnet";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-D5Z4aml82h397ho48HFeXwR6y2XkopFIKjO09jUgFdo=";
+  };
+
+  postPatch = ''
+    # NOTA BENE:
+    # Since socket_vmnet is macOS only the upstream Makefile assumes
+    # standard system utilities such as date from /bin/ and logger
+    # from /usr/bin are available through $PATH.
+    # This is not the case for the nixpkgs build environment.
+    # To maintain compatability with nixpkgs build env nixpkgs dependency
+    # purity and the following replacements are made:
+    substituteInPlace Makefile \
+       --replace-fail "logger" "echo" \
+       --replace-fail "-r $(SOURCE_DATE_EPOCH)" "-d @$(SOURCE_DATE_EPOCH)"
+    substituteInPlace launchd/io.github.lima-vm.socket_vmnet{,.bridged.en0}.plist \
+      --replace-fail "/opt/socket_vmnet/bin/socket_vmnet" "${placeholder "out"}/bin/socket_vmnet"
+  '';
+
+  dontConfigure = true;
+
+  makeFlags = [
+    "VERSION=${finalAttrs.version}"
+    "SOURCE_DATE_EPOCH=0"
+  ];
+
+  makeTargets = [
+    "socket_vmnet"
+    "socket_vmnet_client"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    make PREFIX=$out $makeFlags install.{bin,doc}
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Vmnet.framework support for unmodified rootless QEMU";
+    homepage = "https://github.com/lima-vm/socket_vmnet";
+    changelog = "https://github.com/lima-vm/socket_vmnet/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ afh ];
+    mainProgram = "socket_vmnet";
+    platforms = lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

When starting `minikube` on Darwin with the `qemu` driver and `user` network it warns about:
```
❗  You are using the QEMU driver without a dedicated network, which doesn't support `minikube service` & `minikube tunnel` commands.
```

According to the[ documentation for using the `qemu` driver on macOS](https://minikube.sigs.k8s.io/docs/drivers/qemu/) using the [`socket_vment`](https://github.com/lima-vm/socket_vmnet) is recommended.

This PR adds the `socket_vmnet` package and integrates it with `minikube` when building on Darwin, as otherwise starting minikube with the `qemu` driver and `socket_vmnet` network fails with:
```
🙈  Exiting due to NOT_FOUND_SOCKET_VMNET:
```

To create a socket_vmnet for use with minikube:
```
sudo socket_vmnet \
  --vmnet-gateway=192.168.105.1 \
  --pidfile=/var/run/socket_vmnet.pid \
  /var/run/socket_vmnet
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
