### PR TITLE
top-level/{default,impure,stage}: simplify and reduce package-set evaluation overhead

### DIFF
--- a/pkgs/test/top-level/default.nix
+++ b/pkgs/test/top-level/default.nix
@@ -77,9 +77,11 @@ lib.recurseIntoAttrs {
           system = "aarch64-linux";
         };
       };
-      appended = cross.appendOverlays [ ];
+      empty = cross.appendOverlays [ ];
+      appended = cross.appendOverlays [ (_: _: { }) ];
     in
     assert cross.makeWrapper ? __spliced;
+    assert empty.makeWrapper ? __spliced;
     assert appended.makeWrapper ? __spliced;
     pkgs.emptyFile;
 

--- a/pkgs/test/top-level/default.nix
+++ b/pkgs/test/top-level/default.nix
@@ -85,6 +85,21 @@ lib.recurseIntoAttrs {
     assert appended.makeWrapper ? __spliced;
     pkgs.emptyFile;
 
+  bootstrapStagesExcludeCompatibilityLayers =
+    let
+      evaluated = nixpkgsFun {
+        localSystem = {
+          system = "x86_64-linux";
+        };
+      };
+      bootPackages = evaluated.stdenv.__bootPackages;
+    in
+    assert evaluated ? llvmPackages_latest;
+    assert evaluated ? pkgsChecked;
+    assert !(bootPackages ? llvmPackages_latest);
+    assert !(bootPackages ? pkgsChecked);
+    pkgs.emptyFile;
+
   replaceStdenv =
     let
       replacedPkgs = nixpkgsFun {

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -112,7 +112,10 @@ let
       (throwIfNot (lib.all lib.isFunction crossOverlays) "All crossOverlays passed to nixpkgs must be functions.")
       (
         throwIf (
-          ((localSystem.isDarwin && localSystem.isx86) || (crossSystem.isDarwin && crossSystem.isx86))
+          lib.elem "x86_64-darwin" [
+            localSystem.system
+            crossSystem.system
+          ]
           && config.allowDeprecatedx86_64Darwin != "force"
         ) x86_64DarwinDeprecationMessage
       );

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -3,12 +3,12 @@
 
     1. Elaborates `localSystem` and `crossSystem` with defaults as needed.
 
-    2. Applies the final stage to the given `config` if it is a function
+    2. Evaluates `config`, allowing it to depend on the final package set
 
     3. Defaults to no non-standard config and no cross-compilation target
 
-    4. Uses the above to infer the default standard environment's (stdenv's)
-       stages if no stdenv's are provided
+    4. Uses the above to infer the default standard environment's (stdenv)
+       stages if none are provided
 
     5. Folds the stages to yield the final fully booted package set for the
        chosen stdenv
@@ -49,11 +49,12 @@
   ...
 }@args:
 
-let # Rename the function arguments
-  config0 = config;
-  crossSystem0 = crossSystem;
-
+# The bindings below shadow the function arguments with their elaborated and
+# evaluated counterparts, so keep the arguments as given reachable here.
+let
+  inputs = { inherit localSystem crossSystem config; };
 in
+
 let
   pristineLib = import ../../lib;
 
@@ -104,7 +105,7 @@ let
       https://nixos.org/manual/nixpkgs/unstable/release-notes#x86_64-darwin-26.11
   '';
 
-  checked =
+  validate =
     (throwIfNot (lib.isList overlays) "The overlays argument to nixpkgs must be a list.")
       (throwIfNot (lib.all lib.isFunction overlays) "All overlays passed to nixpkgs must be functions.")
       (throwIfNot (lib.isList crossOverlays) "The crossOverlays argument to nixpkgs must be a list.")
@@ -116,7 +117,7 @@ let
         ) x86_64DarwinDeprecationMessage
       );
 
-  localSystem = lib.systems.elaborate args.localSystem;
+  localSystem = lib.systems.elaborate inputs.localSystem;
 
   # Condition preserves sharing which in turn affects equality.
   #
