### PR TITLE
semcode: init at 0.1.1

### DIFF
--- a/pkgs/by-name/se/semcode/package.nix
+++ b/pkgs/by-name/se/semcode/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  cmake,
+  protobuf,
+  openssl,
+  curl,
+  zlib,
+  zstd,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "semcode";
+  version = "0.1.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "facebookexperimental";
+    repo = "semcode";
+    tag = finalAttrs.version;
+    hash = "sha256-nkb4a+H11gzMGz0zBAH+G77zE+oDl9elTu+bfYmIz9k=";
+  };
+
+  cargoHash = "sha256-xOIaoOaHWYhV9z3IoIAfAaRd+AbVBuX8VKomfuFN2QM=";
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    protobuf
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    curl
+    openssl
+    zlib
+    zstd
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  env = {
+    OPENSSL_NO_VENDOR = true;
+    PROTOC = lib.getExe' protobuf "protoc";
+    ZSTD_SYS_USE_PKG_CONFIG = true;
+  };
+
+  # Skip git tests that need git repository
+  checkFlags = [
+    "--skip=git::tests::test_branch_exists"
+    "--skip=git::tests::test_find_merge_base_same_commit"
+    "--skip=git::tests::test_get_current_branch"
+    "--skip=git::tests::test_list_branches_local"
+    "--skip=git::tests::test_list_branches_with_remote"
+    "--skip=git::tests::test_resolve_branch_head"
+    "--skip=git::tests::test_resolve_branch_main"
+  ];
+
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Semantic code search tool for C/C++";
+    homepage = "https://github.com/facebookexperimental/semcode";
+    license =
+      with lib.licenses;
+      OR [
+        asl20
+        mit
+      ];
+    maintainers = with lib.maintainers; [ liberodark ];
+    mainProgram = "semcode";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+  };
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
