### PR TITLE
ruffle: 0.2.0-nightly-2026-04-23 -> 0.5.0

### DIFF
--- a/pkgs/by-name/ru/ruffle/package.nix
+++ b/pkgs/by-name/ru/ruffle/package.nix
@@ -7,6 +7,8 @@
   pkg-config,
   autoPatchelfHook,
   alsa-lib,
+  dbus,
+  fontconfig,
   wayland,
   libxcursor,
   libxrandr,
@@ -17,6 +19,7 @@
   udev,
   libxkbcommon,
   openh264,
+  openssl,
   writeShellApplication,
   curl,
   jq,
@@ -27,13 +30,13 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ruffle";
-  version = "0.2.0-nightly-2026-04-23";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "ruffle-rs";
     repo = "ruffle";
-    tag = lib.strings.removePrefix "0.2.0-" finalAttrs.version;
-    hash = "sha256-v8o5HbwL/nMcrKcJSFfO9EHeaIeCakHgmSpQSwEOO3I=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/x9blMac62JqA5eWUBqye3g2PWVWYJlOaPysXNSahgA=";
   };
 
   postPatch =
@@ -49,33 +52,36 @@ rustPlatform.buildRustPackage (finalAttrs: {
                        "OpenH264Version(${major}, ${minor}, ${patch})"
     '';
 
-  cargoHash = "sha256-wQ2rM0O9X7xLZsIwdMrIApdDd5nSaDFj+e1TZkSPptU=";
+  cargoHash = "sha256-DSSKisWHbI0Cwiuqyg6EzvHIXB6fdV17nhXDQnqQIdM=";
   cargoBuildFlags = lib.optional withRuffleTools "--workspace";
 
   env =
     let
-      tag = lib.strings.removePrefix "0.2.0-" finalAttrs.version;
-      versionDate = lib.strings.removePrefix "0.2.0-nightly-" finalAttrs.version;
+      commitDate = "2026-07-19";
     in
     {
       VERGEN_IDEMPOTENT = "1";
-      VERGEN_GIT_SHA = tag;
-      VERGEN_GIT_COMMIT_DATE = versionDate;
-      VERGEN_GIT_COMMIT_TIMESTAMP = "${versionDate}T00:00:00Z";
+      VERGEN_GIT_SHA = "v${finalAttrs.version}";
+      VERGEN_GIT_COMMIT_DATE = commitDate;
+      VERGEN_GIT_COMMIT_TIMESTAMP = "${commitDate}T00:00:00Z";
     };
 
   nativeBuildInputs = [
     jre_minimal
+    pkg-config
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
-    pkg-config
     autoPatchelfHook
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ rustPlatform.bindgenHook ];
 
-  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+  buildInputs = [
+    fontconfig
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     alsa-lib
     udev
+    openssl
     (lib.getLib stdenv.cc.cc)
   ];
 
@@ -85,6 +91,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       libxkbcommon
       vulkan-loader
       openh264
+      (lib.getLib dbus)
     ]
     ++ lib.optionals withX11 [
       libxcursor
@@ -121,10 +128,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
       ];
       text = ''
         version="$( \
-          curl https://api.github.com/repos/ruffle-rs/ruffle/releases?per_page=1 | \
-          jq -r ".[0].tag_name" \
+          curl https://api.github.com/repos/ruffle-rs/ruffle/releases/latest | \
+          jq -r ".tag_name" \
         )"
-        exec nix-update --version "0.2.0-$version" ruffle
+        exec nix-update --version "''${version#v}" ruffle
       '';
     });
   };
@@ -147,7 +154,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       lib.licenses.mit
       lib.licenses.asl20
     ];
-    changelog = "https://github.com/ruffle-rs/ruffle/releases/tag/${lib.strings.removePrefix "0.2.0-" finalAttrs.version}";
+    changelog = "https://github.com/ruffle-rs/ruffle/releases/tag/v${finalAttrs.version}";
     maintainers = [
       lib.maintainers.jchw
     ];


### PR DESCRIPTION
Diff : https://github.com/ruffle-rs/ruffle/compare/nightly-2026-04-23...v0.5.0
Changelog : 
- https://github.com/ruffle-rs/ruffle/releases/tag/v0.4.1
- https://github.com/ruffle-rs/ruffle/releases/tag/v0.4.0
- https://github.com/ruffle-rs/ruffle/releases/tag/v0.5.0

Hi,

I think that would be interesting to move on 0.4.1 & not on nightly.
Or create a dedicated nightly version.
Provided all the maintainers agree to it ?

Best Regards

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
