### PR TITLE
python3Packages.starfile: init at 0.5.13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23546,6 +23546,12 @@
     name = "Roland Conybeare";
     keys = [ { fingerprint = "bw5Cr/4ul1C2UvxopphbZbFI1i5PCSnOmPID7mJ/Ogo"; } ];
   };
+  rdk31 = {
+    email = "nixpkgs@rdk31.com";
+    github = "rdk31";
+    githubId = 16737959;
+    name = "rdk31";
+  };
   rdnetto = {
     email = "rdnetto@gmail.com";
     github = "rdnetto";

--- a/pkgs/development/python-modules/starfile/default.nix
+++ b/pkgs/development/python-modules/starfile/default.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+  hatch-vcs,
+
+  # dependencies
+  numpy,
+  pandas,
+  pyarrow,
+
+  # tests
+  typing-extensions,
+  pytestCheckHook,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "starfile";
+  version = "0.5.13";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "teamtomo";
+    repo = "starfile";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-klGGDvfRIBAwUoPvEG5qYukzWO94otUmBoMIkjf307I=";
+  };
+
+  build-system = [
+    hatchling
+    hatch-vcs
+  ];
+
+  nativeCheckInputs = [
+    typing-extensions
+    pytestCheckHook
+  ];
+
+  dependencies = [
+    numpy
+    pandas
+    pyarrow
+  ];
+
+  disabledTestPaths = [
+    # These tests assume string columns use the NumPy object dtype.
+    # Pandas 3 now uses StringDtype instead.
+    "tests/test_parsing.py::test_quote_loop"
+    "tests/test_parsing.py::test_parse_as_string"
+
+    # recent Pandas may return a read-only array from .values, which breaks the test
+    "tests/test_parsing.py::test_parse_na"
+  ];
+
+  pythonImportsCheck = [ "starfile" ];
+
+  meta = {
+    changelog = "https://github.com/teamtomo/starfile/releases/tag/v${finalAttrs.version}";
+    description = "STAR file I/O in Python";
+    homepage = "https://teamtomo.org/starfile";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ rdk31 ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19499,6 +19499,8 @@ self: super: with self; {
 
   stanza = callPackage ../development/python-modules/stanza { };
 
+  starfile = callPackage ../development/python-modules/starfile { };
+
   starkbank-ecdsa = callPackage ../development/python-modules/starkbank-ecdsa { };
 
   starlette = callPackage ../development/python-modules/starlette { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
