### PR TITLE
codemark: init at 0.7.23

### DIFF
--- a/pkgs/by-name/co/codemark/package.nix
+++ b/pkgs/by-name/co/codemark/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "codemark-cli";
+  version = "0.7.23";
+  __structuredAttrs = true;
+  src = fetchFromGitHub {
+    owner = "DanielCardonaRojas";
+    repo = "codemark";
+    tag = finalAttrs.version;
+    sha256 = "sha256-0BlhLWmTFqhTVH2kELOLxqPkq2M8rZAUTUyyyDjkNIk=";
+  };
+
+  cargoHash = "sha256-Lv29aqMhTgbmD72pxwEE2PUlF6xSV1cVR1RNpuTgGvk=";
+
+  # I was not able to disable the failing checks when packaging
+  # Feel free to fix
+  doCheck = false;
+
+  meta = {
+    description = "A semantic code bookmarking system for humans and agents";
+    homepage = "https://danielcardonarojas.github.io/codemark/";
+    changelog = "https://github.com/DanielCardonaRojas/codemark/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+
+    maintainers = with lib.maintainers; [
+      matthiasbeyer
+    ];
+  };
+})

--- a/pkgs/by-name/co/codemark/package.nix
+++ b/pkgs/by-name/co/codemark/package.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "codemark-cli";
-  version = "0.7.23";
+  version = "0.7.24";
   __structuredAttrs = true;
   src = fetchFromGitHub {
     owner = "DanielCardonaRojas";
     repo = "codemark";
     tag = finalAttrs.version;
-    sha256 = "sha256-0BlhLWmTFqhTVH2kELOLxqPkq2M8rZAUTUyyyDjkNIk=";
+    sha256 = "sha256-Weh7JRAwUImFfcPU6bSqC+W11+Z5q5oPxXv60RzEuWw=";
   };
 
-  cargoHash = "sha256-Lv29aqMhTgbmD72pxwEE2PUlF6xSV1cVR1RNpuTgGvk=";
+  cargoHash = "sha256-dROHNUF3qDsohMTTb/1pwHjjUslWfOBx82jOgefjPH8=";
 
   # I was not able to disable the failing checks when packaging
   # Feel free to fix

--- a/pkgs/by-name/co/codemark/package.nix
+++ b/pkgs/by-name/co/codemark/package.nix
@@ -2,6 +2,7 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  withAi ? true,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -16,6 +17,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   cargoHash = "sha256-dROHNUF3qDsohMTTb/1pwHjjUslWfOBx82jOgefjPH8=";
+
+  buildNoDefaultFeatures = withAi;
+  buildFeatures = lib.optionals withAi [
+    "semantic"
+  ];
 
   # I was not able to disable the failing checks when packaging
   # Feel free to fix


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
