### PR TITLE
hercules: 4.8 -> 4.9.1

### DIFF
--- a/pkgs/by-name/he/hercules/package.nix
+++ b/pkgs/by-name/he/hercules/package.nix
@@ -108,13 +108,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "hercules";
-  version = "4.8";
+  version = "4.9.1";
 
   src = fetchFromGitHub {
     owner = "SDL-Hercules-390";
     repo = "hyperion";
     rev = "Release_${finalAttrs.version}";
-    hash = "sha256-3Go5m4/K8d4Vu7Yi8ULQpX83d44fu9XzmG/gClWeUKo=";
+    hash = "sha256-+ti94ubU7CdXRyatvneUES+qaMLwHmdtq04WRu7UiiY=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Release Notes: https://sdl-hercules-390.github.io/html/hercrnot.html#4.9.1
Commits between releases: https://github.com/SDL-Hercules-390/hyperion/compare/Release_4.8...Release_4.9.1

Basically a bunch of *important* fixes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
