### PR TITLE
hydrus: update dependencies, set mainProgram, add pillow-jxl-plugin

### DIFF
--- a/pkgs/by-name/hy/hydrus/package.nix
+++ b/pkgs/by-name/hy/hydrus/package.nix
@@ -7,11 +7,8 @@
   copyDesktopItems,
   makeDesktopItem,
   writableTmpDirAsHomeHook,
-  swftools,
   ffmpeg,
   miniupnpc,
-
-  enableSwftools ? false,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
@@ -35,6 +32,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   buildInputs = [
     qt6.qtbase
     qt6.qtcharts
+    qt6.qtmultimedia
   ];
 
   desktopItems = [
@@ -53,37 +51,40 @@ python3Packages.buildPythonApplication (finalAttrs: {
     })
   ];
 
-  dependencies = with python3Packages; [
-    beautifulsoup4
-    cbor2
-    chardet
-    cloudscraper
-    dateparser
-    html5lib
-    lxml
-    lz4
-    numpy
-    opencv4
-    olefile
-    pillow
-    pillow-heif
-    psutil
-    psd-tools
-    pympler
-    pyopenssl
-    pyqt6
-    pyqt6-charts
-    pysocks
-    python-dateutil
-    python3Packages.mpv
-    pyyaml
-    qtpy
-    requests
-    show-in-file-manager
-    send2trash
-    service-identity
-    twisted
-  ];
+  dependencies =
+    with python3Packages;
+    [
+      beautifulsoup4
+      cbor2
+      chardet
+      dateparser
+      html5lib
+      lxml
+      lz4
+      mpv
+      numpy
+      opencv4
+      olefile
+      pillow
+      pillow-heif
+      pillow-jxl-plugin
+      psutil
+      pympler
+      pyopenssl
+      pyqt6
+      pyqt6-charts
+      pysocks
+      python-dateutil
+      pyyaml
+      qtpy
+      requests
+      show-in-file-manager
+      send2trash
+      service-identity
+      twisted
+    ]
+    ++ python3Packages.twisted.optional-dependencies.tls
+    ++ python3Packages.twisted.optional-dependencies.http2;
 
   nativeCheckInputs =
     (with python3Packages; [
@@ -121,15 +122,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     # desktop item
     mkdir -p "$out/share/icons/hicolor/scalable/apps"
     ln -s "$doc/share/doc/hydrus/assets/hydrus-white.svg" "$out/share/icons/hicolor/scalable/apps/hydrus-client.svg"
-  ''
-  + lib.optionalString enableSwftools ''
-    mkdir -p $out/${python3Packages.python.sitePackages}/bin
-    # swfrender seems to have to be called sfwrender_linux
-    # not sure if it can be loaded through PATH, but this is simpler
-    # $out/python3Packages.python.sitePackages/bin is correct NOT .../hydrus/bin
-    ln -s ${swftools}/bin/swfrender $out/${python3Packages.python.sitePackages}/bin/swfrender_linux
-  ''
-  + ''
+
     runHook postInstall
   '';
 
@@ -159,6 +152,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   meta = {
     description = "Danbooru-like image tagging and searching system for the desktop";
+    mainProgram = "hydrus-client";
     license = lib.licenses.wtfpl;
     homepage = "https://hydrusnetwork.github.io/hydrus/";
     changelog = "https://github.com/hydrusnetwork/hydrus/releases/tag/${finalAttrs.src.tag}";

--- a/pkgs/development/python-modules/pillow-jxl-plugin/default.nix
+++ b/pkgs/development/python-modules/pillow-jxl-plugin/default.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  buildPythonPackage,
+  pytestCheckHook,
+  fetchPypi,
+  rustPlatform,
+  maturin,
+  cmake,
+  packaging,
+  pillow,
+  numpy,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pillow-jxl-plugin";
+  version = "1.3.8";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  # Contains Cargo.lock
+  src = fetchPypi {
+    pname = "pillow_jxl_plugin";
+    inherit (finalAttrs) version;
+    hash = "sha256-RDD9d1eJl0IHnFSKfSU31tY88PHTIxgAlbwPbwPZ1Po=";
+  };
+
+  build-system = [ maturin ];
+
+  nativeBuildInputs = with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+    cmake
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) src;
+    hash = "sha256-IiVTlKtKkfZnRXme7QFA5MS8PPiL8+riOYOEoNaHHXc=";
+  };
+
+  dependencies = [
+    packaging
+    pillow
+  ];
+
+  doCheck = false;
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    numpy
+  ];
+
+  pythonImportsCheck = [
+    "pillow_jxl"
+  ];
+
+  meta = {
+    changelog = "https://github.com/Isotr0py/pillow-jpegxl-plugin/releases/tag/v${finalAttrs.version}";
+    description = "Pillow plugin that adds support for JPEG XL files";
+    homepage = "https://github.com/Isotr0py/pillow-jpegxl-plugin";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      dandellion
+      KunyaKud
+    ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13202,6 +13202,8 @@ self: super: with self; {
 
   pillow-jpls = callPackage ../development/python-modules/pillow-jpls { };
 
+  pillow-jxl-plugin = callPackage ../development/python-modules/pillow-jxl-plugin { };
+
   pillowfight = callPackage ../development/python-modules/pillowfight { };
 
   pims = callPackage ../development/python-modules/pims { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

A continuation of PR #462517, as there has been months of radio silence. I have adapted changes from both @D4ndellion and @Gliczy:

- removed unused dependencies
- set `mainProgram`
- added `qt6.qtmultimedia` to `buildInputs` for the [new media player](https://github.com/hydrusnetwork/hydrus/releases/tag/v661)
- added `pillow-jpegxl-plugin` (now 1.3.8) for JPEG XL support

Tested and I can both import and preview JPEG XL images in Hydrus.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