@@ -131,31 +132,29 @@ let
   # Both systems are semantically equivalent as the same vendor and ABI are
   # inferred from the system double in `localSystem`.
   crossSystem =
-    let
-      system = lib.systems.elaborate crossSystem0;
-    in
-    if crossSystem0 == null || lib.systems.equals system localSystem then localSystem else system;
-
-  # Allow both:
-  # { /* the config */ } and
-  # { pkgs, ... } : { /* the config */ }
-  config1 = if lib.isFunction config0 then config0 { inherit lib pkgs; } else config0;
+    if inputs.crossSystem == null then
+      localSystem
+    else
+      let
+        system = lib.systems.elaborate inputs.crossSystem;
+      in
+      if lib.systems.equals system localSystem then localSystem else system;
 
   configEval = lib.evalModules {
     modules = [
       ./config.nix
-      (
-        { options, ... }:
-        {
-          _file = "nixpkgs.config";
-          config = config1;
-        }
-      )
+      {
+        _file = "nixpkgs.config";
+        # Allow both:
+        # { /* the config */ } and
+        # { pkgs, ... } : { /* the config */ }
+        config =
+          if lib.isFunction inputs.config then inputs.config { inherit lib pkgs; } else inputs.config;
+      }
     ];
     class = "nixpkgsConfig";
   };
 
