### PR TITLE
vigra: fix hdf5 discovery

### DIFF
--- a/pkgs/by-name/vi/vigra/package.nix
+++ b/pkgs/by-name/vi/vigra/package.nix
@@ -7,6 +7,7 @@
   fftw,
   fftwSinglePrec,
   hdf5,
+  libaec,
   libjpeg,
   libpng,
   libtiff,
@@ -43,6 +44,9 @@ stdenv.mkDerivation (finalAttrs: {
     (hdf5.override {
       apiVersion = "v110";
     })
+    # Satisfy the HDF5_SZLIB_OK check in the source's config/FindHDF5.cmake
+    # libaec is a drop-in replacement of szip.
+    libaec
     libjpeg
     libpng
     libtiff


### PR DESCRIPTION
The vigra package currently claims hdf5 not foun
due to szip supporch check `HDF5_SZLIB_OK` not passing.

```
vigra> -- Searching for HDF5
vigra> --    in default locations
vigra> --    Checking HDF5 version (at least 1.8): ok
vigra> -- Could NOT find HDF5 (missing: HDF5_SZLIB_OK)
```

Szip support has been added to the hdf5 package
with PR #509836 , and vigra's `FindHDF5.cmake` is aware of that by testing with H5pubconf.h. What fails the `HDF5_SZLIB_OK` check happens to be szip not presented, which is not quite sensible as vigra itself doesn't use szip.

Before fixing from the upstream, let's present szip and please the check Here, libaec is a FOSS implementation of the unfree szip.

```
vigra> -- Searching for HDF5
vigra> --    in default locations
vigra> --    Checking HDF5 version (at least 1.8): ok
vigra> -- Found HDF5: /nix/store/ns33kp8h1sx58fv2p5z07vfgy8x48yv1-hdf5-cpp-1.14.6/lib/libhdf5.so
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
