### PR TITLE
quickemu: use architecture-specific UEFI firmware

### DIFF
--- a/pkgs/by-name/qu/quickemu/package.nix
+++ b/pkgs/by-name/qu/quickemu/package.nix
@@ -70,8 +70,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     sed -i \
-      -e '/OVMF_CODE_4M.secboot.fd/s|ovmfs=(|ovmfs=("${OVMFFull.firmware}","${OVMFFull.variables}" |' \
-      -e '/OVMF_CODE_4M.fd/s|ovmfs=(|ovmfs=("${OVMF.firmware}","${OVMF.variables}" |' \
+      ${lib.optionalString stdenv.hostPlatform.isx86_64 ''
+        -e '/OVMF_CODE_4M.secboot.fd/s|ovmfs=(|ovmfs=("${OVMFFull.firmware}","${OVMFFull.variablesMs}" |' \
+        -e '/OVMF_CODE_4M.fd/s|ovmfs=(|ovmfs=("${OVMF.firmware}","${OVMF.variables}" |' \
+      ''} \
       -e '/cp "''${VARS_IN}" "''${VARS_OUT}"/a chmod +w "''${VARS_OUT}"' \
       -e 's/Icon=.*qemu.svg/Icon=qemu/' \
       -e 's,\[ -x "\$(command -v smbd)" \],true,' \

--- a/pkgs/by-name/qu/quickemu/package.nix
+++ b/pkgs/by-name/qu/quickemu/package.nix
@@ -74,6 +74,9 @@ stdenv.mkDerivation (finalAttrs: {
         -e '/OVMF_CODE_4M.secboot.fd/s|ovmfs=(|ovmfs=("${OVMFFull.firmware}","${OVMFFull.variablesMs}" |' \
         -e '/OVMF_CODE_4M.fd/s|ovmfs=(|ovmfs=("${OVMF.firmware}","${OVMF.variables}" |' \
       ''} \
+      ${lib.optionalString stdenv.hostPlatform.isAarch64 ''
+        -e '/AAVMF_CODE.fd/s|ovmfs=(|ovmfs=("${OVMF.firmware}","${OVMF.variables}" |' \
+      ''} \
       -e '/cp "''${VARS_IN}" "''${VARS_OUT}"/a chmod +w "''${VARS_OUT}"' \
       -e 's/Icon=.*qemu.svg/Icon=qemu/' \
       -e 's,\[ -x "\$(command -v smbd)" \],true,' \


### PR DESCRIPTION
Use host-architecture firmware when augmenting Quickemu firmware candidates:

- On x86_64, inject OVMF into the x86 guest list and use `OVMFFull.variablesMs` so Secure Boot gets the Microsoft keys.
- On aarch64, inject AAVMF into the ARM guest list.
- Cross-architecture guests continue to use the matching firmware bundled with QEMU.

This ports the Secure Boot VARS correction from quickemu-project/quickemu#1879 without inserting host-native firmware into a different guest architecture list.

## Validation

- `nixfmt --check pkgs/by-name/qu/quickemu/package.nix`
- Ran `nixpkgs-review` against nixos-unstable on x86_64-linux; `quickemu` and `quickgui` built successfully.
- Built the `passthru.tests` version test.
- Exercised all installed binaries using their help/version output or, for `quickreport`, report generation.
- Evaluated the Quickemu derivation on x86_64-linux, aarch64-linux, aarch64-darwin, riscv64-linux, and loongarch64-linux.
- Applied the generated `postPatch` to the source for x86_64 and aarch64 and verified the resulting OVMF/AAVMF pairs.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [Package tests] at `passthru.tests`.
- [x] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits `CONTRIBUTING.md`, `pkgs/README.md`, `maintainers/README.md` and other READMEs.
- [x] Follows the automation/AI policy.

## Automation disclosure

Assisted by Pi coding agent using gpt-5.6-sol. The resulting changes and PR text were manually reviewed before submission.

[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests