### PR TITLE
gdal: add patch for buffer overflow in netCDF driver

### DIFF
--- a/pkgs/by-name/gd/gdal/package.nix
+++ b/pkgs/by-name/gd/gdal/package.nix
@@ -116,6 +116,14 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/OSGeo/gdal/commit/7b8b8de28bbd200b0fd3b09147fdc68b5bf5ce20.patch";
       hash = "sha256-BxWMpiUwM3h7Vo9vxJ4H4A8aQfE3jcSRfRYwaLw/60w=";
     })
+
+    # Fix stack buffer overflow in netCDF driver
+    # https://github.com/OSGeo/gdal/issues/14594
+    (fetchpatch {
+      name = "0005-netcdf-avoid-reading-attributes-without-checking-length.patch";
+      url = "https://github.com/OSGeo/gdal/commit/50eea7456d83c9586f112ef96b43249372839dea.patch";
+      hash = "sha256-m1FsBC37h2uuaEeYezPZJFsDR6Ix/FDIZnuZZiSAYcw=";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Closes #525297


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
