### PR TITLE
blazesym-c: 0.1.8 -> 0.1.9

### DIFF
--- a/pkgs/by-name/bl/blazesym-c/package.nix
+++ b/pkgs/by-name/bl/blazesym-c/package.nix
@@ -9,24 +9,27 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "blazesym-c";
-  version = "0.1.8";
+  version = "0.1.9";
 
   src = fetchFromGitHub {
     owner = "libbpf";
     repo = "blazesym";
     tag = "capi-v${finalAttrs.version}";
-    hash = "sha256-IdeY9FCGziYN9glnvQJu2oa5ogdXb6D9QcY2MRnq7vA=";
+    hash = "sha256-gaDNRVcoI6Nc1zWEwS49FhKPep4uI5560t3AaIRCYfw=";
   };
 
-  cargoHash = "sha256-fsvdhahTKxjrrH9z6m1k3cTkXfMUZXZNZlYRi3tgTlA=";
+  cargoHash = "sha256-ZLGtskOe38fBP8o8zIezzsNwY4Xwr7UnVrbx1KysEis=";
 
   cargoBuildFlags = [
     "--package"
     "blazesym-c"
   ];
 
-  nativeCheckInputs = [
+  nativeBuildInputs = [
     pkg-config
+  ];
+
+  buildInputs = [
     elfutils
     zlib
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
