### PR TITLE
nixos/systemd/tmpfiles: add provision.conf

### DIFF
--- a/nixos/modules/system/boot/systemd/tmpfiles.nix
+++ b/nixos/modules/system/boot/systemd/tmpfiles.nix
@@ -321,6 +321,7 @@ in
         ln -s "${systemd}/example/tmpfiles.d/home.conf"
         ln -s "${systemd}/example/tmpfiles.d/journal-nocow.conf"
         ln -s "${systemd}/example/tmpfiles.d/portables.conf"
+        ln -s "${systemd}/example/tmpfiles.d/provision.conf"
         ln -s "${systemd}/example/tmpfiles.d/static-nodes-permissions.conf"
         ln -s "${systemd}/example/tmpfiles.d/systemd.conf"
         ln -s "${systemd}/example/tmpfiles.d/systemd-nologin.conf"

--- a/nixos/tests/openssh.nix
+++ b/nixos/tests/openssh.nix
@@ -298,6 +298,13 @@ in
         ];
       };
 
+    server-provisioned-key =
+      { ... }:
+      {
+        services.openssh.enable = true;
+        virtualisation.credentials."ssh.authorized_keys.root".text = snakeOilPublicKey;
+      };
+
     client =
       { ... }:
       {
@@ -323,6 +330,7 @@ in
     server_null_pam.wait_for_unit("sshd", timeout=60)
     server_null_pam.fail("journalctl -u sshd.service | grep 'Unsupported option UsePAM'")
     server_sftp.wait_for_unit("sshd", timeout=60)
+    server_provisioned_key.wait_for_unit("sshd", timeout=60)
 
     server_lazy.wait_for_unit("sshd.socket", timeout=60)
     server_localhost_only_lazy.wait_for_unit("sshd.socket", timeout=60)
@@ -386,6 +394,16 @@ in
         )
         client.succeed(
             "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i privkey.snakeoil server-lazy true",
+            timeout=30
+        )
+
+    with subtest("provisioned-authkey"):
+        client.succeed(
+            "cat ${snakeOilPrivateKey} > privkey.snakeoil"
+        )
+        client.succeed("chmod 600 privkey.snakeoil")
+        client.succeed(
+            "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i privkey.snakeoil server-provisioned-key true",
             timeout=30
         )
 


### PR DESCRIPTION
Adds some credentials for provisioning a server with files

this provisions:
* the root user's ssh key from the ssh.authorized_keys.root credential
* /etc/hosts from the network.hosts credential 
* creates a dropin in /etc/motd.d from the login.motd credential 
* and a dropin in /etc/issue.d from the logging.issue credential

The last two drop-ins are not being picked up by NixOS at the moment
but we can add them in follow-up PR

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
