### PR TITLE
python3Packages.falcon: refactor

### DIFF
--- a/pkgs/development/python-modules/falcon/default.nix
+++ b/pkgs/development/python-modules/falcon/default.nix
@@ -14,6 +14,7 @@
   cbor2,
   httpx,
   msgpack,
+  msgspec,
   mujson,
   orjson,
   pytest7CheckHook,
@@ -39,16 +40,12 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ] ++ lib.optionals (!isPyPy) [ cython ];
 
+  # Required by WSGI server tests that bind to localhost.
   __darwinAllowLocalNetworking = true;
 
   preCheck = ''
-    export HOME=$TMPDIR
-    cp -R tests examples $TMPDIR
-    pushd $TMPDIR
-  '';
-
-  postCheck = ''
-    popd
+    # Prevent python -m pytest from importing Falcon from the source tree.
+    export PYTHONSAFEPATH=1
   '';
 
   nativeCheckInputs = [
@@ -70,7 +67,9 @@ buildPythonPackage rec {
     msgpack
     mujson
     ujson
-  ];
+  ]
+  # msgspec does not support PyPy or Python 3.15+.
+  ++ lib.optionals (!isPyPy && !pythonAtLeast "3.15") [ msgspec ];
 
   enabledTestPaths = [ "tests" ];
 
@@ -88,5 +87,6 @@ buildPythonPackage rec {
     description = "Ultra-reliable, fast ASGI+WSGI framework for building data plane APIs at scale";
     homepage = "https://falconframework.org/";
     license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ hoh ];
   };
 }


### PR DESCRIPTION
## Things done

Upgrades [falcon](https://falcon.readthedocs.io/en/stable/) to the latest release, and:
- Simplify `preCheck/postCheck` thanks to recent upstream work
- Add myself as Nixpkgs maintainer
- Add new test dependency `msgspec`

Fixes https://github.com/falconry/falcon/issues/2688

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
