### PR TITLE
[release-26.05] filebrowser: 2.63.15 -> 2.63.18 [CVE]

### DIFF
--- a/pkgs/by-name/fi/filebrowser/package.nix
+++ b/pkgs/by-name/fi/filebrowser/package.nix
@@ -12,13 +12,13 @@
 }:
 
 let
-  version = "2.63.15";
+  version = "2.63.18";
 
   src = fetchFromGitHub {
     owner = "filebrowser";
     repo = "filebrowser";
     rev = "v${version}";
-    hash = "sha256-O2USjwP1g+yDZpz0628YTRN2BUUnmjFvS+0qc6JU294=";
+    hash = "sha256-0j0i6bKKbyUi4O0wBT+xYjvywjRzAGd0/13Yh/dG5GA=";
   };
 
   frontend = buildNpmPackage rec {
@@ -59,7 +59,7 @@ buildGoModule {
   pname = "filebrowser";
   inherit version src;
 
-  vendorHash = "sha256-WXbXD75acK4woS7UC0G73pY48aGmp1l0spDc3sGYXMg=";
+  vendorHash = "sha256-BXw+fURCh1qNlwWo49aXIpSM339bV3Gwn9Ov8HLEVF0=";
 
   excludedPackages = [ "tools" ];
 


### PR DESCRIPTION
Backport of #536496 to `release-26.05`. This is a security update -- see below.

The automatic backport failed to cherry-pick cleanly: master's `filebrowser` was refactored to build its frontend with `pnpmBuildHook` (`stdenvNoCC` + `nodejs-slim`, `tag =`), but `pnpmBuildHook` was added to `pkgs/by-name/` only after `release-26.05` was branched, so it does not exist on this branch. I resolved the conflict manually as a **minimal** backport (same approach as #533883): the branch's existing `buildNpmPackage` + `pnpmConfigHook` frontend builder (and `rev =`) is kept, and only `version`, the `src` hash, and `vendorHash` are updated. The frontend `pnpmDeps` hash is unchanged between 2.63.15 and 2.63.18.

### Security fixes

2.63.17 fixes the following vulnerabilities:

| Advisory | CVE | Severity | Summary |
| -------- | --- | -------- | ------- |
| [GHSA-7rc3-g7h6-22m7](https://github.com/filebrowser/filebrowser/security/advisories/GHSA-7rc3-g7h6-22m7) | CVE-2026-62685 | high | Colliding username normalization gives two users the same home directory |
| [GHSA-83xp-526h-j3ww](https://github.com/filebrowser/filebrowser/security/advisories/GHSA-83xp-526h-j3ww) | CVE-2026-62843 | medium | Archive builder turns backslash filenames into path traversal (zip-slip) |
| [GHSA-pp88-jhwj-5qh5](https://github.com/filebrowser/filebrowser/security/advisories/GHSA-pp88-jhwj-5qh5) | CVE-2026-62683 | low | Trailing-slash delete leaves a stale public share behind |
| [GHSA-833g-cqhp-h72j](https://github.com/filebrowser/filebrowser/security/advisories/GHSA-833g-cqhp-h72j) | CVE-2026-62684 | low | Share API exposes the password hash and bypass token |

It also ships a hardening warning about broad default scopes for self-signup users (GHSA-6759-996p-gpj6, docs/CLI warning only).

2.63.16 additionally fixes dangling-symlink, write and delete scope bugs, and makes following external symlinks an explicit opt-in (`followExternalSymlinks`).

Changelogs: [2.63.16](https://github.com/filebrowser/filebrowser/releases/tag/v2.63.16), [2.63.17](https://github.com/filebrowser/filebrowser/releases/tag/v2.63.17), [2.63.18](https://github.com/filebrowser/filebrowser/releases/tag/v2.63.18)

### Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] `nix-build -A filebrowser` succeeds; `./result/bin/filebrowser version` reports `v2.63.18`.
- [ ] Tested via `nixosTests.filebrowser` (passthru test).
