### PR TITLE
aperture-cli: init at 0.0.8

### DIFF
--- a/pkgs/by-name/ap/aperture-cli/package.nix
+++ b/pkgs/by-name/ap/aperture-cli/package.nix
@@ -1,0 +1,31 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  lib,
+}:
+buildGoModule (finalAttrs: {
+  pname = "aperture-cli";
+  version = "0.0.8";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "tailscale";
+    repo = "aperture-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-s+slAWcv6IJtfCJK8wORGsl7X0KoVXnxajYSD/AvbcI=";
+  };
+
+  vendorHash = "sha256-LXkf5l52+7JflU39MY4aNwiLa9rYaB4G1mPTRhm+l/8=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://github.com/tailscale/aperture-cli";
+    changelog = "https://github.com/tailscale/aperture-cli/releases/tag/${finalAttrs.src.tag}";
+    description = "An agentic coding launcher for Tailscale Aperture";
+    maintainers = with lib.maintainers; [ pascalj ];
+    license = lib.licenses.bsd3;
+    mainProgram = "aperture";
+  };
+})


### PR DESCRIPTION
Introduce the [Tailscale `aperture` CLI](https://tailscale.com/docs/aperture). There is already an aperture package, so I think `aperture-cli` as the name makes sense.

The software is still relatively fresh, so if this should not yet be in nixpkgs, just let me know.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
