### PR TITLE
code-cursor: 3.11.19 -> 3.12.17

### DIFF
--- a/pkgs/by-name/co/code-cursor/sources.json
+++ b/pkgs/by-name/co/code-cursor/sources.json
@@ -1,18 +1,18 @@
 {
-  "version": "3.11.19",
-  "vscodeVersion": "1.125.0",
+  "version": "3.12.17",
+  "vscodeVersion": "1.128.0",
   "sources": {
     "x86_64-linux": {
-      "url": "https://downloads.cursor.com/production/bf249e6efb5b097f23d7e21d7283429f0760b74a/linux/x64/Cursor-3.11.19-x86_64.AppImage",
-      "hash": "sha256-EE5QuTM16sib4MYAkz34PLbAOXjb7hcdwVtrYSEKt/I="
+      "url": "https://downloads.cursor.com/production/0fb762053c34788bb7760d5673f8a6d4c8589d52/linux/x64/Cursor-3.12.17-x86_64.AppImage",
+      "hash": "sha256-Fu00p0vaLNOl9wbGgtseLwhseXxmIQMyyhlNF7VZ+qM="
     },
     "aarch64-linux": {
-      "url": "https://downloads.cursor.com/production/bf249e6efb5b097f23d7e21d7283429f0760b74a/linux/arm64/Cursor-3.11.19-aarch64.AppImage",
-      "hash": "sha256-lFAK6xTIA3d0kmjybDYsMTYZhDbr/xasDG/NuZmE83Y="
+      "url": "https://downloads.cursor.com/production/0fb762053c34788bb7760d5673f8a6d4c8589d52/linux/arm64/Cursor-3.12.17-aarch64.AppImage",
+      "hash": "sha256-/r6lFrSq7aSefGvOWqLw/YmyUy3VocaWRyOUHoHuSeM="
     },
     "aarch64-darwin": {
-      "url": "https://downloads.cursor.com/production/bf249e6efb5b097f23d7e21d7283429f0760b74a/darwin/arm64/Cursor-darwin-arm64.dmg",
-      "hash": "sha256-WQ2OfTaGqELWTfjgU4n5tgfgTHQSA06RxERa6pkdukU="
+      "url": "https://downloads.cursor.com/production/0fb762053c34788bb7760d5673f8a6d4c8589d52/darwin/arm64/Cursor-darwin-arm64.dmg",
+      "hash": "sha256-WaUBglq+Jqa1Cn0sx62ccbBSKhYiBz1u1PjdHxcfQKE="
     }
   }
 }


### PR DESCRIPTION
## Summary
- Update code-cursor from 3.11.19 to 3.12.17

https://cursor.com/changelog

## Things done

- Built on platform:
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests
  - [ ] Package tests at `passthru.tests` (none defined: `tests = { }`)
- [x] Ran `nixpkgs-review` on this PR
- [x] Tested basic functionality of all binary files (verified app bundle version `3.12.17` and notarized signature via `spctl`)
- [x] Fits CONTRIBUTING.md, pkgs/README.md
- [x] Follows the automation/AI policy

## Test plan
- [x] `nix-build -A code-cursor` on aarch64-darwin
- [x] `nixpkgs-review pr 543448` — 1 package built (`code-cursor`)
- [x] `spctl -a -vv` reports accepted / Notarized Developer ID
- [x] `CFBundleShortVersionString` is `3.12.17`