### PR TITLE
tart: 2.30.6 -> 2.33.0

### DIFF
--- a/pkgs/by-name/ta/tart/package.nix
+++ b/pkgs/by-name/ta/tart/package.nix
@@ -6,7 +6,7 @@
   # Softnet support ("--net-softnet") is disabled by default as it requires
   # passwordless-sudo when installed through nix. Alternatively users may install
   # softnet through other means with "setuid"-bit enabled.
-  # See https://github.com/cirruslabs/softnet#installing
+  # See https://github.com/openai/softnet#installing
   enableSoftnet ? false,
   softnet,
   nix-update-script,
@@ -14,11 +14,11 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "tart";
-  version = "2.30.6";
+  version = "2.33.0";
 
   src = fetchurl {
-    url = "https://github.com/cirruslabs/tart/releases/download/${finalAttrs.version}/tart.tar.gz";
-    hash = "sha256-wepqDaJp1oRjGqEVrXUM/JO5gfAKc12AUkZUbfwwdx0=";
+    url = "https://github.com/openai/tart/releases/download/${finalAttrs.version}/tart.tar.gz";
+    hash = "sha256-iUaqS7RZq1Wp9bW843axBsQXqCKNO4kSXevtOvxq46c=";
   };
   sourceRoot = ".";
 
@@ -48,7 +48,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   meta = {
     description = "macOS and Linux VMs on Apple Silicon to use in CI and other automations";
     homepage = "https://tart.run";
-    license = lib.licenses.fairsource09;
+    license = lib.licenses.fsl11Asl20;
     maintainers = with lib.maintainers; [
       emilytrau
       aduh95


### PR DESCRIPTION
Changelogs:

- https://github.com/openai/tart/releases/tag/2.31.0
- https://github.com/openai/tart/releases/tag/2.32.0
- https://github.com/openai/tart/releases/tag/2.32.1
- https://github.com/openai/tart/releases/tag/2.33.0

See also openai/tart#1238 and #543646.

Note that the auto-updater has been failing for a while: https://nixpkgs-update-logs.nix-community.org/tart/2026-03-02.log

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