-  # take all the rest as-is
   config =
     let
       failedAssertionsString = lib.concatMapStringsSep "\n" (x: "- ${x.message}") (
@@ -172,7 +171,7 @@ let
   # give `all-packages.nix` all the arguments to this function, even ones that
   # don't concern it, we give it this function to "re-call" nixpkgs, inheriting
   # whatever arguments it doesn't explicitly provide. This way,
-  # `all-packages.nix` doesn't know more than it needs too.
+  # `all-packages.nix` doesn't know more than it needs to.
   #
   # It's OK that `args` doesn't include default arguments from this file:
   # they'll be deterministically inferred. In fact we must *not* include them,
@@ -180,18 +179,17 @@ let
   # substituted with a different argument, the default is re-inferred.
   #
   # To put this in concrete terms, this function is basically just used today to
-  # use package for a different platform for the current platform (namely cross
+  # use packages for a different platform for the current platform (namely cross
   # compiling toolchains and 32-bit packages on x86_64). In both those cases we
   # want the provided non-native `localSystem` argument to affect the stdenv
   # chosen.
   #
-  # NB!!! This thing gets its `config` argument from `args`, i.e. it's actually
-  # `config0`. It is important to keep it to `config0` format (as opposed to the
-  # result of `evalModules`, i.e. the `config` variable above) throughout all
-  # nixpkgs evaluations since the above function `config0 -> config` implemented
-  # via `evalModules` is not idempotent. In other words, if you add `config` to
-  # `newArgs`, expect strange very hard to debug errors! (Yes, I'm speaking from
-  # experience here.)
+  # NB!!! This thing gets its `config` argument from `args`, i.e. it is the
+  # original function argument, `inputs.config`. It is important to keep it in
+  # that format (as opposed to the result of `evalModules`, i.e. the `config`
+  # binding above) throughout all nixpkgs evaluations since that evaluation is
+  # not idempotent. In other words, if you add `config` to `newArgs`, expect
+  # strange very hard to debug errors! (Yes, I'm speaking from experience here.)
   nixpkgsFun = newArgs: import ./. (args // newArgs);
 
   # Partially apply some arguments for building bootstrapping stage pkgs
@@ -247,10 +245,10 @@ let
     if config.attrPathsDisallowedForInternalUse == [ ] then
       fixedPoint
     else
-      # See ./stage.nix, which replaced config.attrPathsDisallowedForInternalUse with aborts.
+      # See ./stage.nix, which replaces config.attrPathsDisallowedForInternalUse with aborts.
       # To prevent these attributes from causing CI failures we remove them entirely.
       # These attrs are still evaluated but in a different way, see ci/eval/default.nix
       removeInternallyDisallowedAttrPaths fixedPoint;
 
 in
-checked pkgs
+validate pkgs

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -156,15 +156,8 @@ let
   };
 
   config =
-    let
-      failedAssertionsString = lib.concatMapStringsSep "\n" (x: "- ${x.message}") (
-        lib.filter (x: !x.assertion) configEval.config.assertions
-      );
-    in
-    if failedAssertionsString != "" then
-      throw "Failed assertions:\n${failedAssertionsString}"
-    else
-      lib.showWarnings configEval.config.warnings configEval.config;
+    lib.asserts.checkAssertWarn configEval.config.assertions configEval.config.warnings
+      configEval.config;
 
   # A few packages make a new package set to draw their dependencies from.
   # (Currently to get a cross tool chain, or forced-i686 package.) Rather than

--- a/pkgs/top-level/impure.nix
+++ b/pkgs/top-level/impure.nix
@@ -3,12 +3,6 @@
   for the meaning of each argument.
 */
 
-let
-
-  homeDir = builtins.getEnv "HOME";
-
-in
-
 {
   # We put legacy `system` into `localSystem`, if `localSystem` was not passed.
   # If neither is passed, assume we are building packages on the current
@@ -19,14 +13,15 @@ in
 
   # These are needed only because nix's `--arg` command-line logic doesn't work
   # with unnamed parameters allowed by ...
-  system ? localSystem.system,
-  crossSystem ? localSystem,
+  system ? null,
+  crossSystem ? null,
 
   # Fallback: The contents of the configuration file found at $NIXPKGS_CONFIG or
   # $HOME/.config/nixpkgs/config.nix.
   config ?
     let
       configFile = builtins.getEnv "NIXPKGS_CONFIG";
+      homeDir = builtins.getEnv "HOME";
       configFile2 = homeDir + "/.config/nixpkgs/config.nix";
       configFile3 = homeDir + "/.nixpkgs/config.nix"; # obsolete
     in
@@ -49,8 +44,7 @@ in
 
 # If `localSystem` was explicitly passed, legacy `system` should
 # not be passed, and vice-versa.
-assert args ? localSystem -> !(args ? system);
-assert args ? system -> !(args ? localSystem);
+assert !(args ? localSystem && args ? system);
 
 import ./. (
   removeAttrs args [ "system" ]

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -109,7 +109,7 @@ let
     };
 
   stdenvBootstrapAndPlatforms =
-    self: _:
+    self:
     let
       withFallback =
         thisPkgs:
@@ -163,20 +163,18 @@ let
       "The following attributes were defined both in `pkgs/top-level/all-packages.nix` and elsewhere, most likely in `pkgs/by-name/`: ${lib.concatStringsSep ", " (lib.attrNames conflictingAttrs)}";
     packages;
 
-  aliases = self: super: lib.optionalAttrs config.allowAliases (import ./aliases.nix lib self super);
+  aliases = self: super: import ./aliases.nix lib self super;
 
   variants =
     self: super:
-    lib.optionalAttrs config.allowVariants (
-      import ./variants.nix {
-        inherit
-          lib
-          nixpkgsFun
-          stdenv
-          overlays
-          ;
-      } self super
-    );
+    import ./variants.nix {
+      inherit
+        lib
+        nixpkgsFun
+        stdenv
+        overlays
+        ;
+    } self super;
 
   # stdenvOverrides is used to avoid having multiple of versions
   # of certain dependencies that were used in bootstrapping the
@@ -190,8 +188,7 @@ let
   # (un-overridden) set of packages, allowing packageOverrides
   # attributes to refer to the original attributes (e.g. "foo =
   # ... pkgs.foo ...").
-  configOverrides =
-    _: super: lib.optionalAttrs allowCustomOverrides ((config.packageOverrides or (_: { })) super);
+  configOverrides = _: super: config.packageOverrides super;
 
   # Convenience attributes for instantiating package sets. Each of
   # these will instantiate a new version of allPackages. Currently the
@@ -317,43 +314,44 @@ let
   # See also ./default.nix, which removes these attributes entirely from the end result
   internallyDisallowedAttrPathsOverlay =
     _: prev:
-    # Generally only set by CI, don't want to cause a performance hit for users
-    if config.attrPathsDisallowedForInternalUse == [ ] then
-      { }
-    else
-      lib.updateManyAttrsByPath (map (
-        { attrPath, reason }:
-        {
-          path = attrPath;
-          update =
-            _:
-            abort "${lib.concatStringsSep "." attrPath} is disallowed from being used within Nixpkgs${
-              lib.optionalString (reason != null) ", because ${reason}"
-            }";
-        }
-      ) config.attrPathsDisallowedForInternalUse) prev;
+    lib.updateManyAttrsByPath (map (
+      { attrPath, reason }:
+      {
+        path = attrPath;
+        update =
+          _:
+          abort "${lib.concatStringsSep "." attrPath} is disallowed from being used within Nixpkgs${
+            lib.optionalString (reason != null) ", because ${reason}"
+          }";
+      }
+    ) config.attrPathsDisallowedForInternalUse) prev;
+
+  # Layers the user can opt out of, only applied to the stage that accepts
+  # user-facing overrides.
+  customOverrides =
+    lib.optional config.allowAliases aliases
+    ++ lib.optional config.allowVariants variants
+    ++ lib.optional (config ? packageOverrides) configOverrides;
 
   # The complete chain of package set layers, applied from top to bottom.
   # stdenvOverrides must be last as it brings packages forward from the
   # previous bootstrapping phases which have already been overlaid.
