### PR TITLE
add confy-tui

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22085,6 +22085,12 @@
     githubId = 421510;
     name = "Noé Rubinstein";
   };
+  phluxjr = {
+    email = "phluxjr@phluxjr.net";
+    github = "phluxjr";
+    githubId = 185956030;
+    name = "phluxjr";
+  };
   pho = {
     email = "phofin@gmail.com";
     github = "pho";

--- a/pkgs/by-name/co/confy-tui/package.nix
+++ b/pkgs/by-name/co/confy-tui/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "confy-tui";
+  version = "3.0.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "phluxjr";
+    repo = "confy";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-yhzmkIPrOckDxoB10RBX5ul/rYzVKtU6l6O1Zm69e9c=";
+  };
+
+  build-system = [
+    python3Packages.hatchling
+  ];
+
+  postInstall = ''
+    install -Dm644 confy.1 $out/share/man/man1/confy.1
+  '';
+
+  meta = {
+    description = "config manager tui for linux/unix systems";
+    homepage = "https://github.com/phluxjr/confy";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ phluxjr ];
+    mainProgram = "confy";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
adds `confy-tui` (v3.0.0), a lightweight terminal ui for managing config files on linux/unix systems. lets you track, organize into groups, search, and open configs in your $EDITOR with vim-style keybinds. zero runtime dependencies (pure python + stdlib curses). homepage: https://github.com/phluxjr/confy

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
