### PR TITLE
ndi-6: 6.3.1.0 -> 6.3.2.0

### DIFF
--- a/pkgs/by-name/nd/ndi-6/version.json
+++ b/pkgs/by-name/nd/ndi-6/version.json
@@ -1,1 +1,1 @@
-{"hash": "sha256:c0b5df17324888627b65217c7b850d750287c52e33e96485e2aa6b11229e603e", "version": "6.3.1.0"}
+{"hash": "sha256:f0314f245446defc488b63ceb4689acf1a965aeefdadacb70571bb216a8cc183", "version": "6.3.2.0"}


### PR DESCRIPTION
Update version of NDI-6 (package `ndi-6`) from 6.3.1.0 to 6.3.2.0. Using `pkgs/by-name/nd/ndi-6/update.py`.

Before this commit, the `ndi-6` package definition uses the hash of NDI-6 version 6.3.1.0 source,
while using the link https://downloads.ndi.tv/SDK/NDI_SDK_Linux/Install_NDI_SDK_v6_Linux.tar.gz
that always give the latest version with major version 6, which is 6.3.2.0.
As result, it contributes to build failure caused by hash mismatch.
So the main effect of this commit is to solve the current hash mismatch when building ndi-6.

Note that we still have no idea to found a stable link providing the exact version with *y* and *z* of `6.y.z` specified,
just like what described in #437690.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