-  toFix = lib.foldl' (lib.flip lib.extends) (_: { }) (
+  toFix = lib.foldl' (lib.flip lib.extends) stdenvBootstrapAndPlatforms (
     [
-      stdenvBootstrapAndPlatforms
       stdenvAdapters
       trivialBuilders
       splice
       autoCalledPackages
       allPackages
       otherPackageSets
-      aliases
-      variants
-      configOverrides
+    ]
+    ++ lib.optionals allowCustomOverrides customOverrides
+    # Generally only set by CI; avoid an empty overlay for normal evaluations.
+    ++ lib.optionals (config.attrPathsDisallowedForInternalUse != [ ]) [
       internallyDisallowedAttrPathsOverlay
     ]
     ++ overlays
-    ++ [
-      stdenvOverrides
-    ]
+    ++ [ stdenvOverrides ]
   );
 
 in

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -5,9 +5,9 @@
   all the packages in the Nix Packages collection for some particular platform
   for some particular stage.
 
-  Default arguments are only provided for bootstrapping
-  arguments. Normal users should not import this directly but instead
-  import `pkgs/default.nix` or `default.nix`.
+  Default arguments are only provided for bootstrapping arguments. Normal
+  users should not import this directly, but instead import `pkgs/default.nix`
+  or `default.nix`.
 */
 
 let
@@ -72,8 +72,10 @@ in
   # outside of the store.  Thus, GCC, GFortran, & co. must always look for files
   # in standard system directories (/usr/include, etc.)
   noSysDirs ?
-    stdenv.buildPlatform.system != "x86_64-solaris"
-    && stdenv.buildPlatform.system != "x86_64-kfreebsd-gnu",
+    !lib.elem stdenv.buildPlatform.system [
+      "x86_64-solaris"
+      "x86_64-kfreebsd-gnu"
+    ],
 
   # The configuration attribute set
   config,
@@ -85,20 +87,20 @@ in
 
 let
   stdenvAdapters =
-    self: super:
+    self: _:
     let
-      res = import ../stdenv/adapters.nix {
+      adapters = import ../stdenv/adapters.nix {
         inherit lib config;
         pkgs = self;
       };
     in
-    res
+    adapters
     // {
-      stdenvAdapters = res;
+      stdenvAdapters = adapters;
     };
 
   trivialBuilders =
-    self: super:
+    self: _:
     import ../build-support/trivial-builders {
       inherit lib;
       inherit (self) config;
@@ -106,15 +108,15 @@ let
       inherit (self.pkgsBuildHost) jq shellcheck-minimal lndir;
     };
 
