### PR TITLE
haskellModules.darcs: drop unused fgl

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2042,14 +2042,25 @@ with haskellLib;
         } super.regex-compat-tdfa
       );
 
-  darcs = appendPatches [
-    # Cabal 3.12 support in Setup.hs
-    # https://hub.darcs.net/darcs/darcs-reviewed/patch/50d9b0b402a896c83aa7929a50a0e0449838600f
-    ./patches/darcs-cabal-3.12.patch
-    # GHC 9.10 patch plus lifted constraints for hashable
-    # https://hub.darcs.net/darcs/darcs-reviewed/patch/32646b190e019de21a103e950c4eccdd66f7eadc
-    ./patches/darcs-stackage-lts-23.patch
-  ] super.darcs;
+  darcs = lib.pipe (super.darcs.override { fgl = null; }) [
+    (overrideCabal (drv: {
+      # fgl isn’t used; removing it avoids cross-compilation failures.
+      #
+      # See: https://hub.darcs.net/darcs/darcs-reviewed/patch/3a8e57ef9fed776f62a3538f8842b6593546e368
+      postPatch = (drv.postPatch or "") + ''
+        substituteInPlace darcs.cabal \
+          --replace-fail "fgl               >= 5.5.2.3 && < 5.9," ""
+      '';
+    }))
+    (appendPatches [
+      # Cabal 3.12 support in Setup.hs
+      # https://hub.darcs.net/darcs/darcs-reviewed/patch/50d9b0b402a896c83aa7929a50a0e0449838600f
+      ./patches/darcs-cabal-3.12.patch
+      # GHC 9.10 patch plus lifted constraints for hashable
+      # https://hub.darcs.net/darcs/darcs-reviewed/patch/32646b190e019de21a103e950c4eccdd66f7eadc
+      ./patches/darcs-stackage-lts-23.patch
+    ])
+  ];
 
   # 2025-02-11: Too strict bounds on hedgehog < 1.5, hspec-hedgehog < 0.2
   validation-selective = doJailbreak super.validation-selective;


### PR DESCRIPTION
From the IRC

> Sun 19 Jul 2026 05:09:41 AM - gpiero: toastal: you can remove the fgl dependency, it's a relic from before a rewrite of `show dependencies`
> Sun 19 Jul 2026 05:10:10 AM - gpiero: see patches df9802529bf5fd188082d03103116ec8f7c7ee64 and 3a8e57ef9fed776f62a3538f8842b6593546e368

I asked about it being removed in the actual cabal file, but hadn’t gotten a response yet. This dep isn’t used & made cross-compilation fail.

<!--
^ Please summarize the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.