### PR TITLE
kitty: fix libxkbcommon runtime lookup

### DIFF
--- a/pkgs/by-name/ki/kitty/libxkbcommon-runtime-path.patch
+++ b/pkgs/by-name/ki/kitty/libxkbcommon-runtime-path.patch
@@ -1,0 +1,23 @@
+diff --git a/kitty/key_names.py b/kitty/key_names.py
+index 1c4ce3487..00d767d45 100644
+--- a/kitty/key_names.py
++++ b/kitty/key_names.py
+@@ -59,17 +59,7 @@ if is_macos:
+ else:
+     def load_libxkb_lookup() -> LookupFunc:
+         import ctypes
+-        for suffix in ('.0', ''):
+-            with suppress(Exception):
+-                lib = ctypes.CDLL(f'libxkbcommon.so{suffix}')
+-                break
+-        else:
+-            from ctypes.util import find_library
+-            lname = find_library('xkbcommon')
+-            if lname is None:
+-                raise RuntimeError('Failed to find libxkbcommon')
+-            lib = ctypes.CDLL(lname)
+-
++        lib = ctypes.CDLL('@libxkbcommon@')
+         f = lib.xkb_keysym_from_name
+         f.argtypes = [ctypes.c_char_p, ctypes.c_int]
+         f.restype = ctypes.c_int

--- a/pkgs/by-name/ki/kitty/package.nix
+++ b/pkgs/by-name/ki/kitty/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  replaceVars,
   python3Packages,
   libunistring,
   harfbuzz,
@@ -146,6 +147,9 @@ buildPythonApplication rec {
     # OSError: master_fd is in error condition
     ./disable-test_ssh_bootstrap_with_different_launchers.patch
 
+    (replaceVars ./libxkbcommon-runtime-path.patch {
+      libxkbcommon = "${lib.getLib libxkbcommon}/lib/libxkbcommon.so.0";
+    })
   ];
 
   hardeningDisable = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Kitty dynamically loads `libxkbcommon` through Python's `ctypes` module when resolving key names that are not included in its built-in mappings.

It attempts to locate the library using the conventional names such as `libxkbcommon.so.0` and `libxkbcommon.so`, but this does not work on NixOS because `libxkbcommon` is stored at an isolated path in the Nix store rather than a global library search path.

As a result, using keys such as `XF86Copy` and `XF86Paste` fail:

```
Failed to load libxkbcommon.xkb_keysym_from_name with error: Failed to find libxkbcommon
```

The solution is to patch kitty's runtime lookup to use the `libxkbcommon` path provided by the derivation via `replaceVars`.

Fixes #542805 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
