### PR TITLE
home-assistant-custom-components.cover_time_based: init at 4.7.2

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/cover_time_based/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/cover_time_based/package.nix
@@ -1,0 +1,39 @@
+{
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  lib,
+  pytest-homeassistant-custom-component,
+  pytestCheckHook,
+}:
+
+buildHomeAssistantComponent (finalAttrs: {
+  owner = "Sese-Schneider";
+  domain = "cover_time_based";
+  version = "4.7.2";
+
+  src = fetchFromGitHub {
+    inherit (finalAttrs) owner;
+    repo = "ha-cover-time-based";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-c5uX/DIuG9srL/F8llMio84iePjEh+3w7n+JHk7bJHc=";
+  };
+
+  nativeCheckInputs = [
+    pytest-homeassistant-custom-component
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # no need to test development scripts
+    "tests/test_bump_dev_script.py"
+    "tests/test_release_script.py"
+  ];
+
+  meta = {
+    changelog = "https://github.com/Sese-Schneider/ha-cover-time-based/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    description = "Integration which allows cover control based on time";
+    homepage = "https://github.com/Sese-Schneider/ha-cover-time-based";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.dotlambda ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
