### PR TITLE
[Backport release-26.05] grok-build for x86_64-darwin

### DIFF
--- a/pkgs/by-name/gr/grok-build/package.nix
+++ b/pkgs/by-name/gr/grok-build/package.nix
@@ -10,7 +10,7 @@
   grok-build,
 }:
 let
-  version = "0.2.82";
+  version = "0.2.93";
 
   throwSystem = throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}";
 
@@ -27,10 +27,10 @@ let
       url = "https://x.ai/cli/grok-${version}-${upstreamPlatform}";
       hash =
         {
-          x86_64-linux = "sha256-x0+vJ1FB4WVIgCQY6/EHY5R+uqAPJCe7gPAiq6Y2iP4=";
-          aarch64-linux = "sha256-tHJ8YAeG1ko++xn3OmyLlRsHWzXW+nypUZoIlBFQelg=";
-          x86_64-darwin = "sha256-wCiGbPt50wH/he2VJhdqFD2rUiUznZL0Hj8hUo4+s5Y=";
-          aarch64-darwin = "sha256-HkyKeLBQ2TVj4g9iKkGjT46WuAV1sclYrT8JUxb+YYk=";
+          x86_64-linux = "sha256-Tgc407VVDzyEK8CuafRogVxjKcAIoRDQwnppTcNAETU=";
+          aarch64-linux = "sha256-7a4g6SoKM/7ewao0iPPjgI2MTKISj8jzE/vYGOPpX18=";
+          x86_64-darwin = "sha256-8xDJT3lft4OY97M4cxF00Uq6IpqJWJXlyHlpr78/ypU=";
+          aarch64-darwin = "sha256-Kpe6Z1vZkqqbmB4ug3dkYNlPRptRDAuO/ii1DSNtdnw=";
         }
         .${system};
     }

--- a/pkgs/by-name/gr/grok-build/package.nix
+++ b/pkgs/by-name/gr/grok-build/package.nix
@@ -1,0 +1,100 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  installShellFiles,
+  autoPatchelfHook,
+  versionCheckHook,
+  runCommand,
+  testers,
+  grok-build,
+}:
+let
+  version = "0.2.82";
+
+  throwSystem = throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}";
+
+  platform = {
+    x86_64-linux = "linux-x86_64";
+    aarch64-linux = "linux-aarch64";
+    x86_64-darwin = "macos-x86_64";
+    aarch64-darwin = "macos-aarch64";
+  };
+
+  sourceData = lib.mapAttrs (
+    system: upstreamPlatform:
+    fetchurl {
+      url = "https://x.ai/cli/grok-${version}-${upstreamPlatform}";
+      hash =
+        {
+          x86_64-linux = "sha256-x0+vJ1FB4WVIgCQY6/EHY5R+uqAPJCe7gPAiq6Y2iP4=";
+          aarch64-linux = "sha256-tHJ8YAeG1ko++xn3OmyLlRsHWzXW+nypUZoIlBFQelg=";
+          x86_64-darwin = "sha256-wCiGbPt50wH/he2VJhdqFD2rUiUznZL0Hj8hUo4+s5Y=";
+          aarch64-darwin = "sha256-HkyKeLBQ2TVj4g9iKkGjT46WuAV1sclYrT8JUxb+YYk=";
+        }
+        .${system};
+    }
+  ) platform;
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "grok-build";
+  inherit version;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = sourceData.${stdenvNoCC.hostPlatform.system} or throwSystem;
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [
+    installShellFiles
+  ]
+  ++ lib.optionals stdenvNoCC.hostPlatform.isElf [ autoPatchelfHook ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 "$src" "$out/bin/grok"
+    ln -s grok "$out/bin/agent"
+
+    ${lib.optionalString (stdenvNoCC.buildPlatform.canExecute stdenvNoCC.hostPlatform) ''
+      installShellCompletion --cmd grok \
+        --bash <("$out/bin/grok" completions bash) \
+        --fish <("$out/bin/grok" completions fish) \
+        --zsh <("$out/bin/grok" completions zsh)
+    ''}
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    # ensure is a symlink
+    test -L "$out/bin/agent"
+
+    # ensure agent points at grok
+    [ "$(readlink -f "$out/bin/agent")" = "$(readlink -f "$out/bin/grok")" ]
+
+    runHook postInstallCheck
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Command-line coding agent by xAI";
+    homepage = "https://docs.x.ai/build/overview";
+    downloadPage = "https://x.ai/cli/stable";
+    license = lib.licenses.unfreeRedistributable;
+    maintainers = with lib.maintainers; [ crertel ];
+    platforms = lib.attrNames sourceData;
+    mainProgram = "grok";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/gr/grok-build/update.sh
+++ b/pkgs/by-name/gr/grok-build/update.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl common-updater-scripts
+
+set -euo pipefail
+
+version="$(curl -fsSL https://x.ai/cli/stable)"
+
+currentVersion=$(
+  nix-instantiate --eval --raw -E "with import ./. {}; grok-build.version or (lib.getVersion grok-build)"
+)
+
+if [[ "$currentVersion" == "$version" ]]; then
+  echo "package is up-to-date: $version"
+  exit 0
+fi
+
+update-source-version grok-build "${version}" || true
+
+for system in "aarch64-darwin macos-aarch64" "aarch64-linux linux-aarch64" "x86_64-darwin macos-x86_64" "x86_64-linux linux-x86_64"; do
+  # shellcheck disable=SC2086
+  set -- ${system}
+
+  arch="${1}"
+  platform="${2}"
+
+  url="https://x.ai/cli/grok-${version}-${platform}"
+  hash=$(
+    nix --extra-experimental-features nix-command hash convert --hash-algo sha256 "$(
+      nix-prefetch-url "${url}"
+    )"
+  )
+
+  update-source-version grok-build "${version}" "${hash}" --system="${arch}" --ignore-same-version
+done


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Backports `grok-build` to `release-26.05`.

  This includes the existing upstream `grok-build` package as merged in:

  - https://github.com/NixOS/nixpkgs/pull/538004
  - https://github.com/NixOS/nixpkgs/pull/539866

  The backport is useful for `x86_64-darwin` users because 26.05 is the final
  Nixpkgs release branch that supports Intel macOS. The original `grok-build`
  commits still included `x86_64-darwin`; that platform was later removed from
  `master` as part of the 26.11 platform removal work:

  - https://github.com/NixOS/nixpkgs/pull/541145
  - https://github.com/NixOS/nixpkgs/pull/541166

Built and tested on x86_64-darwin
If this PR doesn’t align with your policies, feel free to close it.

---

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
