### PR TITLE
xorg-server: re-enable strictflexarrays1 on darwin

### DIFF
--- a/pkgs/by-name/xo/xorg-server/package.nix
+++ b/pkgs/by-name/xo/xorg-server/package.nix
@@ -176,9 +176,6 @@ stdenv.mkDerivation (finalAttrs: {
       --subst-var-by XQUARTZ_APP "$out/Applications/XQuartz.app"
   '';
 
-  # avoid linux rebuilds
-  ${if stdenv.hostPlatform.isDarwin then "hardeningDisable" else null} = [ "strictflexarrays1" ];
-
   # default X install symlinks this to Xorg, we want XQuartz
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     ln -sf $out/bin/Xquartz $out/bin/X

--- a/pkgs/by-name/xt/xtrans/package.nix
+++ b/pkgs/by-name/xt/xtrans/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   pkg-config,
   writeScript,
   testers,
@@ -14,6 +15,14 @@ stdenv.mkDerivation (finalAttrs: {
     url = "mirror://xorg/individual/lib/xtrans-${finalAttrs.version}.tar.xz";
     hash = "sha256-+q/qFmvyRRoXPZ1ZM1KUDsZAQUXF0dpcITQjzk01npI=";
   };
+
+  patches = [
+    # fix darwin crashes with fortify when using launchctl socket activation
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/xorg/lib/libxtrans/-/commit/79f6b0bfe2170496e8c37626043d009f4cd3f1e1.patch";
+      hash = "sha256-Y8QY1yAiOI/rSNi71/Qhsn6UEql556/pS2av7+vmGQA=";
+    })
+  ];
 
   strictDeps = true;
 


### PR DESCRIPTION
The check was disabled because xquartz crashed on darwin when activated via a
(long named) launchd socket. The cause was in xtrans, and it was fixed
upstream. The PR backports xtrans fix and re-enables the check.

- **xtrans: fix darwin fortify crash in xorg-server**
- **xorg-server: enable strictflexarrays1 on darwin**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
