### PR TITLE
makemkv: fetch sources over https

### DIFF
--- a/pkgs/by-name/ma/makemkv/package.nix
+++ b/pkgs/by-name/ma/makemkv/package.nix
@@ -24,15 +24,15 @@ stdenv.mkDerivation (
     # Using two URLs as the first one will break as soon as a new version is released
     srcs.bin = fetchurl {
       urls = [
-        "http://www.makemkv.com/download/makemkv-bin-${version}.tar.gz"
-        "http://www.makemkv.com/download/old/makemkv-bin-${version}.tar.gz"
+        "https://www.makemkv.com/download/makemkv-bin-${version}.tar.gz"
+        "https://www.makemkv.com/download/old/makemkv-bin-${version}.tar.gz"
       ];
       hash = "sha256-zuVt4LqlUxq+0WvYYnQtMI13K0q02uFu6GW/dPBKFgg=";
     };
     srcs.oss = fetchurl {
       urls = [
-        "http://www.makemkv.com/download/makemkv-oss-${version}.tar.gz"
-        "http://www.makemkv.com/download/old/makemkv-oss-${version}.tar.gz"
+        "https://www.makemkv.com/download/makemkv-oss-${version}.tar.gz"
+        "https://www.makemkv.com/download/old/makemkv-oss-${version}.tar.gz"
       ];
       hash = "sha256-hZAGNkjULsKpWLdFc9cCLw9MM05OT+fdU7cMbnSLpFM=";
     };


### PR DESCRIPTION
Resolves #543778.

www.makemkv.com now returns HTTP 403 for plain-**http** download requests and serves the tarballs only over **https**. Every mirror URL in the `makemkv` `fetchurl` srcs used `http://`, so the fixed-output derivation can no longer fetch its sources and the build fails.

The tarballs and their content hashes are byte-for-byte identical over https, so only the scheme changes (no hash update needed).

Reproduction on current `master`:
```
$ curl -sSo /dev/null -w '%{http_code}\n' http://www.makemkv.com/download/makemkv-bin-1.18.4.tar.gz
403
$ curl -sSo /dev/null -w '%{http_code}\n' https://www.makemkv.com/download/makemkv-bin-1.18.4.tar.gz
200
```

This also affects released channels; a backport to `release-26.05` (and `release-25.11`) would be worthwhile.

## Things done

- Built on platform(s):
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- [x] Verified `NIXPKGS_ALLOW_UNFREE=1 nix-build -A makemkv --impure` fetches both tarballs over https and builds to completion (autopatchelf satisfied). Did not exercise the GUI/`makemkvcon` at runtime (needs optical media).
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Fits CONTRIBUTING.md / pkgs/README.md.
- [x] Follows the automation/AI policy (see disclosure below).

---

**Automation/AI disclosure** (per CONTRIBUTING.md): the root cause was investigated and this URL-scheme change and this PR summary were produced with **Claude Code (Claude Opus 4.8)**, with me as the responsible human in the loop. The change was reviewed and verified by building `makemkv` locally before submission. The commit carries an `Assisted-by:` trailer accordingly.