### PR TITLE
doc: apply styleguide to the Haskell languages-frameworks section

### DIFF
--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -8,7 +8,7 @@ The secondary purpose is to provide support for Haskell development environments
 including prebuilt Haskell libraries. However, in this area sacrifices have been
 made due to self-imposed restrictions in Nixpkgs, to lessen the maintenance
 effort and to improve performance. (More details in the subsection
-[Limitations.](#haskell-limitations))
+[](#haskell-limitations))
 
 ## Available packages {#haskell-available-packages}
 
@@ -38,7 +38,7 @@ For packages that are part of [Stackage] (a curated set of known to be
 compatible packages), we use the version prescribed by a Stackage snapshot
 (usually the current LTS one) as the default version. For all other packages we
 use the latest version from [Hackage](https://hackage.org) (the repository of
-basically all open source Haskell packages). See [below](#haskell-available-versions) for a few more details on this.
+basically all open source Haskell packages). See [](#haskell-available-versions) for a few more details on this.
 
 Roughly half of the 16K packages contained in `haskellPackages` don’t actually
 build and are [marked as broken semi-automatically](https://github.com/NixOS/nixpkgs/blob/haskell-updates/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml).
@@ -186,7 +186,7 @@ Older minor versions for a supported major version will only be kept, if they ar
 
 Every Haskell package set has its own Haskell-aware `mkDerivation` which is used
 to build its packages. Generally you won't have to interact with this builder
-since [cabal2nix](#haskell-cabal2nix) can generate packages
+since [](#haskell-cabal2nix) can generate packages
 using it for an arbitrary cabal package definition. Still it is useful to know
 the parameters it takes when you need to
 [override](#haskell-overriding-haskell-packages) a generated Nix expression.
@@ -225,7 +225,7 @@ If `null` (which is the default value), the one included in `src` is used.
 
 `env`
 : Extra environment variables to set during the build.
-These will also be set inside the [development environment defined by the `passthru.env` attribute in the returned derivation](#haskell-development-environments), but will not be set inside a development environment built with [`shellFor`](#haskell-shellFor) that includes this package.
+These will also be set inside the [development environment defined by the `passthru.env` attribute in the returned derivation](#haskell-development-environments), but will not be set inside a development environment built with [](#haskell-shellFor) that includes this package.
 
 `configureFlags`
 : Extra flags passed when executing the `configure` command of `Setup.hs`.
@@ -485,8 +485,7 @@ recommended to use the more accurate ones listed above when possible.
 ### Meta attributes {#haskell-derivation-meta}
 
 `haskellPackages.mkDerivation` accepts the following attributes as direct
-arguments which are transparently set in `meta` of the resulting derivation. See
-the [Meta-attributes section](#chap-meta) for their documentation.
+arguments which are transparently set in `meta` of the resulting derivation. See [](#chap-meta) for their documentation.
 
 * These attributes are populated with a default value if omitted:
     * `homepage`: defaults to the Hackage page for `pname`.
@@ -554,9 +553,9 @@ provide development environments for Haskell projects. This has the obvious
 advantage that you benefit from `cache.nixos.org` and no longer need to compile
 all project dependencies yourself. While it is often very useful, this is not
 the primary use case of our package set. Have a look at the section
-[available package versions](#haskell-available-versions) to learn which
+[](#haskell-available-versions) to learn which
 versions of packages we provide and the section
-[limitations](#haskell-limitations), to judge whether a `haskellPackages`
+[](#haskell-limitations), to judge whether a `haskellPackages`
 based development environment for your project is feasible.
 
 By default, every derivation built using
@@ -595,7 +594,7 @@ familiar development tools like `cabal-install`, since we rely on plain `Setup.h
 to build all packages. However, `cabal-install` will work as expected if in
 `PATH` (e.g. when installed globally and using a `nix-shell` without `--pure`).
 A declarative and pure way of adding arbitrary development tools is provided
-via [`shellFor`](#haskell-shellFor).
+via [](#haskell-shellFor).
 
 When using `cabal-install` for dependency resolution you need to be a bit
 careful to achieve build purity. `cabal-install` will find and use all
@@ -669,7 +668,7 @@ Defaults to `[]`.
 : Expects a list of derivations to add as library dependencies, like `openssl`.
 This is rarely necessary as the haskell package expressions usually track system
 dependencies as well. Defaults to `[]`. (see also
-[derivation dependencies](#haskell-derivation-deps))
+[](#haskell-derivation-deps))
 
 `withHoogle`
 : If this is true, `hoogle` will be added to `nativeBuildInputs`.

--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -114,7 +114,7 @@ on Hackage and try to pick for every (transitive) dependency of your build
 exactly one version. Those versions need to satisfy all the version constraints
 given in the `.cabal` file of your package and all its dependencies.
 
-The [Haskell builder in nixpkgs](#haskell-mkderivation) does no such thing.
+The [Haskell builder in Nixpkgs](#haskell-mkderivation) does no such thing.
 It will take as input packages with names of the desired dependencies
 and just check whether they fulfill the version bounds and fail if they don’t
 (by default, see `jailbreak` to circumvent this).
@@ -144,15 +144,15 @@ versions may be worse, because builds will not be cached on `cache.nixos.org`
 or may fail.
 
 Thus, to get the best experience, make sure that your project can be compiled
-using the default compiler of nixpkgs and recent versions of its dependencies.
+using the default compiler of Nixpkgs and recent versions of its dependencies.
 
 A result of this setup is, that getting a valid build plan for a given
 package can sometimes be quite painful, and in fact this is where most of the
 maintenance work for `haskellPackages` is required. Besides that, it is not
-possible to get the dependencies of a legacy project from nixpkgs or to use a
+possible to get the dependencies of a legacy project from Nixpkgs or to use a
 specific stack solver for compiling a project.
 
-Even though we couldn’t use them directly in nixpkgs, it would be desirable
+Even though we couldn’t use them directly in Nixpkgs, it would be desirable
 to have tooling to generate working Nix package sets from build plans generated
 by `cabal-install` or a specific Stackage snapshot via import-from-derivation.
 Sadly we currently don’t have tooling for this. For this you might be
@@ -187,7 +187,7 @@ Older minor versions for a supported major version will only be kept, if they ar
 Every Haskell package set has its own Haskell-aware `mkDerivation` which is used
 to build its packages. Generally you won't have to interact with this builder
 since [](#haskell-cabal2nix) can generate packages
-using it for an arbitrary cabal package definition. Still it is useful to know
+using it for an arbitrary Cabal package definition. Still it is useful to know
 the parameters it takes when you need to
 [override](#haskell-overriding-haskell-packages) a generated Nix expression.
 
@@ -391,7 +391,7 @@ If unset, all available targets are built and installed.
 ### Specifying dependencies {#haskell-derivation-deps}
 
 Since `haskellPackages.mkDerivation` is intended to be generated from cabal
-files, it reflects cabal's way of specifying dependencies. For one, dependencies
+files, it reflects Cabal's way of specifying dependencies. For one, dependencies
 are grouped by what part of the package they belong to. This helps to reduce the
 dependency closure of a derivation, for example benchmark dependencies are not
 included if `doBenchmark == false`.
@@ -626,7 +626,7 @@ that:
   pkgs ? import <nixpkgs> { },
 }:
 
-# use the nixpkgs default haskell package set
+# use the Nixpkgs default haskell package set
 pkgs.haskellPackages.callPackage ./my-project.nix { }
 ```
 
@@ -700,7 +700,7 @@ file set up for both, we can add the following `shell.nix` expression:
 
 pkgs.haskellPackages.shellFor {
   packages = hpkgs: [
-    # reuse the nixpkgs for this package
+    # reuse the Nixpkgs for this package
     hpkgs.distribution-nixpkgs
     # call our generated Nix expression manually
     (hpkgs.callPackage ./my-project/my-project.nix { })
@@ -760,10 +760,10 @@ version used by the project you are working on (by asking e.g. cabal or
 stack) and pick the appropriate versioned binary from your path.
 
 Be careful when installing HLS globally and using a pinned nixpkgs for a
-Haskell project in a `nix-shell`. If the nixpkgs versions deviate to much
+Haskell project in a `nix-shell`. If the Nixpkgs versions deviate to much
 (e.g., use different `glibc` versions) the `haskell-language-server-?.?.?`
 executable will try to detect these situations and refuse to start. It is
-recommended to obtain HLS via `nix-shell` from the nixpkgs version pinned in
+recommended to obtain HLS via `nix-shell` from the Nixpkgs version pinned in
 there instead.
 
 The top level `pkgs.haskell-language-server` attribute is just a convenience
@@ -783,7 +783,7 @@ editor plugin to achieve this.
 
 <!-- TODO(@sternenseemann): we should document /somewhere/ that base == null etc. -->
 
-Like many language specific subsystems in nixpkgs, the Haskell infrastructure
+Like many language specific subsystems in Nixpkgs, the Haskell infrastructure
 also has its own quirks when it comes to overriding. Overriding of the *inputs*
 to a package at least follows the standard procedure. For example, imagine you
 need to build `nix-tree` with a more recent version of `brick` than the default
@@ -1241,7 +1241,7 @@ TODO(@NixOS/haskell): finish these planned sections
 ### Backporting {#haskell-backporting}
 
 Backporting changes to a stable NixOS version in general is covered
-in nixpkgs' `CONTRIBUTING.md` in general. In particular refer to the
+in Nixpkgs' `CONTRIBUTING.md` in general. In particular refer to the
 [backporting policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#criteria-for-backporting-changes)
 to check if the change you have in mind may be backported.
 
@@ -1255,7 +1255,7 @@ it does for the unstable branches.
 
 ### Why is topic X not covered in this section? Why is section Y missing? {#haskell-why-not-covered}
 
-We have been working on [moving the nixpkgs Haskell documentation back into the
+We have been working on [moving the Nixpkgs Haskell documentation back into the
 nixpkgs manual](https://github.com/NixOS/nixpkgs/issues/121403). <!-- krank:ignore-line -->
 Since this process has not been completed yet, you may find some topics missing here
 covered in the old [haskell4nix docs](https://haskell4nix.readthedocs.io/).

--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -223,7 +223,7 @@ If `null` (which is the default value), the one included in `src` is used.
 
 `env`
 : Extra environment variables to set during the build.
-These are also set inside the [development environment defined by the `passthru.env` attribute in the returned derivation](#haskell-development-environments), but are not set inside a development environment built with [](#haskell-shellFor) that includes this package.
+These are also set inside the [development environment defined by the `passthru.env` attribute in the returned derivation](#haskell-development-environments). They are not set inside a development environment built with [](#haskell-shellFor) that includes this package.
 
 `configureFlags`
 : Extra flags passed when executing the `configure` command of `Setup.hs`.
@@ -573,8 +573,7 @@ $ nix-shell -A haskellPackages.random.env '<nixpkgs>'
 
 The environment contains a GHC which is set up so it finds all
 dependencies of `random`. This environment does not mirror
-the environment used to build the package, but is intended as a convenient
-tool for development and simple debugging. `env` relies on the `ghcWithPackages`
+the environment used to build the package. It is a convenient tool for development and simple debugging. `env` relies on the `ghcWithPackages`
 wrapper which automatically injects a pre-populated package-db into every
 GHC invocation. In contrast, using `nix-shell -A haskellPackages.random` does not result in an environment in which the dependencies are in GHCs package
 database. Instead, the Haskell builder passes in all dependencies explicitly

--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -153,7 +153,7 @@ specific stack solver for compiling a project.
 Even though Nixpkgs cannot use them directly, it would be desirable
 to have tooling to generate working Nix package sets from build plans generated
 by `cabal-install` or a specific Stackage snapshot via import-from-derivation.
-Sadly we currently don’t have tooling for this. For this you might be
+Nixpkgs currently doesn’t have tooling for this. For this you might be
 interested in the alternative [haskell.nix] framework, which, be warned, is
 completely incompatible with packages from `haskellPackages`.
 
@@ -548,11 +548,7 @@ turtle-incremental-build
 In addition to building and installing Haskell software, Nixpkgs can also
 provide development environments for Haskell projects. This has the advantage that you benefit from `cache.nixos.org` and no longer need to compile
 all project dependencies yourself. While it is often very useful, this is not
-the primary use case of the package set. Have a look at the section
-[](#haskell-available-versions) to learn which
-versions of packages we provide and the section
-[](#haskell-limitations), to judge whether a `haskellPackages`
-based development environment for your project is feasible.
+the primary use case of the package set. Check [](#haskell-available-versions) and [](#haskell-limitations) to judge whether a `haskellPackages`-based development environment for your project is feasible.
 
 By default, every derivation built using
 [`haskellPackages.mkDerivation`](#haskell-mkderivation) exposes an environment
@@ -575,8 +571,8 @@ $ nix-shell -A haskellPackages.random.env '<nixpkgs>'
     …
 ```
 
-As you can see, the environment contains a GHC which is set up so it finds all
-dependencies of `random`. Note that this environment does not mirror
+The environment contains a GHC which is set up so it finds all
+dependencies of `random`. This environment does not mirror
 the environment used to build the package, but is intended as a convenient
 tool for development and simple debugging. `env` relies on the `ghcWithPackages`
 wrapper which automatically injects a pre-populated package-db into every

--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -36,7 +36,7 @@ you need to take care when handling attribute names like `3dmodels`.
 
 For packages that are part of [Stackage] (a curated set of known to be
 compatible packages), Nixpkgs uses the version prescribed by a Stackage snapshot
-(usually the current LTS one) as the default version. For all other packages Nixpkgs uses the latest version from [Hackage](https://hackage.org) (the repository of
+(usually the current LTS snapshot) as the default version. For all other packages Nixpkgs uses the latest version from [Hackage](https://hackage.org) (the repository of
 all open source Haskell packages). See [](#haskell-available-versions) for a few more details on this.
 
 Roughly half of the 16K packages contained in `haskellPackages` don’t actually
@@ -102,7 +102,7 @@ them to the docs. -->
 
 All `haskell.packages.*` package sets use the same package descriptions and the same sets
 of versions by default. There are however GHC version specific override `.nix`
-files to loosen this a bit.
+files to loosen this.
 
 ### Dependency resolution {#haskell-dependency-resolution}
 
@@ -144,9 +144,7 @@ or may fail.
 Thus, to get the best experience, make sure that your project can be compiled
 using the default compiler of Nixpkgs and recent versions of its dependencies.
 
-A result of this setup is, that getting a valid build plan for a given
-package can sometimes be quite painful, and in fact this is where most of the
-maintenance work for `haskellPackages` is required. Besides that, it is not
+Producing a valid build plan for a given package is sometimes painful. That is where most of the maintenance work on `haskellPackages` goes. Besides that, it is not
 possible to get the dependencies of a legacy project from Nixpkgs or to use a
 specific stack solver for compiling a project.
 
@@ -501,10 +499,9 @@ arguments which are transparently set in `meta` of the resulting derivation. See
 newer with the `doInstallIntermediates`, `enableSeparateIntermediatesOutput`,
 and `previousIntermediates` arguments.
 
-The basic idea is to first perform a full build of the package in question,
-save its intermediate build products for later, and then copy those build
-products into the build directory of an incremental build performed later.
-Then GHC uses those build artifacts to avoid recompiling unchanged
+First perform a full build of the package and save its intermediate build
+products. Then copy those products into the build directory of a later build.
+GHC uses those build artifacts to avoid recompiling unchanged
 modules.
 
 For more detail on how to store and use incremental build products, see
@@ -547,8 +544,7 @@ turtle-incremental-build
 
 In addition to building and installing Haskell software, Nixpkgs can also
 provide development environments for Haskell projects. This has the advantage that you benefit from `cache.nixos.org` and no longer need to compile
-all project dependencies yourself. While it is often very useful, this is not
-the primary use case of the package set. Check [](#haskell-available-versions) and [](#haskell-limitations) to judge whether a `haskellPackages`-based development environment for your project is feasible.
+all project dependencies yourself. Development is not the primary use case of the package set. Check [](#haskell-available-versions) and [](#haskell-limitations) to judge whether a `haskellPackages`-based development environment for your project is feasible.
 
 By default, every derivation built using
 [`haskellPackages.mkDerivation`](#haskell-mkderivation) exposes an environment
@@ -586,18 +582,15 @@ to build all packages. However, `cabal-install` works as expected if in
 A declarative and pure way of adding arbitrary development tools is provided
 via [](#haskell-shellFor).
 
-When using `cabal-install` for dependency resolution you need to be a bit
-careful to achieve build purity. `cabal-install` finds and uses all
-dependencies installed from the packages `env` via Nix, but it also consults Hackage to potentially download and compile dependencies if it can’t
-find a valid build plan locally. To prevent this you can either never run
+When using `cabal-install` for dependency resolution, take care to achieve build purity. `cabal-install` finds and uses all
+dependencies installed from the packages `env` via Nix. It may also consult Hackage to download and compile dependencies if it cannot find a valid build plan locally. To prevent this you can either never run
 `cabal update`, remove the cabal database from your `~/.cabal` folder or run
 `cabal` with `--offline`. Note though, that for some usecases `cabal2nix` needs
 the local Hackage db.
 
 Often you won't work on a package that is already part of `haskellPackages` or
 Hackage, so you first need to write a Nix expression to obtain the development
-environment from. You can generate one from an already
-existing cabal file using `cabal2nix`:
+environment from. You can generate a Nix expression from an existing cabal file using `cabal2nix`:
 
 ```console
 $ ls
@@ -814,7 +807,7 @@ haskell.lib.compose.overrideCabal (drv: {
     ${drv.postInstall or ""}
     install -Dm644 man/pnbackup.1 -t $out/share/man/man1
   '';
-}) haskellPackages.pnbackup
+}) haskellPackages.pinboard-notes-backup
 ```
 
 `overrideCabal` takes two arguments:
@@ -836,7 +829,7 @@ let
   });
 
 in
-installManPage haskellPackages.pnbackup
+installManPage haskellPackages.pinboard-notes-backup
 ```
 
 In fact, `haskell.lib.compose` already provides lots of useful helpers for common
@@ -871,8 +864,8 @@ Ideally this section would be generated from the latter in the future.
 -->
 
 All other helper functions are implemented in terms of `overrideCabal` and make
-common overrides shorter and more complicate ones trivial. The simple overrides
-which only change a single argument are only described very briefly in the
+common overrides shorter and more complicated ones trivial. The simple overrides
+which only change a single argument are described briefly in the
 following overview. Refer to the
 [documentation of `haskellPackages.mkDerivation`](#haskell-mkderivation)
 for a more detailed description of the effects of the respective arguments.

--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -161,7 +161,7 @@ completely incompatible with packages from `haskellPackages`.
 
 <!-- TODO(@maralorn) Link to package set generation docs in the contributors guide below. -->
 
-### GHC Deprecation Policy {#ghc-deprecation-policy}
+### GHC deprecation policy {#ghc-deprecation-policy}
 
 We remove GHC versions according to the following policy:
 
@@ -890,7 +890,7 @@ following overview. Refer to the
 [documentation of `haskellPackages.mkDerivation`](#haskell-mkderivation)
 for a more detailed description of the effects of the respective arguments.
 
-##### Packaging Helpers {#haskell-packaging-helpers}
+##### Packaging helpers {#haskell-packaging-helpers}
 
 `overrideSrc { src, version } drv`
 : Replace the source used for building `drv` with the path or derivation given
@@ -982,7 +982,7 @@ sometimes necessary when working with versioned packages in
 altogether. Useful if it fails to evaluate cleanly and is causing
 noise in the evaluation errors tab on Hydra.
 
-##### Development Helpers {#haskell-development-helpers}
+##### Development helpers {#haskell-development-helpers}
 
 `sdistTarball drv`
 : Create a source distribution tarball like those found on Hackage
@@ -1020,7 +1020,7 @@ for debugging with e.g. `gdb`.
 
 <!-- TODO(@sternenseemann): shellAware -->
 
-##### Trivial Helpers {#haskell-trivial-helpers}
+##### Trivial helpers {#haskell-trivial-helpers}
 
 `doJailbreak drv`
 : Sets the `jailbreak` argument to `true` for `drv`.

--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -43,7 +43,7 @@ all open source Haskell packages). See [](#haskell-available-versions) for a few
 Roughly half of the 16K packages contained in `haskellPackages` don’t actually
 build and are [marked as broken semi-automatically](https://github.com/NixOS/nixpkgs/blob/haskell-updates/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml).
 Most of those packages are deprecated or unmaintained, but sometimes packages
-that should build, do not build. Very often fixing them is not a lot of work.
+that should build, do not build. Fixing them is often a small amount of work.
 
 <!--
 TODO(@sternenseemann):
@@ -57,7 +57,7 @@ Available compilers are collected under `haskell.compiler`.
 Each of those compiler versions has a corresponding attribute set `packages` built with
 it. However, the non-standard package sets are not tested regularly and, as a
 result, contain fewer working packages. The corresponding package set for GHC
-9.4.8 is `haskell.packages.ghc948`. In fact, `haskellPackages` (at the time of writing) is an alias
+9.4.8 is `haskell.packages.ghc948`. In fact, `haskellPackages` is an alias
 for `haskell.packages.ghc9103`.
 
 Every package set also re-exposes the GHC used to build its packages as `haskell.packages.*.ghc`.
@@ -433,7 +433,7 @@ ensured that `pkg-config` is available at build time.
 `*FrameworkDepends`
 : Apple SDK Framework which the package depends on when compiling it on Darwin.
 
-Using these two distinctions, you should be able to categorize most of the dependency
+Using these two distinctions, you can categorize most of the dependency
 specifications that are available:
 `benchmarkFrameworkDepends`,
 `benchmarkHaskellDepends`,
@@ -479,8 +479,7 @@ That only leaves the following extra ways for specifying dependencies:
 
 The dependency specification methods in this list which are unconditional
 are especially useful when writing [overrides](#haskell-overriding-haskell-packages)
-when you want to make sure that they are definitely included. However, it is
-recommended to use the more accurate ones listed above when possible.
+when you want to make sure that they are definitely included. However, prefer the more accurate ones listed above when possible.
 
 ### Meta attributes {#haskell-derivation-meta}
 
@@ -644,7 +643,7 @@ development environment inside `nix-shell`:
 
 `packages`
 : This argument is used to select the packages for which to build the
-development environment. This should be a function which takes a haskell package
+development environment. This is a function that takes a Haskell package
 set and returns a list of packages. `shellFor` will pass the used package set to
 this function and include all dependencies of the returned package in the build
 environment. This means you can reuse Nix expressions of packages included in
@@ -1282,7 +1281,7 @@ Nixpkgs' default for your (host) platform, you will lose the ability to
 substitute from the official binary cache.
 
 If you are concerned about build times and thus want to disable profiling, it
-probably makes sense to use `haskell.lib.compose.disableLibraryProfiling` (see
+prefer `haskell.lib.compose.disableLibraryProfiling` (see
 [](#haskell-trivial-helpers)) on the packages you are building locally while
 continuing to substitute their dependencies and GHC.
 :::

--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -15,10 +15,10 @@ effort and to improve performance. (More details in the subsection
 The compiler and most build tools are exposed at the top level:
 
 * `ghc` is the default version of GHC
-* Language specific tools: `cabal-install`, `stack`, `hpack`, …
+* Language-specific tools: `cabal-install`, `stack`, `hpack`, …
 
 Many “normal” user-facing packages written in Haskell, like `niv` or `cachix`,
-are also exposed at the top level, and there is nothing Haskell specific to
+are also exposed at the top level, and there is nothing Haskell-specific to
 installing and using them.
 
 All of these packages are originally defined in the `haskellPackages` package set.
@@ -30,12 +30,11 @@ See [](#chap-language-support) for techniques to explore package sets.
 
 The `haskellPackages` set includes at least one version of every package from [Hackage](https://hackage.haskell.org/) as well as some manually injected packages.
 
-The attribute names in `haskellPackages` always correspond with their name on
+The attribute names in `haskellPackages` always correspond to their names on
 Hackage. Since Hackage allows names that are not valid Nix without escaping,
 you need to take care when handling attribute names like `3dmodels`.
 
-For packages that are part of [Stackage] (a curated set of known to be
-compatible packages), Nixpkgs uses the version prescribed by a Stackage snapshot
+For packages that are part of [Stackage] (a curated set of compatible packages), Nixpkgs uses the version prescribed by a Stackage snapshot
 (usually the current LTS snapshot) as the default version. For all other packages Nixpkgs uses the latest version from [Hackage](https://hackage.org) (the repository of
 all open source Haskell packages). See [](#haskell-available-versions) for a few more details on this.
 
@@ -64,13 +63,13 @@ Every package set also re-exposes the GHC used to build its packages as `haskell
 ### Available package versions {#haskell-available-versions}
 
 Nixpkgs aims for a “blessed” package set which only contains one version of each
-package, like [Stackage], which is a curated set of known to be compatible
+package, like [Stackage], which is a curated set of known-to-be-compatible
 packages. Nixpkgs uses the version information from Stackage snapshots and extends it
 with more packages. Normally in Nixpkgs the number of building Haskell packages
 is roughly two to three times the size of Stackage. For choosing the version to
 use for a certain package Nixpkgs uses the following rules:
 
-1. By default, for `haskellPackages.foo` is the newest version of the package
+1. By default, `haskellPackages.foo` is the newest version of the package
 `foo` found on [Hackage](https://hackage.org), which is the central registry
 of all open source Haskell packages. Nixpkgs contains a reference to a pinned
 Hackage snapshot, thus Nixpkgs uses the state of Hackage as of the last time it
@@ -81,14 +80,14 @@ default version for that package.](https://github.com/NixOS/nixpkgs/blob/haskell
 3. For some packages that are not on Stackage, Nixpkgs has [manual
 overrides to set the default version to a version older than the newest on
 Hackage.](https://github.com/NixOS/nixpkgs/blob/haskell-updates/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml)
-4. For all packages, for which the newest Hackage version is not the default
+4. For all packages for which the newest Hackage version is not the default
 version, there is also a `haskellPackages.foo_x_y_z` package with the
-newest version. The `x_y_z` part encodes the version with dots replaced by
-underscores. When the newest version changes by a new release to Hackage the
+newest version. The `x_y_z` part encodes the version, with dots replaced by
+underscores. When the newest version changes with a new release to Hackage, the
 old package disappears under that name and is replaced by a newer one under
-the name with the new version. The package name including the version also disappears when the default version e.g. from Stackage catches up with the
-newest version from Hackage. E.g. if `haskellPackages.foo` gets updated from
-1.0.0 to 1.1.0 the package `haskellPackages.foo_1_1_0` becomes obsolete and
+the name with the new version. The package name including the version also disappears when the default version, e.g., from Stackage, catches up with the
+newest version from Hackage. E.g., if `haskellPackages.foo` gets updated from
+1.0.0 to 1.1.0, the package `haskellPackages.foo_1_1_0` becomes obsolete and
 gets dropped.
 5. For some packages, Nixpkgs also [manually adds other `haskellPackages.foo_x_y_z`
 versions](https://github.com/NixOS/nixpkgs/blob/haskell-updates/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml),
@@ -101,7 +100,7 @@ set update.
 them to the docs. -->
 
 All `haskell.packages.*` package sets use the same package descriptions and the same sets
-of versions by default. There are however GHC version specific override `.nix`
+of versions by default. There are however GHC-version-specific override `.nix`
 files to loosen this.
 
 ### Dependency resolution {#haskell-dependency-resolution}
@@ -113,13 +112,13 @@ exactly one version. Those versions need to satisfy all the version constraints
 given in the `.cabal` file of your package and all its dependencies.
 
 The [Haskell builder in Nixpkgs](#haskell-mkderivation) does no such thing.
-It takes as input packages with names of the desired dependencies
-and checks whether they fulfill the version bounds and fails if they don’t
-(by default, see `jailbreak` to circumvent this).
+It takes as input packages with the names of the desired dependencies
+and checks whether they fulfill the version bounds, and fails if they don’t
+(by default; see `jailbreak` to circumvent this).
 
 The `haskellPackages.callPackage` function does the package resolution.
-It uses, e.g., `haskellPackages.aeson`which has the default version as
-described above for a package input of name `aeson`. (More general:
+It uses, e.g., `haskellPackages.aeson` which has the default version as
+described above for a package input of name `aeson`. (More generally:
 `<packages>.callPackage f` calls `f` with named inputs provided from the
 package set `<packages>`.)
 While this is the default behavior, it is possible to override the dependencies
@@ -286,7 +285,7 @@ package. Disabled by default.
 : Whether to build static libraries. Enabled by default if supported.
 
 `enableDeadCodeElimination`
-: Whether to enable linker based dead code elimination in GHC.
+: Whether to enable linker-based dead code elimination in GHC.
 Enabled by default if supported.
 
 `enableHsc2hsViaAsm`
@@ -506,7 +505,7 @@ modules.
 
 For more detail on how to store and use incremental build products, see
 [Gabriella Gonzalez’ blog post “Nixpkgs support for incremental Haskell
-builds”.][incremental-builds] motivation behind this feature.
+builds”][incremental-builds] for the motivation behind this feature.
 
 An incremental build for [the `turtle` package][turtle] can be performed like
 so:
@@ -571,7 +570,7 @@ The environment contains a GHC which is set up so it finds all
 dependencies of `random`. This environment does not mirror
 the environment used to build the package. It is a convenient tool for development and simple debugging. `env` relies on the `ghcWithPackages`
 wrapper which automatically injects a pre-populated package-db into every
-GHC invocation. In contrast, using `nix-shell -A haskellPackages.random` does not result in an environment in which the dependencies are in GHCs package
+GHC invocation. In contrast, using `nix-shell -A haskellPackages.random` does not result in an environment in which the dependencies are in GHC's package
 database. Instead, the Haskell builder passes in all dependencies explicitly
 via configure flags.
 
@@ -585,7 +584,7 @@ via [](#haskell-shellFor).
 When using `cabal-install` for dependency resolution, take care to achieve build purity. `cabal-install` finds and uses all
 dependencies installed from the packages `env` via Nix. It may also consult Hackage to download and compile dependencies if it cannot find a valid build plan locally. To prevent this you can either never run
 `cabal update`, remove the cabal database from your `~/.cabal` folder or run
-`cabal` with `--offline`. Note though, that for some usecases `cabal2nix` needs
+`cabal` with `--offline`. Note though, that for some use cases `cabal2nix` needs
 the local Hackage db.
 
 Often you won't work on a package that is already part of `haskellPackages` or
@@ -629,7 +628,7 @@ development environment inside `nix-shell`:
 : This argument is used to select the packages for which to build the
 development environment. This is a function that takes a Haskell package
 set and returns a list of packages. `shellFor` passes the used package set to
-this function and include all dependencies of the returned package in the build
+this function and includes all dependencies of the returned packages in the build
 environment. This means you can reuse Nix expressions of packages included in
 nixpkgs, but also use local Nix expressions like this: `hpkgs: [
 (hpkgs.callPackage ./my-project.nix { }) ]`.
@@ -741,7 +740,7 @@ version used by the project you are working on (by asking e.g. cabal or
 stack) and picks the appropriate versioned binary from your path.
 
 Be careful when installing HLS globally and using a pinned nixpkgs for a
-Haskell project in a `nix-shell`. If the Nixpkgs versions deviate to much
+Haskell project in a `nix-shell`. If the Nixpkgs versions deviate too much
 (e.g., use different `glibc` versions) the `haskell-language-server-?.?.?`
 executable tries to detect these situations and refuses to start. It is
 recommended to obtain HLS via `nix-shell` from the Nixpkgs version pinned in
@@ -749,8 +748,8 @@ there instead.
 
 The top level `pkgs.haskell-language-server` attribute is just a convenience
 wrapper to make it possible to install HLS for multiple GHC versions at the
-same time. If you know, that you only use one GHC version, e.g., in a project
-specific `nix-shell` you can use
+same time. If you know that you only use one GHC version, e.g., in a project-specific
+`nix-shell`, you can use
 `pkgs.haskellPackages.haskell-language-server` or
 `pkgs.haskell.packages.*.haskell-language-server` from the package set you use.
 
@@ -1111,7 +1110,7 @@ Some library functions depend on packages from the Haskell package sets. Thus th
 exposed from those instead of from `haskell.lib.compose` which can only access what is
 passed directly to it. When using the functions below, make sure that you are obtaining them
 from the same package set (`haskellPackages`, `haskell.packages.ghc948` etc.) as the packages
-you are working with or – even better – from the `self`/`final` fix point of your overlay to
+you are working with or – even better – from the `self`/`final` fixpoint of your overlay to
 `haskellPackages`.
 
 Note: Some functions like `shellFor` that are not intended for overriding per se, are omitted

--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -35,9 +35,8 @@ Hackage. Since Hackage allows names that are not valid Nix without escaping,
 you need to take care when handling attribute names like `3dmodels`.
 
 For packages that are part of [Stackage] (a curated set of known to be
-compatible packages), we use the version prescribed by a Stackage snapshot
-(usually the current LTS one) as the default version. For all other packages we
-use the latest version from [Hackage](https://hackage.org) (the repository of
+compatible packages), Nixpkgs uses the version prescribed by a Stackage snapshot
+(usually the current LTS one) as the default version. For all other packages Nixpkgs uses the latest version from [Hackage](https://hackage.org) (the repository of
 all open source Haskell packages). See [](#haskell-available-versions) for a few more details on this.
 
 Roughly half of the 16K packages contained in `haskellPackages` don’t actually
@@ -51,7 +50,7 @@ How you can help with that is
 described in [Fixing a broken package](#haskell-fixing-a-broken-package).
 -->
 
-`haskellPackages` is built with our default compiler, but we also provide other releases of GHC and package sets built with them.
+`haskellPackages` is built with the default compiler, but Nixpkgs also provides other releases of GHC and package sets built with them.
 Available compilers are collected under `haskell.compiler`.
 
 Each of those compiler versions has a corresponding attribute set `packages` built with
@@ -64,22 +63,22 @@ Every package set also re-exposes the GHC used to build its packages as `haskell
 
 ### Available package versions {#haskell-available-versions}
 
-We aim for a “blessed” package set which only contains one version of each
+Nixpkgs aims for a “blessed” package set which only contains one version of each
 package, like [Stackage], which is a curated set of known to be compatible
-packages. We use the version information from Stackage snapshots and extend it
+packages. Nixpkgs uses the version information from Stackage snapshots and extends it
 with more packages. Normally in Nixpkgs the number of building Haskell packages
 is roughly two to three times the size of Stackage. For choosing the version to
-use for a certain package we use the following rules:
+use for a certain package Nixpkgs uses the following rules:
 
 1. By default, for `haskellPackages.foo` is the newest version of the package
 `foo` found on [Hackage](https://hackage.org), which is the central registry
 of all open source Haskell packages. Nixpkgs contains a reference to a pinned
-Hackage snapshot, thus we use the state of Hackage as of the last time we
+Hackage snapshot, thus Nixpkgs uses the state of Hackage as of the last time it
 updated this pin.
-2. If the [Stackage] snapshot that we use (usually the newest LTS snapshot)
-contains a package, [we use instead the version in the Stackage snapshot as
+2. If the [Stackage] snapshot that Nixpkgs uses (usually the newest LTS snapshot)
+contains a package, [Nixpkgs uses the version in the Stackage snapshot as the
 default version for that package.](https://github.com/NixOS/nixpkgs/blob/haskell-updates/pkgs/development/haskell-modules/configuration-hackage2nix/stackage.yaml)
-3. For some packages, which are not on Stackage, we have if necessary [manual
+3. For some packages that are not on Stackage, Nixpkgs has [manual
 overrides to set the default version to a version older than the newest on
 Hackage.](https://github.com/NixOS/nixpkgs/blob/haskell-updates/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml)
 4. For all packages, for which the newest Hackage version is not the default
@@ -91,7 +90,7 @@ the name with the new version. The package name including the version also disap
 newest version from Hackage. E.g. if `haskellPackages.foo` gets updated from
 1.0.0 to 1.1.0 the package `haskellPackages.foo_1_1_0` becomes obsolete and
 gets dropped.
-5. For some packages, we also [manually add other `haskellPackages.foo_x_y_z`
+5. For some packages, Nixpkgs also [manually adds other `haskellPackages.foo_x_y_z`
 versions](https://github.com/NixOS/nixpkgs/blob/haskell-updates/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml),
 if they are required for a certain build.
 
@@ -136,7 +135,7 @@ restrictions of Nixpkgs, partially in the name of maintainability:
 * Only the packages built with the default compiler see extensive testing of the
   whole package set. For other GHC versions only a few essential packages are
   tested and cached.
-* As described above we only build one version of most packages.
+* As described above, Nixpkgs builds only one version of most packages.
 
 The experience using an older or newer packaged compiler or using different
 versions may be worse, because builds are not cached on `cache.nixos.org`
@@ -151,7 +150,7 @@ maintenance work for `haskellPackages` is required. Besides that, it is not
 possible to get the dependencies of a legacy project from Nixpkgs or to use a
 specific stack solver for compiling a project.
 
-Even though we couldn’t use them directly in Nixpkgs, it would be desirable
+Even though Nixpkgs cannot use them directly, it would be desirable
 to have tooling to generate working Nix package sets from build plans generated
 by `cabal-install` or a specific Stackage snapshot via import-from-derivation.
 Sadly we currently don’t have tooling for this. For this you might be
@@ -162,16 +161,16 @@ completely incompatible with packages from `haskellPackages`.
 
 ### GHC deprecation policy {#ghc-deprecation-policy}
 
-We remove GHC versions according to the following policy:
+Nixpkgs removes GHC versions according to the following policy:
 
 #### Major GHC versions {#major-ghc-deprecation}
 
-We keep the following GHC major versions:
+Nixpkgs keeps the following GHC major versions:
 1. The current Stackage LTS as the default and all later major versions.
-2. The two latest major versions older than our default.
+2. The two latest major versions older than the default.
 3. The currently recommended GHCup version and all later major versions.
 
-Older GHC versions might be kept longer, if there are in-tree consumers. We will coordinate with the maintainers of those dependencies to find a way forward.
+Older GHC versions might be kept longer, if there are in-tree consumers. Nixpkgs coordinates with the maintainers of those dependencies to find a way forward.
 
 #### Minor GHC versions {#minor-ghc-deprecation}
 
@@ -282,8 +281,8 @@ package. Disabled by default.
 : Whether to link executables dynamically. By default, executables are linked statically.
 
 `enableSharedLibraries`
-: Whether to build shared Haskell libraries. This is enabled by default unless we are using
-`pkgsStatic` or shared libraries have been disabled in GHC.
+: Whether to build shared Haskell libraries. This is enabled by default unless
+`pkgsStatic` is in use or shared libraries have been disabled in GHC.
 
 `enableStaticLibraries`
 : Whether to build static libraries. Enabled by default if supported.
@@ -413,7 +412,7 @@ included if `doBenchmark == false`.
 The other categorization relates to the way the package depends on the dependency:
 
 `*ToolDepends`
-: Tools we need to run as part of the build process.
+: Tools that run as part of the build process.
 They are added to the derivation's `nativeBuildInputs`.
 
 `*HaskellDepends`
@@ -549,7 +548,7 @@ turtle-incremental-build
 In addition to building and installing Haskell software, Nixpkgs can also
 provide development environments for Haskell projects. This has the advantage that you benefit from `cache.nixos.org` and no longer need to compile
 all project dependencies yourself. While it is often very useful, this is not
-the primary use case of our package set. Have a look at the section
+the primary use case of the package set. Have a look at the section
 [](#haskell-available-versions) to learn which
 versions of packages we provide and the section
 [](#haskell-limitations), to judge whether a `haskellPackages`
@@ -586,7 +585,7 @@ database. Instead, the Haskell builder passes in all dependencies explicitly
 via configure flags.
 
 `env` mirrors the normal derivation environment in one aspect: It does not include
-familiar development tools like `cabal-install`, since we rely on plain `Setup.hs`
+familiar development tools like `cabal-install`, since Nixpkgs relies on plain `Setup.hs`
 to build all packages. However, `cabal-install` works as expected if in
 `PATH` (e.g. when installed globally and using a `nix-shell` without `--pure`).
 A declarative and pure way of adding arbitrary development tools is provided
@@ -601,8 +600,8 @@ find a valid build plan locally. To prevent this you can either never run
 the local Hackage db.
 
 Often you won't work on a package that is already part of `haskellPackages` or
-Hackage, so we first need to write a Nix expression to obtain the development
-environment from. We can generate one from an already
+Hackage, so you first need to write a Nix expression to obtain the development
+environment from. You can generate one from an already
 existing cabal file using `cabal2nix`:
 
 ```console
@@ -612,7 +611,7 @@ $ cabal2nix ./. > my-project.nix
 ```
 
 The generated Nix expression evaluates to a function ready to be
-`callPackage`-ed. For now, we can add a minimal `default.nix` that does this:
+`callPackage`-ed. You can add a minimal `default.nix` that does this:
 
 ```nix
 # Retrieve nixpkgs impurely from NIX_PATH. You can pin it instead.
@@ -624,7 +623,7 @@ The generated Nix expression evaluates to a function ready to be
 pkgs.haskellPackages.callPackage ./my-project.nix { }
 ```
 
-Using `nix-build default.nix` we can now build our project, but we can also
+Using `nix-build default.nix` you can now build your project, but you can also
 enter a shell with all the package's dependencies available using `nix-shell
 -A env default.nix`. If you have `cabal-install` installed globally, it'll work
 inside the shell as expected.
@@ -684,8 +683,8 @@ benchmark dependencies which would be excluded by default. Defaults to `false`.
 One neat property of `shellFor` is that it allows you to work on multiple
 packages using the same environment in conjunction with
 [cabal.project files][cabal-project-files].
-Say our example above depends on `distribution-nixpkgs` and we have a project
-file set up for both, we can add the following `shell.nix` expression:
+Say your example above depends on `distribution-nixpkgs` and you have a project
+file set up for both, you can add the following `shell.nix` expression:
 
 ```nix
 {
@@ -1133,7 +1132,7 @@ in this section. <!-- TODO(@sternenseemann): note about ifd section -->
 `cabalSdist { src, name ? ... }`
 : Generates the Cabal sdist tarball for `src`, suitable for uploading to Hackage.
 Contrary to `haskell.lib.compose.sdistTarball`, it uses `cabal-install` over `Setup.hs`,
-so it is usually faster: No build dependencies need to be downloaded, and we can
+so it is usually faster: No build dependencies need to be downloaded, and it can
 skip compiling `Setup.hs`.
 
 `buildFromCabalSdist drv`
@@ -1177,7 +1176,7 @@ mkDerivation {
 }
 ```
 
-This expression should be called with `haskellPackages.callPackage`, which
+Call this expression with `haskellPackages.callPackage`, which
 supplies [`haskellPackages.mkDerivation`](#haskell-mkderivation) and the Haskell
 dependencies as arguments.
 
@@ -1249,7 +1248,7 @@ it does for the unstable branches.
 
 ### Why is topic X not covered in this section? Why is section Y missing? {#haskell-why-not-covered}
 
-We have been working on [moving the Nixpkgs Haskell documentation back into the
+Nixpkgs is [moving the Nixpkgs Haskell documentation back into the
 nixpkgs manual](https://github.com/NixOS/nixpkgs/issues/121403). <!-- krank:ignore-line -->
 Since this process has not been completed yet, you may find some topics missing here
 covered in the old [haskell4nix docs](https://haskell4nix.readthedocs.io/).
@@ -1283,12 +1282,12 @@ prefer `haskell.lib.compose.disableLibraryProfiling` (see
 continuing to substitute their dependencies and GHC.
 :::
 
-Since we need to change the profiling settings for the desired Haskell package
+Because you need to change the profiling settings for the desired Haskell package
 set _and_ GHC (as the core libraries like `base`, `filepath` etc. are bundled
 with GHC), it is recommended to use overlays for Nixpkgs to change them.
 Since the interrelated parts, i.e. the package set and GHC, are connected
-via the Nixpkgs fixpoint, we need to modify them both in a way that preserves
-their connection (or else we'd have to wire it up again manually). This is
+via the Nixpkgs fixpoint, you need to modify them both in a way that preserves
+their connection (or else you'd have to wire it up again manually). This is
 achieved by changing GHC and the package set in separate overlays to prevent
 the package set from pulling in GHC from `prev`.
 

--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -83,12 +83,11 @@ default version for that package.](https://github.com/NixOS/nixpkgs/blob/haskell
 overrides to set the default version to a version older than the newest on
 Hackage.](https://github.com/NixOS/nixpkgs/blob/haskell-updates/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml)
 4. For all packages, for which the newest Hackage version is not the default
-version, there will also be a `haskellPackages.foo_x_y_z` package with the
+version, there is also a `haskellPackages.foo_x_y_z` package with the
 newest version. The `x_y_z` part encodes the version with dots replaced by
 underscores. When the newest version changes by a new release to Hackage the
-old package will disappear under that name and be replaced by a newer one under
-the name with the new version. The package name including the version will
-also disappear when the default version e.g. from Stackage catches up with the
+old package disappears under that name and is replaced by a newer one under
+the name with the new version. The package name including the version also disappears when the default version e.g. from Stackage catches up with the
 newest version from Hackage. E.g. if `haskellPackages.foo` gets updated from
 1.0.0 to 1.1.0 the package `haskellPackages.foo_1_1_0` becomes obsolete and
 gets dropped.
@@ -109,20 +108,20 @@ files to loosen this a bit.
 ### Dependency resolution {#haskell-dependency-resolution}
 
 Normally when you build Haskell packages with `cabal-install`, `cabal-install`
-does dependency resolution. It will look at all Haskell package versions known
-on Hackage and try to pick for every (transitive) dependency of your build
+does dependency resolution. It looks at all Haskell package versions known
+on Hackage and tries to pick for every (transitive) dependency of your build
 exactly one version. Those versions need to satisfy all the version constraints
 given in the `.cabal` file of your package and all its dependencies.
 
 The [Haskell builder in Nixpkgs](#haskell-mkderivation) does no such thing.
-It will take as input packages with names of the desired dependencies
-and check whether they fulfill the version bounds and fail if they don’t
+It takes as input packages with names of the desired dependencies
+and checks whether they fulfill the version bounds and fails if they don’t
 (by default, see `jailbreak` to circumvent this).
 
 The `haskellPackages.callPackage` function does the package resolution.
-It will, e.g., use `haskellPackages.aeson`which has the default version as
+It uses, e.g., `haskellPackages.aeson`which has the default version as
 described above for a package input of name `aeson`. (More general:
-`<packages>.callPackage f` will call `f` with named inputs provided from the
+`<packages>.callPackage f` calls `f` with named inputs provided from the
 package set `<packages>`.)
 While this is the default behavior, it is possible to override the dependencies
 for a specific package, see
@@ -140,7 +139,7 @@ restrictions of Nixpkgs, partially in the name of maintainability:
 * As described above we only build one version of most packages.
 
 The experience using an older or newer packaged compiler or using different
-versions may be worse, because builds will not be cached on `cache.nixos.org`
+versions may be worse, because builds are not cached on `cache.nixos.org`
 or may fail.
 
 Thus, to get the best experience, make sure that your project can be compiled
@@ -176,9 +175,9 @@ Older GHC versions might be kept longer, if there are in-tree consumers. We will
 
 #### Minor GHC versions {#minor-ghc-deprecation}
 
-Every major version has a default minor version. The default minor version will be updated as soon as viable without breakage.
+Every major version has a default minor version. The default minor version updates as soon as viable without breakage.
 
-Older minor versions for a supported major version will only be kept, if they are the last supported version of a major Stackage LTS release.
+Older minor versions for a supported major version are kept only if they are the last supported version of a major Stackage LTS release.
 
 <!-- Policy introduced here: https://discourse.nixos.org/t/nixpkgs-ghc-deprecation-policy-user-feedback-necessary/64153 -->
 
@@ -225,7 +224,7 @@ If `null` (which is the default value), the one included in `src` is used.
 
 `env`
 : Extra environment variables to set during the build.
-These will also be set inside the [development environment defined by the `passthru.env` attribute in the returned derivation](#haskell-development-environments), but will not be set inside a development environment built with [](#haskell-shellFor) that includes this package.
+These are also set inside the [development environment defined by the `passthru.env` attribute in the returned derivation](#haskell-development-environments), but are not set inside a development environment built with [](#haskell-shellFor) that includes this package.
 
 `configureFlags`
 : Extra flags passed when executing the `configure` command of `Setup.hs`.
@@ -331,7 +330,7 @@ Defaults to `false`.
 Defaults to `true` if supported.
 
 `testTargets`
-: Names of the test suites to build and run. If unset, all test suites will be executed.
+: Names of the test suites to build and run. If unset, all test suites are executed.
 
 `preCompileBuildDriver`
 : Shell code to run before compiling `Setup.hs`.
@@ -506,7 +505,7 @@ and `previousIntermediates` arguments.
 The basic idea is to first perform a full build of the package in question,
 save its intermediate build products for later, and then copy those build
 products into the build directory of an incremental build performed later.
-Then, GHC will use those build artifacts to avoid recompiling unchanged
+Then GHC uses those build artifacts to avoid recompiling unchanged
 modules.
 
 For more detail on how to store and use incremental build products, see
@@ -525,18 +524,18 @@ let
   # Incremental builds work with GHC >=9.4.
   turtle = haskell.packages.ghc948.turtle;
 
-  # This will do a full build of `turtle`, while writing the intermediate build products
+  # This does a full build of `turtle`, while writing the intermediate build products
   # (compiled modules, etc.) to the `intermediates` output.
   turtle-full-build-with-incremental-output = overrideCabal (drv: {
     doInstallIntermediates = true;
     enableSeparateIntermediatesOutput = true;
   }) turtle;
 
-  # This will do an incremental build of `turtle` by copying the previously
+  # This does an incremental build of `turtle` by copying the previously
   # compiled modules and intermediate build products into the source tree
   # before running the build.
   #
-  # GHC will then naturally pick up and reuse these products, making this build
+  # GHC then picks up and reuses these products, making this build
   # complete much more quickly than the previous one.
   turtle-incremental-build = overrideCabal (drv: {
     previousIntermediates = turtle-full-build-with-incremental-output.intermediates;
@@ -582,22 +581,20 @@ dependencies of `random`. Note that this environment does not mirror
 the environment used to build the package, but is intended as a convenient
 tool for development and simple debugging. `env` relies on the `ghcWithPackages`
 wrapper which automatically injects a pre-populated package-db into every
-GHC invocation. In contrast, using `nix-shell -A haskellPackages.random` will
-not result in an environment in which the dependencies are in GHCs package
-database. Instead, the Haskell builder will pass in all dependencies explicitly
+GHC invocation. In contrast, using `nix-shell -A haskellPackages.random` does not result in an environment in which the dependencies are in GHCs package
+database. Instead, the Haskell builder passes in all dependencies explicitly
 via configure flags.
 
 `env` mirrors the normal derivation environment in one aspect: It does not include
 familiar development tools like `cabal-install`, since we rely on plain `Setup.hs`
-to build all packages. However, `cabal-install` will work as expected if in
+to build all packages. However, `cabal-install` works as expected if in
 `PATH` (e.g. when installed globally and using a `nix-shell` without `--pure`).
 A declarative and pure way of adding arbitrary development tools is provided
 via [](#haskell-shellFor).
 
 When using `cabal-install` for dependency resolution you need to be a bit
-careful to achieve build purity. `cabal-install` will find and use all
-dependencies installed from the packages `env` via Nix, but it will also
-consult Hackage to potentially download and compile dependencies if it can’t
+careful to achieve build purity. `cabal-install` finds and uses all
+dependencies installed from the packages `env` via Nix, but it also consults Hackage to potentially download and compile dependencies if it can’t
 find a valid build plan locally. To prevent this you can either never run
 `cabal update`, remove the cabal database from your `~/.cabal` folder or run
 `cabal` with `--offline`. Note though, that for some usecases `cabal2nix` needs
@@ -644,7 +641,7 @@ development environment inside `nix-shell`:
 `packages`
 : This argument is used to select the packages for which to build the
 development environment. This is a function that takes a Haskell package
-set and returns a list of packages. `shellFor` will pass the used package set to
+set and returns a list of packages. `shellFor` passes the used package set to
 this function and include all dependencies of the returned package in the build
 environment. This means you can reuse Nix expressions of packages included in
 nixpkgs, but also use local Nix expressions like this: `hpkgs: [
@@ -668,8 +665,8 @@ dependencies as well. Defaults to `[]`. (see also
 [](#haskell-derivation-deps))
 
 `withHoogle`
-: If this is true, `hoogle` will be added to `nativeBuildInputs`.
-Additionally, its database will be populated with all included dependencies,
+: If this is true, `hoogle` is added to `nativeBuildInputs`.
+Additionally, its database is populated with all included dependencies,
 so you'll be able search through the documentation of your dependencies.
 Defaults to `false`.
 
@@ -681,7 +678,7 @@ dependencies. Defaults to `lib.id`.
 
 `doBenchmark`
 : This is a shortcut for enabling `doBenchmark` via `genericBuilderArgsModifier`.
-Setting it to `true` will cause the development environment to include all
+Setting it to `true` causes the development environment to include all
 benchmark dependencies which would be excluded by default. Defaults to `false`.
 
 One neat property of `shellFor` is that it allows you to work on multiple
@@ -752,14 +749,14 @@ pkgs.haskell-language-server.override {
 Where all strings `version` are allowed such that
 `haskell.packages.ghc${version}` is an existing package set.
 
-When you run `haskell-language-server-wrapper` it will detect the GHC
+When you run `haskell-language-server-wrapper` it detects the GHC
 version used by the project you are working on (by asking e.g. cabal or
-stack) and pick the appropriate versioned binary from your path.
+stack) and picks the appropriate versioned binary from your path.
 
 Be careful when installing HLS globally and using a pinned nixpkgs for a
 Haskell project in a `nix-shell`. If the Nixpkgs versions deviate to much
 (e.g., use different `glibc` versions) the `haskell-language-server-?.?.?`
-executable will try to detect these situations and refuse to start. It is
+executable tries to detect these situations and refuses to start. It is
 recommended to obtain HLS via `nix-shell` from the Nixpkgs version pinned in
 there instead.
 
@@ -907,7 +904,7 @@ for this to work.
   that may refer to other Haskell packages' store paths (like libraries and
   documentation). This dramatically reduces the closure size of the resulting
   derivation. Note that the executables are only statically linked against their
-  Haskell dependencies, but will still link dynamically against libc, GMP and
+  Haskell dependencies, but still link dynamically against libc, GMP and
   other system library dependencies.
 
   If a library or its dependencies use their Cabal-generated
@@ -969,7 +966,7 @@ much smaller closure size.
 : Set the `broken` flag to `false` for `drv`.
 
 `doDistribute drv`
-: Updates `hydraPlatforms` so that Hydra will build `drv`. This is
+: Updates `hydraPlatforms` so that Hydra builds `drv`. This is
 sometimes necessary when working with versioned packages in
 `haskellPackages` which are not built by default.
 
@@ -1156,7 +1153,7 @@ requires executing the binaries in question.
 
 [`cabal2nix`][cabal2nix] can generate Nix package definitions for arbitrary
 Haskell packages using [import from derivation][import-from-derivation].
-`cabal2nix` will generate Nix expressions that look like this:
+`cabal2nix` generates Nix expressions that look like this:
 
 ```nix
 # cabal get mtl-2.2.1 && cd mtl-2.2.1 && cabal2nix .
@@ -1180,8 +1177,8 @@ mkDerivation {
 }
 ```
 
-This expression should be called with `haskellPackages.callPackage`, which will
-supply [`haskellPackages.mkDerivation`](#haskell-mkderivation) and the Haskell
+This expression should be called with `haskellPackages.callPackage`, which
+supplies [`haskellPackages.mkDerivation`](#haskell-mkderivation) and the Haskell
 dependencies as arguments.
 
 `callCabal2nix name src args`
@@ -1195,7 +1192,7 @@ dependencies as arguments.
   `cabal2nix`.
 
   `opts` are extra options for calling `cabal2nix`. If `opts` is a string, it
-  will be used as extra command line arguments for `cabal2nix`, e.g. `--subpath
+  is used as extra command line arguments for `cabal2nix`, e.g. `--subpath
   path/to/dir/containing/cabal-file`. Otherwise, `opts` should be an AttrSet
   which can contain the following attributes:
 
@@ -1206,7 +1203,7 @@ dependencies as arguments.
   : A function which is used to modify the given `src` instead of the default
     filter.
 
-    The default source filter will remove all files from `src` except for
+    The default source filter removes all files from `src` except for
     `.cabal` files and `package.yaml` files.
 
 <!--
@@ -1277,7 +1274,7 @@ over output size. You may want to…
 ::: {.note}
 The method described below affects the build of all libraries in the
 respective Haskell package set as well as GHC. If your choices differ from
-Nixpkgs' default for your (host) platform, you will lose the ability to
+Nixpkgs' default for your (host) platform, you lose the ability to
 substitute from the official binary cache.
 
 If you are concerned about build times and thus want to disable profiling, it

--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -38,7 +38,7 @@ For packages that are part of [Stackage] (a curated set of known to be
 compatible packages), we use the version prescribed by a Stackage snapshot
 (usually the current LTS one) as the default version. For all other packages we
 use the latest version from [Hackage](https://hackage.org) (the repository of
-basically all open source Haskell packages). See [](#haskell-available-versions) for a few more details on this.
+all open source Haskell packages). See [](#haskell-available-versions) for a few more details on this.
 
 Roughly half of the 16K packages contained in `haskellPackages` don’t actually
 build and are [marked as broken semi-automatically](https://github.com/NixOS/nixpkgs/blob/haskell-updates/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml).
@@ -57,7 +57,7 @@ Available compilers are collected under `haskell.compiler`.
 Each of those compiler versions has a corresponding attribute set `packages` built with
 it. However, the non-standard package sets are not tested regularly and, as a
 result, contain fewer working packages. The corresponding package set for GHC
-9.4.8 is `haskell.packages.ghc948`. In fact, `haskellPackages` (at the time of writing) is just an alias
+9.4.8 is `haskell.packages.ghc948`. In fact, `haskellPackages` (at the time of writing) is an alias
 for `haskell.packages.ghc9103`.
 
 Every package set also re-exposes the GHC used to build its packages as `haskell.packages.*.ghc`.
@@ -116,7 +116,7 @@ given in the `.cabal` file of your package and all its dependencies.
 
 The [Haskell builder in Nixpkgs](#haskell-mkderivation) does no such thing.
 It will take as input packages with names of the desired dependencies
-and just check whether they fulfill the version bounds and fail if they don’t
+and check whether they fulfill the version bounds and fail if they don’t
 (by default, see `jailbreak` to circumvent this).
 
 The `haskellPackages.callPackage` function does the package resolution.
@@ -549,8 +549,7 @@ turtle-incremental-build
 ## Development environments {#haskell-development-environments}
 
 In addition to building and installing Haskell software, Nixpkgs can also
-provide development environments for Haskell projects. This has the obvious
-advantage that you benefit from `cache.nixos.org` and no longer need to compile
+provide development environments for Haskell projects. This has the advantage that you benefit from `cache.nixos.org` and no longer need to compile
 all project dependencies yourself. While it is often very useful, this is not
 the primary use case of our package set. Have a look at the section
 [](#haskell-available-versions) to learn which
@@ -607,7 +606,7 @@ the local Hackage db.
 
 Often you won't work on a package that is already part of `haskellPackages` or
 Hackage, so we first need to write a Nix expression to obtain the development
-environment from. Luckily, we can generate one very easily from an already
+environment from. We can generate one from an already
 existing cabal file using `cabal2nix`:
 
 ```console
@@ -617,11 +616,10 @@ $ cabal2nix ./. > my-project.nix
 ```
 
 The generated Nix expression evaluates to a function ready to be
-`callPackage`-ed. For now, we can add a minimal `default.nix` which does just
-that:
+`callPackage`-ed. For now, we can add a minimal `default.nix` that does this:
 
 ```nix
-# Retrieve nixpkgs impurely from NIX_PATH for now, you can pin it instead, of course.
+# Retrieve nixpkgs impurely from NIX_PATH. You can pin it instead.
 {
   pkgs ? import <nixpkgs> { },
 }:
@@ -637,8 +635,8 @@ inside the shell as expected.
 
 ### shellFor {#haskell-shellFor}
 
-Having to install tools globally is obviously not great, especially if you want
-to provide a batteries-included `shell.nix` with your project. Luckily there's a
+Having to install tools globally is not great, especially if you want
+to provide a batteries-included `shell.nix` with your project. There's a
 proper tool for making development environments out of packages' build
 environments: `shellFor`, a function exposed by every haskell package set. It
 takes the following arguments and returns a derivation which is suitable as a
@@ -800,7 +798,7 @@ up, you'll usually notice that Cabal noticed that more than one versions of the 
 package was present in the dependency graph. This typically causes a later compilation
 failure (the error message `haskellPackages.mkDerivation` produces tries to save
 you the time of finding this out yourself, but if you wish to do so, you can
-disable it using `allowInconsistentDependencies`). Luckily, `haskellPackages` provides
+disable it using `allowInconsistentDependencies`). `haskellPackages` provides
 you with a tool to deal with this. `overrideScope` creates a new `haskellPackages`
 instance with the override applied *globally* for this package, so the dependency
 closure automatically uses a consistent version of the overridden package. E. g.
@@ -835,7 +833,7 @@ haskell.lib.compose.overrideCabal (drv: {
    before and returns a set of arguments to replace (or add) with a new value.
 2. The Haskell derivation to override.
 
-The arguments are ordered so that you can easily create helper functions by making
+The arguments are ordered so that you can create helper functions by making
 use of currying:
 
 ```nix

--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -22,7 +22,7 @@ are also exposed at the top level, and there is nothing Haskell specific to
 installing and using them.
 
 All of these packages are originally defined in the `haskellPackages` package set.
-The same packages are re-exposed with a reduced dependency closure for convenience (see `justStaticExecutables` or `separateBinOutput` below).
+The same packages are re-exposed with a reduced dependency closure for convenience (see `justStaticExecutables` or `enableSeparateBinOutput` below).
 
 :::{.note}
 See [](#chap-language-support) for techniques to explore package sets.
@@ -525,7 +525,7 @@ let
   inherit (haskell.lib.compose) overrideCabal;
 
   # Incremental builds work with GHC >=9.4.
-  turtle = haskell.packages.ghc944.turtle;
+  turtle = haskell.packages.ghc948.turtle;
 
   # This will do a full build of `turtle`, while writing the intermediate build products
   # (compiled modules, etc.) to the `intermediates` output.
@@ -791,7 +791,7 @@ need to build `nix-tree` with a more recent version of `brick` than the default
 one provided by `haskellPackages`:
 
 ```nix
-haskellPackages.nix-tree.override { brick = haskellPackages.brick_0_67; }
+haskellPackages.nix-tree.override { brick = haskellPackages.brick_2_12; }
 ```
 
 <!-- TODO(@sternenseemann): This belongs in the next section
@@ -1130,7 +1130,7 @@ benchmark component.
 Some library functions depend on packages from the Haskell package sets. Thus they are
 exposed from those instead of from `haskell.lib.compose` which can only access what is
 passed directly to it. When using the functions below, make sure that you are obtaining them
-from the same package set (`haskellPackages`, `haskell.packages.ghc944` etc.) as the packages
+from the same package set (`haskellPackages`, `haskell.packages.ghc948` etc.) as the packages
 you are working with or – even better – from the `self`/`final` fix point of your overlay to
 `haskellPackages`.
 

--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -41,7 +41,7 @@ all open source Haskell packages). See [](#haskell-available-versions) for a few
 Roughly half of the 16K packages contained in `haskellPackages` don’t actually
 build and are [marked as broken semi-automatically](https://github.com/NixOS/nixpkgs/blob/haskell-updates/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml).
 Most of those packages are deprecated or unmaintained, but sometimes packages
-that should build, do not build. Fixing them is often a small amount of work.
+that should build, do not build. Fixing them requires a small amount of work.
 
 <!--
 TODO(@sternenseemann):
@@ -150,9 +150,8 @@ specific stack solver for compiling a project.
 Even though Nixpkgs cannot use them directly, it would be desirable
 to have tooling to generate working Nix package sets from build plans generated
 by `cabal-install` or a specific Stackage snapshot via import-from-derivation.
-Nixpkgs currently doesn’t have tooling for this. For this you might be
-interested in the alternative [haskell.nix] framework, which, be warned, is
-completely incompatible with packages from `haskellPackages`.
+Nixpkgs currently doesn’t have tooling for this. See the alternative [haskell.nix]
+framework, which is completely incompatible with packages from `haskellPackages`.
 
 <!-- TODO(@maralorn) Link to package set generation docs in the contributors guide below. -->
 
@@ -167,7 +166,7 @@ Nixpkgs keeps the following GHC major versions:
 2. The two latest major versions older than the default.
 3. The currently recommended GHCup version and all later major versions.
 
-Older GHC versions might be kept longer, if there are in-tree consumers. Nixpkgs coordinates with the maintainers of those dependencies to find a way forward.
+Nixpkgs keeps older GHC versions longer if there are in-tree consumers. Nixpkgs coordinates with the maintainers of those dependencies to find a way forward.
 
 #### Minor GHC versions {#minor-ghc-deprecation}
 
@@ -366,8 +365,8 @@ builds”](#haskell-incremental-builds) for more information. Defaults to
 
 `allowInconsistentDependencies`
 : If enabled, allow multiple versions of the same Haskell package in the
-dependency tree at configure time. Often in such a situation compilation would
-later fail because of type mismatches. Defaults to `false`.
+dependency tree at configure time. In such a situation, compilation later
+fails because of type mismatches. Defaults to `false`.
 
 `enableLibraryForGhci`
 : Build and install a special object file for GHCi. This improves performance
@@ -455,7 +454,7 @@ specifications that are available:
 That only leaves the following extra ways for specifying dependencies:
 
 `buildDepends`
-: Allows specifying Haskell dependencies which are added to `propagatedBuildInputs` unconditionally.
+: Specifies Haskell dependencies added to `propagatedBuildInputs` unconditionally.
 
 `buildTools`
 : Like `*ToolDepends`, but are added to `nativeBuildInputs` unconditionally.
@@ -587,9 +586,9 @@ dependencies installed from the packages `env` via Nix. It may also consult Hack
 `cabal` with `--offline`. Note though, that for some use cases `cabal2nix` needs
 the local Hackage db.
 
-Often you won't work on a package that is already part of `haskellPackages` or
-Hackage, so you first need to write a Nix expression to obtain the development
-environment from. You can generate a Nix expression from an existing cabal file using `cabal2nix`:
+To work on a package that is not part of `haskellPackages` or Hackage,
+first write a Nix expression to obtain the development environment.
+Generate a Nix expression from an existing cabal file using `cabal2nix`:
 
 ```console
 $ ls
@@ -646,7 +645,7 @@ Defaults to `[]`.
 
 `buildInputs`
 : Expects a list of derivations to add as library dependencies, like `openssl`.
-This is rarely necessary as the haskell package expressions usually track system
+This is rarely necessary because Haskell package expressions track system
 dependencies as well. Defaults to `[]`. (see also
 [](#haskell-derivation-deps))
 
@@ -667,9 +666,8 @@ dependencies. Defaults to `lib.id`.
 Setting it to `true` causes the development environment to include all
 benchmark dependencies which would be excluded by default. Defaults to `false`.
 
-One neat property of `shellFor` is that it allows you to work on multiple
-packages using the same environment in conjunction with
-[cabal.project files][cabal-project-files].
+`shellFor` enables working on multiple packages using the same environment
+in conjunction with [cabal.project files][cabal-project-files].
 Say your example above depends on `distribution-nixpkgs` and you have a project
 file set up for both, you can add the following `shell.nix` expression:
 
@@ -1119,7 +1117,7 @@ in this section. <!-- TODO(@sternenseemann): note about ifd section -->
 `cabalSdist { src, name ? ... }`
 : Generates the Cabal sdist tarball for `src`, suitable for uploading to Hackage.
 Contrary to `haskell.lib.compose.sdistTarball`, it uses `cabal-install` over `Setup.hs`,
-so it is usually faster: No build dependencies need to be downloaded, and it can
+so it is faster: No build dependencies need to be downloaded, and it can
 skip compiling `Setup.hs`.
 
 `buildFromCabalSdist drv`


### PR DESCRIPTION
Brings `doc/languages-frameworks/haskell.section.md` in line with the [Nixpkgs styleguide](https://github.com/NixOS/nixpkgs/blob/master/doc/styleguide.md). The styleguide demands: "Start with the minimal working code. Progressive disclosure. Introduce concepts only when needed."

## Things done
- Replace all first-person "we/our/us" and active, imperative voice
- Condense verbose prose into short, direct sentences across the file
- Sentence-case headings 
- Replace smart quotes and cut filler
- 
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
