### PR TITLE
nixos/kdeconnect: add openFirewall option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -146,6 +146,8 @@
 
 - `zoneminder` has been updated to 1.38.x release. See [upstream release note](https://github.com/ZoneMinder/zoneminder/releases/tag/1.38.0). While database migration should happen automatically, it's recommended that you make a backup of the database before upgrading your system.
 
+- `programs.kdeconnect` gained an [`openFirewall`](#opt-programs.kdeconnect.openFirewall) option (defaults to `true`, preserving previous behavior), allowing the firewall ports (1714-1764) to be opened independently of installing the package.
+
 - The latest available version of Nextcloud is v34 (available as `pkgs.nextcloud34`). The installation logic is as follows:
   - If [`services.nextcloud.package`](#opt-services.nextcloud.package) is specified explicitly, this package will be installed (**recommended**)
   - If `system.stateVersion` is >=26.11, `pkgs.nextcloud34` will be installed by default.

--- a/nixos/modules/programs/kdeconnect.nix
+++ b/nixos/modules/programs/kdeconnect.nix
@@ -4,13 +4,17 @@
   lib,
   ...
 }:
+let
+  cfg = config.programs.kdeconnect;
+in
 {
   options.programs.kdeconnect = {
     enable = lib.mkEnableOption ''
       kdeconnect.
 
-      Note that it will open the TCP and UDP port from
+      Note that by default it will open the TCP and UDP ports from
       1714 to 1764 as they are needed for it to function properly.
+      See {option}`openFirewall` to control this behavior.
       You can use the {option}`package` to use
       `gnomeExtensions.gsconnect` as an alternative
       implementation if you use Gnome
@@ -19,23 +23,36 @@
       nullable = true;
       example = "gnomeExtensions.gsconnect";
     };
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = cfg.enable;
+      defaultText = lib.literalExpression "config.programs.kdeconnect.enable";
+      description = ''
+        Whether to open the required TCP and UDP ports (1714-1764) needed by KDE Connect.
+      '';
+    };
   };
-  config =
-    let
-      cfg = config.programs.kdeconnect;
-    in
-    lib.mkIf cfg.enable {
+  config = lib.mkMerge [
+    (lib.mkIf cfg.enable {
       environment.systemPackages = lib.optionals (cfg.package != null) [
         cfg.package
       ];
-      networking.firewall = rec {
+    })
+    (lib.mkIf cfg.openFirewall (
+      let
         allowedTCPPortRanges = [
           {
             from = 1714;
             to = 1764;
           }
         ];
-        allowedUDPPortRanges = allowedTCPPortRanges;
-      };
-    };
+      in
+      {
+        networking.firewall = {
+          inherit allowedTCPPortRanges;
+          allowedUDPPortRanges = allowedTCPPortRanges;
+        };
+      }
+    ))
+  ];
 }


### PR DESCRIPTION
Adds `programs.kdeconnect.openFirewall`, allowing the firewall ports
(1714-1764) to be opened independently of installing the package.

This is useful when the `kdeconnect-kde` package itself is managed
elsewhere (e.g. via Home Manager), and only the system-level firewall
rule is still needed here — currently, enabling the firewall rule
requires also installing the system package, even if it's unused.

Defaults to `true`, so existing configurations are unaffected.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].