### PR TITLE
lxgw-neoxihei-code: init at 1.304

### DIFF
--- a/pkgs/by-name/lx/lxgw-neoxihei-code/package.nix
+++ b/pkgs/by-name/lx/lxgw-neoxihei-code/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  fetchurl,
+  stdenvNoCC,
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "lxgw-neoxihei-code";
+  version = "1.304";
+
+  src = fetchurl {
+    url = "https://github.com/lxgw/NeoXiHei-Code/releases/download/v${version}/NeoXiHeiCode-Regular.ttf";
+    hash = "sha256-zp7UFoPonjB75qPi0CQ0VNq5m4ULWfVo6+GxADUx6tE=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 $src $out/share/fonts/truetype/NeoXiHeiCode-Regular.ttf
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Programming font combining LXGW NeoXiHei and M+ monospace (derived from Migu 1M)";
+    homepage = "https://github.com/lxgw/NeoXiHei-Code";
+    license = lib.licenses.ipa;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ xrelkd ];
+  };
+}


### PR DESCRIPTION
lxgw-neoxihei-code: init at 1.304

This PR adds `lxgw-neoxihei-code`, a programming font that merges "LXGW NeoXiHei" (霞鹜新晰黑) with the older version of "M+ monospace" font, further derived from Migu 1M.

[https://github.com/lxgw/NeoXiHei-Code](https://github.com/lxgw/NeoXiHei-Code)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
