### PR TITLE
aeroflare: init at 1.11.0 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12075,6 +12075,14 @@
     githubId = 17727163;
     keys = [ { fingerprint = "FBAA B86A 101B 4C5F D4F1  25D2 E93D DAC1 7E5D 6CA1"; } ];
   };
+  itzemoji = {
+    name = "Cyril";
+    email = "no-reply@itzemoji.com";
+    github = "itzemoji";
+    matrix = "@itzemoji:matrix.org";
+    githubId = 157407989;
+    keys = [ { fingerprint = "0BBF 82C7 DD69 E57B 5BF6  88DB 2B69 366C C04B 4ED3"; } ];
+  };
   ius = {
     email = "j.de.gram@gmail.com";
     name = "Joerie de Gram";

--- a/pkgs/by-name/ae/aeroflare/package.nix
+++ b/pkgs/by-name/ae/aeroflare/package.nix
@@ -32,7 +32,7 @@ buildGoModule (finalAttrs: {
   versionCheckProgramArg = "version";
 
   meta = with lib; {
-    description = "The OCI-based Nix-Binary-Cache written in Go";
+    description = "OCI-based Nix-Binary-Cache written in Go";
     homepage = "https://github.com/itzemoji/aeroflare";
     changelog = "https://github.com/itzemoji/aeroflare/blob/v${finalAttrs.version}/CHANGELOG.md";
     platforms = platforms.unix;

--- a/pkgs/by-name/ae/aeroflare/package.nix
+++ b/pkgs/by-name/ae/aeroflare/package.nix
@@ -29,11 +29,7 @@ buildGoModule (finalAttrs: {
     "cmd/aeroflare"
     "cmd/aeroflare-ci"
   ];
-  passthru.tests.version = pkgs.runCommand "aeroflare-version" { } ''
-    ${finalAttrs.finalPackage}/bin/aeroflare version \
-      | grep "^aeroflare version ${finalAttrs.version}$"
-    touch "$out"
-  '';
+  versionCheckProgramArg = "version";
 
   meta = with lib; {
     description = "The OCI-based Nix-Binary-Cache written in Go";

--- a/pkgs/by-name/ae/aeroflare/package.nix
+++ b/pkgs/by-name/ae/aeroflare/package.nix
@@ -14,7 +14,7 @@ buildGoModule (finalAttrs: {
     owner = "itzemoji";
     repo = "aeroflare";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-4l0QVJAgKqS/tnMD6GncQdbefWPncmS4QDIz7QEiPrk=";
+    hash = "sha256-8R+9/1DNkQg/hS6Mpc9rswK+rUkUUJpWYWfkThRLMJE=";
   };
 
   vendorHash = "sha256-H4jgc08mklolpHQNlcQx5JzpCDBYpujgoKFR2Ct8xR8=";

--- a/pkgs/by-name/ae/aeroflare/package.nix
+++ b/pkgs/by-name/ae/aeroflare/package.nix
@@ -34,7 +34,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "OCI-based Nix-Binary-Cache written in Go";
     homepage = "https://github.com/itzemoji/aeroflare";
-    changelog = "https://github.com/itzemoji/aeroflare/blob/${finalAttrs.version}/CHANGELOG.md";
+    changelog = "https://github.com/itzemoji/aeroflare/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     platforms = lib.platforms.unix;
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ itzemoji ];

--- a/pkgs/by-name/ae/aeroflare/package.nix
+++ b/pkgs/by-name/ae/aeroflare/package.nix
@@ -34,7 +34,7 @@ buildGoModule (finalAttrs: {
   meta = with lib; {
     description = "OCI-based Nix-Binary-Cache written in Go";
     homepage = "https://github.com/itzemoji/aeroflare";
-    changelog = "https://github.com/itzemoji/aeroflare/blob/v${finalAttrs.version}/CHANGELOG.md";
+    changelog = "https://github.com/itzemoji/aeroflare/blob/${finalAttrs.version}/CHANGELOG.md";
     platforms = platforms.unix;
     license = licenses.gpl3Only;
     maintainers = with lib.maintainers; [ itzemoji ];

--- a/pkgs/by-name/ae/aeroflare/package.nix
+++ b/pkgs/by-name/ae/aeroflare/package.nix
@@ -31,12 +31,12 @@ buildGoModule (finalAttrs: {
   ];
   versionCheckProgramArg = "version";
 
-  meta = with lib; {
+  meta = {
     description = "OCI-based Nix-Binary-Cache written in Go";
     homepage = "https://github.com/itzemoji/aeroflare";
     changelog = "https://github.com/itzemoji/aeroflare/blob/${finalAttrs.version}/CHANGELOG.md";
-    platforms = platforms.unix;
-    license = licenses.gpl3Only;
+    platforms = lib.platforms.unix;
+    license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ itzemoji ];
     mainProgram = "aeroflare";
   };

--- a/pkgs/by-name/ae/aeroflare/package.nix
+++ b/pkgs/by-name/ae/aeroflare/package.nix
@@ -13,7 +13,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "itzemoji";
     repo = "aeroflare";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-8R+9/1DNkQg/hS6Mpc9rswK+rUkUUJpWYWfkThRLMJE=";
   };
 

--- a/pkgs/by-name/ae/aeroflare/package.nix
+++ b/pkgs/by-name/ae/aeroflare/package.nix
@@ -33,7 +33,7 @@ buildGoModule (finalAttrs: {
     ${finalAttrs.finalPackage}/bin/aeroflare version \
       | grep "^aeroflare version ${finalAttrs.version}$"
     touch "$out"
-    '';
+  '';
 
   meta = with lib; {
     description = "The OCI-based Nix-Binary-Cache written in Go";

--- a/pkgs/by-name/ae/aeroflare/package.nix
+++ b/pkgs/by-name/ae/aeroflare/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  pkgs,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "aeroflare";
+  version = "1.11.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "itzemoji";
+    repo = "aeroflare";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-4l0QVJAgKqS/tnMD6GncQdbefWPncmS4QDIz7QEiPrk=";
+  };
+
+  vendorHash = "sha256-H4jgc08mklolpHQNlcQx5JzpCDBYpujgoKFR2Ct8xR8=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/itzemoji/aeroflare/internal/build.Version=${finalAttrs.version}"
+  ];
+
+  subPackages = [
+    "cmd/aeroflare"
+    "cmd/aeroflare-ci"
+  ];
+  passthru.tests.version = pkgs.runCommand "aeroflare-version" { } ''
+    ${finalAttrs.finalPackage}/bin/aeroflare version \
+      | grep "^aeroflare version ${finalAttrs.version}$"
+    touch "$out"
+    '';
+
+  meta = with lib; {
+    description = "The OCI-based Nix-Binary-Cache written in Go";
+    homepage = "https://github.com/itzemoji/aeroflare";
+    changelog = "https://github.com/itzemoji/aeroflare/blob/v${finalAttrs.version}/CHANGELOG.md";
+    platforms = platforms.unix;
+    license = licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ itzemoji ];
+    mainProgram = "aeroflare";
+  };
+})


### PR DESCRIPTION
<!--
This PR adds Aeroflare, an OCI-backed binary cache for Nix.

Aeroflare stores Nix artifacts directly in OCI registries (such as GHCR) and uses OCI tags for O(1) lookups instead of maintaining a separate index file.

The project originated as a rewrite of nixcache-oci but has since evolved into a different implementation with a simpler architecture centered around native OCI primitives.

I am the upstream author and will maintain this package.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
