### PR TITLE
cutter: 2.4.1 -> 2.5.0

### DIFF
--- a/pkgs/by-name/cu/cutter/package.nix
+++ b/pkgs/by-name/cu/cutter/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   fetchFromGitHub,
-  fetchpatch2,
   stdenv,
   # for passthru.plugins
   pkgs,
@@ -19,23 +18,15 @@
 let
   cutter = stdenv.mkDerivation rec {
     pname = "cutter";
-    version = "2.4.1";
+    version = "2.5.0";
 
     src = fetchFromGitHub {
       owner = "rizinorg";
       repo = "cutter";
       rev = "v${version}";
-      hash = "sha256-fNOznaFzWJ4Dve9U1+E4xPaznnyxae2jHNaBCdJzDyQ=";
+      hash = "sha256-dnVbtAp7TorPQx4qdK43L2pXMcnWvOYjhRC3MJBrAmM=";
       fetchSubmodules = true;
     };
-
-    patches = [
-      (fetchpatch2 {
-        name = "fix-shiboken6-type-index-case.patch";
-        url = "https://github.com/rizinorg/cutter/commit/07fea9c772dc573588dc2e5771f0740ee1883738.patch?full_index=1";
-        hash = "sha256-/C/s+Ui5F7MCxbzbChQ5Tv/oUHUQxXmk9xOnNI80xwQ=";
-      })
-    ];
 
     nativeBuildInputs = [
       cmake

--- a/pkgs/by-name/ri/rizin/jsdec.nix
+++ b/pkgs/by-name/ri/rizin/jsdec.nix
@@ -10,7 +10,7 @@
 }:
 
 let
-  version = "0.8.0";
+  version = "0.9.0";
 
   libquickjs = fetchFromGitHub {
     owner = "quickjs-ng";
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "rizinorg";
     repo = "jsdec";
     rev = "v${version}";
-    hash = "sha256-Xc8FMKSGdjrp288u49R6YC0xiynwHeoZe2P/UqnfsFU=";
+    hash = "sha256-9FNsFPQf3GyREXsagWDHctfne28lct6dPH8vKvF8kpY=";
   };
 
   postUnpack = ''

--- a/pkgs/by-name/ri/rizin/package.nix
+++ b/pkgs/by-name/ri/rizin/package.nix
@@ -30,11 +30,11 @@
 let
   rizin = stdenv.mkDerivation rec {
     pname = "rizin";
-    version = "0.8.2";
+    version = "0.9.1";
 
     src = fetchurl {
       url = "https://github.com/rizinorg/rizin/releases/download/v${version}/rizin-src-v${version}.tar.xz";
-      hash = "sha256-FjDKUrroby/zfrIgaZ/IL5UbWxgIDt+j9Q3TalJsLZU=";
+      hash = "sha256-esHNfaynr92nQuFUeLH3R/wfgT5Jb+5xg50eEJ5UPco=";
     };
 
     mesonFlags = [

--- a/pkgs/by-name/ri/rizin/rz-ghidra.nix
+++ b/pkgs/by-name/ri/rizin/rz-ghidra.nix
@@ -11,17 +11,18 @@
   enableCutterPlugin ? true,
   cutter,
   qt6,
+  zlib,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rz-ghidra";
-  version = "0.8.0";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "rizinorg";
     repo = "rz-ghidra";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-uI0EnuHAuyrXYKDijh5Tg/WcQ/5yyZnW3d5MMHZxnqA=";
+    hash = "sha256-R9wPmt2WoK4wlTXb0JUX+0Fk8JQgGagb8vZQmjxLXn8=";
     fetchSubmodules = true;
   };
 
@@ -30,6 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
     openssl
     pugixml
     rizin
+    zlib
   ]
   ++ lib.optionals enableCutterPlugin [
     cutter


### PR DESCRIPTION
Update of cutter, rizin, and plugins (the updates are coupled)

- rizin: 0.8.2 -> 0.9.1
- rizinPlugins.jsdec: 0.8.0 -> 0.9.0
- cutterPlugins.rz-ghidra: 0.8.0 -> 0.9.0 (now requires zlib for the Ghidra decompiler)
- cutter: 2.4.1 -> 2.5.0 (removed fix-shiboken6-type-index-case.patch, included upstream since rizinorg/cutter@07fea9c)

Cutter 2.5.0 pins rizin 0.9.1 as its bundled submodule and the plugins follow rizin's minor version.

Testing:
- `rizin -A -c 'pdg @ main'` and `pdd` via `rizin.withPlugins`, both Ghidra and jsdec decompilers work
- Cutter opens and analyzes binaries, "about" says 2.5.0 and rizin 0.9.1. Also checked that the Ghidra decompiler widget works via cutter.withPlugins

Resolves #542574

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
