### PR TITLE
docs: Mention more shell functions in `stdenv`

### DIFF
--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -1223,9 +1223,18 @@ Example removing all references to the compiler in the output:
 
 ### `runHook` \<hook\> {#fun-runHook}
 
-Execute \<hook\> and the values in the array associated with it. The array's name is determined by removing `Hook` from the end of \<hook\> and appending `Hooks`.
+Execute \<hook\> and the values in the array associated with it. The array's name is determined by removing `Hook` from the end of \<hook\> and appending `Hooks`. Execution aborts on the first failing hook.
 
 For example, `runHook postHook` would run the hook `postHook` and all of the values contained in the `postHooks` array, if it exists.
+
+### `runOneHook` \<hook\> {#fun-runOneHook}
+
+Run all hooks that `runHook` would, but exit after the first successful hook.
+Failing hooks are ignored.
+
+### `echoCmd` \<cmd\> \<args...\> {#fun-echoCmd}
+
+Print (but don't execute) a command and unambiguously mark word splits.
 
 ### `substitute` \<infile\> \<outfile\> \<subs\> {#fun-substitute}
 

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -200,6 +200,11 @@ _logHook() {
 # were added, stopping if any fails (returns a non-zero exit
 # code). The hooks for <hookName> are the shell function or variable
 # <hookName>, and the values of the shell array ‘<hookName>Hooks’.
+#
+# Documented in:
+# - source: `doc/stdenv/stdenv.chapter.md`
+# - stable docs: https://nixos.org/manual/nixpkgs/stable/#fun-runHook
+# - unstable docs: https://nixos.org/manual/nixpkgs/unstable/#fun-runHook
 runHook() {
     local hookName="$1"
     shift
@@ -219,6 +224,11 @@ runHook() {
 
 # Run all hooks with the specified name, until one succeeds (returns a
 # zero exit code). If none succeed, return a non-zero exit code.
+#
+# Documented in:
+# - source: `doc/stdenv/stdenv.chapter.md`
+# - stable docs: https://nixos.org/manual/nixpkgs/stable/#fun-runOneHook
+# - unstable docs: https://nixos.org/manual/nixpkgs/unstable/#fun-runOneHook
 runOneHook() {
     local hookName="$1"
     shift
@@ -283,6 +293,11 @@ _eval() {
 # to split the command in three parts because the middle format string
 # will be, and must be, repeated for each argument. The first argument
 # goes before the ':' and is just for convenience.
+#
+# Documented in:
+# - source: `doc/stdenv/stdenv.chapter.md`
+# - stable docs: https://nixos.org/manual/nixpkgs/stable/#fun-echoCmd
+# - unstable docs: https://nixos.org/manual/nixpkgs/unstable/#fun-echoCmd
 echoCmd() {
     printf "%s:" "$1"
     shift


### PR DESCRIPTION
which were previously defined but undocumented outside of `setup.sh` itself. Add back-references from the shell functions to the rendered upstream docs so anyone finding these from bash sources can enjoy a prettier and more integrated learning experience.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
