### PR TITLE
far2l: update dependencies

### DIFF
--- a/pkgs/by-name/_7/_7zz/package.nix
+++ b/pkgs/by-name/_7/_7zz/package.nix
@@ -122,6 +122,7 @@ stdenv.mkDerivation (finalAttrs: {
   outputs = [
     "out"
     "doc"
+    "lib"
   ];
 
   setupHook = ./setup-hook.sh;
@@ -130,11 +131,18 @@ stdenv.mkDerivation (finalAttrs: {
 
   preBuild = "cd CPP/7zip/Bundles/Alone2";
 
+  postBuild = ''
+    make $makeFlags -j $NIX_BUILD_CORES -C ../Format7zF -f ../../cmpl_gcc.mak
+  '';
+
   installPhase = ''
     runHook preInstall
 
     install -Dm555 -t $out/bin b/*/7zz${stdenv.hostPlatform.extensions.executable}
     install -Dm444 -t $out/share/doc/7zz ../../../../DOC/*.txt
+
+    mkdir -p $lib/lib
+    install -Dm555 -t $lib/lib ../Format7zF/b/g/*
 
     runHook postInstall
   '';

--- a/pkgs/by-name/fa/far2l/package.nix
+++ b/pkgs/by-name/fa/far2l/package.nix
@@ -18,6 +18,9 @@
   gnutar,
   p7zip,
   xz,
+  nix-update-script,
+
+  # Backend options
   withTTYX ? true,
   libx11,
   withGUI ? true,
@@ -44,13 +47,13 @@
 
 stdenv.mkDerivation rec {
   pname = "far2l";
-  version = "2.9.0";
+  version = "2.9.0-unstable-06-09-2026";
 
   src = fetchFromGitHub {
     owner = "elfmz";
     repo = "far2l";
-    tag = "v_${version}";
-    hash = "sha256-9mSi3gqZ2jpgUawD3Jr2Pmn1shLpySuFCh4iOZe7CO8=";
+    rev = "1d45c50547f4459c13f3613cb89b09bf8d6139b1";
+    hash = "sha256-/AxtL7L6YYKFrtdsUXiBQ1ljuqCBymkdajeMB2xlVrM=";
   };
 
   nativeBuildInputs = [
@@ -125,6 +128,8 @@ stdenv.mkDerivation rec {
       --prefix PATH : ${lib.makeBinPath runtimeDeps} \
       --suffix PATH : ${lib.makeBinPath [ xdg-utils ]}
   '';
+
+  passthru.updateScript = nix-update-script { extraArgs = "--version=branch=master"; };
 
   meta = {
     description = "Linux port of FAR Manager v2, a program for managing files and archives in Windows operating systems";

--- a/pkgs/by-name/fa/far2l/package.nix
+++ b/pkgs/by-name/fa/far2l/package.nix
@@ -44,7 +44,7 @@
   python3Packages,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "far2l";
   version = "2.9.0-unstable-06-09-2026";
 
@@ -124,7 +124,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     wrapProgram $out/bin/far2l \
-      --prefix PATH : ${lib.makeBinPath runtimeDeps} \
+      --prefix PATH : ${lib.makeBinPath finalAttrs.runtimeDeps} \
       --suffix PATH : ${lib.makeBinPath [ xdg-utils ]}
     # Link 7z plugin
     echo "Linking 7z libraries..."
@@ -143,4 +143,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ smakarov ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/fa/far2l/package.nix
+++ b/pkgs/by-name/fa/far2l/package.nix
@@ -7,7 +7,6 @@
   cmake,
   ninja,
   pkg-config,
-  m4,
   perl,
   bash,
   xdg-utils,
@@ -16,7 +15,7 @@
   gzip,
   bzip2,
   gnutar,
-  p7zip,
+  _7zz,
   xz,
   nix-update-script,
 
@@ -28,13 +27,13 @@
   withUCD ? true,
   libuchardet,
 
-  # Plugins
+  # Plugins (all are enabled by default)
   withColorer ? true,
   spdlog,
   libxml2,
   withMultiArc ? true,
   libarchive,
-  pcre,
+
   withNetRocks ? true,
   openssl,
   libssh,
@@ -60,42 +59,42 @@ stdenv.mkDerivation rec {
     cmake
     ninja
     pkg-config
-    m4
     perl
     makeWrapper
   ];
 
-  buildInputs =
-    lib.optional withTTYX libx11
-    ++ lib.optional withGUI wxwidgets_3_2
-    ++ lib.optional withUCD libuchardet
-    ++ lib.optionals withColorer [
-      spdlog
-      libxml2
+  buildInputs = [
+    bash
+  ]
+  ++ lib.optional withTTYX libx11
+  ++ lib.optional withGUI wxwidgets_3_2
+  ++ lib.optional withUCD libuchardet
+  ++ lib.optionals withColorer [
+    spdlog
+    libxml2
+  ]
+  ++ lib.optionals withMultiArc [
+    libarchive
+  ]
+  ++ lib.optionals withNetRocks [
+    openssl
+    libssh
+    libnfs
+    neon
+  ]
+  ++ lib.optional (withNetRocks && !stdenv.hostPlatform.isDarwin) samba # broken on darwin
+  ++ lib.optionals withPython (
+    with python3Packages;
+    [
+      python
+      cffi
+      debugpy
+      pcpp
     ]
-    ++ lib.optionals withMultiArc [
-      libarchive
-      pcre
-    ]
-    ++ lib.optionals withNetRocks [
-      openssl
-      libssh
-      libnfs
-      neon
-    ]
-    ++ lib.optional (withNetRocks && !stdenv.hostPlatform.isDarwin) samba # broken on darwin
-    ++ lib.optionals withPython (
-      with python3Packages;
-      [
-        python
-        cffi
-        debugpy
-        pcpp
-      ]
-    );
+  );
 
   postPatch = ''
-    patchShebangs python/src/prebuild.sh
+    chmod +x far2l/bootstrap/*.sh
     patchShebangs far2l/bootstrap/view.sh
   '';
 
@@ -114,9 +113,9 @@ stdenv.mkDerivation rec {
   ];
 
   runtimeDeps = [
+    bash
     unzip
     zip
-    p7zip
     xz
     gzip
     bzip2
@@ -127,12 +126,18 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/far2l \
       --prefix PATH : ${lib.makeBinPath runtimeDeps} \
       --suffix PATH : ${lib.makeBinPath [ xdg-utils ]}
+    # Link 7z plugin
+    echo "Linking 7z libraries..."
+    mkdir -p $out/lib/far2l/Plugins/arclite/plug/
+    for file in ${_7zz.lib}/lib/*; do
+      ln -sf "$file" "$out/lib/far2l/Plugins/arclite/plug/"
+    done
   '';
 
   passthru.updateScript = nix-update-script { extraArgs = "--version=branch=master"; };
 
   meta = {
-    description = "Linux port of FAR Manager v2, a program for managing files and archives in Windows operating systems";
+    description = "Linux port of FAR Manager v2 with enhanced plugin support";
     homepage = "https://github.com/elfmz/far2l";
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ smakarov ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update far2l version to master one, as package is frequently updated with some fixes, which are not backported to release. Remove dependencies which are not relevant now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
