### PR TITLE
perfect_dark: fix hash

### DIFF
--- a/pkgs/by-name/pe/perfect_dark/package.nix
+++ b/pkgs/by-name/pe/perfect_dark/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "perfect-dark-pc-port";
     repo = "perfect_dark";
     rev = "514bf7affd3259b7919165201342ff81a026d92c";
-    hash = "sha256-J0n3hBxNZeLaFcR6NMIHO9QWEpKje5aORZOwn4vJG6M=";
+    hash = "sha256-HjkVk7AJFTpWE2RqQTwEp6vUzocIjMp7xs8c6Az7CBo=";
 
     postFetch = ''
       pushd $out


### PR DESCRIPTION
```
❯ nix build -L --impure .#perfect_dark.src
source> structuredAttrs is enabled
source> 
source> trying https://github.com/perfect-dark-pc-port/perfect_dark/archive/514bf7affd3259b7919165201342ff81a026d92c.tar.gz
source>   % Total    % Received % Xferd  Average Speed  Time    Time    Time   Current
source>                                  Dload  Upload  Total   Spent   Left   Speed
source>   0      0   0      0   0      0      0      0                              0
source> 100 28.65M 100 28.65M   0      0 34.39M      0                              0
source> unpacking source archive /build/download.tar.gz
source> /nix/store/0vfjvryx49gs5c1zg4q7flh0agdnlsqr-source /build/unpack
source> /build/unpack
error: hash mismatch in fixed-output derivation '/nix/store/qas3i2970s7lz0dmisjmy607k0k1mn5w-source.drv':
         specified: sha256-J0n3hBxNZeLaFcR6NMIHO9QWEpKje5aORZOwn4vJG6M=
            got:    sha256-HjkVk7AJFTpWE2RqQTwEp6vUzocIjMp7xs8c6Az7CBo=
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
