### PR TITLE
clash-verge-rev: 2.5.1 -> 2.5.2

### DIFF
--- a/pkgs/by-name/cl/clash-verge-rev/package.nix
+++ b/pkgs/by-name/cl/clash-verge-rev/package.nix
@@ -13,17 +13,17 @@
 let
   pname = "clash-verge-rev";
   # Please keep service version in sync
-  version = "2.5.1";
+  version = "2.5.2";
 
   src = fetchFromGitHub {
     owner = "clash-verge-rev";
     repo = "clash-verge-rev";
     tag = "v${version}";
-    hash = "sha256-2X2QlWo12qM7RT0wjf1Xlmh3We2wZR/kJnSxIxVst9Y=";
+    hash = "sha256-5Txjuzq91D+FfBHaXenES4eprIdIKHUFMOKtrHSdbw4=";
   };
 
-  pnpm-hash = "sha256-Z0ToQUPyttebDOjpdisAtjIKM026x9ZtIVPOeq4163A=";
-  vendor-hash = "sha256-nF9d1OWpn3rf4EPhD4vqQbKEp/J5pc7J7XJDgAjd0DA=";
+  pnpm-hash = "sha256-AS07hD3QqPJDLLUvNgArtXpH54ek14PmEjevP1WxTHs=";
+  vendor-hash = "sha256-GPqgzOLFPAb8SNgE3vI5Ypx+zJvk+5TgkttRVktxttU=";
 
   service = callPackage ./service.nix {
     inherit

--- a/pkgs/by-name/cl/clash-verge-rev/patch-service-directory.patch
+++ b/pkgs/by-name/cl/clash-verge-rev/patch-service-directory.patch
@@ -1,26 +1,65 @@
 diff --git a/src/core/server.rs b/src/core/server.rs
-index 45570ea..d459b3e 100644
+index 0098b20..db189e2 100644
 --- a/src/core/server.rs
 +++ b/src/core/server.rs
-@@ -123,7 +123,7 @@ async fn make_ipc_dir() -> Result<()> {
-         // on macOS or the primary group on Linux) to manage the socket's lifecycle. This prevents
-         // permission denied errors when the GUI process, running with non-root privileges,
-         // attempts to recreate the socket during service initialization or sidecar fallbacks.
--        fs::set_permissions(dir_path, Permissions::from_mode(0o2770)).await?;
-+        fs::set_permissions(dir_path, Permissions::from_mode(0o770)).await?;
+@@ -73,7 +73,7 @@ pub async fn run_ipc_server() -> Result<JoinHandle<Result<()>>> {
+                 tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+             }
+             if socket_ready {
+-                fs::set_permissions(paths.ipc_path(), Permissions::from_mode(0o777)).await?;
++                fs::set_permissions(paths.ipc_path(), Permissions::from_mode(0o660)).await?;
+             } else {
+                 warn!(
+                     "IPC socket {:?} did not appear before permission update timeout",
+@@ -298,19 +298,9 @@ fn ensure_ipc_dir(dir: &std::path::Path) -> std::io::Result<()> {
+         return Err(std::io::Error::last_os_error());
      }
-     #[cfg(windows)]
-     {
+
+-    let gid = resolve_ipc_dir_gid();
+-    // 以 root 运行(生产/launchd)时强制属主为 root:若攻击者预置 `/tmp/verge` 为其拥有的
+-    // 真实目录,必须夺回属主,否则其以 owner 身份保留对目录(及内部 socket)的管理权。
+-    // 非 root(测试/开发)既无权设 root 属主也无攻击面,跳过 chown,仅设权限位。
+-    // chown/chmod 失败即 fatal;`&&`/`||` 短路使 `last_os_error()` 为失败 syscall 的 errno。
+-    let chown_ok =
+-        unsafe { platform_lib::geteuid() } != 0 || unsafe { platform_lib::fchown(fd, 0, gid) } == 0;
+-    let ok = chown_ok && unsafe { platform_lib::fchmod(fd, 0o2770 as platform_lib::mode_t) } == 0;
+-    let result = if ok {
+-        Ok(())
+-    } else {
+-        Err(std::io::Error::last_os_error())
+-    };
++    // The NixOS module's RuntimeDirectory owns the directory access policy.
++    // Opening it with O_NOFOLLOW above still validates that it is not a symlink.
++    let result: std::io::Result<()> = Ok(());
+     unsafe {
+         platform_lib::close(fd);
+     }
+@@ -414,14 +404,9 @@ pub fn spawn_socket_dir_watchdog() {
+                 continue;
+             }
+
+-            // 目录已存在：组属可能过期(开机落 staff、之后控制台用户主组不同)，或被替换为
+-            // symlink/文件。用 lstat(no-follow)判断，必要时经 ensure_ipc_dir 安全收敛
+-            // (issue #7333 开机竞态尾部 + /tmp symlink 防护)。一致则跳过，避免抖动。
+-            use std::os::unix::fs::MetadataExt;
+-            let needs_fix = match std::fs::symlink_metadata(dir) {
+-                Ok(meta) if meta.file_type().is_dir() => meta.gid() != resolve_ipc_dir_gid(),
+-                _ => true,
+-            };
++            // RuntimeDirectory owns group and mode; only reject a replaced path.
++            let needs_fix =
++                !matches!(std::fs::symlink_metadata(dir), Ok(meta) if meta.file_type().is_dir());
+             if needs_fix && let Err(e) = ensure_ipc_dir(dir) {
+                 warn!("Failed to re-apply ownership on {:?}: {}", dir, e);
+             }
 diff --git a/src/lib.rs b/src/lib.rs
 index a21f89b..81175fc 100644
 --- a/src/lib.rs
 +++ b/src/lib.rs
-@@ -12,7 +12,7 @@ pub use core::{run_ipc_server, stop_ipc_server};
- pub use client::*;
- 
+@@ -24,6 +24,6 @@ pub use client::*;
+
  #[cfg(all(unix, not(feature = "test")))]
 -pub static IPC_PATH: &str = "/tmp/verge/clash-verge-service.sock";
 +pub static IPC_PATH: &str = "/run/clash-verge-rev/service.sock";
  #[cfg(all(windows, not(feature = "test")))]
  pub static IPC_PATH: &str = r"\\.\pipe\clash-verge-service";
- 

--- a/pkgs/by-name/cl/clash-verge-rev/service.nix
+++ b/pkgs/by-name/cl/clash-verge-rev/service.nix
@@ -7,25 +7,23 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "clash-verge-service-ipc";
-  version = "2.3.0";
+  version = "2.3.3";
 
   src = fetchFromGitHub {
     owner = "clash-verge-rev";
     repo = "clash-verge-service-ipc";
-    # upstream uses branch
-    rev = "21e661fa141e5ad3c705ee4cdb86efff8df6f769";
-    hash = "sha256-XavlZWxuZKCTyIYpuXRvXpXCdakWhbLhOMmOrGBgDRo=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/kr0C+4bhal7DqKudtZvhPYUyn6xbxQw57g6ieJV64w=";
   };
 
   patches = [
-    # 1. Don't SetGID because the path is managed by systemd in NixOS, and we
-    #    use different IPC path for sidecar mode. We can keep RestrictSUIDSGID
-    #    in systemd serviceConfig.
-    # 2. Set IPC socket path
+    # Let the NixOS module's RuntimeDirectory/Group own socket access policy.
+    # Upstream defaults target installer-managed /tmp paths and broad fallback
+    # permissions, which do not fit the hardened systemd service.
     ./patch-service-directory.patch
   ];
 
-  cargoHash = "sha256-WhH2o5wN5vYW8jZl+hWbnk1xqHu61ibAr4+/CI3YKHg=";
+  cargoHash = "sha256-2/lFfhP2414iiH+zG2TvNy6uaCzDldoo7sIfhKrQaFg=";
 
   buildFeatures = [
     "standalone"

--- a/pkgs/by-name/cl/clash-verge-rev/unwrapped.nix
+++ b/pkgs/by-name/cl/clash-verge-rev/unwrapped.nix
@@ -13,7 +13,7 @@
   moreutils,
   nodejs,
   pkg-config,
-  pnpm_10,
+  pnpm_11,
   fetchPnpmDeps,
   pnpmConfigHook,
 
@@ -37,7 +37,7 @@ rustPlatform.buildRustPackage {
       version
       src
       ;
-    pnpm = pnpm_10;
+    pnpm = pnpm_11;
     fetcherVersion = 4;
     hash = pnpm-hash;
   };
@@ -87,7 +87,7 @@ rustPlatform.buildRustPackage {
     nodejs
     pkg-config
     pnpmConfigHook
-    pnpm_10
+    pnpm_11
   ];
 
   buildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
