### PR TITLE
python3Packages.ghrepo-stats: migrate to pyproject, remove outdated patch of requires

### DIFF
--- a/pkgs/development/python-modules/ghrepo-stats/default.nix
+++ b/pkgs/development/python-modules/ghrepo-stats/default.nix
@@ -20,12 +20,6 @@ buildPythonPackage rec {
     hash = "sha256-zdBIX/uetkOAalg4uJPWXRL9WUgNN+hmqUwQDTdzrzA=";
   };
 
-  postPatch = ''
-    # https://github.com/mrbean-bremen/ghrepo-stats/pull/1
-    substituteInPlace setup.py \
-      --replace "bs4" "beautifulsoup4"
-  '';
-
   propagatedBuildInputs = [
     beautifulsoup4
     matplotlib

--- a/pkgs/development/python-modules/ghrepo-stats/default.nix
+++ b/pkgs/development/python-modules/ghrepo-stats/default.nix
@@ -8,7 +8,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "ghrepo-stats";
   version = "0.5.5";
   pyproject = true;
@@ -16,11 +16,13 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "mrbean-bremen";
     repo = "ghrepo-stats";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-zdBIX/uetkOAalg4uJPWXRL9WUgNN+hmqUwQDTdzrzA=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     beautifulsoup4
     matplotlib
     pygithub
@@ -29,16 +31,14 @@ buildPythonPackage rec {
   # Module has no tests
   doCheck = false;
 
-  build-system = [ setuptools ];
-
   pythonImportsCheck = [ "ghrepo_stats" ];
 
   meta = {
     description = "Python module and CLI tool for GitHub repo statistics";
-    mainProgram = "show-ghstats";
     homepage = "https://github.com/mrbean-bremen/ghrepo-stats";
-    changelog = "https://github.com/mrbean-bremen/ghrepo-stats/blob/v${version}/CHANGES.md";
+    changelog = "https://github.com/mrbean-bremen/ghrepo-stats/blob/${finalAttrs.src.tag}/CHANGES.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "show-ghstats";
   };
-}
+})

--- a/pkgs/development/python-modules/ghrepo-stats/default.nix
+++ b/pkgs/development/python-modules/ghrepo-stats/default.nix
@@ -5,12 +5,13 @@
   fetchFromGitHub,
   matplotlib,
   pygithub,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "ghrepo-stats";
   version = "0.5.5";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mrbean-bremen";
@@ -33,6 +34,8 @@ buildPythonPackage rec {
 
   # Module has no tests
   doCheck = false;
+
+  build-system = [ setuptools ];
 
   pythonImportsCheck = [ "ghrepo_stats" ];
 


### PR DESCRIPTION
- #515974
- remove outdated patch of `beautifulsoup4` requires

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
