### PR TITLE
netpeek: 0.2.7 -> 0.3.0

### DIFF
--- a/pkgs/by-name/ne/netpeek/package.nix
+++ b/pkgs/by-name/ne/netpeek/package.nix
@@ -14,7 +14,7 @@
 }:
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "netpeek";
-  version = "0.2.7";
+  version = "0.3.0";
   pyproject = false;
 
   __structuredAttrs = true;
@@ -23,7 +23,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     owner = "ZingyTomato";
     repo = "NetPeek";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Cc8x9diBeKIk1G5fU1WHtgmUwCCbAwIrw8zEQScKlZ4=";
+    hash = "sha256-SpWqj2D0gTjMgcn7TdmCLFqDTQITBQvfOZ9Jx2TerUQ=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Update Netpeek to v0.2.9

[Changelog v0.2.8](https://github.com/ZingyTomato/NetPeek/releases/tag/v0.2.8)
[Changelog v0.2.9](https://github.com/ZingyTomato/NetPeek/releases/tag/v0.2.9)
[Changelog v0.3.0](https://github.com/ZingyTomato/NetPeek/releases/tag/v0.3.0)
Diff: [https://github.com/ZingyTomato/NetPeek/compare/v0.2.7...v0.3.0](https://github.com/ZingyTomato/NetPeek/compare/v0.2.7...v0.3.0)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
