### PR TITLE
fpcloud: init at 0.131.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21998,6 +21998,11 @@
     github = "PhDyellow";
     githubId = 7740661;
   };
+  phelian = {
+    name = "Alexander Félix";
+    github = "phelian";
+    githubId = 7235544;
+  };
   phfroidmont = {
     name = "Paul-Henri Froidmont";
     email = "nix.contact-j9dw4d@froidmont.org";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16328,6 +16328,11 @@
     githubId = 28735087;
     keys = [ { fingerprint = "AB47 3D70 53D2 74CA DC2C  230C B648 02DC 33A6 4FF6"; } ];
   };
+  lorentzlasson = {
+    name = "Lorentz Lasson";
+    github = "lorentzlasson";
+    githubId = 3483136;
+  };
   lorenz = {
     name = "Lorenz Brun";
     email = "lorenz@brun.one";

--- a/pkgs/by-name/fp/fpcloud/package.nix
+++ b/pkgs/by-name/fp/fpcloud/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  testers,
+}:
+buildGoModule (finalAttrs: {
+  pname = "fpcloud";
+  version = "0.131.0";
+
+  src = fetchFromGitHub {
+    owner = "fogpipe";
+    repo = "cloud-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-wm8HUXYZ+Vj/OaAngdVU0MCeyrzZJ0gv4hp34QCrztg=";
+  };
+
+  vendorHash = "sha256-txsSh5vq1/5bXC55My+vYTr7nGnRE6d18tY3UUvyfnM=";
+
+  subPackages = [ "cmd/fpcloud" ];
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd fpcloud \
+      --bash <($out/bin/fpcloud completion bash) \
+      --zsh <($out/bin/fpcloud completion zsh) \
+      --fish <($out/bin/fpcloud completion fish)
+  '';
+
+  passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/fogpipe/cloud-cli/pkg/cli.version=${finalAttrs.version}"
+  ];
+
+  meta = {
+    description = "Command-line interface for the Fogpipe Cloud platform";
+    homepage = "https://github.com/fogpipe/cloud-cli";
+    changelog = "https://github.com/fogpipe/cloud-cli/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      phelian
+      lorentzlasson
+    ];
+    mainProgram = "fpcloud";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Adds `fpcloud`, the command-line interface for the [Fogpipe Cloud](https://cloud.fogpipe.com) platform (deploy apps, manage databases, domains and object storage). Built from source with `buildGoModule` against the tagged release.

Automation disclosure: packaging and PR maintenance were assisted by Claude Code (Claude Opus 5 and Claude Fable 5); commits carry `Assisted-by:` trailers. Both maintainers reviewed the derivation and built and tested the result locally on the platforms below.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
