### PR TITLE
installFonts: split truetype output

### DIFF
--- a/pkgs/by-name/in/installFonts/install-fonts.sh
+++ b/pkgs/by-name/in/installFonts/install-fonts.sh
@@ -32,13 +32,50 @@ installFont() {
   find -iname "*.$1" -print0 | xargs -0 -r install -m644 -D -t "$2"
 }
 
+handleBaseFontTypes() {
+  local otfs=$(find -iname "*.otf")
+  local otcs=$(find -iname "*.otc")
+  set -f
+  otfs=(${otfs[@]})
+  otcs=(${otcs[@]})
+  set +f
+
+  # Individual fonts
+  if [[ ${#otfs[@]} -eq 0 ]]; then
+    installFont 'ttf' "$out/share/fonts/truetype"
+  else
+    if [ -n "${truetype-}" ]; then
+      installFont 'ttf' "$truetype/share/fonts/truetype"
+    else
+      echo "ERROR: installFonts: Please create a 'truetype' output"
+      exit 1
+    fi
+    for otffont in "${otfs[@]}"; do
+      install -Dm644 "$otffont" -t "$out/share/fonts/opentype"
+    done
+  fi
+
+  # Collections
+  if [[ ${#otcs[@]} -eq 0 ]]; then
+    installFont 'ttc' "$out/share/fonts/truetype"
+  else
+    if [ -n "${truetype-}" ]; then
+      installFont 'ttc' "$truetype/share/fonts/truetype"
+    else
+      cho "ERROR: installFonts: Please create a 'truetype' output"
+      exit 1
+    fi
+    for otcfont in "${otcs[@]}"; do
+      install -Dm644 "$otcfont" -t "$out/share/fonts/opentype"
+    done
+  fi
+}
+
 installFonts() {
   if [ "${dontInstallFonts-}" == 1 ]; then return; fi
 
-  installFont 'ttf' "$out/share/fonts/truetype"
-  installFont 'ttc' "$out/share/fonts/truetype"
-  installFont 'otf' "$out/share/fonts/opentype"
-  installFont 'otc' "$out/share/fonts/opentype"
+  handleBaseFontTypes
+
   installFont 'pfa' "$out/share/fonts/type1"
   installFont 'pfb' "$out/share/fonts/type1"
   installFont 'pfm' "$out/share/fonts/type1"


### PR DESCRIPTION
Proof of concept based on a conversation I had inside of #515634 
Figured I'd write this up so we could discuss if it makes sense to do in a more sensible place.

There's an unfortunate thing which is that it's not really possible to install truetype + others (some type1 for example) without opentype specifically, but the odds of needing that seem not very likely, especially since fontconfig seems to prefer matching ttf when it exists. Unfortunately we can't set `meta.outputsToInstall` in a hook, otherwise we could maybe be a little more clever about that but keep a nice interface.

For folks that *always* want truetype though `extraOutputsToInstall` would work.

> [!NOTE]
> this won't actually work until I go through and add the outputs to packages, but I'm not going to bother until we decide if it is useful
>   
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
