### PR TITLE
treewide: use finalAttrs.finalPackage.doCheck

### DIFF
--- a/pkgs/applications/emulators/wibo/default.nix
+++ b/pkgs/applications/emulators/wibo/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
         meta.license = lib.licenses.unfree;
       };
     in
-    lib.optionalString finalAttrs.doCheck ''
+    lib.optionalString finalAttrs.finalPackage.doCheck ''
       MWCIncludes=../test ./wibo ${gc}/GC/2.7/mwcceppc.exe -c ../test/test.c
       file test.o | grep "ELF 32-bit"
     '';

--- a/pkgs/applications/networking/instant-messengers/profanity/default.nix
+++ b/pkgs/applications/networking/instant-messengers/profanity/default.nix
@@ -95,7 +95,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # see also: https://profanity-im.github.io/guide/latest/build.html#expl
   mesonFlags = [
-    (lib.mesonBool "tests" finalAttrs.doCheck)
+    (lib.mesonBool "tests" finalAttrs.finalPackage.doCheck)
     (lib.mesonEnable "notifications" notifySupport)
     (lib.mesonEnable "python-plugins" pythonPluginSupport)
     (lib.mesonEnable "c-plugins" true)

--- a/pkgs/by-name/ap/apparmor-parser/package.nix
+++ b/pkgs/by-name/ap/apparmor-parser/package.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
     "POD2HTML=${lib.getExe' buildPackages.perl "pod2html"}"
     "MANDIR=share/man"
   ]
-  ++ lib.optional finalAttrs.doCheck "PROVE=${lib.getExe' perl "prove"}";
+  ++ lib.optional finalAttrs.finalPackage.doCheck "PROVE=${lib.getExe' perl "prove"}";
 
   installFlags = [
     "DESTDIR=$(out)"

--- a/pkgs/by-name/ar/ardour/package.nix
+++ b/pkgs/by-name/ar/ardour/package.nix
@@ -193,7 +193,7 @@ let
       # https://discourse.ardour.org/t/ardour-8-2-released/109615/8
       # "--use-external-libs"
     ]
-    ++ lib.optional finalAttrs.doCheck "--test"
+    ++ lib.optional finalAttrs.finalPackage.doCheck "--test"
     ++ lib.optional optimize "--optimize";
 
     env = {

--- a/pkgs/by-name/bi/bitcoin-knots/package.nix
+++ b/pkgs/by-name/bi/bitcoin-knots/package.nix
@@ -151,7 +151,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "WITH_USDT" enableTracing)
     (lib.cmakeFeature "RDTS_CONSENT" "RUNTIME_WARN")
   ]
-  ++ lib.optionals (!finalAttrs.doCheck) [
+  ++ lib.optionals (!finalAttrs.finalPackage.doCheck) [
     (lib.cmakeBool "BUILD_TESTS" false)
     (lib.cmakeBool "BUILD_FUZZ_BINARY" false)
     (lib.cmakeBool "BUILD_GUI_TESTS" false)

--- a/pkgs/by-name/bi/bitcoin/package.nix
+++ b/pkgs/by-name/bi/bitcoin/package.nix
@@ -158,7 +158,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "WITH_ZMQ" true)
     (lib.cmakeBool "WITH_USDT" enableTracing)
   ]
-  ++ lib.optionals (!finalAttrs.doCheck) [
+  ++ lib.optionals (!finalAttrs.finalPackage.doCheck) [
     (lib.cmakeBool "BUILD_TESTS" false)
     (lib.cmakeBool "BUILD_FUZZ_BINARY" false)
     (lib.cmakeBool "BUILD_GUI_TESTS" false)

--- a/pkgs/by-name/br/brlcad/package.nix
+++ b/pkgs/by-name/br/brlcad/package.nix
@@ -227,7 +227,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "BRLCAD_ENABLE_STRICT" false)
-    (lib.cmakeBool "BUILD_TESTING" finalAttrs.doCheck)
+    (lib.cmakeBool "BUILD_TESTING" finalAttrs.finalPackage.doCheck)
     (lib.cmakeBool "BRLCAD_ENABLE_QT" enableQt)
     (lib.cmakeFeature "GTE_INCLUDE_DIR" "${gtmathematics}/include/gtmathematics")
     (lib.cmakeFeature "LMDB_LIBRARY" "${lmdb.out}/lib/liblmdb${stdenv.hostPlatform.extensions.sharedLibrary}")

--- a/pkgs/by-name/cm/cmocka/package.nix
+++ b/pkgs/by-name/cm/cmocka/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags =
-    lib.optional finalAttrs.doCheck "-DUNIT_TESTING=ON"
+    lib.optional finalAttrs.finalPackage.doCheck "-DUNIT_TESTING=ON"
     ++ lib.optional stdenv.hostPlatform.isStatic "-DBUILD_SHARED_LIBS=OFF";
 
   doCheck = true;

--- a/pkgs/by-name/el/elements/package.nix
+++ b/pkgs/by-name/el/elements/package.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-boost-libdir=${boost.out}/lib"
     "--disable-bench"
   ]
