### PR TITLE
middleclick: init at 3.2.0

### DIFF
--- a/pkgs/by-name/mi/middleclick/package.nix
+++ b/pkgs/by-name/mi/middleclick/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  nix-update-script,
+  unzip,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "middleclick";
+  version = "3.2.0";
+
+  __structuredAttrs = true;
+
+  src = fetchurl {
+    url = "https://github.com/artginzburg/MiddleClick/releases/download/${finalAttrs.version}/MiddleClick.zip";
+    hash = "sha256-6T8XYSp3QTxefO+UI/DcnbFm1m841B14OpkOLqa6aYw=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ unzip ];
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  # Preserve the upstream Developer ID signature and notarized app bundle.
+  dontFixup = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p unpacked "$out/Applications"
+    unzip -q "$src" -d unpacked
+    mv unpacked/MiddleClick.app "$out/Applications/"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Utility for emulating middle clicks with trackpad and Magic Mouse gestures";
+    homepage = "https://github.com/artginzburg/MiddleClick";
+    downloadPage = "https://github.com/artginzburg/MiddleClick/releases";
+    changelog = "https://github.com/artginzburg/MiddleClick/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ akosseres ];
+    platforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
Packages [MiddleClick](https://github.com/artginzburg/MiddleClick) from the release binaries. It's a utility for emulating middle clicks with trackpad and Magic Mouse gestures.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

AI disclosure: ChatGPT using GPT5.6 Sol was used to research Darwin packaging conventions and generate the initial derivation. I manually tested the resulting package.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
