### PR TITLE
lmstudio-bionic: init at 1.1.1-5

### DIFF
--- a/pkgs/by-name/lm/lmstudio-bionic/darwin.nix
+++ b/pkgs/by-name/lm/lmstudio-bionic/darwin.nix
@@ -1,0 +1,72 @@
+{
+  stdenv,
+  fetchurl,
+  undmg,
+  darwin,
+  meta,
+  pname,
+  version,
+  url,
+  hash,
+  passthru,
+}:
+stdenv.mkDerivation {
+  inherit meta pname version;
+
+  src = fetchurl {
+    inherit url hash;
+  };
+
+  nativeBuildInputs = [
+    undmg
+    darwin.sigtool
+  ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/Applications
+    cp -r *.app $out/Applications
+
+    # Bypass the /Applications path check in the main index.js
+    # Bionic verifies the app is running from /Applications and shows an
+    # error dialog + refuses to auto-update if not. Replace the '/Applications'
+    # string literal with '/' so that any absolute path (e.g. /nix/store/...)
+    # passes the startsWith check. This works across obfuscated versions because
+    # the literal string '/Applications' is stable even when variable names change.
+    local indexJs="$out/Applications/Bionic.app/Contents/Resources/app/.webpack-bionic/main/index.js"
+    substituteInPlace "$indexJs" --replace-quiet "'/Applications'" "'/'"
+
+    # Re-sign the main executable, otherwise macOS reports the app as damaged
+    appBundle="$out/Applications/Bionic.app"
+    mainExe="$appBundle/Contents/MacOS/Bionic"
+    codesign --force --sign - "$mainExe"
+
+    runHook postInstall
+  '';
+
+  # Bionic ships Scripts inside the App Bundle, which may be messed up by standard fixups
+  dontFixup = true;
+
+  # undmg doesn't support APFS and 7zz does break the xattr. Took that approach from https://github.com/NixOS/nixpkgs/blob/a3c6ed7ad2649c1a55ffd94f7747e3176053b833/pkgs/by-name/in/insomnia/package.nix#L52
+  unpackCmd = ''
+    echo "Creating temp directory"
+    mnt=$(TMPDIR=/tmp mktemp -d -t nix-XXXXXXXXXX)
+    function finish {
+      echo "Ejecting temp directory"
+      /usr/bin/hdiutil detach $mnt -force
+      rm -rf $mnt
+    }
+    # Detach volume when receiving SIG "0"
+    trap finish EXIT
+    # Mount DMG file
+    echo "Mounting DMG file into \"$mnt\""
+    /usr/bin/hdiutil attach -nobrowse -mountpoint $mnt $curSrc
+    # Copy content to local dir for later use
+    echo 'Copying extracted content into "sourceRoot"'
+    cp -a $mnt/Bionic.app $PWD/
+  '';
+
+  inherit passthru;
+}

--- a/pkgs/by-name/lm/lmstudio-bionic/linux.nix
+++ b/pkgs/by-name/lm/lmstudio-bionic/linux.nix
@@ -1,0 +1,56 @@
+{
+  appimageTools,
+  fetchurl,
+  version,
+  url,
+  hash,
+  pname,
+  meta,
+  stdenv,
+  lib,
+  passthru,
+  graphicsmagick,
+}:
+let
+  src = fetchurl { inherit url hash; };
+
+  appimageContents = appimageTools.extract { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit
+    meta
+    pname
+    version
+    src
+    passthru
+    ;
+
+  nativeBuildInputs = [ graphicsmagick ];
+
+  extraPkgs = pkgs: [ pkgs.ocl-icd ];
+
+  extraInstallCommands = ''
+    mkdir -p $out/share/applications
+
+    # setup icons (see https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=lmstudio#n55 for how Arch solved this; approach adapted to here)
+    src_icon="${appimageContents}/bionic.png"
+    sizes=("16x16" "32x32" "48x48" "64x64" "128x128" "256x256")
+    for size in "''${sizes[@]}"; do
+      install -dm755 "$out/share/icons/hicolor/$size/apps"
+      gm convert "$src_icon" -resize "$size" "$out/share/icons/hicolor/$size/apps/bionic.png"
+    done
+
+    install -m 444 -D ${appimageContents}/ai.elementlabs.bionic.desktop $out/share/applications/bionic.desktop
+
+    # Rename the main executable from lmstudio-bionic to bionic
+    mv $out/bin/lmstudio-bionic $out/bin/bionic
+
+    substituteInPlace $out/share/applications/bionic.desktop \
+      --replace-fail 'Exec=AppRun %U' 'Exec=bionic'
+
+    # lms cli tool
+    install -m 755 ${appimageContents}/resources/app/.webpack-bionic/lms $out/bin/
+
+    patchelf --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" $out/bin/lms
+  '';
+}

--- a/pkgs/by-name/lm/lmstudio-bionic/package.nix
+++ b/pkgs/by-name/lm/lmstudio-bionic/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  callPackage,
+  ...
+}@args:
+let
+  pname = "lmstudio-bionic";
+
+  version_aarch64-darwin = "1.1.1-5";
+  hash_aarch64-darwin = "sha256-fON6w802HlPaaIi3XBqGnX9oUAko+MclQC6S5uJaoBE=";
+  version_x86_64-linux = "1.1.1-5";
+  hash_x86_64-linux = "sha256-UFjwwQR9iaypAVn/io/5cTMS0POKGkmw9PEWAmtglLw=";
+  version_aarch64-linux = "1.1.1-5";
+  hash_aarch64-linux = "sha256-frRX+LUEdb8qTs0PASdsygyb3WjefrKGKBMYczftxq0=";
+
+  meta = {
+    description = "Bionic is an easy to use desktop app for experimenting with local and open-source Large Language Models (LLMs)";
+    homepage = "https://lmstudio.ai/";
+    license = lib.licenses.unfree;
+    mainProgram = "bionic";
+    maintainers = with lib.maintainers; [
+      crertel
+      deftdawg
+    ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+in
+if stdenv.hostPlatform.system == "aarch64-darwin" then
+  callPackage ./darwin.nix {
+    inherit pname meta;
+    passthru.updateScript = ./update.sh;
+    version = version_aarch64-darwin;
+    url =
+      args.url
+        or "https://bionic-installers.lmstudio.ai/darwin/arm64/${version_aarch64-darwin}/Bionic-${version_aarch64-darwin}-arm64.dmg";
+    hash = args.hash or hash_aarch64-darwin;
+  }
+else if stdenv.hostPlatform.system == "aarch64-linux" then
+  callPackage ./linux.nix {
+    inherit pname meta;
+    passthru.updateScript = ./update.sh;
+    version = version_aarch64-linux;
+    url =
+      args.url
+        or "https://bionic-installers.lmstudio.ai/linux/arm64/${version_aarch64-linux}/Bionic-${version_aarch64-linux}-arm64.AppImage";
+    hash = args.hash or hash_aarch64-linux;
+  }
+else
+  callPackage ./linux.nix {
+    inherit pname meta;
+    passthru.updateScript = ./update.sh;
+    version = version_x86_64-linux;
+    url =
+      args.url
+        or "https://bionic-installers.lmstudio.ai/linux/x64/${version_x86_64-linux}/Bionic-${version_x86_64-linux}-x64.AppImage";
+    hash = args.hash or hash_x86_64-linux;
+  }

--- a/pkgs/by-name/lm/lmstudio-bionic/update.sh
+++ b/pkgs/by-name/lm/lmstudio-bionic/update.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl common-updater-scripts
+
+set -euo pipefail
+
+SUPPORTED_SYSTEMS=(
+  "aarch64-darwin darwin/arm64"
+  "x86_64-linux linux/x64"
+  "aarch64-linux linux/arm64"
+)
+
+for system in "${SUPPORTED_SYSTEMS[@]}"; do
+  # shellcheck disable=SC2086
+  set -- ${system} # split string into variables $1 and $2
+
+  arch="${1}"
+  platform="${2}"
+
+  url=$(curl -ILs -o /dev/null -w %{url_effective} "https://lmstudio.ai/download/bionic/latest/${platform}")
+  version="$(echo "${url}" | cut -d/ -f6)"
+  hash=$(nix --extra-experimental-features nix-command hash convert --hash-algo sha256 "$(nix-prefetch-url "${url}")")
+
+  if update-source-version lmstudio-bionic "${version}" "${hash}" --system="${arch}" --version-key="version_${arch}" \
+      2> >(tee /dev/stderr) | grep -q "nothing to do"; then
+    continue
+  fi
+done


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Copy lmstudio into lmstudio-bionic (there's already a bionic package - Android stuff), rename everything, fix update.sh, disable Linux x86/arm64 (no AppImages available for D/L yet), and update patching...

This allows folks like myself who can't install `/Applications` to run on MacOS: https://github.com/lmstudio-ai/lmstudio-bug-tracker/issues/347

@crertel, I leave this to you to decide if you want to move forward with merging this, I assume based on the content and UI that Bionic is the new LM Studio, so when it arrives for Linux, the original LM Studio UI will probably be discontinued.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

