### PR TITLE
mawk: fix `passthru.tests`, relax hardening options

### DIFF
--- a/pkgs/by-name/ma/mawk/package.nix
+++ b/pkgs/by-name/ma/mawk/package.nix
@@ -21,10 +21,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
+  hardeningDisable = [
+    "strictflexarrays1"
+  ];
+
   passthru = {
     tests.version = testers.testVersion {
       package = finalAttrs.finalPackage;
       command = "mawk -W version";
+      version = lib.replaceString "-" " " finalAttrs.version;
     };
     updateScript = directoryListingUpdater {
       inherit (finalAttrs) pname version;


### PR DESCRIPTION
`nix-build -A mawk.passthru.tests` was previously failing:
> error: builder for '/nix/store/gc20k2mizdw3aacda6nqwyvi7kqzn1dh-mawk-1.3.4-20240819-test-version.drv' failed with exit code 1;
>        last 2 log lines:
>        > mawk -W version returned a non-zero exit code.
>        > *** buffer overflow detected ***: terminated

the `mawk` binary was unusable; would crash on *any* invocation.

context: <https://github.com/NixOS/nixpkgs/pull/533402#issuecomment-4960077454>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
