### PR TITLE
pkgsStatic.shishi: fix build

### DIFF
--- a/pkgs/by-name/sh/shishi/package.nix
+++ b/pkgs/by-name/sh/shishi/package.nix
@@ -14,6 +14,7 @@
   libidn,
   useGnutls ? lib.meta.availableOn stdenv.hostPlatform gnutls,
   gnutls,
+  pkgsStatic,
 }:
 
 let
@@ -60,7 +61,12 @@ stdenv.mkDerivation (finalAttrs: {
     (enableFeature true "arcfour")
   ];
 
-  env.NIX_CFLAGS_COMPILE = optionalString stdenv.hostPlatform.isDarwin "-DBIND_8_COMPAT";
+  env.NIX_CFLAGS_COMPILE = toString [
+    (optionalString stdenv.hostPlatform.isDarwin "-DBIND_8_COMPAT")
+    # gnulib's crc.c exports a "crc32" symbol (unused by shishi, which only calls crc32_update_no_xor).
+    # On static builds it conflicts with "crc32" from zlib (transitive dependency of gnutls).
+    (optionalString stdenv.hostPlatform.isStatic "-Dcrc32=shishi_gnulib_crc32")
+  ];
 
   doCheck = true;
 
@@ -83,6 +89,12 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   strictDeps = true;
+
+  passthru = {
+    tests = {
+      static = pkgsStatic.shishi;
+    };
+  };
 
   meta = {
     homepage = "https://www.gnu.org/software/shishi/";

--- a/pkgs/by-name/sh/shishi/package.nix
+++ b/pkgs/by-name/sh/shishi/package.nix
@@ -40,15 +40,9 @@ stdenv.mkDerivation (finalAttrs: {
     libgpg-error
     libtasn1
   ]
-  ++ lib.optionals usePam [
-    pam
-  ]
-  ++ lib.optionals useLibidn [
-    libidn
-  ]
-  ++ lib.optionals useGnutls [
-    gnutls
-  ];
+  ++ lib.optionals usePam [ pam ]
+  ++ lib.optionals useLibidn [ libidn ]
+  ++ lib.optionals useGnutls [ gnutls ];
 
   configureFlags = [
     "--sysconfdir=/etc"


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