-  ++ lib.optionals (!finalAttrs.doCheck) [
+  ++ lib.optionals (!finalAttrs.finalPackage.doCheck) [
     "--disable-tests"
     "--disable-gui-tests"
   ]

--- a/pkgs/by-name/fe/feedbackd-device-themes/package.nix
+++ b/pkgs/by-name/fe/feedbackd-device-themes/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   mesonFlags = [
-    (lib.mesonOption "validate" (if finalAttrs.doCheck then "enabled" else "disabled"))
+    (lib.mesonOption "validate" (if finalAttrs.finalPackage.doCheck then "enabled" else "disabled"))
   ];
 
   doCheck = true;

--- a/pkgs/by-name/fe/fex/package.nix
+++ b/pkgs/by-name/fe/fex/package.nix
@@ -233,7 +233,7 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
       cmakeFlagsArray+=("-DBUILD_TESTING:BOOL=FALSE")
     else
       echo "Keeping checkPhase as-is"
-      cmakeFlagsArray+=("${lib.cmakeBool "BUILD_TESTING" finalAttrs.doCheck}")
+      cmakeFlagsArray+=("${lib.cmakeBool "BUILD_TESTING" finalAttrs.finalPackage.doCheck}")
     fi
   '';
 

--- a/pkgs/by-name/fl/flatpak/package.nix
+++ b/pkgs/by-name/fl/flatpak/package.nix
@@ -119,7 +119,7 @@ stdenv.mkDerivation (finalAttrs: {
     # and cannot bind FHS paths since those are not available on NixOS.
     finalAttrs.passthru.icon-validator-patch
   ]
-  ++ lib.optionals finalAttrs.doCheck [
+  ++ lib.optionals finalAttrs.finalPackage.doCheck [
     # Hardcode paths used by tests and change test runtime generation to use files from Nix store.
     # https://github.com/flatpak/flatpak/issues/1460
     (replaceVars ./fix-test-paths.patch {

--- a/pkgs/by-name/ft/ftxui/package.nix
+++ b/pkgs/by-name/ft/ftxui/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "FTXUI_BUILD_EXAMPLES" false)
     (lib.cmakeBool "FTXUI_BUILD_DOCS" true)
-    (lib.cmakeBool "FTXUI_BUILD_TESTS" finalAttrs.doCheck)
+    (lib.cmakeBool "FTXUI_BUILD_TESTS" finalAttrs.finalPackage.doCheck)
   ];
 
   meta = {

--- a/pkgs/by-name/fw/fwup/package.nix
+++ b/pkgs/by-name/fw/fwup/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
     unzip
     zip
   ]
-  ++ lib.optionals finalAttrs.doCheck [
+  ++ lib.optionals finalAttrs.finalPackage.doCheck [
     mtools
     dosfstools
   ];

--- a/pkgs/by-name/gs/gsl-lite/package.nix
+++ b/pkgs/by-name/gs/gsl-lite/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    (lib.cmakeBool "GSL_LITE_OPT_BUILD_TESTS" finalAttrs.doCheck)
+    (lib.cmakeBool "GSL_LITE_OPT_BUILD_TESTS" finalAttrs.finalPackage.doCheck)
   ];
 
   # Building tests is broken on Darwin.

--- a/pkgs/by-name/gz/gz-cmake/package.nix
+++ b/pkgs/by-name/gz/gz-cmake/package.nix
@@ -45,8 +45,8 @@ stdenv.mkDerivation (finalAttrs: {
   doBuildExamples = false;
 
   cmakeFlags = [
-    (lib.cmakeBool "BUILDSYSTEM_TESTING" finalAttrs.doCheck)
-    (lib.cmakeBool "BUILD_TESTING" finalAttrs.doCheck)
+    (lib.cmakeBool "BUILDSYSTEM_TESTING" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeBool "BUILD_TESTING" finalAttrs.finalPackage.doCheck)
     (lib.cmakeBool "BUILD_EXAMPLES" finalAttrs.doBuildExamples)
   ];
 

--- a/pkgs/by-name/in/iniparser/package.nix
+++ b/pkgs/by-name/in/iniparser/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-z10S9ODLprd7CbL5Ecgh7H4eOwTetYwFXiWBUm6fIr4=";
   };
 
-  patches = lib.optional finalAttrs.doCheck (
+  patches = lib.optional finalAttrs.finalPackage.doCheck (
     # 1. Do not fetch the Unity GitHub repository
     # 2. Lookup the Unity pkgconfig file
     # 3. Get the generate_test_runner.rb file from the Unity share directory

--- a/pkgs/by-name/ja/jasterix/package.nix
+++ b/pkgs/by-name/ja/jasterix/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED" (!stdenv.hostPlatform.isStatic))
     (lib.cmakeBool "BUILD_STATIC" stdenv.hostPlatform.isStatic)
-    (lib.cmakeBool "WITH_UNIT_TESTS" finalAttrs.doCheck)
+    (lib.cmakeBool "WITH_UNIT_TESTS" finalAttrs.finalPackage.doCheck)
   ];
 
   buildInputs = [

--- a/pkgs/by-name/js/json-tui/package.nix
+++ b/pkgs/by-name/js/json-tui/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     "-Wno-dev" # suppress cmake warning about deprecated usage
-    (lib.cmakeBool "JSON_TUI_BUILD_TESTS" finalAttrs.doCheck)
+    (lib.cmakeBool "JSON_TUI_BUILD_TESTS" finalAttrs.finalPackage.doCheck)
     (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_GOOGLETEST" "${gtest.src}")
   ];
 

--- a/pkgs/by-name/li/libmemcached/package.nix
+++ b/pkgs/by-name/li/libmemcached/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    (lib.cmakeBool "BUILD_TESTING" finalAttrs.doCheck)
+    (lib.cmakeBool "BUILD_TESTING" finalAttrs.finalPackage.doCheck)
     "-DENABLE_SASL=ON"
   ];
 

--- a/pkgs/by-name/li/libpointmatcher/package.nix
+++ b/pkgs/by-name/li/libpointmatcher/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeFeature "EIGEN_INCLUDE_DIR" "${eigen}/include/eigen3")
-    (lib.cmakeBool "BUILD_TESTS" finalAttrs.doCheck)
+    (lib.cmakeBool "BUILD_TESTS" finalAttrs.finalPackage.doCheck)
   ];
 
   doCheck = true;

--- a/pkgs/by-name/li/libvncserver/package.nix
+++ b/pkgs/by-name/li/libvncserver/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "WITH_SYSTEMD" withSystemd)
     (lib.cmakeBool "BUILD_SHARED_LIBS" enableShared)
     (lib.cmakeBool "WITH_EXAMPLES" buildExamples)
-    (lib.cmakeBool "WITH_TESTS" finalAttrs.doCheck)
+    (lib.cmakeBool "WITH_TESTS" finalAttrs.finalPackage.doCheck)
   ];
 
   # This test checks if using the **installed** headers works.

--- a/pkgs/by-name/li/libxmp/package.nix
+++ b/pkgs/by-name/li/libxmp/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED" (!stdenv.hostPlatform.isStatic))
     (lib.cmakeBool "BUILD_STATIC" stdenv.hostPlatform.isStatic)
-    (lib.cmakeBool "WITH_UNIT_TESTS" finalAttrs.doCheck)
+    (lib.cmakeBool "WITH_UNIT_TESTS" finalAttrs.finalPackage.doCheck)
   ];
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;

--- a/pkgs/by-name/ma/mathic/package.nix
+++ b/pkgs/by-name/ma/mathic/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   configureFlags = [
-    (lib.withFeature finalAttrs.doCheck "gtest")
+    (lib.withFeature finalAttrs.finalPackage.doCheck "gtest")
   ];
 
   __structuredAttrs = true;

--- a/pkgs/by-name/ma/mathicgb/package.nix
+++ b/pkgs/by-name/ma/mathicgb/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   configureFlags = [
-    (lib.withFeature finalAttrs.doCheck "gtest")
+    (lib.withFeature finalAttrs.finalPackage.doCheck "gtest")
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/ma/mayo/package.nix
+++ b/pkgs/by-name/ma/mayo/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeOptionType "string" "Mayo_VersionMajor" (lib.versions.major finalAttrs.version))
     (lib.cmakeOptionType "string" "Mayo_VersionMinor" (lib.versions.minor finalAttrs.version))
     (lib.cmakeOptionType "string" "Mayo_VersionPatch" (lib.versions.patch finalAttrs.version))
-    (lib.cmakeBool "Mayo_BuildTests" finalAttrs.doCheck)
+    (lib.cmakeBool "Mayo_BuildTests" finalAttrs.finalPackage.doCheck)
   ]
   ++ lib.optional withAssimp "-DMayo_BuildPluginAssimp=ON";
 

