### PR TITLE
Revert "overlayfs: Use depends"

### DIFF
--- a/nixos/modules/tasks/filesystems/overlayfs.nix
+++ b/nixos/modules/tasks/filesystems/overlayfs.nix
@@ -113,13 +113,6 @@ let
       config = lib.mkIf (config.overlay.lowerdir != null) {
         fsType = "overlay";
         device = lib.mkDefault "overlay";
-        depends = map (x: "${x}") (
-          config.overlay.lowerdir
-          ++ lib.optionals (config.overlay.upperdir != null) [
-            config.overlay.upperdir
-            config.overlay.workdir
-          ]
-        );
 
         options =
           let
@@ -135,7 +128,8 @@ let
           ++ lib.optionals (config.overlay.upperdir != null) [
             "upperdir=${upperdir}"
             "workdir=${workdir}"
-          ];
+          ]
+          ++ (map (s: "x-systemd.requires-mounts-for=${s}") lowerdir);
       };
     };
 in

--- a/nixos/modules/tasks/filesystems/overlayfs.nix
+++ b/nixos/modules/tasks/filesystems/overlayfs.nix
@@ -129,7 +129,18 @@ let
             "upperdir=${upperdir}"
             "workdir=${workdir}"
           ]
-          ++ (map (s: "x-systemd.requires-mounts-for=${s}") lowerdir);
+          ++ (map (s: "x-systemd.requires-mounts-for=${s}") (
+            lowerdir
+            ++ lib.optionals (config.overlay.upperdir != null) [
+              # These aren't strictly required, because of the
+              # transitive dependencies through the
+              # preMountService. But it doesn't hurt to have them, and
+              # it would allow that service to be masked in some
+              # cases.
+              upperdir
+              workdir
+            ]
+          ));
       };
     };
 in

--- a/nixos/tests/filesystems-overlayfs.nix
+++ b/nixos/tests/filesystems-overlayfs.nix
@@ -38,14 +38,6 @@ in
           };
           neededForBoot = true;
         };
-        "/initrd-real-root-overlay" = {
-          overlay = {
-            lowerdir = [ userspaceLowerdir ];
-            upperdir = "/run/upper"; # from initrd
-            workdir = "/run/work"; # from initrd
-            useStage1BaseDirectories = false;
-          };
-        };
         "/userspace-overlay" = {
           overlay = {
             lowerdir = [ userspaceLowerdir ];
@@ -76,11 +68,6 @@ in
       machine.wait_for_file("/initrd-overlay/initrd.txt", 5)
       machine.succeed("touch /initrd-overlay/writable.txt")
       machine.succeed("findmnt --kernel --types overlay /initrd-overlay")
-
-    with subtest("Userspace overlay with upper/workdir in initrd"):
-      machine.wait_for_file("/initrd-real-root-overlay/userspace.txt", 5)
-      machine.succeed("touch /initrd-real-root-overlay/writable.txt")
-      machine.succeed("findmnt --kernel --types overlay /initrd-real-root-overlay")
 
     with subtest("Userspace overlay"):
       machine.wait_for_file("/userspace-overlay/userspace.txt", 5)

--- a/nixos/tests/filesystems-overlayfs.nix
+++ b/nixos/tests/filesystems-overlayfs.nix
@@ -27,7 +27,44 @@ in
   nodes.machine =
     { config, pkgs, ... }:
     {
-      boot.initrd.systemd.enable = true;
+      boot.initrd.systemd = {
+        enable = true;
+        # The goal is to test that the /initrd-no-base-dir-overlay file
+        # system automatically gains a dependency on a mount unit for
+        # its lower dir, but we also want that lower dir to have a
+        # file in it. We can't just use a bind mount from a store
+        # path, because the initrd's store gets deleted by switch-root
+        # before the transition to stage 2, so files in it
+        # disappear. And we can't use a tmpfs mount unit and add files
+        # to it in a unit ordered in between the tmpfs and overlay,
+        # because that would interfere with the very dependency we're
+        # trying to test. So instead let's do both. Create a tmpfs to
+        # store the file, and then a simple bind mount can be the
+        # mount unit that we're testing for the overlay's dependency
+        # on.
+        services.create-lower = {
+          unitConfig.DefaultDependencies = false;
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+          };
+          script = ''
+            mkdir /tmpfs
+            mount -t tmpfs tmpfs /tmpfs
+            echo "initrd-no-base-dir" > /tmpfs/initrd-no-base-dir.txt
+          '';
+        };
+        mounts = [
+          {
+            type = "bind";
+            options = "bind";
+            what = "/tmpfs";
+            where = "/lower";
+            requires = [ "create-lower.service" ];
+            after = [ "create-lower.service" ];
+          }
+        ];
+      };
 
       virtualisation.fileSystems = {
         "/initrd-overlay" = {
@@ -35,6 +72,15 @@ in
             lowerdir = [ initrdLowerdir ];
             upperdir = "/.rw-initrd-overlay/upper";
             workdir = "/.rw-initrd-overlay/work";
+          };
+          neededForBoot = true;
+        };
+        "/initrd-no-base-dir-overlay" = {
+          overlay = {
+            lowerdir = [ "/lower" ];
+            upperdir = "/run/upper";
+            workdir = "/run/work";
+            useStage1BaseDirectories = false;
           };
           neededForBoot = true;
         };
@@ -68,6 +114,11 @@ in
       machine.wait_for_file("/initrd-overlay/initrd.txt", 5)
       machine.succeed("touch /initrd-overlay/writable.txt")
       machine.succeed("findmnt --kernel --types overlay /initrd-overlay")
+
+    with subtest("Initrd overlay with non-sysroot dependencies"):
+      machine.wait_for_file("/initrd-no-base-dir-overlay/initrd-no-base-dir.txt", 5)
+      machine.succeed("touch /initrd-no-base-dir-overlay/writable.txt")
+      machine.succeed("findmnt --kernel --types overlay /initrd-no-base-dir-overlay")
 
     with subtest("Userspace overlay"):
       machine.wait_for_file("/userspace-overlay/userspace.txt", 5)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
