### PR TITLE
kubeconform: 0.7.0 -> 0.8.0

### DIFF
--- a/pkgs/by-name/ku/kubeconform/package.nix
+++ b/pkgs/by-name/ku/kubeconform/package.nix
@@ -2,18 +2,21 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "kubeconform";
-  version = "0.7.0";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "yannh";
     repo = "kubeconform";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-FTUPARckpecz1V/Io4rY6SXhlih3VJr/rTGAiik4ALA=";
+    sha256 = "sha256-HcYKmit67ZGABDfpr281FiStMZmM/vkkj9wxXH5H9zc=";
   };
+
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s"
@@ -22,6 +25,16 @@ buildGoModule (finalAttrs: {
   ];
 
   vendorHash = null;
+
+  excludedPackages = [ "./openapi2jsonschema-go" ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  doInstallCheck = true;
+
+  versionCheckProgramArg = "-v";
+
+  __darwinAllowLocalNetworking = true;
 
   meta = {
     description = "FAST Kubernetes manifests validator, with support for Custom Resources";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Release notes: [yannh/kubeconform@`v0.8.0` (release)](https://github.com/yannh/kubeconform/releases/tag/v0.8.0)

* Exclude `./openapi2jsonschema-go` package, it has its own `go.mod`. Fixes:

  ```
  Building subPackage ./cmd/kubeconform
  Building subPackage ./openapi2jsonschema-go
  main module (github.com/yannh/kubeconform) does not contain package github.com/yannh/. kubeconform/openapi2jsonschema-go
  ```
* Disable CGo, aligning with upstream
* Add `versionCheckHook`
* Fix tests using local networking in darwin sandbox

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
