### PR TITLE
doc/style.css: add dark mode to sidebar

### DIFF
--- a/doc/style.css
+++ b/doc/style.css
@@ -479,6 +479,8 @@ div.appendix .variablelist .term {
 nav.toc-sidebar {
   height: 100%;
   padding: 0 1rem 2rem;
+  background-color: var(--background);
+  color: var(--main-text-color);
 }
 
 /* menu button, shown on mobile, hidden on desktop */
@@ -546,7 +548,7 @@ nav.toc-sidebar a {
     border-color 120ms ease;
 }
 nav.toc-sidebar a:hover {
-  background-color: #f2f2f2;
+  background-color: #f2f2f2 !important;
 }
 
 nav.toc-sidebar a.active {
@@ -557,6 +559,22 @@ nav.toc-sidebar a.active {
 nav.toc-sidebar a.active-trail {
   border-left-color: #bbb;
   background-color: #e8e8e8;
+}
+
+@media (prefers-color-scheme: dark) {
+  nav.toc-sidebar a:hover {
+    /* hover should win over scroll selectors despite beeing less specific */
+    background-color: #606060 !important;
+  }
+  nav.toc-sidebar a.active {
+    background-color: #373737;
+    border-left-color: #eee;
+    font-weight: 600;
+  }
+  nav.toc-sidebar a.active-trail {
+    border-left-color: #eee;
+    background-color: #323232;
+  }
 }
 
 @media screen and (min-width: 768px) {


### PR DESCRIPTION
Add explicit colors to sidebar for dark mode support

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
