### PR TITLE
python3Packages.colorlog: 6.10.1 -> 6.11.0

### DIFF
--- a/pkgs/development/python-modules/colorlog/default.nix
+++ b/pkgs/development/python-modules/colorlog/default.nix
@@ -6,7 +6,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "colorlog";
   version = "6.11.0";
   pyproject = true;
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "borntyping";
     repo = "python-colorlog";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-iRtS2g23gu7LAhOfmRhPISf90lVwC2O+oTiTGaeZlas=";
   };
 
@@ -25,10 +25,10 @@ buildPythonPackage rec {
   nativeCheckInputs = [ pytestCheckHook ];
 
   meta = {
-    changelog = "https://github.com/borntyping/python-colorlog/releases/tag/${src.tag}";
+    changelog = "https://github.com/borntyping/python-colorlog/releases/tag/${finalAttrs.src.tag}";
     description = "Log formatting with colors";
     homepage = "https://github.com/borntyping/python-colorlog";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ dotlambda ];
   };
-}
+})

--- a/pkgs/development/python-modules/colorlog/default.nix
+++ b/pkgs/development/python-modules/colorlog/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "colorlog";
-  version = "6.10.1";
+  version = "6.11.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "borntyping";
     repo = "python-colorlog";
     tag = "v${version}";
-    hash = "sha256-vb7OzIVcEIfnhJGpO0DgeEdhL6NCKlrynoNMxNp8Yg4=";
+    hash = "sha256-iRtS2g23gu7LAhOfmRhPISf90lVwC2O+oTiTGaeZlas=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
Diff: https://github.com/borntyping/python-colorlog/compare/v6.10.1...v6.11.0

Changelog: https://github.com/borntyping/python-colorlog/releases/tag/v6.11.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