-  stdenvBootstappingAndPlatforms =
-    self: super:
+  stdenvBootstrapAndPlatforms =
+    self: _:
     let
       withFallback =
         thisPkgs:
         (if adjacentPackages == null then self else thisPkgs) // { recurseForDerivations = false; };
     in
     {
-      # Here are package sets of from related stages. They are all in the form
+      # Here are package sets from related stages. They are all in the form
       # `pkgs{theirHost}{theirTarget}`. For example, `pkgsBuildHost` means their
       # host platform is our build platform, and their target platform is our host
       # platform. We only care about their host/target platforms, not their build
@@ -131,7 +133,7 @@ let
       pkgsTargetTarget = withFallback adjacentPackages.pkgsTargetTarget;
 
       # Older names for package sets. Use these when only the host platform of the
-      # package set matter (i.e. use `buildPackages` where any of `pkgsBuild*`
+      # package set matters (i.e. use `buildPackages` where any of `pkgsBuild*`
       # would do, and `targetPackages` when any of `pkgsTarget*` would do (if we
       # had more than just `pkgsTargetTarget`).)
       buildPackages = self.pkgsBuildHost;
@@ -141,25 +143,25 @@ let
       inherit stdenv stdenvNoCC;
     };
 
-  splice = self: super: import ./splice.nix lib self (adjacentPackages != null);
+  splice = self: _: import ./splice.nix lib self (adjacentPackages != null);
 
   allPackages =
     self: super:
     let
-      res = import ./all-packages.nix {
+      packages = import ./all-packages.nix {
         inherit
           lib
           noSysDirs
           config
           overlays
           ;
-      } res self super;
+      } packages self super;
 
-      conflictingAttrs = lib.intersectAttrs res super;
+      conflictingAttrs = lib.intersectAttrs packages super;
     in
     assert lib.assertMsg (conflictingAttrs == { })
       "The following attributes were defined both in `pkgs/top-level/all-packages.nix` and elsewhere, most likely in `pkgs/by-name/`: ${lib.concatStringsSep ", " (lib.attrNames conflictingAttrs)}";
-    res;
+    packages;
 
   aliases = self: super: lib.optionalAttrs config.allowAliases (import ./aliases.nix lib self super);
 
@@ -189,10 +191,9 @@ let
   # attributes to refer to the original attributes (e.g. "foo =
   # ... pkgs.foo ...").
   configOverrides =
-    self: super:
-    lib.optionalAttrs allowCustomOverrides ((config.packageOverrides or (super: { })) super);
+    _: super: lib.optionalAttrs allowCustomOverrides ((config.packageOverrides or (_: { })) super);
 
-  # Convenience attributes for instantitating package sets. Each of
+  # Convenience attributes for instantiating package sets. Each of
   # these will instantiate a new version of allPackages. Currently the
   # following package sets are provided:
   #
@@ -200,13 +201,13 @@ let
   # - pkgsMusl
   # - pkgsi686Linux
   # NOTE: add new non-critical package sets to "pkgs/top-level/variants.nix"
