### PR TITLE
sssd: patch CVE-2026-14476

### DIFF
--- a/pkgs/by-name/ss/sssd/package.nix
+++ b/pkgs/by-name/ss/sssd/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   autoreconfHook,
   makeWrapper,
   glibc,
@@ -78,6 +79,13 @@ stdenv.mkDerivation (finalAttrs: {
     # Keep in mind to check /src/external/pac_responder.m4 for Kerberos compatibility before update Kerberos !!!
     # Fix Kerberos Support version for PAC responder
     #./fix-kerberos-version.patch
+
+    # Remove once a release containing this upstream fix is packaged.
+    (fetchpatch2 {
+      name = "CVE-2026-14476.patch";
+      url = "https://github.com/SSSD/sssd/commit/ba207eab76ff5253662a763b9b6e9ea42f03d31b.patch?full_index=1";
+      hash = "sha256-55V8RfIcGF49GGebg+pgCLPU9MGY2S/7PaOGIqwNL0w=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
Backports SSSD's upstream 2.13 fix for CVE-2026-14476, rejecting path traversal in `gPCFileSysPath` before constructing GPO cache paths.

Tracker suggestion: https://tracker.security.nixos.org/suggestions/by-id/10902/
Upstream fix: https://github.com/SSSD/sssd/commit/ba207eab76ff5253662a763b9b6e9ea42f03d31b

`nixpkgs-review` built four of five affected packages. `freeipa` remains blocked by the identical baseline `python3.14-lesscpy` `pkg_resources` failure.

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
