### PR TITLE
wifite2: migrate to pyproject

### DIFF
--- a/pkgs/by-name/wi/wifite2/package.nix
+++ b/pkgs/by-name/wi/wifite2/package.nix
@@ -2,7 +2,6 @@
   lib,
   fetchFromGitHub,
   fetchpatch,
-  python3,
   python3Packages,
   wirelesstools,
   aircrack-ng,
@@ -20,16 +19,10 @@
   macchanger,
 }:
 
-let
-  pythonDependencies = with python3Packages; [
-    chardet
-    scapy
-  ];
-in
-python3.pkgs.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "wifite2";
   version = "2.7.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "kimocoder";
@@ -37,6 +30,8 @@ python3.pkgs.buildPythonApplication rec {
     rev = version;
     hash = "sha256-G2AKKZUDS2UQm95TEhGJIucyMRcm7oL0d3J8uduEQhw=";
   };
+
+  build-system = with python3Packages; [ setuptools ];
 
   patches = [
     (fetchpatch {
@@ -53,6 +48,13 @@ python3.pkgs.buildPythonApplication rec {
     })
   ];
 
+  dependencies = with python3Packages; [
+    chardet
+    scapy
+  ];
+
+  pythonRemoveDeps = [ "argparse" ];
+
   propagatedBuildInputs = [
     aircrack-ng
     wireshark-cli
@@ -68,10 +70,9 @@ python3.pkgs.buildPythonApplication rec {
     john
     iw
     macchanger
-  ]
-  ++ pythonDependencies;
+  ];
 
-  nativeCheckInputs = propagatedBuildInputs ++ [ python3.pkgs.unittestCheckHook ];
+  nativeCheckInputs = propagatedBuildInputs ++ [ python3Packages.pytestCheckHook ];
 
   meta = {
     homepage = "https://github.com/kimocoder/wifite2";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- https://github.com/NixOS/nixpkgs/issues/515974

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
