### PR TITLE
python3Packages.pysimplesoap: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/pysimplesoap/default.nix
+++ b/pkgs/development/python-modules/pysimplesoap/default.nix
@@ -4,13 +4,14 @@
   fetchPypi,
   buildPythonPackage,
   m2crypto,
+  setuptools,
   nix-update-script,
 }:
 
 buildPythonPackage rec {
   pname = "pysimplesoap";
   version = "1.16.2";
-  format = "setuptools";
+  pyproject = true;
 
   passthru.updateScript = nix-update-script { };
 
@@ -19,6 +20,8 @@ buildPythonPackage rec {
     inherit version;
     hash = "sha256-sbv00NCt/5tlIZfWGqG3ZzGtYYhJ4n0o/lyyUJFtZ+E=";
   };
+
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [ m2crypto ];
 

--- a/pkgs/development/python-modules/pysimplesoap/default.nix
+++ b/pkgs/development/python-modules/pysimplesoap/default.nix
@@ -8,7 +8,7 @@
   nix-update-script,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pysimplesoap";
   version = "1.16.2";
   pyproject = true;
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     pname = "PySimpleSOAP";
-    inherit version;
+    inherit (finalAttrs) version;
     hash = "sha256-sbv00NCt/5tlIZfWGqG3ZzGtYYhJ4n0o/lyyUJFtZ+E=";
   };
 
@@ -32,7 +32,7 @@ buildPythonPackage rec {
         args:
         fetchDebianPatch (
           {
-            inherit pname version;
+            inherit (finalAttrs) pname version;
             debianRevision = "5";
           }
           // args
@@ -74,4 +74,4 @@ buildPythonPackage rec {
     #  so co-maintainers would be welcome.
     maintainers = [ lib.maintainers.nicoo ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- #515974

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
