### PR TITLE
cline: init at 3.0.44

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17984,6 +17984,12 @@
     name = "meator";
     keys = [ { fingerprint = "7B0F 58A5 E0F1 A2EA 1157  8A73 1A14 CB34 64CB E5BF"; } ];
   };
+  medetcan = {
+    email = "medet@canakus.com";
+    github = "medetcan";
+    githubId = 10031984;
+    name = "Medet Can Akus";
+  };
   meditans = {
     email = "meditans@gmail.com";
     github = "meditans";

--- a/pkgs/by-name/cl/cline/manifest.json
+++ b/pkgs/by-name/cl/cline/manifest.json
@@ -1,0 +1,14 @@
+{
+  "version": "3.0.44",
+  "platforms": {
+    "darwin-arm64": {
+      "hash": "sha256-BxmUpOg+8vZ4oTUgsibamefO6Vny+dSKdeGcwK+YXy8="
+    },
+    "linux-arm64": {
+      "hash": "sha256-dtO6yZZ7J3DhdEopd000ykyFMQP9IAB8kgzRCMQDzCs="
+    },
+    "linux-x64": {
+      "hash": "sha256-cLFWMX5K+aiH050VCr9CWYbvbXi4cNlysbJlTkqP83U="
+    }
+  }
+}

--- a/pkgs/by-name/cl/cline/package.nix
+++ b/pkgs/by-name/cl/cline/package.nix
@@ -1,0 +1,111 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  makeBinaryWrapper,
+  autoPatchelfHook,
+  libsecret,
+  ripgrep,
+  git,
+  xdg-utils,
+  darwin,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+let
+  stdenv = stdenvNoCC;
+  manifest = lib.importJSON ./manifest.json;
+  platformKey = "${stdenv.hostPlatform.node.platform}-${stdenv.hostPlatform.node.arch}";
+  platformManifestEntry =
+    manifest.platforms.${platformKey}
+      or (throw "cline: unsupported platform ${stdenv.hostPlatform.system}");
+  binaryName = "cline";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cline";
+  inherit (manifest) version;
+
+  __structuredAttrs = true;
+
+  src = fetchurl {
+    url = "https://registry.npmjs.org/@cline/cli-${platformKey}/-/cli-${platformKey}-${finalAttrs.version}.tgz";
+    inherit (platformManifestEntry) hash;
+  };
+
+  # The npm tarball unpacks into ./package
+  sourceRoot = "package";
+
+  # The compiled binary embeds the Bun runtime; stripping breaks it.
+  dontStrip = true;
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isElf [ autoPatchelfHook ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.autoSignDarwinBinariesHook ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isElf [
+    libsecret
+  ];
+
+  strictDeps = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    # The binary resolves adjacent asset directories (cline-hub/webview,
+    # extensions) relative to its own path (process.execPath), so keep the
+    # binary and its assets together under libexec.
+    mkdir -p "$out/libexec/cline"
+    cp -r bin "$out/libexec/cline/bin"
+    if [ -d cline-hub ]; then
+      cp -r cline-hub "$out/libexec/cline/cline-hub"
+    fi
+    if [ -d extensions ]; then
+      cp -r extensions "$out/libexec/cline/extensions"
+    fi
+    chmod 755 "$out/libexec/cline/bin/${binaryName}"
+
+    makeWrapper "$out/libexec/cline/bin/${binaryName}" "$out/bin/cline" \
+      --set-default CLINE_NO_AUTO_UPDATE 1 \
+      --prefix PATH : ${
+        lib.makeBinPath (
+          [
+            ripgrep
+            git
+          ]
+          ++ lib.optionals stdenv.hostPlatform.isLinux [ xdg-utils ]
+        )
+      } \
+      ${lib.optionalString stdenv.hostPlatform.isLinux ''
+        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libsecret ]}
+      ''}
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    writableTmpDirAsHomeHook
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+  versionCheckKeepEnvironment = [ "HOME" ];
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Autonomous coding agent CLI capable of creating/editing files, running commands, and using the browser";
+    homepage = "https://cline.bot";
+    changelog = "https://github.com/cline/cline/blob/main/apps/cli/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ medetcan ];
+    mainProgram = "cline";
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+  };
+})

--- a/pkgs/by-name/cl/cline/update.sh
+++ b/pkgs/by-name/cl/cline/update.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env nix
+#!nix shell --ignore-environment .#cacert .#coreutils .#curl .#jq .#nix .#bash --command bash
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+VERSION="${1:-$(curl -fsSL https://registry.npmjs.org/cline/latest | jq -r .version)}"
+
+echo "Updating cline to ${VERSION}"
+
+platforms=(darwin-arm64 linux-arm64 linux-x64)
+
+entries=""
+for platform in "${platforms[@]}"; do
+  url="https://registry.npmjs.org/@cline/cli-${platform}/-/cli-${platform}-${VERSION}.tgz"
+  echo "Prefetching ${url}" >&2
+  hash=$(nix store prefetch-file --json "$url" | jq -r .hash)
+  entries=$(jq -n --argjson acc "${entries:-{}}" --arg k "$platform" --arg h "$hash" \
+    '$acc + { ($k): { hash: $h } }')
+done
+
+jq -n --arg version "$VERSION" --argjson platforms "$entries" \
+  '{ version: $version, platforms: $platforms }' > manifest.json
+
+echo "Wrote manifest.json for cline ${VERSION}"


### PR DESCRIPTION
## Description of changes

Adds the [Cline](https://cline.bot) CLI (`cline`) — an autonomous coding agent for the terminal.

Cline's CLI is distributed as standalone [Bun](https://bun.sh)-compiled binaries published to npm as per-platform packages (`@cline/cli-<os>-<arch>`), with a thin `cline` wrapper package that resolves the correct binary via `optionalDependencies`. This derivation fetches the prebuilt platform binary directly from npm and wraps it, following the same approach already used by `claude-code` (which is architecturally identical — also a Bun-compiled binary).

Notes:
- The binary resolves adjacent asset directories (`cline-hub/webview`, `extensions`) relative to `process.execPath`, so the binary and assets are installed together under `$out/libexec/cline` and wrapped.
- Linux: `autoPatchelfHook` patches the ELF; `libsecret` (dlopen'd for secret storage) is provided via `LD_LIBRARY_PATH`.
- Darwin: the shipped linker-signed ad-hoc signature is invalidated on copy into the store (macOS SIGKILLs it), so `autoSignDarwinBinariesHook` re-signs it.
- `dontStrip = true` because the embedded Bun runtime must not be stripped.
- The built-in self-updater is disabled (`CLINE_NO_AUTO_UPDATE=1`) since the store is immutable.
- `x86_64-darwin` is intentionally excluded (support dropped in nixpkgs).

## Things done

- Built and ran `cline --version` / `cline --help` on `aarch64-darwin` (native) and `aarch64-linux` (via container).
- Verified ELF interpreter/NEEDED patching and `libsecret` resolution on Linux.
- Verified webview/extensions assets are installed and resolved.
- `nixfmt-rfc-style` applied.

- [x] Built on platform(s):
  - [x] aarch64-darwin
  - [x] aarch64-linux
  - [ ] x86_64-linux (evaluated; not built)
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage]. (leaf package, N/A)
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking. (new package)
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
