### PR TITLE
nixos/imapgoose: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -46,6 +46,8 @@
 
 - [mail-tlsa-check-exporter](https://github.com/ietf-tools/mail-tlsa-check-exporter), validates SMTP / IMAP server certificates against a TLSA record as a Prometheus exporter. Available as [services.prometheus.exporters.mail-tlsa-check](#opt-services.prometheus.exporters.mail-tlsa-check.enable).
 
+- [ImapGoose](https://git.sr.ht/~whynothugo/ImapGoose), a daemon that keeps local Maildir directories synchronised with IMAP servers. Available as [services.imapgoose.instances.\<name\>](options.html#opt-services.imapgoose.instances), which runs one daemon per configured user, each synchronising that user's IMAP accounts under its own OS user.
+
 - [feishin](https://github.com/jeffvli/feishin), a modern self-hosted music player. Available as [services.feishin](#opt-services.feishin.enable).
 
 - [CastSponsorSkip](https://github.com/gabe565/CastSponsorSkip/), skips YouTube sponsorships (and sometimes ads) on all local Google Cast devices.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -786,6 +786,7 @@
   ./services/mail/dspam.nix
   ./services/mail/exim.nix
   ./services/mail/goeland.nix
+  ./services/mail/imapgoose.nix
   ./services/mail/listmonk.nix
   ./services/mail/maddy.nix
   ./services/mail/mail.nix

--- a/nixos/modules/services/mail/imapgoose.nix
+++ b/nixos/modules/services/mail/imapgoose.nix
@@ -1,0 +1,439 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.imapgoose;
+
+  # scfg tokens are whitespace-separated; any token containing whitespace or
+  # special characters must be double-quoted with backslashes escaped. Quoting
+  # every token unconditionally is always valid scfg and keeps rendering simple.
+  quoteToken = token: ''"${lib.escape [ "\\" "\"" ] token}"'';
+
+  # Where an instance's SQLite status databases live, and whether that directory
+  # is a systemd-managed StateDirectory (the default) or a caller-chosen path.
+  stateLocationOf =
+    name: inst:
+    if inst.stateDir == null then
+      {
+        path = "/var/lib/imapgoose/${name}";
+        managed = true;
+      }
+    else
+      {
+        path = inst.stateDir;
+        managed = false;
+      };
+
+  renderAccount =
+    name: account:
+    let
+      lines = [
+        "server ${quoteToken "${account.server}:${toString account.port}"}"
+        "username ${quoteToken account.username}"
+        "password-cmd ${lib.concatMapStringsSep " " quoteToken account.passwordCommand}"
+        "local-path ${quoteToken account.localPath}"
+        "max-connections ${toString account.maxConnections}"
+      ]
+      ++
+        lib.optional (account.postSyncCommand != [ ])
+          "post-sync-cmd ${lib.concatMapStringsSep " " quoteToken account.postSyncCommand}"
+
+      ++ map (regex: "ignore ${quoteToken regex}") account.ignore
+      ++ lib.optional account.disableTLS "plaintext true";
+    in
+    ''
+      account ${quoteToken name} {
+      ${lib.concatMapStringsSep "\n" (line: "\t${line}") lines}
+      }
+    '';
+
+  configFileFor =
+    name: inst:
+    pkgs.writeText "imapgoose-${name}.scfg" (
+      lib.concatStringsSep "\n" (lib.mapAttrsToList renderAccount inst.accounts)
+    );
+
+  accountOpts =
+    { ... }:
+    {
+      options = {
+        server = lib.mkOption {
+          type = lib.types.nonEmptyStr;
+          example = "imap.example.com";
+          description = "Hostname of the IMAP server. imapgoose connects over TLS on the given port unless {option}`services.imapgoose.instances.<name>.accounts.<name>.disableTLS` is set.";
+        };
+
+        port = lib.mkOption {
+          type = lib.types.port;
+          default = 993;
+          description = "Port of the IMAP server.";
+        };
+
+        username = lib.mkOption {
+          type = lib.types.nonEmptyStr;
+          example = "alice@example.com";
+          description = "Username to authenticate with.";
+        };
+
+        passwordCommand = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          example = [
+            "pass"
+            "show"
+            "email/personal"
+          ];
+          description = ''
+            Command whose standard output (trimmed) is used as the account's
+            password. Given as a list of tokens (command and arguments). This
+            avoids storing the password in the world-readable Nix store.
+          '';
+        };
+
+        localPath = lib.mkOption {
+          type = lib.types.str;
+          # Strip trailing slashes so builtins.dirOf (used for the tmpfiles
+          # parent) computes the true parent rather than the path itself.
+          apply = lib.converge (lib.removeSuffix "/");
+          example = "/home/alice/mail/personal";
+          description = ''
+            Absolute path of the local Maildir directory to synchronise. The
+            Maildir and its immediate parent directory are created automatically
+            (owned by the instance's
+            {option}`services.imapgoose.instances.<name>.user`) if they do not
+            exist. The immediate parent directory's ownership is also set to the
+            instance user, so `localPath` should not sit directly inside a
+            directory whose ownership matters — place the Maildir at
+            `~/mail/<account>` rather than directly in `$HOME`. If this path is
+            nested more than one level below an existing directory, you must
+            create the intervening directories yourself.
+          '';
+        };
+
+        maxConnections = lib.mkOption {
+          type = lib.types.ints.positive;
+          default = 3;
+          description = "Maximum number of concurrent IMAP connections. Must be at least 2.";
+        };
+
+        postSyncCommand = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          example = [
+            "notmuch"
+            "new"
+          ];
+          description = ''
+            Command to run after each sync, given as a list of tokens (command
+            and arguments). Leave empty to disable.
+          '';
+        };
+
+        ignore = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          example = [ "^Junk$" ];
+          description = "Regular expressions of mailbox names to skip. May be given multiple times.";
+        };
+
+        disableTLS = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = ''
+            Connect in plaintext instead of over TLS. This is typically quite
+            insecure, but necessary for situations like email-oauth2-proxy.
+
+            Requires imapgoose >= 0.5.4.
+          '';
+        };
+      };
+    };
+
+  instanceOpts =
+    { name, ... }:
+    {
+      options = {
+        user = lib.mkOption {
+          type = lib.types.nonEmptyStr;
+          default = name;
+          defaultText = lib.literalMD "the instance name";
+          example = "alice";
+          description = ''
+            Existing user whose Maildir directories are synchronised and as whom
+            this instance's daemon (including
+            {option}`services.imapgoose.instances.<name>.accounts.<name>.passwordCommand`
+            and
+            {option}`services.imapgoose.instances.<name>.accounts.<name>.postSyncCommand`)
+            runs.
+          '';
+        };
+
+        group = lib.mkOption {
+          type = lib.types.nullOr lib.types.nonEmptyStr;
+          default = null;
+          example = "users";
+          description = ''
+            Group the daemon runs as. When null, systemd uses the primary group
+            of {option}`services.imapgoose.instances.<name>.user`.
+          '';
+        };
+
+        stateDir = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          # Strip trailing slashes for the same reason as localPath: a stable
+          # ReadWritePaths entry and correct builtins.dirOf/tmpfiles hygiene.
+          apply = v: if v == null then null else lib.converge (lib.removeSuffix "/") v;
+          defaultText = lib.literalMD "`/var/lib/imapgoose/<name>` (a systemd `StateDirectory`)";
+          example = "/home/alice/.imapgoose-state";
+          description = ''
+            Directory holding imapgoose's per-account SQLite status databases for
+            this instance. When null, the databases live under
+            `/var/lib/imapgoose/<name>`, managed as a systemd StateDirectory. Set
+            this to relocate them — for example onto an encrypted filesystem
+            mounted alongside the Maildir, so the sync state is stored at rest
+            with the mail it describes. The directory is created if missing, owned
+            by the instance's user. Within it, imapgoose writes each account's
+            database as `<stateDir>/imapgoose/<account>-<hash>.db`, deriving the
+            filename from the account name. As with
+            {option}`services.imapgoose.instances.<name>.accounts.<name>.localPath`,
+            only one parent level is created: if this path is nested more than one
+            directory below an existing path, you must create the intervening
+            directories yourself.
+          '';
+        };
+
+        verbose = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable verbose logging.";
+        };
+
+        accounts = lib.mkOption {
+          type = lib.types.attrsOf (lib.types.submodule accountOpts);
+          default = { };
+          example = lib.literalExpression ''
+            {
+              personal = {
+                server = "imap.example.com";
+                username = "alice@example.com";
+                passwordCommand = [ "pass" "show" "email/personal" ];
+                localPath = "/home/alice/mail/personal";
+                postSyncCommand = [ "notmuch" "new" ];
+              };
+            }
+          '';
+          description = "IMAP accounts to synchronise for this instance. The attribute name is the account name.";
+        };
+      };
+    };
+in
+{
+  options.services.imapgoose = {
+    package = lib.mkPackageOption pkgs "imapgoose" { };
+
+    instances = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.submodule instanceOpts);
+      default = { };
+      example = lib.literalExpression ''
+        {
+          alice.accounts.personal = {
+            server = "imap.example.com";
+            username = "alice@example.com";
+            passwordCommand = [ "pass" "show" "email/personal" ];
+            localPath = "/home/alice/mail/personal";
+          };
+
+          bob = {
+            group = "users";
+            accounts.work = {
+              server = "imap.example.org";
+              username = "bob@example.org";
+              passwordCommand = [ "pass" "show" "email/work" ];
+              localPath = "/home/bob/mail/work";
+            };
+          };
+        }
+      '';
+      description = ''
+        imapgoose instances, keyed by name. Each instance runs as its own
+        systemd service under its own OS user (defaulting to the instance name)
+        and synchronises that user's set of IMAP accounts. An empty attrset (the
+        default) generates nothing.
+      '';
+    };
+  };
+
+  config = lib.mkIf (cfg.instances != { }) {
+    assertions = lib.concatLists (
+      lib.mapAttrsToList (
+        name: inst:
+        [
+          {
+            assertion = inst.accounts != { };
+            message = "services.imapgoose.instances.${name}.accounts must contain at least one account.";
+          }
+          {
+            assertion = inst.stateDir == null || lib.hasPrefix "/" inst.stateDir;
+            message = "services.imapgoose.instances.${name}.stateDir must be an absolute path.";
+          }
+        ]
+        ++ lib.concatLists (
+          lib.mapAttrsToList (acct: account: [
+            {
+              assertion = account.passwordCommand != [ ];
+              message = "services.imapgoose.instances.${name}.accounts.${acct}.passwordCommand must not be empty.";
+            }
+            {
+              assertion = account.maxConnections >= 2;
+              message = "services.imapgoose.instances.${name}.accounts.${acct}.maxConnections must be at least 2.";
+            }
+            {
+              assertion = lib.hasPrefix "/" account.localPath;
+              message = "services.imapgoose.instances.${name}.accounts.${acct}.localPath must be an absolute path.";
+            }
+            {
+              assertion = !account.disableTLS || lib.versionAtLeast cfg.package.version "0.5.4";
+              message = "services.imapgoose.instances.${name}.accounts.${acct}.disableTLS requires imapgoose >= 0.5.4, but services.imapgoose.package is version ${cfg.package.version}.";
+            }
+          ]) inst.accounts
+        )
+      ) cfg.instances
+    );
+
+    # Ensure each account's Maildir exists and is owned by the daemon's user, so
+    # imapgoose can populate it and ReadWritePaths= can bind-mount it. The
+    # immediate parent is created with the same ownership too, otherwise
+    # systemd-tmpfiles refuses the root->user "unsafe path transition" when the
+    # Maildir lives under a user-owned home directory.
+    #
+    # The leaf (Maildir) rule uses mode 0700 because imapgoose manages that dir.
+    # The parent rule uses mode "-" so an *existing* directory (e.g. a shared
+    # ~/mail also used by another tool) keeps its current mode instead of being
+    # force-chmod'd to 0700; a newly-created parent gets the tmpfiles default
+    # mode. The parent's owner is still set to the instance user (tmpfiles
+    # requires this to allow the user-owned leaf beneath it without an "unsafe
+    # path transition" refusal), so this rule will chown an existing parent — it
+    # only avoids clobbering its mode. Limitation: only one parent level is
+    # created. If localPath is nested more than one directory below an existing
+    # path, the intervening directories must already exist.
+    #
+    # Each instance gets its own namespaced tmpfiles key so instances never
+    # collide on a shared config key; within an instance, mkMerge lets accounts
+    # that share a parent directory coexist cleanly.
+    systemd.tmpfiles.settings = lib.mapAttrs' (
+      name: inst:
+      let
+        group = if inst.group != null then inst.group else "-";
+        leafRule = {
+          d = {
+            user = inst.user;
+            inherit group;
+            mode = "0700";
+          };
+        };
+        # Wrap the parent rule's attributes in mkDefault so that if another
+        # account's leaf rule (a concrete localPath/stateDir with mode 0700)
+        # resolves to the same path, the leaf's concrete values win instead of
+        # mkMerge throwing a "conflicting definition values" error.
+        parentRule = {
+          d = {
+            user = lib.mkDefault inst.user;
+            group = lib.mkDefault group;
+            mode = lib.mkDefault "-";
+          };
+        };
+        stateLocation = stateLocationOf name inst;
+      in
+      lib.nameValuePair "imapgoose-${name}" (
+        lib.mkMerge (
+          # When stateDir is set, imapgoose's SQLite databases live at a
+          # caller-chosen path instead of a systemd StateDirectory. Exposing this
+          # is the whole point of the option: it lets the sync state be placed on
+          # encrypted storage alongside the Maildir it describes. Create that dir
+          # (owned by the instance user, mode 0700) so the hardened unit can write
+          # to it; imapgoose creates the "imapgoose/" subdir beneath it itself.
+          lib.optional (!stateLocation.managed) { ${stateLocation.path} = leafRule; }
+          ++ lib.concatLists (
+            lib.mapAttrsToList (_: account: [
+              { ${builtins.dirOf account.localPath} = parentRule; }
+              { ${account.localPath} = leafRule; }
+            ]) inst.accounts
+          )
+        )
+      )
+    ) cfg.instances;
+
+    systemd.services = lib.mapAttrs' (
+      name: inst:
+      let
+        stateLocation = stateLocationOf name inst;
+      in
+      lib.nameValuePair "imapgoose-${name}" {
+        description = "imapgoose IMAP synchronisation for ${inst.user}";
+        after = [ "network-online.target" ];
+        wants = [ "network-online.target" ];
+        wantedBy = [ "multi-user.target" ];
+
+        # imapgoose stores one SQLite db per account under
+        # $XDG_STATE_HOME/imapgoose/ with flat account-name filenames, so two
+        # instances sharing a state dir would collide. Give each instance its
+        # own StateDirectory and point XDG_STATE_HOME at it; imapgoose then
+        # writes /var/lib/imapgoose/${name}/imapgoose/<account>.db (the extra
+        # "imapgoose/" component is imposed by imapgoose itself).
+        #
+        # When stateDir is set the databases move to a caller-chosen absolute
+        # path (e.g. encrypted storage next to the Maildir), which cannot be a
+        # systemd StateDirectory: XDG_STATE_HOME points there instead, the dir is
+        # created via tmpfiles above, and it is added to ReadWritePaths so the
+        # hardened unit (ProtectSystem=strict) may write to it.
+        environment.XDG_STATE_HOME = stateLocation.path;
+
+        serviceConfig = {
+          ExecStart =
+            "${lib.getExe cfg.package} -c ${configFileFor name inst}" + lib.optionalString inst.verbose " -v";
+          User = inst.user;
+          Restart = "on-failure";
+          RestartSec = 5;
+
+          # Hardening. ProtectHome is deliberately not set because Maildirs live
+          # under the user's home; each localPath is added to ReadWritePaths.
+          ProtectSystem = "strict";
+          ReadWritePaths =
+            (map (a: a.localPath) (lib.attrValues inst.accounts))
+            ++ lib.optional (!stateLocation.managed) stateLocation.path;
+          NoNewPrivileges = true;
+          PrivateTmp = true;
+          ProtectKernelTunables = true;
+          ProtectControlGroups = true;
+          LockPersonality = true;
+          RestrictRealtime = true;
+          RestrictNamespaces = true;
+          ProtectProc = "invisible";
+          ProcSubset = "pid";
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+            "AF_UNIX"
+            # glibc getaddrinfo() opens an AF_NETLINK (NETLINK_ROUTE) socket to
+            # enumerate local addresses for RFC 3484 source-address selection;
+            # without it DNS resolution against real IMAP hosts degrades or fails.
+            "AF_NETLINK"
+          ];
+          SystemCallFilter = [ "@system-service" ];
+          SystemCallErrorNumber = "EPERM";
+          CapabilityBoundingSet = [ "" ];
+        }
+        // lib.optionalAttrs stateLocation.managed {
+          StateDirectory = "imapgoose/${name}";
+          StateDirectoryMode = "0700";
+        }
+        // lib.optionalAttrs (inst.group != null) { Group = inst.group; };
+      }
+    ) cfg.instances;
+  };
+
+  meta.maintainers = with lib.maintainers; [ bobberb ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -816,6 +816,7 @@ in
   ifstate = import ./ifstate { inherit runTest; };
   iftop = runTest ./iftop.nix;
   image-contents = handleTest ./image-contents.nix { };
+  imapgoose = runTest ./imapgoose.nix;
   immich = runTest ./web-apps/immich.nix;
   immich-kiosk = runTest ./web-apps/immich-kiosk.nix;
   immich-public-proxy = runTest ./web-apps/immich-public-proxy.nix;

--- a/nixos/tests/imapgoose.nix
+++ b/nixos/tests/imapgoose.nix
@@ -1,0 +1,176 @@
+{ lib, ... }:
+let
+  certs = import ./common/acme/server/snakeoil-certs.nix;
+  # imapgoose always connects over TLS and validates the certificate, so we use
+  # the snakeoil cert's hostname consistently and trust its CA system-wide.
+  domain = certs.domain;
+  # matches the alice and bob accounts from common/user-account.nix
+  password = "foobar";
+in
+{
+  name = "imapgoose";
+  meta.maintainers = with lib.maintainers; [ bobberb ];
+
+  nodes.machine =
+    { config, pkgs, ... }:
+    let
+      # Appends a message to a user's INBOX over IMAP+TLS. User, password,
+      # Subject and Message-ID are taken from argv so the same client can inject
+      # both the startup-sync probes and the later live-NOTIFY probe against the
+      # running dovecot server, for either mailbox user.
+      appendTestMail = pkgs.writers.writePython3Bin "append-testmail" { } ''
+        import imaplib
+        import sys
+
+        user = sys.argv[1]
+        subject = sys.argv[2]
+        message_id = sys.argv[3]
+
+        message = (
+            b"From: root@localhost\r\n"
+            b"To: " + user.encode() + b"@localhost\r\n"
+            b"Subject: " + subject.encode() + b"\r\n"
+            b"Message-ID: <" + message_id.encode() + b"@localhost>\r\n"
+            b"\r\n"
+            b"Hello from the IMAP server!\r\n"
+        )
+
+        imap = imaplib.IMAP4_SSL("${domain}", 993)
+        imap.login(user, "${password}")
+        status, data = imap.append("INBOX", None, None, message)
+        assert status == "OK", (status, data)
+        imap.logout()
+      '';
+
+      passwordCommand = [
+        "${pkgs.writeShellScript "imapgoose-pw" "echo ${password}"}"
+      ];
+    in
+    {
+      imports = [ ./common/user-account.nix ];
+
+      networking.hosts."127.0.0.1" = [ domain ];
+      security.pki.certificateFiles = [ certs.ca.cert ];
+      networking.firewall.allowedTCPPorts = [ 993 ];
+
+      services.dovecot2 = {
+        enable = true;
+        enablePAM = true;
+        settings = {
+          dovecot_config_version = config.services.dovecot2.package.version;
+          dovecot_storage_version = config.services.dovecot2.package.version;
+          mail_driver = "maildir";
+          # Keep the server-side mailstore out of ~/mail so it does not collide
+          # with imapgoose's local Maildirs at ~/mail/personal.
+          mail_path = "~/Mail";
+          protocols.imap = true;
+          ssl_server_ca_file = "${certs.ca.cert}";
+          ssl_server_cert_file = "${certs.${domain}.cert}";
+          ssl_server_key_file = "${certs.${domain}.key}";
+
+          # Enable the IMAP NOTIFY extension imapgoose uses for real-time sync.
+          mailbox_list_index = true;
+          "protocol imap".mail_plugins.notify = true;
+        };
+      };
+
+      # Two instances, one per OS user, each syncing that user's own mailbox
+      # into that user's home. This proves per-user isolation: each daemon runs
+      # as its own user and writes only its own Maildir.
+      services.imapgoose.instances = {
+        alice = {
+          verbose = true;
+          accounts.personal = {
+            server = domain;
+            username = "alice";
+            inherit passwordCommand;
+            localPath = "/home/alice/mail/personal";
+          };
+        };
+        bob = {
+          verbose = true;
+          # Relocate bob's SQLite status databases out of the default
+          # /var/lib/imapgoose/bob StateDirectory to a path under his home. This
+          # exercises the stateDir option: the dir must be created by tmpfiles,
+          # owned by bob, and writable under the hardened unit (ReadWritePaths).
+          stateDir = "/home/bob/.imapgoose-state";
+          accounts.personal = {
+            server = domain;
+            username = "bob";
+            inherit passwordCommand;
+            localPath = "/home/bob/mail/personal";
+          };
+        };
+      };
+
+      environment.systemPackages = [ appendTestMail ];
+    };
+
+  testScript = ''
+    machine.wait_for_unit("dovecot.service")
+
+    # Startup-sync path: inject a message into each user's INBOX BEFORE the
+    # daemons start so they are picked up by imapgoose's full sync on connect.
+    # APPEND over TLS as each user so dovecot stores and indexes with correct
+    # ownership.
+    machine.succeed("append-testmail alice AliceStartupProbe alice-startup-12345")
+    machine.succeed("append-testmail bob BobStartupProbe bob-startup-12345")
+
+    # Both instances are distinct systemd units; each performs a full sync on
+    # startup so the seeded message should appear in the matching local Maildir.
+    machine.wait_for_unit("imapgoose-alice.service")
+    machine.wait_for_unit("imapgoose-bob.service")
+
+    machine.wait_until_succeeds(
+        "grep -rl 'alice-startup-12345@localhost' /home/alice/mail/personal/", timeout=120
+    )
+    machine.wait_until_succeeds(
+        "grep -rl 'bob-startup-12345@localhost' /home/bob/mail/personal/", timeout=120
+    )
+
+    # Isolation: each instance ran as its own user, so the delivered file must be
+    # owned by that user. This is the core guarantee of the per-user design.
+    alice_file = machine.succeed(
+        "grep -rl 'alice-startup-12345@localhost' /home/alice/mail/personal/"
+    ).strip()
+    bob_file = machine.succeed(
+        "grep -rl 'bob-startup-12345@localhost' /home/bob/mail/personal/"
+    ).strip()
+    assert machine.succeed(f"stat -c %U {alice_file}").strip() == "alice", "alice's mail not owned by alice"
+    assert machine.succeed(f"stat -c %U {bob_file}").strip() == "bob", "bob's mail not owned by bob"
+
+    # Per-instance state isolation and the stateDir override. alice keeps the
+    # default: her SQLite db lands under her StateDirectory
+    # (XDG_STATE_HOME=/var/lib/imapgoose/alice, plus imapgoose's own "imapgoose/"
+    # component), owned by alice. bob relocated his via stateDir, so his db must
+    # instead land under /home/bob/.imapgoose-state/imapgoose/, owned by bob, and
+    # nothing must appear under the default /var/lib/imapgoose/bob path.
+    machine.wait_until_succeeds("ls /var/lib/imapgoose/alice/imapgoose/*.db")
+    machine.wait_until_succeeds("ls /home/bob/.imapgoose-state/imapgoose/*.db")
+    assert machine.succeed(
+        "stat -c %U /var/lib/imapgoose/alice/imapgoose/*.db"
+    ).strip() == "alice"
+    assert machine.succeed(
+        "stat -c %U /home/bob/.imapgoose-state/imapgoose/*.db"
+    ).strip() == "bob"
+    # bob's custom stateDir itself must be owned by bob (created by tmpfiles).
+    assert machine.succeed(
+        "stat -c %U /home/bob/.imapgoose-state"
+    ).strip() == "bob"
+    # And the default StateDirectory for bob must not hold his databases.
+    machine.fail("ls /var/lib/imapgoose/bob/imapgoose/*.db")
+
+    # Live-push path: with alice's daemon already running and the initial sync
+    # done, APPEND a second, distinct message to alice's INBOX. It is not covered
+    # by the startup full sync, so its arrival in the local Maildir proves the
+    # live, IMAP-NOTIFY-driven pull while the daemon is up.
+    machine.succeed("append-testmail alice AliceLiveProbe alice-live-67890")
+    machine.wait_until_succeeds(
+        "grep -rl 'alice-live-67890@localhost' /home/alice/mail/personal/", timeout=120
+    )
+
+    machine.log(
+        machine.succeed("systemd-analyze security imapgoose-alice.service | grep -v ✓ || true")
+    )
+  '';
+}


### PR DESCRIPTION
###### Description of changes

Adds a `services.imapgoose` NixOS module for [imapgoose](https://git.sr.ht/~whynothugo/ImapGoose), a daemon by @WhyNotHugo (`shotman` `pimsync` `candyboot` `wayidle` `libdav`) that keeps local Maildir directories synchronised with IMAP servers (offlineimap-style bidirectional sync with real-time IMAP `NOTIFY`). The package already exists in nixpkgs; this adds the service. The `imapgoose` package was introduced by me, it seems to have some active use as seen by issues/PR made by others aside from me, and I did promise a module :D. 

Because imapgoose runs one process per user, the module is organised as **per-user instances** — each `instances.<name>` becomes its own `imapgoose-<name>` systemd unit running as its own user, with its own config, state directory, and Maildirs:

```nix
services.imapgoose.instances = {
  alice = {                       # `user` defaults to the instance name
    accounts.personal = {
      server = "imap.example.com";
      username = "alice@example.com";
      passwordCommand = [ "pass" "show" "email/personal" ];
      localPath = "/home/alice/mail/personal";
      postSyncCommand = [ "notmuch" "new" ];
    };
  };
  bob = {
    user = "bob";                 # set explicitly when instance name ≠ user
    accounts.work = {
      server = "imap.example.org";
      username = "bob@example.org";
      passwordCommand = [ "cat" "/run/secrets/bob-imap" ];
      localPath = "/home/bob/mail/work";
    };
  };
};
```

A single user with multiple IMAP accounts is just one instance with several `accounts.<name>` entries.

Details:

- Each `accounts.<name>` submodule maps to imapgoose's `scfg` directives (`server`/`port`, `username`, `password-cmd`, `local-path`, `max-connections`, `post-sync-cmd`, `ignore`, and `plaintext` — exposed as `disableTLS`, which requires imapgoose ≥ 0.5.4); tokens are escaped when rendered.
- Passwords are never written to the store — only `passwordCommand` is (the generated config is secret-free by construction), so the config file being world-readable in the store is intentional.
- Hardened `systemd` unit per instance (`ProtectSystem=strict`, restricted syscalls/address families incl. `AF_NETLINK` for `getaddrinfo`, empty capability set). `ProtectHome` is deliberately left unset because Maildirs live under `/home`; each account's `localPath` is added to that instance's `ReadWritePaths`.
- Per-instance SQLite status databases are isolated under `StateDirectory` (`/var/lib/imapgoose/<name>`) via `XDG_STATE_HOME`, so instances can't collide on imapgoose's flat per-account db filenames. A per-instance `stateDir` option can relocate them — e.g. onto an encrypted filesystem alongside the Maildir, so the sync state is stored at rest with the mail it describes.
- Each account's Maildir (and its immediate parent) is created via `systemd.tmpfiles` if missing, owned by the instance's user, so the `ReadWritePaths=` bind-mount succeeds on first start.
- Assertions reject an instance with no accounts, empty `passwordCommand`, `maxConnections < 2`, and non-absolute `localPath`.
- The module is inert by default: an empty `instances` set generates nothing.

Includes a dovecot-backed NixOS VM test (`nixosTests.imapgoose`) with **two** OS users, asserting each user's mail syncs into their own Maildir *owned by that user* (and their status dbs likewise), that the two `imapgoose-<name>` units are distinct and active, and a live `NOTIFY`-driven pull of a message appended after the daemon is running. Plus a release-notes entry.

###### Motivating use case: encrypted mail at rest

The `stateDir` option grew out of running this on a headless server where a user (`charlie`) keeps their mail on an on-demand **encrypted** dataset that is only unlocked interactively. Pointing `stateDir` at that dataset keeps imapgoose's SQLite sync state encrypted at rest alongside the mail it describes, instead of leaving that metadata behind in the default `/var/lib`:

```nix
services.imapgoose.instances.charlie = {
  stateDir = "/home/charlie/.mail/.imapgoose-state";   # on the encrypted dataset
  accounts.personal = {
    server = "imap.example.com";
    username = "charlie@example.com";
    passwordCommand = [ "cat" config.sops.secrets.charlie-imap.path ];
    localPath = "/home/charlie/.mail/personal";
  };
};
```

Because each instance is a plain systemd unit, `imapgoose-charlie.service` can be bound to the encrypted mount (`bindsTo`/`partOf` + `unitConfig.ConditionPathIsMountPoint`), so it starts only while the dataset is unlocked and is stopped gracefully before it is unmounted.

I have been running this, syncing email without issue on my own box. 

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: N/A (Linux-only service module).
- [x] Tested via a NixOS test (`nix-build -A nixosTests.imapgoose`), passing.
- Tested compilation of all packages that depend on this change: N/A — module-only change, no package rebuilds.
- [x] Formatted the changed files with `nix fmt` (treefmt).
- [x] Added a release notes entry (`nixos/doc/manual/release-notes/rl-2611.section.md`).
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

imapgoose pkg maintainer:
cc @philocalyst 

###### Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

