### PR TITLE
obs-wayland-hotkeys: 1.1.0 -> 1.1.1

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/obs-wayland-hotkeys/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-wayland-hotkeys/default.nix
@@ -6,17 +6,17 @@
   obs-studio,
   pkg-config,
   qtbase,
+  nix-update-script,
 }:
-
 stdenv.mkDerivation (finalAttr: {
   pname = "obs-wayland-hotkeys";
-  version = "1.1.0";
+  version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "leia-uwu";
     repo = "obs-wayland-hotkeys";
     tag = "v${finalAttr.version}";
-    hash = "sha256-vOQfOEAnxn5vCaWpwDED1C107BB/d7T10kmKTXJ4k8k=";
+    hash = "sha256-m/AW2glyxJLPWcptZYbZ9Befm4gNmD1V3JDC8hjKtkA=";
   };
 
   nativeBuildInputs = [
@@ -30,6 +30,8 @@ stdenv.mkDerivation (finalAttr: {
   ];
 
   dontWrapQtApps = true;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "OBS Studio plugin to integrate OBS hotkeys with the Wayland global shortcuts portal";


### PR DESCRIPTION
## Things done

updates the package, and adds a passthru.updateScript so the package will be bumped automatically next time

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
