### PR TITLE
nixos/openvswitch: clean up transient ports on boot

### DIFF
--- a/nixos/modules/virtualisation/openvswitch.nix
+++ b/nixos/modules/virtualisation/openvswitch.nix
@@ -80,6 +80,7 @@ in
         wantedBy = [ "multi-user.target" ];
         requires = [ "ovsdb.socket" ];
         after = [ "ovsdb.socket" ];
+        wants = [ "ovs-delete-transient-ports.service" ];
         path = [ cfg.package ];
         restartTriggers = [
           db
@@ -127,6 +128,19 @@ in
         postStart = ''
           ${cfg.package}/bin/ovs-vsctl --timeout 3 --retry --no-wait init
         '';
+      };
+
+      systemd.services.ovs-delete-transient-ports = {
+        description = "Open vSwitch Delete Transient Ports";
+        after = [ "ovsdb.service" ];
+        before = [ "ovs-vswitchd.service" ];
+        path = [ cfg.package ];
+        unitConfig.AssertPathExists = "${runDir}/db.sock";
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          ExecStart = "${cfg.package}/share/openvswitch/scripts/ovs-ctl delete-transient-ports";
+        };
       };
 
       systemd.services.ovs-vswitchd = {

--- a/nixos/modules/virtualisation/openvswitch.nix
+++ b/nixos/modules/virtualisation/openvswitch.nix
@@ -67,6 +67,7 @@ in
       systemd.services.ovsdb = {
         description = "Open_vSwitch Database Server";
         wantedBy = [ "multi-user.target" ];
+        wants = [ "ovs-delete-transient-ports.service" ];
         path = [ cfg.package ];
         restartTriggers = [
           db
@@ -113,6 +114,19 @@ in
         postStart = ''
           ${cfg.package}/bin/ovs-vsctl --timeout 3 --retry --no-wait init
         '';
+      };
+
+      systemd.services.ovs-delete-transient-ports = {
+        description = "Open vSwitch Delete Transient Ports";
+        after = [ "ovsdb.service" ];
+        before = [ "ovs-vswitchd.service" ];
+        path = [ cfg.package ];
+        unitConfig.AssertPathExists = "${runDir}/db.sock";
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          ExecStart = "${cfg.package}/share/openvswitch/scripts/ovs-ctl delete-transient-ports";
+        };
       };
 
       systemd.services.ovs-vswitchd = {

--- a/nixos/tests/openvswitch.nix
+++ b/nixos/tests/openvswitch.nix
@@ -50,7 +50,8 @@
 
   testScript = # python
     ''
-      start_all()
+      node1.start(allow_reboot=True)
+      node2.start()
       node1.wait_for_unit("ovsdb.service")
       node1.wait_for_unit("ovs-vswitchd.service")
       node2.wait_for_unit("ovsdb.service")
@@ -80,5 +81,20 @@
           node1.wait_for_unit("vs0-netdev.service")
 
           check_marker_flow()
+
+      with subtest("Transient ports are removed after reboot"):
+          node1.succeed(
+              "ovs-vsctl --no-wait add-br transient-test-br"
+              " -- add-port transient-test-br transient-test-port"
+              " -- set Interface transient-test-port type=internal"
+              " -- set Port transient-test-port other_config:transient=true"
+          )
+          node1.succeed("ovs-vsctl port-to-br transient-test-port")
+
+          node1.reboot()
+          node1.wait_for_unit("ovsdb.service")
+          node1.wait_for_unit("ovs-vswitchd.service")
+
+          node1.fail("ovs-vsctl port-to-br transient-test-port")
     '';
 }

--- a/nixos/tests/openvswitch.nix
+++ b/nixos/tests/openvswitch.nix
@@ -50,7 +50,8 @@
 
   testScript = # python
     ''
-      start_all()
+      node1.start(allow_reboot=True)
+      node2.start()
       node1.wait_for_unit("ovsdb.service")
       node1.wait_for_unit("ovs-vswitchd.service")
       node2.wait_for_unit("ovsdb.service")
@@ -58,5 +59,20 @@
 
       node1.wait_until_succeeds("ping -c1 10.0.0.2", timeout=30)
       node2.wait_until_succeeds("ping -c1 10.0.0.1", timeout=30)
+
+      with subtest("Transient ports are removed after reboot"):
+          node1.succeed(
+              "ovs-vsctl --no-wait add-br transient-test-br"
+              " -- add-port transient-test-br transient-test-port"
+              " -- set Interface transient-test-port type=internal"
+              " -- set Port transient-test-port other_config:transient=true"
+          )
+          node1.succeed("ovs-vsctl port-to-br transient-test-port")
+
+          node1.reboot()
+          node1.wait_for_unit("ovsdb.service")
+          node1.wait_for_unit("ovs-vswitchd.service")
+
+          node1.fail("ovs-vsctl port-to-br transient-test-port")
     '';
 }


### PR DESCRIPTION
- **nixos/openvswitch: clean up transient ports on boot**
- **nixos/tests/openvswitch: test transient port cleanup**

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
