### PR TITLE
gtk-pipe-viewer: migrate to pkgs/by-name

### DIFF
--- a/pkgs/by-name/gt/gtk-pipe-viewer/package.nix
+++ b/pkgs/by-name/gt/gtk-pipe-viewer/package.nix
@@ -1,0 +1,7 @@
+{
+  pipe-viewer,
+}:
+
+pipe-viewer.override {
+  withGtk3 = true;
+}

--- a/pkgs/by-name/pi/pipe-viewer/package.nix
+++ b/pkgs/by-name/pi/pipe-viewer/package.nix
@@ -52,6 +52,9 @@ perlPackages.buildPerlModule rec {
     hash = "sha256-24y/4NfGAyGkn9kUnuEoibkzUPBkgabE/Jp7NUNIHco=";
   };
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   nativeBuildInputs = [ makeWrapper ] ++ lib.optionals withGtk3 [ wrapGAppsHook3 ];
 
   buildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8637,8 +8637,6 @@ with pkgs;
 
   gimpPlugins = recurseIntoAttrs (callPackage ../applications/graphics/gimp/plugins { });
 
-  gtk-pipe-viewer = pipe-viewer.override { withGtk3 = true; };
-
   jetbrains = (
     recurseIntoAttrs (
       callPackages ../applications/editors/jetbrains {


### PR DESCRIPTION
This pull request refactors the packaging of `pipe-viewer` and its GTK3-enabled variant in Nixpkgs. The changes migrate the package to the `pkgs/by-name` namespace, modernize the packaging approach to use `perlPackages.buildPerlModule`, and update the way GTK3 support is handled. The top-level package definitions are updated to reflect these changes.

**Pipe-viewer packaging refactor:**

* Migrated `pipe-viewer` from `pkgs/applications/video/pipe-viewer/default.nix` to `pkgs/by-name/pi/pipe-viewer/package.nix`, updating the packaging to use `perlPackages.buildPerlModule` and modern Nix conventions. (`[[1]](diffhunk://#diff-68c6a4432747e6a304ceb8405014a1d22b0074c8e489051eb1a73f30b55745d1L4-L5)`, `[[2]](diffhunk://#diff-68c6a4432747e6a304ceb8405014a1d22b0074c8e489051eb1a73f30b55745d1L14-R43)`, `[[3]](diffhunk://#diff-68c6a4432747e6a304ceb8405014a1d22b0074c8e489051eb1a73f30b55745d1L41-R73)`)
* Improved GTK3 support by introducing a separate override in `pkgs/by-name/gt/gtk-pipe-viewer/package.nix`, which enables GTK3 via the `withGtk3` flag. (`[pkgs/by-name/gt/gtk-pipe-viewer/package.nixR1-R7](diffhunk://#diff-19f8ef3a7ae71ae12307e16c943e5effa0b733793e1b232105adf6267bfc7615R1-R7)`)

**Top-level package list updates:**

* Removed old references to `pipe-viewer` and `gtk-pipe-viewer` from `pkgs/top-level/all-packages.nix`, as these are now handled through the new locations and mechanisms. (`[[1]](diffhunk://#diff-ab5748dc9567516fefba8344056b51ec1866adeace380f46e58a7af3d619ea22L8768-L8769)`, `[[2]](diffhunk://#diff-ab5748dc9567516fefba8344056b51ec1866adeace380f46e58a7af3d619ea22L9118-L9119)`)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
