### PR TITLE
dcmtk: patch CVE-2026-5663

### DIFF
--- a/pkgs/by-name/dc/dcmtk/package.nix
+++ b/pkgs/by-name/dc/dcmtk/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   fetchurl,
   zlib,
   libtiff,
@@ -23,9 +24,15 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-JUF3IX0LOtpeAJPuTbAJo79sCuPuhh7KNIuQJfcFN/A=";
   };
 
-  # The following patches are taken from the Debian package
-  # See https://salsa.debian.org/med-team/dcmtk
   patches = [
+    # Remove when updating past 3.7.0.
+    (fetchpatch {
+      name = "CVE-2026-5663.patch";
+      url = "https://github.com/DCMTK/dcmtk/commit/edbb085e45788dccaf0e64d71534cfca925784b8.patch";
+      hash = "sha256-aSK/G5zI1Zyz0aonxnbWP/W5Ra6xCBYGxgPhM+05LXs=";
+    })
+    # The following patches are taken from the Debian package
+    # See https://salsa.debian.org/med-team/dcmtk
     (fetchurl {
       url = "https://salsa.debian.org/med-team/dcmtk/-/raw/debian/3.6.9-4/debian/patches/01_dcmtk_3.6.0-1.patch";
       hash = "sha256-kDEZvPqcF8+PYID24srMoPSBPltmnGiJ67LHsLVcPYM=";


### PR DESCRIPTION
Backports [upstream's fix](https://github.com/DCMTK/dcmtk/commit/edbb085e45788dccaf0e64d71534cfca925784b8) for [CVE-2026-5663](https://nvd.nist.gov/vuln/detail/CVE-2026-5663). Nixpkgs packages affected DCMTK 3.7.0. The patch sanitizes user-controlled values before substituting them into `storescp` execution hooks, preventing remote command injection.
`release-26.05`  is also affected and requires a separate backport for its dcmtk 3.6.9 package.

Nix Security Tracker: https://tracker.security.nixos.org/suggestions/by-cve/CVE-2026-5663/

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
