### PR TITLE
python3Packages.{mmengine,mmcv}: pin setuptools at 80 to fix build

### DIFF
--- a/pkgs/development/python-modules/mmcv/default.nix
+++ b/pkgs/development/python-modules/mmcv/default.nix
@@ -12,6 +12,9 @@
   pybind11,
   torch,
 
+  # build-system
+  setuptools_80,
+
   # dependencies
   addict,
   mmengine,
@@ -79,6 +82,10 @@ buildPythonPackage (finalAttrs: {
       libcusparse # cusparse.h
     ]
   );
+
+  # https://github.com/open-mmlab/mmengine/issues/1616
+  # also applies here
+  build-system = [ setuptools_80 ];
 
   dependencies = [
     addict

--- a/pkgs/development/python-modules/mmengine/default.nix
+++ b/pkgs/development/python-modules/mmengine/default.nix
@@ -6,7 +6,7 @@
   fetchpatch,
 
   # build-system
-  setuptools,
+  setuptools_80,
 
   # dependencies
   addict,
@@ -71,7 +71,8 @@ buildPythonPackage (finalAttrs: {
         --replace-fail "import numpy.compat" ""
     '';
 
-  build-system = [ setuptools ];
+  # https://github.com/open-mmlab/mmengine/issues/1616
+  build-system = [ setuptools_80 ];
 
   dependencies = [
     addict


### PR DESCRIPTION
Build fails with `ModuleNotFoundError: No module named 'pkg_resources'`

1. `pkg_resources` was dropped in `setuptools` 83, so pin at `setuptools_80`
2.  Added note to https://github.com/open-mmlab/mmengine/issues/1616

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
