### PR TITLE
buildPython hooks: keep bytecode out of dist-info directories

### DIFF
--- a/pkgs/development/interpreters/python/hooks/pip-install-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pip-install-hook.sh
@@ -24,6 +24,14 @@ pipInstallPhase() {
     @pythonInterpreter@ -m pip install ./*.whl "${flagsArray[@]}"
     popd || return 1
 
+    # Some wheels ship .py files inside their dist-info (e.g. av carries
+    # licenses/AUTHORS.py); pip byte-compiles those too, embedding the
+    # package's own store path in bytecode inside its metadata.
+    for metadata in "$out"/@pythonSitePackages@/*.dist-info; do
+        [ -d "$metadata" ] || continue
+        find "$metadata" -name '__pycache__' -type d -prune -exec rm -rf {} +
+    done
+
     runHook postInstall
     echo "Finished executing pipInstallPhase"
 }

--- a/pkgs/development/interpreters/python/hooks/pypa-install-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pypa-install-hook.sh
@@ -14,6 +14,14 @@ pypaInstallPhase() {
 
     popd >/dev/null
 
+    # Some wheels ship .py files inside their dist-info (e.g. av carries
+    # licenses/AUTHORS.py); installer byte-compiles those too, embedding
+    # the package's own store path in bytecode inside its metadata.
+    for metadata in "$out"/@pythonSitePackages@/*.dist-info; do
+        [ -d "$metadata" ] || continue
+        find "$metadata" -name '__pycache__' -type d -prune -exec rm -rf {} +
+    done
+
     export PYTHONPATH="$out/@pythonSitePackages@:$PYTHONPATH"
 
     runHook postInstall

--- a/pkgs/development/interpreters/python/hooks/python-recompile-bytecode-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-recompile-bytecode-hook.sh
@@ -16,7 +16,9 @@ pythonRecompileBytecodePhase() {
         done
     fi
 
-    find "$out"/@pythonSitePackages@ -name "*.py" -exec @pythonInterpreter@ -OO -m compileall @compileArgs@ {} +
+    # Skip metadata directories: some packages ship .py files inside their
+    # dist-info, and compiling those embeds the store path in the metadata.
+    find "$out"/@pythonSitePackages@ \( -name '*.dist-info' -o -name '*.egg-info' \) -prune -o -name '*.py' -exec @pythonInterpreter@ -OO -m compileall @compileArgs@ {} +
 }
 
 if [ -z "${dontUsePythonRecompileBytecode-}" ]; then


### PR DESCRIPTION
Some wheels ship Python files inside their distribution metadata. `python3Packages.av` is an in-tree example: PyAV's wheel carries `licenses/AUTHORS.py` inside its dist-info. All three bytecode-producing install paths compile such files into `__pycache__` directories inside the package metadata:

- `pypaInstallPhase`: `python -m installer` bytecompiles every `.py` it installs, dist-info contents included. The generated `.pyc` is not listed in RECORD.
- `pipInstallPhase`: pip does the same for the wheels it installs.
- `pythonRecompileBytecodePhase` (packages using the hook from #81441): the `compileall` sweep over site-packages has the same effect.

The resulting `.pyc` embeds the package's own absolute store path inside its metadata:

```
$ nix-build -A python3Packages.av
$ find result -path '*dist-info*' -name '*.pyc'
result/lib/python3.14/site-packages/av-17.0.1.dist-info/licenses/__pycache__/AUTHORS.cpython-314.pyc
result/lib/python3.14/site-packages/av-17.0.1.dist-info/licenses/__pycache__/AUTHORS.cpython-314.opt-1.pyc
```

Compile artifacts do not belong in metadata directories: the installed dist-info diverges from what the wheel declares, and the embedded store path trips downstream tooling that copies dist-info directories or scans them for store path references (allowedReferences-style checks reject the self-referencing `.pyc`).

This change removes metadata `__pycache__` directories after the wheel installers run (rooted at the top-level `*.dist-info` dirs, so nothing outside metadata is touched), and prunes `*.dist-info`/`*.egg-info` from the recompile hook's `compileall` sweep (its preceding bytecode wipe already removes stale artifacts from the whole output). Regular module byte-compilation is unaffected.

Tested with a minimal flit package declaring `license-files = ["AUTHORS.py"]` (the same mechanism as av): before, its dist-info gains `licenses/__pycache__/AUTHORS.cpython-314{,.opt-1}.pyc` with the store path embedded; after, the dist-info carries only `licenses/AUTHORS.py` and the package's modules still byte-compile normally.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
