### PR TITLE
invidious: patch CVE-2026-58447

### DIFF
--- a/pkgs/by-name/in/invidious/package.nix
+++ b/pkgs/by-name/in/invidious/package.nix
@@ -3,6 +3,7 @@
   callPackage,
   crystal,
   fetchFromGitHub,
+  fetchpatch2,
   librsvg,
   pkg-config,
   libxml2,
@@ -40,6 +41,15 @@ crystal.buildCrystalPackage rec {
     rev = versions.invidious.rev or "refs/tags/v${version}";
     inherit (versions.invidious) hash;
   };
+
+  patches = [
+    # Remove with the first release containing this commit.
+    (fetchpatch2 {
+      name = "CVE-2026-58447.patch";
+      url = "https://github.com/iv-org/invidious/commit/77ad41678b45c4f6815940123f1796fc51259f45.patch?full_index=1";
+      hash = "sha256-0pf6eu0ckQ2gYHLr2tEDy+1dvAhVjepG26kuxuHbZl8=";
+    })
+  ];
 
   postPatch =
     let


### PR DESCRIPTION
Backport upstream's fix for CVE-2026-58447, which prevents authenticated users from deleting videos from other users' playlists.

Upstream fix: https://github.com/iv-org/invidious/commit/77ad41678b45c4f6815940123f1796fc51259f45
Security tracker suggestion: https://tracker.security.nixos.org/suggestions/by-id/10419/

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
