### PR TITLE
gnome: 50.2 -> 50.3

### DIFF
--- a/pkgs/by-name/ge/gexiv2_0_16/package.nix
+++ b/pkgs/by-name/ge/gexiv2_0_16/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "gexiv2";
   __structuredAttrs = true;
   strictDeps = true;
-  version = "0.16.0";
+  version = "0.16.1";
 
   outputs = [
     "out"
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gexiv2/${lib.versions.majorMinor finalAttrs.version}/gexiv2-${finalAttrs.version}.tar.xz";
-    sha256 = "2W+JXyRTn5ZvV3srskia6E+CMpcKjQwGTkoAdHSne7s=";
+    sha256 = "sha256-GOmgXGN6d+gAsAHYf3Dk0Cp7pBt3RUAKMUoQcqHdyUM=";
   };
 
   depsBuildBuild = [

--- a/pkgs/by-name/gl/glibmm_2_68/package.nix
+++ b/pkgs/by-name/gl/glibmm_2_68/package.nix
@@ -13,7 +13,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "glibmm";
-  version = "2.88.0";
+  version = "2.88.1";
 
   outputs = [
     "out"
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/glibmm/${lib.versions.majorMinor finalAttrs.version}/glibmm-${finalAttrs.version}.tar.xz";
-    hash = "sha256-plSdo6bEPeg7hxfa5UE8V6YNkvbsxiRhXGEtC7CtD+I=";
+    hash = "sha256-wTn5YrFXXIgnzTnRrCG3o2e+O9oUCcDH4hopCQ83FQY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-remote-desktop/package.nix
+++ b/pkgs/by-name/gn/gnome-remote-desktop/package.nix
@@ -35,11 +35,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-remote-desktop";
-  version = "50.1";
+  version = "50.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-remote-desktop/${lib.versions.major finalAttrs.version}/gnome-remote-desktop-${finalAttrs.version}.tar.xz";
-    hash = "sha256-CJBJEZ4fJEL+l3PwKFNlztwgf0y8fOmvOI4VNmjisXE=";
+    hash = "sha256-Md9ij0ETVz8Tb/yNwAF2Ou1jPNhb7SHli8YfihffCR8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-shell/package.nix
+++ b/pkgs/by-name/gn/gnome-shell/package.nix
@@ -73,7 +73,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-shell";
-  version = "50.2";
+  version = "50.3";
 
   outputs = [
     "out"
@@ -82,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-shell/${lib.versions.major finalAttrs.version}/gnome-shell-${finalAttrs.version}.tar.xz";
-    hash = "sha256-UyFUIOUO/dTQYRultZ4Qy0yJ+j9R4q3f2Vyt4GGgmik=";
+    hash = "sha256-RQRYxEom0lqbhCiOErkAXUxcRGSM/Gt5C+GaBd5/FzU=";
   };
 
   patches = [

--- a/pkgs/by-name/li/libglycin/package.nix
+++ b/pkgs/by-name/li/libglycin/package.nix
@@ -32,7 +32,7 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "libglycin";
-  version = "2.1.1";
+  version = "2.1.5";
 
   outputs = [
     "out"
@@ -44,12 +44,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/glycin/${lib.versions.majorMinor finalAttrs.version}/glycin-${finalAttrs.version}.tar.xz";
-    hash = "sha256-jo6S4xKxTSxfOgR73FMFrcuZMe8BUM90v1JqN0Hm+zI=";
+    hash = "sha256-bAl1fukGMwpgtnBXU6pWvKAHrSGblebjU3UQ1BvDQcg=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-BaIQs2be/W/dQFbO9KthJUWVE2vCT6H594geYJqzIzc=";
+    hash = "sha256-6vCucnT3xPWSm3TSi3WzgJdiiBFHvGMpab4d53OfThg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/mm/mm-common/package.nix
+++ b/pkgs/by-name/mm/mm-common/package.nix
@@ -11,11 +11,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mm-common";
-  version = "1.0.7";
+  version = "1.0.8";
 
   src = fetchurl {
     url = "mirror://gnome/sources/mm-common/${lib.versions.majorMinor version}/mm-common-${version}.tar.xz";
-    sha256 = "SUq/zngUGCWbHp2IiMc69N5LbzvjbMddm6qLqg8qejk=";
+    sha256 = "sYnuY26DnRLADavvrgmf1IirI1jewk0mR2HAEZULAqk=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/mu/mutter/package.nix
+++ b/pkgs/by-name/mu/mutter/package.nix
@@ -1,6 +1,5 @@
 {
   fetchurl,
-  fetchpatch,
   runCommand,
   lib,
   stdenv,
@@ -73,7 +72,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mutter";
-  version = "50.2";
+  version = "50.3";
 
   outputs = [
     "out"
@@ -84,17 +83,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/mutter/${lib.versions.major finalAttrs.version}/mutter-${finalAttrs.version}.tar.xz";
-    hash = "sha256-/ejfinRlAMUfHJJbUeV8PdhwByM771Yweegx9Tv6O1Y=";
+    hash = "sha256-JWY/p6/JakwJJEiZDA2mZLfwTdjZ9eO5vitJixswPLQ=";
   };
-
-  patches = [
-    # mutter 50.2 spams logs, clutter_input_focus_set_cursor_location
-    # https://gitlab.gnome.org/GNOME/mutter/-/work_items/4840
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/mutter/-/commit/f1570318ec3e9a38615eb91708bb71628ab8bcfd.patch";
-      hash = "sha256-73GI2DTgoEBUQGa7nTUIur/ZuDHgDu4SwjUWHBRCyuo=";
-    })
-  ];
 
   mesonFlags = [
     "-Degl_device=true"

--- a/pkgs/development/libraries/pangomm/2.48.nix
+++ b/pkgs/development/libraries/pangomm/2.48.nix
@@ -14,7 +14,7 @@
 
 stdenv.mkDerivation rec {
   pname = "pangomm";
-  version = "2.56.1";
+  version = "2.56.2";
 
   outputs = [
     "out"
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/pangomm/${lib.versions.majorMinor version}/pangomm-${version}.tar.xz";
-    hash = "sha256-U59apg6b3GuVW7RI4qYswUVidE32kCWAQPu3S/iFdV0=";
+    hash = "sha256-8emEyFqFtqDmFhY2ZSH1HdgoKgcrtF0VtQhHYrYvTA4=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
- Announcement: https://discourse.gnome.org/t/gnome-50-3-is-released/36690
- Changelog: https://download.gnome.org/sources/gnome-build-meta/50/gnome-build-meta-50.3.news

Some of the necessary updates are already on `staging` and/or `master`.

Package updates that are handled separately as they need to go through staging:

- https://github.com/NixOS/nixpkgs/pull/543053 + https://github.com/NixOS/nixpkgs/pull/549705
  - Also included in https://github.com/NixOS/nixpkgs/pull/541158
- https://github.com/NixOS/nixpkgs/pull/543060
- https://github.com/NixOS/nixpkgs/pull/543309
- https://github.com/NixOS/nixpkgs/pull/543299

Closes https://github.com/NixOS/nixpkgs/issues/547791

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. — `nixosTests.gnome{,-extensions}`
  - [x] [Package tests] at `passthru.tests`. — For `glycin-loaders`, `glycin-thumbnailer`, `libglycin`, `mutter`
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Verified basic functionality of GNOME in a VM.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
