### PR TITLE
python3Packages.hepdata-lib: init at 0.21.0

### DIFF
--- a/pkgs/development/python-modules/hepdata-converter/default.nix
+++ b/pkgs/development/python-modules/hepdata-converter/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  hepdata-validator,
+  root,
+  yoda,
+  pytestCheckHook,
+  coverage,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "hepdata-converter";
+  version = "0.3.3";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "HEPData";
+    repo = "hepdata-converter";
+    tag = finalAttrs.version;
+    hash = "sha256-1aq+7JM/4J5gfnzkYTOdhXoXm8KJEB5xuqLTCeKSBsE=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    hepdata-validator
+    # ROOT and yoda writers are loaded unconditionally at import time.
+    root
+    yoda
+  ];
+
+  nativeCheckInputs = [
+    coverage
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # Fails with newer ROOT due to a mismatch in produced histogram names.
+    "hepdata_converter/testsuite/test_rootwriter.py::ROOTWriterTestSuite::test_simple_parse"
+    # yoda in nixpkgs is not built with HDF5 support.
+    "hepdata_converter/testsuite/test_yodawriter.py::YODAWriterTestSuite::test_parse_h5"
+  ];
+
+  pythonImportsCheck = [ "hepdata_converter" ];
+
+  meta = {
+    description = "Library providing means of conversion between oldhepdata format and the new one, and the new one to csv / yoda / root etc";
+    homepage = "https://github.com/HEPData/hepdata-converter";
+    changelog = "https://github.com/HEPData/hepdata-converter/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ veprbl ];
+    mainProgram = "hepdata-converter";
+  };
+})

--- a/pkgs/development/python-modules/hepdata-lib/default.nix
+++ b/pkgs/development/python-modules/hepdata-lib/default.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  numpy,
+  pyyaml,
+  hist,
+  scipy,
+  hepdata-validator,
+  root,
+  imagemagick,
+  pytestCheckHook,
+  pytest-cov,
+  withRootSupport ? false,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "hepdata_lib";
+  version = "0.21.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "HEPData";
+    repo = "hepdata_lib";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+RoiH0yFfR2dJxstk4JWUHWNk5TQH6fgEl7f78Ej2KI=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    numpy
+    pyyaml
+    hist
+    scipy
+    hepdata-validator
+  ]
+  ++ lib.optionals withRootSupport [ root ];
+
+  nativeCheckInputs = [
+    (imagemagick.override { ghostscriptSupport = true; })
+    pytest-cov
+    pytestCheckHook
+  ];
+
+  disabledTestMarks = lib.optionals (!withRootSupport) [ "needs_root" ];
+
+  # These execute example Jupyter notebooks via papermill, requiring extra
+  # test-only dependencies (papermill, ipykernel) that are not packaged here.
+  disabledTestPaths = [ "tests/test_notebooks.py" ];
+
+  pythonImportsCheck = [ "hepdata_lib" ];
+
+  meta = {
+    description = "Library for getting your data into HEPData";
+    homepage = "https://github.com/HEPData/hepdata_lib";
+    changelog = "https://github.com/HEPData/hepdata_lib/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ veprbl ];
+  };
+})

--- a/pkgs/development/python-modules/hepdata-validator/default.nix
+++ b/pkgs/development/python-modules/hepdata-validator/default.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  click,
+  jsonschema,
+  packaging,
+  pyyaml,
+  requests,
+  pytestCheckHook,
+  pytest-cov,
+  mock,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "hepdata-validator";
+  version = "0.3.6";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "HEPData";
+    repo = "hepdata-validator";
+    tag = finalAttrs.version;
+    hash = "sha256-Cp5UF6ULnZhebwOuVKImwtz3ceL2iXFyDNH3RQPgpIA=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    click
+    jsonschema
+    packaging
+    pyyaml
+    requests
+  ];
+
+  nativeCheckInputs = [
+    mock
+    pytest-cov
+    pytestCheckHook
+  ];
+
+  # These tests require network access to download or resolve schemas.
+  disabledTestPaths = [
+    "testsuite/test_schema_downloader.py"
+    "testsuite/test_schema_resolver.py"
+  ];
+
+  disabledTests = [
+    # These require network access.
+    "test_valid_schema_with_no_local_copy"
+    "test_valid_submission_dir_remote_schema"
+    "test_valid_submission_dir_remote_schema_no_autoloading"
+    "test_valid_submission_dir_remote_schema_multiple_loads"
+    "test_invalid_remote_schema"
+  ];
+
+  pythonImportsCheck = [ "hepdata_validator" ];
+
+  meta = {
+    description = "JSON schema and validation code for HEPData submissions";
+    homepage = "https://github.com/HEPData/hepdata-validator";
+    changelog = "https://github.com/HEPData/hepdata-validator/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ veprbl ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7492,6 +7492,8 @@ self: super: with self; {
 
   hepdata-converter = callPackage ../development/python-modules/hepdata-converter { };
 
+  hepdata-lib = callPackage ../development/python-modules/hepdata-lib { };
+
   hepdata-validator = callPackage ../development/python-modules/hepdata-validator { };
 
   hepmc3 = toPythonModule (pkgs.hepmc3.override { inherit python; });

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7490,6 +7490,8 @@ self: super: with self; {
 
   helper = callPackage ../development/python-modules/helper { };
 
+  hepdata-validator = callPackage ../development/python-modules/hepdata-validator { };
+
   hepmc3 = toPythonModule (pkgs.hepmc3.override { inherit python; });
 
   hepunits = callPackage ../development/python-modules/hepunits { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7490,6 +7490,8 @@ self: super: with self; {
 
   helper = callPackage ../development/python-modules/helper { };
 
+  hepdata-converter = callPackage ../development/python-modules/hepdata-converter { };
+
   hepdata-validator = callPackage ../development/python-modules/hepdata-validator { };
 
   hepmc3 = toPythonModule (pkgs.hepmc3.override { inherit python; });


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
