### PR TITLE
doc/style.css: fix .nav-sidebar class selector

### DIFF
--- a/doc/style.css
+++ b/doc/style.css
@@ -525,37 +525,36 @@ nav.toc-sidebar summary {
   list-style: none;
 }
 
-nav.toc summary::before {
+nav.toc-sidebar summary::before {
   content: "▸";
   flex: none;
   font-size: 0.75em;
 }
-nav.toc details[open] > summary::before {
+nav.toc-sidebar details[open] > summary::before {
   content: "▾";
 }
 
-nav.toc a {
+nav.toc-sidebar a {
   display: block;
   width: 100%;
   padding: 3px 8px;
   border-left: 3px solid transparent;
   border-radius: 3px;
   color: inherit;
-  text-decoration: none;
   transition:
     background-color 120ms ease,
     border-color 120ms ease;
 }
-nav.toc a:hover {
+nav.toc-sidebar a:hover {
   background-color: #f2f2f2;
 }
 
-nav.toc a.active {
+nav.toc-sidebar a.active {
   background-color: #d8d8d8;
   border-left-color: #444;
   font-weight: 600;
 }
-nav.toc a.active-trail {
+nav.toc-sidebar a.active-trail {
   border-left-color: #bbb;
   background-color: #e8e8e8;
 }


### PR DESCRIPTION
Fix regression introduced in https://github.com/NixOS/nixpkgs/pull/542596

I did not notice that nav.toc is not selecting the correct element. Users are now unable to expand the details in the sidebar.
The correct selector would have been "nav.toc-sidebar" or "ol.nav"

Ideally this gets merged asap, so we don't publish some broken manual into the unstable channel

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
