### PR TITLE
shira: 1.8.2 → 1.8.5

### DIFF
--- a/pkgs/by-name/sh/shira/package.nix
+++ b/pkgs/by-name/sh/shira/package.nix
@@ -7,14 +7,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "shira";
-  version = "1.8.2";
+  version = "1.8.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "KraXen72";
     repo = "shira";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-SgxEvIpjRfc0saoarqw8KySwhbk1UYCGjMcbhhWMhZg=";
+    hash = "sha256-SPR2Jtc6mYURwMl4c/v2fPGydBu7aOhrvetgFoBvjoM=";
   };
 
   build-system = [
@@ -29,6 +29,12 @@ python3Packages.buildPythonApplication (finalAttrs: {
     requests-cache
     yt-dlp
     ytmusicapi
+  ];
+
+  # Needed because of:
+  # yt-dlp==2026.3.17 not satisfied by version 2026.7.4
+  pythonRelaxDeps = [
+    "yt-dlp"
   ];
 
   makeWrapperArgs = [


### PR DESCRIPTION
Changes: https://github.com/KraXen72/shira/compare/v1.8.2...v1.8.5

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
