### PR TITLE
sem-vcs: init at 0.21.0

### DIFF
--- a/pkgs/by-name/se/sem-vcs/package.nix
+++ b/pkgs/by-name/se/sem-vcs/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  nix-update-script,
+  versionCheckHook,
+  pkg-config,
+  openssl,
+  zstd,
+  libgit2,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "sem-vcs";
+  version = "0.21.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "ataraxy-labs";
+    repo = "sem";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-3lAcIxNM/4IFSj+7rMOjXsLZiIcAC4EESJBzWYkuDK0=";
+  };
+
+  cargoHash = "sha256-0/nTkOrGIWDJ3b1LbcIjR4yIZ8s/e5CcbgJ4m1AfxBs=";
+
+  cargoRoot = "crates";
+  buildAndTestSubdir = "crates";
+
+  # Disable self-update feature for package-managed builds
+  buildNoDefaultFeatures = true;
+
+  cargoBuildFlags = [
+    "--bin"
+    "sem"
+
+    "--bin"
+    "sem-mcp"
+  ];
+
+  # Integration tests expect git repository state and telemetry configuration
+  doCheck = false;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    openssl
+    zstd
+    libgit2
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Semantic version control CLI";
+    homepage = "https://github.com/ataraxy-labs/sem";
+    changelog = "https://github.com/ataraxy-labs/sem/releases/tag/v${finalAttrs.version}";
+    license =
+      with lib.licenses;
+      OR [
+        asl20
+        mit
+      ];
+    maintainers = with lib.maintainers; [ malix ];
+    mainProgram = "sem";
+  };
+})


### PR DESCRIPTION
Add [sem](https://github.com/ataraxy-labs/sem), a semantic version control CLI tool providing entity-level diffs, blame, and impact analysis on top of Git.

Package named `sem-vcs` because `sem` attribute is already used by `semaphoreci/cli`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## Related

- [ ] #543667