### PR TITLE
mcron: 1.2.1 -> 1.2.3

### DIFF
--- a/pkgs/by-name/mc/mcron/mac-username.patch
+++ b/pkgs/by-name/mc/mcron/mac-username.patch
@@ -1,0 +1,11 @@
+--- a/src/mcron/vixie-specification.scm
++++ b/src/mcron/vixie-specification.scm
+@@ -67,7 +67,7 @@
+ 
+ (define parse-system-vixie-line-regexp
+   (make-regexp (string-append "^[[:space:]]*(([^[:space:]]+[[:space:]]+){5})"
+-                              "([[:alpha:]][[:alnum:]_]*)[[:space:]]+(.*)$")))
++                              "([[:alpha:]_][[:alnum:]_.-]*)[[:space:]]+(.*)$")))
+ 
+ (define (parse-system-vixie-line line)
+   (let ((match (regexp-exec parse-system-vixie-line-regexp line)))

--- a/pkgs/by-name/mc/mcron/package.nix
+++ b/pkgs/by-name/mc/mcron/package.nix
@@ -8,16 +8,23 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mcron";
-  version = "1.2.1";
+  version = "1.2.3";
 
   src = fetchurl {
     url = "mirror://gnu/mcron/mcron-${finalAttrs.version}.tar.gz";
-    sha256 = "0bkn235g2ia4f7ispr9d55c7bc18282r3qd8ldhh5q2kiin75zi0";
+    sha256 = "sha256-G8jA02LTsaMPoAcdf6tpa7/B2h7VNsQuBIC7n/0iFU4=";
   };
 
-  # don't attempt to chmod +s files in the nix store
+  patches = lib.optionals stdenv.hostPlatform.isDarwin [
+    ./mac-username.patch
+  ];
+
+  # Setuid is not usable from the Nix store; also drop -static on the
+  # crontab-access helper (needs a static libc, fails on Darwin).
   postPatch = ''
     sed -E -i '/chmod u\+s/d' Makefile.in
+    substituteInPlace Makefile.in \
+      --replace-fail 'bin_crontab_access_LDFLAGS = -static' 'bin_crontab_access_LDFLAGS ='
   '';
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
## Summary
Update GNU mcron from 1.2.1 to 1.2.3.
Notable changes: Vixie cron mode fixes, crontab split into a setuid helper, Guile/autoconf detection updates, Guile 2.2 support dropped.
https://git.savannah.gnu.org/cgit/mcron.git/log/?h=v1.2.3
## Things done
- [x] Fits CONTRIBUTING.md / pkgs/README.md
- [x] Follows the automation/AI policy