### PR TITLE
latexml-oxide: init at 0.7.6

### DIFF
--- a/pkgs/by-name/la/latexml-oxide/dumps-in-share.patch
+++ b/pkgs/by-name/la/latexml-oxide/dumps-in-share.patch
@@ -1,0 +1,33 @@
+--- a/build.rs
++++ b/build.rs
+@@ -262,7 +262,7 @@ fn resolve_dump_path(prefer: Option<u32>) -> Option<(std::path::PathBuf, u32)> {
+     }}
+   }}
+   // 2. Directory override — pick best versioned dump in that dir.
+-  if let Ok(dir) = std::env::var("LATEXML_DUMP_DIR") {{
++  if let Some(dir) = std::env::var("LATEXML_DUMP_DIR").ok().or(Some(concat!(env!("out"),"/share/latexml-oxide/resources/dumps").to_owned())) {{
+     if let Some(found) = crate::dump_paths::resolve_versioned_in_dir(
+       std::path::Path::new(&dir), "latex", prefer
+     ) {{ return Some(found); }}
+--- a/src/latex.rs
++++ b/src/latex.rs
+@@ -16,7 +16,7 @@ use crate::prelude::*;
+ 
+ // Process-once cached env vars (see WISDOM #56 — getenv hot-path race).
+ static DUMP_PATH: Lazy<Option<String>> = Lazy::new(|| std::env::var("LATEXML_DUMP_PATH").ok());
+-static DUMP_DIR: Lazy<Option<String>> = Lazy::new(|| std::env::var("LATEXML_DUMP_DIR").ok());
++static DUMP_DIR: Lazy<Option<String>> = Lazy::new(|| std::env::var("LATEXML_DUMP_DIR").ok().or(Some(concat!(env!("out"),"/share/latexml-oxide/resources/dumps").to_owned())));
+ static INI_MODE: Lazy<bool> = Lazy::new(|| std::env::var_os("LATEXML_INI_MODE").is_some());
+ static NODUMP: Lazy<bool> = Lazy::new(|| std::env::var_os("LATEXML_NODUMP").is_some());
+ 
+--- a/src/plain_dump.rs
++++ b/src/plain_dump.rs
+@@ -36,7 +36,7 @@ const DEV_DUMPS_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../resources/d
+ static NODUMP: Lazy<bool> = Lazy::new(|| std::env::var_os("LATEXML_NODUMP").is_some());
+ static PLAIN_DUMP_PATH: Lazy<Option<String>> =
+   Lazy::new(|| std::env::var("LATEXML_PLAIN_DUMP_PATH").ok());
+-static DUMP_DIR: Lazy<Option<String>> = Lazy::new(|| std::env::var("LATEXML_DUMP_DIR").ok());
++static DUMP_DIR: Lazy<Option<String>> = Lazy::new(|| std::env::var("LATEXML_DUMP_DIR").ok().or(Some(concat!(env!("out"),"/share/latexml-oxide/resources/dumps").to_owned())));
+ 
+ pub fn load_definitions() -> Result<()> {
+   if *NODUMP {

--- a/pkgs/by-name/la/latexml-oxide/package.nix
+++ b/pkgs/by-name/la/latexml-oxide/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  buildPackages,
+  fetchCrate,
+  libxml2,
+  libxslt,
+  pkg-config,
+  rustPlatform,
+  stdenv,
+  texliveBasic,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "latexml-oxide";
+  version = "0.7.6";
+
+  src = fetchCrate {
+    inherit (finalAttrs) version;
+    pname = "latexml";
+    hash = "sha256-2OIQ8gv0wSJEk1QNKHYQOOXbzfilW45WX9bzHKOSu7c=";
+  };
+
+  cargoHash = "sha256-1/4kIhPY03eX8stbkeDu8P7BBJ+W9k5jgx9YWG4/dx4=";
+
+  postPatch = ''
+    patch -d "$cargoDepsCopy"/source-registry-0/latexml_engine-* -p1 < "${./dumps-in-share.patch}"
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+    texliveBasic
+  ];
+
+  buildInputs = [
+    libxml2
+    libxslt
+  ];
+
+  # use kpsewhich in PATH instead of linking to libkpathsea, which Nixpkgs does not provide
+  env.KPATHSEA_SKIP_TOOLCHAIN_CHECK = 1;
+  # requires #![feature(thread_local)]
+  env.RUSTC_BOOTSTRAP = 1;
+
+  # create the formats after build and check, or cargo does a costly rebuild
+  # with the formats embedded in the binary
+  postInstall =
+    if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+      ''
+        mkdir -p "$out"/share/latexml-oxide/resources/dumps
+        (
+          cd "$out"/share/latexml-oxide
+          "$out"/bin/latexml_oxide --init=plain.tex
+          "$out"/bin/latexml_oxide --init=latex.ltx
+        )
+      ''
+    else
+      ''
+        mkdir -p "$out"/share/latexml-oxide/resources/dumps
+        cp "${buildPackages.latexml-oxide}"/share/latexml-oxide/resources/dumps/*.txt "$out"/share/latexml-oxide/resources/dumps
+      '';
+
+  meta = {
+    description = "TeX to XML/HTML/ePub converter: a LaTeXML reimplementation in Rust";
+    homepage = "https://crates.io/crates/latexml";
+    license = lib.licenses.cc0;
+    maintainers = with lib.maintainers; [ xworld21 ];
+    mainProgram = "latexml_oxide";
+  };
+})


### PR DESCRIPTION
New, and still highly experimental Rust port of LaTeXML
https://dginev.github.io/latexml-oxide/latexml/
https://crates.io/crates/latexml

Naming based on the upstream name of the project rather than the crate, to avoid confusion with `perlPackages.LaTeXML`.

## Things done
Built on x86_64-darwin!

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
