### PR TITLE
b4: expose misc/ source tree via passthru.src-misc & emacs & vim plugin

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/b4-review-mode/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/b4-review-mode/package.nix
@@ -1,0 +1,19 @@
+{
+  lib,
+  b4,
+  melpaBuild,
+}:
+melpaBuild {
+  pname = "b4-review-mode";
+  inherit (b4) version;
+
+  src = b4.src-misc;
+  sourceRoot = "${b4.src-misc.name}/misc/emacs";
+
+  meta = {
+    description = "Emacs major mode with highlighting for the b4 review reply editor";
+    homepage = "https://git.kernel.org/pub/scm/utils/b4/b4.git/about";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ fzakaria ];
+  };
+}

--- a/pkgs/applications/editors/vim/plugins/non-generated/b4-review-vim/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/b4-review-vim/default.nix
@@ -1,0 +1,19 @@
+{
+  lib,
+  vimUtils,
+  b4,
+}:
+vimUtils.buildVimPlugin {
+  pname = "b4-review-vim";
+  inherit (b4) version;
+
+  src = b4.src-misc;
+  sourceRoot = "${b4.src-misc.name}/misc/vim";
+
+  meta = {
+    description = "Vim syntax highlighting for the b4 review reply editor";
+    homepage = "https://git.kernel.org/pub/scm/utils/b4/b4.git/about";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ fzakaria ];
+  };
+}

--- a/pkgs/by-name/b4/b4/package.nix
+++ b/pkgs/by-name/b4/b4/package.nix
@@ -2,6 +2,7 @@
   lib,
   python3Packages,
   fetchPypi,
+  fetchgit,
   patatt,
 }:
 
@@ -30,6 +31,15 @@ python3Packages.buildPythonApplication (finalAttrs: {
     git-filter-repo
     textual
   ];
+
+  passthru = {
+    src-misc = fetchgit {
+      url = "https://git.kernel.org/pub/scm/utils/b4/b4.git";
+      rev = "v${finalAttrs.version}";
+      hash = "sha256-NjYL3RKQpjDkU98qbXyl/cvLTJYVAfIowm8E2Rg8AgI=";
+      fetchSubmodules = false;
+    };
+  };
 
   meta = {
     homepage = "https://git.kernel.org/pub/scm/utils/b4/b4.git/about";


### PR DESCRIPTION
b4's `misc/vim` directory provides ftdetect/ftplugin/syntax files that highlight the `b4 review` reply editor.
It also provides a default agent review markdown file. They are not published in the wheel.

Package them as a Vim/Neovim plugin, sourced from the b4 package's `passthru.src-misc` so the version stays in lockstep with b4 itself, following the notmuch-vim/hurl precedent.

reference: https://github.com/nix-community/home-manager/pull/9658/changes

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
