### PR TITLE
tokentopper: init at 0.6.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14049,6 +14049,11 @@
     githubId = 5124422;
     name = "Julien Urraca";
   };
+  juskashi = {
+    github = "Juskashi";
+    githubId = 305914940;
+    name = "Juskashi";
+  };
   justanotherariel = {
     email = "ariel@ebersberger.io";
     github = "justanotherariel";

--- a/pkgs/by-name/to/tokentopper/package.nix
+++ b/pkgs/by-name/to/tokentopper/package.nix
@@ -11,17 +11,17 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "tokentopper";
-  version = "0.5.1";
+  version = "0.6.0";
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "Kalmantic";
     repo = "tokentopper";
     tag = "tokentopper-v${finalAttrs.version}";
-    hash = "sha256-e6qlGlQ6Nmlxp7ZZFsz2VoVmPOfsKuuFnX8eBS9RpQ8=";
+    hash = "sha256-vQu6zjT72CNmTJEn4iz4cChz3PS7xgdyNkc7gXPN6zk=";
   };
 
-  npmDepsHash = "sha256-iv3S/g0Fwwl2d9tlYAcmqI7SUVIBIrJtUaecb+uEdeI=";
+  npmDepsHash = "sha256-fRpS3/PkuWEhm4X9aIMbyRmTD+yeGuC0+kkdsAe0ew0=";
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [
@@ -59,7 +59,7 @@ buildNpmPackage (finalAttrs: {
   };
 
   meta = {
-    description = "Professional AI Usage Index for Claude Code, Codex, and OpenCode";
+    description = "Professional AI Usage Index for Claude Code, Codex, OpenCode, and Gemini CLI";
     homepage = "https://openfactoryai.com/tools/tokentopper/";
     changelog = "https://github.com/Kalmantic/tokentopper/releases/tag/tokentopper-v${finalAttrs.version}";
     license = lib.licenses.mit;

--- a/pkgs/by-name/to/tokentopper/package.nix
+++ b/pkgs/by-name/to/tokentopper/package.nix
@@ -11,17 +11,17 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "tokentopper";
-  version = "0.6.0";
+  version = "0.6.1";
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "Kalmantic";
     repo = "tokentopper";
     tag = "tokentopper-v${finalAttrs.version}";
-    hash = "sha256-vQu6zjT72CNmTJEn4iz4cChz3PS7xgdyNkc7gXPN6zk=";
+    hash = "sha256-ZN6/a2+O6H0TkLA7E5mzCkqnsLn+FuzcH0Gy/2Zsqjo=";
   };
 
-  npmDepsHash = "sha256-fRpS3/PkuWEhm4X9aIMbyRmTD+yeGuC0+kkdsAe0ew0=";
+  npmDepsHash = "sha256-R+fUPgMlrDHifjXAwIyCe6zHC3MjDxMR4vjgqGZh+RE=";
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [

--- a/pkgs/by-name/to/tokentopper/package.nix
+++ b/pkgs/by-name/to/tokentopper/package.nix
@@ -12,6 +12,7 @@
 buildNpmPackage (finalAttrs: {
   pname = "tokentopper";
   version = "0.5.1";
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "Kalmantic";

--- a/pkgs/by-name/to/tokentopper/package.nix
+++ b/pkgs/by-name/to/tokentopper/package.nix
@@ -34,25 +34,28 @@ buildNpmPackage (finalAttrs: {
   passthru = {
     updateScript = nix-update-script { };
 
-    tests.smoke = runCommand "tokentopper-smoke-test" {
-      nativeBuildInputs = [
-        finalAttrs.finalPackage
-        jq
-      ];
-    } ''
-      export HOME="$(mktemp -d)"
-      mkdir -p "$HOME/.claude/projects/nix-smoke"
-      printf '%s\n' '{"type":"assistant","timestamp":"2026-07-01T10:00:00.000Z","sessionId":"nix-smoke","message":{"id":"nix-smoke-message","model":"claude-sonnet-4","usage":{"input_tokens":100,"output_tokens":25}}}' \
-        > "$HOME/.claude/projects/nix-smoke/session.jsonl"
-      tokentopper json > report.json
-      jq -e '
-        .schema == "tokentopper-summary/1" and
-        .tool.name == "tokentopper" and
-        .tool.version == "${finalAttrs.version}" and
-        (has("machine") | not)
-      ' report.json
-      touch "$out"
-    '';
+    tests.smoke =
+      runCommand "tokentopper-smoke-test"
+        {
+          nativeBuildInputs = [
+            finalAttrs.finalPackage
+            jq
+          ];
+        }
+        ''
+          export HOME="$(mktemp -d)"
+          mkdir -p "$HOME/.claude/projects/nix-smoke"
+          printf '%s\n' '{"type":"assistant","timestamp":"2026-07-01T10:00:00.000Z","sessionId":"nix-smoke","message":{"id":"nix-smoke-message","model":"claude-sonnet-4","usage":{"input_tokens":100,"output_tokens":25}}}' \
+            > "$HOME/.claude/projects/nix-smoke/session.jsonl"
+          tokentopper json > report.json
+          jq -e '
+            .schema == "tokentopper-summary/1" and
+            .tool.name == "tokentopper" and
+            .tool.version == "${finalAttrs.version}" and
+            (has("machine") | not)
+          ' report.json
+          touch "$out"
+        '';
   };
 
   meta = {

--- a/pkgs/by-name/to/tokentopper/package.nix
+++ b/pkgs/by-name/to/tokentopper/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  jq,
+  nix-update-script,
+  runCommand,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "tokentopper";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "Kalmantic";
+    repo = "tokentopper";
+    tag = "tokentopper-v${finalAttrs.version}";
+    hash = "sha256-e6qlGlQ6Nmlxp7ZZFsz2VoVmPOfsKuuFnX8eBS9RpQ8=";
+  };
+
+  npmDepsHash = "sha256-iv3S/g0Fwwl2d9tlYAcmqI7SUVIBIrJtUaecb+uEdeI=";
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  versionCheckKeepEnvironment = [ "HOME" ];
+  versionCheckProgramArg = "--version";
+
+  passthru = {
+    updateScript = nix-update-script { };
+
+    tests.smoke = runCommand "tokentopper-smoke-test" {
+      nativeBuildInputs = [
+        finalAttrs.finalPackage
+        jq
+      ];
+    } ''
+      export HOME="$(mktemp -d)"
+      mkdir -p "$HOME/.claude/projects/nix-smoke"
+      printf '%s\n' '{"type":"assistant","timestamp":"2026-07-01T10:00:00.000Z","sessionId":"nix-smoke","message":{"id":"nix-smoke-message","model":"claude-sonnet-4","usage":{"input_tokens":100,"output_tokens":25}}}' \
+        > "$HOME/.claude/projects/nix-smoke/session.jsonl"
+      tokentopper json > report.json
+      jq -e '
+        .schema == "tokentopper-summary/1" and
+        .tool.name == "tokentopper" and
+        .tool.version == "${finalAttrs.version}" and
+        (has("machine") | not)
+      ' report.json
+      touch "$out"
+    '';
+  };
+
+  meta = {
+    description = "Professional AI Usage Index for Claude Code, Codex, and OpenCode";
+    homepage = "https://openfactoryai.com/tools/tokentopper/";
+    changelog = "https://github.com/Kalmantic/tokentopper/releases/tag/tokentopper-v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ juskashi ];
+    mainProgram = "tokentopper";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
TokenTopper is a Professional AI Usage Index for Claude Code, Codex, and OpenCode. This adds the 0.5.1 CLI as a top-level by-name package, an update script, a privacy-contract smoke test, and the upstream maintainer entry.

The package was evaluated and built in a Nix sandbox against current Nixpkgs master. Its installed CLI version, public JSON schema, absence of machine identity in public JSON, and passthru smoke test were verified in [the upstream-preparation workflow](https://github.com/Kalmantic/tokentopper/actions/runs/29676607119).

Automation disclosure: this commit and PR summary were prepared with OpenAI Codex (GPT-5). The package expression was checked with deterministic fixed-output hashes and the sandboxed workflow above. This draft must be reviewed by the submitting human before it is marked ready.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] Package tests at `passthru.tests`.
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files.
- [x] Fits the Nixpkgs contribution and package conventions.
- [x] Follows the automation/AI policy.