### PR TITLE
python3Packages.babelgladeextractor: 0.7.0 -> 0.7.2, enable tests

### DIFF
--- a/pkgs/development/python-modules/babelgladeextractor/default.nix
+++ b/pkgs/development/python-modules/babelgladeextractor/default.nix
@@ -5,6 +5,7 @@
   fetchPypi,
   setuptools,
   babel,
+  pytestCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -29,6 +30,8 @@ buildPythonPackage (finalAttrs: {
   doCheck = isPy3k;
 
   pythonImportsCheck = [ "babelglade" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
 
   meta = {
     homepage = "https://github.com/gnome-keysign/babel-glade";

--- a/pkgs/development/python-modules/babelgladeextractor/default.nix
+++ b/pkgs/development/python-modules/babelgladeextractor/default.nix
@@ -9,7 +9,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "babelgladeextractor";
-  version = "0.7.0";
+  version = "0.7.2";
   pyproject = true;
 
   __structuredAttrs = true;
@@ -17,10 +17,8 @@ buildPythonPackage (finalAttrs: {
   disabled = (!isPy3k); # uses python3 specific file io in setup.py
 
   src = fetchPypi {
-    pname = "BabelGladeExtractor";
-    inherit (finalAttrs) version;
-    extension = "tar.bz2";
-    hash = "sha256-vPgF4otLsYyLaQmmWnz1x8K8v0rlCxZIeMloLSInF5g=";
+    inherit (finalAttrs) pname version;
+    hash = "sha256-8LWmsQMPbgX0UbZld77m2WXn4VR+46lvfKoNlJ/GNv0=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
