### PR TITLE
python314Packages.python-lsp-black

### DIFF
--- a/pkgs/development/python-modules/python-lsp-black/default.nix
+++ b/pkgs/development/python-modules/python-lsp-black/default.nix
@@ -10,7 +10,6 @@
 
   # dependencies
   python-lsp-server,
-  tomli,
 
   # checks
   pytestCheckHook,

--- a/pkgs/development/python-modules/python-lsp-black/default.nix
+++ b/pkgs/development/python-modules/python-lsp-black/default.nix
@@ -15,6 +15,7 @@
 
   # checks
   pytestCheckHook,
+  setuptools_80,
 }:
 
 buildPythonPackage rec {
@@ -41,7 +42,14 @@ buildPythonPackage rec {
     ++ lib.optional (lib.versionAtLeast black.version "24.3.0") (fetchpatch {
       url = "https://github.com/python-lsp/python-lsp-black/commit/9298585a9d14d25920c33b188d79e820dc98d4a9.patch";
       hash = "sha256-4u0VIS7eidVEiKRW2wc8lJVkJwhzJD/M+uuqmTtiZ7E=";
-    });
+    })
+    # https://github.com/python-lsp/python-lsp-black/pull/65 (black >= 26.5)
+    ++ [
+      (fetchpatch {
+        url = "https://github.com/python-lsp/python-lsp-black/commit/35b5bc6f944bddac0c896127dc44a9404e95f482.patch";
+        hash = "sha256-FRxM8leFVkPjRiR3wNjy5g5BazHc6ZvtnoI8Qgz4co4=";
+      })
+    ];
 
   build-system = [ setuptools ];
 
@@ -52,7 +60,10 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pylsp_black" ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    setuptools_80 # for pkg_resources, removed in setuptools 81+ (tests/test_plugin.py)
+  ];
 
   meta = {
     homepage = "https://github.com/python-lsp/python-lsp-black";

--- a/pkgs/development/python-modules/python-lsp-black/default.nix
+++ b/pkgs/development/python-modules/python-lsp-black/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   buildPythonPackage,
-  pythonOlder,
   fetchFromGitHub,
   black,
   fetchpatch,
@@ -30,26 +29,23 @@ buildPythonPackage rec {
     hash = "sha256-nV6mePSWzfPW2RwXg/mxgzfT9wD95mmTuPnPEro1kEY=";
   };
 
-  patches =
-    /**
-      includes a series of patches fixing tests not yet released as 2.0.1+ version
-       they are meant to keep up to date with black releases
-    */
-    lib.optional (lib.versionAtLeast black.version "24.2.0") (fetchpatch {
+  patches = [
+    # includes a series of patches fixing tests not yet released as 2.0.1+ version
+    # they are meant to keep up to date with black releases
+    (fetchpatch {
       url = "https://github.com/python-lsp/python-lsp-black/commit/d43b41431379f9c9bb05fab158c4d97e6d515f8f.patch";
       hash = "sha256-38bYU27+xtA8Kq3appXTkNnkG5/XgrUJ2nQ5+yuSU2U=";
     })
-    ++ lib.optional (lib.versionAtLeast black.version "24.3.0") (fetchpatch {
+    (fetchpatch {
       url = "https://github.com/python-lsp/python-lsp-black/commit/9298585a9d14d25920c33b188d79e820dc98d4a9.patch";
       hash = "sha256-4u0VIS7eidVEiKRW2wc8lJVkJwhzJD/M+uuqmTtiZ7E=";
     })
     # https://github.com/python-lsp/python-lsp-black/pull/65 (black >= 26.5)
-    ++ [
-      (fetchpatch {
-        url = "https://github.com/python-lsp/python-lsp-black/commit/35b5bc6f944bddac0c896127dc44a9404e95f482.patch";
-        hash = "sha256-FRxM8leFVkPjRiR3wNjy5g5BazHc6ZvtnoI8Qgz4co4=";
-      })
-    ];
+    (fetchpatch {
+      url = "https://github.com/python-lsp/python-lsp-black/commit/35b5bc6f944bddac0c896127dc44a9404e95f482.patch";
+      hash = "sha256-FRxM8leFVkPjRiR3wNjy5g5BazHc6ZvtnoI8Qgz4co4=";
+    })
+  ];
 
   build-system = [ setuptools ];
 


### PR DESCRIPTION
`python-lsp-black` fails to build on the default Python 3.14 / setuptools 82 stack for two independent reasons:

- `tests/test_plugin.py` imports `pkg_resources`, which setuptools 81+ no longer ships → add `setuptools_80` to `nativeCheckInputs` (test-only).
- black 26.5 split `SourceASTParseError` out of `ASTSafetyError`; backport the upstream fix ([python-lsp-black#65](https://github.com/python-lsp/python-lsp-black/pull/65)).

This unblocks `spyder`.

Result of `nixpkgs-review wip` (x86_64-linux) — 4 built, 0 failed: `python313Packages.python-lsp-black`, `python314Packages.python-lsp-black`, `python313Packages.spyder`, `spyder`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---
Prepared with Claude Code (Claude Opus 4.8): failure diagnosis, patch, and this PR summary.
Reviewed, built, and verified by me before submission.