--- a/pkgs/by-name/me/memtailor/package.nix
+++ b/pkgs/by-name/me/memtailor/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   configureFlags = [
-    (lib.withFeature finalAttrs.doCheck "gtest")
+    (lib.withFeature finalAttrs.finalPackage.doCheck "gtest")
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/mi/mimalloc/package.nix
+++ b/pkgs/by-name/mi/mimalloc/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     MI_SECURE = secureBuild;
     MI_BUILD_SHARED = stdenv.hostPlatform.hasSharedLibraries;
     MI_LIBC_MUSL = stdenv.hostPlatform.libc == "musl";
-    MI_BUILD_TESTS = finalAttrs.doCheck;
+    MI_BUILD_TESTS = finalAttrs.finalPackage.doCheck;
 
     # MI_OPT_ARCH is inaccurate (e.g. it assumes aarch64 == armv8.1-a).
     # Nixpkgs's native platform configuration does a better job.

--- a/pkgs/by-name/mi/minizip-ng/package.nix
+++ b/pkgs/by-name/mi/minizip-ng/package.nix
@@ -42,8 +42,8 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "MZ_OPENSSL" true)
     (lib.cmakeBool "MZ_PPMD" false) # PPMD support requres internet access to make a git clone
     (lib.cmakeBool "MZ_LIBCOMP" false) # builds only on Darwin by default where it fails due to mising headers
