### PR TITLE
python3Packages.torchao: fix build with Python 3.14

### DIFF
--- a/pkgs/development/python-modules/torchao/default.nix
+++ b/pkgs/development/python-modules/torchao/default.nix
@@ -3,7 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonAtLeast,
+  fetchpatch,
   replaceVars,
 
   # build-system
@@ -53,11 +53,14 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-Mry6jsZKkoC8dq3fYNsRyGbL4+S8ZYuHpkETNDy5qsg=";
   };
 
-  # AttributeError: 'typing.Union' object has no attribute '__module__' and no __dict__ for setting
-  # new attributes. Did you mean: '__reduce__'?
-  disabled = pythonAtLeast "3.14";
-
-  patches = lib.optionals isAarch64Darwin [
+  patches = [
+    # Fix Python 3.14 compatibility
+    (fetchpatch {
+      url = "https://github.com/pytorch/ao/commit/5e92da482ba8f2e3aa64d74fbfa7131c259b693d.patch";
+      hash = "sha256-OZKPy92Fy+09SDx4wSnGBH/4QbbRsYJOu8d/oX2NkkA=";
+    })
+  ]
+  ++ lib.optionals isAarch64Darwin [
     ./use-system-cpuinfo.patch
     (replaceVars ./use-llvm-openmp.patch {
       inherit (llvmPackages) openmp;


### PR DESCRIPTION
The latest release of `python3Packages.torchao` did not build with Python 3.14. This backports the [upstream fix](https://github.com/pytorch/ao/pull/4427) to fix the issue and make the package work.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
