### PR TITLE
android-studio: add aarch64-darwin support

### DIFF
--- a/pkgs/applications/editors/android-studio/darwin.nix
+++ b/pkgs/applications/editors/android-studio/darwin.nix
@@ -1,0 +1,152 @@
+{
+  channel,
+  pname,
+  version,
+  sources,
+  meta,
+}:
+
+{
+  androidenv,
+  fetchurl,
+  lib,
+  makeWrapper,
+  runCommand,
+  runtimeShell,
+  stdenvNoCC,
+  undmg,
+}:
+
+let
+  source = sources.${stdenvNoCC.hostPlatform.system};
+  appName =
+    {
+      stable = "Android Studio.app";
+      beta = "Android Studio Preview Beta.app";
+      canary = "Android Studio Preview Canary.app";
+      dev = "Android Studio Preview Dev.app";
+    }
+    .${channel};
+
+  androidStudio = stdenvNoCC.mkDerivation {
+    pname = "${pname}-unwrapped";
+    inherit version;
+
+    src = fetchurl {
+      inherit (source) url;
+      sha256 = source.sha256Hash;
+    };
+
+    nativeBuildInputs = [
+      makeWrapper
+      undmg
+    ];
+
+    sourceRoot = ".";
+    dontFixup = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      shopt -s nullglob
+      apps=( *.app )
+      if (( ''${#apps[@]} != 1 )); then
+        echo "expected exactly one app bundle, found ''${#apps[@]}" >&2
+        exit 1
+      fi
+
+      mkdir -p "$out/Applications/${appName}" "$out/bin"
+      cp -R "''${apps[0]}/." "$out/Applications/${appName}"
+      /usr/bin/xattr -cr "$out/Applications/${appName}"
+      makeWrapper \
+        "$out/Applications/${appName}/Contents/MacOS/studio" \
+        "$out/bin/studio"
+
+      runHook postInstall
+    '';
+
+    meta.mainProgram = "studio";
+  };
+
+  mkAndroidStudioWrapper =
+    {
+      androidStudio,
+      androidSdk ? null,
+    }:
+    runCommand "${pname}-${version}"
+      {
+        inherit pname version;
+        dontFixup = true;
+        startScript =
+          let
+            hasAndroidSdk = androidSdk != null;
+            androidHome = lib.optionalString hasAndroidSdk "${androidSdk}/libexec/android-sdk";
+          in
+          ''
+            #!${runtimeShell}
+            ${lib.optionalString hasAndroidSdk ''
+              echo "=== nixpkgs Android Studio wrapper" >&2
+
+              # Default ANDROID_HOME to the packaged one, if not provided.
+              ANDROID_HOME="''${ANDROID_HOME-${androidHome}}"
+
+              if [ -d "$ANDROID_HOME" ]; then
+                export ANDROID_HOME
+                echo "  - ANDROID_HOME=$ANDROID_HOME" >&2
+
+                # Legacy compatibility.
+                export ANDROID_SDK_ROOT="$ANDROID_HOME"
+
+                # See if we can export ANDROID_NDK_ROOT too.
+                ANDROID_NDK_ROOT="$ANDROID_SDK_ROOT/ndk-bundle"
+                if [ ! -d "$ANDROID_NDK_ROOT" ]; then
+                  ANDROID_NDK_ROOT="$(ls "$ANDROID_SDK_ROOT/ndk/"* 2>/dev/null | head -n1)"
+                fi
+
+                if [ -d "$ANDROID_NDK_ROOT" ]; then
+                  export ANDROID_NDK_ROOT
+                  echo "  - ANDROID_NDK_ROOT=$ANDROID_NDK_ROOT" >&2
+                else
+                  unset ANDROID_NDK_ROOT
+                fi
+              else
+                unset ANDROID_HOME
+                unset ANDROID_SDK_ROOT
+              fi
+            ''}
+            exec "${androidStudio}/Applications/${appName}/Contents/MacOS/studio" "$@"
+          '';
+        preferLocalBuild = true;
+        allowSubstitutes = false;
+        passthru =
+          let
+            withSdk = androidSdk: mkAndroidStudioWrapper { inherit androidStudio androidSdk; };
+          in
+          {
+            unwrapped = androidStudio;
+            full = withSdk androidenv.androidPkgs.androidsdk;
+            inherit withSdk;
+            sdk = androidSdk;
+            updateScript = [
+              ./update.sh
+              "${channel}"
+            ];
+          };
+        inherit meta;
+      }
+      ''
+        appDir="$out/Applications/${appName}/Contents"
+        unwrappedAppDir="${androidStudio}/Applications/${appName}/Contents"
+
+        mkdir -p "$appDir/MacOS" "$appDir/Resources" "$out/bin"
+        cp "$unwrappedAppDir/Info.plist" "$appDir/Info.plist"
+        cp "$unwrappedAppDir/Resources/"*.icns "$appDir/Resources/"
+
+        echo -n "$startScript" > "$appDir/MacOS/studio"
+        chmod +x "$appDir/MacOS/studio"
+        ln -s "../Applications/${appName}/Contents/MacOS/studio" "$out/bin/${pname}"
+
+        /usr/bin/codesign --force --sign - "$out/Applications/${appName}"
+      '';
+in
+mkAndroidStudioWrapper { inherit androidStudio; }

--- a/pkgs/applications/editors/android-studio/default.nix
+++ b/pkgs/applications/editors/android-studio/default.nix
@@ -1,34 +1,117 @@
 {
   callPackage,
+  lib,
   makeFontsConf,
   buildFHSEnv,
+  stdenv,
   tiling_wm ? false,
 }:
 
 let
   mkStudio =
     opts:
-    callPackage (import ./common.nix opts) {
-      fontsConf = makeFontsConf {
-        fontDirectories = [ ];
+    let
+      inherit (opts) channel pname;
+      meta = {
+        description = "Official IDE for Android (${channel} channel)";
+        longDescription = ''
+          Android Studio is the official IDE for Android app development, based on
+          IntelliJ IDEA.
+        '';
+        homepage =
+          if channel == "stable" then
+            "https://developer.android.com/studio/index.html"
+          else
+            "https://developer.android.com/studio/preview/index.html";
+        license = with lib.licenses; [
+          asl20
+          unfree
+        ]; # The code is under Apache-2.0, but:
+        # If one selects Help -> Licenses in Android Studio, the dialog shows the following:
+        # "Android Studio includes proprietary code subject to separate license,
+        # including JetBrains CLion(R) (www.jetbrains.com/clion) and IntelliJ(R)
+        # IDEA Community Edition (www.jetbrains.com/idea)."
+        # Also: For actual development the Android SDK is required and the Google
+        # binaries are also distributed as proprietary software (unlike the
+        # source-code itself).
+        platforms = [
+          "x86_64-linux"
+          "aarch64-darwin"
+        ];
+        maintainers =
+          rec {
+            stable = with lib.maintainers; [
+              alapshin
+            ];
+            beta = stable;
+            canary = stable;
+            dev = stable;
+          }
+          ."${channel}";
+        teams =
+          rec {
+            stable = with lib.teams; [
+              android
+            ];
+            beta = stable;
+            canary = stable;
+            dev = stable;
+          }
+          ."${channel}";
+        mainProgram = pname;
+        sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
       };
-      inherit buildFHSEnv;
-      inherit tiling_wm;
-    };
+      builder = if stdenv.hostPlatform.isDarwin then ./darwin.nix else ./linux.nix;
+    in
+    callPackage (import builder (opts // { inherit meta; })) (
+      if stdenv.hostPlatform.isDarwin then
+        { }
+      else
+        {
+          inherit buildFHSEnv tiling_wm;
+          fontsConf = makeFontsConf {
+            fontDirectories = [ ];
+          };
+        }
+    );
   stableVersion = {
     version = "2026.1.3.8"; # "Android Studio Quail 3 | 2026.1.3 Patch 1"
-    sha256Hash = "sha256-W9XuXW50exP4L7oyQTgL01jML0qEeBXI6GB1ffE9w18=";
-    url = "https://edgedl.me.gvt1.com/android/studio/ide-zips/2026.1.3.8/android-studio-quail3-patch1-linux.tar.gz";
+    sources = {
+      x86_64-linux = {
+        sha256Hash = "sha256-W9XuXW50exP4L7oyQTgL01jML0qEeBXI6GB1ffE9w18=";
+        url = "https://edgedl.me.gvt1.com/android/studio/ide-zips/2026.1.3.8/android-studio-quail3-patch1-linux.tar.gz";
+      };
+      aarch64-darwin = {
+        sha256Hash = "sha256-qnfvaRmyK+UVZtzXlgPDI/fEA/qR3HncQT7tf2oFwEg=";
+        url = "https://edgedl.me.gvt1.com/android/studio/install/2026.1.3.8/android-studio-quail3-patch1-mac_arm.dmg";
+      };
+    };
   };
   betaVersion = {
     version = "2026.1.3.6"; # "Android Studio Quail 3 | 2026.1.3 RC 2"
-    sha256Hash = "sha256-Mgwy+Cbx5yBCHWUEcvMfAsC1zMk3j7A5fWtMrVJgmAk=";
-    url = "https://edgedl.me.gvt1.com/android/studio/ide-zips/2026.1.3.6/android-studio-quail3-rc2-linux.tar.gz";
+    sources = {
+      x86_64-linux = {
+        sha256Hash = "sha256-Mgwy+Cbx5yBCHWUEcvMfAsC1zMk3j7A5fWtMrVJgmAk=";
+        url = "https://edgedl.me.gvt1.com/android/studio/ide-zips/2026.1.3.6/android-studio-quail3-rc2-linux.tar.gz";
+      };
+      aarch64-darwin = {
+        sha256Hash = "sha256-5SJmTQRweFeAJsZWv0vHgK+ZtSHu0gp+al8iDGEAg+E=";
+        url = "https://edgedl.me.gvt1.com/android/studio/install/2026.1.3.6/android-studio-quail3-rc2-mac_arm.dmg";
+      };
+    };
   };
   latestVersion = {
     version = "2026.1.4.4"; # "Android Studio Quail 4 | 2026.1.4 Canary 4"
-    sha256Hash = "sha256-gcVlZzJ1/euSsKVrmYLXHt1Ym2kNghTzIk6crZXhGKQ=";
-    url = "https://edgedl.me.gvt1.com/android/studio/ide-zips/2026.1.4.4/android-studio-quail4-canary4-linux.tar.gz";
+    sources = {
+      x86_64-linux = {
+        sha256Hash = "sha256-gcVlZzJ1/euSsKVrmYLXHt1Ym2kNghTzIk6crZXhGKQ=";
+        url = "https://edgedl.me.gvt1.com/android/studio/ide-zips/2026.1.4.4/android-studio-quail4-canary4-linux.tar.gz";
+      };
+      aarch64-darwin = {
+        sha256Hash = "sha256-lEgZnmRbMNZ9HKC5JtjSo01MLX5hCFp7CvV67eKHGr0=";
+        url = "https://edgedl.me.gvt1.com/android/studio/install/2026.1.4.4/android-studio-quail4-canary4-mac_arm.dmg";
+      };
+    };
   };
 in
 {

--- a/pkgs/applications/editors/android-studio/linux.nix
+++ b/pkgs/applications/editors/android-studio/linux.nix
@@ -2,8 +2,8 @@
   channel,
   pname,
   version,
-  url,
-  sha256Hash,
+  sources,
+  meta,
 }:
 
 {
@@ -83,14 +83,15 @@
 
 let
   filename = "android-studio-${version}-linux.tar.gz";
+  source = sources.${stdenv.hostPlatform.system};
 
   androidStudio = stdenv.mkDerivation {
     pname = "${pname}-unwrapped";
     inherit version;
 
     src = fetchurl {
-      url = url;
-      sha256 = sha256Hash;
+      inherit (source) url;
+      sha256 = source.sha256Hash;
     };
 
     nativeBuildInputs = [
@@ -305,52 +306,7 @@ let
               "${channel}"
             ];
           };
-        meta = {
-          description = "Official IDE for Android (${channel} channel)";
-          longDescription = ''
-            Android Studio is the official IDE for Android app development, based on
-            IntelliJ IDEA.
-          '';
-          homepage =
-            if channel == "stable" then
-              "https://developer.android.com/studio/index.html"
-            else
-              "https://developer.android.com/studio/preview/index.html";
-          license = with lib.licenses; [
-            asl20
-            unfree
-          ]; # The code is under Apache-2.0, but:
-          # If one selects Help -> Licenses in Android Studio, the dialog shows the following:
-          # "Android Studio includes proprietary code subject to separate license,
-          # including JetBrains CLion(R) (www.jetbrains.com/clion) and IntelliJ(R)
-          # IDEA Community Edition (www.jetbrains.com/idea)."
-          # Also: For actual development the Android SDK is required and the Google
-          # binaries are also distributed as proprietary software (unlike the
-          # source-code itself).
-          platforms = [ "x86_64-linux" ];
-          maintainers =
-            rec {
-              stable = with lib.maintainers; [
-                alapshin
-              ];
-              beta = stable;
-              canary = stable;
-              dev = stable;
-            }
-            ."${channel}";
-          teams =
-            rec {
-              stable = with lib.teams; [
-                android
-              ];
-              beta = stable;
-              canary = stable;
-              dev = stable;
-            }
-            ."${channel}";
-          mainProgram = pname;
-          sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
-        };
+        inherit meta;
       }
       ''
         mkdir -p $out/{bin,share/pixmaps}

--- a/pkgs/applications/editors/android-studio/update.sh
+++ b/pkgs/applications/editors/android-studio/update.sh
@@ -1,10 +1,14 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -I nixpkgs=./. -i bash -p jq nix-prefetch-scripts
+#! nix-shell -I nixpkgs=./. -i bash -p jq
 
 set -euo pipefail
 
 DEFAULT_NIX="$(realpath "./pkgs/applications/editors/android-studio/default.nix")"
 RELEASES_JSON="$(curl --silent -L https://jb.gg/android-studio-releases-list.json)"
+PLATFORMS=(
+    "x86_64-linux|-linux.tar.gz"
+    "aarch64-darwin|-mac_arm.dmg"
+)
 
 # Available channels: Release/Patch (stable), Beta, Canary
 getLatest() {
@@ -15,7 +19,8 @@ getLatest() {
         "beta") local select='.channel == "Beta" or .channel == "RC"' ;;
         *) local select=".channel == \"${channel^}\"" ;;
     esac
-    local result="$(echo "$RELEASES_JSON" \
+    local result
+    result="$(echo "$RELEASES_JSON" \
         | jq -r ".content.item[] | select(${select}) | [.version, (${attribute})] | join(\" \")" \
         | sort --version-sort \
         | cut -d' ' -f 2- \
@@ -31,31 +36,52 @@ getLatest() {
 
 updateChannel() {
     local channel="$1"
-    local latestVersion="$(getLatest ".version" "$channel")"
+    local latestVersion
+    latestVersion="$(getLatest ".version" "$channel")"
 
-    local localVersion="$(nix --extra-experimental-features nix-command eval --raw --file . androidStudioPackages."${channel}".version)"
+    local localVersion
+    localVersion="$(nix --extra-experimental-features nix-command eval --raw --file . androidStudioPackages."${channel}".version)"
     if [[ "${latestVersion}" == "${localVersion}" ]]; then
         echo "$channel is already up to date at $latestVersion"
         return 0
     fi
     echo "updating $channel from $localVersion to $latestVersion"
 
-    local latestUrl="$(getLatest "[.download[] | select(.link | endswith(\"-linux.tar.gz\"))][0].link" "$channel")"
-    local latestHash="$(getLatest "[.download[] | select(.link | endswith(\"-linux.tar.gz\"))][0].checksum" "$channel")"
+    local platformSpec
+    local replacements=()
+    for platformSpec in "${PLATFORMS[@]}"; do
+        local system="${platformSpec%%|*}"
+        local suffix="${platformSpec#*|}"
+        local latestUrl
+        latestUrl="$(getLatest "[.download[] | select(.link | endswith(\"${suffix}\"))][0].link" "$channel")"
+        local latestHash
+        latestHash="$(getLatest "[.download[] | select(.link | endswith(\"${suffix}\"))][0].checksum" "$channel")"
 
-    if [[ "$latestUrl" != https://edgedl.me.gvt1.com/android/studio/* ]]; then
-        echo "URL '$latestUrl' had an unexpected value, maybe the server changed?" >&2
-        exit 1
-    fi
+        if [[ "$latestUrl" != https://edgedl.me.gvt1.com/android/studio/* ]]; then
+            echo "URL '$latestUrl' had an unexpected value, maybe the server changed?" >&2
+            exit 1
+        fi
 
-    local latestSri="$(nix --extra-experimental-features nix-command hash convert --from base16 --hash-algo sha256 "$latestHash")"
-    local localUrl="$(nix --extra-experimental-features nix-command eval --json --file . androidStudioPackages."${channel}".unwrapped.src.drvAttrs.urls | jq -r '.[0]')"
-    local localHash="$(nix --extra-experimental-features nix-command eval --raw --file . androidStudioPackages."${channel}".unwrapped.src.drvAttrs.outputHash)"
-    sed -i "s~${localHash}~${latestSri}~g" "${DEFAULT_NIX}"
+        local latestSri
+        latestSri="$(nix --extra-experimental-features nix-command hash to-sri --type sha256 "$latestHash")"
+        local localUrl
+        localUrl="$(nix --extra-experimental-features nix-command eval --system "$system" --json --file . androidStudioPackages."${channel}".unwrapped.src.drvAttrs.urls | jq -r '.[0]')"
+        local localHash
+        localHash="$(nix --extra-experimental-features nix-command eval --system "$system" --raw --file . androidStudioPackages."${channel}".unwrapped.src.drvAttrs.outputHash)"
+        replacements+=("${localHash}|${latestSri}")
+        replacements+=("${localUrl}|${latestUrl}")
+    done
+
+    local replacement
+    for replacement in "${replacements[@]}"; do
+        local oldValue="${replacement%%|*}"
+        local newValue="${replacement#*|}"
+        sed -i "s~${oldValue}~${newValue}~g" "${DEFAULT_NIX}"
+    done
 
     # Match the formatting of default.nix: `version = "2021.3.1.14"; # "Android Studio Dolphin (2021.3.1) Beta 5"`
-    local versionString="${latestVersion}\"; # \"$(getLatest ".name" "${channel}")\""
-    sed -i "s~${localUrl}~${latestUrl}~g" "${DEFAULT_NIX}"
+    local versionString
+    versionString="${latestVersion}\"; # \"$(getLatest ".name" "${channel}")\""
     sed -i "s~${localVersion}.*~${versionString}~g" "${DEFAULT_NIX}"
     echo "updated ${channel} to ${latestVersion}" >&2
 }


### PR DESCRIPTION
## Description of changes

Add native `aarch64-darwin` support to all Android Studio channels using Google's official Apple Silicon DMGs.

The Darwin implementation:

- installs the upstream, signed Android Studio application without modifying it;
- provides a small ad-hoc-signed launcher application so Finder launches inherit the packaged Android SDK environment;
- preserves the existing `.unwrapped`, `.full`, `.withSdk`, and `.sdk` interfaces;
- keeps the existing Linux FHS implementation unchanged; and
- updates both Linux and Apple Silicon sources atomically in `update.sh`.

This intentionally does not add `x86_64-darwin` support.

Related: #303968, #75603, and #328137.

## Things done

- Built all four channels (`stable`, `beta`, `canary`, and `dev`) on `aarch64-darwin`.
- Tested command-line and Finder launches on macOS.
- Verified the upstream application and generated launcher signatures.
- Built and launched a synthetic `.withSdk` package to verify SDK environment propagation.
- Ran the updater twice: the first run updated both platform sources and hashes, and the second was idempotent.
- Evaluated all four channels for both `aarch64-darwin` and `x86_64-linux`.
- Ran `nixfmt --check`, `bash -n`, `shellcheck`, and `git diff --check`.

AI disclosure: Implementation and this pull request description were assisted by OpenAI Codex (GPT-5), then manually reviewed and validated.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests).
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`.
  - [ ] Tests in `lib/tests` or `pkgs/test` for functions and core functionality.
- [ ] Ran `nixpkgs-review` on this PR. All affected Darwin variants were instead built directly because this is a new platform implementation.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md), and other READMEs.
- [x] Follows the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy).