-    (lib.cmakeBool "MZ_BUILD_TESTS" finalAttrs.doCheck)
-    (lib.cmakeBool "MZ_BUILD_UNIT_TESTS" finalAttrs.doCheck)
+    (lib.cmakeBool "MZ_BUILD_TESTS" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeBool "MZ_BUILD_UNIT_TESTS" finalAttrs.finalPackage.doCheck)
     (lib.cmakeBool "MZ_COMPAT" enableCompat)
   ]
   ++ lib.optionals stdenv.hostPlatform.isi686 [

--- a/pkgs/by-name/mo/mosquitto/package.nix
+++ b/pkgs/by-name/mo/mosquitto/package.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "WITH_BUNDLED_DEPS" false)
     (lib.cmakeBool "WITH_WEBSOCKETS" true)
     (lib.cmakeBool "WITH_SYSTEMD" withSystemd)
-    (lib.cmakeBool "WITH_TESTS" finalAttrs.doCheck)
+    (lib.cmakeBool "WITH_TESTS" finalAttrs.finalPackage.doCheck)
   ];
 
   postFixup = ''

--- a/pkgs/by-name/mu/mu/package.nix
+++ b/pkgs/by-name/mu/mu/package.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.strings.mesonEnable "guile" false)
     (lib.strings.mesonEnable "scm" false)
     (lib.strings.mesonEnable "readline" false)
-    (lib.strings.mesonEnable "tests" finalAttrs.doCheck)
+    (lib.strings.mesonEnable "tests" finalAttrs.finalPackage.doCheck)
     (lib.strings.mesonOption "lispdir" "${placeholder "mu4e"}/share/emacs/site-lisp")
   ];
 

--- a/pkgs/by-name/mu/muon/package.nix
+++ b/pkgs/by-name/mu/muon/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals buildDocs [
     scdoc
   ]
