### PR TITLE
python3Packages.cppheaderparser: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/cppheaderparser/default.nix
+++ b/pkgs/development/python-modules/cppheaderparser/default.nix
@@ -3,18 +3,21 @@
   fetchPypi,
   ply,
   lib,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "cppheaderparser";
   version = "2.7.4";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     pname = "CppHeaderParser";
     inherit version;
     hash = "sha256-OCswQW2VsKXoUCshSBDcrCpWQykX4mUUR9Or4lPjzEI=";
   };
+
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [ ply ];
 

--- a/pkgs/development/python-modules/cppheaderparser/default.nix
+++ b/pkgs/development/python-modules/cppheaderparser/default.nix
@@ -6,20 +6,20 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "cppheaderparser";
   version = "2.7.4";
   pyproject = true;
 
   src = fetchPypi {
     pname = "CppHeaderParser";
-    inherit version;
+    inherit (finalAttrs) version;
     hash = "sha256-OCswQW2VsKXoUCshSBDcrCpWQykX4mUUR9Or4lPjzEI=";
   };
 
   build-system = [ setuptools ];
 
-  propagatedBuildInputs = [ ply ];
+  dependencies = [ ply ];
 
   pythonImportsCheck = [ "CppHeaderParser" ];
 
@@ -29,4 +29,4 @@ buildPythonPackage rec {
     license = lib.licenses.bsdOriginal;
     maintainers = with lib.maintainers; [ pamplemousse ];
   };
-}
+})


### PR DESCRIPTION
- #515974

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
