### PR TITLE
egl-wayland, egl-wayland2: update to latest upstream commits

### DIFF
--- a/pkgs/by-name/eg/egl-wayland/package.nix
+++ b/pkgs/by-name/eg/egl-wayland/package.nix
@@ -16,7 +16,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "egl-wayland";
-  version = "1.1.21";
+  version = "1.1.21-unstable-2026-01-06";
 
   outputs = [
     "out"
@@ -26,8 +26,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "egl-wayland";
-    tag = finalAttrs.version;
-    hash = "sha256-a98DzmzCG6DlLJ1HCl/LeD21Q7yyNbTce1poOoAnTjA=";
+    rev = "a557bed172dcd7ba379095f784d047202281c0de";
+    hash = "sha256-zRL2hzh2ZRE4ZhvG3+OvreRhwY7JEwOrisFVK38Uu4w=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/eg/egl-wayland2/package.nix
+++ b/pkgs/by-name/eg/egl-wayland2/package.nix
@@ -17,13 +17,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "egl-wayland2";
-  version = "1.0.1";
+  version = "1.0.1-unstable-2026-07-07";
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "egl-wayland2";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-Udr+tihx/Si2ynFyM1FW2CIUgTg9SQn7AgrOPpGTxpY=";
+    rev = "b2834a6c05ea0892edf1aaf15f0f0d72418a2a0f";
+    hash = "sha256-sYknMcjFLFHFb3lw5XgTLWBWPXawn5mjpyZTf7ZxLlk=";
   };
 
   depsBuildBuild = [


### PR DESCRIPTION
Update NVIDIA's two EGL Wayland external-platform libraries to their current upstream commits. Neither repository has tagged the versions currently declared by its Meson project yet, so these use Nixpkgs unstable versioning.

Notable upstream changes:

- `egl-wayland`: removes a synchronous `wl_display_roundtrip_queue()` from the explicit-sync swap path and uses `wl_display_flush()` instead, avoiding a per-frame Wayland round trip.
- `egl-wayland2`: includes post-1.0.1 DMA-BUF/swapchain fixes, including closing DMA-BUF file descriptors on swapchain creation failure and correcting `eplWlHookQueryString`'s error return.

Upstream comparisons:

- https://github.com/NVIDIA/egl-wayland/compare/1.1.21...a557bed172dcd7ba379095f784d047202281c0de
- https://github.com/NVIDIA/egl-wayland2/compare/v1.0.1...b2834a6c05ea0892edf1aaf15f0f0d72418a2a0f

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/tree/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/tree/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/tree/master/pkgs/test