-  ++ lib.optionals (buildDocs || finalAttrs.doCheck) [
+  ++ lib.optionals (buildDocs || finalAttrs.finalPackage.doCheck) [
     (python3.withPackages (ps: [ ps.pyyaml ]))
   ];
 
@@ -73,7 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
     find subprojects -name "*.py" -exec chmod +x {} \;
     patchShebangs subprojects
   ''
-  + lib.optionalString finalAttrs.doCheck ''
+  + lib.optionalString finalAttrs.finalPackage.doCheck ''
     substituteInPlace \
       "subprojects/meson-tests/common/14 configure file/test.py.in" \
       "subprojects/meson-tests/common/274 customtarget exe for test/generate.py" \
@@ -106,7 +106,7 @@ stdenv.mkDerivation (finalAttrs: {
         (muonBool "static" stdenv.targetPlatform.isStatic)
         (muonEnable "man-pages" buildDocs)
         (muonEnable "meson-docs" buildDocs)
-        (muonEnable "meson-tests" finalAttrs.doCheck)
+        (muonEnable "meson-tests" finalAttrs.finalPackage.doCheck)
         (muonEnable "samurai" embedSamurai)
         (muonEnable "tracy" false)
         (muonEnable "website" false)
@@ -177,7 +177,7 @@ stdenv.mkDerivation (finalAttrs: {
       owner = "muon-build";
       rev = "db92588773a24f67cda2f331b945825ca3a63fa7";
       hash = "sha256-z4Fc1lr/m2MwIwhXJwoFWpzeNg+udzMxuw5Q/zVvpSM=";
-      passthru.use = finalAttrs.doCheck;
+      passthru.use = finalAttrs.finalPackage.doCheck;
     };
   };
 

--- a/pkgs/by-name/ne/nexusmods-app/package.nix
+++ b/pkgs/by-name/ne/nexusmods-app/package.nix
@@ -70,7 +70,7 @@ buildDotnetModule (finalAttrs: {
     substituteInPlace src/NexusMods.Networking.NexusWebApi/NexusMods.Networking.NexusWebApi.csproj \
       --replace-fail '$(BaseIntermediateOutputPath)games.json' ${./vendored/games.json}
 
-    ${lib.optionalString finalAttrs.doCheck ''
+    ${lib.optionalString finalAttrs.finalPackage.doCheck ''
       # For some reason these tests fail (intermittently?) with a zero timestamp
       touch tests/NexusMods.UI.Tests/WorkspaceSystem/*.verified.png
     ''}

--- a/pkgs/by-name/nl/nlopt/package.nix
+++ b/pkgs/by-name/nl/nlopt/package.nix
@@ -88,7 +88,7 @@ clangStdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "NLOPT_MATLAB" false)
     (lib.cmakeBool "NLOPT_GUILE" false)
     (lib.cmakeBool "NLOPT_LUKSAN" (!withoutLuksanSolvers))
-    (lib.cmakeBool "NLOPT_TESTS" finalAttrs.doCheck)
+    (lib.cmakeBool "NLOPT_TESTS" finalAttrs.finalPackage.doCheck)
   ]
   ++ lib.optional withPython (
     lib.cmakeFeature "Python_EXECUTABLE" "${buildPythonBindingsEnv.interpreter}"

--- a/pkgs/by-name/ns/ns-3/package.nix
+++ b/pkgs/by-name/ns/ns-3/package.nix
@@ -152,7 +152,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-DNS3_GTK3=ON"
     "-DGTK3_GLIBCONFIG_INCLUDE_DIR=${glib.out}/lib/glib-2.0/include"
   ]
-  ++ lib.optional finalAttrs.doCheck "-DNS3_TESTS=ON";
+  ++ lib.optional finalAttrs.finalPackage.doCheck "-DNS3_TESTS=ON";
 
   # strictoverflow prevents clang from discovering pyembed when bindings
   hardeningDisable = [

--- a/pkgs/by-name/on/onnx/package.nix
+++ b/pkgs/by-name/on/onnx/package.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
     # NOTE: Darwin requires a static build; otherwise, tests fail in the Python package.
     BUILD_SHARED_LIBS = if stdenv.hostPlatform.isDarwin then "0" else "1";
     ONNX_BUILD_PYTHON = "1";
-    ONNX_BUILD_TESTS = if finalAttrs.doCheck then "1" else "0";
+    ONNX_BUILD_TESTS = if finalAttrs.finalPackage.doCheck then "1" else "0";
     # ONNX_ML is enabled by default.
     # See: https://github.com/onnx/onnx/blob/b751946c3d59a3c8358abcc0569b59e6ddb08cdd/CMakeLists.txt#L66-L73
     ONNX_ML = "1";

--- a/pkgs/by-name/on/onnxruntime/package.nix
+++ b/pkgs/by-name/on/onnxruntime/package.nix
@@ -295,7 +295,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     # fails to find protoc on darwin, so specify it
     (lib.cmakeFeature "ONNX_CUSTOM_PROTOC_EXECUTABLE" (lib.getExe buildPackages.protobuf))
     (lib.cmakeBool "onnxruntime_BUILD_SHARED_LIB" true)
-    (lib.cmakeBool "onnxruntime_BUILD_UNIT_TESTS" finalAttrs.doCheck)
+    (lib.cmakeBool "onnxruntime_BUILD_UNIT_TESTS" finalAttrs.finalPackage.doCheck)
     (lib.cmakeBool "onnxruntime_USE_FULL_PROTOBUF" withFullProtobuf)
     (lib.cmakeBool "onnxruntime_USE_CUDA" cudaSupport)
     (lib.cmakeBool "onnxruntime_USE_NCCL" ncclSupport)

--- a/pkgs/by-name/pa/particl-core/package.nix
+++ b/pkgs/by-name/pa/particl-core/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--disable-bench"
     "--with-boost-libdir=${boost.out}/lib"
   ]
-  ++ lib.optionals (!finalAttrs.doCheck) [
+  ++ lib.optionals (!finalAttrs.finalPackage.doCheck) [
     "--enable-tests=no"
   ];
 

--- a/pkgs/by-name/pi/picolibc/package.nix
+++ b/pkgs/by-name/pi/picolibc/package.nix
@@ -185,7 +185,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     (mesonBool "want-math-errno" want-math-errno)
   ]
-  ++ lib.optionals finalAttrs.doCheck [
+  ++ lib.optionals finalAttrs.finalPackage.doCheck [
     (mesonBool "tests" true)
     # Something is broken with this and I'm not sure what.
     (mesonOption "tests-cdefs" "false")

--- a/pkgs/by-name/po/pocket-id/package.nix
+++ b/pkgs/by-name/po/pocket-id/package.nix
@@ -43,7 +43,7 @@ buildGo127Module (finalAttrs: {
   ];
 
   # required for TestIsURLPrivate
-  __darwinAllowLocalNetworking = finalAttrs.doCheck;
+  __darwinAllowLocalNetworking = finalAttrs.finalPackage.doCheck;
 
   preFixup = ''
     mv $out/bin/cmd $out/bin/pocket-id

--- a/pkgs/by-name/pr/prevail/package.nix
+++ b/pkgs/by-name/pr/prevail/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    (lib.cmakeBool "prevail_ENABLE_TESTS" finalAttrs.doCheck)
+    (lib.cmakeBool "prevail_ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
   ];
 
   installPhase = ''

--- a/pkgs/by-name/ra/radiotray-ng/package.nix
+++ b/pkgs/by-name/ra/radiotray-ng/package.nix
@@ -107,7 +107,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   cmakeFlags = [
-    (lib.cmakeBool "BUILD_TESTS" finalAttrs.doCheck)
+    (lib.cmakeBool "BUILD_TESTS" finalAttrs.finalPackage.doCheck)
   ];
 
   # 'wxFont::wxFont(int, int, int, int, bool, const wxString&, wxFontEncoding)' is deprecated

--- a/pkgs/by-name/so/sobjectizer/package.nix
+++ b/pkgs/by-name/so/sobjectizer/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "SOBJECTIZER_BUILD_STATIC" withStatic)
     (lib.cmakeBool "SOBJECTIZER_BUILD_SHARED" withShared)
     (lib.cmakeBool "BUILD_EXAMPLES" (buildExamples && withStatic))
-    (lib.cmakeBool "BUILD_TESTS" (finalAttrs.doCheck && withShared))
+    (lib.cmakeBool "BUILD_TESTS" (finalAttrs.finalPackage.doCheck && withShared))
   ];
 
   # The tests require the shared library thanks to the patch.

--- a/pkgs/by-name/sy/syncthingtray/package.nix
+++ b/pkgs/by-name/sy/syncthingtray/package.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeFeature "QT_PACKAGE_PREFIX" "Qt${lib.versions.major kdePackages.qtbase.version}")
     (lib.cmakeFeature "KF_PACKAGE_PREFIX" "KF${lib.versions.major kdePackages.qtbase.version}")
-    (lib.cmakeBool "BUILD_TESTING" (finalAttrs.doCheck or false))
+    (lib.cmakeBool "BUILD_TESTING" (finalAttrs.finalPackage.doCheck or false))
     # See https://github.com/Martchus/syncthingtray/issues/208
     (lib.cmakeBool "EXCLUDE_TESTS_FROM_ALL" false)
     (lib.cmakeFeature "AUTOSTART_EXEC_PATH" autostartExecPath)

--- a/pkgs/by-name/tp/tpm2-pkcs11/package.nix
+++ b/pkgs/by-name/tp/tpm2-pkcs11/package.nix
@@ -84,8 +84,8 @@ chosenStdenv.mkDerivation (finalAttrs: {
   '';
 
   configureFlags = [
-    (lib.enableFeature finalAttrs.doCheck "unit")
-    (lib.enableFeature finalAttrs.doCheck "integration")
+    (lib.enableFeature finalAttrs.finalPackage.doCheck "unit")
+    (lib.enableFeature finalAttrs.finalPackage.doCheck "integration")
 
     # Strangely, it uses --with-fapi=yes|no instead of a normal configure flag.
     "--with-fapi=${lib.boolToYesNo fapiSupport}"

--- a/pkgs/by-name/tt/tt-umd/package.nix
+++ b/pkgs/by-name/tt/tt-umd/package.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
         hash = "sha256-g+ZPKBUhBGlgvce8uTkuR983unD2kbQKgoddko7x+fk=";
       })
     ))
-    (lib.cmakeBool "TT_UMD_BUILD_TESTS" finalAttrs.doCheck)
+    (lib.cmakeBool "TT_UMD_BUILD_TESTS" finalAttrs.finalPackage.doCheck)
     (lib.cmakeBool "TT_UMD_BUILD_STATIC" stdenv.hostPlatform.isStatic)
     (lib.cmakeBool "TT_UMD_BUILD_PYTHON" true)
     (lib.cmakeFeature "nanobind_DIR" "${python3.pkgs.nanobind}/${python3.sitePackages}/nanobind/cmake")

--- a/pkgs/by-name/wi/wireguard-go/package.nix
+++ b/pkgs/by-name/wi/wireguard-go/package.nix
@@ -39,7 +39,7 @@ buildGoModule (finalAttrs: {
   '';
 
   # Tests require networking.
-  __darwinAllowLocalNetworking = finalAttrs.doCheck;
+  __darwinAllowLocalNetworking = finalAttrs.finalPackage.doCheck;
 
   postInstall = ''
     mv $out/bin/wireguard $out/bin/wireguard-go

--- a/pkgs/by-name/z3/z3/package.nix
+++ b/pkgs/by-name/z3/z3/package.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "Z3_SINGLE_THREADED" (!finalAttrs.enableParallelBuilding))
     (lib.cmakeBool "Z3_BUILD_LIBZ3_SHARED" (!stdenv.hostPlatform.isStatic))
     (lib.cmakeFeature "CMAKE_INSTALL_PREFIX" (placeholder "out"))
-    (lib.cmakeBool "Z3_BUILD_TEST_EXECUTABLES" finalAttrs.doCheck)
+    (lib.cmakeBool "Z3_BUILD_TEST_EXECUTABLES" finalAttrs.finalPackage.doCheck)
     (lib.cmakeBool "Z3_ENABLE_EXAMPLE_TARGETS" false)
   ]
   ++ lib.optionals pythonBindings [

--- a/pkgs/development/compilers/sbcl/default.nix
+++ b/pkgs/development/compilers/sbcl/default.nix
@@ -90,7 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     texinfo
   ]
-  ++ lib.optionals finalAttrs.doCheck (
+  ++ lib.optionals finalAttrs.finalPackage.doCheck (
     [
       which
       writableTmpDirAsHomeHook

--- a/pkgs/development/cuda-modules/packages/cutlass.nix
+++ b/pkgs/development/cuda-modules/packages/cutlass.nix
@@ -152,8 +152,8 @@ backendStdenv.mkDerivation (finalAttrs: {
     (cmakeBool "CUTLASS_ENABLE_EXAMPLES" false)
 
     # Tests.
-    (cmakeBool "CUTLASS_ENABLE_TESTS" finalAttrs.doCheck)
-    (cmakeBool "CUTLASS_ENABLE_GTEST_UNIT_TESTS" finalAttrs.doCheck)
+    (cmakeBool "CUTLASS_ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
+    (cmakeBool "CUTLASS_ENABLE_GTEST_UNIT_TESTS" finalAttrs.finalPackage.doCheck)
     (cmakeBool "CUTLASS_USE_SYSTEM_GOOGLETEST" true)
 
     # NOTE: Both CUDNN and CUBLAS can be used by the examples and the profiler. Since they are large dependencies, they
@@ -189,12 +189,12 @@ backendStdenv.mkDerivation (finalAttrs: {
   # NOTE: Because the test cases immediately create and try to run the binaries, we don't have an opportunity
   # to patch them with autoAddDriverRunpath. To get around this, we add the driver runpath to the environment.
   # TODO: This would break Jetson when using cuda_compat, as it must come first.
-  preCheck = optionalString finalAttrs.doCheck ''
+  preCheck = optionalString finalAttrs.finalPackage.doCheck ''
     export LD_LIBRARY_PATH="$(readlink -mnv "${addDriverRunpath.driverLink}/lib")"
   '';
 
   # This is *not* a derivation you want to build on a small machine.
-  requiredSystemFeatures = optionals finalAttrs.doCheck [
+  requiredSystemFeatures = optionals finalAttrs.finalPackage.doCheck [
     "big-parallel"
     "cuda"
   ];

--- a/pkgs/development/ocaml-modules/graphql/cohttp.nix
+++ b/pkgs/development/ocaml-modules/graphql/cohttp.nix
@@ -28,7 +28,7 @@ buildDunePackage (finalAttrs: {
     ocplib-endian
   ];
 
-  checkInputs = lib.optionals finalAttrs.doCheck [
+  checkInputs = lib.optionals finalAttrs.finalPackage.doCheck [
     alcotest
     cohttp-lwt-unix
     graphql-lwt

--- a/pkgs/development/ocaml-modules/uucp/default.nix
+++ b/pkgs/development/ocaml-modules/uucp/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildPhase = ''
     runHook preBuild
-    ${topkg.buildPhase} --with-cmdliner false --tests ${lib.boolToString finalAttrs.doCheck}
+    ${topkg.buildPhase} --with-cmdliner false --tests ${lib.boolToString finalAttrs.finalPackage.doCheck}
     runHook postBuild
   '';
 

--- a/pkgs/development/rocm-modules/rocprof-trace-decoder/default.nix
+++ b/pkgs/development/rocm-modules/rocprof-trace-decoder/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    (lib.cmakeBool "BUILD_TESTS" finalAttrs.doCheck)
+    (lib.cmakeBool "BUILD_TESTS" finalAttrs.finalPackage.doCheck)
   ];
 
   nativeCheckInputs = [

--- a/pkgs/os-specific/linux/iputils/default.nix
+++ b/pkgs/os-specific/linux/iputils/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-DNO_SETCAP_OR_SUID=true"
     "-Dsystemdunitdir=etc/systemd/system"
     "-DINSTALL_SYSTEMD_UNITS=true"
-    "-DSKIP_TESTS=${lib.boolToString (!finalAttrs.doCheck)}"
+    "-DSKIP_TESTS=${lib.boolToString (!finalAttrs.finalPackage.doCheck)}"
   ]
   # Disable idn usage w/musl (https://github.com/iputils/iputils/pull/111):
   ++ lib.optional stdenv.hostPlatform.isMusl "-DUSE_IDN=false";

--- a/pkgs/tools/system/nvtop/build-nvtop.nix
+++ b/pkgs/tools/system/nvtop/build-nvtop.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
   ]
-  ++ lib.optionals finalAttrs.doCheck [
+  ++ lib.optionals finalAttrs.finalPackage.doCheck [
     gtest
   ]
   ++ lib.optional nvidia addDriverRunpath;


### PR DESCRIPTION
It's not that many that accumulate in 2 years

* https://github.com/NixOS/nixpkgs/issues/272978

should be 0 rebuilds, as this only affects cross

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
