### PR TITLE
python3Packages.i3-py: migrate to pyproject, use finalAttrs, use hash attribute

### DIFF
--- a/pkgs/development/python-modules/i3-py/default.nix
+++ b/pkgs/development/python-modules/i3-py/default.nix
@@ -2,11 +2,12 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   version = "0.6.4";
-  format = "setuptools";
+  pyproject = true;
   pname = "i3-py";
 
   src = fetchPypi {
@@ -16,6 +17,8 @@ buildPythonPackage rec {
 
   # no tests in tarball
   doCheck = false;
+
+  build-system = [ setuptools ];
 
   meta = {
     description = "Tools for i3 users and developers";

--- a/pkgs/development/python-modules/i3-py/default.nix
+++ b/pkgs/development/python-modules/i3-py/default.nix
@@ -5,20 +5,20 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   version = "0.6.4";
   pyproject = true;
   pname = "i3-py";
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "1sgl438jrb4cdyl7hbc3ymwsf7y3zy09g1gh7ynilxpllp37jc8y";
+    inherit (finalAttrs) pname version;
+    hash = "sha256-HjF5xqX0dhqtP/CFl4D/wx+nefWDLXiob4ysLNEg9Ok=";
   };
+
+  build-system = [ setuptools ];
 
   # no tests in tarball
   doCheck = false;
-
-  build-system = [ setuptools ];
 
   meta = {
     description = "Tools for i3 users and developers";
@@ -26,4 +26,4 @@ buildPythonPackage rec {
     license = lib.licenses.gpl3;
     platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
- #515974
- use `finalAttrs`
- use `hash` attribute instead of `sha256`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
