### PR TITLE
[Backport release-26.05] wordpress_7_0: 7.0.0 -> 7.0.2, wordpress_6_9: 6.9.4 -> 6.9.5, wordpress_6_8: 6.8.5 -> 6.8.6

### DIFF
--- a/pkgs/servers/web-apps/wordpress/default.nix
+++ b/pkgs/servers/web-apps/wordpress/default.nix
@@ -6,8 +6,8 @@ builtins.mapAttrs (_: callPackage ./generic.nix) rec {
     hash = "sha256-IS9B6kwjWLYLybmWG2Ym5+JAgFExMqhcEQsJJF2puXg=";
   };
   wordpress_6_8 = {
-    version = "6.8.5";
-    hash = "sha256-N/WVUQxI0W3t4L+lr6KcuK8S2/Dj00WyXElMFfjIHYE=";
+    version = "6.8.6";
+    hash = "sha256-ID5C12xn+GprUynX8WLS5dl9iJyv13yDxYbqMDPB8P4=";
   };
   wordpress_6_9 = {
     version = "6.9.5";

--- a/pkgs/servers/web-apps/wordpress/default.nix
+++ b/pkgs/servers/web-apps/wordpress/default.nix
@@ -14,7 +14,7 @@ builtins.mapAttrs (_: callPackage ./generic.nix) rec {
     hash = "sha256-22EK2fVJ4Ku1rz49XGcpxY2HRDllTN8K/qQlsuqJXzU=";
   };
   wordpress_7_0 = {
-    version = "7.0";
-    hash = "sha256-UwyP3rFvsK/9tT63J7agS7jRZmIcIAKeOJyrsBoPqSE=";
+    version = "7.0.1";
+    hash = "sha256-3BBZLam1gMdSVjKFDgzO03GxMIGFOsKa/pO11bsA25g=";
   };
 }

--- a/pkgs/servers/web-apps/wordpress/default.nix
+++ b/pkgs/servers/web-apps/wordpress/default.nix
@@ -10,8 +10,8 @@ builtins.mapAttrs (_: callPackage ./generic.nix) rec {
     hash = "sha256-N/WVUQxI0W3t4L+lr6KcuK8S2/Dj00WyXElMFfjIHYE=";
   };
   wordpress_6_9 = {
-    version = "6.9.4";
-    hash = "sha256-22EK2fVJ4Ku1rz49XGcpxY2HRDllTN8K/qQlsuqJXzU=";
+    version = "6.9.5";
+    hash = "sha256-01h7VJpvXZDG5PQmj/xsI2cUY2Jc+ImiyBWnB86fXEE=";
   };
   wordpress_7_0 = {
     version = "7.0.2";

--- a/pkgs/servers/web-apps/wordpress/default.nix
+++ b/pkgs/servers/web-apps/wordpress/default.nix
@@ -14,7 +14,7 @@ builtins.mapAttrs (_: callPackage ./generic.nix) rec {
     hash = "sha256-22EK2fVJ4Ku1rz49XGcpxY2HRDllTN8K/qQlsuqJXzU=";
   };
   wordpress_7_0 = {
-    version = "7.0.1";
-    hash = "sha256-3BBZLam1gMdSVjKFDgzO03GxMIGFOsKa/pO11bsA25g=";
+    version = "7.0.2";
+    hash = "sha256-1KTSGd6mTGxo5i8v/D8zHFR1UQJG1sRPYftS83fSlbk=";
   };
 }


### PR DESCRIPTION
- **wordpress_7_0: 7.0 -> 7.0.1**
- **wordpress_7_0: 7.0.1 -> 7.0.2**
- **wordpress_6_9: 6.9.4 -> 6.9.5**
- **wordpress_6_8: 6.8.5 -> 6.8.6**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
