### PR TITLE
casync: drop fuse support

### DIFF
--- a/pkgs/by-name/ca/casync/package.nix
+++ b/pkgs/by-name/ca/casync/package.nix
@@ -9,12 +9,10 @@
   sphinx,
   acl,
   curl,
-  fuse,
   libselinux,
   udev,
   xz,
   zstd,
-  fuseSupport ? true,
   selinuxSupport ? true,
   udevSupport ? true,
   glibcLocales,
@@ -39,7 +37,6 @@ stdenv.mkDerivation {
     xz
     zstd
   ]
-  ++ lib.optionals fuseSupport [ fuse ]
   ++ lib.optionals selinuxSupport [ libselinux ]
   ++ lib.optionals udevSupport [ udev ];
   nativeBuildInputs = [
@@ -66,10 +63,12 @@ stdenv.mkDerivation {
 
   env.PKG_CONFIG_UDEV_UDEVDIR = "lib/udev";
 
-  mesonFlags =
-    lib.optionals (!fuseSupport) [ "-Dfuse=false" ]
-    ++ lib.optionals (!udevSupport) [ "-Dudev=false" ]
-    ++ lib.optionals (!selinuxSupport) [ "-Dselinux=false" ];
+  mesonFlags = [
+    # fuse2 only, https://github.com/systemd/casync/issues/269
+    "-Dfuse=false"
+  ]
+  ++ lib.optionals (!udevSupport) [ "-Dudev=false" ]
+  ++ lib.optionals (!selinuxSupport) [ "-Dselinux=false" ];
 
   doCheck = true;
   preCheck = ''


### PR DESCRIPTION
Upstream does not seem to support fuse3 any time soon: https://github.com/systemd/casync/issues/269

Drop fuse support for now to get rid of our FUSE dependency.

Closes #534923.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
