### PR TITLE
llvm: enable zstd support

### DIFF
--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -20,6 +20,7 @@
   version,
   release_version,
   zlib,
+  zstd,
   which,
   sysctl,
   buildLlvmPackages,
@@ -276,6 +277,7 @@ stdenv.mkDerivation (
     propagatedBuildInputs = [
       ncurses
       zlib
+      zstd
     ];
 
     nativeCheckInputs = [
@@ -521,6 +523,10 @@ stdenv.mkDerivation (
         # triple. The result of this is that a single clang build can be used for
         # multiple targets.
         (lib.cmakeFeature "LLVM_BINUTILS_INCDIR" "${libbfd.plugin-api-header}/include")
+      ]
+      ++ optionals (zstd != null) [
+        (lib.cmakeFeature "LLVM_ENABLE_ZSTD" "FORCE_ON")
+        (lib.cmakeBool "LLVM_USE_STATIC_ZSTD" stdenv.hostPlatform.isStatic)
       ]
       ++ optionals stdenv.hostPlatform.isDarwin [
         (lib.cmakeBool "LLVM_ENABLE_LIBCXX" true)


### PR DESCRIPTION
Fixes #347795

## Things done


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
