### PR TITLE
nixos/navidrome: Add administration wrapper

### DIFF
--- a/nixos/modules/services/audio/navidrome.nix
+++ b/nixos/modules/services/audio/navidrome.nix
@@ -13,6 +13,7 @@ let
     mkPackageOption
     mkOption
     maintainers
+    optionals
     ;
   inherit (lib.types)
     addCheck
@@ -23,6 +24,11 @@ let
     str
     submodule
     ;
+  inherit (pkgs)
+    symlinkJoin
+    makeWrapper
+    ;
+
   cfg = config.services.navidrome;
   settingsFormat = pkgs.formats.json { };
 in
@@ -33,6 +39,16 @@ in
       enable = mkEnableOption "Navidrome music server";
 
       package = mkPackageOption pkgs "navidrome" { };
+
+      adminWrapper = mkOption {
+        type = bool;
+        default = true;
+        example = false;
+        description = ''
+          Add a wrapped Navidrome to PATH for CLI admin tasks.
+          This wrapped Navidrome will be called "navidrome-cli".
+        '';
+      };
 
       plugins = mkOption {
         type = listOf (
@@ -146,6 +162,46 @@ in
     let
       inherit (lib) mkIf optional getExe;
       WorkingDirectory = "/var/lib/navidrome";
+
+      settingsFile = settingsFormat.generate "navidrome.json" cfg.settings;
+
+      # Wrapper so that users can do admin tasks with the configured navidrome
+      wrappedNavi = symlinkJoin {
+        inherit (cfg.finalPackage) pname version;
+
+        paths = [
+          cfg.finalPackage
+        ];
+
+        strictDeps = true;
+        __structuredAttrs = true;
+
+        nativeBuildInputs = [
+          makeWrapper
+        ];
+
+        wrapperArgs = [
+          "--add-flag"
+          "--configfile"
+          "--add-flag"
+          "${settingsFile}"
+        ]
+        ++ optionals (cfg.environmentFile != null) [
+          "--run"
+          "source ${cfg.environmentFile}"
+        ];
+
+        postBuild = ''
+          makeWrapper "${lib.getExe cfg.finalPackage}" "$out/bin/navidrome-cli" \
+            "''${wrapperArgs[@]}"
+
+          rm "$out/bin/navidrome"
+        '';
+
+        meta = cfg.finalPackage.meta // {
+          mainProgram = "navidrome-cli";
+        };
+      };
     in
     mkIf cfg.enable {
       systemd = {
@@ -169,9 +225,7 @@ in
           after = [ "network.target" ];
           wantedBy = [ "multi-user.target" ];
           serviceConfig = {
-            ExecStart = ''
-              ${getExe cfg.finalPackage} --configfile ${settingsFormat.generate "navidrome.json" cfg.settings}
-            '';
+            ExecStart = "${lib.getExe cfg.finalPackage} --configfile ${settingsFile}";
             EnvironmentFile = lib.mkIf (cfg.environmentFile != null) [ cfg.environmentFile ];
             User = cfg.user;
             Group = cfg.group;
@@ -235,6 +289,10 @@ in
       users.groups = mkIf (cfg.group == "navidrome") { navidrome = { }; };
 
       networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.settings.Port ];
+
+      environment.systemPackages = mkIf cfg.adminWrapper [
+        wrappedNavi
+      ];
     };
   meta.maintainers = with maintainers; [
     fsnkty


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add an optional (but defaulted to true) wrapper for administration tasks to PATH. This allows users to run things like `navidrome backup` from the CLI easier.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
