### PR TITLE
nixos/openlist: init

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -424,6 +424,33 @@
   "module-services-opencloud-basic-usage": [
     "index.html#module-services-opencloud-basic-usage"
   ],
+  "module-services-openlist": [
+    "index.html#module-services-openlist"
+  ],
+  "module-services-openlist-configuration": [
+    "index.html#module-services-openlist-configuration"
+  ],
+  "module-services-openlist-database": [
+    "index.html#module-services-openlist-database"
+  ],
+  "module-services-openlist-extra-flags": [
+    "index.html#module-services-openlist-extra-flags"
+  ],
+  "module-services-openlist-extra-packages": [
+    "index.html#module-services-openlist-extra-packages"
+  ],
+  "module-services-openlist-mutable-config": [
+    "index.html#module-services-openlist-mutable-config"
+  ],
+  "module-services-openlist-quickstart": [
+    "index.html#module-services-openlist-quickstart"
+  ],
+  "module-services-openlist-secrets": [
+    "index.html#module-services-openlist-secrets"
+  ],
+  "module-services-openlist-tls": [
+    "index.html#module-services-openlist-tls"
+  ],
   "module-services-networking-pihole-ftl-configuration-inherit-dnsmasq": [
     "index.html#module-services-networking-pihole-ftl-configuration-inherit-dnsmasq"
   ],

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -38,6 +38,8 @@
 
 - [Cardwire](https://github.com/OpenGamingCollective/cardwire), a GPU manager for Linux that uses eBPF+LSM hooks to control GPUs. Available as [services.cardwired](#opt-services.cardwired.enable).
 
+- [OpenList](https://github.com/OpenListTeam/OpenList), a file list program that supports multiple storage providers, forked from Alist. Available as [services.openlist](#opt-services.openlist.enable).
+
 - [Moonlight Qt](https://moonlight-stream.org/), a client for playing your PC games on almost any device. Available as [programs.moonlight-qt](#opt-programs.moonlight-qt.enable).
 
 - [udp514-journal](https://github.com/eworm-de/udp514-journal), a service to forward remote syslog messages to systemd-journal. Available as [services.udp514-journal](#opt-services.udp514-journal.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1806,6 +1806,7 @@
   ./services/web-apps/onlyoffice.nix
   ./services/web-apps/open-web-calendar.nix
   ./services/web-apps/opencloud.nix
+  ./services/web-apps/openlist.nix
   ./services/web-apps/openvscode-server.nix
   ./services/web-apps/openwebrx.nix
   ./services/web-apps/outline.nix

--- a/nixos/modules/services/web-apps/openlist.md
+++ b/nixos/modules/services/web-apps/openlist.md
@@ -1,0 +1,134 @@
+# OpenList {#module-services-openlist}
+
+[OpenList](https://github.com/OpenListTeam/OpenList) is a file list program
+that supports multiple storage providers, forked from Alist.
+
+## Quickstart {#module-services-openlist-quickstart}
+
+A minimal local instance listening on `http://[::1]:5244`:
+
+```nix
+{
+  services.openlist = {
+    enable = true;
+  };
+}
+```
+
+On first start, an initial random admin password is printed to the journal:
+
+```shell
+journalctl -u openlist --no-pager | grep -i "initial password"
+```
+
+Log in with it and set a new password in the web interface.
+
+## Configuration {#module-services-openlist-configuration}
+
+OpenList is configured through
+{option}`services.openlist.settings`, which is written to
+`config.json` in the state directory. See the
+[upstream configuration documentation](https://doc.oplist.org/configuration/configuration)
+for all available options. Options not declared in the module are passed
+through verbatim.
+
+For example, to listen on all interfaces with a fixed JWT secret:
+
+```nix
+{
+  services.openlist = {
+    enable = true;
+    settings = {
+      scheme.address = "0.0.0.0";
+      jwt_secret._secret = "/run/secrets/openlist-jwt";
+    };
+  };
+}
+```
+
+### Secrets {#module-services-openlist-secrets}
+
+Options containing secret data should be set to an attribute set containing
+the attribute `_secret`, pointing to a file that contains the value. The file
+is read at service start and the option is replaced with its content, so the
+secret never enters the Nix store:
+
+```nix
+{
+  services.openlist.settings.database.password._secret = "/run/secrets/openlist-db-password";
+}
+```
+
+### Persistent settings {#module-services-openlist-mutable-config}
+
+By default ({option}`services.openlist.mutableConfig = true`), settings
+changed at runtime through the web interface are kept: on each start, the
+declarative configuration is merged into the existing `config.json`, with
+declarative values taking precedence. Runtime values are preserved only where
+not overridden by the declarative configuration. Set `mutableConfig` to
+`false` to fully manage the configuration declaratively.
+
+### Database {#module-services-openlist-database}
+
+OpenList defaults to SQLite. To use MySQL or PostgreSQL instead:
+
+```nix
+{
+  services.openlist.settings.database = {
+    type = "postgres";
+    host = "/run/postgresql";
+    port = 5432;
+    user = "openlist";
+    password._secret = "/run/secrets/openlist-db-password";
+    name = "openlist";
+  };
+}
+```
+
+A custom DSN can be set with
+{option}`services.openlist.settings.database.dsn`, which overrides the other
+connection options.
+
+### TLS {#module-services-openlist-tls}
+
+HTTPS can be enabled by providing a certificate and key. The files are passed
+to the service through systemd credentials, so they are never copied into the
+Nix store:
+
+```nix
+{
+  services.openlist.settings.scheme = {
+    https_port = 443;
+    cert_file = "/var/lib/acme/example.org/fullchain.pem";
+    key_file = "/var/lib/acme/example.org/key.pem";
+  };
+}
+```
+
+### Extra packages {#module-services-openlist-extra-packages}
+
+Additional packages can be added to the service's `PATH` via
+{option}`services.openlist.extraPackages`. By default the list is empty.
+To enable video thumbnail generation, add `pkgs.ffmpeg-headless`:
+
+```nix
+{
+  services.openlist.extraPackages = with pkgs; [
+    ffmpeg-headless
+  ];
+}
+```
+
+### Extra flags {#module-services-openlist-extra-flags}
+
+Extra command-line flags can be passed to the server with
+{option}`services.openlist.extraFlags`, for example:
+
+```nix
+{
+  services.openlist.extraFlags = [
+    "--dev"
+    "--no-prefix"
+  ];
+}
+```

--- a/nixos/modules/services/web-apps/openlist.nix
+++ b/nixos/modules/services/web-apps/openlist.nix
@@ -1,0 +1,392 @@
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+let
+  cfg = config.services.openlist;
+  settingsFormat = pkgs.formats.json { };
+
+  certFile = cfg.settings.scheme.cert_file;
+  keyFile = cfg.settings.scheme.key_file;
+in
+{
+  options = {
+    services.openlist = {
+      enable = lib.mkEnableOption "OpenList, a file list program";
+
+      stateDir = lib.mkOption {
+        type = lib.types.str;
+        default = "/var/lib/openlist";
+        description = "OpenList stores data and config file in this directory. Corresponds to the `--data` CLI argument.";
+      };
+
+      user = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "OpenList user name. If not set, a user named `openlist` will be created.";
+      };
+
+      group = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "OpenList group name. If not set, a group named `openlist` will be created.";
+      };
+
+      mutableConfig = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Allow OpenList to persist settings in the config file.";
+      };
+
+      extraFlags = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        example = [
+          "--log-std"
+          "--dev"
+          "--no-prefix"
+        ];
+        description = "Extra flags passed to the openlist server command. Use this to pass CLI arguments such as `--debug`, `--dev`, `--no-prefix`, or `--force-bin-dir`.";
+      };
+
+      package = lib.mkPackageOption pkgs "openlist" { };
+
+      extraPackages = lib.mkOption {
+        type = lib.types.listOf lib.types.package;
+        default = [ ];
+        example = lib.literalExpression "[ pkgs.ffmpeg-headless ]";
+        description = "Additional packages to add to the service's PATH environment variable. For video thumbnail support, add pkgs.ffmpeg-headless.";
+      };
+
+      settings = lib.mkOption {
+        type = lib.types.submodule {
+          freeformType = settingsFormat.type;
+          options = {
+            force = lib.mkOption {
+              type = lib.types.bool;
+              default = true;
+              description = "By default OpenList reads the configuration from environment variables, set this field to true to force OpenList to read config from the configuration file.";
+            };
+
+            site_url = lib.mkOption {
+              type = lib.types.str;
+              default = "";
+              description = ''
+                The address of your OpenList server. This address is essential for some features, and thus thry may not work properly if unset:
+                - thumbnailing LocalStorage
+                - previewing site after setting web proxy
+                - displaying download address after setting web proxy
+                - reverse-proxying to site sub directories
+                - ...
+                Do not include the slash (/) at the end of the address.
+              '';
+            };
+
+            cdn = lib.mkOption {
+              type = lib.types.str;
+              default = "";
+              description = ''
+                The address of the CDN. Included `$version` values will be dynamically replaced by the version of OpenList. Existing dist resources are hosted on both npm and GitHub, which can be found at:
+
+                - https://www.npmjs.com/package/@openlist-frontend/openlist-frontend
+                - https://github.com/OpenListTeam/OpenList-Frontend
+                Thus it is possible to use any npm or GitHub CDN path for this field. For example:
+
+                - https://registry.npmmirror.com/@openlist-frontend/openlist-frontend/$version/files/dist/
+                - https://cdn.jsdelivr.net/npm/@openlist-frontend/openlist-frontend@$version/dist/
+                - https://unpkg.com/@openlist-frontend/openlist-frontend@$version/dist/
+
+                Keep empty to use local dist resources.
+              '';
+            };
+
+            jwt_secret = lib.mkOption {
+              type = lib.types.nullOr (lib.types.attrsOf lib.types.path);
+              default = null;
+              example = {
+                _secret = "/run/secrets/openlist-jwt";
+              };
+              description = ''
+                The secret used to sign the JWT token, should be a random string.
+
+                This setting is optional. However, if `mutableConfig` is set to false and
+                this option is not configured, OpenList will generate a different
+                `jwt_secret` each time it restarts. This may affect the functionality
+                of the `sign` feature as well as session persistence.
+              '';
+            };
+
+            token_expires_in = lib.mkOption {
+              type = lib.types.int;
+              default = 48;
+              description = "User login expiration time, in hours.";
+            };
+
+            database = {
+              type = lib.mkOption {
+                type = lib.types.enum [
+                  "sqlite3"
+                  "mysql"
+                  "postgres"
+                ];
+                default = "sqlite3";
+                description = "Database type to use.";
+              };
+
+              host = lib.mkOption {
+                type = lib.types.str;
+                default = "";
+                example = "127.0.0.1";
+                description = "Database host. Only used when `database.type` is `mysql` or `postgres`.";
+              };
+
+              port = lib.mkOption {
+                type = lib.types.port;
+                default = 0;
+                example = 3306;
+                description = "Database port. Only used when `database.type` is `mysql` or `postgres`.";
+              };
+
+              user = lib.mkOption {
+                type = lib.types.str;
+                default = "";
+                example = "root";
+                description = "Database account. Only used when `database.type` is `mysql` or `postgres`.";
+              };
+
+              password = lib.mkOption {
+                type = lib.types.nullOr (lib.types.attrsOf lib.types.path);
+                default = null;
+                example = {
+                  _secret = "/run/secrets/openlist-db-password";
+                };
+                description = "Database password. Only used when `database.type` is `mysql` or `postgres`. Set to an attribute set containing `_secret` to reference a secret file.";
+              };
+
+              name = lib.mkOption {
+                type = lib.types.str;
+                default = "";
+                example = "openlist";
+                description = "Database name. Only used when `database.type` is `mysql` or `postgres`.";
+              };
+
+              db_file = lib.mkOption {
+                type = lib.types.str;
+                default = "/var/lib/openlist/data.db";
+                description = "Database location. Only used when `database.type` is `sqlite3`.";
+              };
+
+              table_prefix = lib.mkOption {
+                type = lib.types.str;
+                default = "openlist_";
+                description = "Database table name prefix.";
+              };
+
+              ssl_mode = lib.mkOption {
+                type = lib.types.str;
+                default = "";
+                description = "To control the encryption options during the SSL handshake. Only used when `database.type` is `mysql` or `postgres`.";
+              };
+
+              dsn = lib.mkOption {
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+                example = "";
+                description = ''
+                  Custom DSN connection string. If set, overrides all other database
+                  connection options (`host`, `port`, `user`, `password`, `name`,
+                  `ssl_mode`). Useful for advanced connection parameters not exposed
+                  as individual options.
+
+                  Example (MySQL):
+                    `root:password@unix(/run/mysqld/mysqld.sock)/testdb?charset=utf8mb4&parseTime=True&loc=Local`
+
+                  Example (PostgreSQL):
+                    `user=username password=password host=/run/postgresql dbname=dbname port=5432 sslmode=disable`
+
+                  For more details, see <https://gorm.io/docs/connecting_to_the_database.html>.
+                '';
+              };
+            };
+
+            scheme = {
+              address = lib.mkOption {
+                type = lib.types.str;
+                default = "[::1]";
+                description = "The http/https address to listen on.";
+              };
+              http_port = lib.mkOption {
+                type = lib.types.nullOr lib.types.port;
+                default = 5244;
+                apply = v: if v != null then v else -1;
+                description = "The http port to listen on, default `5244`, set it to `null` to disable http.";
+              };
+              https_port = lib.mkOption {
+                type = lib.types.nullOr lib.types.port;
+                default = null;
+                apply = v: if v != null then v else -1;
+                description = "The https port to listen on, default `null`, set it to non `null` to enable https.";
+              };
+              force_https = lib.mkOption {
+                type = lib.types.bool;
+                default = false;
+                description = "Whether the HTTPS protocol is forcibly, if it is set to True, the user can only access the website through HTTPS.";
+              };
+              cert_file = lib.mkOption {
+                type = lib.types.nullOr lib.types.path;
+                default = null;
+                description = "Path of cert file.";
+              };
+              key_file = lib.mkOption {
+                type = lib.types.nullOr lib.types.path;
+                default = null;
+                description = "Path of key file.";
+              };
+              unix_file = lib.mkOption {
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+                description = "Unix socket file path to listen on. Set to non-null to enable unix socket.";
+              };
+              unix_file_perm = lib.mkOption {
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+                description = "Unix socket file permission, set to the appropriate permissions, like `0644`.";
+              };
+            };
+          };
+        };
+        default = { };
+        apply = s: if s.jwt_secret == null then lib.removeAttrs s [ "jwt_secret" ] else s;
+        description = ''
+          The OpenList configuration, see <https://doc.oplist.org/configuration/configuration>
+          for possible options.
+
+          Options containing secret data should be set to an attribute set
+          containing the attribute `_secret`. This attribute should be a string
+          or structured JSON with `quote = false;`, pointing to a file that
+          contains the value the option should be set to.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.openlist.settings = {
+      force = false;
+      temp_dir = "/tmp";
+    };
+
+    users = {
+      users.openlist = lib.mkIf (cfg.user == null) {
+        description = "OpenList user";
+        isSystemUser = true;
+        group = if cfg.group == null then "openlist" else cfg.group;
+      };
+      groups.openlist = lib.mkIf (cfg.group == null) { };
+    };
+
+    systemd.services.openlist = {
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      preStart = ''
+        umask 0077
+        mkdir -p ${cfg.stateDir}
+        ${utils.genJqSecretsReplacementSnippet cfg.settings "/run/openlist/new"}
+      ''
+      + (
+        if cfg.mutableConfig then
+          ''
+            if [ -e "${cfg.stateDir}/config.json" ]; then
+              cp "${cfg.stateDir}/config.json" /run/openlist/old
+              ${lib.getExe pkgs.jq} -s '.[0] * .[1]' /run/openlist/old /run/openlist/new > /run/openlist/result
+              mv /run/openlist/result /run/openlist/new
+              rm -f /run/openlist/old
+            fi
+            mv /run/openlist/new "${cfg.stateDir}/config.json"
+          ''
+        else
+          ''
+            mv /run/openlist/new "${cfg.stateDir}/config.json"
+          ''
+      )
+      + lib.optionalString (certFile != null) ''
+        export OPENLIST_CERT_FILE="''${CREDENTIALS_DIRECTORY}/tls-cert"
+        export CERT_FILE="''${CREDENTIALS_DIRECTORY}/tls-cert"
+      ''
+      + lib.optionalString (keyFile != null) ''
+        export OPENLIST_KEY_FILE="''${CREDENTIALS_DIRECTORY}/tls-key"
+        export KEY_FILE="''${CREDENTIALS_DIRECTORY}/tls-key"
+      '';
+
+      serviceConfig =
+        let
+          needPerm =
+            (cfg.settings.scheme.http_port != -1 && cfg.settings.scheme.http_port < 1024)
+            || (cfg.settings.scheme.https_port != -1 && cfg.settings.scheme.https_port < 1024);
+        in
+        {
+          User = if cfg.user == null then "openlist" else cfg.user;
+          Group = if cfg.group == null then "openlist" else cfg.group;
+          Type = "simple";
+
+          ExecStart =
+            "${lib.getExe cfg.package} server --log-std "
+            + lib.escapeShellArgs (
+              [
+                "--data"
+                cfg.stateDir
+              ]
+              ++ cfg.extraFlags
+            );
+
+          Restart = "on-failure";
+          RestartSec = "10s";
+
+          StateDirectory = [ "openlist" ];
+          RuntimeDirectory = [ "openlist" ];
+          WorkingDirectory = cfg.stateDir;
+
+          LoadCredential =
+            lib.optional (certFile != null) "tls-cert:${certFile}"
+            ++ lib.optional (keyFile != null) "tls-key:${keyFile}";
+
+          ProtectSystem = "strict";
+          ProtectHome = true;
+          PrivateTmp = true;
+          PrivateUsers = !needPerm;
+          NoNewPrivileges = true;
+          ReadWritePaths = [ cfg.stateDir ];
+          RestrictSUIDSGID = true;
+          RemoveIPC = true;
+          PrivateDevices = true;
+          ProtectClock = true;
+          ProtectControlGroups = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectHostname = true;
+          ProtectProc = "invisible";
+          MemoryDenyWriteExecute = true;
+          UMask = "0077";
+          SystemCallFilter = [
+            "@system-service"
+            "~@privileged"
+          ];
+          AmbientCapabilities = lib.optional needPerm "CAP_NET_BIND_SERVICE";
+          CapabilityBoundingSet = lib.optional needPerm "CAP_NET_BIND_SERVICE";
+        };
+
+      path = cfg.extraPackages;
+    };
+  };
+
+  meta = {
+    doc = ./openlist.md;
+    maintainers = with lib.maintainers; [
+      knightfemale
+    ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1394,6 +1394,7 @@ in
   openbao = runTest ./openbao.nix;
   opencloud = runTest ./opencloud.nix;
   openldap = runTest ./openldap.nix;
+  openlist = runTest ./openlist.nix;
   openresty-lua = runTest ./openresty-lua.nix;
   opensearch = discoverTests (import ./opensearch.nix);
   opensmtpd = handleTest ./opensmtpd.nix { };

--- a/nixos/tests/openlist.nix
+++ b/nixos/tests/openlist.nix
@@ -1,0 +1,123 @@
+{ lib, ... }:
+let
+  certs = import ./common/acme/server/snakeoil-certs.nix;
+  domain = certs.domain;
+in
+{
+  name = "openlist";
+
+  meta.maintainers = with lib.maintainers; [ knightfemale ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      security.pki.certificateFiles = [ certs.ca.cert ];
+      environment.systemPackages = with pkgs; [
+        curl
+        openlist
+        sudo
+      ];
+      networking.hosts = {
+        "::1" = [ domain ];
+      };
+      services.openlist = {
+        enable = true;
+        mutableConfig = true;
+        settings = {
+          scheme = {
+            # Test CAP_NET_BIND_SERVICE
+            https_port = 443;
+            http_port = 5244;
+            cert_file = certs.${domain}.cert;
+            key_file = certs.${domain}.key;
+          };
+        };
+      };
+    };
+
+  testScript = ''
+    import json
+
+    machine.wait_for_unit("openlist.service")
+
+    with subtest("Initial admin password is logged"):
+        machine.wait_until_succeeds("journalctl -u openlist | grep -i 'initial password'")
+
+    # Test mutableConfig: runtime values are preserved where the
+    # declarative configuration does not override them.
+    with subtest("mutableConfig"):
+        machine.succeed("systemctl stop openlist")
+        machine.succeed("""
+            echo '{"custom_runtime_key": "preserved"}' > /var/lib/openlist/config.json
+        """)
+        machine.succeed("systemctl start openlist")
+        machine.wait_for_unit("openlist.service")
+        result = json.loads(machine.succeed("cat /var/lib/openlist/config.json"))
+        # Undeclared runtime key survives the merge
+        assert result['custom_runtime_key'] == "preserved"
+        # Declarative values take precedence
+        assert result['scheme']['https_port'] == 443
+        machine.wait_for_open_port(5244)
+        machine.wait_for_open_port(443)
+
+    with subtest("Ping"):
+        assert "pong" in machine.succeed("curl --fail --max-time 10 http://${domain}:5244/ping")
+        assert "pong" in machine.succeed("curl --fail --max-time 10 https://${domain}/ping")
+
+    # Set admin password (the package's binary is named `OpenList`)
+    machine.succeed("OpenList admin set password --data /var/lib/openlist")
+
+    with subtest("Get token"):
+        result = json.loads(machine.succeed("""
+            curl --fail -X POST --json '{ "username": "admin", "password": "password"}' \
+            https://${domain}/api/auth/login
+        """))
+        token = result['data']['token']
+
+    with subtest("Add local storage"):
+        machine.succeed("sudo -uopenlist mkdir -p /var/lib/openlist/storage1")
+        result = machine.succeed("""
+          curl --fail -X POST --header 'Authorization: %s' \
+              --json '{
+                "mount_path": "/storage1",
+                "order": 0,
+                "remark": "",
+                "cache_expiration": 30,
+                "web_proxy": false,
+                "webdav_policy": "native_proxy",
+                "down_proxy_url": "",
+                "extract_folder": "front",
+                "enable_sign": false,
+                "driver": "Local",
+                "order_by": "name",
+                "order_direction": "asc",
+                "addition": "{\\"root_folder_path\\":\\"/var/lib/openlist/storage1\\",\\"thumbnail\\":false,\\"thumb_cache_folder\\":\\"\\",\\"show_hidden\\":true,\\"mkdir_perm\\":\\"777\\"}"
+              }' 'https://${domain}/api/admin/storage/create'
+        """ % token)
+
+    with subtest("Upload and Download"):
+        machine.succeed(f"""
+          echo HelloWorld > /tmp/hello
+          curl -X PUT --form 'file=@/tmp/hello' \
+            --header 'Authorization: {token}' \
+            --header 'File-Path: %2Fstorage1%2Fhello' \
+            --header 'As-Task: false' \
+            'https://${domain}/api/fs/form'
+        """)
+        result = json.loads(machine.succeed("""
+          curl -X POST --header 'Authorization: %s' \
+            --json '{
+                "path": "/storage1/hello",
+                "password": "",
+                "page": 1,
+                "per_page": 0,
+                "refresh": false
+              }' 'https://${domain}/api/fs/get'
+        """ % token))
+        sign = result['data']['sign']
+        assert "HelloWorld" in machine.succeed("curl --fail 'https://${domain}/d/storage1/hello?sign=%s'" % sign)
+
+        # Verify local file
+        assert "HelloWorld" in machine.succeed("cat /var/lib/openlist/storage1/hello")
+  '';
+}

--- a/pkgs/by-name/op/openlist/package.nix
+++ b/pkgs/by-name/op/openlist/package.nix
@@ -7,6 +7,7 @@
   iana-etc,
   installShellFiles,
   libredirect,
+  nixosTests,
   versionCheckHook,
 }:
 
@@ -102,7 +103,10 @@ buildGoModule (finalAttrs: {
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "version";
 
-  passthru.updateScript = lib.getExe (callPackage ./update.nix { });
+  passthru = {
+    tests = nixosTests.openlist;
+    updateScript = lib.getExe (callPackage ./update.nix { });
+  };
 
   meta = {
     description = "AList Fork to Anti Trust Crisis";


### PR DESCRIPTION
Add a NixOS module for OpenList, a file list program supporting multiple storage providers, forked from Alist: https://github.com/OpenListTeam/OpenList

This PR adds `services.openlist`: a hardened systemd service with a freeform settings submodule, `_secret` support via `genJqSecretsReplacementSnippet`, TLS through systemd credentials, runtime config merging (`mutableConfig`), and extraPackages/extraFlags following RFC 42. It includes NixOS manual documentation, a NixOS test, and a release notes entry.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
