### PR TITLE
msnap: init at 0.6.1

### DIFF
--- a/pkgs/by-name/ms/msnap/package.nix
+++ b/pkgs/by-name/ms/msnap/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  makeWrapper,
+  versionCheckHook,
+  nix-update-script,
+  bashNonInteractive,
+  grim,
+  slurp,
+  wl-clipboard,
+  libnotify,
+  wayfreeze,
+  satty,
+  gpu-screen-recorder,
+  ffmpeg,
+  quickshell,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  pname = "msnap";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "xtheeq";
+    repo = "msnap";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Iy15f5dPO3WC/W1avDNYQdFERSXHxwH7ZrpUcIFeLhw=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ bashNonInteractive ];
+
+  dontConfigure = true;
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "SYSCONFDIR=$(out)/etc/xdg"
+    "LOCALSTATEDIR=$(out)/var/lib"
+  ];
+
+  postInstall = ''
+    wrapProgram "$out/bin/msnap" \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          grim
+          slurp
+          wl-clipboard
+          libnotify
+          wayfreeze
+          satty
+          gpu-screen-recorder
+          ffmpeg
+          quickshell
+        ]
+      }
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Screenshot and screencast utility for mango";
+    homepage = "https://github.com/xtheeq/msnap";
+    changelog = "https://github.com/xtheeq/msnap/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yvnth ];
+    platforms = lib.platforms.linux;
+    mainProgram = "msnap";
+  };
+})


### PR DESCRIPTION
Add `msnap` https://github.com/xtheeq/msnap, a screenshot and screencast utility for `mango`.
## Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [[NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests)] in [[nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)].
  - [ ] [[Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)] at `passthru.tests`.
  - [ ] Tests in [[lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests)] or [[pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [[nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [[CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)], [[pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md)], [[maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md)] and other READMEs.
- [x] Follows the [[automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy)].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test