### PR TITLE
firefighter: init at 1.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27695,6 +27695,12 @@
     githubId = 2389333;
     name = "Andy Tockman";
   };
+  tdback = {
+    name = "Tyler Dunneback";
+    github = "tdback";
+    githubId = 98326106;
+    email = "tyler@tdback.net";
+  };
   teatwig = {
     email = "nix@teatwig.net";
     name = "tea";

--- a/pkgs/by-name/fi/firefighter/package.nix
+++ b/pkgs/by-name/fi/firefighter/package.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  fetchFromGitLab,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "firefighter";
+  version = "1.2.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitLab {
+    owner = "esr";
+    repo = finalAttrs.pname;
+    tag = finalAttrs.version;
+    hash = "sha256-C3Q/3RipUFfVpMV0Zk9LbTHIqt39zDT3iR9Aspk3Tfc=";
+  };
+
+  cargoHash = "sha256-rQjVS2VLbE8hQzIqqFpiYtUiGAwL4Gh3WbAKGyGFGBM=";
+
+  meta = {
+    description = "Save the houses and trees from a raging, wind-driven forest fire!";
+    homepage = "https://gitlab.com/esr/firefighter";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ tdback ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds firefighter, a UNIX port of a DOS shareware game from 1985. 

Homepage: https://gitlab.com/esr/firefighter

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
