### PR TITLE
softnet: 0.7.1 -> 0.21.1

### DIFF
--- a/pkgs/by-name/so/softnet/package.nix
+++ b/pkgs/by-name/so/softnet/package.nix
@@ -5,11 +5,11 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "softnet";
-  version = "0.7.1";
+  version = "0.21.1";
 
   src = fetchurl {
-    url = "https://github.com/cirruslabs/softnet/releases/download/${finalAttrs.version}/softnet.tar.gz";
-    sha256 = "1g274x524xc85hfzxi3vb4xp720bjgk740bp6hc92d1ikmp0b664";
+    url = "https://github.com/openai/softnet/releases/download/${finalAttrs.version}/softnet.tar.gz";
+    hash = "sha256-vhxz1Hxbn/26Ie++Zbi2QLnUYlCt5YisSVDbziQRq6Y=";
   };
   sourceRoot = ".";
 
@@ -24,8 +24,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Software networking with isolation for Tart";
-    homepage = "https://github.com/cirruslabs/softnet";
-    license = lib.licenses.agpl3Plus;
+    homepage = "https://github.com/openai/softnet";
+    license = lib.licenses.fsl11Asl20;
     maintainers = with lib.maintainers; [ emilytrau ];
     platforms = [ "aarch64-darwin" ];
     # Source build will be possible after darwin SDK 12.0 bump


### PR DESCRIPTION
For changes see https://github.com/openai/softnet/releases and more specifically openai/softnet#166.

Note also that the auto-updater has been failing for quite a while: https://nixpkgs-update-logs.nix-community.org/softnet/2025-10-26.log

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
