### PR TITLE
photoprism: 251130-b3068414c -> 260601-a7d098548

### DIFF
--- a/pkgs/by-name/ph/photoprism/backend.nix
+++ b/pkgs/by-name/ph/photoprism/backend.nix
@@ -48,7 +48,7 @@ buildGoModule {
     substituteInPlace internal/commands/passwd.go --replace-fail '/bin/stty' "${coreutils}/bin/stty"
   '';
 
-  vendorHash = "sha256-nOytOKceVuRryixDxx791my0JkdLPfyYdK6dAUG4CQc=";
+  vendorHash = "sha256-mF07Lz61IIvUi4SLIMkMlKMH9zm6Zrp/KAdutl+mUzI=";
 
   subPackages = [ "cmd/photoprism" ];
 

--- a/pkgs/by-name/ph/photoprism/frontend.nix
+++ b/pkgs/by-name/ph/photoprism/frontend.nix
@@ -9,21 +9,15 @@ buildNpmPackage {
   inherit src version;
   pname = "photoprism-frontend";
 
-  postPatch = ''
-    cd frontend
-  '';
+  npmDepsHash = "sha256-HBzul2fyISwOqf8w92yt0friMnLhMmvKPm8yI2I3ngE=";
 
-  npmDepsHash = "sha256-RjPTtIm1BhyeQLUN9mWI+sXakNju4up0FbrdwZzkTS0=";
-
-  # Some dependencies are fetched from git repositories
-  forceGitDeps = true;
-  makeCacheWritable = true;
+  npmWorkspace = "frontend";
 
   installPhase = ''
     runHook preInstall
 
     mkdir $out
-    cp -r ../assets $out/
+    cp -r assets $out/
 
     runHook postInstall
   '';

--- a/pkgs/by-name/ph/photoprism/package.nix
+++ b/pkgs/by-name/ph/photoprism/package.nix
@@ -17,14 +17,14 @@
 }:
 
 let
-  version = "251130-b3068414c";
+  version = "260601-a7d098548";
   pname = "photoprism";
 
   src = fetchFromGitHub {
     owner = "photoprism";
     repo = "photoprism";
     rev = version;
-    hash = "sha256-8yg5CtvBtSKRaOUj9f+Db7rruXIVuF2cR50vZ+WUU6A=";
+    hash = "sha256-6zE9bqHFF9ifcqbvA0yjSF69+BA/M2U6ABnPta4dpl4=";
   };
 
   backend = callPackage ./backend.nix { inherit src version; };


### PR DESCRIPTION
https://github.com/photoprism/photoprism/releases/tag/260305-fad9d5395
https://github.com/photoprism/photoprism/releases/tag/260523-0544f71c1
https://github.com/photoprism/photoprism/releases/tag/260601-a7d098548

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
