### PR TITLE
wordhunter: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11994,6 +11994,11 @@
     githubId = 137306;
     name = "Michele Catalano";
   };
+  ironship = {
+    github = "Ironship";
+    githubId = 25068602;
+    name = "Ironship";
+  };
   isabelroses = {
     email = "isabel@isabelroses.com";
     matrix = "@isabel:isabelroses.com";

--- a/pkgs/by-name/wo/wordhunter/package.nix
+++ b/pkgs/by-name/wo/wordhunter/package.nix
@@ -2,40 +2,23 @@
   appimageTools,
   fetchurl,
   lib,
-  syncthing,
 }:
 
 let
   pname = "wordhunter";
-  version = "1.0.6";
+  version = "1.1.0";
 
   src = fetchurl {
     url = "https://github.com/Ironship/WordHunter/releases/download/WordHunter${version}/WordHunter-${version}-x86_64.AppImage";
-    hash = "sha256-ARlLOghVz9THbmeXe0vS60qiM8OTy9rxe3qam9AJ2z8=";
+    hash = "sha256-e+dduzoxYahFHKitLcEWGSHA7XkagQj0iGl4HuLKMCI=";
   };
 
-  appimageContents = appimageTools.extract {
-    inherit pname version src;
-
-    postExtract = ''
-      rm "$out/usr/bin/syncthing"
-      test ! -e "$out/usr/bin/syncthing"
-    '';
-  };
-
-  syncthingExecutable = lib.getExe syncthing;
-  wrapperProfile = ''
-    export WORDHUNTER_SYNCTHING="${syncthingExecutable}"
-  '';
+  appimageContents = appimageTools.extract { inherit pname version src; };
 in
 (appimageTools.wrapAppImage {
   inherit pname version;
 
   src = appimageContents;
-
-  extraPkgs = _pkgs: [ syncthing ];
-
-  profile = wrapperProfile;
 
   extraInstallCommands = ''
     install -m 444 -D \
@@ -51,21 +34,12 @@ in
       "$out/share/metainfo/com.wordhunter.app.metainfo.xml"
     substituteInPlace "$out/share/metainfo/com.wordhunter.app.metainfo.xml" \
       --replace-fail \
-        '<launchable type="desktop-id">Word Hunter.desktop</launchable>' \
-        '<launchable type="desktop-id">com.wordhunter.app.desktop</launchable>' \
-      --replace-fail \
         '<binary>word-hunter-rustified</binary>' \
         '<binary>wordhunter</binary>'
   '';
 
   passthru = {
-    inherit
-      appimageContents
-      src
-      syncthingExecutable
-      wrapperProfile
-      ;
-    systemSyncthing = syncthing;
+    inherit appimageContents src;
   };
 
   meta = {

--- a/pkgs/by-name/wo/wordhunter/package.nix
+++ b/pkgs/by-name/wo/wordhunter/package.nix
@@ -1,0 +1,85 @@
+{
+  appimageTools,
+  fetchurl,
+  lib,
+  syncthing,
+}:
+
+let
+  pname = "wordhunter";
+  version = "1.0.6";
+
+  src = fetchurl {
+    url = "https://github.com/Ironship/WordHunter/releases/download/WordHunter${version}/WordHunter-${version}-x86_64.AppImage";
+    hash = "sha256-ARlLOghVz9THbmeXe0vS60qiM8OTy9rxe3qam9AJ2z8=";
+  };
+
+  appimageContents = appimageTools.extract {
+    inherit pname version src;
+
+    postExtract = ''
+      rm "$out/usr/bin/syncthing"
+      test ! -e "$out/usr/bin/syncthing"
+    '';
+  };
+
+  syncthingExecutable = lib.getExe syncthing;
+  wrapperProfile = ''
+    export WORDHUNTER_SYNCTHING="${syncthingExecutable}"
+  '';
+in
+(appimageTools.wrapAppImage {
+  inherit pname version;
+
+  src = appimageContents;
+
+  extraPkgs = _pkgs: [ syncthing ];
+
+  profile = wrapperProfile;
+
+  extraInstallCommands = ''
+    install -m 444 -D \
+      "${appimageContents}/usr/share/applications/Word Hunter.desktop" \
+      "$out/share/applications/com.wordhunter.app.desktop"
+    substituteInPlace "$out/share/applications/com.wordhunter.app.desktop" \
+      --replace-fail 'Exec=word-hunter-rustified' 'Exec=wordhunter'
+
+    cp -r "${appimageContents}/usr/share/icons" "$out/share/"
+
+    install -m 444 -D \
+      "${appimageContents}/usr/share/metainfo/com.wordhunter.app.metainfo.xml" \
+      "$out/share/metainfo/com.wordhunter.app.metainfo.xml"
+    substituteInPlace "$out/share/metainfo/com.wordhunter.app.metainfo.xml" \
+      --replace-fail \
+        '<launchable type="desktop-id">Word Hunter.desktop</launchable>' \
+        '<launchable type="desktop-id">com.wordhunter.app.desktop</launchable>' \
+      --replace-fail \
+        '<binary>word-hunter-rustified</binary>' \
+        '<binary>wordhunter</binary>'
+  '';
+
+  passthru = {
+    inherit
+      appimageContents
+      src
+      syncthingExecutable
+      wrapperProfile
+      ;
+    systemSyncthing = syncthing;
+  };
+
+  meta = {
+    description = "Local-first reader and vocabulary trainer";
+    homepage = "https://ironship.github.io/WordHunter-site/";
+    downloadPage = "https://github.com/Ironship/WordHunter/releases";
+    changelog = "https://github.com/Ironship/WordHunter/releases/tag/WordHunter${version}";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ ironship ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "wordhunter";
+    platforms = [ "x86_64-linux" ];
+  };
+}).overrideAttrs
+  (_: {
+    strictDeps = true;
+  })


### PR DESCRIPTION
Adds Word Hunter 1.0.6, a local-first reader and vocabulary trainer.

The package wraps the upstream x86_64 AppImage, removes its bundled Syncthing executable, and uses the `syncthing` package from nixpkgs through `WORDHUNTER_SYNCTHING`. It also installs the desktop entry, icons, and AppStream metadata under stable names.

Validation performed against nixpkgs commit `e2db8789f543b90a35581583c29f29c44fa8c4f0`:

- formatted with `nixfmt`;
- `nixpkgs-vet`: `Validated successfully`;
- evaluated with `strictDeps = true`;
- built successfully on x86_64-linux;
- checked the launcher, desktop entry, AppStream metadata, system Syncthing path, and removal of the bundled Syncthing binary.

An interactive GUI smoke test is intentionally not claimed below: the available headless WSL/Xvfb environment stopped in WebKit at EGL display initialization.

Automation/AI disclosure: this package and pull request text were prepared with OpenAI Codex (GPT-5). The commits include matching `Assisted-by` trailers. This is submitted as a draft for responsible human review before it is marked ready.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
