### PR TITLE
doc: add documentation for writers

### DIFF
--- a/doc/build-helpers.md
+++ b/doc/build-helpers.md
@@ -20,6 +20,7 @@ There is no uniform interface for build helpers.
 build-helpers/fixed-point-arguments.chapter.md
 build-helpers/fetchers.chapter.md
 build-helpers/trivial-build-helpers.chapter.md
+build-helpers/writers.chapter.md
 build-helpers/testers.chapter.md
 build-helpers/dev-shell-tools.chapter.md
 build-helpers/special.md

--- a/doc/build-helpers/writers.chapter.md
+++ b/doc/build-helpers/writers.chapter.md
@@ -1,11 +1,11 @@
 # Writers {#chap-writers}
 
-The `pkgs.writers` helpers let you write a small Python script directly inside a Nix expression. You provide a script as text, and it builds a ready to run program for you.
+The `pkgs.writers` helpers let you write a small script directly inside a Nix expression. You provide a script as text, and it builds a ready to run program for you.
 
 They do two useful things:
 
 - If your script needs a library, the writer makes it available, so you don't have to install anything or use `nix-shell`.
-- Before finishing, the writer checks your script with `flake8`. If something is wrong, the build fails, so a broken script never gets built.
+- Before finishing, the writer checks your script. For Python that check is `flake8`; other languages use their own compiler or linter. If something is wrong, the build fails, so a broken script never gets built.
 
 They are meant for short scripts. For real programs made of many files, use [`buildPythonApplication`](#buildpythonapplication-function) instead.
 
@@ -44,3 +44,15 @@ writePython3Bin "whatsmyip"
 ```
 
 This builds `bin/whatsmyip`. The script can `import requests` because the writer set Python up with that library. You would run this using: `nix-build writers-test.nix`
+:::
+
+## Other writers {#ssec-writers-other}
+
+Python is not the only language with a writer. They all work the same way: give a name, sometimes a set of options, and the script. Each writer also has a `Bin` version that puts the program in a `bin/` folder.
+
+- Shells: `writeBash`, `writeDash`, `writeFish`, `writeNu`. These need no options, just a name and the script.
+- Other languages: `writeBabashka`, `writeFSharp`, `writeGuile`, `writeHaskell`, `writeJS`, `writeLua`, `writeNim`, `writePerl`, `writeRuby`, `writeRust`. Like Python, these take a `libraries` option for the packages your script imports.
+
+There are also writers for data files, which turn a Nix value into a config file: `writeJSON`, `writeTOML`, and `writeYAML`.
+
+For a working example of every writer, see the test file at [`pkgs/build-support/writers/test.nix`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/writers/test.nix). You can build the tests yourself by running `nix-build . -A tests.writers` from the root of Nixpkgs.

--- a/doc/build-helpers/writers.chapter.md
+++ b/doc/build-helpers/writers.chapter.md
@@ -1,0 +1,46 @@
+# Writers {#chap-writers}
+
+The `pkgs.writers` helpers let you write a small Python script directly inside a Nix expression. You provide a script as text, and it builds a ready to run program for you.
+
+They do two useful things:
+
+- If your script needs a library, the writer makes it available, so you don't have to install anything or use `nix-shell`.
+- Before finishing, the writer checks your script with `flake8`. If something is wrong, the build fails, so a broken script never gets built.
+
+They are meant for short scripts. For real programs made of many files, use [`buildPythonApplication`](#buildpythonapplication-function) instead.
+
+## Python writers {#ssec-writers-python}
+
+There are two writers, and each has a `Bin` version:
+
+- `writePython3` gives you the script itself. `writePyPy3` is the same but uses PyPy.
+- `writePython3Bin` gives you a small package with the program in a `bin/` folder, ready to add to `PATH`.
+
+Each one takes a name, a set of options, and the script. The options are:
+
+`libraries` (default: none)
+:   The packages your script needs to import, like `[ pkgs.python3Packages.pyyaml ]`.
+
+`flakeIgnore` (default: none)
+:   [`flake8` warnings](https://flake8.pycqa.org/en/latest/user/error-codes.html) to ignore, like `[ "E501" ]` for long lines.
+
+`doCheck` (default: `true`)
+:   Set to `false` to turn off the `flake8` check.
+
+:::{.example #ex-writers-writePython3Bin}
+# A Python 3 program that uses a library
+
+```nix
+writePython3Bin "whatsmyip"
+  {
+    libraries = [ pkgs.python3Packages.requests ];
+  }
+  ''
+    import requests
+
+    resp = requests.get("https://api.ipify.org?format=json", timeout=10)
+    print("your public IP is:", resp.json()["ip"])
+  ''
+```
+
+This builds `bin/whatsmyip`. The script can `import requests` because the writer set Python up with that library. You would run this using: `nix-build writers-test.nix`

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -11,6 +11,9 @@
   "chap-toolchains": [
     "index.html#chap-toolchains"
   ],
+  "chap-writers": [
+    "index.html#chap-writers"
+  ],
   "cmake-ctest": [
     "index.html#cmake-ctest"
   ],
@@ -139,6 +142,9 @@
   ],
   "ex-writeShellApplication": [
     "index.html#ex-writeShellApplication"
+  ],
+  "ex-writers-writePython3Bin": [
+    "index.html#ex-writers-writePython3Bin"
   ],
   "first-package-go": [
     "index.html#first-package-go"
@@ -916,6 +922,9 @@
   ],
   "footnote-stdenv-find-inputs-location.__back.0": [
     "index.html#footnote-stdenv-find-inputs-location.__back.0"
+  ],
+  "ssec-writers-python": [
+    "index.html#ssec-writers-python"
   ],
   "sssec-testing-octave-packages": [
     "index.html#sssec-testing-octave-packages"

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -926,6 +926,9 @@
   "ssec-writers-python": [
     "index.html#ssec-writers-python"
   ],
+  "ssec-writers-other": [
+    "index.html#ssec-writers-other"
+  ],
   "sssec-testing-octave-packages": [
     "index.html#sssec-testing-octave-packages"
   ],

--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -140,6 +140,8 @@
   They were missing before because Ceph omitted logs when this directory was missing.
   Ceph logs can grow large, so you may want to configure rotation of these logs.
 
+- The `pkgs.writers` build helpers are now documented in the [Writers](#chap-writers) chapter of the Nixpkgs manual.
+
 ## Nixpkgs Library {#sec-nixpkgs-release-26.11-lib}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->


### PR DESCRIPTION


Closes #89759.



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add a "Writers" chapter to the Nixpkgs manual documenting the `pkgs.writers` Python helpers, wire it into the build-helpers manual, register its anchors, and add a release note.

[index.html#chap-writers](http://127.0.0.1:54824/share/doc/nixpkgs/index.html#chap-writers)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
