### PR TITLE
mopidy: 3.4.2 -> 4.0.3

### DIFF
--- a/pkgs/applications/audio/mopidy/fix-youtube-mopidy-4.patch
+++ b/pkgs/applications/audio/mopidy/fix-youtube-mopidy-4.patch
@@ -1,0 +1,81 @@
+From: Gerhard Schwanzer <geri@sdf.org>
+Subject: [PATCH] Restore Mopidy 4 cache metadata serialization
+Upstream-Status: Submitted [https://github.com/natumbri/mopidy-youtube/pull/265]
+
+diff --git a/mopidy_youtube/youtube.py b/mopidy_youtube/youtube.py
+index 4a988d0..d02d9e6 100644
+--- a/mopidy_youtube/youtube.py
++++ b/mopidy_youtube/youtube.py
+@@ -733,13 +733,16 @@ def my_hook(d):
+                         with open(
+                             os.path.join(cache_location, f"{self.id}.json"), "w"
+                         ) as outfile:
+-                            json.dump(
+-                                convert_video_to_track(
+-                                    self, bitrate=int(info.get("tbr", 0))
+-                                ),
+-                                cls=ModelJSONEncoder,
+-                                fp=outfile,
+-                            )
++                            if ModelJSONEncoder:
++                                # Mopidy < 4.0
++                                json.dump(track, cls=ModelJSONEncoder, fp=outfile)
++                            else:
++                                # Mopidy >= 4.0
++                                outfile.write(
++                                    track.model_dump_json(
++                                        by_alias=True, exclude_none=True
++                                    )
++                                )
+                 else:
+                     with youtube_dl.YoutubeDL(ytdl_options) as ydl:
+                         info = ydl.extract_info(
+diff --git a/tests/test_extension.py b/tests/test_extension.py
+index 4c9ab45..85b900a 100644
+--- a/tests/test_extension.py
++++ b/tests/test_extension.py
+@@ -26,7 +26,7 @@ def test_get_config_schema():
+     assert "api_enabled" in schema
+     assert "channel_id" in schema
+     assert "musicapi_enabled" in schema
+-    assert "musicapi_cookie" in schema
++    assert "musicapi_cookiefile" in schema
+     assert "autoplay_enabled" in schema
+     assert "strict_autoplay" in schema
+     assert "max_autoplay_length" in schema
+diff --git a/tests/test_youtube.py b/tests/test_youtube.py
+index c1ec385..ba27c4a 100644
+--- a/tests/test_youtube.py
++++ b/tests/test_youtube.py
+@@ -1,3 +1,5 @@
++import json
++
+ import pytest
+
+ from mopidy_youtube import youtube
+@@ -84,20 +86,20 @@ def test_audio_url(api, config, headers, youtube_dl_mock_with_video):
+
+ @pytest.mark.parametrize("api", apis)
+ def test_audio_url_with_cache_metadata(
+-    api, config, headers, youtube_dl_mock_with_video, tmp_path
++    api, config, headers, youtube_dl_mock_with_video, tmp_path, monkeypatch
+ ):
+     setup_entry_api(api, config, headers)
+     youtube.Video.proxy = None
+-    youtube.cache_location = str(tmp_path)
++    monkeypatch.setattr(youtube, "cache_location", str(tmp_path))
+     video = youtube.Video.get("e1YqueG2gtQ")
+
+     (tmp_path / f"{video.id}.webm").write_bytes(b"cached audio")
+     (tmp_path / f"{video.id}.webp").write_bytes(b"cached image")
+
+     assert video.audio_url.get()
+-    assert (tmp_path / f"{video.id}.json").exists()
+-
+-    youtube.cache_location = None
++    with (tmp_path / f"{video.id}.json").open() as metadata_file:
++        metadata = json.load(metadata_file)
++    assert metadata["uri"] == f"youtube:video:{video.id}"
+
+
+ @pytest.mark.parametrize("api", apis)

--- a/pkgs/applications/audio/mopidy/jellyfin.nix
+++ b/pkgs/applications/audio/mopidy/jellyfin.nix
@@ -20,6 +20,7 @@ pythonPackages.buildPythonApplication (finalAttrs: {
 
   dependencies = [
     mopidy
+    pythonPackages.requests
     pythonPackages.unidecode
     pythonPackages.websocket-client
   ];

--- a/pkgs/applications/audio/mopidy/listenbrainz.nix
+++ b/pkgs/applications/audio/mopidy/listenbrainz.nix
@@ -7,14 +7,14 @@
 
 pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-listenbrainz";
-  version = "0.3.0";
+  version = "0.4.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "suaviloquence";
     repo = "mopidy-listenbrainz";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-kYZgG2KQMTxMR8tdwwCKkfexDcxcndXG9LSdlnoN/CY=";
+    hash = "sha256-e3VrOILOqBvX3j8jEsseFY6ihZiXIm0ela66VRwvlgg=";
   };
 
   build-system = [
@@ -24,7 +24,14 @@ pythonPackages.buildPythonApplication (finalAttrs: {
   dependencies = [
     mopidy
     pythonPackages.musicbrainzngs
+    pythonPackages.pykka
   ];
+
+  nativeCheckInputs = [
+    pythonPackages.pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "mopidy_listenbrainz" ];
 
   meta = {
     homepage = "https://github.com/suaviloquence/mopidy-listenbrainz";

--- a/pkgs/applications/audio/mopidy/local.nix
+++ b/pkgs/applications/audio/mopidy/local.nix
@@ -7,17 +7,18 @@
 
 pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-local";
-  version = "3.3.0";
+  version = "4.0.1";
   pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) version;
     pname = "mopidy_local";
-    hash = "sha256-y6btbGk5UiVan178x7d9jq5OTnKMbuliHv0aRxuZK3o=";
+    hash = "sha256-C+zGi81jfzmo6J9izaSJ/rdjVCeQZcNnPR+/agvrVwg=";
   };
 
   build-system = [
     pythonPackages.setuptools
+    pythonPackages.setuptools-scm
   ];
 
   dependencies = [

--- a/pkgs/applications/audio/mopidy/mopidy.nix
+++ b/pkgs/applications/audio/mopidy/mopidy.nix
@@ -13,14 +13,14 @@
 
 pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy";
-  version = "3.4.2";
+  version = "4.0.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mopidy";
     repo = "mopidy";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-2OFav2HaQq/RphmZxLyL1n3suwzt1Y/d4h33EdbStjk=";
+    hash = "sha256-EmifQxL6HVZrBU1FXR8eMidllhK7Lt+pvfT0DrSP59U=";
   };
 
   nativeBuildInputs = [ wrapGAppsNoGuiHook ];
@@ -42,24 +42,38 @@ pythonPackages.buildPythonApplication (finalAttrs: {
 
   propagatedBuildInputs = [ gobject-introspection ];
 
-  build-system = [ pythonPackages.setuptools ];
+  build-system = with pythonPackages; [
+    setuptools
+    setuptools-scm
+  ];
 
   dependencies =
     with pythonPackages;
     [
+      cyclopts
       gst-python
+      httpx
+      platformdirs
+      pydantic
       pygobject3
       pykka
-      requests
-      # Provides pkg_resources required by Mopidy 3 and affected extensions.
-      # Remove when updating to Mopidy 4.
-      setuptools_80
+      rich
       tornado
     ]
     ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [ dbus-python ];
 
-  # There are no tests
-  doCheck = false;
+  nativeCheckInputs = with pythonPackages; [
+    dirty-equals
+    polyfactory
+    pytestCheckHook
+    pytest-httpx
+    pytest-mock
+  ];
+
+  disabledTests = [
+    # GStreamer 1.28 does not report the duration of the WAV fixture.
+    "test_lookup_converts_uri_metadata_to_track"
+  ];
 
   passthru.tests = {
     inherit (nixosTests) mopidy;

--- a/pkgs/applications/audio/mopidy/mpd.nix
+++ b/pkgs/applications/audio/mopidy/mpd.nix
@@ -7,21 +7,26 @@
 
 pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-mpd";
-  version = "3.3.0";
+  version = "4.0.1";
   pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) version;
-    pname = "Mopidy-MPD";
-    hash = "sha256-CeLMRqj9cwBvQrOx7XHVV8MjDjwOosONVlsN2o+vTVM=";
+    pname = "mopidy_mpd";
+    hash = "sha256-iWMEJHJROeU3YU+ollWieAGQWOIYSI+RFWQb3AGE3Nw=";
   };
 
-  build-system = [ pythonPackages.setuptools ];
+  build-system = [
+    pythonPackages.setuptools
+    pythonPackages.setuptools-scm
+  ];
 
   dependencies = [ mopidy ];
 
-  # no tests implemented
-  doCheck = false;
+  nativeCheckInputs = [
+    pythonPackages.pytestCheckHook
+  ];
+
   pythonImportsCheck = [ "mopidy_mpd" ];
 
   meta = {

--- a/pkgs/applications/audio/mopidy/mpris.nix
+++ b/pkgs/applications/audio/mopidy/mpris.nix
@@ -7,17 +7,18 @@
 
 pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-mpris";
-  version = "3.0.3";
+  version = "4.0.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) version;
-    pname = "Mopidy-MPRIS";
-    hash = "sha256-rHQgNIyludTEL7RDC8dIpyGTMOt1Tazn6i/orKlSP4U=";
+    pname = "mopidy_mpris";
+    hash = "sha256-6cQlXxqno96SMQqlheAY3SkttVpEoVJmPjGndcJ4qQA=";
   };
 
   build-system = [
     pythonPackages.setuptools
+    pythonPackages.setuptools-scm
   ];
 
   dependencies = [

--- a/pkgs/applications/audio/mopidy/muse.nix
+++ b/pkgs/applications/audio/mopidy/muse.nix
@@ -23,6 +23,8 @@ pythonPackages.buildPythonApplication (finalAttrs: {
   dependencies = [
     mopidy
     pythonPackages.pykka
+    # Provides pkg_resources; remove when upstream replaces it.
+    pythonPackages.setuptools_80
   ];
 
   pythonImportsCheck = [ "mopidy_muse" ];

--- a/pkgs/applications/audio/mopidy/notify.nix
+++ b/pkgs/applications/audio/mopidy/notify.nix
@@ -17,6 +17,13 @@ pythonPackages.buildPythonApplication (finalAttrs: {
     hash = "sha256-oAOJvonDDmtpmzgu8Y+BczuLYpfrVlwASIFOW7rhZ94=";
   };
 
+  # Mopidy 4 exposes CoreListener from mopidy.core instead of mopidy.core.listener.
+  # Remove when upstream supports Mopidy 4.
+  postPatch = ''
+    substituteInPlace mopidy_notify/frontend.py \
+      --replace-fail 'from mopidy.core.listener import CoreListener' 'from mopidy.core import CoreListener'
+  '';
+
   build-system = [
     pythonPackages.setuptools
   ];
@@ -26,6 +33,7 @@ pythonPackages.buildPythonApplication (finalAttrs: {
   dependencies = [
     mopidy
     pythonPackages.pydbus
+    pythonPackages.requests
   ];
 
   nativeBuildInputs = [

--- a/pkgs/applications/audio/mopidy/podcast.nix
+++ b/pkgs/applications/audio/mopidy/podcast.nix
@@ -7,17 +7,18 @@
 
 pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-podcast";
-  version = "3.0.1";
+  version = "4.0.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) version;
-    pname = "Mopidy-Podcast";
-    hash = "sha256-grNPVEVM2PlpYhBXe6sabFjWVB9+q+apIRjcHUxH52A=";
+    pname = "mopidy_podcast";
+    hash = "sha256-EnFMEhJeVjhrwOApgeU92WzYZGraBFTAntmUsc423+o=";
   };
 
   build-system = [
     pythonPackages.setuptools
+    pythonPackages.setuptools-scm
   ];
 
   dependencies = [

--- a/pkgs/applications/audio/mopidy/scrobbler.nix
+++ b/pkgs/applications/audio/mopidy/scrobbler.nix
@@ -7,17 +7,18 @@
 
 pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-scrobbler";
-  version = "2.0.1";
+  version = "3.1.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) version;
-    pname = "Mopidy-Scrobbler";
-    sha256 = "11vxgax4xgkggnq4fr1rh2rcvzspkkimck5p3h4phdj3qpnj0680";
+    pname = "mopidy_scrobbler";
+    hash = "sha256-kYBah5eUZGwFTPlyN+ILjKcZVpW4e1+VFSu2OSlN9Sw=";
   };
 
   build-system = [
     pythonPackages.setuptools
+    pythonPackages.setuptools-scm
   ];
 
   dependencies = [

--- a/pkgs/applications/audio/mopidy/somafm.nix
+++ b/pkgs/applications/audio/mopidy/somafm.nix
@@ -7,17 +7,18 @@
 
 pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-somafm";
-  version = "2.0.2";
+  version = "2.1.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) version;
-    pname = "Mopidy-SomaFM";
-    sha256 = "DC0emxkoWfjGHih2C8nINBFByf521Xf+3Ks4JRxNPLM=";
+    pname = "mopidy_somafm";
+    hash = "sha256-d7yr3jbZ28Sj5I06i34xvxZtXnynW5f6+Iem5lQ6EZ4=";
   };
 
   build-system = [
     pythonPackages.setuptools
+    pythonPackages.setuptools-scm
   ];
 
   dependencies = [

--- a/pkgs/applications/audio/mopidy/soundcloud.nix
+++ b/pkgs/applications/audio/mopidy/soundcloud.nix
@@ -7,23 +7,25 @@
 
 pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-soundcloud";
-  version = "3.0.2";
+  version = "4.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mopidy";
     repo = "mopidy-soundcloud";
     tag = "v${finalAttrs.version}";
-    sha256 = "sha256-1Qqbfw6NZ+2K1w+abMBfWo0RAmIRbNyIErEmalmWJ0s=";
+    sha256 = "sha256-3t04O9jtFe4VNl9im1sC/FY4/tTD+yQIfd+vh02VD3E=";
   };
 
   build-system = [
     pythonPackages.setuptools
+    pythonPackages.setuptools-scm
   ];
 
   dependencies = [
     mopidy
     pythonPackages.beautifulsoup4
+    pythonPackages.requests
   ];
 
   doCheck = false;

--- a/pkgs/applications/audio/mopidy/spotify.nix
+++ b/pkgs/applications/audio/mopidy/spotify.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  fetchpatch,
   pythonPackages,
   mopidy,
   nix-update-script,
@@ -8,17 +9,28 @@
 
 pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-spotify";
-  version = "5.0.0a3";
+  version = "5.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mopidy";
     repo = "mopidy-spotify";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-pM+kqeWYiPXv9DZDBTgwiEwC6Sbqv6uz5vJ5odcixOw=";
+    hash = "sha256-0h1BkC3cY1klxVQ+QsyhY/ZJgbb+LlnDuQRYQbqpHJQ=";
   };
 
-  build-system = [ pythonPackages.setuptools ];
+  patches = [
+    # Fix single-argument parametrization with pytest 9.1.
+    (fetchpatch {
+      url = "https://github.com/mopidy/mopidy-spotify/commit/5fbc4104d78ef15f81ef080c427551f9d4369873.patch";
+      hash = "sha256-JPy9l8uKWUggpfszpwfMiuNN8abnIlno+zOCB4r5s0s=";
+    })
+  ];
+
+  build-system = [
+    pythonPackages.setuptools
+    pythonPackages.setuptools-scm
+  ];
 
   dependencies = [
     mopidy

--- a/pkgs/applications/audio/mopidy/subidy.nix
+++ b/pkgs/applications/audio/mopidy/subidy.nix
@@ -24,6 +24,8 @@ pythonPackages.buildPythonApplication (finalAttrs: {
   dependencies = [
     mopidy
     pythonPackages.py-sonic
+    # Provides pkg_resources; remove when upstream replaces it.
+    pythonPackages.setuptools_80
   ];
 
   nativeCheckInputs = [

--- a/pkgs/applications/audio/mopidy/tidal.nix
+++ b/pkgs/applications/audio/mopidy/tidal.nix
@@ -32,6 +32,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
   enabledTestPaths = [ "tests/" ];
 
   meta = {
+    # The extension does not support Mopidy 4's Pydantic-based models yet.
+    broken = true;
     description = "Mopidy extension for playing music from Tidal";
     homepage = "https://github.com/EbbLabs/mopidy-tidal";
     changelog = "https://github.com/EbbLabs/mopidy-tidal/releases/tag/${finalAttrs.src.tag}";

--- a/pkgs/applications/audio/mopidy/tunein.nix
+++ b/pkgs/applications/audio/mopidy/tunein.nix
@@ -22,6 +22,9 @@ pythonPackages.buildPythonApplication (finalAttrs: {
 
   dependencies = [
     mopidy
+    pythonPackages.requests
+    # Provides pkg_resources; remove when upstream replaces it.
+    pythonPackages.setuptools_80
   ];
 
   pythonImportsCheck = [ "mopidy_tunein.tunein" ];

--- a/pkgs/applications/audio/mopidy/youtube.nix
+++ b/pkgs/applications/audio/mopidy/youtube.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitHub,
+  fetchPypi,
   pythonPackages,
   mopidy,
   pkgs,
@@ -9,15 +9,19 @@
 
 pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-youtube";
-  version = "3.7";
+  version = "4.0.2";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "natumbri";
-    repo = "mopidy-youtube";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-iFt7r8Ljymc+grNJiOClTHkZOeo7AcYpcNc8tLMPROk=";
+  src = fetchPypi {
+    pname = "mopidy_youtube";
+    inherit (finalAttrs) version;
+    hash = "sha256-KgD6cE10efNPyP0XWkpSl386Vgw+ad7Ogqo96ZGJs7w=";
   };
+
+  patches = [
+    # https://github.com/natumbri/mopidy-youtube/pull/265
+    ./fix-youtube-mopidy-4.patch
+  ];
 
   postPatch = ''
     substituteInPlace mopidy_youtube/youtube.py \
@@ -39,6 +43,8 @@ pythonPackages.buildPythonApplication (finalAttrs: {
     pythonPackages.cachetools
     pythonPackages.pykka
     pythonPackages.requests
+    # Provides pkg_resources; remove when upstream replaces it.
+    pythonPackages.setuptools_80
     pythonPackages.ytmusicapi
     pythonPackages.yt-dlp
   ]

--- a/pkgs/applications/audio/mopidy/ytmusic.nix
+++ b/pkgs/applications/audio/mopidy/ytmusic.nix
@@ -41,6 +41,8 @@ python.pkgs.buildPythonApplication (finalAttrs: {
   doCheck = false;
 
   meta = {
+    # No Mopidy 4-compatible release yet; see upstream PR #8.
+    broken = true;
     changelog = "https://github.com/jmcdo29/mopidy-ytmusic/releases/tag/${finalAttrs.src.rev}";
     description = "Mopidy extension for playing music from YouTube Music";
     homepage = "https://github.com/jmcdo29/mopidy-ytmusic";


### PR DESCRIPTION
Updates Mopidy and its extension set to Core 4. Extensions without compatible upstream releases (`mopidy-tidal` and `mopidy-ytmusic`) are marked broken instead of carrying unmerged downstream ports.

Mopidy changelog: https://github.com/mopidy/mopidy/blob/v4.0.3/docs/changelog/index.md#v403-2026-09-06

Additional patch releases included:
- Mopidy-Local 4.0.1: https://github.com/mopidy/mopidy-local/releases/tag/v4.0.1
- Mopidy-MPD 4.0.1: https://github.com/mopidy/mopidy-mpd/releases/tag/v4.0.1

Closes #528800
Closes #528790
Supersedes #537133

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
