### PR TITLE
nextcloudPackages: add Diagramming app and update apps

### DIFF
--- a/pkgs/servers/nextcloud/packages/32.json
+++ b/pkgs/servers/nextcloud/packages/32.json
@@ -89,6 +89,16 @@
       "agpl"
     ]
   },
+  "drawio": {
+    "hash": "sha256-CPwTRdS9pHNzIeLYSqSbY9nVUGqBT3awr9IlKng0baI=",
+    "url": "https://github.com/arnowelzel/drawio-nextcloud/releases/download/v4.1.2/drawio-v4.1.2.tar.gz",
+    "version": "4.1.2",
+    "description": "Integrates the diagrams.net diagram editor with Nextcloud. Users can create and edit .drawio diagrams and .dwb whiteboards directly within the Nextcloud file manager.\n\n**Features:**\n\n- Create and edit diagrams and whiteboards from the Nextcloud \"+\" menu\n- Click any .drawio or .dwb file to open the editor inline\n- Autosave with optimistic conflict detection\n- Inline diagram previews in Text, Collectives, Talk, Notes, and Deck\n- Supports public share links (read-only and editable)\n- Offline mode for privacy-sensitive deployments\n- Configurable editor URL for self-hosted diagrams.net instances",
+    "homepage": "https://github.com/arnowelzel/drawio-nextcloud",
+    "licenses": [
+      "agpl"
+    ]
+  },
   "end_to_end_encryption": {
     "hash": "sha256-Tlv1zPWp8mLpZFrsxcbfqqro1tx5XGS+vgxrEYWe054=",
     "url": "https://github.com/nextcloud-releases/end_to_end_encryption/releases/download/v1.18.3/end_to_end_encryption-v1.18.3.tar.gz",

--- a/pkgs/servers/nextcloud/packages/32.json
+++ b/pkgs/servers/nextcloud/packages/32.json
@@ -1,8 +1,8 @@
 {
   "bookmarks": {
-    "hash": "sha256-8F+sNG/+M8Ed/q5dcxW95KS5ZBNsEeZNR0P2OIe/HqQ=",
-    "url": "https://github.com/nextcloud/bookmarks/releases/download/v16.2.2/bookmarks-16.2.2.tar.gz",
-    "version": "16.2.2",
+    "hash": "sha256-0jBKcGX6ljlXruILcKlsm7ZBrC5hyDuHp/9lgG0eoBE=",
+    "url": "https://github.com/nextcloud/bookmarks/releases/download/v16.2.4/bookmarks-16.2.4.tar.gz",
+    "version": "16.2.4",
     "description": "- 📂 Sort bookmarks into folders\n- 🏷 Add tags and personal notes\n- ☠ Find broken links and duplicates\n- 📲 Synchronize with all your browsers and devices\n- 📔 Store archived versions of your links in case they are depublished\n- 🔍 Full-text search on site contents\n- 👪 Share bookmarks with other users, groups and teams or via public links\n- ⚛ Generate RSS feeds of your collections\n- 📈 Stats on how often you access which links\n- 🔒 Automatic backups of your bookmarks collection\n- 💼 Built-in Dashboard widgets for frequent and recent links\n\nRequirements:\n - PHP extensions:\n   - intl: *\n   - mbstring: *\n - when using MySQL, use at least v8.0",
     "homepage": "https://github.com/nextcloud/bookmarks",
     "licenses": [
@@ -10,9 +10,9 @@
     ]
   },
   "calendar": {
-    "hash": "sha256-k7A38geyX6PS2j2t5iIXMMZMJsPKIiySVRKxcPAj+pM=",
-    "url": "https://github.com/nextcloud-releases/calendar/releases/download/v6.5.0/calendar-v6.5.0.tar.gz",
-    "version": "6.5.0",
+    "hash": "sha256-aqMBHxBDvOba/4nP93iJfmYYKz7J0QRs3S8xOQCEHNY=",
+    "url": "https://github.com/nextcloud-releases/calendar/releases/download/v6.5.1/calendar-v6.5.1.tar.gz",
+    "version": "6.5.1",
     "description": "A Calendar app for Nextcloud. Easily sync events from various devices with your Nextcloud and edit them online.\n\n* 🚀 **Integration with other Nextcloud apps!** Like Contacts, Talk, Tasks, Deck and Circles\n* 🌐 **WebCal Support!** Want to see your favorite team's matchdays in your calendar? No problem!\n* 🙋 **Attendees!** Invite people to your events\n* ⌚ **Free/Busy!** See when your attendees are available to meet\n* ⏰ **Reminders!** Get alarms for events inside your browser and via email\n* 🔍 **Search!** Find your events at ease\n* ☑️ **Tasks!** See tasks or Deck cards with a due date directly in the calendar\n* 🔈 **Talk rooms!** Create an associated Talk room when booking a meeting with just one click\n* 📆 **Appointment booking** Send people a link so they can book an appointment with you [using this app](https://apps.nextcloud.com/apps/appointments)\n* 📎 **Attachments!** Add, upload and view event attachments\n* 🙈 **We’re not reinventing the wheel!** Based on the great [c-dav library](https://github.com/nextcloud/cdav-library), [ical.js](https://github.com/mozilla-comm/ical.js) and [fullcalendar](https://github.com/fullcalendar/fullcalendar) libraries.",
     "homepage": "https://github.com/nextcloud/calendar/",
     "licenses": [
@@ -40,9 +40,9 @@
     ]
   },
   "contacts": {
-    "hash": "sha256-rFKmEZtyQgFjGBN44H167hGQP+n72uhUEiXlD7OguTI=",
-    "url": "https://github.com/nextcloud-releases/contacts/releases/download/v8.3.15/contacts-v8.3.15.tar.gz",
-    "version": "8.3.15",
+    "hash": "sha256-KiSsvKFN2D+qoJcOGY1pfWA6FDP92rmGuPJnYPxybgc=",
+    "url": "https://github.com/nextcloud-releases/contacts/releases/download/v8.3.16/contacts-v8.3.16.tar.gz",
+    "version": "8.3.16",
     "description": "The Nextcloud contacts app is a user interface for Nextcloud's CardDAV server. Easily sync contacts from various devices with your Nextcloud and edit them online.\n\n* 🚀 **Integration with other Nextcloud apps!** Currently Mail and Calendar – more to come.\n* 🎉 **Never forget a birthday!** You can sync birthdays and other recurring events with your Nextcloud Calendar.\n* 👥 **Sharing of Adressbooks!** You want to share your contacts with your friends or coworkers? No problem!\n* 🙈 **We’re not reinventing the wheel!** Based on the great and open SabreDAV library.",
     "homepage": "https://github.com/nextcloud/contacts#readme",
     "licenses": [
@@ -90,13 +90,13 @@
     ]
   },
   "end_to_end_encryption": {
-    "hash": "sha256-McIkFt53L1O+kb4zA3VisbgCKlcdht/DqPQKDOQTLds=",
-    "url": "https://github.com/nextcloud-releases/end_to_end_encryption/releases/download/v1.18.2/end_to_end_encryption-v1.18.2.tar.gz",
-    "version": "1.18.2",
+    "hash": "sha256-Tlv1zPWp8mLpZFrsxcbfqqro1tx5XGS+vgxrEYWe054=",
+    "url": "https://github.com/nextcloud-releases/end_to_end_encryption/releases/download/v1.18.3/end_to_end_encryption-v1.18.3.tar.gz",
+    "version": "1.18.3",
     "description": "## **End-to-End Encryption**\n\n### For End Users\n\n**Protect your most sensitive files with strong encryption.**\n\nThe End-to-End Encryption app gives you complete control over your data privacy.\nWith this app, you can encrypt specific folders so that only you (and those you trust) can access their contents.\nYour files are encrypted on your device before they reach the server, ensuring that no one—not even the server administrator—can read them.\n\n**Benefits:**\n- 🔒 **True privacy**: Files are encrypted on your device and can only be decrypted by you\n- 📱 **Works across all platforms**: Fully supported on desktop, Android, iOS clients, and as you wish even in the browser\n- 🎯 **Selective encryption**: Choose which folders to encrypt\n- 🛡️ **Secure sharing**: Share encrypted files with other users or even secure public upload using the encrypted file drop\n\n---\n\n### For Administrators\n\n**Enterprise-ready end-to-end encryption infrastructure for your Nextcloud instance.**\n\nThis app provides all the necessary server-side APIs and infrastructure to enable End-to-End encryption (E2EE) for your users.\nIt ensures that encrypted data remains secure throughout its lifecycle on your server.\n\n**Technical highlights:**\n- 🔐 **Complete API suite**: Provides all client-side APIs needed for E2EE implementation\n- 🔒 **Secure FileDrop integration**: Enables secure file sharing with encryption\n- 🛡️ **Zero-knowledge architecture**: Server never has access to encryption keys\n- ⚙️ **Group restrictions**: Limit app usage to specific user groups if needed\n- 🔄 **Background job management**: Automatic rollback handling for failed operations\n\n### Setup\nThis application provides the server-side infrastructure for end-to-end encryption, but it requires client support to function.\nTo enable end-to-end encryption, users will need to install the corresponding client-side app on their devices (desktop, Android, iOS) or use the web client.\n\nUsing the web interface, after enabling it in the personal settings, allows you to encrypt files and folders directly in the browser,\nproviding a seamless experience without needing additional software. But also requires some kind of trust in the server as the code is delivered by the server and could be manipulated.\n\nOnce enable through clients or the web interface, you can create encrypted folders and upload or move files into them.\nThe clients and the web interface will handle the encryption and decryption processes automatically.\n\n⚠️ This comes with some limitations and caveats, as only normal file operations can be handled.\nMeaning that some apps in the web interface do not work with encrypted files.",
     "homepage": "https://github.com/nextcloud/end_to_end_encryption",
     "licenses": [
-      "agpl"
+      "AGPL-3.0-or-later"
     ]
   },
   "files_automatedtagging": {
@@ -130,9 +130,9 @@
     ]
   },
   "forms": {
-    "hash": "sha256-r570gxd4j/AEMzT3vul6qxJsJ/bTEW459LONUOYA8ZM=",
-    "url": "https://github.com/nextcloud-releases/forms/releases/download/v5.3.2/forms-v5.3.2.tar.gz",
-    "version": "5.3.2",
+    "hash": "sha256-vd6qwBAGUtm+Fbfc/Ei1mtmENX5Zvz5ZlW1MGggytJ0=",
+    "url": "https://github.com/nextcloud-releases/forms/releases/download/v5.3.4/forms-v5.3.4.tar.gz",
+    "version": "5.3.4",
     "description": "**Simple surveys and questionnaires, self-hosted!**\n\n- **📝 Simple design:** No mass of options, only the essentials. Works well on mobile of course.\n- **📊 View & export results:** Results are visualized and can also be exported as CSV in the same format used by Google Forms.\n- **🔒 Data under your control!** Unlike in Google Forms, Typeform, Doodle and others, the survey info and responses are kept private on your instance.\n- **🧑‍💻 Connect to your software:** Easily integrate Forms into your service with our full-fledged [REST-API](https://github.com/nextcloud/forms/blob/main/docs/API_v3.md).\n- **🙋 Get involved!** We have lots of stuff planned like more question types, collaboration on forms, [and much more](https://github.com/nextcloud/forms/milestones)!",
     "homepage": "https://github.com/nextcloud/forms",
     "licenses": [
@@ -150,9 +150,9 @@
     ]
   },
   "groupfolders": {
-    "hash": "sha256-rOa82k/IwJdAweCzkZKLLqiOtP63eRdq98zxlnttFzc=",
-    "url": "https://github.com/nextcloud-releases/groupfolders/releases/download/v20.1.16/groupfolders-v20.1.16.tar.gz",
-    "version": "20.1.16",
+    "hash": "sha256-7afza6xNdNqNzIhiRuRHyhruATFrJmlaQm/fYQNS3Pw=",
+    "url": "https://github.com/nextcloud-releases/groupfolders/releases/download/v20.1.17/groupfolders-v20.1.17.tar.gz",
+    "version": "20.1.17",
     "description": "Team Folders (formerly \"Group Folders\") allows administrators to create and manage shared\nfolders for selected teams within Nextcloud.\n\nAdmins can grant one or more teams access to a folder, configure permissions (such as read,\nwrite, and sharing rights), and assign storage quotas from the Team Folders section (under\nadmin settings). The app also supports advanced permissions and integration with Nextcloud’s\ntrash and versioning systems.\n\nAs of Hub 10 / Nextcloud 31, admins must be members of a team to assign that team to a Team\nFolder.",
     "homepage": "https://github.com/nextcloud/groupfolders",
     "licenses": [
@@ -210,9 +210,9 @@
     ]
   },
   "mail": {
-    "hash": "sha256-c0pMd+A2Fbxa/20BAkg3lPeVRIdu0XRTbAGJxb/9NT0=",
-    "url": "https://github.com/nextcloud-releases/mail/releases/download/v5.10.7/mail-v5.10.7.tar.gz",
-    "version": "5.10.7",
+    "hash": "sha256-r7x9WkBAYw2KJ6D2FcLqbKHTHpVUP/z2eLjy4QorL7k=",
+    "url": "https://github.com/nextcloud-releases/mail/releases/download/v5.10.8/mail-v5.10.8.tar.gz",
+    "version": "5.10.8",
     "description": "**💌 A mail app for Nextcloud**\n\n- **🚀 Integration with other Nextcloud apps!** Currently Contacts, Calendar & Files – more to come.\n- **📥 Multiple mail accounts!** Personal and company account? No problem, and a nice unified inbox. Connect any IMAP account.\n- **🔒 Send & receive encrypted mails!** Using the great [Mailvelope](https://mailvelope.com) browser extension.\n- **🙈 We’re not reinventing the wheel!** Based on the great [Horde](https://www.horde.org) libraries.\n- **📬 Want to host your own mail server?** We do not have to reimplement this as you could set up [Mail-in-a-Box](https://mailinabox.email)!\n\n## Ethical AI Rating\n\n### Priority Inbox\n\nPositive:\n* The software for training and inferencing of this model is open source.\n* The model is created and trained on-premises based on the user's own data.\n* The training data is accessible to the user, making it possible to check or correct for bias or optimise the performance and CO2 usage.\n\n### Thread Summaries (opt-in)\n\n**Rating:** 🟢/🟡/🟠/🔴\n\nThe rating depends on the installed text processing backend. See [the rating overview](https://docs.nextcloud.com/server/latest/admin_manual/ai/index.html) for details.\n\nLearn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud.com/blog/nextcloud-ethical-ai-rating/).",
     "homepage": "https://github.com/nextcloud/mail#readme",
     "licenses": [
@@ -230,9 +230,9 @@
     ]
   },
   "music": {
-    "hash": "sha256-bQ9NBo5R/en3f68ag+mAsVWuhREjr/ajlKrfLn4Tvtg=",
-    "url": "https://github.com/nc-music/music/releases/download/v3.1.0/nc-music-3.1.0.tar.gz",
-    "version": "3.1.0",
+    "hash": "sha256-H8GsbDCdtHMKqsOVsyZA7nTBdBx0B+sfKdL5QupHEDI=",
+    "url": "https://github.com/nc-music/music/releases/download/v3.1.1/nc-music-3.1.1.tar.gz",
+    "version": "3.1.1",
     "description": "A stand-alone music player app and a \"lite\" player for the Files app\n\n- On modern browsers, supports audio types .mp3, .ogg, .m4a, .m4b, .flac, .wav, and more\n- Playlist support with import from .m3u, .m3u8, .pls, and .wpl files\n- Show lyrics from the file metadata or .lrc files\n- Browse by artists, albums, genres, or folders\n- Gapless play\n- Filter the shown content with the search function\n- Advanced search to freely use and combine dozens of search criteria\n- Play internet radio and podcast channels\n- Setup Last.fm connection to scrobble plays and/or see background information on artists, albums, and songs\n- Control with media control keys on the keyboard or OS\n- The app can handle libraries consisting of thousands of albums and tens of thousands of songs\n- Includes a server backend compatible with the Subsonic and Ampache protocols, allowing playback and browsing of your library on dozens of external apps on Android, iOS, Windows, Linux, etc.\n- Widget for the Nextcloud Dashboard",
     "homepage": "https://github.com/nc-music/music",
     "licenses": [
@@ -370,9 +370,9 @@
     ]
   },
   "richdocuments": {
-    "hash": "sha256-oLV1AFCGt/ukZ06TkOpEBGxOPQ3Z66dY2rpDj0tXiP4=",
-    "url": "https://github.com/nextcloud-releases/richdocuments/releases/download/v9.1.0/richdocuments-v9.1.0.tar.gz",
-    "version": "9.1.0",
+    "hash": "sha256-s/3SPckGmlTH+nS7VTqbDcBOgiLjW6RQsc6dwdg/zYE=",
+    "url": "https://github.com/nextcloud-releases/richdocuments/releases/download/v9.1.1/richdocuments-v9.1.1.tar.gz",
+    "version": "9.1.1",
     "description": "This application can connect to a Collabora Online (or other) server (WOPI-like Client). Nextcloud is the WOPI Host. Please read the documentation to learn more about that.\n\nYou can also edit your documents off-line with the Collabora Office app from the **[Android](https://play.google.com/store/apps/details?id=com.collabora.libreoffice)** and **[iOS](https://apps.apple.com/us/app/collabora-office/id1440482071)** store.",
     "homepage": "https://collaboraoffice.com/",
     "licenses": [
@@ -380,9 +380,9 @@
     ]
   },
   "sociallogin": {
-    "hash": "sha256-8yB+PFGi9+bUjiEEHBJxAyySMluPO/1m3sPUThe5+t0=",
-    "url": "https://github.com/zorn-v/nextcloud-social-login/releases/download/v6.5.2/release.tar.gz",
-    "version": "6.5.2",
+    "hash": "sha256-/mnpEUfyhjGG31TKzFEfKUuzflPL+pGcf6PRbNnkaUE=",
+    "url": "https://github.com/zorn-v/nextcloud-social-login/releases/download/v6.5.3/release.tar.gz",
+    "version": "6.5.3",
     "description": "# Social Login\n\nMake it possible to create users and log in via Telegram, OAuth, or OpenID.\n\nFor OAuth, you must create an app with certain providers. Login buttons will appear on the login page if an app ID is specified. Settings are located in the \"Social login\" section of the settings page.\n\n## Installation\n\nLog in to your Nextcloud installation as an administrator. Under \"Apps\", click \"Download and enable\" next to the \"Social Login\" app.\n\nSee below for setup and configuration instructions.\n\n## Custom OAuth2/OIDC Groups\n\nYou can use groups from your custom provider. For this, specify the \"Groups claim\" in the custom OAuth2/OIDC provider settings. This claim should be returned from the provider in the `id_token` or at the user info endpoint. Multiple claims (comma separated) also supported - groups will be merged.\nThe format should be an `array` or a comma-separated string. E.g., (with a claim named `roles`):\n\n```json\n{\"roles\": [\"admin\", \"user\"]}\n```\nor\n```json\n{\"roles\": \"admin,user\"}\n```\n\nNested claims are also supported. For example, `resource_access.client-id.roles` for:\n\n```json\n\"resource_access\": {\n   \"client-id\": {\n     \"roles\": [\n       \"client-role-1\",\n       \"client-role-2\"\n     ]\n   }\n}\n```\n\n**DisplayName** support is also available:\n```json\n{\"roles\": [{\"gid\": 1, \"displayName\": \"admin\"}, {\"gid\": 2, \"displayName\": \"user\"}]}\n```\n\nYou can use provider groups in two ways:\n\n1. Map provider groups to existing Nextcloud groups.\n2. Create provider groups in Nextcloud and associate them with users (if the appropriate option is enabled).\n\nTo sync groups on every login, ensure the \"Update user profile every login\" setting is checked.\n\n## Examples for Groups\n\n* Configure WSO2IS to return a roles claim with OIDC [here](https://medium.com/@dewni.matheesha/claim-mapping-and-retrieving-end-user-information-in-wso2is-cffd5f3937ff).\n* [GitLab OIDC configuration to allow specific GitLab groups](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/gitlab.md).\n\n## Built-in OAuth Providers\n\nCopy the link from a specific login button to get the correct \"redirect URL\" for OAuth app settings.\n\n* [Amazon](https://developer.amazon.com/loginwithamazon/console/site/lwa/overview.html)\n* [Apple](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/apple.md)\n* [Codeberg](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/codeberg.md)\n* [Discord](#configure-discord)\n* [Facebook](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/facebook.md)\n* [GitHub](https://github.com/settings/developers)\n* [GitLab](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/gitlab.md)\n* [Google](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/google.md)\n* [Keycloak](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/keycloak.md)\n* [Mail.ru](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/mailru.md)\n* **PlexTv**: Use any title as the app ID.\n* [Telegram](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/telegram.md)\n* [Twitter](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/twitter.md)\n\nFor details about Google's \"Allow login only from specified domain\" setting, see [#44](https://github.com/zorn-v/nextcloud-social-login/issues/44). Use a comma-separated list for multiple domains.\n\n## Configuration\n\nAdd `'social_login_auto_redirect' => true` to `config.php` to automatically redirect unauthorized users to social login if only one provider is configured. To temporarily disable this (e.g., for local admin login), add `noredir=1` to the login URL: `https://cloud.domain.com/login?noredir=1`.\n\nConfigure HTTP client options using:\n```php\n  'social_login_http_client' => [\n    'timeout' => 45,\n    'proxy' => 'socks4://127.0.0.1:9050', // See <https://curl.se/libcurl/c/CURLOPT_PROXY.html> for allowed formats\n  ],\n```\nin `config.php`.\n\n### Configure a Provider via CLI\n\nUse the `occ` utility to configure providers via the command line. Replace variables and URLs with your deployment values:\n```bash\nphp occ config:app:set sociallogin custom_providers --value='{\"custom_oidc\": [{\"name\": \"gitlab_oidc\", \"title\": \"Gitlab\", \"authorizeUrl\": \"https://gitlab.my-domain.org/oauth/authorize\", \"tokenUrl\": \"https://gitlab.my-domain.org/oauth/token\", \"userInfoUrl\": \"https://gitlab.my-domain.org/oauth/userinfo\", \"logoutUrl\": \"\", \"clientId\": \"$my_application_id\", \"clientSecret\": \"$my_super_secret_secret\", \"scope\": \"openid\", \"groupsClaim\": \"groups\", \"style\": \"gitlab\", \"defaultGroup\": \"\"}]}'\n```\nFor Docker, prepend `docker exec -t -uwww-data CONTAINER_NAME` to the command or run interactively via `docker exec -it -uwww-data CONTAINER_NAME sh`.\n\nTo inspect configurations:\n```sql\nmysql -u nextcloud -p nextcloud\nPassword: <yourpassword>\n\n> SELECT * FROM oc_appconfig WHERE appid='sociallogin';\n```\nOr run:\n```bash\ndocker exec -t -uwww-data CONTAINER_NAME php occ config:app:get sociallogin custom_providers\n```\n\n### Configure Discord\n\n1. Create a Discord application at [Discord Developer Portal](https://discord.com/developers/applications).\n2. Navigate to `Settings > OAuth2 > General`. Add a redirect URL: `https://nextcloud.mydomain.com/apps/sociallogin/oauth/discord`.\n3. Copy the `CLIENT ID` and generate a `CLIENT SECRET`.\n4. In Nextcloud, go to `Settings > Social Login`. Paste the `CLIENT ID` into \"App id\" and `CLIENT SECRET` into \"Secret\".\n5. Select a default group for new users.\n6. For group mapping, see [#395](https://github.com/zorn-v/nextcloud-social-login/pull/395).\n\n## Hint\n\n### Callback (Reply) URL\nCopy the link from a login button on the Nextcloud login page and use it as the callback URL on your provider's site. To make the button visible temporarily, fill provider settings with placeholder data and update later.\n\nIf you encounter callback URL errors despite correct settings, ensure your Nextcloud server generates HTTPS URLs by adding `'overwriteprotocol' => 'https'` to `config.php`.",
     "homepage": "https://github.com/zorn-v/nextcloud-social-login",
     "licenses": [
@@ -480,9 +480,9 @@
     ]
   },
   "user_saml": {
-    "hash": "sha256-LDiWtEaVJbNECJkcn80L4behkUyUsRlDFDd2lk2g+pE=",
-    "url": "https://github.com/nextcloud-releases/user_saml/releases/download/v8.1.4/user_saml-v8.1.4.tar.gz",
-    "version": "8.1.4",
+    "hash": "sha256-HseXj3gaVa1rjJ/C1N6x223yU0usyJ7rt8RqhVMKiDY=",
+    "url": "https://github.com/nextcloud-releases/user_saml/releases/download/v8.2.0/user_saml-v8.2.0.tar.gz",
+    "version": "8.2.0",
     "description": "Using the SSO & SAML app of your Nextcloud you can make it easily possible to integrate your existing Single-Sign-On solution with Nextcloud. In addition, you can use the Nextcloud LDAP user provider to keep the convenience for users. (e.g. when sharing)\nThe following providers are supported and tested at the moment:\n\n* **SAML 2.0**\n\t* OneLogin\n\t* Shibboleth\n\t* Active Directory Federation Services (ADFS)\n\t* Authentik\n\n* **Authentication via Environment Variable**\n\t* Kerberos (mod_auth_kerb)\n\t* Any other provider that authenticates using the environment variable\n\nWhile theoretically any other authentication provider implementing either one of those standards is compatible, we like to note that they are not part of any internal test matrix.",
     "homepage": "https://github.com/nextcloud/user_saml",
     "licenses": [

--- a/pkgs/servers/nextcloud/packages/33.json
+++ b/pkgs/servers/nextcloud/packages/33.json
@@ -1,8 +1,8 @@
 {
   "bookmarks": {
-    "hash": "sha256-8F+sNG/+M8Ed/q5dcxW95KS5ZBNsEeZNR0P2OIe/HqQ=",
-    "url": "https://github.com/nextcloud/bookmarks/releases/download/v16.2.2/bookmarks-16.2.2.tar.gz",
-    "version": "16.2.2",
+    "hash": "sha256-0jBKcGX6ljlXruILcKlsm7ZBrC5hyDuHp/9lgG0eoBE=",
+    "url": "https://github.com/nextcloud/bookmarks/releases/download/v16.2.4/bookmarks-16.2.4.tar.gz",
+    "version": "16.2.4",
     "description": "- 📂 Sort bookmarks into folders\n- 🏷 Add tags and personal notes\n- ☠ Find broken links and duplicates\n- 📲 Synchronize with all your browsers and devices\n- 📔 Store archived versions of your links in case they are depublished\n- 🔍 Full-text search on site contents\n- 👪 Share bookmarks with other users, groups and teams or via public links\n- ⚛ Generate RSS feeds of your collections\n- 📈 Stats on how often you access which links\n- 🔒 Automatic backups of your bookmarks collection\n- 💼 Built-in Dashboard widgets for frequent and recent links\n\nRequirements:\n - PHP extensions:\n   - intl: *\n   - mbstring: *\n - when using MySQL, use at least v8.0",
     "homepage": "https://github.com/nextcloud/bookmarks",
     "licenses": [
@@ -10,9 +10,9 @@
     ]
   },
   "calendar": {
-    "hash": "sha256-k7A38geyX6PS2j2t5iIXMMZMJsPKIiySVRKxcPAj+pM=",
-    "url": "https://github.com/nextcloud-releases/calendar/releases/download/v6.5.0/calendar-v6.5.0.tar.gz",
-    "version": "6.5.0",
+    "hash": "sha256-aqMBHxBDvOba/4nP93iJfmYYKz7J0QRs3S8xOQCEHNY=",
+    "url": "https://github.com/nextcloud-releases/calendar/releases/download/v6.5.1/calendar-v6.5.1.tar.gz",
+    "version": "6.5.1",
     "description": "A Calendar app for Nextcloud. Easily sync events from various devices with your Nextcloud and edit them online.\n\n* 🚀 **Integration with other Nextcloud apps!** Like Contacts, Talk, Tasks, Deck and Circles\n* 🌐 **WebCal Support!** Want to see your favorite team's matchdays in your calendar? No problem!\n* 🙋 **Attendees!** Invite people to your events\n* ⌚ **Free/Busy!** See when your attendees are available to meet\n* ⏰ **Reminders!** Get alarms for events inside your browser and via email\n* 🔍 **Search!** Find your events at ease\n* ☑️ **Tasks!** See tasks or Deck cards with a due date directly in the calendar\n* 🔈 **Talk rooms!** Create an associated Talk room when booking a meeting with just one click\n* 📆 **Appointment booking** Send people a link so they can book an appointment with you [using this app](https://apps.nextcloud.com/apps/appointments)\n* 📎 **Attachments!** Add, upload and view event attachments\n* 🙈 **We’re not reinventing the wheel!** Based on the great [c-dav library](https://github.com/nextcloud/cdav-library), [ical.js](https://github.com/mozilla-comm/ical.js) and [fullcalendar](https://github.com/fullcalendar/fullcalendar) libraries.",
     "homepage": "https://github.com/nextcloud/calendar/",
     "licenses": [
@@ -40,9 +40,9 @@
     ]
   },
   "contacts": {
-    "hash": "sha256-Lgw+wF40FlZTlbw5IXG/eUW8Chaw5Cm1i9f2R8YyPRU=",
-    "url": "https://github.com/nextcloud-releases/contacts/releases/download/v8.7.3/contacts-v8.7.3.tar.gz",
-    "version": "8.7.3",
+    "hash": "sha256-2oDKASmKBOahKq2cDSIDr7ud2/plNK0DL0ReJKpHzAc=",
+    "url": "https://github.com/nextcloud-releases/contacts/releases/download/v8.7.4/contacts-v8.7.4.tar.gz",
+    "version": "8.7.4",
     "description": "The Nextcloud contacts app is a user interface for Nextcloud's CardDAV server. Easily sync contacts from various devices with your Nextcloud and edit them online.\n\n* 🚀 **Integration with other Nextcloud apps!** Currently Mail and Calendar – more to come.\n* 🎉 **Never forget a birthday!** You can sync birthdays and other recurring events with your Nextcloud Calendar.\n* 👥 **Sharing of Adressbooks!** You want to share your contacts with your friends or coworkers? No problem!\n* 🙈 **We’re not reinventing the wheel!** Based on the great and open SabreDAV library.",
     "homepage": "https://github.com/nextcloud/contacts#readme",
     "licenses": [
@@ -90,9 +90,9 @@
     ]
   },
   "end_to_end_encryption": {
-    "hash": "sha256-Z6MyXz//LNVy7Mt+yFbHIY5zGEMfsdwnAEDFsIcrs1M=",
-    "url": "https://github.com/nextcloud-releases/end_to_end_encryption/releases/download/v2.2.0/end_to_end_encryption-v2.2.0.tar.gz",
-    "version": "2.2.0",
+    "hash": "sha256-NfnIdc2Q8GgfgjqD8PeTS+O5vTWMBld+vCX/6ng/Im8=",
+    "url": "https://github.com/nextcloud-releases/end_to_end_encryption/releases/download/v2.2.1/end_to_end_encryption-v2.2.1.tar.gz",
+    "version": "2.2.1",
     "description": "## **End-to-End Encryption**\n\n### For End Users\n\n**Protect your most sensitive files with strong encryption.**\n\nThe End-to-End Encryption app gives you complete control over your data privacy.\nWith this app, you can encrypt specific folders so that only you (and those you trust) can access their contents.\nYour files are encrypted on your device before they reach the server, ensuring that no one—not even the server administrator—can read them.\n\n**Benefits:**\n- 🔒 **True privacy**: Files are encrypted on your device and can only be decrypted by you\n- 📱 **Works across all platforms**: Fully supported on desktop, Android, iOS clients, and as you wish even in the browser\n- 🎯 **Selective encryption**: Choose which folders to encrypt\n- 🛡️ **Secure sharing**: Share encrypted files with other users or even secure public upload using the encrypted file drop\n\n---\n\n### For Administrators\n\n**Enterprise-ready end-to-end encryption infrastructure for your Nextcloud instance.**\n\nThis app provides all the necessary server-side APIs and infrastructure to enable End-to-End encryption (E2EE) for your users.\nIt ensures that encrypted data remains secure throughout its lifecycle on your server.\n\n**Technical highlights:**\n- 🔐 **Complete API suite**: Provides all client-side APIs needed for E2EE implementation\n- 🔒 **Secure FileDrop integration**: Enables secure file sharing with encryption\n- 🛡️ **Zero-knowledge architecture**: Server never has access to encryption keys\n- ⚙️ **Group restrictions**: Limit app usage to specific user groups if needed\n- 🔄 **Background job management**: Automatic rollback handling for failed operations\n\n### Setup\nThis application provides the server-side infrastructure for end-to-end encryption, but it requires client support to function.\nTo enable end-to-end encryption, users will need to install the corresponding client-side app on their devices (desktop, Android, iOS) or use the web client.\n\nUsing the web interface, after enabling it in the personal settings, allows you to encrypt files and folders directly in the browser,\nproviding a seamless experience without needing additional software. But also requires some kind of trust in the server as the code is delivered by the server and could be manipulated.\n\nOnce enable through clients or the web interface, you can create encrypted folders and upload or move files into them.\nThe clients and the web interface will handle the encryption and decryption processes automatically.\n\n⚠️ This comes with some limitations and caveats, as only normal file operations can be handled.\nMeaning that some apps in the web interface do not work with encrypted files.",
     "homepage": "https://github.com/nextcloud/end_to_end_encryption",
     "licenses": [
@@ -130,9 +130,9 @@
     ]
   },
   "forms": {
-    "hash": "sha256-r570gxd4j/AEMzT3vul6qxJsJ/bTEW459LONUOYA8ZM=",
-    "url": "https://github.com/nextcloud-releases/forms/releases/download/v5.3.2/forms-v5.3.2.tar.gz",
-    "version": "5.3.2",
+    "hash": "sha256-vd6qwBAGUtm+Fbfc/Ei1mtmENX5Zvz5ZlW1MGggytJ0=",
+    "url": "https://github.com/nextcloud-releases/forms/releases/download/v5.3.4/forms-v5.3.4.tar.gz",
+    "version": "5.3.4",
     "description": "**Simple surveys and questionnaires, self-hosted!**\n\n- **📝 Simple design:** No mass of options, only the essentials. Works well on mobile of course.\n- **📊 View & export results:** Results are visualized and can also be exported as CSV in the same format used by Google Forms.\n- **🔒 Data under your control!** Unlike in Google Forms, Typeform, Doodle and others, the survey info and responses are kept private on your instance.\n- **🧑‍💻 Connect to your software:** Easily integrate Forms into your service with our full-fledged [REST-API](https://github.com/nextcloud/forms/blob/main/docs/API_v3.md).\n- **🙋 Get involved!** We have lots of stuff planned like more question types, collaboration on forms, [and much more](https://github.com/nextcloud/forms/milestones)!",
     "homepage": "https://github.com/nextcloud/forms",
     "licenses": [
@@ -150,13 +150,13 @@
     ]
   },
   "groupfolders": {
-    "hash": "sha256-2LlfB3hCX2RvIxG6W0LY4vz9833C/TX8rI0/Ab3jiiE=",
-    "url": "https://github.com/nextcloud-releases/groupfolders/releases/download/v21.0.9/groupfolders-v21.0.9.tar.gz",
-    "version": "21.0.9",
+    "hash": "sha256-elHsIh1LD/5c1BT/+YLMSMLtMXdLacTPpU4SSORdjw0=",
+    "url": "https://github.com/nextcloud-releases/groupfolders/releases/download/v21.0.10/groupfolders-v21.0.10.tar.gz",
+    "version": "21.0.10",
     "description": "Team Folders (formerly \"Group Folders\") allows administrators to create and manage shared\nfolders for selected teams within Nextcloud.\n\nAdmins can grant one or more teams access to a folder, configure permissions (such as read,\nwrite, and sharing rights), and assign storage quotas from the Team Folders section (under\nadmin settings). The app also supports advanced permissions and integration with Nextcloud’s\ntrash and versioning systems.\n\nAs of Hub 10 / Nextcloud 31, admins must be members of a team to assign that team to a Team\nFolder.",
     "homepage": "https://github.com/nextcloud/groupfolders",
     "licenses": [
-      "agpl"
+      "AGPL-3.0-or-later"
     ]
   },
   "guests": {
@@ -210,9 +210,9 @@
     ]
   },
   "mail": {
-    "hash": "sha256-c0pMd+A2Fbxa/20BAkg3lPeVRIdu0XRTbAGJxb/9NT0=",
-    "url": "https://github.com/nextcloud-releases/mail/releases/download/v5.10.7/mail-v5.10.7.tar.gz",
-    "version": "5.10.7",
+    "hash": "sha256-r7x9WkBAYw2KJ6D2FcLqbKHTHpVUP/z2eLjy4QorL7k=",
+    "url": "https://github.com/nextcloud-releases/mail/releases/download/v5.10.8/mail-v5.10.8.tar.gz",
+    "version": "5.10.8",
     "description": "**💌 A mail app for Nextcloud**\n\n- **🚀 Integration with other Nextcloud apps!** Currently Contacts, Calendar & Files – more to come.\n- **📥 Multiple mail accounts!** Personal and company account? No problem, and a nice unified inbox. Connect any IMAP account.\n- **🔒 Send & receive encrypted mails!** Using the great [Mailvelope](https://mailvelope.com) browser extension.\n- **🙈 We’re not reinventing the wheel!** Based on the great [Horde](https://www.horde.org) libraries.\n- **📬 Want to host your own mail server?** We do not have to reimplement this as you could set up [Mail-in-a-Box](https://mailinabox.email)!\n\n## Ethical AI Rating\n\n### Priority Inbox\n\nPositive:\n* The software for training and inferencing of this model is open source.\n* The model is created and trained on-premises based on the user's own data.\n* The training data is accessible to the user, making it possible to check or correct for bias or optimise the performance and CO2 usage.\n\n### Thread Summaries (opt-in)\n\n**Rating:** 🟢/🟡/🟠/🔴\n\nThe rating depends on the installed text processing backend. See [the rating overview](https://docs.nextcloud.com/server/latest/admin_manual/ai/index.html) for details.\n\nLearn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud.com/blog/nextcloud-ethical-ai-rating/).",
     "homepage": "https://github.com/nextcloud/mail#readme",
     "licenses": [
@@ -230,9 +230,9 @@
     ]
   },
   "music": {
-    "hash": "sha256-bQ9NBo5R/en3f68ag+mAsVWuhREjr/ajlKrfLn4Tvtg=",
-    "url": "https://github.com/nc-music/music/releases/download/v3.1.0/nc-music-3.1.0.tar.gz",
-    "version": "3.1.0",
+    "hash": "sha256-H8GsbDCdtHMKqsOVsyZA7nTBdBx0B+sfKdL5QupHEDI=",
+    "url": "https://github.com/nc-music/music/releases/download/v3.1.1/nc-music-3.1.1.tar.gz",
+    "version": "3.1.1",
     "description": "A stand-alone music player app and a \"lite\" player for the Files app\n\n- On modern browsers, supports audio types .mp3, .ogg, .m4a, .m4b, .flac, .wav, and more\n- Playlist support with import from .m3u, .m3u8, .pls, and .wpl files\n- Show lyrics from the file metadata or .lrc files\n- Browse by artists, albums, genres, or folders\n- Gapless play\n- Filter the shown content with the search function\n- Advanced search to freely use and combine dozens of search criteria\n- Play internet radio and podcast channels\n- Setup Last.fm connection to scrobble plays and/or see background information on artists, albums, and songs\n- Control with media control keys on the keyboard or OS\n- The app can handle libraries consisting of thousands of albums and tens of thousands of songs\n- Includes a server backend compatible with the Subsonic and Ampache protocols, allowing playback and browsing of your library on dozens of external apps on Android, iOS, Windows, Linux, etc.\n- Widget for the Nextcloud Dashboard",
     "homepage": "https://github.com/nc-music/music",
     "licenses": [
@@ -370,9 +370,9 @@
     ]
   },
   "richdocuments": {
-    "hash": "sha256-HGNCueLlZuauHi/0dltApMDj8FBZ4Ruj2T2F+/4qWY4=",
-    "url": "https://github.com/nextcloud-releases/richdocuments/releases/download/v10.2.0/richdocuments-v10.2.0.tar.gz",
-    "version": "10.2.0",
+    "hash": "sha256-MfqxhuPGUiKBP8a8yrzFWORaMxyOWRhkYPCPFDh2K/A=",
+    "url": "https://github.com/nextcloud-releases/richdocuments/releases/download/v10.2.1/richdocuments-v10.2.1.tar.gz",
+    "version": "10.2.1",
     "description": "This application can connect to a Collabora Online (or other) server (WOPI-like Client). Nextcloud is the WOPI Host. Please read the documentation to learn more about that.\n\nYou can also edit your documents off-line with the Collabora Office app from the **[Android](https://play.google.com/store/apps/details?id=com.collabora.libreoffice)** and **[iOS](https://apps.apple.com/us/app/collabora-office/id1440482071)** store.",
     "homepage": "https://collaboraoffice.com/",
     "licenses": [
@@ -380,9 +380,9 @@
     ]
   },
   "sociallogin": {
-    "hash": "sha256-8yB+PFGi9+bUjiEEHBJxAyySMluPO/1m3sPUThe5+t0=",
-    "url": "https://github.com/zorn-v/nextcloud-social-login/releases/download/v6.5.2/release.tar.gz",
-    "version": "6.5.2",
+    "hash": "sha256-/mnpEUfyhjGG31TKzFEfKUuzflPL+pGcf6PRbNnkaUE=",
+    "url": "https://github.com/zorn-v/nextcloud-social-login/releases/download/v6.5.3/release.tar.gz",
+    "version": "6.5.3",
     "description": "# Social Login\n\nMake it possible to create users and log in via Telegram, OAuth, or OpenID.\n\nFor OAuth, you must create an app with certain providers. Login buttons will appear on the login page if an app ID is specified. Settings are located in the \"Social login\" section of the settings page.\n\n## Installation\n\nLog in to your Nextcloud installation as an administrator. Under \"Apps\", click \"Download and enable\" next to the \"Social Login\" app.\n\nSee below for setup and configuration instructions.\n\n## Custom OAuth2/OIDC Groups\n\nYou can use groups from your custom provider. For this, specify the \"Groups claim\" in the custom OAuth2/OIDC provider settings. This claim should be returned from the provider in the `id_token` or at the user info endpoint. Multiple claims (comma separated) also supported - groups will be merged.\nThe format should be an `array` or a comma-separated string. E.g., (with a claim named `roles`):\n\n```json\n{\"roles\": [\"admin\", \"user\"]}\n```\nor\n```json\n{\"roles\": \"admin,user\"}\n```\n\nNested claims are also supported. For example, `resource_access.client-id.roles` for:\n\n```json\n\"resource_access\": {\n   \"client-id\": {\n     \"roles\": [\n       \"client-role-1\",\n       \"client-role-2\"\n     ]\n   }\n}\n```\n\n**DisplayName** support is also available:\n```json\n{\"roles\": [{\"gid\": 1, \"displayName\": \"admin\"}, {\"gid\": 2, \"displayName\": \"user\"}]}\n```\n\nYou can use provider groups in two ways:\n\n1. Map provider groups to existing Nextcloud groups.\n2. Create provider groups in Nextcloud and associate them with users (if the appropriate option is enabled).\n\nTo sync groups on every login, ensure the \"Update user profile every login\" setting is checked.\n\n## Examples for Groups\n\n* Configure WSO2IS to return a roles claim with OIDC [here](https://medium.com/@dewni.matheesha/claim-mapping-and-retrieving-end-user-information-in-wso2is-cffd5f3937ff).\n* [GitLab OIDC configuration to allow specific GitLab groups](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/gitlab.md).\n\n## Built-in OAuth Providers\n\nCopy the link from a specific login button to get the correct \"redirect URL\" for OAuth app settings.\n\n* [Amazon](https://developer.amazon.com/loginwithamazon/console/site/lwa/overview.html)\n* [Apple](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/apple.md)\n* [Codeberg](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/codeberg.md)\n* [Discord](#configure-discord)\n* [Facebook](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/facebook.md)\n* [GitHub](https://github.com/settings/developers)\n* [GitLab](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/gitlab.md)\n* [Google](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/google.md)\n* [Keycloak](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/keycloak.md)\n* [Mail.ru](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/mailru.md)\n* **PlexTv**: Use any title as the app ID.\n* [Telegram](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/telegram.md)\n* [Twitter](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/twitter.md)\n\nFor details about Google's \"Allow login only from specified domain\" setting, see [#44](https://github.com/zorn-v/nextcloud-social-login/issues/44). Use a comma-separated list for multiple domains.\n\n## Configuration\n\nAdd `'social_login_auto_redirect' => true` to `config.php` to automatically redirect unauthorized users to social login if only one provider is configured. To temporarily disable this (e.g., for local admin login), add `noredir=1` to the login URL: `https://cloud.domain.com/login?noredir=1`.\n\nConfigure HTTP client options using:\n```php\n  'social_login_http_client' => [\n    'timeout' => 45,\n    'proxy' => 'socks4://127.0.0.1:9050', // See <https://curl.se/libcurl/c/CURLOPT_PROXY.html> for allowed formats\n  ],\n```\nin `config.php`.\n\n### Configure a Provider via CLI\n\nUse the `occ` utility to configure providers via the command line. Replace variables and URLs with your deployment values:\n```bash\nphp occ config:app:set sociallogin custom_providers --value='{\"custom_oidc\": [{\"name\": \"gitlab_oidc\", \"title\": \"Gitlab\", \"authorizeUrl\": \"https://gitlab.my-domain.org/oauth/authorize\", \"tokenUrl\": \"https://gitlab.my-domain.org/oauth/token\", \"userInfoUrl\": \"https://gitlab.my-domain.org/oauth/userinfo\", \"logoutUrl\": \"\", \"clientId\": \"$my_application_id\", \"clientSecret\": \"$my_super_secret_secret\", \"scope\": \"openid\", \"groupsClaim\": \"groups\", \"style\": \"gitlab\", \"defaultGroup\": \"\"}]}'\n```\nFor Docker, prepend `docker exec -t -uwww-data CONTAINER_NAME` to the command or run interactively via `docker exec -it -uwww-data CONTAINER_NAME sh`.\n\nTo inspect configurations:\n```sql\nmysql -u nextcloud -p nextcloud\nPassword: <yourpassword>\n\n> SELECT * FROM oc_appconfig WHERE appid='sociallogin';\n```\nOr run:\n```bash\ndocker exec -t -uwww-data CONTAINER_NAME php occ config:app:get sociallogin custom_providers\n```\n\n### Configure Discord\n\n1. Create a Discord application at [Discord Developer Portal](https://discord.com/developers/applications).\n2. Navigate to `Settings > OAuth2 > General`. Add a redirect URL: `https://nextcloud.mydomain.com/apps/sociallogin/oauth/discord`.\n3. Copy the `CLIENT ID` and generate a `CLIENT SECRET`.\n4. In Nextcloud, go to `Settings > Social Login`. Paste the `CLIENT ID` into \"App id\" and `CLIENT SECRET` into \"Secret\".\n5. Select a default group for new users.\n6. For group mapping, see [#395](https://github.com/zorn-v/nextcloud-social-login/pull/395).\n\n## Hint\n\n### Callback (Reply) URL\nCopy the link from a login button on the Nextcloud login page and use it as the callback URL on your provider's site. To make the button visible temporarily, fill provider settings with placeholder data and update later.\n\nIf you encounter callback URL errors despite correct settings, ensure your Nextcloud server generates HTTPS URLs by adding `'overwriteprotocol' => 'https'` to `config.php`.",
     "homepage": "https://github.com/zorn-v/nextcloud-social-login",
     "licenses": [
@@ -480,9 +480,9 @@
     ]
   },
   "user_saml": {
-    "hash": "sha256-LDiWtEaVJbNECJkcn80L4behkUyUsRlDFDd2lk2g+pE=",
-    "url": "https://github.com/nextcloud-releases/user_saml/releases/download/v8.1.4/user_saml-v8.1.4.tar.gz",
-    "version": "8.1.4",
+    "hash": "sha256-HseXj3gaVa1rjJ/C1N6x223yU0usyJ7rt8RqhVMKiDY=",
+    "url": "https://github.com/nextcloud-releases/user_saml/releases/download/v8.2.0/user_saml-v8.2.0.tar.gz",
+    "version": "8.2.0",
     "description": "Using the SSO & SAML app of your Nextcloud you can make it easily possible to integrate your existing Single-Sign-On solution with Nextcloud. In addition, you can use the Nextcloud LDAP user provider to keep the convenience for users. (e.g. when sharing)\nThe following providers are supported and tested at the moment:\n\n* **SAML 2.0**\n\t* OneLogin\n\t* Shibboleth\n\t* Active Directory Federation Services (ADFS)\n\t* Authentik\n\n* **Authentication via Environment Variable**\n\t* Kerberos (mod_auth_kerb)\n\t* Any other provider that authenticates using the environment variable\n\nWhile theoretically any other authentication provider implementing either one of those standards is compatible, we like to note that they are not part of any internal test matrix.",
     "homepage": "https://github.com/nextcloud/user_saml",
     "licenses": [

--- a/pkgs/servers/nextcloud/packages/33.json
+++ b/pkgs/servers/nextcloud/packages/33.json
@@ -89,6 +89,16 @@
       "agpl"
     ]
   },
+  "drawio": {
+    "hash": "sha256-nVcO2V0zo7VdL/o8c6IRbiIqFnGBH7NdqL/eefQ/ip0=",
+    "url": "https://github.com/arnowelzel/drawio-nextcloud/releases/download/v4.3.0/drawio-v4.3.0.tar.gz",
+    "version": "4.3.0",
+    "description": "Integrates the diagrams.net diagram editor with Nextcloud. Users can create and edit .drawio diagrams and .dwb whiteboards directly within the Nextcloud file manager.\n\n**Features:**\n\n- Create and edit diagrams and whiteboards from the Nextcloud \"+\" menu\n- Click any .drawio or .dwb file to open the editor inline\n- Autosave with optimistic conflict detection\n- Inline diagram previews in Text, Collectives, Talk, Notes, and Deck\n- Supports public share links (read-only and editable)\n- Offline mode for privacy-sensitive deployments\n- Configurable editor URL for self-hosted diagrams.net instances",
+    "homepage": "https://github.com/arnowelzel/drawio-nextcloud",
+    "licenses": [
+      "agpl"
+    ]
+  },
   "end_to_end_encryption": {
     "hash": "sha256-NfnIdc2Q8GgfgjqD8PeTS+O5vTWMBld+vCX/6ng/Im8=",
     "url": "https://github.com/nextcloud-releases/end_to_end_encryption/releases/download/v2.2.1/end_to_end_encryption-v2.2.1.tar.gz",

--- a/pkgs/servers/nextcloud/packages/34.json
+++ b/pkgs/servers/nextcloud/packages/34.json
@@ -1,8 +1,8 @@
 {
   "bookmarks": {
-    "hash": "sha256-8F+sNG/+M8Ed/q5dcxW95KS5ZBNsEeZNR0P2OIe/HqQ=",
-    "url": "https://github.com/nextcloud/bookmarks/releases/download/v16.2.2/bookmarks-16.2.2.tar.gz",
-    "version": "16.2.2",
+    "hash": "sha256-0jBKcGX6ljlXruILcKlsm7ZBrC5hyDuHp/9lgG0eoBE=",
+    "url": "https://github.com/nextcloud/bookmarks/releases/download/v16.2.4/bookmarks-16.2.4.tar.gz",
+    "version": "16.2.4",
     "description": "- 📂 Sort bookmarks into folders\n- 🏷 Add tags and personal notes\n- ☠ Find broken links and duplicates\n- 📲 Synchronize with all your browsers and devices\n- 📔 Store archived versions of your links in case they are depublished\n- 🔍 Full-text search on site contents\n- 👪 Share bookmarks with other users, groups and teams or via public links\n- ⚛ Generate RSS feeds of your collections\n- 📈 Stats on how often you access which links\n- 🔒 Automatic backups of your bookmarks collection\n- 💼 Built-in Dashboard widgets for frequent and recent links\n\nRequirements:\n - PHP extensions:\n   - intl: *\n   - mbstring: *\n - when using MySQL, use at least v8.0",
     "homepage": "https://github.com/nextcloud/bookmarks",
     "licenses": [
@@ -10,9 +10,9 @@
     ]
   },
   "calendar": {
-    "hash": "sha256-k7A38geyX6PS2j2t5iIXMMZMJsPKIiySVRKxcPAj+pM=",
-    "url": "https://github.com/nextcloud-releases/calendar/releases/download/v6.5.0/calendar-v6.5.0.tar.gz",
-    "version": "6.5.0",
+    "hash": "sha256-aqMBHxBDvOba/4nP93iJfmYYKz7J0QRs3S8xOQCEHNY=",
+    "url": "https://github.com/nextcloud-releases/calendar/releases/download/v6.5.1/calendar-v6.5.1.tar.gz",
+    "version": "6.5.1",
     "description": "A Calendar app for Nextcloud. Easily sync events from various devices with your Nextcloud and edit them online.\n\n* 🚀 **Integration with other Nextcloud apps!** Like Contacts, Talk, Tasks, Deck and Circles\n* 🌐 **WebCal Support!** Want to see your favorite team's matchdays in your calendar? No problem!\n* 🙋 **Attendees!** Invite people to your events\n* ⌚ **Free/Busy!** See when your attendees are available to meet\n* ⏰ **Reminders!** Get alarms for events inside your browser and via email\n* 🔍 **Search!** Find your events at ease\n* ☑️ **Tasks!** See tasks or Deck cards with a due date directly in the calendar\n* 🔈 **Talk rooms!** Create an associated Talk room when booking a meeting with just one click\n* 📆 **Appointment booking** Send people a link so they can book an appointment with you [using this app](https://apps.nextcloud.com/apps/appointments)\n* 📎 **Attachments!** Add, upload and view event attachments\n* 🙈 **We’re not reinventing the wheel!** Based on the great [c-dav library](https://github.com/nextcloud/cdav-library), [ical.js](https://github.com/mozilla-comm/ical.js) and [fullcalendar](https://github.com/fullcalendar/fullcalendar) libraries.",
     "homepage": "https://github.com/nextcloud/calendar/",
     "licenses": [
@@ -40,9 +40,9 @@
     ]
   },
   "contacts": {
-    "hash": "sha256-Lgw+wF40FlZTlbw5IXG/eUW8Chaw5Cm1i9f2R8YyPRU=",
-    "url": "https://github.com/nextcloud-releases/contacts/releases/download/v8.7.3/contacts-v8.7.3.tar.gz",
-    "version": "8.7.3",
+    "hash": "sha256-2oDKASmKBOahKq2cDSIDr7ud2/plNK0DL0ReJKpHzAc=",
+    "url": "https://github.com/nextcloud-releases/contacts/releases/download/v8.7.4/contacts-v8.7.4.tar.gz",
+    "version": "8.7.4",
     "description": "The Nextcloud contacts app is a user interface for Nextcloud's CardDAV server. Easily sync contacts from various devices with your Nextcloud and edit them online.\n\n* 🚀 **Integration with other Nextcloud apps!** Currently Mail and Calendar – more to come.\n* 🎉 **Never forget a birthday!** You can sync birthdays and other recurring events with your Nextcloud Calendar.\n* 👥 **Sharing of Adressbooks!** You want to share your contacts with your friends or coworkers? No problem!\n* 🙈 **We’re not reinventing the wheel!** Based on the great and open SabreDAV library.",
     "homepage": "https://github.com/nextcloud/contacts#readme",
     "licenses": [
@@ -90,9 +90,9 @@
     ]
   },
   "end_to_end_encryption": {
-    "hash": "sha256-Z6MyXz//LNVy7Mt+yFbHIY5zGEMfsdwnAEDFsIcrs1M=",
-    "url": "https://github.com/nextcloud-releases/end_to_end_encryption/releases/download/v2.2.0/end_to_end_encryption-v2.2.0.tar.gz",
-    "version": "2.2.0",
+    "hash": "sha256-NfnIdc2Q8GgfgjqD8PeTS+O5vTWMBld+vCX/6ng/Im8=",
+    "url": "https://github.com/nextcloud-releases/end_to_end_encryption/releases/download/v2.2.1/end_to_end_encryption-v2.2.1.tar.gz",
+    "version": "2.2.1",
     "description": "## **End-to-End Encryption**\n\n### For End Users\n\n**Protect your most sensitive files with strong encryption.**\n\nThe End-to-End Encryption app gives you complete control over your data privacy.\nWith this app, you can encrypt specific folders so that only you (and those you trust) can access their contents.\nYour files are encrypted on your device before they reach the server, ensuring that no one—not even the server administrator—can read them.\n\n**Benefits:**\n- 🔒 **True privacy**: Files are encrypted on your device and can only be decrypted by you\n- 📱 **Works across all platforms**: Fully supported on desktop, Android, iOS clients, and as you wish even in the browser\n- 🎯 **Selective encryption**: Choose which folders to encrypt\n- 🛡️ **Secure sharing**: Share encrypted files with other users or even secure public upload using the encrypted file drop\n\n---\n\n### For Administrators\n\n**Enterprise-ready end-to-end encryption infrastructure for your Nextcloud instance.**\n\nThis app provides all the necessary server-side APIs and infrastructure to enable End-to-End encryption (E2EE) for your users.\nIt ensures that encrypted data remains secure throughout its lifecycle on your server.\n\n**Technical highlights:**\n- 🔐 **Complete API suite**: Provides all client-side APIs needed for E2EE implementation\n- 🔒 **Secure FileDrop integration**: Enables secure file sharing with encryption\n- 🛡️ **Zero-knowledge architecture**: Server never has access to encryption keys\n- ⚙️ **Group restrictions**: Limit app usage to specific user groups if needed\n- 🔄 **Background job management**: Automatic rollback handling for failed operations\n\n### Setup\nThis application provides the server-side infrastructure for end-to-end encryption, but it requires client support to function.\nTo enable end-to-end encryption, users will need to install the corresponding client-side app on their devices (desktop, Android, iOS) or use the web client.\n\nUsing the web interface, after enabling it in the personal settings, allows you to encrypt files and folders directly in the browser,\nproviding a seamless experience without needing additional software. But also requires some kind of trust in the server as the code is delivered by the server and could be manipulated.\n\nOnce enable through clients or the web interface, you can create encrypted folders and upload or move files into them.\nThe clients and the web interface will handle the encryption and decryption processes automatically.\n\n⚠️ This comes with some limitations and caveats, as only normal file operations can be handled.\nMeaning that some apps in the web interface do not work with encrypted files.",
     "homepage": "https://github.com/nextcloud/end_to_end_encryption",
     "licenses": [
@@ -130,9 +130,9 @@
     ]
   },
   "forms": {
-    "hash": "sha256-r570gxd4j/AEMzT3vul6qxJsJ/bTEW459LONUOYA8ZM=",
-    "url": "https://github.com/nextcloud-releases/forms/releases/download/v5.3.2/forms-v5.3.2.tar.gz",
-    "version": "5.3.2",
+    "hash": "sha256-vd6qwBAGUtm+Fbfc/Ei1mtmENX5Zvz5ZlW1MGggytJ0=",
+    "url": "https://github.com/nextcloud-releases/forms/releases/download/v5.3.4/forms-v5.3.4.tar.gz",
+    "version": "5.3.4",
     "description": "**Simple surveys and questionnaires, self-hosted!**\n\n- **📝 Simple design:** No mass of options, only the essentials. Works well on mobile of course.\n- **📊 View & export results:** Results are visualized and can also be exported as CSV in the same format used by Google Forms.\n- **🔒 Data under your control!** Unlike in Google Forms, Typeform, Doodle and others, the survey info and responses are kept private on your instance.\n- **🧑‍💻 Connect to your software:** Easily integrate Forms into your service with our full-fledged [REST-API](https://github.com/nextcloud/forms/blob/main/docs/API_v3.md).\n- **🙋 Get involved!** We have lots of stuff planned like more question types, collaboration on forms, [and much more](https://github.com/nextcloud/forms/milestones)!",
     "homepage": "https://github.com/nextcloud/forms",
     "licenses": [
@@ -150,13 +150,13 @@
     ]
   },
   "groupfolders": {
-    "hash": "sha256-zyN6n2oSeO+I2wyc2Q9l1TUumdVmEThvERGC7xBkm3s=",
-    "url": "https://github.com/nextcloud-releases/groupfolders/releases/download/v22.0.2/groupfolders-v22.0.2.tar.gz",
-    "version": "22.0.2",
+    "hash": "sha256-TsxpVaJJtARyUwRu0h9ZpC1QYZ8Izikk8MgdEPXlUrw=",
+    "url": "https://github.com/nextcloud-releases/groupfolders/releases/download/v22.0.3/groupfolders-v22.0.3.tar.gz",
+    "version": "22.0.3",
     "description": "Team Folders (formerly \"Group Folders\") allows administrators to create and manage shared\nfolders for selected teams within Nextcloud.\n\nAdmins can grant one or more teams access to a folder, configure permissions (such as read,\nwrite, and sharing rights), and assign storage quotas from the Team Folders section (under\nadmin settings). The app also supports advanced permissions and integration with Nextcloud’s\ntrash and versioning systems.\n\nAs of Hub 10 / Nextcloud 31, admins must be members of a team to assign that team to a Team\nFolder.",
     "homepage": "https://github.com/nextcloud/groupfolders",
     "licenses": [
-      "agpl"
+      "AGPL-3.0-or-later"
     ]
   },
   "guests": {
@@ -210,9 +210,9 @@
     ]
   },
   "mail": {
-    "hash": "sha256-c0pMd+A2Fbxa/20BAkg3lPeVRIdu0XRTbAGJxb/9NT0=",
-    "url": "https://github.com/nextcloud-releases/mail/releases/download/v5.10.7/mail-v5.10.7.tar.gz",
-    "version": "5.10.7",
+    "hash": "sha256-r7x9WkBAYw2KJ6D2FcLqbKHTHpVUP/z2eLjy4QorL7k=",
+    "url": "https://github.com/nextcloud-releases/mail/releases/download/v5.10.8/mail-v5.10.8.tar.gz",
+    "version": "5.10.8",
     "description": "**💌 A mail app for Nextcloud**\n\n- **🚀 Integration with other Nextcloud apps!** Currently Contacts, Calendar & Files – more to come.\n- **📥 Multiple mail accounts!** Personal and company account? No problem, and a nice unified inbox. Connect any IMAP account.\n- **🔒 Send & receive encrypted mails!** Using the great [Mailvelope](https://mailvelope.com) browser extension.\n- **🙈 We’re not reinventing the wheel!** Based on the great [Horde](https://www.horde.org) libraries.\n- **📬 Want to host your own mail server?** We do not have to reimplement this as you could set up [Mail-in-a-Box](https://mailinabox.email)!\n\n## Ethical AI Rating\n\n### Priority Inbox\n\nPositive:\n* The software for training and inferencing of this model is open source.\n* The model is created and trained on-premises based on the user's own data.\n* The training data is accessible to the user, making it possible to check or correct for bias or optimise the performance and CO2 usage.\n\n### Thread Summaries (opt-in)\n\n**Rating:** 🟢/🟡/🟠/🔴\n\nThe rating depends on the installed text processing backend. See [the rating overview](https://docs.nextcloud.com/server/latest/admin_manual/ai/index.html) for details.\n\nLearn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud.com/blog/nextcloud-ethical-ai-rating/).",
     "homepage": "https://github.com/nextcloud/mail#readme",
     "licenses": [
@@ -230,9 +230,9 @@
     ]
   },
   "music": {
-    "hash": "sha256-bQ9NBo5R/en3f68ag+mAsVWuhREjr/ajlKrfLn4Tvtg=",
-    "url": "https://github.com/nc-music/music/releases/download/v3.1.0/nc-music-3.1.0.tar.gz",
-    "version": "3.1.0",
+    "hash": "sha256-H8GsbDCdtHMKqsOVsyZA7nTBdBx0B+sfKdL5QupHEDI=",
+    "url": "https://github.com/nc-music/music/releases/download/v3.1.1/nc-music-3.1.1.tar.gz",
+    "version": "3.1.1",
     "description": "A stand-alone music player app and a \"lite\" player for the Files app\n\n- On modern browsers, supports audio types .mp3, .ogg, .m4a, .m4b, .flac, .wav, and more\n- Playlist support with import from .m3u, .m3u8, .pls, and .wpl files\n- Show lyrics from the file metadata or .lrc files\n- Browse by artists, albums, genres, or folders\n- Gapless play\n- Filter the shown content with the search function\n- Advanced search to freely use and combine dozens of search criteria\n- Play internet radio and podcast channels\n- Setup Last.fm connection to scrobble plays and/or see background information on artists, albums, and songs\n- Control with media control keys on the keyboard or OS\n- The app can handle libraries consisting of thousands of albums and tens of thousands of songs\n- Includes a server backend compatible with the Subsonic and Ampache protocols, allowing playback and browsing of your library on dozens of external apps on Android, iOS, Windows, Linux, etc.\n- Widget for the Nextcloud Dashboard",
     "homepage": "https://github.com/nc-music/music",
     "licenses": [
@@ -360,9 +360,9 @@
     ]
   },
   "richdocuments": {
-    "hash": "sha256-uGoXL/LnFaWlLRDdx95qmhD4HIW3p51CWlpKiWTScYg=",
-    "url": "https://github.com/nextcloud-releases/richdocuments/releases/download/v11.0.0/richdocuments-v11.0.0.tar.gz",
-    "version": "11.0.0",
+    "hash": "sha256-GVK1v6DdskpMElqcKLEnmKY0oSY+iBNtMkSoZAjEyZY=",
+    "url": "https://github.com/nextcloud-releases/richdocuments/releases/download/v11.0.1/richdocuments-v11.0.1.tar.gz",
+    "version": "11.0.1",
     "description": "This application can connect to a Collabora Online (or other) server (WOPI-like Client). Nextcloud is the WOPI Host. Please read the documentation to learn more about that.\n\nYou can also edit your documents off-line with the Collabora Office app from the **[Android](https://play.google.com/store/apps/details?id=com.collabora.libreoffice)** and **[iOS](https://apps.apple.com/us/app/collabora-office/id1440482071)** store.",
     "homepage": "https://collaboraoffice.com/",
     "licenses": [
@@ -370,9 +370,9 @@
     ]
   },
   "sociallogin": {
-    "hash": "sha256-8yB+PFGi9+bUjiEEHBJxAyySMluPO/1m3sPUThe5+t0=",
-    "url": "https://github.com/zorn-v/nextcloud-social-login/releases/download/v6.5.2/release.tar.gz",
-    "version": "6.5.2",
+    "hash": "sha256-/mnpEUfyhjGG31TKzFEfKUuzflPL+pGcf6PRbNnkaUE=",
+    "url": "https://github.com/zorn-v/nextcloud-social-login/releases/download/v6.5.3/release.tar.gz",
+    "version": "6.5.3",
     "description": "# Social Login\n\nMake it possible to create users and log in via Telegram, OAuth, or OpenID.\n\nFor OAuth, you must create an app with certain providers. Login buttons will appear on the login page if an app ID is specified. Settings are located in the \"Social login\" section of the settings page.\n\n## Installation\n\nLog in to your Nextcloud installation as an administrator. Under \"Apps\", click \"Download and enable\" next to the \"Social Login\" app.\n\nSee below for setup and configuration instructions.\n\n## Custom OAuth2/OIDC Groups\n\nYou can use groups from your custom provider. For this, specify the \"Groups claim\" in the custom OAuth2/OIDC provider settings. This claim should be returned from the provider in the `id_token` or at the user info endpoint. Multiple claims (comma separated) also supported - groups will be merged.\nThe format should be an `array` or a comma-separated string. E.g., (with a claim named `roles`):\n\n```json\n{\"roles\": [\"admin\", \"user\"]}\n```\nor\n```json\n{\"roles\": \"admin,user\"}\n```\n\nNested claims are also supported. For example, `resource_access.client-id.roles` for:\n\n```json\n\"resource_access\": {\n   \"client-id\": {\n     \"roles\": [\n       \"client-role-1\",\n       \"client-role-2\"\n     ]\n   }\n}\n```\n\n**DisplayName** support is also available:\n```json\n{\"roles\": [{\"gid\": 1, \"displayName\": \"admin\"}, {\"gid\": 2, \"displayName\": \"user\"}]}\n```\n\nYou can use provider groups in two ways:\n\n1. Map provider groups to existing Nextcloud groups.\n2. Create provider groups in Nextcloud and associate them with users (if the appropriate option is enabled).\n\nTo sync groups on every login, ensure the \"Update user profile every login\" setting is checked.\n\n## Examples for Groups\n\n* Configure WSO2IS to return a roles claim with OIDC [here](https://medium.com/@dewni.matheesha/claim-mapping-and-retrieving-end-user-information-in-wso2is-cffd5f3937ff).\n* [GitLab OIDC configuration to allow specific GitLab groups](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/gitlab.md).\n\n## Built-in OAuth Providers\n\nCopy the link from a specific login button to get the correct \"redirect URL\" for OAuth app settings.\n\n* [Amazon](https://developer.amazon.com/loginwithamazon/console/site/lwa/overview.html)\n* [Apple](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/apple.md)\n* [Codeberg](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/codeberg.md)\n* [Discord](#configure-discord)\n* [Facebook](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/facebook.md)\n* [GitHub](https://github.com/settings/developers)\n* [GitLab](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/gitlab.md)\n* [Google](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/google.md)\n* [Keycloak](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/keycloak.md)\n* [Mail.ru](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/mailru.md)\n* **PlexTv**: Use any title as the app ID.\n* [Telegram](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/telegram.md)\n* [Twitter](https://github.com/zorn-v/nextcloud-social-login/blob/master/docs/sso/twitter.md)\n\nFor details about Google's \"Allow login only from specified domain\" setting, see [#44](https://github.com/zorn-v/nextcloud-social-login/issues/44). Use a comma-separated list for multiple domains.\n\n## Configuration\n\nAdd `'social_login_auto_redirect' => true` to `config.php` to automatically redirect unauthorized users to social login if only one provider is configured. To temporarily disable this (e.g., for local admin login), add `noredir=1` to the login URL: `https://cloud.domain.com/login?noredir=1`.\n\nConfigure HTTP client options using:\n```php\n  'social_login_http_client' => [\n    'timeout' => 45,\n    'proxy' => 'socks4://127.0.0.1:9050', // See <https://curl.se/libcurl/c/CURLOPT_PROXY.html> for allowed formats\n  ],\n```\nin `config.php`.\n\n### Configure a Provider via CLI\n\nUse the `occ` utility to configure providers via the command line. Replace variables and URLs with your deployment values:\n```bash\nphp occ config:app:set sociallogin custom_providers --value='{\"custom_oidc\": [{\"name\": \"gitlab_oidc\", \"title\": \"Gitlab\", \"authorizeUrl\": \"https://gitlab.my-domain.org/oauth/authorize\", \"tokenUrl\": \"https://gitlab.my-domain.org/oauth/token\", \"userInfoUrl\": \"https://gitlab.my-domain.org/oauth/userinfo\", \"logoutUrl\": \"\", \"clientId\": \"$my_application_id\", \"clientSecret\": \"$my_super_secret_secret\", \"scope\": \"openid\", \"groupsClaim\": \"groups\", \"style\": \"gitlab\", \"defaultGroup\": \"\"}]}'\n```\nFor Docker, prepend `docker exec -t -uwww-data CONTAINER_NAME` to the command or run interactively via `docker exec -it -uwww-data CONTAINER_NAME sh`.\n\nTo inspect configurations:\n```sql\nmysql -u nextcloud -p nextcloud\nPassword: <yourpassword>\n\n> SELECT * FROM oc_appconfig WHERE appid='sociallogin';\n```\nOr run:\n```bash\ndocker exec -t -uwww-data CONTAINER_NAME php occ config:app:get sociallogin custom_providers\n```\n\n### Configure Discord\n\n1. Create a Discord application at [Discord Developer Portal](https://discord.com/developers/applications).\n2. Navigate to `Settings > OAuth2 > General`. Add a redirect URL: `https://nextcloud.mydomain.com/apps/sociallogin/oauth/discord`.\n3. Copy the `CLIENT ID` and generate a `CLIENT SECRET`.\n4. In Nextcloud, go to `Settings > Social Login`. Paste the `CLIENT ID` into \"App id\" and `CLIENT SECRET` into \"Secret\".\n5. Select a default group for new users.\n6. For group mapping, see [#395](https://github.com/zorn-v/nextcloud-social-login/pull/395).\n\n## Hint\n\n### Callback (Reply) URL\nCopy the link from a login button on the Nextcloud login page and use it as the callback URL on your provider's site. To make the button visible temporarily, fill provider settings with placeholder data and update later.\n\nIf you encounter callback URL errors despite correct settings, ensure your Nextcloud server generates HTTPS URLs by adding `'overwriteprotocol' => 'https'` to `config.php`.",
     "homepage": "https://github.com/zorn-v/nextcloud-social-login",
     "licenses": [
@@ -460,9 +460,9 @@
     ]
   },
   "user_saml": {
-    "hash": "sha256-LDiWtEaVJbNECJkcn80L4behkUyUsRlDFDd2lk2g+pE=",
-    "url": "https://github.com/nextcloud-releases/user_saml/releases/download/v8.1.4/user_saml-v8.1.4.tar.gz",
-    "version": "8.1.4",
+    "hash": "sha256-HseXj3gaVa1rjJ/C1N6x223yU0usyJ7rt8RqhVMKiDY=",
+    "url": "https://github.com/nextcloud-releases/user_saml/releases/download/v8.2.0/user_saml-v8.2.0.tar.gz",
+    "version": "8.2.0",
     "description": "Using the SSO & SAML app of your Nextcloud you can make it easily possible to integrate your existing Single-Sign-On solution with Nextcloud. In addition, you can use the Nextcloud LDAP user provider to keep the convenience for users. (e.g. when sharing)\nThe following providers are supported and tested at the moment:\n\n* **SAML 2.0**\n\t* OneLogin\n\t* Shibboleth\n\t* Active Directory Federation Services (ADFS)\n\t* Authentik\n\n* **Authentication via Environment Variable**\n\t* Kerberos (mod_auth_kerb)\n\t* Any other provider that authenticates using the environment variable\n\nWhile theoretically any other authentication provider implementing either one of those standards is compatible, we like to note that they are not part of any internal test matrix.",
     "homepage": "https://github.com/nextcloud/user_saml",
     "licenses": [

--- a/pkgs/servers/nextcloud/packages/34.json
+++ b/pkgs/servers/nextcloud/packages/34.json
@@ -89,6 +89,16 @@
       "agpl"
     ]
   },
+  "drawio": {
+    "hash": "sha256-nVcO2V0zo7VdL/o8c6IRbiIqFnGBH7NdqL/eefQ/ip0=",
+    "url": "https://github.com/arnowelzel/drawio-nextcloud/releases/download/v4.3.0/drawio-v4.3.0.tar.gz",
+    "version": "4.3.0",
+    "description": "Integrates the diagrams.net diagram editor with Nextcloud. Users can create and edit .drawio diagrams and .dwb whiteboards directly within the Nextcloud file manager.\n\n**Features:**\n\n- Create and edit diagrams and whiteboards from the Nextcloud \"+\" menu\n- Click any .drawio or .dwb file to open the editor inline\n- Autosave with optimistic conflict detection\n- Inline diagram previews in Text, Collectives, Talk, Notes, and Deck\n- Supports public share links (read-only and editable)\n- Offline mode for privacy-sensitive deployments\n- Configurable editor URL for self-hosted diagrams.net instances",
+    "homepage": "https://github.com/arnowelzel/drawio-nextcloud",
+    "licenses": [
+      "agpl"
+    ]
+  },
   "end_to_end_encryption": {
     "hash": "sha256-NfnIdc2Q8GgfgjqD8PeTS+O5vTWMBld+vCX/6ng/Im8=",
     "url": "https://github.com/nextcloud-releases/end_to_end_encryption/releases/download/v2.2.1/end_to_end_encryption-v2.2.1.tar.gz",

--- a/pkgs/servers/nextcloud/packages/nextcloud-apps.json
+++ b/pkgs/servers/nextcloud/packages/nextcloud-apps.json
@@ -9,6 +9,7 @@
 , "cospend": "agpl3Plus"
 , "dav_push": "agpl3Plus"
 , "deck": "agpl3Plus"
+, "drawio": "agpl3Plus"
 , "end_to_end_encryption": "agpl3Plus"
 , "files_automatedtagging" : "agpl3Plus"
 , "files_linkeditor": "agpl3Plus"


### PR DESCRIPTION
Adds the App Store Diagramming (Draw.io) app to the generated Nextcloud app sets:

- `nextcloud32Packages.apps.drawio`: 4.1.2
- `nextcloud33Packages.apps.drawio`: 4.3.0
- `nextcloud34Packages.apps.drawio`: 4.3.0

Also refreshes the existing generated Nextcloud app metadata.

Homepage: https://apps.nextcloud.com/apps/drawio

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

## Automation / AI disclosure

This contribution was prepared with assistance from OpenAI Codex (GPT-5). The assistant helped identify the existing generated-app workflow, regenerate metadata, and add the maintainer-team entry. The commits carry `Assisted-by: Codex (GPT-5)` trailers. @staticdev is the responsible contributor and will review the changes before marking this draft ready for review.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
