### PR TITLE
rustfs: 1.0.0-beta.9 -> 1.0.0-beta.10

### DIFF
--- a/pkgs/by-name/ru/rustfs/package.nix
+++ b/pkgs/by-name/ru/rustfs/package.nix
@@ -15,7 +15,7 @@
 let
   console = stdenv.mkDerivation (finalAttrs: {
     pname = "rustfs-console";
-    version = "0.1.13";
+    version = "0.1.16";
     __structuredAttrs = true;
     __darwinAllowLocalNetworking = true;
 
@@ -23,7 +23,7 @@ let
       owner = "rustfs";
       repo = "console";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-pxpT3kV30qA+Ob/RWi11rsapGyNc6h1EN79fcPi1e1E=";
+      hash = "sha256-WZ1vROBZJltcaXdwIuTsRmOY2iZxIoi7yW8lapZcaHo=";
     };
 
     pnpmDeps = fetchPnpmDeps {
@@ -51,14 +51,14 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "rustfs";
-  version = "1.0.0-beta.9";
+  version = "1.0.0-beta.10";
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "rustfs";
     repo = "rustfs";
     tag = version;
-    hash = "sha256-aNbicnNHaJn05k5EffgPEURf/Uj2A8PjOHiH2UGPz4M=";
+    hash = "sha256-lBkfaTH36MhWHk39Ie2uQqcU+yf76uImPdV91C8kWV8=";
   };
 
   postPatch = ''
@@ -66,7 +66,7 @@ rustPlatform.buildRustPackage rec {
     cp -rL ${console} ./rustfs/static
   '';
 
-  cargoHash = "sha256-abbsElP4dSSZnL4UfQEoHUtiEW8B/p6Y81UA7EbqbD4=";
+  cargoHash = "sha256-PMgC4+/n/UOpBa5oiZ1F17oht5YmN1RzoFIA0qE+h6M=";
 
   nativeBuildInputs = [
     protobuf
@@ -84,10 +84,11 @@ rustPlatform.buildRustPackage rec {
   cargoTestFlags = "-p rustfs";
 
   checkFlags = [
-    # failing since 1.0.0-beta.9, seem like upstream issues
+    # require real disks
     "--skip=app::capacity_dirty_scope_test"
     "--skip=app::delete_objects_stat_gating_test"
     "--skip=app::put_prelookup_gating_test"
+    # non-deterministically panics
     "--skip=two_embedded_servers_isolate_auth_and_data_planes"
   ];
 


### PR DESCRIPTION
Diff: https://github.com/rustfs/rustfs/compare/1.0.0-beta.9...1.0.0-beta.10


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
