### PR TITLE
rocmPackages.aotriton: disable verbose logs for ninja install

### DIFF
--- a/pkgs/development/rocm-modules/aotriton/default.nix
+++ b/pkgs/development/rocm-modules/aotriton/default.nix
@@ -105,7 +105,7 @@ stdenv.mkDerivation (finalAttrs: {
   # This builds+installs
   installPhase = ''
     runHook preInstall
-    ninja -v install
+    ninja install
     runHook postInstall
   '';
   # tests are intended to be ran manually as test/ python scripts and need accelerator


### PR DESCRIPTION
Builds get killed in Hydra because of excessive logging:
https://hydra.nixos.org/build/338201313

Caveat is that without -v the build log is mute. It's not printing anything at
all. This should not be a problem for hydra since infra config sets the silence
threshold at 3h, and the derivation takes around 1-1.5h total to build.

Locally, the log grows to 130MB; [default limit in hydra is 64MB](https://github.com/NixOS/hydra/blob/c5e3a66c668a1c9858e1d8e9b22db7ffb9b9a6e0/subprojects/hydra-queue-runner/src/config.rs#L198) - which was not enforced in Hydra till [recently](https://github.com/NixOS/hydra/commit/5c3607ce3d7452599eae85c26f6c52bf005d9fe6).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