-  otherPackageSets = self: super: {
+  otherPackageSets = self: _: {
     # This maps each entry in lib.systems.examples to its own package
     # set. Each of these will contain all packages cross compiled for
     # that target system. For instance, pkgsCross.raspberryPi.hello,
     # will refer to the "hello" package built for the ARM6-based
     # Raspberry Pi.
-    pkgsCross = lib.mapAttrs (n: crossSystem: nixpkgsFun { inherit crossSystem; }) lib.systems.examples;
+    pkgsCross = lib.mapAttrs (_: crossSystem: nixpkgsFun { inherit crossSystem; }) lib.systems.examples;
 
     # All packages built for i686 Linux.
     # Used by wine, firefox with debugging version of Flash, ...
@@ -217,7 +218,7 @@ let
       if !config.allowAliases || isSupported then
         nixpkgsFun {
           overlays = [
-            (self': super': {
+            (_: super': {
               pkgsi686Linux = super';
               # Overrides pkgsi686Linux.stdenv.mkDerivation to produce only broken derivations,
               # when used on a non x86_64-linux platform in CI.
@@ -258,7 +259,7 @@ let
         self
       else
         nixpkgsFun {
-          localSystem = lib.systems.elaborate "${stdenv.hostPlatform.parsed.cpu.name}-linux";
+          localSystem.system = "${stdenv.hostPlatform.parsed.cpu.name}-linux";
         };
 
     # Extend the package set with zero or more overlays. This preserves
@@ -285,7 +286,7 @@ let
     pkgsStatic = nixpkgsFun {
       overlays = [
         (
-          self': super':
+          _: super':
           {
             pkgsStatic = super';
           }
@@ -315,7 +316,7 @@ let
   # Not throws because those would be ignored by nix-env, which is what CI uses to evaluate everything
   # See also ./default.nix, which removes these attributes entirely from the end result
   internallyDisallowedAttrPathsOverlay =
-    final: prev:
+    _: prev:
     # Generally only set by CI, don't want to cause a performance hit for users
     if config.attrPathsDisallowedForInternalUse == [ ] then
       { }
@@ -332,12 +333,12 @@ let
         }
       ) config.attrPathsDisallowedForInternalUse) prev;
 
-  # The complete chain of package set builders, applied from top to bottom.
-  # stdenvOverlays must be last as it brings package forward from the
+  # The complete chain of package set layers, applied from top to bottom.
+  # stdenvOverrides must be last as it brings packages forward from the
   # previous bootstrapping phases which have already been overlaid.
-  toFix = lib.foldl' (lib.flip lib.extends) (self: { }) (
+  toFix = lib.foldl' (lib.flip lib.extends) (_: { }) (
     [
-      stdenvBootstappingAndPlatforms
+      stdenvBootstrapAndPlatforms
       stdenvAdapters
       trivialBuilders
       splice

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -81,7 +81,7 @@ in
   # A list of overlays (Additional `self: super: { .. }` customization
   # functions) to be fixed together in the produced package set
   overlays,
-}@args:
+}:
 
 let
   stdenvAdapters =
@@ -269,7 +269,7 @@ let
       if extraOverlays == [ ] then
         self.__splicedPackages
       else
-        nixpkgsFun { overlays = args.overlays ++ extraOverlays; };
+        nixpkgsFun { overlays = overlays ++ extraOverlays; };
 
     # NOTE: each call to extend causes a full nixpkgs rebuild, adding ~130MB
     #       of allocations. DO NOT USE THIS IN NIXPKGS.


### PR DESCRIPTION
Make argument forwarding explicit in impure.nix and stage.nix, and distinguish input values from their evaluated forms in default.nix. Also simplify config validation and check x86_64-darwin using the system string directly.

Clean up stage composition and use the bootstrap layer directly as the fixed-point base. Only add aliases, variants, package overrides, and internal overlays when they are relevant, avoiding unnecessary work in intermediate bootstrap package sets.

Keep aliases and variants available in the final package set, and add a regression test ensuring they are excluded from bootstrap stages.

Assisted-by: codex with gpt-5.6-sol-high

## Benchmarking

Stats diff for `pkgs.firefox`:

```json
{
  "attrset": {
    "lookups": "-0.01%",
    "merges": "-0.05%",
    "mergeCopies": "-4.75%"
  },
  "list": {
    "concats": "+0.03%"
  },
  "parser": {
    "expressions": "-0%"
  },
  "memoryBytes": {
    "envs": "-0.17%",
    "list": "-0.9%",
    "sets": "-3.55%",
    "symbols": "-0%",
    "values": "-2.14%",
    "total": "-2.57%"
  },
  "speed": {
    "primops": "-0.02%",
    "functionCalls": "-0.29%",
    "thunksMade": "-1.45%",
    "thunksAvoided": "-0.28%"
  }
}
```

Every counter above is exactly reproducible across runs except `memoryBytes.total`, which the garbage collector varies by a few MB per run, so that one is a median of 5 interleaved runs per side.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

