### PR TITLE
androidenv: generate metadata correctly for abi variants

### DIFF
--- a/doc/languages-frameworks/android.section.md
+++ b/doc/languages-frameworks/android.section.md
@@ -116,7 +116,7 @@ options:
 For each requested system image we can specify the following options:
 
 * `systemImageTypes` specifies what kind of system images should be included.
-  Defaults to: `default`.
+  Defaults to: `google_apis`, `google_apis_playstore`, `google_apis_ps16k` and `google_apis_playstore_ps16k`.
 * `abiVersions` specifies what kind of ABI version of each system image should
   be included. Defaults to `armeabi-v7a` and `arm64-v8a`.
 

--- a/pkgs/development/mobile/androidenv/compose-android-packages.nix
+++ b/pkgs/development/mobile/androidenv/compose-android-packages.nix
@@ -140,6 +140,8 @@ in
   systemImageTypes ? [
     "google_apis"
     "google_apis_playstore"
+    "google_apis_ps16k"
+    "google_apis_playstore_ps16k"
   ],
   abiVersions ? [
     "x86"

--- a/pkgs/development/mobile/androidenv/repo.json
+++ b/pkgs/development/mobile/androidenv/repo.json
@@ -12,7 +12,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-10",
@@ -26,22 +26,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns8:addonDetailsType"
-          },
-          "libraries:4": {
-            "library:0": {
-              "description:0": "API for Google Maps",
-              "element-attributes": {
-                "localJarPath": "maps.jar",
-                "name": "com.google.android.maps"
-              }
-            },
-            "library:1": {
-              "description:0": "API for USB Accessories",
-              "element-attributes": {
-                "localJarPath": "usb.jar",
-                "name": "com.android.future.usb.accessory"
-              }
-            }
           },
           "libraries:5": {
             "library:0": {
@@ -59,17 +43,9 @@
               }
             }
           },
-          "tag:3": {
-            "display:1": "Google APIs",
-            "id:0": "google_apis"
-          },
           "tag:4": {
             "display:1": "Google APIs",
             "id:0": "google_apis"
-          },
-          "vendor:2": {
-            "display:1": "Google Inc.",
-            "id:0": "google"
           },
           "vendor:3": {
             "display:1": "Google Inc.",
@@ -90,7 +66,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-11",
@@ -105,15 +81,6 @@
           "element-attributes": {
             "xsi:type": "ns8:addonDetailsType"
           },
-          "libraries:4": {
-            "library:0": {
-              "description:0": "API for Google Maps",
-              "element-attributes": {
-                "localJarPath": "maps.jar",
-                "name": "com.google.android.maps"
-              }
-            }
-          },
           "libraries:5": {
             "library:0": {
               "description:0": "API for Google Maps",
@@ -123,17 +90,9 @@
               }
             }
           },
-          "tag:3": {
-            "display:1": "Google APIs",
-            "id:0": "google_apis"
-          },
           "tag:4": {
             "display:1": "Google APIs",
             "id:0": "google_apis"
-          },
-          "vendor:2": {
-            "display:1": "Google Inc.",
-            "id:0": "google"
           },
           "vendor:3": {
             "display:1": "Google Inc.",
@@ -154,7 +113,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-12",
@@ -168,22 +127,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns8:addonDetailsType"
-          },
-          "libraries:4": {
-            "library:0": {
-              "description:0": "API for Google Maps",
-              "element-attributes": {
-                "localJarPath": "maps.jar",
-                "name": "com.google.android.maps"
-              }
-            },
-            "library:1": {
-              "description:0": "API for USB Accessories",
-              "element-attributes": {
-                "localJarPath": "usb.jar",
-                "name": "com.android.future.usb.accessory"
-              }
-            }
           },
           "libraries:5": {
             "library:0": {
@@ -201,17 +144,9 @@
               }
             }
           },
-          "tag:3": {
-            "display:1": "Google APIs",
-            "id:0": "google_apis"
-          },
           "tag:4": {
             "display:1": "Google APIs",
             "id:0": "google_apis"
-          },
-          "vendor:2": {
-            "display:1": "Google Inc.",
-            "id:0": "google"
           },
           "vendor:3": {
             "display:1": "Google Inc.",
@@ -230,7 +165,7 @@
           }
         ],
         "displayName": "Google TV Addon",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-googletv-license",
         "name": "google_tv_addon",
         "path": "add-ons/addon-google_tv_addon-google-12",
@@ -245,17 +180,9 @@
           "element-attributes": {
             "xsi:type": "ns8:addonDetailsType"
           },
-          "tag:3": {
-            "display:1": "Google TV Addon",
-            "id:0": "google_tv_addon"
-          },
           "tag:4": {
             "display:1": "Google TV Addon",
             "id:0": "google_tv_addon"
-          },
-          "vendor:2": {
-            "display:1": "Google Inc.",
-            "id:0": "google"
           },
           "vendor:3": {
             "display:1": "Google Inc.",
@@ -276,7 +203,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-13",
@@ -290,22 +217,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns8:addonDetailsType"
-          },
-          "libraries:4": {
-            "library:0": {
-              "description:0": "API for Google Maps",
-              "element-attributes": {
-                "localJarPath": "maps.jar",
-                "name": "com.google.android.maps"
-              }
-            },
-            "library:1": {
-              "description:0": "API for USB Accessories",
-              "element-attributes": {
-                "localJarPath": "usb.jar",
-                "name": "com.android.future.usb.accessory"
-              }
-            }
           },
           "libraries:5": {
             "library:0": {
@@ -323,17 +234,9 @@
               }
             }
           },
-          "tag:3": {
-            "display:1": "Google APIs",
-            "id:0": "google_apis"
-          },
           "tag:4": {
             "display:1": "Google APIs",
             "id:0": "google_apis"
-          },
-          "vendor:2": {
-            "display:1": "Google Inc.",
-            "id:0": "google"
           },
           "vendor:3": {
             "display:1": "Google Inc.",
@@ -352,7 +255,7 @@
           }
         ],
         "displayName": "Google TV Addon",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-googletv-license",
         "name": "google_tv_addon",
         "path": "add-ons/addon-google_tv_addon-google-13",
@@ -367,17 +270,9 @@
           "element-attributes": {
             "xsi:type": "ns8:addonDetailsType"
           },
-          "tag:3": {
-            "display:1": "Google TV Addon",
-            "id:0": "google_tv_addon"
-          },
           "tag:4": {
             "display:1": "Google TV Addon",
             "id:0": "google_tv_addon"
-          },
-          "vendor:2": {
-            "display:1": "Google Inc.",
-            "id:0": "google"
           },
           "vendor:3": {
             "display:1": "Google Inc.",
@@ -398,7 +293,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-14",
@@ -412,22 +307,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns8:addonDetailsType"
-          },
-          "libraries:4": {
-            "library:0": {
-              "description:0": "API for Google Maps",
-              "element-attributes": {
-                "localJarPath": "maps.jar",
-                "name": "com.google.android.maps"
-              }
-            },
-            "library:1": {
-              "description:0": "API for USB Accessories",
-              "element-attributes": {
-                "localJarPath": "usb.jar",
-                "name": "com.android.future.usb.accessory"
-              }
-            }
           },
           "libraries:5": {
             "library:0": {
@@ -445,17 +324,9 @@
               }
             }
           },
-          "tag:3": {
-            "display:1": "Google APIs",
-            "id:0": "google_apis"
-          },
           "tag:4": {
             "display:1": "Google APIs",
             "id:0": "google_apis"
-          },
-          "vendor:2": {
-            "display:1": "Google Inc.",
-            "id:0": "google"
           },
           "vendor:3": {
             "display:1": "Google Inc.",
@@ -476,7 +347,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-15",
@@ -490,29 +361,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns8:addonDetailsType"
-          },
-          "libraries:4": {
-            "library:0": {
-              "description:0": "API for Google Maps",
-              "element-attributes": {
-                "localJarPath": "maps.jar",
-                "name": "com.google.android.maps"
-              }
-            },
-            "library:1": {
-              "description:0": "API for USB Accessories",
-              "element-attributes": {
-                "localJarPath": "usb.jar",
-                "name": "com.android.future.usb.accessory"
-              }
-            },
-            "library:2": {
-              "description:0": "Collection of video effects",
-              "element-attributes": {
-                "localJarPath": "effects.jar",
-                "name": "com.google.android.media.effects"
-              }
-            }
           },
           "libraries:5": {
             "library:0": {
@@ -537,17 +385,9 @@
               }
             }
           },
-          "tag:3": {
-            "display:1": "Google APIs",
-            "id:0": "google_apis"
-          },
           "tag:4": {
             "display:1": "Google APIs",
             "id:0": "google_apis"
-          },
-          "vendor:2": {
-            "display:1": "Google Inc.",
-            "id:0": "google"
           },
           "vendor:3": {
             "display:1": "Google Inc.",
@@ -568,7 +408,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-16",
@@ -582,29 +422,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns8:addonDetailsType"
-          },
-          "libraries:4": {
-            "library:0": {
-              "description:0": "API for Google Maps",
-              "element-attributes": {
-                "localJarPath": "maps.jar",
-                "name": "com.google.android.maps"
-              }
-            },
-            "library:1": {
-              "description:0": "API for USB Accessories",
-              "element-attributes": {
-                "localJarPath": "usb.jar",
-                "name": "com.android.future.usb.accessory"
-              }
-            },
-            "library:2": {
-              "description:0": "Collection of video effects",
-              "element-attributes": {
-                "localJarPath": "effects.jar",
-                "name": "com.google.android.media.effects"
-              }
-            }
           },
           "libraries:5": {
             "library:0": {
@@ -629,17 +446,9 @@
               }
             }
           },
-          "tag:3": {
-            "display:1": "Google APIs",
-            "id:0": "google_apis"
-          },
           "tag:4": {
             "display:1": "Google APIs",
             "id:0": "google_apis"
-          },
-          "vendor:2": {
-            "display:1": "Google Inc.",
-            "id:0": "google"
           },
           "vendor:3": {
             "display:1": "Google Inc.",
@@ -660,7 +469,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-17",
@@ -674,29 +483,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns8:addonDetailsType"
-          },
-          "libraries:4": {
-            "library:0": {
-              "description:0": "API for Google Maps",
-              "element-attributes": {
-                "localJarPath": "maps.jar",
-                "name": "com.google.android.maps"
-              }
-            },
-            "library:1": {
-              "description:0": "API for USB Accessories",
-              "element-attributes": {
-                "localJarPath": "usb.jar",
-                "name": "com.android.future.usb.accessory"
-              }
-            },
-            "library:2": {
-              "description:0": "Collection of video effects",
-              "element-attributes": {
-                "localJarPath": "effects.jar",
-                "name": "com.google.android.media.effects"
-              }
-            }
           },
           "libraries:5": {
             "library:0": {
@@ -721,17 +507,9 @@
               }
             }
           },
-          "tag:3": {
-            "display:1": "Google APIs",
-            "id:0": "google_apis"
-          },
           "tag:4": {
             "display:1": "Google APIs",
             "id:0": "google_apis"
-          },
-          "vendor:2": {
-            "display:1": "Google Inc.",
-            "id:0": "google"
           },
           "vendor:3": {
             "display:1": "Google Inc.",
@@ -752,7 +530,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-18",
@@ -766,29 +544,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns8:addonDetailsType"
-          },
-          "libraries:4": {
-            "library:0": {
-              "description:0": "API for Google Maps",
-              "element-attributes": {
-                "localJarPath": "maps.jar",
-                "name": "com.google.android.maps"
-              }
-            },
-            "library:1": {
-              "description:0": "API for USB Accessories",
-              "element-attributes": {
-                "localJarPath": "usb.jar",
-                "name": "com.android.future.usb.accessory"
-              }
-            },
-            "library:2": {
-              "description:0": "Collection of video effects",
-              "element-attributes": {
-                "localJarPath": "effects.jar",
-                "name": "com.google.android.media.effects"
-              }
-            }
           },
           "libraries:5": {
             "library:0": {
@@ -813,17 +568,9 @@
               }
             }
           },
-          "tag:3": {
-            "display:1": "Google APIs",
-            "id:0": "google_apis"
-          },
           "tag:4": {
             "display:1": "Google APIs",
             "id:0": "google_apis"
-          },
-          "vendor:2": {
-            "display:1": "Google Inc.",
-            "id:0": "google"
           },
           "vendor:3": {
             "display:1": "Google Inc.",
@@ -844,7 +591,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-19",
@@ -858,29 +605,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns8:addonDetailsType"
-          },
-          "libraries:4": {
-            "library:0": {
-              "description:0": "API for Google Maps",
-              "element-attributes": {
-                "localJarPath": "maps.jar",
-                "name": "com.google.android.maps"
-              }
-            },
-            "library:1": {
-              "description:0": "API for USB Accessories",
-              "element-attributes": {
-                "localJarPath": "usb.jar",
-                "name": "com.android.future.usb.accessory"
-              }
-            },
-            "library:2": {
-              "description:0": "Collection of video effects",
-              "element-attributes": {
-                "localJarPath": "effects.jar",
-                "name": "com.google.android.media.effects"
-              }
-            }
           },
           "libraries:5": {
             "library:0": {
@@ -905,17 +629,9 @@
               }
             }
           },
-          "tag:3": {
-            "display:1": "Google APIs",
-            "id:0": "google_apis"
-          },
           "tag:4": {
             "display:1": "Google APIs",
             "id:0": "google_apis"
-          },
-          "vendor:2": {
-            "display:1": "Google Inc.",
-            "id:0": "google"
           },
           "vendor:3": {
             "display:1": "Google Inc.",
@@ -936,7 +652,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-21",
@@ -950,29 +666,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns8:addonDetailsType"
-          },
-          "libraries:4": {
-            "library:0": {
-              "description:0": "API for Google Maps",
-              "element-attributes": {
-                "localJarPath": "maps.jar",
-                "name": "com.google.android.maps"
-              }
-            },
-            "library:1": {
-              "description:0": "API for USB Accessories",
-              "element-attributes": {
-                "localJarPath": "usb.jar",
-                "name": "com.android.future.usb.accessory"
-              }
-            },
-            "library:2": {
-              "description:0": "Collection of video effects",
-              "element-attributes": {
-                "localJarPath": "effects.jar",
-                "name": "com.google.android.media.effects"
-              }
-            }
           },
           "libraries:5": {
             "library:0": {
@@ -997,17 +690,9 @@
               }
             }
           },
-          "tag:3": {
-            "display:1": "Google APIs",
-            "id:0": "google_apis"
-          },
           "tag:4": {
             "display:1": "Google APIs",
             "id:0": "google_apis"
-          },
-          "vendor:2": {
-            "display:1": "Google Inc.",
-            "id:0": "google"
           },
           "vendor:3": {
             "display:1": "Google Inc.",
@@ -1028,7 +713,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-22",
@@ -1043,29 +728,6 @@
           "element-attributes": {
             "xsi:type": "ns8:addonDetailsType"
           },
-          "libraries:4": {
-            "library:0": {
-              "description:0": "API for Google Maps",
-              "element-attributes": {
-                "localJarPath": "maps.jar",
-                "name": "com.google.android.maps"
-              }
-            },
-            "library:1": {
-              "description:0": "API for USB Accessories",
-              "element-attributes": {
-                "localJarPath": "usb.jar",
-                "name": "com.android.future.usb.accessory"
-              }
-            },
-            "library:2": {
-              "description:0": "Collection of video effects",
-              "element-attributes": {
-                "localJarPath": "effects.jar",
-                "name": "com.google.android.media.effects"
-              }
-            }
-          },
           "libraries:5": {
             "library:0": {
               "description:0": "API for Google Maps",
@@ -1089,17 +751,9 @@
               }
             }
           },
-          "tag:3": {
-            "display:1": "Google APIs",
-            "id:0": "google_apis"
-          },
           "tag:4": {
             "display:1": "Google APIs",
             "id:0": "google_apis"
-          },
-          "vendor:2": {
-            "display:1": "Google Inc.",
-            "id:0": "google"
           },
           "vendor:3": {
             "display:1": "Google Inc.",
@@ -1108,98 +762,7 @@
         }
       }
     },
-    "23": {
-      "google_apis": {
-        "archives": [
-          {
-            "arch": "all",
-            "os": "all",
-            "sha1": "04c5cc1a7c88967250ebba9561d81e24104167db",
-            "size": 179900,
-            "url": "https://dl.google.com/android/repository/google_apis-23_r01.zip"
-          }
-        ],
-        "displayName": "Google APIs",
-        "last-available-day": 20549,
-        "license": "android-sdk-license",
-        "name": "google_apis",
-        "path": "add-ons/addon-google_apis-google-23",
-        "revision": "23",
-        "revision-details": {
-          "major:0": "1"
-        },
-        "type-details": {
-          "api-level:0": "23",
-          "base-extension:2": "true",
-          "codename:1": {},
-          "element-attributes": {
-            "xsi:type": "ns8:addonDetailsType"
-          },
-          "libraries:4": {
-            "library:0": {
-              "description:0": "API for Google Maps",
-              "element-attributes": {
-                "localJarPath": "maps.jar",
-                "name": "com.google.android.maps"
-              }
-            },
-            "library:1": {
-              "description:0": "API for USB Accessories",
-              "element-attributes": {
-                "localJarPath": "usb.jar",
-                "name": "com.android.future.usb.accessory"
-              }
-            },
-            "library:2": {
-              "description:0": "Collection of video effects",
-              "element-attributes": {
-                "localJarPath": "effects.jar",
-                "name": "com.google.android.media.effects"
-              }
-            }
-          },
-          "libraries:5": {
-            "library:0": {
-              "description:0": "API for Google Maps",
-              "element-attributes": {
-                "localJarPath": "maps.jar",
-                "name": "com.google.android.maps"
-              }
-            },
-            "library:1": {
-              "description:0": "API for USB Accessories",
-              "element-attributes": {
-                "localJarPath": "usb.jar",
-                "name": "com.android.future.usb.accessory"
-              }
-            },
-            "library:2": {
-              "description:0": "Collection of video effects",
-              "element-attributes": {
-                "localJarPath": "effects.jar",
-                "name": "com.google.android.media.effects"
-              }
-            }
-          },
-          "tag:3": {
-            "display:1": "Google APIs",
-            "id:0": "google_apis"
-          },
-          "tag:4": {
-            "display:1": "Google APIs",
-            "id:0": "google_apis"
-          },
-          "vendor:2": {
-            "display:1": "Google Inc.",
-            "id:0": "google"
-          },
-          "vendor:3": {
-            "display:1": "Google Inc.",
-            "id:0": "google"
-          }
-        }
-      }
-    },
+    "23": {},
     "24": {
       "google_apis": {
         "archives": [
@@ -1212,7 +775,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-24",
@@ -1227,29 +790,6 @@
           "element-attributes": {
             "xsi:type": "ns8:addonDetailsType"
           },
-          "libraries:4": {
-            "library:0": {
-              "description:0": "API for Google Maps",
-              "element-attributes": {
-                "localJarPath": "maps.jar",
-                "name": "com.google.android.maps"
-              }
-            },
-            "library:1": {
-              "description:0": "API for USB Accessories",
-              "element-attributes": {
-                "localJarPath": "usb.jar",
-                "name": "com.android.future.usb.accessory"
-              }
-            },
-            "library:2": {
-              "description:0": "Collection of video effects",
-              "element-attributes": {
-                "localJarPath": "effects.jar",
-                "name": "com.google.android.media.effects"
-              }
-            }
-          },
           "libraries:5": {
             "library:0": {
               "description:0": "API for Google Maps",
@@ -1273,17 +813,9 @@
               }
             }
           },
-          "tag:3": {
-            "display:1": "Google APIs",
-            "id:0": "google_apis"
-          },
           "tag:4": {
             "display:1": "Google APIs",
             "id:0": "google_apis"
-          },
-          "vendor:2": {
-            "display:1": "Google Inc.",
-            "id:0": "google"
           },
           "vendor:3": {
             "display:1": "Google Inc.",
@@ -1304,7 +836,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-25",
@@ -1318,29 +850,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns8:addonDetailsType"
-          },
-          "libraries:4": {
-            "library:0": {
-              "description:0": "API for Google Maps",
-              "element-attributes": {
-                "localJarPath": "maps.jar",
-                "name": "com.google.android.maps"
-              }
-            },
-            "library:1": {
-              "description:0": "API for USB Accessories",
-              "element-attributes": {
-                "localJarPath": "usb.jar",
-                "name": "com.android.future.usb.accessory"
-              }
-            },
-            "library:2": {
-              "description:0": "Collection of video effects",
-              "element-attributes": {
-                "localJarPath": "effects.jar",
-                "name": "com.google.android.media.effects"
-              }
-            }
           },
           "libraries:5": {
             "library:0": {
@@ -1365,17 +874,9 @@
               }
             }
           },
-          "tag:3": {
-            "display:1": "Google APIs",
-            "id:0": "google_apis"
-          },
           "tag:4": {
             "display:1": "Google APIs",
             "id:0": "google_apis"
-          },
-          "vendor:2": {
-            "display:1": "Google Inc.",
-            "id:0": "google"
           },
           "vendor:3": {
             "display:1": "Google Inc.",
@@ -1396,7 +897,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-3",
@@ -1411,15 +912,6 @@
           "element-attributes": {
             "xsi:type": "ns8:addonDetailsType"
           },
-          "libraries:4": {
-            "library:0": {
-              "description:0": "API for Google Maps",
-              "element-attributes": {
-                "localJarPath": "maps.jar",
-                "name": "com.google.android.maps"
-              }
-            }
-          },
           "libraries:5": {
             "library:0": {
               "description:0": "API for Google Maps",
@@ -1429,17 +921,9 @@
               }
             }
           },
-          "tag:3": {
-            "display:1": "Google APIs",
-            "id:0": "google_apis"
-          },
           "tag:4": {
             "display:1": "Google APIs",
             "id:0": "google_apis"
-          },
-          "vendor:2": {
-            "display:1": "Google Inc.",
-            "id:0": "google"
           },
           "vendor:3": {
             "display:1": "Google Inc.",
@@ -1460,7 +944,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-4",
@@ -1475,15 +959,6 @@
           "element-attributes": {
             "xsi:type": "ns8:addonDetailsType"
           },
-          "libraries:4": {
-            "library:0": {
-              "description:0": "API for Google Maps",
-              "element-attributes": {
-                "localJarPath": "maps.jar",
-                "name": "com.google.android.maps"
-              }
-            }
-          },
           "libraries:5": {
             "library:0": {
               "description:0": "API for Google Maps",
@@ -1493,17 +968,9 @@
               }
             }
           },
-          "tag:3": {
-            "display:1": "Google APIs",
-            "id:0": "google_apis"
-          },
           "tag:4": {
             "display:1": "Google APIs",
             "id:0": "google_apis"
-          },
-          "vendor:2": {
-            "display:1": "Google Inc.",
-            "id:0": "google"
           },
           "vendor:3": {
             "display:1": "Google Inc.",
@@ -1524,7 +991,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-5",
@@ -1539,15 +1006,6 @@
           "element-attributes": {
             "xsi:type": "ns8:addonDetailsType"
           },
-          "libraries:4": {
-            "library:0": {
-              "description:0": "API for Google Maps",
-              "element-attributes": {
-                "localJarPath": "maps.jar",
-                "name": "com.google.android.maps"
-              }
-            }
-          },
           "libraries:5": {
             "library:0": {
               "description:0": "API for Google Maps",
@@ -1557,17 +1015,9 @@
               }
             }
           },
-          "tag:3": {
-            "display:1": "Google APIs",
-            "id:0": "google_apis"
-          },
           "tag:4": {
             "display:1": "Google APIs",
             "id:0": "google_apis"
-          },
-          "vendor:2": {
-            "display:1": "Google Inc.",
-            "id:0": "google"
           },
           "vendor:3": {
             "display:1": "Google Inc.",
@@ -1588,7 +1038,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-6",
@@ -1603,15 +1053,6 @@
           "element-attributes": {
             "xsi:type": "ns8:addonDetailsType"
           },
-          "libraries:4": {
-            "library:0": {
-              "description:0": "API for Google Maps",
-              "element-attributes": {
-                "localJarPath": "maps.jar",
-                "name": "com.google.android.maps"
-              }
-            }
-          },
           "libraries:5": {
             "library:0": {
               "description:0": "API for Google Maps",
@@ -1621,17 +1062,9 @@
               }
             }
           },
-          "tag:3": {
-            "display:1": "Google APIs",
-            "id:0": "google_apis"
-          },
           "tag:4": {
             "display:1": "Google APIs",
             "id:0": "google_apis"
-          },
-          "vendor:2": {
-            "display:1": "Google Inc.",
-            "id:0": "google"
           },
           "vendor:3": {
             "display:1": "Google Inc.",
@@ -1652,7 +1085,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-7",
@@ -1667,15 +1100,6 @@
           "element-attributes": {
             "xsi:type": "ns8:addonDetailsType"
           },
-          "libraries:4": {
-            "library:0": {
-              "description:0": "API for Google Maps",
-              "element-attributes": {
-                "localJarPath": "maps.jar",
-                "name": "com.google.android.maps"
-              }
-            }
-          },
           "libraries:5": {
             "library:0": {
               "description:0": "API for Google Maps",
@@ -1685,17 +1109,9 @@
               }
             }
           },
-          "tag:3": {
-            "display:1": "Google APIs",
-            "id:0": "google_apis"
-          },
           "tag:4": {
             "display:1": "Google APIs",
             "id:0": "google_apis"
-          },
-          "vendor:2": {
-            "display:1": "Google Inc.",
-            "id:0": "google"
           },
           "vendor:3": {
             "display:1": "Google Inc.",
@@ -1716,7 +1132,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-8",
@@ -1731,15 +1147,6 @@
           "element-attributes": {
             "xsi:type": "ns8:addonDetailsType"
           },
-          "libraries:4": {
-            "library:0": {
-              "description:0": "API for Google Maps",
-              "element-attributes": {
-                "localJarPath": "maps.jar",
-                "name": "com.google.android.maps"
-              }
-            }
-          },
           "libraries:5": {
             "library:0": {
               "description:0": "API for Google Maps",
@@ -1749,17 +1156,9 @@
               }
             }
           },
-          "tag:3": {
-            "display:1": "Google APIs",
-            "id:0": "google_apis"
-          },
           "tag:4": {
             "display:1": "Google APIs",
             "id:0": "google_apis"
-          },
-          "vendor:2": {
-            "display:1": "Google Inc.",
-            "id:0": "google"
           },
           "vendor:3": {
             "display:1": "Google Inc.",
@@ -1780,7 +1179,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-9",
@@ -1795,15 +1194,6 @@
           "element-attributes": {
             "xsi:type": "ns8:addonDetailsType"
           },
-          "libraries:4": {
-            "library:0": {
-              "description:0": "API for Google Maps",
-              "element-attributes": {
-                "localJarPath": "maps.jar",
-                "name": "com.google.android.maps"
-              }
-            }
-          },
           "libraries:5": {
             "library:0": {
               "description:0": "API for Google Maps",
@@ -1813,17 +1203,9 @@
               }
             }
           },
-          "tag:3": {
-            "display:1": "Google APIs",
-            "id:0": "google_apis"
-          },
           "tag:4": {
             "display:1": "Google APIs",
             "id:0": "google_apis"
-          },
-          "vendor:2": {
-            "display:1": "Google Inc.",
-            "id:0": "google"
           },
           "vendor:3": {
             "display:1": "Google Inc.",
@@ -1845,7 +1227,7 @@
         }
       ],
       "displayName": "Android Support Repository",
-      "last-available-day": 20665,
+      "last-available-day": 20676,
       "license": "android-sdk-license",
       "name": "extras-android-m2repository",
       "path": "extras/android/m2repository",
@@ -1876,7 +1258,7 @@
         }
       ],
       "displayName": "Android Emulator hypervisor driver (installer)",
-      "last-available-day": 20665,
+      "last-available-day": 20676,
       "license": "android-sdk-license",
       "name": "extras-google-Android_Emulator_Hypervisor_Driver",
       "path": "extras/google/Android_Emulator_Hypervisor_Driver",
@@ -1907,7 +1289,7 @@
         }
       ],
       "displayName": "Google AdMob Ads SDK",
-      "last-available-day": 20665,
+      "last-available-day": 20676,
       "license": "android-sdk-license",
       "name": "extras-google-admob_ads_sdk",
       "path": "extras/google/admob_ads_sdk",
@@ -1936,7 +1318,7 @@
         }
       ],
       "displayName": "Google Analytics App Tracking SDK",
-      "last-available-day": 20665,
+      "last-available-day": 20676,
       "license": "android-sdk-license",
       "name": "extras-google-analytics_sdk_v2",
       "path": "extras/google/analytics_sdk_v2",
@@ -1986,7 +1368,7 @@
         }
       ],
       "displayName": "Android Auto Desktop Head Unit Emulator",
-      "last-available-day": 20665,
+      "last-available-day": 20676,
       "license": "android-sdk-license",
       "name": "extras-google-auto",
       "path": "extras/google/auto",
@@ -2012,7 +1394,7 @@
         }
       ],
       "displayName": "Google Cloud Messaging for Android Library",
-      "last-available-day": 20665,
+      "last-available-day": 20676,
       "license": "android-sdk-license",
       "name": "extras-google-gcm",
       "path": "extras/google/gcm",
@@ -2040,15 +1422,8 @@
           "url": "https://dl.google.com/android/repository/google_play_services_v16_1_rc09.zip"
         }
       ],
-      "dependencies": {
-        "dependency:0": {
-          "element-attributes": {
-            "path": "patcher;v4"
-          }
-        }
-      },
       "displayName": "Google Play services",
-      "last-available-day": 20665,
+      "last-available-day": 20676,
       "license": "android-sdk-license",
       "name": "extras-google-google_play_services",
       "path": "extras/google/google_play_services",
@@ -2077,7 +1452,7 @@
         }
       ],
       "displayName": "Google Play services for Froyo",
-      "last-available-day": 20665,
+      "last-available-day": 20676,
       "license": "android-sdk-license",
       "name": "extras-google-google_play_services_froyo",
       "path": "extras/google/google_play_services_froyo",
@@ -2106,7 +1481,7 @@
         }
       ],
       "displayName": "Google Play Instant Development SDK (Deprecated)",
-      "last-available-day": 20665,
+      "last-available-day": 20676,
       "license": "android-sdk-license",
       "name": "extras-google-instantapps",
       "path": "extras/google/instantapps",
@@ -2136,15 +1511,8 @@
           "url": "https://dl.google.com/android/repository/google_m2repository_gms_v11_3_rc05_wear_2_0_5.zip"
         }
       ],
-      "dependencies": {
-        "dependency:0": {
-          "element-attributes": {
-            "path": "patcher;v4"
-          }
-        }
-      },
       "displayName": "Google Repository",
-      "last-available-day": 20665,
+      "last-available-day": 20676,
       "license": "android-sdk-license",
       "name": "extras-google-m2repository",
       "path": "extras/google/m2repository",
@@ -2173,7 +1541,7 @@
         }
       ],
       "displayName": "Google Play APK Expansion library",
-      "last-available-day": 20665,
+      "last-available-day": 20676,
       "license": "android-sdk-license",
       "name": "extras-google-market_apk_expansion",
       "path": "extras/google/market_apk_expansion",
@@ -2202,7 +1570,7 @@
         }
       ],
       "displayName": "Google Play Licensing Library",
-      "last-available-day": 20665,
+      "last-available-day": 20676,
       "license": "android-sdk-license",
       "name": "extras-google-market_licensing",
       "path": "extras/google/market_licensing",
@@ -2231,7 +1599,7 @@
         }
       ],
       "displayName": "Android Auto API Simulators",
-      "last-available-day": 20665,
+      "last-available-day": 20676,
       "license": "android-sdk-license",
       "name": "extras-google-simulators",
       "path": "extras/google/simulators",
@@ -2260,7 +1628,7 @@
         }
       ],
       "displayName": "Google USB Driver",
-      "last-available-day": 20665,
+      "last-available-day": 20676,
       "license": "android-sdk-license",
       "name": "extras-google-usb_driver",
       "path": "extras/google/usb_driver",
@@ -2289,7 +1657,7 @@
         }
       ],
       "displayName": "Google Web Driver",
-      "last-available-day": 20665,
+      "last-available-day": 20676,
       "license": "android-sdk-license",
       "name": "extras-google-webdriver",
       "path": "extras/google/webdriver",
@@ -2321,15 +1689,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-10_r05.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-10-default-armeabi-v7a",
           "path": "system-images/android-10/default/armeabi-v7a",
@@ -2338,16 +1699,11 @@
             "major:0": "5"
           },
           "type-details": {
-            "abi:2": "armeabi-v7a",
             "abi:3": "armeabi-v7a",
             "api-level:0": "10",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -2365,15 +1721,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86-10_r05.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-10-default-x86",
           "path": "system-images/android-10/default/x86",
@@ -2382,16 +1731,11 @@
             "major:0": "5"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "10",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -2411,15 +1755,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-10_r06.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-10-google_apis-armeabi-v7a",
           "path": "system-images/android-10/google_apis/armeabi-v7a",
@@ -2428,24 +1765,15 @@
             "major:0": "6"
           },
           "type-details": {
-            "abi:3": "armeabi-v7a",
             "abi:4": "armeabi-v7a",
             "api-level:0": "10",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -2463,15 +1791,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-10_r06.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-10-google_apis-x86",
           "path": "system-images/android-10/google_apis/x86",
@@ -2480,24 +1801,15 @@
             "major:0": "6"
           },
           "type-details": {
-            "abi:3": "x86",
             "abi:4": "x86",
             "api-level:0": "10",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -2520,7 +1832,7 @@
             }
           ],
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-14-default-armeabi-v7a",
           "path": "system-images/android-14/default/armeabi-v7a",
@@ -2529,16 +1841,11 @@
             "major:0": "2"
           },
           "type-details": {
-            "abi:2": "armeabi-v7a",
             "abi:3": "armeabi-v7a",
             "api-level:0": "14",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -2560,15 +1867,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-15_r05.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-15-default-armeabi-v7a",
           "path": "system-images/android-15/default/armeabi-v7a",
@@ -2577,16 +1877,11 @@
             "major:0": "5"
           },
           "type-details": {
-            "abi:2": "armeabi-v7a",
             "abi:3": "armeabi-v7a",
             "api-level:0": "15",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -2604,15 +1899,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86-15_r07.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-15-default-x86",
           "path": "system-images/android-15/default/x86",
@@ -2621,16 +1909,11 @@
             "major:0": "7"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "15",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -2650,15 +1933,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-15_r06.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-15-google_apis-armeabi-v7a",
           "path": "system-images/android-15/google_apis/armeabi-v7a",
@@ -2667,24 +1943,15 @@
             "major:0": "6"
           },
           "type-details": {
-            "abi:3": "armeabi-v7a",
             "abi:4": "armeabi-v7a",
             "api-level:0": "15",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -2702,15 +1969,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-15_r07.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-15-google_apis-x86",
           "path": "system-images/android-15/google_apis/x86",
@@ -2719,24 +1979,15 @@
             "major:0": "7"
           },
           "type-details": {
-            "abi:3": "x86",
             "abi:4": "x86",
             "api-level:0": "15",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -2758,15 +2009,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-16_r06.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-16-default-armeabi-v7a",
           "path": "system-images/android-16/default/armeabi-v7a",
@@ -2775,16 +2019,11 @@
             "major:0": "6"
           },
           "type-details": {
-            "abi:2": "armeabi-v7a",
             "abi:3": "armeabi-v7a",
             "api-level:0": "16",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -2803,7 +2042,7 @@
             }
           ],
           "displayName": "MIPS System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "mips-android-sysimage-license",
           "name": "system-image-16-default-mips",
           "path": "system-images/android-16/default/mips",
@@ -2812,16 +2051,11 @@
             "major:0": "1"
           },
           "type-details": {
-            "abi:2": "mips",
             "abi:3": "mips",
             "api-level:0": "16",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -2839,15 +2073,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86-16_r07.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-16-default-x86",
           "path": "system-images/android-16/default/x86",
@@ -2856,16 +2083,11 @@
             "major:0": "7"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "16",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -2885,15 +2107,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-16_r06.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-16-google_apis-armeabi-v7a",
           "path": "system-images/android-16/google_apis/armeabi-v7a",
@@ -2902,24 +2117,15 @@
             "major:0": "6"
           },
           "type-details": {
-            "abi:3": "armeabi-v7a",
             "abi:4": "armeabi-v7a",
             "api-level:0": "16",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -2937,15 +2143,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-16_r07.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-16-google_apis-x86",
           "path": "system-images/android-16/google_apis/x86",
@@ -2954,24 +2153,15 @@
             "major:0": "7"
           },
           "type-details": {
-            "abi:3": "x86",
             "abi:4": "x86",
             "api-level:0": "16",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -2993,15 +2183,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-17_r06.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-17-default-armeabi-v7a",
           "path": "system-images/android-17/default/armeabi-v7a",
@@ -3010,16 +2193,11 @@
             "major:0": "6"
           },
           "type-details": {
-            "abi:2": "armeabi-v7a",
             "abi:3": "armeabi-v7a",
             "api-level:0": "17",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -3038,7 +2216,7 @@
             }
           ],
           "displayName": "MIPS System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "mips-android-sysimage-license",
           "name": "system-image-17-default-mips",
           "path": "system-images/android-17/default/mips",
@@ -3047,16 +2225,11 @@
             "major:0": "1"
           },
           "type-details": {
-            "abi:2": "mips",
             "abi:3": "mips",
             "api-level:0": "17",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -3074,15 +2247,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86-17_r07.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-17-default-x86",
           "path": "system-images/android-17/default/x86",
@@ -3091,24 +2257,15 @@
             "major:0": "7"
           },
           "type-details": {
-            "abi:3": "x86",
             "abi:4": "x86",
             "api-level:0": "17",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "default"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "default"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -3128,15 +2285,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-17_r06.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-17-google_apis-armeabi-v7a",
           "path": "system-images/android-17/google_apis/armeabi-v7a",
@@ -3145,24 +2295,15 @@
             "major:0": "6"
           },
           "type-details": {
-            "abi:3": "armeabi-v7a",
             "abi:4": "armeabi-v7a",
             "api-level:0": "17",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -3180,15 +2321,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-17_r07.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-17-google_apis-x86",
           "path": "system-images/android-17/google_apis/x86",
@@ -3197,24 +2331,15 @@
             "major:0": "7"
           },
           "type-details": {
-            "abi:3": "x86",
             "abi:4": "x86",
             "api-level:0": "17",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -3236,15 +2361,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-18_r05.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-18-default-armeabi-v7a",
           "path": "system-images/android-18/default/armeabi-v7a",
@@ -3253,16 +2371,11 @@
             "major:0": "5"
           },
           "type-details": {
-            "abi:2": "armeabi-v7a",
             "abi:3": "armeabi-v7a",
             "api-level:0": "18",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -3280,15 +2393,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86-18_r04.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-18-default-x86",
           "path": "system-images/android-18/default/x86",
@@ -3297,16 +2403,11 @@
             "major:0": "4"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "18",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -3326,15 +2427,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-18_r06.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-18-google_apis-armeabi-v7a",
           "path": "system-images/android-18/google_apis/armeabi-v7a",
@@ -3343,24 +2437,15 @@
             "major:0": "6"
           },
           "type-details": {
-            "abi:3": "armeabi-v7a",
             "abi:4": "armeabi-v7a",
             "api-level:0": "18",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -3378,15 +2463,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-18_r06.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-18-google_apis-x86",
           "path": "system-images/android-18/google_apis/x86",
@@ -3395,24 +2473,15 @@
             "major:0": "6"
           },
           "type-details": {
-            "abi:3": "x86",
             "abi:4": "x86",
             "api-level:0": "18",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -3434,15 +2503,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-19_r05.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-19-default-armeabi-v7a",
           "path": "system-images/android-19/default/armeabi-v7a",
@@ -3451,16 +2513,11 @@
             "major:0": "5"
           },
           "type-details": {
-            "abi:2": "armeabi-v7a",
             "abi:3": "armeabi-v7a",
             "api-level:0": "19",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -3478,15 +2535,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86-19_r06.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-19-default-x86",
           "path": "system-images/android-19/default/x86",
@@ -3495,16 +2545,11 @@
             "major:0": "6"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "19",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -3524,15 +2569,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-19_r40.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-19-google_apis-armeabi-v7a",
           "path": "system-images/android-19/google_apis/armeabi-v7a",
@@ -3541,24 +2579,15 @@
             "major:0": "40"
           },
           "type-details": {
-            "abi:3": "armeabi-v7a",
             "abi:4": "armeabi-v7a",
             "api-level:0": "19",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -3576,15 +2605,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-19_r40.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-19-google_apis-x86",
           "path": "system-images/android-19/google_apis/x86",
@@ -3593,24 +2615,15 @@
             "major:0": "40"
           },
           "type-details": {
-            "abi:3": "x86",
             "abi:4": "x86",
             "api-level:0": "19",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -3633,7 +2646,7 @@
             }
           ],
           "displayName": "Android TV ARM EABI v7a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-21-android-tv-armeabi-v7a",
           "path": "system-images/android-21/android-tv/armeabi-v7a",
@@ -3642,16 +2655,11 @@
             "major:0": "3"
           },
           "type-details": {
-            "abi:2": "armeabi-v7a",
             "abi:3": "armeabi-v7a",
             "api-level:0": "21",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Android TV",
-              "id:0": "android-tv"
             },
             "tag:2": {
               "display:1": "Android TV",
@@ -3670,7 +2678,7 @@
             }
           ],
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-21-android-tv-x86",
           "path": "system-images/android-21/android-tv/x86",
@@ -3679,16 +2687,11 @@
             "major:0": "3"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "21",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Android TV",
-              "id:0": "android-tv"
             },
             "tag:2": {
               "display:1": "Android TV",
@@ -3709,7 +2712,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-21-default-arm64-v8a",
           "path": "system-images/android-21/default/arm64-v8a",
@@ -3718,16 +2721,11 @@
             "major:0": "4"
           },
           "type-details": {
-            "abi:2": "arm64-v8a",
             "abi:3": "arm64-v8a",
             "api-level:0": "21",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -3745,15 +2743,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-21_r04.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-21-default-armeabi-v7a",
           "path": "system-images/android-21/default/armeabi-v7a",
@@ -3762,16 +2753,11 @@
             "major:0": "4"
           },
           "type-details": {
-            "abi:2": "armeabi-v7a",
             "abi:3": "armeabi-v7a",
             "api-level:0": "21",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -3789,15 +2775,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86-21_r05.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-21-default-x86",
           "path": "system-images/android-21/default/x86",
@@ -3806,16 +2785,11 @@
             "major:0": "5"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "21",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -3833,15 +2807,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-21_r05.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-21-default-x86_64",
           "path": "system-images/android-21/default/x86_64",
@@ -3850,16 +2817,11 @@
             "major:0": "5"
           },
           "type-details": {
-            "abi:2": "x86_64",
             "abi:3": "x86_64",
             "api-level:0": "21",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -3880,7 +2842,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-arm64-v8a",
           "path": "system-images/android-21/google_apis/arm64-v8a",
@@ -3889,24 +2851,15 @@
             "major:0": "32"
           },
           "type-details": {
-            "abi:3": "arm64-v8a",
             "abi:4": "arm64-v8a",
             "api-level:0": "21",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -3924,15 +2877,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-21_r32.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-armeabi-v7a",
           "path": "system-images/android-21/google_apis/armeabi-v7a",
@@ -3941,24 +2887,15 @@
             "major:0": "32"
           },
           "type-details": {
-            "abi:3": "armeabi-v7a",
             "abi:4": "armeabi-v7a",
             "api-level:0": "21",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -3976,15 +2913,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-21_r32.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-x86",
           "path": "system-images/android-21/google_apis/x86",
@@ -3993,24 +2923,15 @@
             "major:0": "32"
           },
           "type-details": {
-            "abi:3": "x86",
             "abi:4": "x86",
             "api-level:0": "21",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -4028,15 +2949,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-21_r32.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-x86_64",
           "path": "system-images/android-21/google_apis/x86_64",
@@ -4045,24 +2959,15 @@
             "major:0": "32"
           },
           "type-details": {
-            "abi:3": "x86_64",
             "abi:4": "x86_64",
             "api-level:0": "21",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -4085,7 +2990,7 @@
             }
           ],
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-22-android-tv-x86",
           "path": "system-images/android-22/android-tv/x86",
@@ -4094,16 +2999,11 @@
             "major:0": "3"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "22",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Android TV",
-              "id:0": "android-tv"
             },
             "tag:2": {
               "display:1": "Android TV",
@@ -4124,7 +3024,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-22-default-arm64-v8a",
           "path": "system-images/android-22/default/arm64-v8a",
@@ -4133,16 +3033,11 @@
             "major:0": "2"
           },
           "type-details": {
-            "abi:2": "arm64-v8a",
             "abi:3": "arm64-v8a",
             "api-level:0": "22",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -4160,15 +3055,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-22_r02.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-22-default-armeabi-v7a",
           "path": "system-images/android-22/default/armeabi-v7a",
@@ -4177,16 +3065,11 @@
             "major:0": "2"
           },
           "type-details": {
-            "abi:2": "armeabi-v7a",
             "abi:3": "armeabi-v7a",
             "api-level:0": "22",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -4204,15 +3087,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86-22_r06.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-22-default-x86",
           "path": "system-images/android-22/default/x86",
@@ -4221,16 +3097,11 @@
             "major:0": "6"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "22",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -4248,15 +3119,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-22_r06.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-22-default-x86_64",
           "path": "system-images/android-22/default/x86_64",
@@ -4265,16 +3129,11 @@
             "major:0": "6"
           },
           "type-details": {
-            "abi:2": "x86_64",
             "abi:3": "x86_64",
             "api-level:0": "22",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -4295,7 +3154,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-arm64-v8a",
           "path": "system-images/android-22/google_apis/arm64-v8a",
@@ -4304,24 +3163,15 @@
             "major:0": "26"
           },
           "type-details": {
-            "abi:3": "arm64-v8a",
             "abi:4": "arm64-v8a",
             "api-level:0": "22",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -4339,15 +3189,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-22_r26.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-armeabi-v7a",
           "path": "system-images/android-22/google_apis/armeabi-v7a",
@@ -4356,24 +3199,15 @@
             "major:0": "26"
           },
           "type-details": {
-            "abi:3": "armeabi-v7a",
             "abi:4": "armeabi-v7a",
             "api-level:0": "22",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -4391,15 +3225,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-22_r26.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-x86",
           "path": "system-images/android-22/google_apis/x86",
@@ -4408,24 +3235,15 @@
             "major:0": "26"
           },
           "type-details": {
-            "abi:3": "x86",
             "abi:4": "x86",
             "api-level:0": "22",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -4443,15 +3261,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-22_r26.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-x86_64",
           "path": "system-images/android-22/google_apis/x86_64",
@@ -4460,24 +3271,15 @@
             "major:0": "26"
           },
           "type-details": {
-            "abi:3": "x86_64",
             "abi:4": "x86_64",
             "api-level:0": "22",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -4500,7 +3302,7 @@
             }
           ],
           "displayName": "Android TV ARM EABI v7a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-23-android-tv-armeabi-v7a",
           "path": "system-images/android-23/android-tv/armeabi-v7a",
@@ -4509,16 +3311,11 @@
             "major:0": "12"
           },
           "type-details": {
-            "abi:2": "armeabi-v7a",
             "abi:3": "armeabi-v7a",
             "api-level:0": "23",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Android TV",
-              "id:0": "android-tv"
             },
             "tag:2": {
               "display:1": "Android TV",
@@ -4536,15 +3333,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-tv/x86-23_r21.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-23-android-tv-x86",
           "path": "system-images/android-23/android-tv/x86",
@@ -4553,16 +3343,11 @@
             "major:0": "21"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "23",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Android TV",
-              "id:0": "android-tv"
             },
             "tag:2": {
               "display:1": "Android TV",
@@ -4583,7 +3368,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-23-default-arm64-v8a",
           "path": "system-images/android-23/default/arm64-v8a",
@@ -4592,16 +3377,11 @@
             "major:0": "7"
           },
           "type-details": {
-            "abi:2": "arm64-v8a",
             "abi:3": "arm64-v8a",
             "api-level:0": "23",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -4619,15 +3399,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-23_r06.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-23-default-armeabi-v7a",
           "path": "system-images/android-23/default/armeabi-v7a",
@@ -4636,16 +3409,11 @@
             "major:0": "6"
           },
           "type-details": {
-            "abi:2": "armeabi-v7a",
             "abi:3": "armeabi-v7a",
             "api-level:0": "23",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -4663,15 +3431,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86-23_r10.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-23-default-x86",
           "path": "system-images/android-23/default/x86",
@@ -4680,16 +3441,11 @@
             "major:0": "10"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "23",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -4707,15 +3463,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-23_r10.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-23-default-x86_64",
           "path": "system-images/android-23/default/x86_64",
@@ -4724,16 +3473,11 @@
             "major:0": "10"
           },
           "type-details": {
-            "abi:2": "x86_64",
             "abi:3": "x86_64",
             "api-level:0": "23",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -4754,7 +3498,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-arm64-v8a",
           "path": "system-images/android-23/google_apis/arm64-v8a",
@@ -4763,24 +3507,15 @@
             "major:0": "33"
           },
           "type-details": {
-            "abi:3": "arm64-v8a",
             "abi:4": "arm64-v8a",
             "api-level:0": "23",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -4798,15 +3533,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-23_r33.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-armeabi-v7a",
           "path": "system-images/android-23/google_apis/armeabi-v7a",
@@ -4815,24 +3543,15 @@
             "major:0": "33"
           },
           "type-details": {
-            "abi:3": "armeabi-v7a",
             "abi:4": "armeabi-v7a",
             "api-level:0": "23",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -4850,15 +3569,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-23_r33.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-x86",
           "path": "system-images/android-23/google_apis/x86",
@@ -4867,24 +3579,15 @@
             "major:0": "33"
           },
           "type-details": {
-            "abi:3": "x86",
             "abi:4": "x86",
             "api-level:0": "23",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -4902,15 +3605,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-23_r33.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-x86_64",
           "path": "system-images/android-23/google_apis/x86_64",
@@ -4919,24 +3615,15 @@
             "major:0": "33"
           },
           "type-details": {
-            "abi:3": "x86_64",
             "abi:4": "x86_64",
             "api-level:0": "23",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -4958,15 +3645,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-tv/x86-24_r22.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-24-android-tv-x86",
           "path": "system-images/android-24/android-tv/x86",
@@ -4975,16 +3655,11 @@
             "major:0": "22"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "24",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Android TV",
-              "id:0": "android-tv"
             },
             "tag:2": {
               "display:1": "Android TV",
@@ -5005,7 +3680,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-24-default-arm64-v8a",
           "path": "system-images/android-24/default/arm64-v8a",
@@ -5014,16 +3689,11 @@
             "major:0": "9"
           },
           "type-details": {
-            "abi:2": "arm64-v8a",
             "abi:3": "arm64-v8a",
             "api-level:0": "24",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -5041,15 +3711,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-24_r07.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-24-default-armeabi-v7a",
           "path": "system-images/android-24/default/armeabi-v7a",
@@ -5058,16 +3721,11 @@
             "major:0": "7"
           },
           "type-details": {
-            "abi:2": "armeabi-v7a",
             "abi:3": "armeabi-v7a",
             "api-level:0": "24",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -5085,15 +3743,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86-24_r08.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-24-default-x86",
           "path": "system-images/android-24/default/x86",
@@ -5102,16 +3753,11 @@
             "major:0": "8"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "24",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -5129,15 +3775,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-24_r08.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-24-default-x86_64",
           "path": "system-images/android-24/default/x86_64",
@@ -5146,16 +3785,11 @@
             "major:0": "8"
           },
           "type-details": {
-            "abi:2": "x86_64",
             "abi:3": "x86_64",
             "api-level:0": "24",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -5175,15 +3809,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-24_r29.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-arm64-v8a",
           "path": "system-images/android-24/google_apis/arm64-v8a",
@@ -5192,24 +3819,15 @@
             "major:0": "27"
           },
           "type-details": {
-            "abi:3": "arm64-v8a",
             "abi:4": "arm64-v8a",
             "api-level:0": "24",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -5227,15 +3845,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-24_r27.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-x86",
           "path": "system-images/android-24/google_apis/x86",
@@ -5244,24 +3855,15 @@
             "major:0": "27"
           },
           "type-details": {
-            "abi:3": "x86",
             "abi:4": "x86",
             "api-level:0": "24",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -5279,15 +3881,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-24_r27.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-x86_64",
           "path": "system-images/android-24/google_apis/x86_64",
@@ -5296,24 +3891,15 @@
             "major:0": "27"
           },
           "type-details": {
-            "abi:3": "x86_64",
             "abi:4": "x86_64",
             "api-level:0": "24",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -5333,15 +3919,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86-24_r19.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis_playstore-x86",
           "path": "system-images/android-24/google_apis_playstore/x86",
@@ -5350,24 +3929,15 @@
             "major:0": "19"
           },
           "type-details": {
-            "abi:3": "x86",
             "abi:4": "x86",
             "api-level:0": "24",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
             "tag:2": {
               "display:1": "Google Play",
               "id:0": "google_apis_playstore"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -5389,15 +3959,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-tv/x86-25_r16.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-25-android-tv-x86",
           "path": "system-images/android-25/android-tv/x86",
@@ -5406,16 +3969,11 @@
             "major:0": "16"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "25",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Android TV",
-              "id:0": "android-tv"
             },
             "tag:2": {
               "display:1": "Android TV",
@@ -5435,15 +3993,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-wear/armeabi-v7a-25_r03.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Android Wear ARM EABI v7a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-25-android-wear-armeabi-v7a",
           "path": "system-images/android-25/android-wear/armeabi-v7a",
@@ -5452,16 +4003,11 @@
             "major:0": "3"
           },
           "type-details": {
-            "abi:2": "armeabi-v7a",
             "abi:3": "armeabi-v7a",
             "api-level:0": "25",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Android Wear",
-              "id:0": "android-wear"
             },
             "tag:2": {
               "display:1": "Android Wear",
@@ -5479,15 +4025,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-wear/x86-25_r03.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Android Wear Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-25-android-wear-x86",
           "path": "system-images/android-25/android-wear/x86",
@@ -5496,16 +4035,11 @@
             "major:0": "3"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "25",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Android Wear",
-              "id:0": "android-wear"
             },
             "tag:2": {
               "display:1": "Android Wear",
@@ -5526,7 +4060,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-25-default-arm64-v8a",
           "path": "system-images/android-25/default/arm64-v8a",
@@ -5535,16 +4069,11 @@
             "major:0": "2"
           },
           "type-details": {
-            "abi:2": "arm64-v8a",
             "abi:3": "arm64-v8a",
             "api-level:0": "25",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -5562,15 +4091,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86-25_r01.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-25-default-x86",
           "path": "system-images/android-25/default/x86",
@@ -5579,16 +4101,11 @@
             "major:0": "1"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "25",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -5606,15 +4123,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-25_r01.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-25-default-x86_64",
           "path": "system-images/android-25/default/x86_64",
@@ -5623,16 +4133,11 @@
             "major:0": "1"
           },
           "type-details": {
-            "abi:2": "x86_64",
             "abi:3": "x86_64",
             "api-level:0": "25",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": {},
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": {},
@@ -5653,7 +4158,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-arm64-v8a",
           "path": "system-images/android-25/google_apis/arm64-v8a",
@@ -5662,24 +4167,15 @@
             "major:0": "20"
           },
           "type-details": {
-            "abi:3": "arm64-v8a",
             "abi:4": "arm64-v8a",
             "api-level:0": "25",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -5697,15 +4193,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-25_r18.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-armeabi-v7a",
           "path": "system-images/android-25/google_apis/armeabi-v7a",
@@ -5714,24 +4203,15 @@
             "major:0": "18"
           },
           "type-details": {
-            "abi:3": "armeabi-v7a",
             "abi:4": "armeabi-v7a",
             "api-level:0": "25",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -5749,15 +4229,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-25_r18.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-x86",
           "path": "system-images/android-25/google_apis/x86",
@@ -5766,24 +4239,15 @@
             "major:0": "18"
           },
           "type-details": {
-            "abi:3": "x86",
             "abi:4": "x86",
             "api-level:0": "25",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -5801,15 +4265,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-25_r18.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-x86_64",
           "path": "system-images/android-25/google_apis/x86_64",
@@ -5818,24 +4275,15 @@
             "major:0": "18"
           },
           "type-details": {
-            "abi:3": "x86_64",
             "abi:4": "x86_64",
             "api-level:0": "25",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -5855,15 +4303,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86-25_r09.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis_playstore-x86",
           "path": "system-images/android-25/google_apis_playstore/x86",
@@ -5872,24 +4313,15 @@
             "major:0": "9"
           },
           "type-details": {
-            "abi:3": "x86",
             "abi:4": "x86",
             "api-level:0": "25",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
             "tag:2": {
               "display:1": "Google Play",
               "id:0": "google_apis_playstore"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -5921,20 +4353,10 @@
                 "micro:2": "3",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "26",
-                "micro:2": "3",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-preview-license",
           "name": "system-image-26-android-tv-x86",
           "path": "system-images/android-26/android-tv/x86",
@@ -5943,16 +4365,11 @@
             "major:0": "14"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "26",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Android TV",
-              "id:0": "android-tv"
             },
             "tag:2": {
               "display:1": "Android TV",
@@ -5972,15 +4389,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-wear/x86-26_r04.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Android Wear Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-26-android-wear-x86",
           "path": "system-images/android-26/android-wear/x86",
@@ -5989,16 +4399,11 @@
             "major:0": "4"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "26",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Android Wear",
-              "id:0": "android-wear"
             },
             "tag:2": {
               "display:1": "Android Wear",
@@ -6031,7 +4436,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-26-default-arm64-v8a",
           "path": "system-images/android-26/default/arm64-v8a",
@@ -6040,16 +4445,11 @@
             "major:0": "2"
           },
           "type-details": {
-            "abi:2": "arm64-v8a",
             "abi:3": "arm64-v8a",
             "api-level:0": "26",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Default Android System Image",
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": "Default Android System Image",
@@ -6067,15 +4467,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86-26_r01.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-26-default-x86",
           "path": "system-images/android-26/default/x86",
@@ -6084,16 +4477,11 @@
             "major:0": "1"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "26",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Default Android System Image",
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": "Default Android System Image",
@@ -6111,15 +4499,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-26_r01.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-26-default-x86_64",
           "path": "system-images/android-26/default/x86_64",
@@ -6128,16 +4509,11 @@
             "major:0": "1"
           },
           "type-details": {
-            "abi:2": "x86_64",
             "abi:3": "x86_64",
             "api-level:0": "26",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Default Android System Image",
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": "Default Android System Image",
@@ -6170,7 +4546,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-arm64-v8a",
           "path": "system-images/android-26/google_apis/arm64-v8a",
@@ -6179,24 +4555,15 @@
             "major:0": "3"
           },
           "type-details": {
-            "abi:3": "arm64-v8a",
             "abi:4": "arm64-v8a",
             "api-level:0": "26",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -6224,20 +4591,10 @@
                 "micro:2": "3",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "26",
-                "micro:2": "3",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-x86",
           "path": "system-images/android-26/google_apis/x86",
@@ -6246,24 +4603,15 @@
             "major:0": "16"
           },
           "type-details": {
-            "abi:3": "x86",
             "abi:4": "x86",
             "api-level:0": "26",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -6291,20 +4639,10 @@
                 "micro:2": "3",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "26",
-                "micro:2": "3",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-x86_64",
           "path": "system-images/android-26/google_apis/x86_64",
@@ -6313,24 +4651,15 @@
             "major:0": "16"
           },
           "type-details": {
-            "abi:3": "x86_64",
             "abi:4": "x86_64",
             "api-level:0": "26",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -6360,20 +4689,10 @@
                 "micro:2": "3",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "26",
-                "micro:2": "3",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-preview-license",
           "name": "system-image-26-google_apis_playstore-x86",
           "path": "system-images/android-26/google_apis_playstore/x86",
@@ -6382,24 +4701,15 @@
             "major:0": "7"
           },
           "type-details": {
-            "abi:3": "x86",
             "abi:4": "x86",
             "api-level:0": "26",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
             "tag:2": {
               "display:1": "Google Play",
               "id:0": "google_apis_playstore"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -6421,15 +4731,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-tv/x86-27_r09.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-preview-license",
           "name": "system-image-27-android-tv-x86",
           "path": "system-images/android-27/android-tv/x86",
@@ -6438,16 +4741,11 @@
             "major:0": "9"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "27",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Android TV",
-              "id:0": "android-tv"
             },
             "tag:2": {
               "display:1": "Android TV",
@@ -6480,7 +4778,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-27-default-arm64-v8a",
           "path": "system-images/android-27/default/arm64-v8a",
@@ -6489,16 +4787,11 @@
             "major:0": "2"
           },
           "type-details": {
-            "abi:2": "arm64-v8a",
             "abi:3": "arm64-v8a",
             "api-level:0": "27",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Default Android System Image",
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": "Default Android System Image",
@@ -6516,15 +4809,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86-27_r01.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-27-default-x86",
           "path": "system-images/android-27/default/x86",
@@ -6533,16 +4819,11 @@
             "major:0": "1"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "27",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Default Android System Image",
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": "Default Android System Image",
@@ -6560,15 +4841,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-27_r01.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-27-default-x86_64",
           "path": "system-images/android-27/default/x86_64",
@@ -6577,16 +4851,11 @@
             "major:0": "1"
           },
           "type-details": {
-            "abi:2": "x86_64",
             "abi:3": "x86_64",
             "api-level:0": "27",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Default Android System Image",
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": "Default Android System Image",
@@ -6619,7 +4888,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis-arm64-v8a",
           "path": "system-images/android-27/google_apis/arm64-v8a",
@@ -6628,24 +4897,15 @@
             "major:0": "3"
           },
           "type-details": {
-            "abi:3": "arm64-v8a",
             "abi:4": "arm64-v8a",
             "api-level:0": "27",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -6673,20 +4933,10 @@
                 "micro:2": "7",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "27",
-                "micro:2": "7",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis-x86",
           "path": "system-images/android-27/google_apis/x86",
@@ -6695,24 +4945,15 @@
             "major:0": "11"
           },
           "type-details": {
-            "abi:3": "x86",
             "abi:4": "x86",
             "api-level:0": "27",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -6742,20 +4983,10 @@
                 "micro:2": "3",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "26",
-                "micro:2": "3",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis_playstore-x86",
           "path": "system-images/android-27/google_apis_playstore/x86",
@@ -6764,24 +4995,15 @@
             "major:0": "3"
           },
           "type-details": {
-            "abi:3": "x86",
             "abi:4": "x86",
             "api-level:0": "27",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
             "tag:2": {
               "display:1": "Google Play",
               "id:0": "google_apis_playstore"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -6800,7 +5022,7 @@
               "os": "all",
               "sha1": "a1f224245056ddaa89651e379efbde7357b15046",
               "size": 859616969,
-              "url": "https://dl.google.com/android/repository/sys-img/android-automotive-playstore/x86-28_r05.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android-automotive/x86-28_r05.zip"
             }
           ],
           "dependencies": {
@@ -6816,7 +5038,7 @@
             }
           },
           "displayName": "Automotive Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-28-android-automotive-playstore-x86",
           "path": "system-images/android-28/android-automotive-playstore/x86",
@@ -6853,15 +5075,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-tv/x86-28_r10.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-preview-license",
           "name": "system-image-28-android-tv-x86",
           "path": "system-images/android-28/android-tv/x86",
@@ -6870,16 +5085,11 @@
             "major:0": "10"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "28",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Android TV",
-              "id:0": "android-tv"
             },
             "tag:2": {
               "display:1": "Android TV",
@@ -6899,15 +5109,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-wear/x86-28_r09.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Wear OS Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-28-android-wear-x86",
           "path": "system-images/android-28/android-wear/x86",
@@ -6916,16 +5119,11 @@
             "major:0": "9"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "28",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Wear OS",
-              "id:0": "android-wear"
             },
             "tag:2": {
               "display:1": "Wear OS",
@@ -6958,7 +5156,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-28-default-arm64-v8a",
           "path": "system-images/android-28/default/arm64-v8a",
@@ -6967,16 +5165,11 @@
             "major:0": "2"
           },
           "type-details": {
-            "abi:2": "arm64-v8a",
             "abi:3": "arm64-v8a",
             "api-level:0": "28",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Default Android System Image",
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": "Default Android System Image",
@@ -6995,7 +5188,7 @@
             }
           ],
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-preview-license",
           "name": "system-image-28-default-x86",
           "path": "system-images/android-28/default/x86",
@@ -7004,16 +5197,11 @@
             "major:0": "4"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "28",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Default Android System Image",
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": "Default Android System Image",
@@ -7032,7 +5220,7 @@
             }
           ],
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-preview-license",
           "name": "system-image-28-default-x86_64",
           "path": "system-images/android-28/default/x86_64",
@@ -7041,16 +5229,11 @@
             "major:0": "4"
           },
           "type-details": {
-            "abi:2": "x86_64",
             "abi:3": "x86_64",
             "api-level:0": "28",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Default Android System Image",
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": "Default Android System Image",
@@ -7083,7 +5266,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis-arm64-v8a",
           "path": "system-images/android-28/google_apis/arm64-v8a",
@@ -7092,24 +5275,15 @@
             "major:0": "2"
           },
           "type-details": {
-            "abi:3": "arm64-v8a",
             "abi:4": "arm64-v8a",
             "api-level:0": "28",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -7137,20 +5311,10 @@
                 "micro:2": "12",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "29",
-                "micro:2": "12",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-28-google_apis-x86",
           "path": "system-images/android-28/google_apis/x86",
@@ -7159,24 +5323,15 @@
             "major:0": "12"
           },
           "type-details": {
-            "abi:3": "x86",
             "abi:4": "x86",
             "api-level:0": "28",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -7204,20 +5359,10 @@
                 "micro:2": "12",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "29",
-                "micro:2": "12",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis-x86_64",
           "path": "system-images/android-28/google_apis/x86_64",
@@ -7226,24 +5371,15 @@
             "major:0": "11"
           },
           "type-details": {
-            "abi:3": "x86_64",
             "abi:4": "x86_64",
             "api-level:0": "28",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -7276,7 +5412,7 @@
             }
           },
           "displayName": "Google ARM64-V8a Play ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-28-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-28/google_apis_playstore/arm64-v8a",
@@ -7285,24 +5421,15 @@
             "major:0": "2"
           },
           "type-details": {
-            "abi:3": "arm64-v8a",
             "abi:4": "arm64-v8a",
             "api-level:0": "28",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google ARM64-V8a Play",
-              "id:0": "google_apis_playstore"
-            },
             "tag:2": {
               "display:1": "Google ARM64-V8a Play",
               "id:0": "google_apis_playstore"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -7330,20 +5457,10 @@
                 "micro:2": "7",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "27",
-                "micro:2": "7",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis_playstore-x86",
           "path": "system-images/android-28/google_apis_playstore/x86",
@@ -7352,24 +5469,15 @@
             "major:0": "8"
           },
           "type-details": {
-            "abi:3": "x86",
             "abi:4": "x86",
             "api-level:0": "28",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
             "tag:2": {
               "display:1": "Google Play",
               "id:0": "google_apis_playstore"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -7397,20 +5505,10 @@
                 "micro:2": "7",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "27",
-                "micro:2": "7",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis_playstore-x86_64",
           "path": "system-images/android-28/google_apis_playstore/x86_64",
@@ -7419,24 +5517,15 @@
             "major:0": "8"
           },
           "type-details": {
-            "abi:3": "x86_64",
             "abi:4": "x86_64",
             "api-level:0": "28",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
             "tag:2": {
               "display:1": "Google Play",
               "id:0": "google_apis_playstore"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -7455,7 +5544,7 @@
               "os": "all",
               "sha1": "8fb2624c63c34a01c27dd8085277b2a5fb8d7fbc",
               "size": 923839106,
-              "url": "https://dl.google.com/android/repository/sys-img/android-automotive-playstore/x86-29_r01.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android-automotive/x86-29_r01.zip"
             }
           ],
           "dependencies": {
@@ -7471,7 +5560,7 @@
             }
           },
           "displayName": "Automotive with Play Store Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-29-android-automotive-playstore-x86",
           "path": "system-images/android-29/android-automotive-playstore/x86",
@@ -7518,20 +5607,10 @@
                 "micro:2": "6",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "28",
-                "micro:2": "6",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-preview-license",
           "name": "system-image-29-android-tv-x86",
           "path": "system-images/android-29/android-tv/x86",
@@ -7540,16 +5619,11 @@
             "major:0": "3"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "29",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Android TV",
-              "id:0": "android-tv"
             },
             "tag:2": {
               "display:1": "Android TV",
@@ -7570,7 +5644,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-29-default-arm64-v8a",
           "path": "system-images/android-29/default/arm64-v8a",
@@ -7579,16 +5653,11 @@
             "major:0": "8"
           },
           "type-details": {
-            "abi:2": "arm64-v8a",
             "abi:3": "arm64-v8a",
             "api-level:0": "29",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Default Android System Image",
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": "Default Android System Image",
@@ -7633,7 +5702,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-29-default-x86",
           "path": "system-images/android-29/default/x86",
@@ -7642,16 +5711,11 @@
             "major:0": "8"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "29",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Default Android System Image",
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": "Default Android System Image",
@@ -7696,7 +5760,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-29-default-x86_64",
           "path": "system-images/android-29/default/x86_64",
@@ -7705,16 +5769,11 @@
             "major:0": "8"
           },
           "type-details": {
-            "abi:2": "x86_64",
             "abi:3": "x86_64",
             "api-level:0": "29",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Default Android System Image",
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": "Default Android System Image",
@@ -7747,7 +5806,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-29-google_apis-arm64-v8a",
           "path": "system-images/android-29/google_apis/arm64-v8a",
@@ -7756,24 +5815,15 @@
             "major:0": "13"
           },
           "type-details": {
-            "abi:3": "arm64-v8a",
             "abi:4": "arm64-v8a",
             "api-level:0": "29",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -7804,7 +5854,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis-x86",
           "path": "system-images/android-29/google_apis/x86",
@@ -7813,24 +5863,15 @@
             "major:0": "13"
           },
           "type-details": {
-            "abi:3": "x86",
             "abi:4": "x86",
             "api-level:0": "29",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -7861,7 +5902,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis-x86_64",
           "path": "system-images/android-29/google_apis/x86_64",
@@ -7870,24 +5911,15 @@
             "major:0": "13"
           },
           "type-details": {
-            "abi:3": "x86_64",
             "abi:4": "x86_64",
             "api-level:0": "29",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -7920,7 +5952,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-29-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-29/google_apis_playstore/arm64-v8a",
@@ -7929,24 +5961,15 @@
             "major:0": "9"
           },
           "type-details": {
-            "abi:3": "arm64-v8a",
             "abi:4": "arm64-v8a",
             "api-level:0": "29",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
             "tag:2": {
               "display:1": "Google Play",
               "id:0": "google_apis_playstore"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -7988,20 +6011,10 @@
                 "micro:2": "2",
                 "minor:1": "8"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "28",
-                "micro:2": "9",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis_playstore-x86",
           "path": "system-images/android-29/google_apis_playstore/x86",
@@ -8010,24 +6023,15 @@
             "major:0": "9"
           },
           "type-details": {
-            "abi:3": "x86",
             "abi:4": "x86",
             "api-level:0": "29",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
             "tag:2": {
               "display:1": "Google Play",
               "id:0": "google_apis_playstore"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -8069,20 +6073,10 @@
                 "micro:2": "2",
                 "minor:1": "8"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "28",
-                "micro:2": "9",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis_playstore-x86_64",
           "path": "system-images/android-29/google_apis_playstore/x86_64",
@@ -8091,24 +6085,15 @@
             "major:0": "9"
           },
           "type-details": {
-            "abi:3": "x86_64",
             "abi:4": "x86_64",
             "api-level:0": "29",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
             "tag:2": {
               "display:1": "Google Play",
               "id:0": "google_apis_playstore"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -8127,7 +6112,7 @@
               "os": "all",
               "sha1": "7aec48997addb860118a98741458922bdec606c9",
               "size": 1182802747,
-              "url": "https://dl.google.com/android/repository/sys-img/android-automotive-playstore/x86_64-30_r02.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android-automotive/x86_64-30_r02.zip"
             }
           ],
           "dependencies": {
@@ -8143,7 +6128,7 @@
             }
           },
           "displayName": "Automotive with Play Store Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-30-android-automotive-playstore-x86_64",
           "path": "system-images/android-30/android-automotive-playstore/x86_64",
@@ -8190,20 +6175,10 @@
                 "micro:2": "6",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "28",
-                "micro:2": "6",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-preview-license",
           "name": "system-image-30-android-tv-x86",
           "path": "system-images/android-30/android-tv/x86",
@@ -8212,16 +6187,11 @@
             "major:0": "4"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "30",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Android TV",
-              "id:0": "android-tv"
             },
             "tag:2": {
               "display:1": "Android TV",
@@ -8236,38 +6206,92 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "ef7b5554a5f77fb33c7965604552411c155a38ac",
-              "size": 649112314,
+              "sha1": "56c0c2550580f2ba1b33009c77db017dbcb3d470",
+              "size": 827418923,
               "url": "https://dl.google.com/android/repository/sys-img/android-wear/arm64-v8a-30_r12.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
-          "displayName": "China version of Wear OS 3 ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "displayName": "Wear OS 3 ARM 64 v8a System Image",
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-30-android-wear-arm64-v8a",
-          "path": "system-images/android-30/android-wear-cn/arm64-v8a",
+          "path": "system-images/android-30/android-wear/arm64-v8a",
           "revision": "30-android-wear-arm64-v8a",
           "revision-details": {
             "major:0": "12"
           },
           "type-details": {
-            "abi:2": "arm64-v8a",
             "abi:3": "arm64-v8a",
             "api-level:0": "30",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
+            "tag:2": {
               "display:1": "Wear OS 3",
               "id:0": "android-wear"
+            }
+          }
+        },
+        "x86": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "73a96614a2ddcf586e4c659c436d2360bc25badc",
+              "size": 901929440,
+              "url": "https://dl.google.com/android/repository/sys-img/android-wear/x86-30_r12.zip"
+            }
+          ],
+          "displayName": "Wear OS 3 Intel x86 Atom System Image",
+          "last-available-day": 20676,
+          "license": "android-sdk-license",
+          "name": "system-image-30-android-wear-x86",
+          "path": "system-images/android-30/android-wear/x86",
+          "revision": "30-android-wear-x86",
+          "revision-details": {
+            "major:0": "12"
+          },
+          "type-details": {
+            "abi:3": "x86",
+            "api-level:0": "30",
+            "base-extension:1": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:2": {
+              "display:1": "Wear OS 3",
+              "id:0": "android-wear"
+            }
+          }
+        }
+      },
+      "android-wear-cn": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "ef7b5554a5f77fb33c7965604552411c155a38ac",
+              "size": 649112314,
+              "url": "https://dl.google.com/android/repository/sys-img/android-wear-cn/arm64-v8a-30_r12.zip"
+            }
+          ],
+          "displayName": "China version of Wear OS 3 ARM 64 v8a System Image",
+          "last-available-day": 20676,
+          "license": "android-sdk-license",
+          "name": "system-image-30-android-wear-cn-arm64-v8a",
+          "path": "system-images/android-30/android-wear-cn/arm64-v8a",
+          "revision": "30-android-wear-cn-arm64-v8a",
+          "revision-details": {
+            "major:0": "12"
+          },
+          "type-details": {
+            "abi:3": "arm64-v8a",
+            "api-level:0": "30",
+            "base-extension:1": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
             },
             "tag:2": {
               "display:1": "China version of Wear OS 3",
@@ -8282,36 +6306,24 @@
               "os": "all",
               "sha1": "42548b2bd1696ad6bd2f01a1cf83ef7a10971932",
               "size": 759598676,
-              "url": "https://dl.google.com/android/repository/sys-img/android-wear/x86-30_r12.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android-wear-cn/x86-30_r12.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "China version of Wear OS 3 Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
-          "name": "system-image-30-android-wear-x86",
+          "name": "system-image-30-android-wear-cn-x86",
           "path": "system-images/android-30/android-wear-cn/x86",
-          "revision": "30-android-wear-x86",
+          "revision": "30-android-wear-cn-x86",
           "revision-details": {
             "major:0": "12"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "30",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Wear OS 3",
-              "id:0": "android-wear"
             },
             "tag:2": {
               "display:1": "China version of Wear OS 3",
@@ -8332,7 +6344,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-30-default-arm64-v8a",
           "path": "system-images/android-30/default/arm64-v8a",
@@ -8341,16 +6353,11 @@
             "major:0": "2"
           },
           "type-details": {
-            "abi:2": "arm64-v8a",
             "abi:3": "arm64-v8a",
             "api-level:0": "30",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Default Android System Image",
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": "Default Android System Image",
@@ -8381,7 +6388,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-30-default-x86_64",
           "path": "system-images/android-30/default/x86_64",
@@ -8390,16 +6397,11 @@
             "major:0": "11"
           },
           "type-details": {
-            "abi:2": "x86_64",
             "abi:3": "x86_64",
             "api-level:0": "30",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Default Android System Image",
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": "Default Android System Image",
@@ -8432,7 +6434,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis-arm64-v8a",
           "path": "system-images/android-30/google_apis/arm64-v8a",
@@ -8441,24 +6443,15 @@
             "major:0": "16"
           },
           "type-details": {
-            "abi:3": "arm64-v8a",
             "abi:4": "arm64-v8a",
             "api-level:0": "30",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -8486,20 +6479,10 @@
                 "micro:2": "0",
                 "minor:1": "8"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "4",
-                "minor:1": "0"
-              }
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-30-google_apis-x86",
           "path": "system-images/android-30/google_apis/x86",
@@ -8508,24 +6491,15 @@
             "major:0": "16"
           },
           "type-details": {
-            "abi:3": "x86",
             "abi:4": "x86",
             "api-level:0": "30",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -8553,20 +6527,10 @@
                 "micro:2": "0",
                 "minor:1": "8"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "0",
-                "minor:1": "8"
-              }
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-30-google_apis-x86_64",
           "path": "system-images/android-30/google_apis/x86_64",
@@ -8575,24 +6539,15 @@
             "major:0": "16"
           },
           "type-details": {
-            "abi:3": "x86_64",
             "abi:4": "x86_64",
             "api-level:0": "30",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -8632,7 +6587,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-30/google_apis_playstore/arm64-v8a",
@@ -8641,24 +6596,15 @@
             "major:0": "10"
           },
           "type-details": {
-            "abi:3": "arm64-v8a",
             "abi:4": "arm64-v8a",
             "api-level:0": "30",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
             "tag:2": {
               "display:1": "Google Play",
               "id:0": "google_apis_playstore"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -8700,20 +6646,10 @@
                 "micro:2": "4",
                 "minor:1": "0"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "4",
-                "minor:1": "0"
-              }
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-30-google_apis_playstore-x86",
           "path": "system-images/android-30/google_apis_playstore/x86",
@@ -8722,24 +6658,15 @@
             "major:0": "9"
           },
           "type-details": {
-            "abi:3": "x86",
             "abi:4": "x86",
             "api-level:0": "30",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
             "tag:2": {
               "display:1": "Google Play",
               "id:0": "google_apis_playstore"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -8781,20 +6708,10 @@
                 "micro:2": "4",
                 "minor:1": "0"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "4",
-                "minor:1": "0"
-              }
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis_playstore-x86_64",
           "path": "system-images/android-30/google_apis_playstore/x86_64",
@@ -8803,24 +6720,15 @@
             "major:0": "10"
           },
           "type-details": {
-            "abi:3": "x86_64",
             "abi:4": "x86_64",
             "api-level:0": "30",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
             "tag:2": {
               "display:1": "Google Play",
               "id:0": "google_apis_playstore"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -8852,20 +6760,10 @@
                 "micro:2": "6",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "28",
-                "micro:2": "6",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Android TV ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-31-android-tv-arm64-v8a",
           "path": "system-images/android-31/android-tv/arm64-v8a",
@@ -8874,16 +6772,11 @@
             "major:0": "4"
           },
           "type-details": {
-            "abi:2": "arm64-v8a",
             "abi:3": "arm64-v8a",
             "api-level:0": "31",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Android TV",
-              "id:0": "android-tv"
             },
             "tag:2": {
               "display:1": "Android TV",
@@ -8911,20 +6804,10 @@
                 "micro:2": "6",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "28",
-                "micro:2": "6",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-31-android-tv-x86",
           "path": "system-images/android-31/android-tv/x86",
@@ -8933,16 +6816,11 @@
             "major:0": "4"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "31",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Android TV",
-              "id:0": "android-tv"
             },
             "tag:2": {
               "display:1": "Android TV",
@@ -8975,7 +6853,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-31-default-arm64-v8a",
           "path": "system-images/android-31/default/arm64-v8a",
@@ -8984,16 +6862,11 @@
             "major:0": "4"
           },
           "type-details": {
-            "abi:2": "arm64-v8a",
             "abi:3": "arm64-v8a",
             "api-level:0": "31",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Default Android System Image",
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": "Default Android System Image",
@@ -9024,7 +6897,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-31-default-x86_64",
           "path": "system-images/android-31/default/x86_64",
@@ -9033,16 +6906,11 @@
             "major:0": "5"
           },
           "type-details": {
-            "abi:2": "x86_64",
             "abi:3": "x86_64",
             "api-level:0": "31",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Default Android System Image",
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": "Default Android System Image",
@@ -9072,20 +6940,10 @@
                 "micro:2": "7",
                 "minor:1": "2"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "31",
-                "micro:2": "7",
-                "minor:1": "2"
-              }
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis-arm64-v8a",
           "path": "system-images/android-31/google_apis/arm64-v8a",
@@ -9094,24 +6952,15 @@
             "major:0": "11"
           },
           "type-details": {
-            "abi:3": "arm64-v8a",
             "abi:4": "arm64-v8a",
             "api-level:0": "31",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -9139,20 +6988,10 @@
                 "micro:2": "7",
                 "minor:1": "2"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "31",
-                "micro:2": "7",
-                "minor:1": "2"
-              }
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-preview-license",
           "name": "system-image-31-google_apis-x86_64",
           "path": "system-images/android-31/google_apis/x86_64",
@@ -9161,24 +7000,15 @@
             "major:0": "14"
           },
           "type-details": {
-            "abi:3": "x86_64",
             "abi:4": "x86_64",
             "api-level:0": "31",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -9215,20 +7045,10 @@
                 "micro:2": "7",
                 "minor:1": "2"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "31",
-                "micro:2": "7",
-                "minor:1": "2"
-              }
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-31/google_apis_playstore/arm64-v8a",
@@ -9237,24 +7057,15 @@
             "major:0": "9"
           },
           "type-details": {
-            "abi:3": "arm64-v8a",
             "abi:4": "arm64-v8a",
             "api-level:0": "31",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
             "tag:2": {
               "display:1": "Google Play",
               "id:0": "google_apis_playstore"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -9282,20 +7093,10 @@
                 "micro:2": "3",
                 "minor:1": "7"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis_playstore-x86_64",
           "path": "system-images/android-31/google_apis_playstore/x86_64",
@@ -9304,24 +7105,15 @@
             "major:0": "9"
           },
           "type-details": {
-            "abi:3": "x86_64",
             "abi:4": "x86_64",
             "api-level:0": "31",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
             "tag:2": {
               "display:1": "Google Play",
               "id:0": "google_apis_playstore"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -9340,7 +7132,7 @@
               "os": "all",
               "sha1": "1b07fe1bc8a4f5a9b249ff12d5bf142cb43a2093",
               "size": 948247935,
-              "url": "https://dl.google.com/android/repository/sys-img/android-automotive-playstore/arm64-v8a-32_r01.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android-automotive/arm64-v8a-32_r01.zip"
             }
           ],
           "dependencies": {
@@ -9356,7 +7148,7 @@
             }
           },
           "displayName": "Android Automotive with Google Play arm64-v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-android-automotive-playstore-arm64-v8a",
           "path": "system-images/android-32/android-automotive-playstore/arm64-v8a",
@@ -9393,7 +7185,7 @@
               "os": "all",
               "sha1": "8f8309ae9e25b0c5eeb869bb0cb2515021073693",
               "size": 1012590435,
-              "url": "https://dl.google.com/android/repository/sys-img/android-automotive-playstore/x86_64-32_r01.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android-automotive/x86_64-32_r01.zip"
             }
           ],
           "dependencies": {
@@ -9409,7 +7201,7 @@
             }
           },
           "displayName": "Android Automotive with Google Play x86_64 System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-android-automotive-playstore-x86_64",
           "path": "system-images/android-32/android-automotive-playstore/x86_64",
@@ -9464,7 +7256,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-32-default-arm64-v8a",
           "path": "system-images/android-32/default/arm64-v8a",
@@ -9473,16 +7265,11 @@
             "major:0": "2"
           },
           "type-details": {
-            "abi:2": "arm64-v8a",
             "abi:3": "arm64-v8a",
             "api-level:0": "32",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Default Android System Image",
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": "Default Android System Image",
@@ -9513,7 +7300,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-32-default-x86_64",
           "path": "system-images/android-32/default/x86_64",
@@ -9522,16 +7309,11 @@
             "major:0": "2"
           },
           "type-details": {
-            "abi:2": "x86_64",
             "abi:3": "x86_64",
             "api-level:0": "32",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Default Android System Image",
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": "Default Android System Image",
@@ -9561,20 +7343,10 @@
                 "micro:2": "3",
                 "minor:1": "7"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-32-google_apis-arm64-v8a",
           "path": "system-images/android-32/google_apis/arm64-v8a",
@@ -9583,24 +7355,15 @@
             "major:0": "8"
           },
           "type-details": {
-            "abi:3": "arm64-v8a",
             "abi:4": "arm64-v8a",
             "api-level:0": "32",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -9628,20 +7391,10 @@
                 "micro:2": "3",
                 "minor:1": "7"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-google_apis-x86_64",
           "path": "system-images/android-32/google_apis/x86_64",
@@ -9650,24 +7403,15 @@
             "major:0": "8"
           },
           "type-details": {
-            "abi:3": "x86_64",
             "abi:4": "x86_64",
             "api-level:0": "32",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -9704,20 +7448,10 @@
                 "micro:2": "3",
                 "minor:1": "7"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-32-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-32/google_apis_playstore/arm64-v8a",
@@ -9726,24 +7460,15 @@
             "major:0": "4"
           },
           "type-details": {
-            "abi:3": "arm64-v8a",
             "abi:4": "arm64-v8a",
             "api-level:0": "32",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
             "tag:2": {
               "display:1": "Google Play",
               "id:0": "google_apis_playstore"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -9785,20 +7510,10 @@
                 "micro:2": "3",
                 "minor:1": "7"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-google_apis_playstore-x86_64",
           "path": "system-images/android-32/google_apis_playstore/x86_64",
@@ -9807,24 +7522,15 @@
             "major:0": "4"
           },
           "type-details": {
-            "abi:3": "x86_64",
             "abi:4": "x86_64",
             "api-level:0": "32",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
             "tag:2": {
               "display:1": "Google Play",
               "id:0": "google_apis_playstore"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -9859,7 +7565,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs arm64-v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-33-android-automotive-arm64-v8a",
           "path": "system-images/android-33/android-automotive/arm64-v8a",
@@ -9912,7 +7618,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs x86_64 System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-33-android-automotive-x86_64",
           "path": "system-images/android-33/android-automotive/x86_64",
@@ -9964,20 +7670,10 @@
                 "micro:2": "6",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "28",
-                "micro:2": "6",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Android TV ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-33-android-tv-arm64-v8a",
           "path": "system-images/android-33/android-tv/arm64-v8a",
@@ -9986,16 +7682,11 @@
             "major:0": "5"
           },
           "type-details": {
-            "abi:2": "arm64-v8a",
             "abi:3": "arm64-v8a",
             "api-level:0": "33",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Android TV",
-              "id:0": "android-tv"
             },
             "tag:2": {
               "display:1": "Android TV",
@@ -10023,20 +7714,10 @@
                 "micro:2": "6",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "28",
-                "micro:2": "6",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-33-android-tv-x86",
           "path": "system-images/android-33/android-tv/x86",
@@ -10045,16 +7726,11 @@
             "major:0": "5"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:3": "x86",
             "api-level:0": "33",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Android TV",
-              "id:0": "android-tv"
             },
             "tag:2": {
               "display:1": "Android TV",
@@ -10074,15 +7750,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-wear/arm64-v8a-33_r04.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Wear OS 4 ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-33-android-wear-arm64-v8a",
           "path": "system-images/android-33/android-wear/arm64-v8a",
@@ -10091,16 +7760,11 @@
             "major:0": "4"
           },
           "type-details": {
-            "abi:2": "arm64-v8a",
             "abi:3": "arm64-v8a",
             "api-level:0": "33",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Wear OS 4",
-              "id:0": "android-wear"
             },
             "tag:2": {
               "display:1": "Wear OS 4",
@@ -10118,15 +7782,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-wear/x86_64-33_r04.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Wear OS 4 Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-33-android-wear-x86_64",
           "path": "system-images/android-33/android-wear/x86_64",
@@ -10135,16 +7792,11 @@
             "major:0": "4"
           },
           "type-details": {
-            "abi:2": "x86_64",
             "abi:3": "x86_64",
             "api-level:0": "33",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Wear OS 4",
-              "id:0": "android-wear"
             },
             "tag:2": {
               "display:1": "Wear OS 4",
@@ -10177,7 +7829,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-33-default-arm64-v8a",
           "path": "system-images/android-33/default/arm64-v8a",
@@ -10186,16 +7838,11 @@
             "major:0": "2"
           },
           "type-details": {
-            "abi:2": "arm64-v8a",
             "abi:3": "arm64-v8a",
             "api-level:0": "33",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Default Android System Image",
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": "Default Android System Image",
@@ -10226,7 +7873,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-33-default-x86_64",
           "path": "system-images/android-33/default/x86_64",
@@ -10235,16 +7882,11 @@
             "major:0": "2"
           },
           "type-details": {
-            "abi:2": "x86_64",
             "abi:3": "x86_64",
             "api-level:0": "33",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Default Android System Image",
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": "Default Android System Image",
@@ -10274,20 +7916,10 @@
                 "micro:2": "3",
                 "minor:1": "7"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-33-google_apis-arm64-v8a",
           "path": "system-images/android-33/google_apis/arm64-v8a",
@@ -10296,24 +7928,15 @@
             "major:0": "17"
           },
           "type-details": {
-            "abi:3": "arm64-v8a",
             "abi:4": "arm64-v8a",
             "api-level:0": "33",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -10341,20 +7964,10 @@
                 "micro:2": "3",
                 "minor:1": "7"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-33-google_apis-x86_64",
           "path": "system-images/android-33/google_apis/x86_64",
@@ -10363,24 +7976,15 @@
             "major:0": "17"
           },
           "type-details": {
-            "abi:3": "x86_64",
             "abi:4": "x86_64",
             "api-level:0": "33",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:2": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -10410,20 +8014,10 @@
                 "micro:2": "3",
                 "minor:1": "7"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-33-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-33/google_apis_playstore/arm64-v8a",
@@ -10432,24 +8026,15 @@
             "major:0": "9"
           },
           "type-details": {
-            "abi:3": "arm64-v8a",
             "abi:4": "arm64-v8a",
             "api-level:0": "33",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
             "tag:2": {
               "display:1": "Google Play",
               "id:0": "google_apis_playstore"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -10477,20 +8062,10 @@
                 "micro:2": "3",
                 "minor:1": "7"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-33-google_apis_playstore-x86_64",
           "path": "system-images/android-33/google_apis_playstore/x86_64",
@@ -10499,24 +8074,15 @@
             "major:0": "9"
           },
           "type-details": {
-            "abi:3": "x86_64",
             "abi:4": "x86_64",
             "api-level:0": "33",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "tag:1": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
             "tag:2": {
               "display:1": "Google Play",
               "id:0": "google_apis_playstore"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:3": {
               "display:1": "Google Inc.",
@@ -10565,7 +8131,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-33x-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-33-ext4/google_apis_playstore/arm64-v8a",
@@ -10614,7 +8180,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-preview-license",
           "name": "system-image-33x-google_apis_playstore-x86_64",
           "path": "system-images/android-33-ext4/google_apis_playstore/x86_64",
@@ -10664,20 +8230,10 @@
                 "micro:2": "6",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "28",
-                "micro:2": "6",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Android TV ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-34-android-tv-arm64-v8a",
           "path": "system-images/android-34/android-tv/arm64-v8a",
@@ -10686,7 +8242,6 @@
             "major:0": "3"
           },
           "type-details": {
-            "abi:2": "arm64-v8a",
             "abi:4": "arm64-v8a",
             "api-level:0": "34",
             "base-extension:2": "true",
@@ -10694,10 +8249,6 @@
               "xsi:type": "ns12:sysImgDetailsType"
             },
             "extension-level:1": "7",
-            "tag:1": {
-              "display:1": "Android TV",
-              "id:0": "android-tv"
-            },
             "tag:3": {
               "display:1": "Android TV",
               "id:0": "android-tv"
@@ -10724,20 +8275,10 @@
                 "micro:2": "6",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "28",
-                "micro:2": "6",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-34-android-tv-x86",
           "path": "system-images/android-34/android-tv/x86",
@@ -10746,7 +8287,6 @@
             "major:0": "3"
           },
           "type-details": {
-            "abi:2": "x86",
             "abi:4": "x86",
             "api-level:0": "34",
             "base-extension:2": "true",
@@ -10754,10 +8294,6 @@
               "xsi:type": "ns12:sysImgDetailsType"
             },
             "extension-level:1": "7",
-            "tag:1": {
-              "display:1": "Android TV",
-              "id:0": "android-tv"
-            },
             "tag:3": {
               "display:1": "Android TV",
               "id:0": "android-tv"
@@ -10777,7 +8313,7 @@
             }
           ],
           "displayName": "Wear OS 5 ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-34-android-wear-arm64-v8a",
           "path": "system-images/android-34/android-wear/arm64-v8a",
@@ -10786,16 +8322,11 @@
             "major:0": "1"
           },
           "type-details": {
-            "abi:2": "arm64-v8a",
             "abi:3": "arm64-v8a",
             "api-level:0": "34",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Wear OS 5",
-              "id:0": "android-wear"
             },
             "tag:2": {
               "display:1": "Wear OS 5",
@@ -10814,7 +8345,7 @@
             }
           ],
           "displayName": "Wear OS 5 Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-34-android-wear-x86_64",
           "path": "system-images/android-34/android-wear/x86_64",
@@ -10823,16 +8354,11 @@
             "major:0": "1"
           },
           "type-details": {
-            "abi:2": "x86_64",
             "abi:3": "x86_64",
             "api-level:0": "34",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Wear OS 5",
-              "id:0": "android-wear"
             },
             "tag:2": {
               "display:1": "Wear OS 5",
@@ -10865,7 +8391,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-34-default-arm64-v8a",
           "path": "system-images/android-34/default/arm64-v8a",
@@ -10874,16 +8400,11 @@
             "major:0": "4"
           },
           "type-details": {
-            "abi:2": "arm64-v8a",
             "abi:3": "arm64-v8a",
             "api-level:0": "34",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Default Android System Image",
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": "Default Android System Image",
@@ -10914,7 +8435,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-34-default-x86_64",
           "path": "system-images/android-34/default/x86_64",
@@ -10923,16 +8444,11 @@
             "major:0": "4"
           },
           "type-details": {
-            "abi:2": "x86_64",
             "abi:3": "x86_64",
             "api-level:0": "34",
             "base-extension:1": "true",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:1": {
-              "display:1": "Default Android System Image",
-              "id:0": "default"
             },
             "tag:2": {
               "display:1": "Default Android System Image",
@@ -10962,20 +8478,10 @@
                 "micro:2": "16",
                 "minor:1": "2"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "32",
-                "micro:2": "8",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-34-google_apis-arm64-v8a",
           "path": "system-images/android-34/google_apis/arm64-v8a",
@@ -10984,7 +8490,6 @@
             "major:0": "14"
           },
           "type-details": {
-            "abi:3": "arm64-v8a",
             "abi:5": "arm64-v8a",
             "api-level:0": "34",
             "base-extension:2": "true",
@@ -10992,17 +8497,9 @@
               "xsi:type": "ns12:sysImgDetailsType"
             },
             "extension-level:1": "7",
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:3": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:4": {
               "display:1": "Google Inc.",
@@ -11030,20 +8527,10 @@
                 "micro:2": "16",
                 "minor:1": "2"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "32",
-                "micro:2": "8",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-34-google_apis-x86_64",
           "path": "system-images/android-34/google_apis/x86_64",
@@ -11052,7 +8539,6 @@
             "major:0": "14"
           },
           "type-details": {
-            "abi:3": "x86_64",
             "abi:5": "x86_64",
             "api-level:0": "34",
             "base-extension:2": "true",
@@ -11060,17 +8546,9 @@
               "xsi:type": "ns12:sysImgDetailsType"
             },
             "extension-level:1": "7",
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:3": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:4": {
               "display:1": "Google Inc.",
@@ -11100,20 +8578,10 @@
                 "micro:2": "16",
                 "minor:1": "2"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "32",
-                "micro:2": "8",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-34-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-34/google_apis_playstore/arm64-v8a",
@@ -11122,8 +8590,6 @@
             "major:0": "14"
           },
           "type-details": {
-            "abi:2": "arm64-v8a",
-            "abi:3": "arm64-v8a",
             "abi:5": "arm64-v8a",
             "api-level:0": "34",
             "base-extension:2": "true",
@@ -11131,17 +8597,9 @@
               "xsi:type": "ns12:sysImgDetailsType"
             },
             "extension-level:1": "7",
-            "tag:1": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
             "tag:3": {
               "display:1": "Google Play",
               "id:0": "google_apis_playstore"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:4": {
               "display:1": "Google Inc.",
@@ -11169,20 +8627,10 @@
                 "micro:2": "16",
                 "minor:1": "2"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "32",
-                "micro:2": "8",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-34-google_apis_playstore-x86_64",
           "path": "system-images/android-34/google_apis_playstore/x86_64",
@@ -11191,8 +8639,6 @@
             "major:0": "14"
           },
           "type-details": {
-            "abi:2": "x86_64",
-            "abi:3": "x86_64",
             "abi:5": "x86_64",
             "api-level:0": "34",
             "base-extension:2": "true",
@@ -11200,17 +8646,9 @@
               "xsi:type": "ns12:sysImgDetailsType"
             },
             "extension-level:1": "7",
-            "tag:1": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
             "tag:3": {
               "display:1": "Google Play",
               "id:0": "google_apis_playstore"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:4": {
               "display:1": "Google Inc.",
@@ -11227,9 +8665,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "ce75a3152c34862f8092e31be13024693564cfa5",
-              "size": 1409602624,
-              "url": "https://dl.google.com/android/repository/sys-img/android-automotive/arm64-v8a-34-ext9_playstore_r04.zip"
+              "sha1": "898559aa3c3ec2f276866e998ba074dc32c10405",
+              "size": 1337707768,
+              "url": "https://dl.google.com/android/repository/sys-img/android-automotive/arm64-v8a-34-ext9_r05.zip"
             }
           ],
           "dependencies": {
@@ -11245,7 +8683,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs arm64-v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-34x-android-automotive-arm64-v8a",
           "path": "system-images/android-34-ext9/android-automotive/arm64-v8a",
@@ -11280,9 +8718,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "1a52bb3dc6a1b0e7ac19b1f512047df9d0b93c1b",
-              "size": 1451722407,
-              "url": "https://dl.google.com/android/repository/sys-img/android-automotive/x86_64-34-ext9_playstore_r04.zip"
+              "sha1": "a24cc4b1fb8aa31d50663b2b681ae7493a31106c",
+              "size": 1367927843,
+              "url": "https://dl.google.com/android/repository/sys-img/android-automotive/x86_64-34-ext9_r05.zip"
             }
           ],
           "dependencies": {
@@ -11298,7 +8736,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs x86_64 System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-34x-android-automotive-x86_64",
           "path": "system-images/android-34-ext9/android-automotive/x86_64",
@@ -11321,6 +8759,114 @@
             "tag:4": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
+            },
+            "vendor:5": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        }
+      },
+      "android-automotive-playstore": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "ce75a3152c34862f8092e31be13024693564cfa5",
+              "size": 1409602624,
+              "url": "https://dl.google.com/android/repository/sys-img/android-automotive/arm64-v8a-34-ext9_playstore_r04.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "1"
+              }
+            }
+          },
+          "displayName": "Android Automotive with Google Play arm64-v8a System Image",
+          "last-available-day": 20676,
+          "license": "android-sdk-license",
+          "name": "system-image-34x-android-automotive-playstore-arm64-v8a",
+          "path": "system-images/android-34-ext9/android-automotive-playstore/arm64-v8a",
+          "revision": "34x-android-automotive-playstore-arm64-v8a",
+          "revision-details": {
+            "major:0": "4"
+          },
+          "type-details": {
+            "abi:6": "arm64-v8a",
+            "api-level:0": "34x",
+            "base-extension:2": "false",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "9",
+            "tag:3": {
+              "display:1": "Automotive",
+              "id:0": "android-automotive"
+            },
+            "tag:4": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:5": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "1a52bb3dc6a1b0e7ac19b1f512047df9d0b93c1b",
+              "size": 1451722407,
+              "url": "https://dl.google.com/android/repository/sys-img/android-automotive/x86_64-34-ext9_playstore_r04.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "1"
+              }
+            }
+          },
+          "displayName": "Android Automotive with Google Play x86_64 System Image",
+          "last-available-day": 20676,
+          "license": "android-sdk-license",
+          "name": "system-image-34x-android-automotive-playstore-x86_64",
+          "path": "system-images/android-34-ext9/android-automotive-playstore/x86_64",
+          "revision": "34x-android-automotive-playstore-x86_64",
+          "revision-details": {
+            "major:0": "4"
+          },
+          "type-details": {
+            "abi:6": "x86_64",
+            "api-level:0": "34x",
+            "base-extension:2": "false",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "9",
+            "tag:3": {
+              "display:1": "Automotive",
+              "id:0": "android-automotive"
+            },
+            "tag:4": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
             },
             "vendor:5": {
               "display:1": "Google Inc.",
@@ -11367,7 +8913,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-34x-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-34-ext12/google_apis_playstore/arm64-v8a",
@@ -11416,7 +8962,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-34x-google_apis_playstore-x86_64",
           "path": "system-images/android-34-ext12/google_apis_playstore/x86_64",
@@ -11457,7 +9003,7 @@
             }
           ],
           "displayName": "Wear OS 5.1 - Preview ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-preview-license",
           "name": "system-image-35-android-wear-arm64-v8a",
           "path": "system-images/android-35/android-wear/arm64-v8a",
@@ -11489,7 +9035,7 @@
             }
           ],
           "displayName": "Wear OS 5.1 - Preview Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-preview-license",
           "name": "system-image-35-android-wear-x86_64",
           "path": "system-images/android-35/android-wear/x86_64",
@@ -11535,7 +9081,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-35-default-arm64-v8a",
           "path": "system-images/android-35/default/arm64-v8a",
@@ -11580,7 +9126,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-35-default-x86_64",
           "path": "system-images/android-35/default/x86_64",
@@ -11627,7 +9173,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35-google_apis-arm64-v8a",
           "path": "system-images/android-35/google_apis/arm64-v8a",
@@ -11636,7 +9182,6 @@
             "major:0": "9"
           },
           "type-details": {
-            "abi:3": "arm64-v8a",
             "abi:5": "arm64-v8a",
             "api-level:0": "35",
             "base-extension:2": "true",
@@ -11644,17 +9189,9 @@
               "xsi:type": "ns12:sysImgDetailsType"
             },
             "extension-level:1": "13",
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:3": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:4": {
               "display:1": "Google Inc.",
@@ -11685,7 +9222,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-35-google_apis-x86_64",
           "path": "system-images/android-35/google_apis/x86_64",
@@ -11694,7 +9231,6 @@
             "major:0": "9"
           },
           "type-details": {
-            "abi:3": "x86_64",
             "abi:5": "x86_64",
             "api-level:0": "35",
             "base-extension:2": "true",
@@ -11702,17 +9238,9 @@
               "xsi:type": "ns12:sysImgDetailsType"
             },
             "extension-level:1": "13",
-            "tag:1": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
             "tag:3": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:4": {
               "display:1": "Google Inc.",
@@ -11745,7 +9273,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-35/google_apis_playstore/arm64-v8a",
@@ -11754,7 +9282,6 @@
             "major:0": "9"
           },
           "type-details": {
-            "abi:3": "arm64-v8a",
             "abi:5": "arm64-v8a",
             "api-level:0": "35",
             "base-extension:2": "true",
@@ -11762,17 +9289,9 @@
               "xsi:type": "ns12:sysImgDetailsType"
             },
             "extension-level:1": "13",
-            "tag:1": {
-              "display:1": "Google APIs PlayStore",
-              "id:0": "google_apis_playstore"
-            },
             "tag:3": {
               "display:1": "Google Play",
               "id:0": "google_apis_playstore"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:4": {
               "display:1": "Google Inc.",
@@ -11803,7 +9322,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-35-google_apis_playstore-x86_64",
           "path": "system-images/android-35/google_apis_playstore/x86_64",
@@ -11812,7 +9331,6 @@
             "major:0": "9"
           },
           "type-details": {
-            "abi:3": "x86_64",
             "abi:5": "x86_64",
             "api-level:0": "35",
             "base-extension:2": "true",
@@ -11820,17 +9338,9 @@
               "xsi:type": "ns12:sysImgDetailsType"
             },
             "extension-level:1": "13",
-            "tag:1": {
-              "display:1": "Google APIs PlayStore",
-              "id:0": "google_apis_playstore"
-            },
             "tag:3": {
               "display:1": "Google Play",
               "id:0": "google_apis_playstore"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:4": {
               "display:1": "Google Inc.",
@@ -11839,7 +9349,7 @@
           }
         }
       },
-      "page_size_16kb": {
+      "google_apis_playstore_ps16k": {
         "arm64-v8a": {
           "archives": [
             {
@@ -11847,7 +9357,7 @@
               "os": "all",
               "sha1": "106d90f480a5e9619062944271b94eaf5b22ffb6",
               "size": 1590150760,
-              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/arm64-v8a-playstore-ps16k-35_r05.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-playstore-ps16k-35_r05.zip"
             }
           ],
           "dependencies": {
@@ -11863,16 +9373,15 @@
             }
           },
           "displayName": "16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
-          "name": "system-image-35-page_size_16kb-arm64-v8a",
+          "name": "system-image-35-google_apis_playstore_ps16k-arm64-v8a",
           "path": "system-images/android-35/google_apis_playstore_ps16k/arm64-v8a",
-          "revision": "35-page_size_16kb-arm64-v8a",
+          "revision": "35-google_apis_playstore_ps16k-arm64-v8a",
           "revision-details": {
             "major:0": "5"
           },
           "type-details": {
-            "abi:3": "arm64-v8a",
             "abi:6": "arm64-v8a",
             "api-level:0": "35",
             "base-extension:2": "true",
@@ -11880,10 +9389,6 @@
               "xsi:type": "ns12:sysImgDetailsType"
             },
             "extension-level:1": "13",
-            "tag:1": {
-              "display:1": "16 KB Page Size",
-              "id:0": "page_size_16kb"
-            },
             "tag:3": {
               "display:1": "16 KB Page Size",
               "id:0": "page_size_16kb"
@@ -11891,10 +9396,6 @@
             "tag:4": {
               "display:1": "Google APIs PlayStore",
               "id:0": "google_apis_playstore"
-            },
-            "vendor:2": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:5": {
               "display:1": "Google Inc.",
@@ -11909,7 +9410,7 @@
               "os": "all",
               "sha1": "921af95f9566e79cd2e2c9d08fd253c58d18595e",
               "size": 1510397655,
-              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/x86_64-playstore-ps16k-35_r05.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-playstore-ps16k-35_r05.zip"
             }
           ],
           "dependencies": {
@@ -11925,16 +9426,15 @@
             }
           },
           "displayName": "16 KB Page Size Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
-          "name": "system-image-35-page_size_16kb-x86_64",
+          "name": "system-image-35-google_apis_playstore_ps16k-x86_64",
           "path": "system-images/android-35/google_apis_playstore_ps16k/x86_64",
-          "revision": "35-page_size_16kb-x86_64",
+          "revision": "35-google_apis_playstore_ps16k-x86_64",
           "revision-details": {
             "major:0": "5"
           },
           "type-details": {
-            "abi:3": "x86_64",
             "abi:6": "x86_64",
             "api-level:0": "35",
             "base-extension:2": "true",
@@ -11942,10 +9442,6 @@
               "xsi:type": "ns12:sysImgDetailsType"
             },
             "extension-level:1": "13",
-            "tag:1": {
-              "display:1": "16 KB Page Size",
-              "id:0": "page_size_16kb"
-            },
             "tag:3": {
               "display:1": "16 KB Page Size",
               "id:0": "page_size_16kb"
@@ -11954,9 +9450,113 @@
               "display:1": "Google APIs PlayStore",
               "id:0": "google_apis_playstore"
             },
-            "vendor:2": {
+            "vendor:5": {
               "display:1": "Google Inc.",
               "id:0": "google"
+            }
+          }
+        }
+      },
+      "google_apis_ps16k": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "9d834fe640beff22d25025a8028b98ab4366be4d",
+              "size": 1778788352,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-ps16k-35_r05.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "33",
+                "micro:2": "24",
+                "minor:1": "1"
+              }
+            }
+          },
+          "displayName": "16 KB Page Size Google APIs ARM 64 v8a System Image",
+          "last-available-day": 20676,
+          "license": "android-sdk-arm-dbt-license",
+          "name": "system-image-35-google_apis_ps16k-arm64-v8a",
+          "path": "system-images/android-35/google_apis_ps16k/arm64-v8a",
+          "revision": "35-google_apis_ps16k-arm64-v8a",
+          "revision-details": {
+            "major:0": "5"
+          },
+          "type-details": {
+            "abi:6": "arm64-v8a",
+            "api-level:0": "35",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "13",
+            "tag:3": {
+              "display:1": "16 KB Page Size",
+              "id:0": "page_size_16kb"
+            },
+            "tag:4": {
+              "display:1": " Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:5": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "d709cf26b375abecfbbf5803afd20749ddfa2865",
+              "size": 1696342085,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-ps16k-35_r05.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "33",
+                "micro:2": "24",
+                "minor:1": "1"
+              }
+            }
+          },
+          "displayName": "16 KB Page Size Google APIs Intel x86_64 Atom System Image",
+          "last-available-day": 20676,
+          "license": "android-sdk-license",
+          "name": "system-image-35-google_apis_ps16k-x86_64",
+          "path": "system-images/android-35/google_apis_ps16k/x86_64",
+          "revision": "35-google_apis_ps16k-x86_64",
+          "revision-details": {
+            "major:0": "5"
+          },
+          "type-details": {
+            "abi:6": "x86_64",
+            "api-level:0": "35",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "13",
+            "tag:3": {
+              "display:1": "16 KB Page Size",
+              "id:0": "page_size_16kb"
+            },
+            "tag:4": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
             },
             "vendor:5": {
               "display:1": "Google Inc.",
@@ -11973,9 +9573,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "18d0e0be69d9883321d547ce099897196a7d646c",
-              "size": 1516199389,
-              "url": "https://dl.google.com/android/repository/sys-img/android-automotive/arm64-v8a-35-ext15_playstore_r03.zip"
+              "sha1": "57954251f8067926f90e87b8f7bfaaebb14804c0",
+              "size": 1423204133,
+              "url": "https://dl.google.com/android/repository/sys-img/android-automotive/arm64-v8a-35-ext15_r03.zip"
             }
           ],
           "dependencies": {
@@ -11991,7 +9591,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs arm64-v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-35x-android-automotive-arm64-v8a",
           "path": "system-images/android-35-ext15/android-automotive/arm64-v8a",
@@ -12026,9 +9626,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "75df7f594424350bbdb59ef31c9b2e98951993f1",
-              "size": 1567573000,
-              "url": "https://dl.google.com/android/repository/sys-img/android-automotive/x86_64-35-ext15_playstore_r03.zip"
+              "sha1": "608cbbc33005fb4a13ad041c8a0e76f3033ac0f5",
+              "size": 1461955988,
+              "url": "https://dl.google.com/android/repository/sys-img/android-automotive/x86_64-35-ext15_r03.zip"
             }
           ],
           "dependencies": {
@@ -12044,7 +9644,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs x86_64 System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-35x-android-automotive-x86_64",
           "path": "system-images/android-35-ext15/android-automotive/x86_64",
@@ -12075,6 +9675,114 @@
           }
         }
       },
+      "android-automotive-playstore": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "18d0e0be69d9883321d547ce099897196a7d646c",
+              "size": 1516199389,
+              "url": "https://dl.google.com/android/repository/sys-img/android-automotive/arm64-v8a-35-ext15_playstore_r03.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "36",
+                "micro:2": "1",
+                "minor:1": "3"
+              }
+            }
+          },
+          "displayName": "Android Automotive with Google Play arm64-v8a System Image",
+          "last-available-day": 20676,
+          "license": "android-sdk-license",
+          "name": "system-image-35x-android-automotive-playstore-arm64-v8a",
+          "path": "system-images/android-35-ext15/android-automotive-playstore/arm64-v8a",
+          "revision": "35x-android-automotive-playstore-arm64-v8a",
+          "revision-details": {
+            "major:0": "3"
+          },
+          "type-details": {
+            "abi:6": "arm64-v8a",
+            "api-level:0": "35x",
+            "base-extension:2": "false",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "15",
+            "tag:3": {
+              "display:1": "Automotive",
+              "id:0": "android-automotive"
+            },
+            "tag:4": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:5": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "75df7f594424350bbdb59ef31c9b2e98951993f1",
+              "size": 1567573000,
+              "url": "https://dl.google.com/android/repository/sys-img/android-automotive/x86_64-35-ext15_playstore_r03.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "36",
+                "micro:2": "1",
+                "minor:1": "3"
+              }
+            }
+          },
+          "displayName": "Android Automotive with Google Play x86_64 System Image",
+          "last-available-day": 20676,
+          "license": "android-sdk-license",
+          "name": "system-image-35x-android-automotive-playstore-x86_64",
+          "path": "system-images/android-35-ext15/android-automotive-playstore/x86_64",
+          "revision": "35x-android-automotive-playstore-x86_64",
+          "revision-details": {
+            "major:0": "3"
+          },
+          "type-details": {
+            "abi:6": "x86_64",
+            "api-level:0": "35x",
+            "base-extension:2": "false",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "15",
+            "tag:3": {
+              "display:1": "Automotive",
+              "id:0": "android-automotive"
+            },
+            "tag:4": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:5": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        }
+      },
       "android-wear": {
         "arm64-v8a": {
           "archives": [
@@ -12087,7 +9795,7 @@
             }
           ],
           "displayName": "Wear OS 5.1 ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-35x-android-wear-arm64-v8a",
           "path": "system-images/android-35-ext15/android-wear/arm64-v8a",
@@ -12120,7 +9828,7 @@
             }
           ],
           "displayName": "Wear OS 5.1 Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-35x-android-wear-x86_64",
           "path": "system-images/android-35-ext15/android-wear/x86_64",
@@ -12167,7 +9875,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35x-google_apis-arm64-v8a",
           "path": "system-images/android-35-ext15/google_apis/arm64-v8a",
@@ -12216,7 +9924,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-35x-google_apis-x86_64",
           "path": "system-images/android-35-ext15/google_apis/x86_64",
@@ -12267,7 +9975,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35x-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-35-ext15/google_apis_playstore/arm64-v8a",
@@ -12316,7 +10024,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-35x-google_apis_playstore-x86_64",
           "path": "system-images/android-35-ext15/google_apis_playstore/x86_64",
@@ -12369,7 +10077,7 @@
             }
           },
           "displayName": "Android TV ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-36-android-tv-arm64-v8a",
           "path": "system-images/android-36/android-tv/arm64-v8a",
@@ -12414,7 +10122,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-36-android-tv-x86",
           "path": "system-images/android-36/android-tv/x86",
@@ -12459,7 +10167,7 @@
             }
           },
           "displayName": "Android TV Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-36-android-tv-x86_64",
           "path": "system-images/android-36/android-tv/x86_64",
@@ -12482,7 +10190,7 @@
           }
         }
       },
-      "android-wear": {
+      "android-wear-signed": {
         "arm64-v8a": {
           "archives": [
             {
@@ -12494,11 +10202,11 @@
             }
           ],
           "displayName": "Wear OS 6.0 ARM 64 v8a System Image (signed)",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
-          "name": "system-image-36-android-wear-arm64-v8a",
+          "name": "system-image-36-android-wear-signed-arm64-v8a",
           "path": "system-images/android-36/android-wear-signed/arm64-v8a",
-          "revision": "36-android-wear-arm64-v8a",
+          "revision": "36-android-wear-signed-arm64-v8a",
           "revision-details": {
             "major:0": "1"
           },
@@ -12527,11 +10235,11 @@
             }
           ],
           "displayName": "Wear OS 6.0 Intel x86_64 Atom System Image (signed)",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
-          "name": "system-image-36-android-wear-x86_64",
+          "name": "system-image-36-android-wear-signed-x86_64",
           "path": "system-images/android-36/android-wear-signed/x86_64",
-          "revision": "36-android-wear-x86_64",
+          "revision": "36-android-wear-signed-x86_64",
           "revision-details": {
             "major:0": "1"
           },
@@ -12574,7 +10282,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-36-default-arm64-v8a",
           "path": "system-images/android-36/default/arm64-v8a",
@@ -12619,7 +10327,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-36-default-x86_64",
           "path": "system-images/android-36/default/x86_64",
@@ -12666,7 +10374,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-36-google_apis-arm64-v8a",
           "path": "system-images/android-36/google_apis/arm64-v8a",
@@ -12715,7 +10423,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-36-google_apis-x86_64",
           "path": "system-images/android-36/google_apis/x86_64",
@@ -12766,7 +10474,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-36-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-36/google_apis_playstore/arm64-v8a",
@@ -12815,7 +10523,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-36-google_apis_playstore-x86_64",
           "path": "system-images/android-36/google_apis_playstore/x86_64",
@@ -12842,7 +10550,7 @@
           }
         }
       },
-      "page_size_16kb": {
+      "google_apis_playstore_ps16k": {
         "arm64-v8a": {
           "archives": [
             {
@@ -12850,7 +10558,7 @@
               "os": "all",
               "sha1": "ddc41c615cf57cb91c9646d208e29234d92f881c",
               "size": 1953548168,
-              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/arm64-v8a-playstore-ps16k-36_r07.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-playstore-ps16k-36_r07.zip"
             }
           ],
           "dependencies": {
@@ -12866,11 +10574,11 @@
             }
           },
           "displayName": "16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
-          "name": "system-image-36-page_size_16kb-arm64-v8a",
+          "name": "system-image-36-google_apis_playstore_ps16k-arm64-v8a",
           "path": "system-images/android-36/google_apis_playstore_ps16k/arm64-v8a",
-          "revision": "36-page_size_16kb-arm64-v8a",
+          "revision": "36-google_apis_playstore_ps16k-arm64-v8a",
           "revision-details": {
             "major:0": "7"
           },
@@ -12903,7 +10611,7 @@
               "os": "all",
               "sha1": "3814a7b029c3b8aa0a9c8f110459f412a20882e7",
               "size": 1937396599,
-              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/x86_64-playstore-ps16k-36_r07.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-playstore-ps16k-36_r07.zip"
             }
           ],
           "dependencies": {
@@ -12919,11 +10627,11 @@
             }
           },
           "displayName": "16 KB Page Size Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
-          "name": "system-image-36-page_size_16kb-x86_64",
+          "name": "system-image-36-google_apis_playstore_ps16k-x86_64",
           "path": "system-images/android-36/google_apis_playstore_ps16k/x86_64",
-          "revision": "36-page_size_16kb-x86_64",
+          "revision": "36-google_apis_playstore_ps16k-x86_64",
           "revision-details": {
             "major:0": "7"
           },
@@ -12949,10 +10657,118 @@
             }
           }
         }
+      },
+      "google_apis_ps16k": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "dda632745023567113d9954101709c6526a3c250",
+              "size": 1875087037,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-ps16k-36_r07.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "16 KB Page Size Google APIs ARM 64 v8a System Image",
+          "last-available-day": 20676,
+          "license": "android-sdk-arm-dbt-license",
+          "name": "system-image-36-google_apis_ps16k-arm64-v8a",
+          "path": "system-images/android-36/google_apis_ps16k/arm64-v8a",
+          "revision": "36-google_apis_ps16k-arm64-v8a",
+          "revision-details": {
+            "major:0": "7"
+          },
+          "type-details": {
+            "abi:6": "arm64-v8a",
+            "api-level:0": "36",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "17",
+            "tag:3": {
+              "display:1": "16 KB Page Size",
+              "id:0": "page_size_16kb"
+            },
+            "tag:4": {
+              "display:1": " Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:5": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "dd783282e84bf475a02eba6777c79fc5695e1583",
+              "size": 1849428145,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-ps16k-36_r07.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "16 KB Page Size Google APIs Intel x86_64 Atom System Image",
+          "last-available-day": 20676,
+          "license": "android-sdk-license",
+          "name": "system-image-36-google_apis_ps16k-x86_64",
+          "path": "system-images/android-36/google_apis_ps16k/x86_64",
+          "revision": "36-google_apis_ps16k-x86_64",
+          "revision-details": {
+            "major:0": "7"
+          },
+          "type-details": {
+            "abi:6": "x86_64",
+            "api-level:0": "36",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "17",
+            "tag:3": {
+              "display:1": "16 KB Page Size",
+              "id:0": "page_size_16kb"
+            },
+            "tag:4": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:5": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        }
       }
     },
     "36.1": {
-      "android-wear": {
+      "android-wear-signed": {
         "arm64-v8a": {
           "archives": [
             {
@@ -12964,11 +10780,11 @@
             }
           ],
           "displayName": "Wear OS 6.1 ARM 64 v8a System Image (signed)",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
-          "name": "system-image-36.1-android-wear-arm64-v8a",
+          "name": "system-image-36.1-android-wear-signed-arm64-v8a",
           "path": "system-images/android-36.1/android-wear-signed/arm64-v8a",
-          "revision": "36.1-android-wear-arm64-v8a",
+          "revision": "36.1-android-wear-signed-arm64-v8a",
           "revision-details": {
             "major:0": "1"
           },
@@ -12997,11 +10813,11 @@
             }
           ],
           "displayName": "Wear OS 6.1 Intel x86_64 Atom System Image (signed)",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
-          "name": "system-image-36.1-android-wear-x86_64",
+          "name": "system-image-36.1-android-wear-signed-x86_64",
           "path": "system-images/android-36.1/android-wear-signed/x86_64",
-          "revision": "36.1-android-wear-x86_64",
+          "revision": "36.1-android-wear-signed-x86_64",
           "revision-details": {
             "major:0": "1"
           },
@@ -13043,18 +10859,17 @@
               }
             }
           },
-          "displayName": "16 KB Page Size Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "displayName": "Google APIs ARM 64 v8a System Image",
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-36.1-google_apis-arm64-v8a",
-          "path": "system-images/android-36.1/google_apis_ps16k/arm64-v8a",
+          "path": "system-images/android-36.1/google_apis/arm64-v8a",
           "revision": "36.1-google_apis-arm64-v8a",
           "revision-details": {
             "major:0": "4"
           },
           "type-details": {
             "abi:5": "arm64-v8a",
-            "abi:6": "arm64-v8a",
             "api-level:0": "36.1",
             "base-extension:2": "true",
             "element-attributes": {
@@ -13065,15 +10880,7 @@
               "display:1": "Google APIs",
               "id:0": "google_apis"
             },
-            "tag:4": {
-              "display:1": "16 KB Page Size",
-              "id:0": "page_size_16kb"
-            },
             "vendor:4": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            },
-            "vendor:5": {
               "display:1": "Google Inc.",
               "id:0": "google"
             }
@@ -13101,18 +10908,17 @@
               }
             }
           },
-          "displayName": "16 KB Page Size Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "displayName": "Google APIs Intel x86_64 Atom System Image",
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-36.1-google_apis-x86_64",
-          "path": "system-images/android-36.1/google_apis_ps16k/x86_64",
+          "path": "system-images/android-36.1/google_apis/x86_64",
           "revision": "36.1-google_apis-x86_64",
           "revision-details": {
             "major:0": "4"
           },
           "type-details": {
             "abi:5": "x86_64",
-            "abi:6": "x86_64",
             "api-level:0": "36.1",
             "base-extension:2": "true",
             "element-attributes": {
@@ -13123,15 +10929,7 @@
               "display:1": "Google APIs",
               "id:0": "google_apis"
             },
-            "tag:4": {
-              "display:1": "16 KB Page Size",
-              "id:0": "page_size_16kb"
-            },
             "vendor:4": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            },
-            "vendor:5": {
               "display:1": "Google Inc.",
               "id:0": "google"
             }
@@ -13161,18 +10959,17 @@
               }
             }
           },
-          "displayName": "16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "displayName": "Google Play ARM 64 v8a System Image",
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-36.1-google_apis_playstore-arm64-v8a",
-          "path": "system-images/android-36.1/google_apis_playstore_ps16k/arm64-v8a",
+          "path": "system-images/android-36.1/google_apis_playstore/arm64-v8a",
           "revision": "36.1-google_apis_playstore-arm64-v8a",
           "revision-details": {
             "major:0": "4"
           },
           "type-details": {
             "abi:5": "arm64-v8a",
-            "abi:6": "arm64-v8a",
             "api-level:0": "36.1",
             "base-extension:2": "true",
             "element-attributes": {
@@ -13180,18 +10977,10 @@
             },
             "extension-level:1": "20",
             "tag:3": {
-              "display:1": "Google APIs PlayStore",
+              "display:1": "Google Play",
               "id:0": "google_apis_playstore"
             },
-            "tag:4": {
-              "display:1": "Page Size 16KB",
-              "id:0": "page_size_16kb"
-            },
             "vendor:4": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            },
-            "vendor:5": {
               "display:1": "Google Inc.",
               "id:0": "google"
             }
@@ -13219,17 +11008,120 @@
               }
             }
           },
-          "displayName": "16 KB Page Size Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "displayName": "Google Play Intel x86_64 Atom System Image",
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-36.1-google_apis_playstore-x86_64",
-          "path": "system-images/android-36.1/google_apis_playstore_ps16k/x86_64",
+          "path": "system-images/android-36.1/google_apis_playstore/x86_64",
           "revision": "36.1-google_apis_playstore-x86_64",
           "revision-details": {
             "major:0": "4"
           },
           "type-details": {
             "abi:5": "x86_64",
+            "api-level:0": "36.1",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "20",
+            "tag:3": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:4": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        }
+      },
+      "google_apis_playstore_ps16k": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "4fd077b3c01003442ec2024558d7d5ae204f0fc3",
+              "size": 2014291833,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-playstore-ps16k-36.1_r04.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "16 KB Page Size Google Play ARM 64 v8a System Image",
+          "last-available-day": 20676,
+          "license": "android-sdk-arm-dbt-license",
+          "name": "system-image-36.1-google_apis_playstore_ps16k-arm64-v8a",
+          "path": "system-images/android-36.1/google_apis_playstore_ps16k/arm64-v8a",
+          "revision": "36.1-google_apis_playstore_ps16k-arm64-v8a",
+          "revision-details": {
+            "major:0": "4"
+          },
+          "type-details": {
+            "abi:6": "arm64-v8a",
+            "api-level:0": "36.1",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "20",
+            "tag:3": {
+              "display:1": "Google APIs PlayStore",
+              "id:0": "google_apis_playstore"
+            },
+            "tag:4": {
+              "display:1": "Page Size 16KB",
+              "id:0": "page_size_16kb"
+            },
+            "vendor:5": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "3bf3e0826ff7bf1825fc68bdad40ffa29e714920",
+              "size": 2001888462,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-playstore-ps16k-36.1_r04.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "16 KB Page Size Google Play Intel x86_64 Atom System Image",
+          "last-available-day": 20676,
+          "license": "android-sdk-license",
+          "name": "system-image-36.1-google_apis_playstore_ps16k-x86_64",
+          "path": "system-images/android-36.1/google_apis_playstore_ps16k/x86_64",
+          "revision": "36.1-google_apis_playstore_ps16k-x86_64",
+          "revision-details": {
+            "major:0": "4"
+          },
+          "type-details": {
             "abi:6": "x86_64",
             "api-level:0": "36.1",
             "base-extension:2": "true",
@@ -13245,10 +11137,6 @@
               "display:1": "Page Size 16KB",
               "id:0": "page_size_16kb"
             },
-            "vendor:4": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            },
             "vendor:5": {
               "display:1": "Google Inc.",
               "id:0": "google"
@@ -13256,15 +11144,15 @@
           }
         }
       },
-      "page_size_16kb": {
+      "google_apis_ps16k": {
         "arm64-v8a": {
           "archives": [
             {
               "arch": "all",
               "os": "all",
-              "sha1": "fd7faf08bef691a89c6770f8d6965b23cf960ee7",
-              "size": 2017121646,
-              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/arm64-v8a-playstore-ps16k-36.1_r02.zip"
+              "sha1": "a48079a4c1c7781d157ff9ff1c0fc9d5ab3ffc58",
+              "size": 1936180596,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-ps16k-36.1_r04.zip"
             }
           ],
           "dependencies": {
@@ -13279,14 +11167,14 @@
               }
             }
           },
-          "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "displayName": "16 KB Page Size Google APIs ARM 64 v8a System Image",
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
-          "name": "system-image-36.1-page_size_16kb-arm64-v8a",
-          "path": "system-images/android-36.1/google_apis_playstore_ps16k/arm64-v8a",
-          "revision": "36.1-page_size_16kb-arm64-v8a",
+          "name": "system-image-36.1-google_apis_ps16k-arm64-v8a",
+          "path": "system-images/android-36.1/google_apis_ps16k/arm64-v8a",
+          "revision": "36.1-google_apis_ps16k-arm64-v8a",
           "revision-details": {
-            "major:0": "2"
+            "major:0": "4"
           },
           "type-details": {
             "abi:6": "arm64-v8a",
@@ -13297,12 +11185,12 @@
             },
             "extension-level:1": "20",
             "tag:3": {
-              "display:1": "16 KB Page Size",
-              "id:0": "page_size_16kb"
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
             },
             "tag:4": {
-              "display:1": "Google APIs PlayStore",
-              "id:0": "google_apis_playstore"
+              "display:1": "16 KB Page Size",
+              "id:0": "page_size_16kb"
             },
             "vendor:5": {
               "display:1": "Google Inc.",
@@ -13315,9 +11203,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "41c208d5c4cc0100589999abca73814e78e951db",
-              "size": 2009997930,
-              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/x86_64-playstore-ps16k-36.1_r02.zip"
+              "sha1": "d812164d3704c2d5846d34e0a4d2c61cb1224a02",
+              "size": 1913923004,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-ps16k-36.1_r04.zip"
             }
           ],
           "dependencies": {
@@ -13332,14 +11220,14 @@
               }
             }
           },
-          "displayName": "Pre-Release 16 KB Page Size Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "displayName": "16 KB Page Size Google APIs Intel x86_64 Atom System Image",
+          "last-available-day": 20676,
           "license": "android-sdk-license",
-          "name": "system-image-36.1-page_size_16kb-x86_64",
-          "path": "system-images/android-36.1/google_apis_playstore_ps16k/x86_64",
-          "revision": "36.1-page_size_16kb-x86_64",
+          "name": "system-image-36.1-google_apis_ps16k-x86_64",
+          "path": "system-images/android-36.1/google_apis_ps16k/x86_64",
+          "revision": "36.1-google_apis_ps16k-x86_64",
           "revision-details": {
-            "major:0": "2"
+            "major:0": "4"
           },
           "type-details": {
             "abi:6": "x86_64",
@@ -13350,12 +11238,12 @@
             },
             "extension-level:1": "20",
             "tag:3": {
-              "display:1": "16 KB Page Size",
-              "id:0": "page_size_16kb"
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
             },
             "tag:4": {
-              "display:1": "Google APIs PlayStore",
-              "id:0": "google_apis_playstore"
+              "display:1": "16 KB Page Size",
+              "id:0": "page_size_16kb"
             },
             "vendor:5": {
               "display:1": "Google Inc.",
@@ -13390,7 +11278,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-36x-google_apis-arm64-v8a",
           "path": "system-images/android-36-ext19/google_apis/arm64-v8a",
@@ -13439,7 +11327,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-36x-google_apis-x86_64",
           "path": "system-images/android-36-ext19/google_apis/x86_64",
@@ -13490,7 +11378,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-36x-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-36-ext19/google_apis_playstore/arm64-v8a",
@@ -13539,7 +11427,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-36x-google_apis_playstore-x86_64",
           "path": "system-images/android-36-ext19/google_apis_playstore/x86_64",
@@ -13568,7 +11456,7 @@
       }
     },
     "37.0": {
-      "android-wear": {
+      "android-wear-signed": {
         "arm64-v8a": {
           "archives": [
             {
@@ -13580,11 +11468,11 @@
             }
           ],
           "displayName": "Wear OS 7.0 ARM 64 v8a System Image (signed)",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
-          "name": "system-image-37.0-android-wear-arm64-v8a",
+          "name": "system-image-37.0-android-wear-signed-arm64-v8a",
           "path": "system-images/android-37.0/android-wear-signed/arm64-v8a",
-          "revision": "37.0-android-wear-arm64-v8a",
+          "revision": "37.0-android-wear-signed-arm64-v8a",
           "revision-details": {
             "major:0": "1"
           },
@@ -13613,11 +11501,11 @@
             }
           ],
           "displayName": "Wear OS 7.0 Intel x86_64 Atom System Image (signed)",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
-          "name": "system-image-37.0-android-wear-x86_64",
+          "name": "system-image-37.0-android-wear-signed-x86_64",
           "path": "system-images/android-37.0/android-wear-signed/x86_64",
-          "revision": "37.0-android-wear-x86_64",
+          "revision": "37.0-android-wear-signed-x86_64",
           "revision-details": {
             "major:0": "1"
           },
@@ -13642,9 +11530,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "06ae085fdf86b6bcce3c3f8a8d37aebe3cc2101e",
-              "size": 2192196128,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-ps16k-37.0_r06.zip"
+              "sha1": "e007fb23024c59bffdf944b95c61143bc38101ce",
+              "size": 2194282378,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-37.0_r06.zip"
             }
           ],
           "dependencies": {
@@ -13660,7 +11548,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-37.0-google_apis-arm64-v8a",
           "path": "system-images/android-37.0/google_apis/arm64-v8a",
@@ -13670,7 +11558,6 @@
           },
           "type-details": {
             "abi:6": "arm64-v8a",
-            "abi:7": "arm64-v8a",
             "api-level:0": "37.0",
             "base-extension:2": "true",
             "element-attributes": {
@@ -13685,15 +11572,7 @@
               "display:1": "AI Glasses Compatible",
               "id:0": "ai_glasses_compatible"
             },
-            "tag:5": {
-              "display:1": "AI Glasses Compatible",
-              "id:0": "ai_glasses_compatible"
-            },
             "vendor:5": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            },
-            "vendor:6": {
               "display:1": "Google Inc.",
               "id:0": "google"
             }
@@ -13704,9 +11583,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "0edc4b2fba9fd684113224f1a9fb52133b4fc2c8",
-              "size": 2172129969,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-ps16k-37.0_r06.zip"
+              "sha1": "629e507fd5b737c2c836b12b52c81cd0e3b12399",
+              "size": 2234615040,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-37.0_r06.zip"
             }
           ],
           "dependencies": {
@@ -13722,7 +11601,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
           "name": "system-image-37.0-google_apis-x86_64",
           "path": "system-images/android-37.0/google_apis/x86_64",
@@ -13732,7 +11611,6 @@
           },
           "type-details": {
             "abi:6": "x86_64",
-            "abi:7": "x86_64",
             "api-level:0": "37.0",
             "base-extension:2": "true",
             "element-attributes": {
@@ -13747,15 +11625,7 @@
               "display:1": "AI Glasses Compatible",
               "id:0": "ai_glasses_compatible"
             },
-            "tag:5": {
-              "display:1": "AI Glasses Compatible",
-              "id:0": "ai_glasses_compatible"
-            },
             "vendor:5": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            },
-            "vendor:6": {
               "display:1": "Google Inc.",
               "id:0": "google"
             }
@@ -13763,6 +11633,114 @@
         }
       },
       "google_apis_playstore": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "642cf494464b4d1d4d37fa50630fe153599be3fb",
+              "size": 2257751510,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-37.0_r06.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "36",
+                "micro:2": "11",
+                "minor:1": "5"
+              }
+            }
+          },
+          "displayName": "Google Play ARM 64 v8a System Image",
+          "last-available-day": 20676,
+          "license": "android-sdk-arm-dbt-license",
+          "name": "system-image-37.0-google_apis_playstore-arm64-v8a",
+          "path": "system-images/android-37.0/google_apis_playstore/arm64-v8a",
+          "revision": "37.0-google_apis_playstore-arm64-v8a",
+          "revision-details": {
+            "major:0": "6"
+          },
+          "type-details": {
+            "abi:6": "arm64-v8a",
+            "api-level:0": "37.0",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "22",
+            "tag:3": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "tag:4": {
+              "display:1": "AI Glasses Compatible",
+              "id:0": "ai_glasses_compatible"
+            },
+            "vendor:5": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "6950c614f07592b18d21a6e3e65d40a9aa1c3635",
+              "size": 2326241523,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-37.0_r06.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "36",
+                "micro:2": "11",
+                "minor:1": "5"
+              }
+            }
+          },
+          "displayName": "Google Play Intel x86_64 Atom System Image",
+          "last-available-day": 20676,
+          "license": "android-sdk-license",
+          "name": "system-image-37.0-google_apis_playstore-x86_64",
+          "path": "system-images/android-37.0/google_apis_playstore/x86_64",
+          "revision": "37.0-google_apis_playstore-x86_64",
+          "revision-details": {
+            "major:0": "6"
+          },
+          "type-details": {
+            "abi:6": "x86_64",
+            "api-level:0": "37.0",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "22",
+            "tag:3": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "tag:4": {
+              "display:1": "AI Glasses Compatible",
+              "id:0": "ai_glasses_compatible"
+            },
+            "vendor:5": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        }
+      },
+      "google_apis_playstore_ps16k": {
         "arm64-v8a": {
           "archives": [
             {
@@ -13785,17 +11763,16 @@
               }
             }
           },
-          "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "displayName": "16 KB Page Size Google Play ARM 64 v8a System Image",
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
-          "name": "system-image-37.0-google_apis_playstore-arm64-v8a",
-          "path": "system-images/android-37.0/google_apis_playstore/arm64-v8a",
-          "revision": "37.0-google_apis_playstore-arm64-v8a",
+          "name": "system-image-37.0-google_apis_playstore_ps16k-arm64-v8a",
+          "path": "system-images/android-37.0/google_apis_playstore_ps16k/arm64-v8a",
+          "revision": "37.0-google_apis_playstore_ps16k-arm64-v8a",
           "revision-details": {
             "major:0": "6"
           },
           "type-details": {
-            "abi:6": "arm64-v8a",
             "abi:7": "arm64-v8a",
             "api-level:0": "37.0",
             "base-extension:2": "true",
@@ -13804,20 +11781,16 @@
             },
             "extension-level:1": "22",
             "tag:3": {
-              "display:1": "Google Play",
+              "display:1": "Google APIs PlayStore",
               "id:0": "google_apis_playstore"
             },
             "tag:4": {
-              "display:1": "AI Glasses Compatible",
-              "id:0": "ai_glasses_compatible"
+              "display:1": "Page Size 16KB",
+              "id:0": "page_size_16kb"
             },
             "tag:5": {
               "display:1": "AI Glasses Compatible",
               "id:0": "ai_glasses_compatible"
-            },
-            "vendor:5": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
             },
             "vendor:6": {
               "display:1": "Google Inc.",
@@ -13847,17 +11820,16 @@
               }
             }
           },
-          "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "displayName": "16 KB Page Size Google Play Intel x86_64 Atom System Image",
+          "last-available-day": 20676,
           "license": "android-sdk-license",
-          "name": "system-image-37.0-google_apis_playstore-x86_64",
-          "path": "system-images/android-37.0/google_apis_playstore/x86_64",
-          "revision": "37.0-google_apis_playstore-x86_64",
+          "name": "system-image-37.0-google_apis_playstore_ps16k-x86_64",
+          "path": "system-images/android-37.0/google_apis_playstore_ps16k/x86_64",
+          "revision": "37.0-google_apis_playstore_ps16k-x86_64",
           "revision-details": {
             "major:0": "6"
           },
           "type-details": {
-            "abi:6": "x86_64",
             "abi:7": "x86_64",
             "api-level:0": "37.0",
             "base-extension:2": "true",
@@ -13866,20 +11838,132 @@
             },
             "extension-level:1": "22",
             "tag:3": {
-              "display:1": "Google Play",
+              "display:1": "Google APIs PlayStore",
               "id:0": "google_apis_playstore"
             },
             "tag:4": {
-              "display:1": "AI Glasses Compatible",
-              "id:0": "ai_glasses_compatible"
+              "display:1": "Page Size 16KB",
+              "id:0": "page_size_16kb"
             },
             "tag:5": {
               "display:1": "AI Glasses Compatible",
               "id:0": "ai_glasses_compatible"
             },
-            "vendor:5": {
+            "vendor:6": {
               "display:1": "Google Inc.",
               "id:0": "google"
+            }
+          }
+        }
+      },
+      "google_apis_ps16k": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "06ae085fdf86b6bcce3c3f8a8d37aebe3cc2101e",
+              "size": 2192196128,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-ps16k-37.0_r06.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "36",
+                "micro:2": "11",
+                "minor:1": "5"
+              }
+            }
+          },
+          "displayName": "16 KB Page Size Google APIs ARM 64 v8a System Image",
+          "last-available-day": 20676,
+          "license": "android-sdk-arm-dbt-license",
+          "name": "system-image-37.0-google_apis_ps16k-arm64-v8a",
+          "path": "system-images/android-37.0/google_apis_ps16k/arm64-v8a",
+          "revision": "37.0-google_apis_ps16k-arm64-v8a",
+          "revision-details": {
+            "major:0": "6"
+          },
+          "type-details": {
+            "abi:7": "arm64-v8a",
+            "api-level:0": "37.0",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "22",
+            "tag:3": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "tag:4": {
+              "display:1": "16 KB Page Size",
+              "id:0": "page_size_16kb"
+            },
+            "tag:5": {
+              "display:1": "AI Glasses Compatible",
+              "id:0": "ai_glasses_compatible"
+            },
+            "vendor:6": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "0edc4b2fba9fd684113224f1a9fb52133b4fc2c8",
+              "size": 2172129969,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-ps16k-37.0_r06.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "36",
+                "micro:2": "11",
+                "minor:1": "5"
+              }
+            }
+          },
+          "displayName": "16 KB Page Size Google APIs Intel x86_64 Atom System Image",
+          "last-available-day": 20676,
+          "license": "android-sdk-license",
+          "name": "system-image-37.0-google_apis_ps16k-x86_64",
+          "path": "system-images/android-37.0/google_apis_ps16k/x86_64",
+          "revision": "37.0-google_apis_ps16k-x86_64",
+          "revision-details": {
+            "major:0": "6"
+          },
+          "type-details": {
+            "abi:7": "x86_64",
+            "api-level:0": "37.0",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "22",
+            "tag:3": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "tag:4": {
+              "display:1": "16 KB Page Size",
+              "id:0": "page_size_16kb"
+            },
+            "tag:5": {
+              "display:1": "AI Glasses Compatible",
+              "id:0": "ai_glasses_compatible"
             },
             "vendor:6": {
               "display:1": "Google Inc.",
@@ -13890,15 +11974,123 @@
       }
     },
     "37.1": {
-      "google_apis": {
+      "google_apis_playstore_ps16k": {
         "arm64-v8a": {
           "archives": [
             {
               "arch": "all",
               "os": "all",
-              "sha1": "d4785e29b1930b657ee1cde117cb237ef5710925",
-              "size": 2097078633,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-ps16k-37.1_r07.zip"
+              "sha1": "5fb57f9fffcb2975e7082eeb8a30cfcb8c7dfaa2",
+              "size": 2127015004,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-playstore-ps16k-37.1_r08.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "36",
+                "micro:2": "11",
+                "minor:1": "5"
+              }
+            }
+          },
+          "displayName": "16 KB Page Size Google Play ARM 64 v8a System Image",
+          "last-available-day": 20676,
+          "license": "android-sdk-arm-dbt-license",
+          "name": "system-image-37.1-google_apis_playstore_ps16k-arm64-v8a",
+          "path": "system-images/android-37.1/google_apis_playstore_ps16k/arm64-v8a",
+          "revision": "37.1-google_apis_playstore_ps16k-arm64-v8a",
+          "revision-details": {
+            "major:0": "8"
+          },
+          "type-details": {
+            "abi:6": "arm64-v8a",
+            "api-level:0": "37.1",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "23",
+            "tag:3": {
+              "display:1": "Google APIs PlayStore",
+              "id:0": "google_apis_playstore"
+            },
+            "tag:4": {
+              "display:1": "Page Size 16KB",
+              "id:0": "page_size_16kb"
+            },
+            "vendor:5": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "8fda4be531c62d87a9f4025f869a511de8ecc383",
+              "size": 2198737325,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-playstore-ps16k-37.1_r08.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "36",
+                "micro:2": "11",
+                "minor:1": "5"
+              }
+            }
+          },
+          "displayName": "16 KB Page Size Google Play Intel x86_64 Atom System Image",
+          "last-available-day": 20676,
+          "license": "android-sdk-license",
+          "name": "system-image-37.1-google_apis_playstore_ps16k-x86_64",
+          "path": "system-images/android-37.1/google_apis_playstore_ps16k/x86_64",
+          "revision": "37.1-google_apis_playstore_ps16k-x86_64",
+          "revision-details": {
+            "major:0": "8"
+          },
+          "type-details": {
+            "abi:6": "x86_64",
+            "api-level:0": "37.1",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "23",
+            "tag:3": {
+              "display:1": "Google APIs PlayStore",
+              "id:0": "google_apis_playstore"
+            },
+            "tag:4": {
+              "display:1": "Page Size 16KB",
+              "id:0": "page_size_16kb"
+            },
+            "vendor:5": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        }
+      },
+      "google_apis_ps16k": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "c15415a5c03eb128cf86c050bef302e117e62cab",
+              "size": 2098361492,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-ps16k-37.1_r08.zip"
             }
           ],
           "dependencies": {
@@ -13914,13 +12106,13 @@
             }
           },
           "displayName": "16 KB Page Size Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
-          "name": "system-image-37.1-google_apis-arm64-v8a",
+          "name": "system-image-37.1-google_apis_ps16k-arm64-v8a",
           "path": "system-images/android-37.1/google_apis_ps16k/arm64-v8a",
-          "revision": "37.1-google_apis-arm64-v8a",
+          "revision": "37.1-google_apis_ps16k-arm64-v8a",
           "revision-details": {
-            "major:0": "7"
+            "major:0": "8"
           },
           "type-details": {
             "abi:6": "arm64-v8a",
@@ -13949,9 +12141,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "88e208a83a5f0b18958275b7c1a047e931395f3f",
-              "size": 2176688306,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-ps16k-37.1_r07.zip"
+              "sha1": "f1bcb91783e9f780260c3aab39b6c96eaee29b20",
+              "size": 2177744458,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-ps16k-37.1_r08.zip"
             }
           ],
           "dependencies": {
@@ -13967,13 +12159,13 @@
             }
           },
           "displayName": "16 KB Page Size Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
-          "name": "system-image-37.1-google_apis-x86_64",
+          "name": "system-image-37.1-google_apis_ps16k-x86_64",
           "path": "system-images/android-37.1/google_apis_ps16k/x86_64",
-          "revision": "37.1-google_apis-x86_64",
+          "revision": "37.1-google_apis_ps16k-x86_64",
           "revision-details": {
-            "major:0": "7"
+            "major:0": "8"
           },
           "type-details": {
             "abi:6": "x86_64",
@@ -13992,430 +12184,6 @@
               "id:0": "page_size_16kb"
             },
             "vendor:5": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        }
-      },
-      "google_apis_playstore": {
-        "arm64-v8a": {
-          "archives": [
-            {
-              "arch": "all",
-              "os": "all",
-              "sha1": "53d2a5e3b6427d4b3c732cb8b03afe308a12a434",
-              "size": 2124630403,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-playstore-ps16k-37.1_r07.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "36",
-                "micro:2": "11",
-                "minor:1": "5"
-              }
-            }
-          },
-          "displayName": "16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20665,
-          "license": "android-sdk-arm-dbt-license",
-          "name": "system-image-37.1-google_apis_playstore-arm64-v8a",
-          "path": "system-images/android-37.1/google_apis_playstore_ps16k/arm64-v8a",
-          "revision": "37.1-google_apis_playstore-arm64-v8a",
-          "revision-details": {
-            "major:0": "7"
-          },
-          "type-details": {
-            "abi:6": "arm64-v8a",
-            "api-level:0": "37.1",
-            "base-extension:2": "true",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "extension-level:1": "23",
-            "tag:3": {
-              "display:1": "Google APIs PlayStore",
-              "id:0": "google_apis_playstore"
-            },
-            "tag:4": {
-              "display:1": "Page Size 16KB",
-              "id:0": "page_size_16kb"
-            },
-            "vendor:5": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        },
-        "x86_64": {
-          "archives": [
-            {
-              "arch": "all",
-              "os": "all",
-              "sha1": "19b91b705b5d4908b7dc84ea9d1411d86cb7a699",
-              "size": 2194317666,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-playstore-ps16k-37.1_r07.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "36",
-                "micro:2": "11",
-                "minor:1": "5"
-              }
-            }
-          },
-          "displayName": "16 KB Page Size Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
-          "license": "android-sdk-license",
-          "name": "system-image-37.1-google_apis_playstore-x86_64",
-          "path": "system-images/android-37.1/google_apis_playstore_ps16k/x86_64",
-          "revision": "37.1-google_apis_playstore-x86_64",
-          "revision-details": {
-            "major:0": "7"
-          },
-          "type-details": {
-            "abi:6": "x86_64",
-            "api-level:0": "37.1",
-            "base-extension:2": "true",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "extension-level:1": "23",
-            "tag:3": {
-              "display:1": "Google APIs PlayStore",
-              "id:0": "google_apis_playstore"
-            },
-            "tag:4": {
-              "display:1": "Page Size 16KB",
-              "id:0": "page_size_16kb"
-            },
-            "vendor:5": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        }
-      }
-    },
-    "Baklava": {
-      "google_apis": {
-        "arm64-v8a": {
-          "archives": [
-            {
-              "arch": "all",
-              "os": "all",
-              "sha1": "315442c5f27b1a03704c0262bd6e99af4e905140",
-              "size": 1918116152,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-36.0-Baklava_r01.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "35",
-                "micro:2": "9",
-                "minor:1": "4"
-              }
-            }
-          },
-          "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20621,
-          "license": "android-sdk-arm-dbt-license",
-          "name": "system-image-Baklava-google_apis-arm64-v8a",
-          "path": "system-images/android-36.0-Baklava/google_apis/arm64-v8a",
-          "revision": "Baklava-google_apis-arm64-v8a",
-          "revision-details": {
-            "major:0": "1"
-          },
-          "type-details": {
-            "abi:6": "arm64-v8a",
-            "api-level:0": "36.0",
-            "base-extension:3": "true",
-            "codename:1": "Baklava",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "extension-level:2": "19",
-            "tag:4": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
-            "vendor:5": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        },
-        "x86_64": {
-          "archives": [
-            {
-              "arch": "all",
-              "os": "all",
-              "sha1": "dc5a0f14318ac2f18c876e1286809fcde665f507",
-              "size": 1948776235,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-36.0-Baklava_r01.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "35",
-                "micro:2": "9",
-                "minor:1": "4"
-              }
-            }
-          },
-          "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20621,
-          "license": "android-sdk-license",
-          "name": "system-image-Baklava-google_apis-x86_64",
-          "path": "system-images/android-36.0-Baklava/google_apis/x86_64",
-          "revision": "Baklava-google_apis-x86_64",
-          "revision-details": {
-            "major:0": "1"
-          },
-          "type-details": {
-            "abi:6": "x86_64",
-            "api-level:0": "36.0",
-            "base-extension:3": "true",
-            "codename:1": "Baklava",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "extension-level:2": "19",
-            "tag:4": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
-            "vendor:5": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        }
-      },
-      "google_apis_playstore": {
-        "arm64-v8a": {
-          "archives": [
-            {
-              "arch": "all",
-              "os": "all",
-              "sha1": "52ea8a6c582c4027bd5b401b017a22af1070ddf8",
-              "size": 1945286774,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-36.0-Baklava_r01.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "35",
-                "micro:2": "9",
-                "minor:1": "4"
-              }
-            }
-          },
-          "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20621,
-          "license": "android-sdk-arm-dbt-license",
-          "name": "system-image-Baklava-google_apis_playstore-arm64-v8a",
-          "path": "system-images/android-36.0-Baklava/google_apis_playstore/arm64-v8a",
-          "revision": "Baklava-google_apis_playstore-arm64-v8a",
-          "revision-details": {
-            "major:0": "1"
-          },
-          "type-details": {
-            "abi:6": "arm64-v8a",
-            "api-level:0": "36.0",
-            "base-extension:3": "true",
-            "codename:1": "Baklava",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "extension-level:2": "19",
-            "tag:4": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
-            "vendor:5": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        },
-        "x86_64": {
-          "archives": [
-            {
-              "arch": "all",
-              "os": "all",
-              "sha1": "1bea1a3bcd67c3be28818f087d8e3497f8cd5050",
-              "size": 1991845954,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-36.0-Baklava_r01.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "35",
-                "micro:2": "9",
-                "minor:1": "4"
-              }
-            }
-          },
-          "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20621,
-          "license": "android-sdk-license",
-          "name": "system-image-Baklava-google_apis_playstore-x86_64",
-          "path": "system-images/android-36.0-Baklava/google_apis_playstore/x86_64",
-          "revision": "Baklava-google_apis_playstore-x86_64",
-          "revision-details": {
-            "major:0": "1"
-          },
-          "type-details": {
-            "abi:6": "x86_64",
-            "api-level:0": "36.0",
-            "base-extension:3": "true",
-            "codename:1": "Baklava",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "extension-level:2": "19",
-            "tag:4": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
-            "vendor:5": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        }
-      },
-      "page_size_16kb": {
-        "arm64-v8a": {
-          "archives": [
-            {
-              "arch": "all",
-              "os": "all",
-              "sha1": "dfd829e7efb9fd8f548be2f9c5610d79f7f41e21",
-              "size": 2001327175,
-              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/arm64-v8a-playstore-ps16k-36.0-Baklava_r01.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "35",
-                "micro:2": "9",
-                "minor:1": "4"
-              }
-            }
-          },
-          "displayName": "16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20621,
-          "license": "android-sdk-arm-dbt-license",
-          "name": "system-image-Baklava-page_size_16kb-arm64-v8a",
-          "path": "system-images/android-36.0-Baklava/google_apis_playstore_ps16k/arm64-v8a",
-          "revision": "Baklava-page_size_16kb-arm64-v8a",
-          "revision-details": {
-            "major:0": "1"
-          },
-          "type-details": {
-            "abi:7": "arm64-v8a",
-            "api-level:0": "36.0",
-            "base-extension:3": "true",
-            "codename:1": "Baklava",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "extension-level:2": "19",
-            "tag:4": {
-              "display:1": "16 KB Page Size",
-              "id:0": "page_size_16kb"
-            },
-            "tag:5": {
-              "display:1": "Google APIs PlayStore",
-              "id:0": "google_apis_playstore"
-            },
-            "vendor:6": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        },
-        "x86_64": {
-          "archives": [
-            {
-              "arch": "all",
-              "os": "all",
-              "sha1": "492f339f3767a4a2cd1a428ac5ed99c8ccf249aa",
-              "size": 1993597199,
-              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/x86_64-playstore-ps16k-36.0-Baklava_r01.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "35",
-                "micro:2": "9",
-                "minor:1": "4"
-              }
-            }
-          },
-          "displayName": "16 KB Page Size Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20621,
-          "license": "android-sdk-license",
-          "name": "system-image-Baklava-page_size_16kb-x86_64",
-          "path": "system-images/android-36.0-Baklava/google_apis_playstore_ps16k/x86_64",
-          "revision": "Baklava-page_size_16kb-x86_64",
-          "revision-details": {
-            "major:0": "1"
-          },
-          "type-details": {
-            "abi:7": "x86_64",
-            "api-level:0": "36.0",
-            "base-extension:3": "true",
-            "codename:1": "Baklava",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "extension-level:2": "19",
-            "tag:4": {
-              "display:1": "16 KB Page Size",
-              "id:0": "page_size_16kb"
-            },
-            "tag:5": {
-              "display:1": "Google APIs PlayStore",
-              "id:0": "google_apis_playstore"
-            },
-            "vendor:6": {
               "display:1": "Google Inc.",
               "id:0": "google"
             }
@@ -14424,15 +12192,133 @@
       }
     },
     "CANARY": {
-      "google_apis": {
+      "google_apis_playstore_ps16k": {
         "arm64-v8a": {
           "archives": [
             {
               "arch": "all",
               "os": "all",
-              "sha1": "bf0663990865c3b31528840dbc53259f050f17c1",
-              "size": 2186218057,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-ps16k-CANARY_r14.zip"
+              "sha1": "83b56b336a7d2e4bc3228de357fdabb718f2afff",
+              "size": 2235010994,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-playstore-ps16k-CANARY_r15.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "36",
+                "micro:2": "11",
+                "minor:1": "5"
+              }
+            }
+          },
+          "displayName": "16 KB Page Size Google Play ARM 64 v8a System Image",
+          "last-available-day": 20676,
+          "license": "android-sdk-arm-dbt-license",
+          "name": "system-image-CANARY-google_apis_playstore_ps16k-arm64-v8a",
+          "path": "system-images/android-CANARY/google_apis_playstore_ps16k/arm64-v8a",
+          "revision": "CANARY-google_apis_playstore_ps16k-arm64-v8a",
+          "revision-details": {
+            "major:0": "15"
+          },
+          "type-details": {
+            "abi:8": "arm64-v8a",
+            "api-level:0": "37.1",
+            "base-extension:3": "true",
+            "codename:1": "CANARY",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:2": "23",
+            "tag:4": {
+              "display:1": "Google APIs PlayStore",
+              "id:0": "google_apis_playstore"
+            },
+            "tag:5": {
+              "display:1": "Page Size 16KB",
+              "id:0": "page_size_16kb"
+            },
+            "tag:6": {
+              "display:1": "AI Glasses Compatible",
+              "id:0": "ai_glasses_compatible"
+            },
+            "vendor:7": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "406ff718e3c3a2ca03b8a0621317b314f407e847",
+              "size": 2305263192,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-playstore-ps16k-CANARY_r15.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "36",
+                "micro:2": "11",
+                "minor:1": "5"
+              }
+            }
+          },
+          "displayName": "16 KB Page Size Google Play Intel x86_64 Atom System Image",
+          "last-available-day": 20676,
+          "license": "android-sdk-license",
+          "name": "system-image-CANARY-google_apis_playstore_ps16k-x86_64",
+          "path": "system-images/android-CANARY/google_apis_playstore_ps16k/x86_64",
+          "revision": "CANARY-google_apis_playstore_ps16k-x86_64",
+          "revision-details": {
+            "major:0": "15"
+          },
+          "type-details": {
+            "abi:8": "x86_64",
+            "api-level:0": "37.1",
+            "base-extension:3": "true",
+            "codename:1": "CANARY",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:2": "23",
+            "tag:4": {
+              "display:1": "Google APIs PlayStore",
+              "id:0": "google_apis_playstore"
+            },
+            "tag:5": {
+              "display:1": "Page Size 16KB",
+              "id:0": "page_size_16kb"
+            },
+            "tag:6": {
+              "display:1": "AI Glasses Compatible",
+              "id:0": "ai_glasses_compatible"
+            },
+            "vendor:7": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        }
+      },
+      "google_apis_ps16k": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "b3555cd7ad7ad1d637d03971938f8cde2e5eedea",
+              "size": 2204352831,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-ps16k-CANARY_r15.zip"
             }
           ],
           "dependencies": {
@@ -14448,16 +12334,15 @@
             }
           },
           "displayName": "16 KB Page Size Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
-          "name": "system-image-CANARY-google_apis-arm64-v8a",
+          "name": "system-image-CANARY-google_apis_ps16k-arm64-v8a",
           "path": "system-images/android-CANARY/google_apis_ps16k/arm64-v8a",
-          "revision": "CANARY-google_apis-arm64-v8a",
+          "revision": "CANARY-google_apis_ps16k-arm64-v8a",
           "revision-details": {
-            "major:0": "14"
+            "major:0": "15"
           },
           "type-details": {
-            "abi:6": "arm64-v8a",
             "abi:8": "arm64-v8a",
             "api-level:0": "37.1",
             "base-extension:3": "true",
@@ -14478,10 +12363,6 @@
               "display:1": "AI Glasses Compatible",
               "id:0": "ai_glasses_compatible"
             },
-            "vendor:5": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            },
             "vendor:7": {
               "display:1": "Google Inc.",
               "id:0": "google"
@@ -14493,9 +12374,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "671e41bda24076e1226acc44b6bda596eaee1a0a",
-              "size": 2267928836,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-ps16k-CANARY_r14.zip"
+              "sha1": "79b3559e3d6e129177495ce717151bc7dca8bee5",
+              "size": 2285596027,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-ps16k-CANARY_r15.zip"
             }
           ],
           "dependencies": {
@@ -14511,16 +12392,15 @@
             }
           },
           "displayName": "16 KB Page Size Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
-          "name": "system-image-CANARY-google_apis-x86_64",
+          "name": "system-image-CANARY-google_apis_ps16k-x86_64",
           "path": "system-images/android-CANARY/google_apis_ps16k/x86_64",
-          "revision": "CANARY-google_apis-x86_64",
+          "revision": "CANARY-google_apis_ps16k-x86_64",
           "revision-details": {
-            "major:0": "14"
+            "major:0": "15"
           },
           "type-details": {
-            "abi:6": "x86_64",
             "abi:8": "x86_64",
             "api-level:0": "37.1",
             "base-extension:3": "true",
@@ -14541,249 +12421,7 @@
               "display:1": "AI Glasses Compatible",
               "id:0": "ai_glasses_compatible"
             },
-            "vendor:5": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            },
             "vendor:7": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        }
-      },
-      "google_apis_playstore": {
-        "arm64-v8a": {
-          "archives": [
-            {
-              "arch": "all",
-              "os": "all",
-              "sha1": "e9912f4fd25d63467484913d6cac03aa5af54b85",
-              "size": 2213671181,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-playstore-ps16k-CANARY_r14.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "36",
-                "micro:2": "11",
-                "minor:1": "5"
-              }
-            }
-          },
-          "displayName": "16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20665,
-          "license": "android-sdk-arm-dbt-license",
-          "name": "system-image-CANARY-google_apis_playstore-arm64-v8a",
-          "path": "system-images/android-CANARY/google_apis_playstore_ps16k/arm64-v8a",
-          "revision": "CANARY-google_apis_playstore-arm64-v8a",
-          "revision-details": {
-            "major:0": "14"
-          },
-          "type-details": {
-            "abi:6": "arm64-v8a",
-            "abi:8": "arm64-v8a",
-            "api-level:0": "37.1",
-            "base-extension:3": "true",
-            "codename:1": "CANARY",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "extension-level:2": "23",
-            "tag:4": {
-              "display:1": "Google APIs PlayStore",
-              "id:0": "google_apis_playstore"
-            },
-            "tag:5": {
-              "display:1": "Page Size 16KB",
-              "id:0": "page_size_16kb"
-            },
-            "tag:6": {
-              "display:1": "AI Glasses Compatible",
-              "id:0": "ai_glasses_compatible"
-            },
-            "vendor:5": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            },
-            "vendor:7": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        },
-        "x86_64": {
-          "archives": [
-            {
-              "arch": "all",
-              "os": "all",
-              "sha1": "0c57211535e81766ec0a484d813d8c187e5bcede",
-              "size": 2285680518,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-playstore-ps16k-CANARY_r14.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "36",
-                "micro:2": "11",
-                "minor:1": "5"
-              }
-            }
-          },
-          "displayName": "16 KB Page Size Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
-          "license": "android-sdk-license",
-          "name": "system-image-CANARY-google_apis_playstore-x86_64",
-          "path": "system-images/android-CANARY/google_apis_playstore_ps16k/x86_64",
-          "revision": "CANARY-google_apis_playstore-x86_64",
-          "revision-details": {
-            "major:0": "14"
-          },
-          "type-details": {
-            "abi:6": "x86_64",
-            "abi:8": "x86_64",
-            "api-level:0": "37.1",
-            "base-extension:3": "true",
-            "codename:1": "CANARY",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "extension-level:2": "23",
-            "tag:4": {
-              "display:1": "Google APIs PlayStore",
-              "id:0": "google_apis_playstore"
-            },
-            "tag:5": {
-              "display:1": "Page Size 16KB",
-              "id:0": "page_size_16kb"
-            },
-            "tag:6": {
-              "display:1": "AI Glasses Compatible",
-              "id:0": "ai_glasses_compatible"
-            },
-            "vendor:5": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            },
-            "vendor:7": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        }
-      },
-      "page_size_16kb": {
-        "arm64-v8a": {
-          "archives": [
-            {
-              "arch": "all",
-              "os": "all",
-              "sha1": "bb42e465d6e0786c95b106731a117fad5a52fd97",
-              "size": 2007500541,
-              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/arm64-v8a-playstore-ps16k-36.0-CANARY_r03.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "35",
-                "micro:2": "9",
-                "minor:1": "4"
-              }
-            }
-          },
-          "displayName": "16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20621,
-          "license": "android-sdk-arm-dbt-license",
-          "name": "system-image-CANARY-page_size_16kb-arm64-v8a",
-          "path": "system-images/android-36.0-CANARY/google_apis_playstore_ps16k/arm64-v8a",
-          "revision": "CANARY-page_size_16kb-arm64-v8a",
-          "revision-details": {
-            "major:0": "3"
-          },
-          "type-details": {
-            "abi:7": "arm64-v8a",
-            "api-level:0": "36.0",
-            "base-extension:3": "true",
-            "codename:1": "CANARY",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "extension-level:2": "19",
-            "tag:4": {
-              "display:1": "16 KB Page Size",
-              "id:0": "page_size_16kb"
-            },
-            "tag:5": {
-              "display:1": "Google APIs PlayStore",
-              "id:0": "google_apis_playstore"
-            },
-            "vendor:6": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        },
-        "x86_64": {
-          "archives": [
-            {
-              "arch": "all",
-              "os": "all",
-              "sha1": "4e3a2b8e5c639da2e31e8ecc3a4db48cffaae24d",
-              "size": 2004446653,
-              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/x86_64-playstore-ps16k-36.0-CANARY_r03.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "35",
-                "micro:2": "9",
-                "minor:1": "4"
-              }
-            }
-          },
-          "displayName": "16 KB Page Size Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20621,
-          "license": "android-sdk-preview-license",
-          "name": "system-image-CANARY-page_size_16kb-x86_64",
-          "path": "system-images/android-36.0-CANARY/google_apis_playstore_ps16k/x86_64",
-          "revision": "CANARY-page_size_16kb-x86_64",
-          "revision-details": {
-            "major:0": "3"
-          },
-          "type-details": {
-            "abi:7": "x86_64",
-            "api-level:0": "36.0",
-            "base-extension:3": "true",
-            "codename:1": "CANARY",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "extension-level:2": "19",
-            "tag:4": {
-              "display:1": "16 KB Page Size",
-              "id:0": "page_size_16kb"
-            },
-            "tag:5": {
-              "display:1": "Google APIs PlayStore",
-              "id:0": "google_apis_playstore"
-            },
-            "vendor:6": {
               "display:1": "Google Inc.",
               "id:0": "google"
             }
@@ -14792,135 +12430,7 @@
       }
     },
     "CinnamonBun": {
-      "google_apis": {
-        "arm64-v8a": {
-          "archives": [
-            {
-              "arch": "all",
-              "os": "all",
-              "sha1": "5bc2a62ef9885fefaff8c98b9fa739a97b45f577",
-              "size": 2324480545,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-ps16k-37.2-beta1_r01.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "36",
-                "micro:2": "11",
-                "minor:1": "5"
-              }
-            }
-          },
-          "displayName": "16 KB Page Size Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20665,
-          "license": "android-sdk-arm-dbt-license",
-          "name": "system-image-CinnamonBun-google_apis-arm64-v8a",
-          "path": "system-images/android-37.2-beta1/google_apis_ps16k/arm64-v8a",
-          "revision": "CinnamonBun-google_apis-arm64-v8a",
-          "revision-details": {
-            "major:0": "1"
-          },
-          "type-details": {
-            "abi:7": "arm64-v8a",
-            "abi:8": "arm64-v8a",
-            "api-level:0": "37.1",
-            "base-extension:3": "true",
-            "codename:1": "CinnamonBun",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "extension-level:2": "23",
-            "tag:4": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
-            "tag:5": {
-              "display:1": "16 KB Page Size",
-              "id:0": "page_size_16kb"
-            },
-            "tag:6": {
-              "display:1": "AI Glasses Compatible",
-              "id:0": "ai_glasses_compatible"
-            },
-            "vendor:6": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            },
-            "vendor:7": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        },
-        "x86_64": {
-          "archives": [
-            {
-              "arch": "all",
-              "os": "all",
-              "sha1": "12ad6acabf3ab7a51f618776b94713665f5a3e18",
-              "size": 2404586110,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-ps16k-37.2-beta1_r01.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "36",
-                "micro:2": "11",
-                "minor:1": "5"
-              }
-            }
-          },
-          "displayName": "16 KB Page Size Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
-          "license": "android-sdk-license",
-          "name": "system-image-CinnamonBun-google_apis-x86_64",
-          "path": "system-images/android-37.2-beta1/google_apis_ps16k/x86_64",
-          "revision": "CinnamonBun-google_apis-x86_64",
-          "revision-details": {
-            "major:0": "1"
-          },
-          "type-details": {
-            "abi:7": "x86_64",
-            "abi:8": "x86_64",
-            "api-level:0": "37.1",
-            "base-extension:3": "true",
-            "codename:1": "CinnamonBun",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "extension-level:2": "23",
-            "tag:4": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
-            "tag:5": {
-              "display:1": "16 KB Page Size",
-              "id:0": "page_size_16kb"
-            },
-            "tag:6": {
-              "display:1": "AI Glasses Compatible",
-              "id:0": "ai_glasses_compatible"
-            },
-            "vendor:6": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            },
-            "vendor:7": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        }
-      },
-      "google_apis_playstore": {
+      "google_apis_playstore_ps16k": {
         "arm64-v8a": {
           "archives": [
             {
@@ -14944,17 +12454,16 @@
             }
           },
           "displayName": "16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-arm-dbt-license",
-          "name": "system-image-CinnamonBun-google_apis_playstore-arm64-v8a",
+          "name": "system-image-CinnamonBun-google_apis_playstore_ps16k-arm64-v8a",
           "path": "system-images/android-37.2-beta1/google_apis_playstore_ps16k/arm64-v8a",
-          "revision": "CinnamonBun-google_apis_playstore-arm64-v8a",
+          "revision": "CinnamonBun-google_apis_playstore_ps16k-arm64-v8a",
           "revision-details": {
             "major:0": "1"
           },
           "type-details": {
             "abi:7": "arm64-v8a",
-            "abi:8": "arm64-v8a",
             "api-level:0": "37.1",
             "base-extension:3": "true",
             "codename:1": "CinnamonBun",
@@ -14970,15 +12479,7 @@
               "display:1": "Page Size 16KB",
               "id:0": "page_size_16kb"
             },
-            "tag:6": {
-              "display:1": "AI Glasses Compatible",
-              "id:0": "ai_glasses_compatible"
-            },
             "vendor:6": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            },
-            "vendor:7": {
               "display:1": "Google Inc.",
               "id:0": "google"
             }
@@ -15007,17 +12508,16 @@
             }
           },
           "displayName": "16 KB Page Size Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20665,
+          "last-available-day": 20676,
           "license": "android-sdk-license",
-          "name": "system-image-CinnamonBun-google_apis_playstore-x86_64",
+          "name": "system-image-CinnamonBun-google_apis_playstore_ps16k-x86_64",
           "path": "system-images/android-37.2-beta1/google_apis_playstore_ps16k/x86_64",
-          "revision": "CinnamonBun-google_apis_playstore-x86_64",
+          "revision": "CinnamonBun-google_apis_playstore_ps16k-x86_64",
           "revision-details": {
             "major:0": "1"
           },
           "type-details": {
             "abi:7": "x86_64",
-            "abi:8": "x86_64",
             "api-level:0": "37.1",
             "base-extension:3": "true",
             "codename:1": "CinnamonBun",
@@ -15033,15 +12533,339 @@
               "display:1": "Page Size 16KB",
               "id:0": "page_size_16kb"
             },
-            "tag:6": {
-              "display:1": "AI Glasses Compatible",
-              "id:0": "ai_glasses_compatible"
+            "vendor:6": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        }
+      },
+      "google_apis_ps16k": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "5bc2a62ef9885fefaff8c98b9fa739a97b45f577",
+              "size": 2324480545,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-ps16k-37.2-beta1_r01.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "36",
+                "micro:2": "11",
+                "minor:1": "5"
+              }
+            }
+          },
+          "displayName": "16 KB Page Size Google APIs ARM 64 v8a System Image",
+          "last-available-day": 20676,
+          "license": "android-sdk-arm-dbt-license",
+          "name": "system-image-CinnamonBun-google_apis_ps16k-arm64-v8a",
+          "path": "system-images/android-37.2-beta1/google_apis_ps16k/arm64-v8a",
+          "revision": "CinnamonBun-google_apis_ps16k-arm64-v8a",
+          "revision-details": {
+            "major:0": "1"
+          },
+          "type-details": {
+            "abi:7": "arm64-v8a",
+            "api-level:0": "37.1",
+            "base-extension:3": "true",
+            "codename:1": "CinnamonBun",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:2": "23",
+            "tag:4": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "tag:5": {
+              "display:1": "16 KB Page Size",
+              "id:0": "page_size_16kb"
             },
             "vendor:6": {
               "display:1": "Google Inc.",
               "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "12ad6acabf3ab7a51f618776b94713665f5a3e18",
+              "size": 2404586110,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-ps16k-37.2-beta1_r01.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "36",
+                "micro:2": "11",
+                "minor:1": "5"
+              }
+            }
+          },
+          "displayName": "16 KB Page Size Google APIs Intel x86_64 Atom System Image",
+          "last-available-day": 20676,
+          "license": "android-sdk-license",
+          "name": "system-image-CinnamonBun-google_apis_ps16k-x86_64",
+          "path": "system-images/android-37.2-beta1/google_apis_ps16k/x86_64",
+          "revision": "CinnamonBun-google_apis_ps16k-x86_64",
+          "revision-details": {
+            "major:0": "1"
+          },
+          "type-details": {
+            "abi:7": "x86_64",
+            "api-level:0": "37.1",
+            "base-extension:3": "true",
+            "codename:1": "CinnamonBun",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
             },
-            "vendor:7": {
+            "extension-level:2": "23",
+            "tag:4": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "tag:5": {
+              "display:1": "16 KB Page Size",
+              "id:0": "page_size_16kb"
+            },
+            "vendor:6": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        }
+      }
+    },
+    "DEV": {
+      "google_apis_playstore_ps16k": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "39a796c2445b502fc5d7bb8e75cf08bc400ac7d1",
+              "size": 2362598397,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-playstore-ps16k-37.2-beta2_r02.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "36",
+                "micro:2": "11",
+                "minor:1": "5"
+              }
+            }
+          },
+          "displayName": "16 KB Page Size Google Play ARM 64 v8a System Image",
+          "last-available-day": 20676,
+          "license": "android-sdk-arm-dbt-license",
+          "name": "system-image-DEV-google_apis_playstore_ps16k-arm64-v8a",
+          "path": "system-images/android-37.2-beta2/google_apis_playstore_ps16k/arm64-v8a",
+          "revision": "DEV-google_apis_playstore_ps16k-arm64-v8a",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:7": "arm64-v8a",
+            "api-level:0": "37.1",
+            "base-extension:3": "true",
+            "codename:1": "DEV",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:2": "23",
+            "tag:4": {
+              "display:1": "Google APIs PlayStore",
+              "id:0": "google_apis_playstore"
+            },
+            "tag:5": {
+              "display:1": "Page Size 16KB",
+              "id:0": "page_size_16kb"
+            },
+            "vendor:6": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "6d022c4a5290d9330e523f502a1816293ca9889b",
+              "size": 2431338092,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-playstore-ps16k-37.2-beta2_r02.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "36",
+                "micro:2": "11",
+                "minor:1": "5"
+              }
+            }
+          },
+          "displayName": "16 KB Page Size Google Play Intel x86_64 Atom System Image",
+          "last-available-day": 20676,
+          "license": "android-sdk-license",
+          "name": "system-image-DEV-google_apis_playstore_ps16k-x86_64",
+          "path": "system-images/android-37.2-beta2/google_apis_playstore_ps16k/x86_64",
+          "revision": "DEV-google_apis_playstore_ps16k-x86_64",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:7": "x86_64",
+            "api-level:0": "37.1",
+            "base-extension:3": "true",
+            "codename:1": "DEV",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:2": "23",
+            "tag:4": {
+              "display:1": "Google APIs PlayStore",
+              "id:0": "google_apis_playstore"
+            },
+            "tag:5": {
+              "display:1": "Page Size 16KB",
+              "id:0": "page_size_16kb"
+            },
+            "vendor:6": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        }
+      },
+      "google_apis_ps16k": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "9c33ca3a117b1b67e67ee5aa95be433c5432fd71",
+              "size": 2331709358,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-ps16k-37.2-beta2_r02.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "36",
+                "micro:2": "11",
+                "minor:1": "5"
+              }
+            }
+          },
+          "displayName": "16 KB Page Size Google APIs ARM 64 v8a System Image",
+          "last-available-day": 20676,
+          "license": "android-sdk-arm-dbt-license",
+          "name": "system-image-DEV-google_apis_ps16k-arm64-v8a",
+          "path": "system-images/android-37.2-beta2/google_apis_ps16k/arm64-v8a",
+          "revision": "DEV-google_apis_ps16k-arm64-v8a",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:7": "arm64-v8a",
+            "api-level:0": "37.1",
+            "base-extension:3": "true",
+            "codename:1": "DEV",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:2": "23",
+            "tag:4": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "tag:5": {
+              "display:1": "16 KB Page Size",
+              "id:0": "page_size_16kb"
+            },
+            "vendor:6": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "c2ece4bc0dc42d33d1c725c661ff8a344d457150",
+              "size": 2411488936,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-ps16k-37.2-beta2_r02.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "36",
+                "micro:2": "11",
+                "minor:1": "5"
+              }
+            }
+          },
+          "displayName": "16 KB Page Size Google APIs Intel x86_64 Atom System Image",
+          "last-available-day": 20676,
+          "license": "android-sdk-license",
+          "name": "system-image-DEV-google_apis_ps16k-x86_64",
+          "path": "system-images/android-37.2-beta2/google_apis_ps16k/x86_64",
+          "revision": "DEV-google_apis_ps16k-x86_64",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:7": "x86_64",
+            "api-level:0": "37.1",
+            "base-extension:3": "true",
+            "codename:1": "DEV",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:2": "23",
+            "tag:4": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "tag:5": {
+              "display:1": "16 KB Page Size",
+              "id:0": "page_size_16kb"
+            },
+            "vendor:6": {
               "display:1": "Google Inc.",
               "id:0": "google"
             }
@@ -15050,574 +12874,19 @@
       }
     },
     "TiramisuPrivacySandbox": {
-      "google_apis": {
-        "arm64-v8a": {
-          "archives": [
-            {
-              "os": "all",
-              "sha1": "fc34553283bcd0a52966e503d2a20f7de33a2600",
-              "size": 1630843209,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-TiramisuPrivacySandbox_r01.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
-            }
-          },
-          "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 19954,
-          "license": "android-sdk-license",
-          "name": "system-image-TiramisuPrivacySandbox-google_apis-arm64-v8a",
-          "path": "system-images/android-TiramisuPrivacySandbox/google_apis/arm64-v8a",
-          "revision": "TiramisuPrivacySandbox-google_apis-arm64-v8a",
-          "revision-details": {
-            "major:0": "1"
-          },
-          "type-details": {
-            "abi:4": "arm64-v8a",
-            "api-level:0": "33",
-            "codename:1": "TiramisuPrivacySandbox",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:2": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
-            "vendor:3": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        },
-        "x86_64": {
-          "archives": [
-            {
-              "os": "all",
-              "sha1": "47c1b56d4974e4fbe22e36580cf6cfdc6aa1de85",
-              "size": 1521841948,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-TiramisuPrivacySandbox_r01.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
-            }
-          },
-          "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 19954,
-          "license": "android-sdk-license",
-          "name": "system-image-TiramisuPrivacySandbox-google_apis-x86_64",
-          "path": "system-images/android-TiramisuPrivacySandbox/google_apis/x86_64",
-          "revision": "TiramisuPrivacySandbox-google_apis-x86_64",
-          "revision-details": {
-            "major:0": "1"
-          },
-          "type-details": {
-            "abi:4": "x86_64",
-            "api-level:0": "33",
-            "codename:1": "TiramisuPrivacySandbox",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:2": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
-            "vendor:3": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        }
-      },
-      "google_apis_playstore": {
-        "arm64-v8a": {
-          "archives": [
-            {
-              "os": "macosx",
-              "sha1": "d4cb5f1b985cb9f6ee093a00a910c5afc1bb0912",
-              "size": 1592946784,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-TiramisuPrivacySandbox_r09-darwin.zip"
-            },
-            {
-              "os": "linux",
-              "sha1": "d4cb5f1b985cb9f6ee093a00a910c5afc1bb0912",
-              "size": 1592946784,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-TiramisuPrivacySandbox_r09-linux.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
-            }
-          },
-          "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 19954,
-          "license": "android-sdk-arm-dbt-license",
-          "name": "system-image-TiramisuPrivacySandbox-google_apis_playstore-arm64-v8a",
-          "path": "system-images/android-TiramisuPrivacySandbox/google_apis_playstore/arm64-v8a",
-          "revision": "TiramisuPrivacySandbox-google_apis_playstore-arm64-v8a",
-          "revision-details": {
-            "major:0": "9"
-          },
-          "type-details": {
-            "abi:4": "arm64-v8a",
-            "api-level:0": "33",
-            "codename:1": "TiramisuPrivacySandbox",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:2": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
-            "vendor:3": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        },
-        "x86_64": {
-          "archives": [
-            {
-              "os": "all",
-              "sha1": "4893f6e62413e97e2bad5f183319d65d3947a375",
-              "size": 1492912127,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-TiramisuPrivacySandbox_r09.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
-            }
-          },
-          "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 19954,
-          "license": "android-sdk-preview-license",
-          "name": "system-image-TiramisuPrivacySandbox-google_apis_playstore-x86_64",
-          "path": "system-images/android-TiramisuPrivacySandbox/google_apis_playstore/x86_64",
-          "revision": "TiramisuPrivacySandbox-google_apis_playstore-x86_64",
-          "revision-details": {
-            "major:0": "9"
-          },
-          "type-details": {
-            "abi:4": "x86_64",
-            "api-level:0": "33",
-            "codename:1": "TiramisuPrivacySandbox",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:2": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
-            "vendor:3": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        }
-      }
+      "google_apis": {},
+      "google_apis_playstore": {}
     },
     "UpsideDownCake": {
       "google_apis": {},
       "google_apis_playstore": {}
     },
     "UpsideDownCakePrivacySandbox": {
-      "google_apis_playstore": {
-        "arm64-v8a": {
-          "archives": [
-            {
-              "os": "macosx",
-              "sha1": "90ccfc150180d529bc96ddc7d4a32249303ebd7f",
-              "size": 1548724067,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-UpsideDownCakePrivacySandbox_r03-darwin.zip"
-            },
-            {
-              "os": "linux",
-              "sha1": "90ccfc150180d529bc96ddc7d4a32249303ebd7f",
-              "size": 1548724067,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-UpsideDownCakePrivacySandbox_r03-linux.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "32",
-                "micro:2": "8",
-                "minor:1": "1"
-              }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "32",
-                "micro:2": "8",
-                "minor:1": "1"
-              }
-            }
-          },
-          "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 19954,
-          "license": "android-sdk-arm-dbt-license",
-          "name": "system-image-UpsideDownCakePrivacySandbox-google_apis_playstore-arm64-v8a",
-          "path": "system-images/android-UpsideDownCakePrivacySandbox/google_apis_playstore/arm64-v8a",
-          "revision": "UpsideDownCakePrivacySandbox-google_apis_playstore-arm64-v8a",
-          "revision-details": {
-            "major:0": "3"
-          },
-          "type-details": {
-            "abi:4": "arm64-v8a",
-            "api-level:0": "34",
-            "codename:1": "UpsideDownCakePrivacySandbox",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:2": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
-            "vendor:3": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        },
-        "x86_64": {
-          "archives": [
-            {
-              "os": "all",
-              "sha1": "f9b885d496787374be0c8be23eb7b69594c751a5",
-              "size": 1510877347,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-UpsideDownCakePrivacySandbox_r03.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "32",
-                "micro:2": "8",
-                "minor:1": "1"
-              }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "32",
-                "micro:2": "8",
-                "minor:1": "1"
-              }
-            }
-          },
-          "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 19954,
-          "license": "android-sdk-preview-license",
-          "name": "system-image-UpsideDownCakePrivacySandbox-google_apis_playstore-x86_64",
-          "path": "system-images/android-UpsideDownCakePrivacySandbox/google_apis_playstore/x86_64",
-          "revision": "UpsideDownCakePrivacySandbox-google_apis_playstore-x86_64",
-          "revision-details": {
-            "major:0": "3"
-          },
-          "type-details": {
-            "abi:4": "x86_64",
-            "api-level:0": "34",
-            "codename:1": "UpsideDownCakePrivacySandbox",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:2": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
-            "vendor:3": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        }
-      }
+      "google_apis_playstore": {}
     },
     "VanillaIceCream": {
-      "google_apis": {
-        "arm64-v8a": {
-          "archives": [
-            {
-              "os": "all",
-              "sha1": "896dec0aaae40954e2da30527f0763f292511217",
-              "size": 1737853248,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-VanillaIceCream_r05.zip"
-            }
-          ],
-          "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 19954,
-          "license": "android-sdk-arm-dbt-license",
-          "name": "system-image-VanillaIceCream-google_apis-arm64-v8a",
-          "path": "system-images/android-VanillaIceCream/google_apis/arm64-v8a",
-          "revision": "VanillaIceCream-google_apis-arm64-v8a",
-          "revision-details": {
-            "major:0": "5"
-          },
-          "type-details": {
-            "abi:3": "arm64-v8a",
-            "abi:4": "arm64-v8a",
-            "api-level:0": "34",
-            "codename:1": "VanillaIceCream",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:2": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
-            "vendor:3": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        },
-        "x86_64": {
-          "archives": [
-            {
-              "os": "all",
-              "sha1": "2efa686b5a420f3b9cb30e45a1e0e78a10a5fba8",
-              "size": 1682110854,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-VanillaIceCream_r05.zip"
-            }
-          ],
-          "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 19954,
-          "license": "android-sdk-license",
-          "name": "system-image-VanillaIceCream-google_apis-x86_64",
-          "path": "system-images/android-VanillaIceCream/google_apis/x86_64",
-          "revision": "VanillaIceCream-google_apis-x86_64",
-          "revision-details": {
-            "major:0": "5"
-          },
-          "type-details": {
-            "abi:3": "x86_64",
-            "abi:4": "x86_64",
-            "api-level:0": "34",
-            "codename:1": "VanillaIceCream",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:2": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
-            "vendor:3": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        }
-      },
-      "google_apis_playstore": {
-        "arm64-v8a": {
-          "archives": [
-            {
-              "os": "all",
-              "sha1": "41c8b6df52b60c76881fa5f819363678f9ef096c",
-              "size": 1745670932,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-VanillaIceCream_r05.zip"
-            }
-          ],
-          "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 19954,
-          "license": "android-sdk-arm-dbt-license",
-          "name": "system-image-VanillaIceCream-google_apis_playstore-arm64-v8a",
-          "path": "system-images/android-VanillaIceCream/google_apis_playstore/arm64-v8a",
-          "revision": "VanillaIceCream-google_apis_playstore-arm64-v8a",
-          "revision-details": {
-            "major:0": "5"
-          },
-          "type-details": {
-            "abi:3": "arm64-v8a",
-            "abi:4": "arm64-v8a",
-            "api-level:0": "34",
-            "codename:1": "VanillaIceCream",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:2": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
-            "vendor:3": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        },
-        "x86_64": {
-          "archives": [
-            {
-              "os": "all",
-              "sha1": "0d4c047003eaa8c78698f9aea0708e71b0895248",
-              "size": 1704139494,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-VanillaIceCream_r05.zip"
-            }
-          ],
-          "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 19954,
-          "license": "android-sdk-license",
-          "name": "system-image-VanillaIceCream-google_apis_playstore-x86_64",
-          "path": "system-images/android-VanillaIceCream/google_apis_playstore/x86_64",
-          "revision": "VanillaIceCream-google_apis_playstore-x86_64",
-          "revision-details": {
-            "major:0": "5"
-          },
-          "type-details": {
-            "abi:3": "x86_64",
-            "abi:4": "x86_64",
-            "api-level:0": "34",
-            "codename:1": "VanillaIceCream",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:2": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
-            "vendor:3": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        }
-      },
-      "page_size_16kb": {
-        "arm64-v8a": {
-          "archives": [
-            {
-              "os": "all",
-              "sha1": "167fc0f1baae778d3382a7ec4a463a1bfbc3253c",
-              "size": 1392391828,
-              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/arm64-v8a-ps16k-VanillaIceCream_r01.zip"
-            }
-          ],
-          "displayName": "Pre-Release 16 KB Page Size Google APIs ARM 64 v8a System Image",
-          "last-available-day": 19954,
-          "license": "android-sdk-arm-dbt-license",
-          "name": "system-image-VanillaIceCream-page_size_16kb-arm64-v8a",
-          "path": "system-images/android-VanillaIceCream/google_apis_ps16k/arm64-v8a",
-          "revision": "VanillaIceCream-page_size_16kb-arm64-v8a",
-          "revision-details": {
-            "major:0": "1"
-          },
-          "type-details": {
-            "abi:4": "arm64-v8a",
-            "api-level:0": "34",
-            "codename:1": "VanillaIceCream",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:2": {
-              "display:1": "16 KB Page Size",
-              "id:0": "page_size_16kb"
-            },
-            "vendor:3": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        },
-        "x86_64": {
-          "archives": [
-            {
-              "os": "all",
-              "sha1": "4a48eab34ea526f9a4cd60948ed7e6698b3e5cfd",
-              "size": 1332306731,
-              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/x86_64-ps16k-VanillaIceCream_r01.zip"
-            }
-          ],
-          "displayName": "Pre-Release 16 KB Page Size Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 19954,
-          "license": "android-sdk-license",
-          "name": "system-image-VanillaIceCream-page_size_16kb-x86_64",
-          "path": "system-images/android-VanillaIceCream/google_apis_ps16k/x86_64",
-          "revision": "VanillaIceCream-page_size_16kb-x86_64",
-          "revision-details": {
-            "major:0": "1"
-          },
-          "type-details": {
-            "abi:4": "x86_64",
-            "api-level:0": "34",
-            "codename:1": "VanillaIceCream",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:2": {
-              "display:1": "16 KB Page Size",
-              "id:0": "page_size_16kb"
-            },
-            "vendor:3": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        }
-      }
+      "google_apis": {},
+      "google_apis_playstore": {}
     }
   },
   "latest": {
@@ -15702,7 +12971,7 @@
           }
         ],
         "displayName": "Lightbuild",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "build",
         "path": "build/lightbuild/0.0.10-alpha01",
@@ -15712,33 +12981,6 @@
           "micro:2": "10",
           "minor:1": "0",
           "preview:3": "01"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "0.1.0": {
-        "archives": [
-          {
-            "arch": "all",
-            "os": "all",
-            "sha1": "126fdb3e284f850fd617ba89ddae918620a73e0f",
-            "size": 98951,
-            "url": "https://dl.google.com/android/repository/templates-sdk-package-15429553.zip"
-          }
-        ],
-        "displayName": "Android Project Templates",
-        "last-available-day": 20594,
-        "license": "android-sdk-license",
-        "name": "build",
-        "path": "build/templates",
-        "revision": "0.1.0",
-        "revision-details": {
-          "major:0": "0",
-          "micro:2": "0",
-          "minor:1": "1"
         },
         "type-details": {
           "element-attributes": {
@@ -15757,7 +12999,7 @@
           }
         ],
         "displayName": "Android Project Templates",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build",
         "path": "build/templates",
@@ -15799,15 +13041,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r17-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 17",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15848,15 +13083,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r18.0.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 18.0.1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15897,15 +13125,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r18.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 18.1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15946,15 +13167,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r18.1.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 18.1.1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15995,15 +13209,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r19-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 19",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -16044,15 +13251,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r19.0.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 19.0.1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -16093,15 +13293,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r19.0.2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 19.0.2",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -16142,15 +13335,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r19.0.3-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 19.0.3",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -16191,15 +13377,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r19.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 19.1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/19.1.0",
@@ -16239,15 +13418,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r20-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 20",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/20.0.0",
@@ -16287,15 +13459,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r21-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 21",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -16336,15 +13501,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r21.0.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 21.0.1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -16385,15 +13543,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r21.0.2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 21.0.2",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -16434,15 +13585,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r21.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 21.1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -16483,15 +13627,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r21.1.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 21.1.1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -16532,15 +13669,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r21.1.2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 21.1.2",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/21.1.2",
@@ -16580,15 +13710,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r22-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 22",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -16629,15 +13752,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r22.0.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 22.0.1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/22.0.1",
@@ -16677,15 +13793,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r23-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 23",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -16726,15 +13835,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r23.0.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 23.0.1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.1",
@@ -16774,15 +13876,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r23.0.2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 23.0.2",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.2",
@@ -16822,15 +13917,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r23.0.3-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 23.0.3",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.3",
@@ -16870,15 +13958,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r24-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 24",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.0",
@@ -16918,15 +13999,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r24.0.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 24.0.1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.1",
@@ -16966,15 +14040,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r24.0.2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 24.0.2",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.2",
@@ -17014,15 +14081,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r24.0.3-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 24.0.3",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.3",
@@ -17062,15 +14122,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r25-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 25",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.0",
@@ -17110,15 +14163,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r25.0.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 25.0.1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.1",
@@ -17158,15 +14204,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r25.0.2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 25.0.2",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.2",
@@ -17206,15 +14245,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r25.0.3-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 25.0.3",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.3",
@@ -17254,15 +14286,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r26-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 26",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.0",
@@ -17302,15 +14327,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r26.0.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 26.0.1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.1",
@@ -17350,15 +14368,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r26.0.2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 26.0.2",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.2",
@@ -17398,15 +14409,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r26.0.3-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 26.0.3",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.3",
@@ -17446,15 +14450,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r27-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 27",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.0",
@@ -17494,15 +14491,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r27.0.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 27.0.1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.1",
@@ -17542,15 +14532,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r27.0.2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 27.0.2",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.2",
@@ -17590,15 +14573,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r27.0.3-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 27.0.3",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.3",
@@ -17638,15 +14614,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r28-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 28",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.0",
@@ -17686,15 +14655,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r28-rc1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 28-rc1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -17736,15 +14698,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r28-rc2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 28-rc2",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -17786,15 +14741,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r28.0.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 28.0.1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.1",
@@ -17834,15 +14782,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r28.0.2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 28.0.2",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.2",
@@ -17882,15 +14823,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r28.0.3-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 28.0.3",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.3",
@@ -17930,15 +14864,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r29-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 29",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.0",
@@ -17978,15 +14905,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r29-rc1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 29-rc1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -18028,15 +14948,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r29-rc2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 29-rc2",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -18078,15 +14991,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r29-rc3-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 29-rc3",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -18128,15 +15034,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r29.0.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 29.0.1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.1",
@@ -18176,15 +15075,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r29.0.2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 29.0.2",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.2",
@@ -18224,15 +15116,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r29.0.3-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 29.0.3",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.3",
@@ -18272,15 +15157,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r30-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 30",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.0",
@@ -18320,15 +15198,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r30.0.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 30.0.1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.1",
@@ -18368,15 +15239,8 @@
             "url": "https://dl.google.com/android/repository/efbaa277338195608aa4e3dbd43927e97f60218c.build-tools_r30.0.2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 30.0.2",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.2",
@@ -18416,15 +15280,8 @@
             "url": "https://dl.google.com/android/repository/f6d24b187cc6bd534c6c37604205171784ac5621.build-tools_r30.0.3-macosx.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 30.0.3",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.3",
@@ -18465,7 +15322,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 31",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/31.0.0",
@@ -18506,7 +15363,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 32",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/32.0.0",
@@ -18547,7 +15404,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 32.1-rc1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/32.1.0-rc1",
@@ -18589,7 +15446,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.0",
@@ -18630,7 +15487,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33.0.1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.1",
@@ -18671,7 +15528,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33.0.2",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.2",
@@ -18712,7 +15569,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33.0.3",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.3",
@@ -18753,7 +15610,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0",
@@ -18794,7 +15651,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34-rc1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0-rc1",
@@ -18836,7 +15693,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34-rc2",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0-rc2",
@@ -18878,7 +15735,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34-rc3",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0-rc3",
@@ -18920,7 +15777,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0",
@@ -18961,7 +15818,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc1",
@@ -19003,7 +15860,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc2",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc2",
@@ -19045,7 +15902,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc3",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc3",
@@ -19087,7 +15944,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc4",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc4",
@@ -19129,7 +15986,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35.0.1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/35.0.1",
@@ -19170,7 +16027,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0",
@@ -19211,7 +16068,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc1",
@@ -19253,7 +16110,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc3",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc3",
@@ -19295,7 +16152,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc4",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc4",
@@ -19337,7 +16194,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc5",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc5",
@@ -19379,7 +16236,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36.1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/36.1.0",
@@ -19420,7 +16277,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36.1-rc1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.1.0-rc1",
@@ -19462,7 +16319,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 37",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/37.0.0",
@@ -19503,7 +16360,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 37-rc1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/37.0.0-rc1",
@@ -19545,7 +16402,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 37-rc2",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/37.0.0-rc2",
@@ -19596,7 +16453,7 @@
           }
         ],
         "displayName": "CMake 3.10.2.4988404",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.10.2.4988404",
@@ -19637,7 +16494,7 @@
           }
         ],
         "displayName": "CMake 3.18.1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.18.1",
@@ -19678,7 +16535,7 @@
           }
         ],
         "displayName": "CMake 3.22.1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.22.1",
@@ -19719,7 +16576,7 @@
           }
         ],
         "displayName": "CMake 3.30.3",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.30.3",
@@ -19760,7 +16617,7 @@
           }
         ],
         "displayName": "CMake 3.30.4",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.30.4",
@@ -19801,7 +16658,7 @@
           }
         ],
         "displayName": "CMake 3.30.5",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.30.5",
@@ -19842,7 +16699,7 @@
           }
         ],
         "displayName": "CMake 3.31.0",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.0",
@@ -19883,7 +16740,7 @@
           }
         ],
         "displayName": "CMake 3.31.1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.1",
@@ -19924,7 +16781,7 @@
           }
         ],
         "displayName": "CMake 3.31.4",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.4",
@@ -19965,7 +16822,7 @@
           }
         ],
         "displayName": "CMake 3.31.5",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.5",
@@ -20006,7 +16863,7 @@
           }
         ],
         "displayName": "CMake 3.31.6",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.6",
@@ -20054,7 +16911,7 @@
           }
         ],
         "displayName": "CMake 3.6.4111459",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.6.4111459",
@@ -20095,7 +16952,7 @@
           }
         ],
         "displayName": "CMake 4.0.2",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/4.0.2",
@@ -20136,7 +16993,7 @@
           }
         ],
         "displayName": "CMake 4.0.3",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/4.0.3",
@@ -20177,7 +17034,7 @@
           }
         ],
         "displayName": "CMake 4.1.0",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/4.1.0",
@@ -20218,7 +17075,7 @@
           }
         ],
         "displayName": "CMake 4.1.1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/4.1.1",
@@ -20259,7 +17116,7 @@
           }
         ],
         "displayName": "CMake 4.1.2",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/4.1.2",
@@ -20302,7 +17159,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/1.0",
@@ -20342,7 +17199,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/10.0",
@@ -20382,7 +17239,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/11.0",
@@ -20422,7 +17279,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/12.0",
@@ -20462,7 +17319,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/13.0",
@@ -20502,7 +17359,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/13.0-rc01",
@@ -20543,7 +17400,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/14.0-alpha01",
@@ -20584,7 +17441,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/16.0",
@@ -20624,7 +17481,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/16.0-alpha01",
@@ -20665,7 +17522,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/17.0",
@@ -20705,7 +17562,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/19.0",
@@ -20745,7 +17602,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/19.0-alpha01",
@@ -20786,7 +17643,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "obsolete": "true",
@@ -20827,7 +17684,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/2.1",
@@ -20867,7 +17724,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/20.0",
@@ -20907,7 +17764,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/21.0",
@@ -20954,7 +17811,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/22.0",
@@ -20994,7 +17851,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/3.0",
@@ -21034,7 +17891,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/4.0",
@@ -21074,7 +17931,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/5.0",
@@ -21114,7 +17971,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/6.0",
@@ -21154,7 +18011,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/7.0",
@@ -21194,7 +18051,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/8.0",
@@ -21234,7 +18091,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/9.0",
@@ -21251,1656 +18108,6 @@
       }
     },
     "emulator": {
-      "34.2.16": {
-        "archives": [
-          {
-            "os": "linux",
-            "sha1": "fe7a96bf6fbe7b026555dd7f76b713f22a07ec8b",
-            "size": 292750827,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-12038310.zip"
-          },
-          {
-            "os": "macosx",
-            "sha1": "8da9494f5a08c2a04f50aeef543fd32ca8424f12",
-            "size": 387388734,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-12038310.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "76a5cbca04dc11bc04421e30392e78ab3b744d33",
-            "size": 412503831,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-12038310.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 19954,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "34.2.16",
-        "revision-details": {
-          "major:0": "34",
-          "micro:2": "16",
-          "minor:1": "2"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "35.1.19": {
-        "archives": [
-          {
-            "os": "linux",
-            "sha1": "728fb67266a7648aee58c1f4eaadeb8781c646d8",
-            "size": 295185796,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-12171648.zip"
-          },
-          {
-            "os": "macosx",
-            "sha1": "a7c61d2f057186e54f41e0573f5cb5659daca9c4",
-            "size": 390781280,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-12171648.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "a954a95bf3f49907ea8e3b4dbeda8f963394540c",
-            "size": 420058404,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-12171648.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 19954,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "35.1.19",
-        "revision-details": {
-          "major:0": "35",
-          "micro:2": "19",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "35.2.5": {
-        "archives": [
-          {
-            "os": "linux",
-            "sha1": "cc22b6fb2d6dbb17f436af29364929aba5f776ae",
-            "size": 301992613,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-12205771.zip"
-          },
-          {
-            "os": "macosx",
-            "sha1": "32e32d993b1af0c4c93a3aed775baeed881e0ce7",
-            "size": 399727915,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-12205771.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "739dd017682373c745ec60189d2cb52be016181d",
-            "size": 426685873,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-12205771.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 19954,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "35.2.5",
-        "revision-details": {
-          "major:0": "35",
-          "micro:2": "5",
-          "minor:1": "2"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "35.3.11": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "99d847b09428b9842a3e52430e3f0decfc79c080",
-            "size": 297018762,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-12836668.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "e6149d02d8c05b6184b9f8c8d1d86420335974ec",
-            "size": 392168292,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-12836668.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "74f35bb080574d307d1e12b6baef1afbf9f581fa",
-            "size": 311185526,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-12836668.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "4facc1af6ee937aca3831248c25195204e827b01",
-            "size": 419748179,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-12836668.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20131,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "35.3.11",
-        "revision-details": {
-          "major:0": "35",
-          "micro:2": "11",
-          "minor:1": "3"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "35.3.12": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "c859ea9c0aa625cc4cf43ad13ba665891155c101",
-            "size": 297030576,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-12990079.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "67d4cc43dfb3983ae210ab51371a3c698fe9b226",
-            "size": 392170242,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-12990079.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "074fd2fb62febe34ba75c4eed75668aff7c7cc03",
-            "size": 311190387,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-12990079.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "9319f59bf621430a0f8ec25f124343fadcc4912f",
-            "size": 419761989,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-12990079.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20139,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "35.3.12",
-        "revision-details": {
-          "major:0": "35",
-          "micro:2": "12",
-          "minor:1": "3"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "35.4.8": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "9ed664edb9c2f59df8ba322e0703d3f5a87b8990",
-            "size": 298120058,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-12990073.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "40bd8f2332068eb11492640cbeb3267293585606",
-            "size": 393815670,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-12990073.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "ebc1adb3fafdea595be64c67e719500282120504",
-            "size": 311960415,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-12990073.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "c8fc55380f321455a8cd515bfc6289b21fdfd5d5",
-            "size": 421986278,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-12990073.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20139,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "35.4.8",
-        "revision-details": {
-          "major:0": "35",
-          "micro:2": "8",
-          "minor:1": "4"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "35.4.9": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "dc8d58c3948dcfa946417afaa60ad397c7329765",
-            "size": 298118508,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-13025442.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "230baf96ebcb0d27779e5bd55ffeab7cfa98294c",
-            "size": 393818294,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-13025442.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "08ff527ae85394e8d9957d5ea17fffdc14abf035",
-            "size": 311961707,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-13025442.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "819cf13914861226713ca61beb9cbc01165d5044",
-            "size": 421982739,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-13025442.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20174,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "35.4.9",
-        "revision-details": {
-          "major:0": "35",
-          "micro:2": "9",
-          "minor:1": "4"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "35.5.10": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "0f7336a0477654cfbe5593f1888d9c2b1bdf30e0",
-            "size": 301181039,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-13402964.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "5339e2be893ee74e352b3dde3d0700deda380a7d",
-            "size": 394068912,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-13402964.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "4b607dfa4797de2356bf54f4c6caaef3b8bf187d",
-            "size": 312167479,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-13402964.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "5523c285900e345adad65b1bd50daba101d692d0",
-            "size": 423391334,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-13402964.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20237,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "35.5.10",
-        "revision-details": {
-          "major:0": "35",
-          "micro:2": "10",
-          "minor:1": "5"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "35.5.2": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "8409e1da1cc7dfd52133ecabd566dd9d2362caa9",
-            "size": 303757245,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-13003482.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "f300f67cd8f24699f0574504013fb2b0f6a92166",
-            "size": 401061491,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-13003482.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "0a93985646dce849c5c356571133d45d67368780",
-            "size": 319100573,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-13003482.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "a3f654716e123489ee1858b7c3a9218d616518b6",
-            "size": 429135086,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-13003482.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20131,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "35.5.2",
-        "revision-details": {
-          "major:0": "35",
-          "micro:2": "2",
-          "minor:1": "5"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "35.5.3": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "cea757d3e73c0cf40bb6f74b2aa40831d9c3a87b",
-            "size": 303896991,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-13023280.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "5f2004b9cf55db7473803069e77c5facce07a585",
-            "size": 401205692,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-13023280.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "4c997b00e0814603fbab1a19821ecda469e0cbec",
-            "size": 319180896,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-13023280.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "7b1bdb613b34af21fd5888c811999ba173e553a9",
-            "size": 429277282,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-13023280.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20139,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "35.5.3",
-        "revision-details": {
-          "major:0": "35",
-          "micro:2": "3",
-          "minor:1": "5"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "35.5.8": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "30a3e80f55f09d64ffc72e7ecd4dc962e2385fad",
-            "size": 301171981,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-13181580.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "ab51e1aaa71e1c95ac96b0087af0442ac80a62d6",
-            "size": 394047089,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-13181580.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "cee00a0495b1cdde264e71c364f411b6f84ca3bc",
-            "size": 312156337,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-13181580.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "11fb3933985bb97b49861ef42299c8a3800bc9d7",
-            "size": 423381031,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-13181580.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20174,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "35.5.8",
-        "revision-details": {
-          "major:0": "35",
-          "micro:2": "8",
-          "minor:1": "5"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "35.6.2": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "d895e040a36a339490b44187bb57d09aa0e9e514",
-            "size": 323950884,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-13248170.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "5c46bfdbb66bad0926ea01028e7224b7c10ee1f7",
-            "size": 401371702,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-13248170.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "8ef0aeaa7b1224bf66021c077885741eab64a42f",
-            "size": 319286666,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-13248170.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "d9bbf3b50551e8a68df56b137c7cdb14428c8b5b",
-            "size": 429402312,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-13248170.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20174,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "35.6.2",
-        "revision-details": {
-          "major:0": "35",
-          "micro:2": "2",
-          "minor:1": "6"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "35.6.9": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "66a9c575d3bcc2098e0eba68fcf8b2c87d0eb241",
-            "size": 319085855,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-13473012.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "a9d670e765fc573c99273de7eb768a5256dea883",
-            "size": 394682677,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-13473012.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "569e708aa89eb4d3d5787d97764215690f31b46b",
-            "size": 312519726,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-13473012.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "2288e8aa9b9db7943093435875052f9c1cda7817",
-            "size": 440020709,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-13473012.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20237,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "35.6.9",
-        "revision-details": {
-          "major:0": "35",
-          "micro:2": "9",
-          "minor:1": "6"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "36.1.2": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "74a1c093bea491f3ecbd80a027bc28dd7c184688",
-            "size": 324772288,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-13544801.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "802bbec21bbbe151440690f65fdb24b33005ef2a",
-            "size": 402124565,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-13544801.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "26087d0d3b70cc196c2317d24d71b02b699fc3d8",
-            "size": 319759472,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-13544801.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "8f7a97fb9d23e2c7f670bd2b03ea61215f43b25d",
-            "size": 446247044,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-13544801.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20237,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "36.1.2",
-        "revision-details": {
-          "major:0": "36",
-          "micro:2": "2",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "36.1.8": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "85c198dcc67bc02c7682b410c362663f1221f127",
-            "size": 319200975,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-13784423.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "478e9a9f93c7d56140a1748f8f2ee24404231f3a",
-            "size": 394949463,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-13784423.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "f73484c5c62d6211fe2741ce40b9e6b4b27e3cff",
-            "size": 312530769,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-13784423.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "c3c9a497085b0ce173a3ff053743c9191a49aa90",
-            "size": 440864909,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-13784423.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20318,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "36.1.8",
-        "revision-details": {
-          "major:0": "36",
-          "micro:2": "8",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "36.1.9": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "6640cd1d6ca5cf306cfe51d4957ace7e5f3c1d8c",
-            "size": 319203216,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-13823996.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "7688a93c4162dd26e961fa26e260dbb638aa2679",
-            "size": 394943617,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-13823996.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "540cad31129eb9518082647a67cf634c51f565de",
-            "size": 312528104,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-13823996.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "b9542962753c1b2774691d758247cac6a2384655",
-            "size": 440857308,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-13823996.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20369,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "36.1.9",
-        "revision-details": {
-          "major:0": "36",
-          "micro:2": "9",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "36.2.10": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "be997b895f4813f063de60b19da55d1faf364707",
-            "size": 320127757,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-14110321.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "9574ce9a61f39a8e5249205ea40eb533f9c3249c",
-            "size": 395795926,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-14110321.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "eb99c872ac3c90a136589b60522b17fa844d170f",
-            "size": 313350828,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-14110321.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "b58146adf64103d46e7157637c7e7822fe458c39",
-            "size": 443358079,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-14110321.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20377,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "36.2.10",
-        "revision-details": {
-          "major:0": "36",
-          "micro:2": "10",
-          "minor:1": "2"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "36.2.12": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "b87561b33f5f1df3647519628c3597353dbf534d",
-            "size": 320123396,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-14214601.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "5c1b8bcd88285a343b4436d1082e8a544408e592",
-            "size": 395794431,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-14214601.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "e53928cb3b24acb942ff8003cd9a9a91eddece04",
-            "size": 313352024,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-14214601.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "1140a142d87fa2f6be84f5ebe7ef781a9eba429c",
-            "size": 443355796,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-14214601.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20410,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "36.2.12",
-        "revision-details": {
-          "major:0": "36",
-          "micro:2": "12",
-          "minor:1": "2"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "36.2.4": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "287915ab3349c2304893dc0ed2fc27bff8219bd2",
-            "size": 324654299,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-13899551.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "6134b9d9cfb201438a2bcf2d3c2469f708d77357",
-            "size": 401818934,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-13899551.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "f1c4fd99341f24bc22dce34db92d708636a9ca1e",
-            "size": 319414458,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-13899551.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "4e4ab339536f7cb26f5af4d8dfd4836bcffb46a0",
-            "size": 446720651,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-13899551.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20318,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "36.2.4",
-        "revision-details": {
-          "major:0": "36",
-          "micro:2": "4",
-          "minor:1": "2"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "36.3.10": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "90cf9a2d3d9f802998345bc8251b482a84f9c72e",
-            "size": 320951246,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-14472402.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "d508ad4b0fe167e278b3cc680f276b4add44ad97",
-            "size": 460823642,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-14472402.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "42f7746cdecf679f8bf2724afe39ea2392721456",
-            "size": 390093951,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-14472402.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "ed2012d56cb7fe5650cd5909a581399a35479a75",
-            "size": 447454873,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-14472402.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20429,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "36.3.10",
-        "revision-details": {
-          "major:0": "36",
-          "micro:2": "10",
-          "minor:1": "3"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "36.3.3": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "e21c011ffadbf29413aa168786e445075249e634",
-            "size": 325930034,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-14204996.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "4ea7d17a22a4eb9935549e90706a8e21a1e11a03",
-            "size": 468828491,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-14204996.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "08c0b09ba9651a2ce2c6f596efcf5592e27b5eea",
-            "size": 380627684,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-14204996.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "e650e368272687e65f599424c064ee0983d9d9f3",
-            "size": 449700640,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-14204996.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20369,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "36.3.3",
-        "revision-details": {
-          "major:0": "36",
-          "micro:2": "3",
-          "minor:1": "3"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "36.3.4": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "bc4a8c9f80ad58842fe2286bf03e78e4e1292e19",
-            "size": 325925467,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-14257411.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "b40ab44776ebb18d064554bdc623a1549fc802a3",
-            "size": 468816526,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-14257411.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "205aa614c02fc8f59be6bc1dcf7f3ec4f209f27e",
-            "size": 380621007,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-14257411.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "edd34ac4150107b5f9a5840c1810747745d6611e",
-            "size": 449704089,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-14257411.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20377,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "36.3.4",
-        "revision-details": {
-          "major:0": "36",
-          "micro:2": "4",
-          "minor:1": "3"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "36.3.9": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "1b6fd0a0c281f0a34f35f1c4cf32800a1c8d98a2",
-            "size": 320949442,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-14404213.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "33b6536343e94fb420fb802420cd2ec8945c202e",
-            "size": 460825057,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-14404213.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "5d5f0c1518da2b5f5316e2195079dd54bf0609b3",
-            "size": 390098783,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-14404213.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "beec1f62a075359ccc03712b6332b9b28ddd6ac7",
-            "size": 447453001,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-14404213.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20429,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "36.3.9",
-        "revision-details": {
-          "major:0": "36",
-          "micro:2": "9",
-          "minor:1": "3"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "36.4.1": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "0227e07831f9bde3a59e760024c1a816ddfd7af6",
-            "size": 326240176,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-14433334.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "2ad57f4e65d5e573e89b5e809435ac74e44ad4ef",
-            "size": 457844193,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-14433334.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "a97f164ebbc1d7a2cda600cdcbff3bda6727090c",
-            "size": 391350668,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-14433334.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "f8b7cde483c12dacf77e65566bc7b8d7618b91b6",
-            "size": 456348380,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-14433334.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20410,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "36.4.1",
-        "revision-details": {
-          "major:0": "36",
-          "micro:2": "1",
-          "minor:1": "4"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "36.4.2": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "11399ca8d84c5d4cbe7f805e7488b161d03db884",
-            "size": 328061962,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-14518053.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "8ba80d9dc4e3e845cc8830cd0e457d071ff7f1a7",
-            "size": 457500029,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-14518053.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "2cb262f94590da3c5fb0b4647011604240b085f6",
-            "size": 390758862,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-14518053.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "aaa4b065d72ea51ea9ea271d373969d8d2c71635",
-            "size": 425424063,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-14518053.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20429,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "36.4.2",
-        "revision-details": {
-          "major:0": "36",
-          "micro:2": "2",
-          "minor:1": "4"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "36.5.10": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "9f03296214df837c608d0d101e5e03ebcebb4343",
-            "size": 331543272,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-15081367.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "3ad9f81115436aed6b4feb76f8e5d3e356f2f6e0",
-            "size": 449808912,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-15081367.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "0093f579e798c91b589a8d7bc84e1ca7ee528624",
-            "size": 384550690,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-15081367.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "1d5cc76415b9717cec08694d171ceb526b1dedb7",
-            "size": 418622111,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-15081367.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20552,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "36.5.10",
-        "revision-details": {
-          "major:0": "36",
-          "micro:2": "10",
-          "minor:1": "5"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "36.5.11": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "a6d99c53669d2eb750b6949adb85668fbd7355fe",
-            "size": 331545207,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-15261927.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "f7ed5a0413c492c11fcffcf19f2024787d6bac9b",
-            "size": 449816006,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-15261927.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "0d33a553d860410f9b05801c11e1779a40fa1ea5",
-            "size": 384547861,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-15261927.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "384b7fe8dccdc8c11f0596be4589adf44528c6e5",
-            "size": 418625872,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-15261927.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20603,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "36.5.11",
-        "revision-details": {
-          "major:0": "36",
-          "micro:2": "11",
-          "minor:1": "5"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "36.6.10": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "bcc03e73a10c39babfaa549c1998d7d5ab1b1c27",
-            "size": 331231524,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-15452618.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "ba4d8435c7a79c8e986595a092cdffbcfc7ebe03",
-            "size": 448833126,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-15452618.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "3069c253975de0e5bdf18d8936e45bf018e375f9",
-            "size": 383909060,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-15452618.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "34c7d7811242931ed5f32819f59ab2ca9e53b9cf",
-            "size": 418510542,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-15452618.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20603,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "36.6.10",
-        "revision-details": {
-          "major:0": "36",
-          "micro:2": "10",
-          "minor:1": "6"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "36.6.11": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "f8d8b83cf21a04966326eb1378bacda255f63b93",
-            "size": 331232577,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-15507667.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "0a0c9409692d73d31c860e50f6ae59a74211afe7",
-            "size": 448835510,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-15507667.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "45328141bb585e096a5bebf870ff351e140bcda3",
-            "size": 383903546,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-15507667.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "d5f07a99221c6e528a4942887dc36ada7d1602f8",
-            "size": 418510366,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-15507667.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20656,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "36.6.11",
-        "revision-details": {
-          "major:0": "36",
-          "micro:2": "11",
-          "minor:1": "6"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "36.6.2": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "dd54bbe318cb070b2f8de3de3ee347de13eab611",
-            "size": 346489008,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-15098414.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "c6b41397c64a05d9cc3b8a0432dbe2a14acd3a8f",
-            "size": 462238423,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-15098414.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "08d485c88de5770f4f36bd06de5d2fc36bbc2620",
-            "size": 395994578,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-15098414.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "f4666edf8e729236ab32221d5a5cad23ee051610",
-            "size": 428574271,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-15098414.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20549,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "36.6.2",
-        "revision-details": {
-          "major:0": "36",
-          "micro:2": "2",
-          "minor:1": "6"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "36.6.3": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "4d1ddbbcc6d708fd933b08931163182e0e205ad0",
-            "size": 347008218,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-15142779.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "a3718deefc7d16ef3376626807cebcadb73ca5f4",
-            "size": 462646251,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-15142779.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "a46e8160288ff40dd2768536fa70f2d5f13a67ce",
-            "size": 396370301,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-15142779.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "8f5ff31b854cf4f9eaf15c1b571148240edfcaf4",
-            "size": 428894868,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-15142779.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20552,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "36.6.3",
-        "revision-details": {
-          "major:0": "36",
-          "micro:2": "3",
-          "minor:1": "6"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "36.6.5": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "0db7ea0a28dfbbcab6d43e43fa6f4b177a088bb3",
-            "size": 347666973,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-15221694.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "f1303f9f14bdbe2a38ab661b7cb065979437fc79",
-            "size": 463292401,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-15221694.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "6512876f641240c78657b32f6fabddc1e5cddde1",
-            "size": 397030375,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-15221694.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "d7de9d1ae3fbcd782085d9cc7b658a846efb2414",
-            "size": 429608279,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-15221694.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20569,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "36.6.5",
-        "revision-details": {
-          "major:0": "36",
-          "micro:2": "5",
-          "minor:1": "6"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "36.6.9": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "ab4680f37109d1d3615cd23908f4d42b3a5eba91",
-            "size": 347200337,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-15442530.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "a4776c5879fdd96d2237243404e2bbab4e445a14",
-            "size": 462110582,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-15442530.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "843bb2181a480fc303303209d47d630c5ff7d4dd",
-            "size": 396321167,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-15442530.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "0031c469a804eb08a4e238b07327c4fed90a469e",
-            "size": 429273107,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-15442530.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20594,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "36.6.9",
-        "revision-details": {
-          "major:0": "36",
-          "micro:2": "9",
-          "minor:1": "6"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "37.1.1": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "6b0a44b0683e9bcdb565b5ea7c32bc6b675fb8fa",
-            "size": 347224810,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-15469576.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "aa6c648f510d1d5cfc8d1f5471ff972b094e652d",
-            "size": 462141310,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-15469576.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "70d7299111db1ba9ddc01832f4bf92981aa6d778",
-            "size": 396647974,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-15469576.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "edcc131234f98077f37c613bdf1bf3f44aca5e68",
-            "size": 429306689,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-15469576.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20603,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "37.1.1",
-        "revision-details": {
-          "major:0": "37",
-          "micro:2": "1",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "37.1.10": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "489e57e560e310f9dfadf098951a713bf5651cd2",
-            "size": 334377561,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-15888535.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "ae3192d0a814168fca6317f02e45417602d8a9f5",
-            "size": 465774014,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-15888535.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "31fd5016927f1f513d1f7630b79a9f288c367d1a",
-            "size": 394553854,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-15888535.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "982681268eb1703ee285fb174c7f5b7d4d7d70c8",
-            "size": 441928380,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-15888535.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20656,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "37.1.10",
-        "revision-details": {
-          "major:0": "37",
-          "micro:2": "10",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
       "37.1.11": {
         "archives": [
           {
@@ -22933,7 +18140,7 @@
           }
         ],
         "displayName": "Android Emulator",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "emulator",
         "path": "emulator",
@@ -22949,238 +18156,46 @@
           }
         }
       },
-      "37.1.2": {
+      "37.2.4": {
         "archives": [
           {
             "arch": "x64",
             "os": "linux",
-            "sha1": "e1a50b5fa26c771fbb18c747944907aa67b1ca96",
-            "size": 347618707,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-15513348.zip"
+            "sha1": "cff0980d45af566fdee5de3334f67d2530d5d305",
+            "size": 358668070,
+            "url": "https://dl.google.com/android/repository/emulator-linux_x64-16031380.zip"
           },
           {
             "arch": "x64",
             "os": "macosx",
-            "sha1": "2ffa9109d7ab2014a22704ae82444e55401ea829",
-            "size": 462567414,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-15513348.zip"
+            "sha1": "f0e445323c1ed85fd255b7d77fd798d3b638cf40",
+            "size": 497212963,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-16031380.zip"
           },
           {
             "arch": "aarch64",
             "os": "macosx",
-            "sha1": "cd3a21cb3018f7c70c0f3587a827ed36e9b055f3",
-            "size": 396951355,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-15513348.zip"
+            "sha1": "927d5f82f718ed11d4d80ddad4d52efca23c8504",
+            "size": 423832696,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-16031380.zip"
           },
           {
             "arch": "x64",
             "os": "windows",
-            "sha1": "560880168862a4278494cb5d183374ddae50e135",
-            "size": 429551646,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-15513348.zip"
+            "sha1": "f514c42b51add4015d8c4dd17a79794929ce09b1",
+            "size": 463103168,
+            "url": "https://dl.google.com/android/repository/emulator-windows_x64-16031380.zip"
           }
         ],
         "displayName": "Android Emulator",
-        "last-available-day": 20612,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "emulator",
         "path": "emulator",
-        "revision": "37.1.2",
-        "revision-details": {
-          "major:0": "37",
-          "micro:2": "2",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "37.1.4": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "8f37a1a82059a06e6f32f5297886f86422dcf923",
-            "size": 347758159,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-15622418.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "3902bb279786362a36ddccd40a28ff30879dab5c",
-            "size": 462727723,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-15622418.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "f4b378a3ef6c7bf5c2552781987cfc637ed7b320",
-            "size": 397056588,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-15622418.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "90d9866afd1f216c9245165953bd9fb8ef0d82e2",
-            "size": 429846199,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-15622418.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20621,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "37.1.4",
+        "revision": "37.2.4",
         "revision-details": {
           "major:0": "37",
           "micro:2": "4",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "37.1.7": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "0bed8aa5972eb1e1a4fc2b24faea46ebd160459f",
-            "size": 346483673,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-15769812.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "40e8e131255e7b2ead0fe6529ce23fd82485eea5",
-            "size": 477449117,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-15769812.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "d4974d38cc05cd13b67d48994591ff69b9b2ce56",
-            "size": 405381417,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-15769812.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "33f49b34be3a1863cee42cf2abfd2b113ad4d897",
-            "size": 452935068,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-15769812.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20647,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "37.1.7",
-        "revision-details": {
-          "major:0": "37",
-          "micro:2": "7",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "37.2.1": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "1c39ceb4bca042b973344d252a051189d367ab83",
-            "size": 346539649,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-15875889.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "92a0e64420eb712b5ccaef526894478455dee4aa",
-            "size": 477610243,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-15875889.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "b959066bf27e9262d74ee81d33fd1a9f6bc9c72c",
-            "size": 405538040,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-15875889.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "467df0f9c597df052991d8e22c422749bb354a43",
-            "size": 453554579,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-15875889.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20656,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "37.2.1",
-        "revision-details": {
-          "major:0": "37",
-          "micro:2": "1",
-          "minor:1": "2"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "37.2.2": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "fc2166a8864005432a91c2360b8f97c35cd59fc2",
-            "size": 346861517,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-15937705.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "8ce9c95a4206cb9c36f29249505f27c433464ef0",
-            "size": 477927789,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-15937705.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "bae68e1a8c89731b18a7d0c91a98a6faccb9121c",
-            "size": 405827177,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-15937705.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "ef54972d76a467b7abc7402e5f8def549aff4f5f",
-            "size": 453975707,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-15937705.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20665,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "37.2.2",
-        "revision-details": {
-          "major:0": "37",
-          "micro:2": "2",
           "minor:1": "2"
         },
         "type-details": {
@@ -23216,7 +18231,7 @@
           }
         ],
         "displayName": "Android Emulator (Preview)",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "emulators",
         "path": "emulators/15885905",
@@ -23232,75 +18247,52 @@
             "xsi:type": "ns5:genericDetailsType"
           }
         }
-      }
-    },
-    "extras": {
-      "2.0": {
-        "archives": [
-          {
-            "os": "macosx",
-            "sha1": "d4d12a2173fef608ad62b94fed3a112bfa146759",
-            "size": 8030009,
-            "url": "https://dl.google.com/android/repository/desktop-head-unit-darwin-x64_r02.0.zip"
-          },
-          {
-            "os": "linux",
-            "sha1": "77e3f80c2834e1fad33f56539ceb0215da408fab",
-            "size": 6895443,
-            "url": "https://dl.google.com/android/repository/desktop-head-unit-linux-x64_r02.0.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "680418d5aca256cce151eb7f9527294e95b6bb8a",
-            "size": 6801703,
-            "url": "https://dl.google.com/android/repository/desktop-head-unit-windows-x64_r02.0.zip"
-          }
-        ],
-        "displayName": "Android Auto Desktop Head Unit Emulator",
-        "last-available-day": 19954,
-        "license": "android-sdk-license",
-        "name": "extras",
-        "path": "extras/google/auto",
-        "revision": "2.0",
-        "revision-details": {
-          "major:0": "2",
-          "minor:1": "0"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
       },
-      "2.1": {
+      "37.1.1": {
         "archives": [
           {
-            "os": "macosx",
-            "sha1": "4f8a3d3e32b27de1fc190d149039842e76a55bdd",
-            "size": 7797329,
-            "url": "https://dl.google.com/android/repository/desktop-head-unit-darwin-x64_r02.1.zip"
-          },
-          {
+            "arch": "x64",
             "os": "linux",
-            "sha1": "5d87eb87a1421e59d528eac1f5cdd406c0b39f51",
-            "size": 6927985,
-            "url": "https://dl.google.com/android/repository/desktop-head-unit-linux-x64_r02.1.zip"
+            "sha1": "4a8c33a0961f1f92220c81685cca7b359a671876",
+            "size": 501654802,
+            "url": "https://dl.google.com/android/repository/emulator_linux_x64-16013376.zip"
           },
           {
+            "arch": "aarch64",
+            "os": "macosx",
+            "sha1": "ac7a12fb630031521cb86ff8b8c522571632eb2a",
+            "size": 455764583,
+            "url": "https://dl.google.com/android/repository/emulator_darwin_aarch64-16013376.zip"
+          },
+          {
+            "arch": "x64",
             "os": "windows",
-            "sha1": "c27bf84e59dda7b79315b6ca2a314063feffd6ac",
-            "size": 7012059,
-            "url": "https://dl.google.com/android/repository/desktop-head-unit-windows-x64_r02.1.zip"
+            "sha1": "591724aa6d39b2f68b261d50d309d83eb838c2ea",
+            "size": 274607412,
+            "url": "https://dl.google.com/android/repository/emulator_windows_x64-16013376.zip"
           }
         ],
-        "displayName": "Android Auto Desktop Head Unit Emulator",
-        "last-available-day": 19954,
-        "license": "android-sdk-license",
-        "name": "extras",
-        "path": "extras/google/auto",
-        "revision": "2.1",
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "emulator"
+            },
+            "min-revision:0": {
+              "major:0": "36",
+              "micro:2": "11",
+              "minor:1": "6"
+            }
+          }
+        },
+        "displayName": "Android Emulator (Preview)",
+        "last-available-day": 20676,
+        "license": "android-sdk-preview-license",
+        "name": "emulators",
+        "path": "emulators/16013376",
+        "revision": "37.1.1",
         "revision-details": {
-          "major:0": "2",
+          "major:0": "37",
+          "micro:2": "1",
           "minor:1": "1"
         },
         "type-details": {
@@ -23310,6 +18302,7 @@
         }
       }
     },
+    "extras": {},
     "ndk": {
       "16.1.4479499": {
         "archives": [
@@ -23349,15 +18342,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r16b-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 16.1.4479499",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/16.1.4479499",
@@ -23411,15 +18397,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r17c-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 17.2.4988734",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/17.2.4988734",
@@ -23473,15 +18452,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r18b-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 18.1.5063045",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/18.1.5063045",
@@ -23535,15 +18507,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r19-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 19.0.5232133",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "obsolete": "true",
@@ -23598,15 +18563,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r19c-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 19.2.5345600",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/19.2.5345600",
@@ -23660,15 +18618,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r20-beta2-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 20.0.5392854",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "obsolete": "true",
@@ -23724,15 +18675,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r20-beta3-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 20.0.5471264",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "obsolete": "true",
@@ -23788,15 +18732,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r20-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 20.0.5594570",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/20.0.5594570",
@@ -23850,15 +18787,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r20b-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 20.1.5948944",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/20.1.5948944",
@@ -23898,15 +18828,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21-beta2-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 21.0.6011959",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.0.6011959",
@@ -23947,15 +18870,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 21.0.6113669",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.0.6113669",
@@ -23995,15 +18911,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21b-beta1-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 21.1.6210238",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6210238",
@@ -24051,15 +18960,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21b-beta2-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 21.1.6273396",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6273396",
@@ -24107,15 +19009,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21b-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 21.1.6352462",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.1.6352462",
@@ -24162,15 +19057,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21b-beta3-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 21.1.6363665",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6363665",
@@ -24218,15 +19106,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21c-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 21.2.6472646",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.2.6472646",
@@ -24273,15 +19154,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21d-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 21.3.6528147",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.3.6528147",
@@ -24328,15 +19202,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21e-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 21.4.7075529",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.4.7075529",
@@ -24383,15 +19250,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r22-beta1-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 22.0.6917172",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/22.0.6917172",
@@ -24439,15 +19299,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r22-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 22.0.7026061",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/22.0.7026061",
@@ -24494,15 +19347,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r22b-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 22.1.7171670",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/22.1.7171670",
@@ -24549,15 +19395,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta1-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 23.0.7123448",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7123448",
@@ -24605,15 +19444,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta2-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 23.0.7196353",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7196353",
@@ -24661,15 +19493,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta3-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 23.0.7272597",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7272597",
@@ -24717,15 +19542,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta4-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 23.0.7344513",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7344513",
@@ -24766,15 +19584,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta5-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 23.0.7421159",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7421159",
@@ -24815,15 +19626,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta6-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 23.0.7530507",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7530507",
@@ -24864,15 +19668,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 23.0.7599858",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.0.7599858",
@@ -24912,15 +19709,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23b-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 23.1.7779620",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.1.7779620",
@@ -24960,15 +19750,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23c-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 23.2.8568313",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.2.8568313",
@@ -25008,15 +19791,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r24-beta1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 24.0.7856742",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.7856742",
@@ -25057,15 +19833,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r24-beta2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 24.0.7956693",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.7956693",
@@ -25106,15 +19875,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r24-rc1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 24.0.8079956",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.8079956",
@@ -25155,15 +19917,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r24-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 24.0.8215888",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/24.0.8215888",
@@ -25203,15 +19958,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r25-beta1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 25.0.8151533",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8151533",
@@ -25252,15 +20000,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r25-beta2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 25.0.8221429",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8221429",
@@ -25301,15 +20042,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r25-beta3-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 25.0.8355429",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8355429",
@@ -25350,15 +20084,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r25-beta4-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 25.0.8528842",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8528842",
@@ -25399,15 +20126,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r25-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 25.0.8775105",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/25.0.8775105",
@@ -25447,15 +20167,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r25b-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 25.1.8937393",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/25.1.8937393",
@@ -25495,15 +20208,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r25c-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 25.2.9519653",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/25.2.9519653",
@@ -25543,15 +20249,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r26-beta1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 26.0.10404224",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/26.0.10404224",
@@ -25593,7 +20292,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.0.10636728",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/26.0.10636728",
@@ -25635,7 +20334,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.0.10792818",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.0.10792818",
@@ -25676,7 +20375,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.1.10909125",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.1.10909125",
@@ -25717,7 +20416,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.2.11394342",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.2.11394342",
@@ -25758,7 +20457,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.3.11579264",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.3.11579264",
@@ -25799,7 +20498,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.0.11718014",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/27.0.11718014",
@@ -25841,7 +20540,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.0.11902837",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/27.0.11902837",
@@ -25883,7 +20582,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.0.12077973",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/27.0.12077973",
@@ -25924,7 +20623,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.1.12297006",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/27.1.12297006",
@@ -25965,7 +20664,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.2.12479018",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/27.2.12479018",
@@ -26006,7 +20705,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.3.13750724",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/27.3.13750724",
@@ -26047,7 +20746,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.12433566",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/28.0.12433566",
@@ -26089,7 +20788,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.12674087",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/28.0.12674087",
@@ -26131,7 +20830,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.12916984",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/28.0.12916984",
@@ -26173,7 +20872,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.13004108",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/28.0.13004108",
@@ -26214,7 +20913,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.1.13356709",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/28.1.13356709",
@@ -26255,7 +20954,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.2.13676358",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/28.2.13676358",
@@ -26296,7 +20995,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 29.0.13113456",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/29.0.13113456",
@@ -26338,7 +21037,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 29.0.13599879",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/29.0.13599879",
@@ -26380,7 +21079,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 29.0.13846066",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/29.0.13846066",
@@ -26422,7 +21121,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 29.0.14033849",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/29.0.14033849",
@@ -26464,7 +21163,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 29.0.14206865",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/29.0.14206865",
@@ -26505,7 +21204,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 30.0.14904198",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/30.0.14904198",
@@ -26547,7 +21246,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 30.0.15729638",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/30.0.15729638",
@@ -26604,15 +21303,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r16b-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -26666,15 +21358,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r17c-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -26728,15 +21413,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r18b-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -26790,15 +21468,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r19-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "obsolete": "true",
@@ -26853,15 +21524,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r19c-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -26915,15 +21579,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r20-beta2-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "obsolete": "true",
@@ -26979,15 +21636,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r20-beta3-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "obsolete": "true",
@@ -27043,15 +21693,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r20-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -27105,15 +21748,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r20b-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -27153,15 +21789,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21-beta2-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -27202,15 +21831,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -27250,15 +21872,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21b-beta1-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -27306,15 +21921,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21b-beta2-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -27362,15 +21970,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21b-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -27417,15 +22018,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21b-beta3-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -27473,15 +22067,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21c-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -27528,15 +22115,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21d-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -27583,15 +22163,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21e-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -27638,15 +22211,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r22-beta1-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -27694,15 +22260,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r22-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -27749,15 +22308,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r22b-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -27804,15 +22356,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta1-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -27860,15 +22405,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta2-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -27916,15 +22454,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta3-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -27972,15 +22503,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta4-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -28000,211 +22524,6 @@
     },
     "patcher": {},
     "platform-tools": {
-      "35.0.2": {
-        "archives": [
-          {
-            "arch": "all",
-            "os": "linux",
-            "sha1": "f6406982a79d67e40b1ca3cb9e5e2cc783c0f232",
-            "size": 7472902,
-            "url": "https://dl.google.com/android/repository/platform-tools_r35.0.2-linux.zip"
-          },
-          {
-            "arch": "all",
-            "os": "macosx",
-            "sha1": "f6b3158097ca0e9d6fe2024b790ac68af3f2faf2",
-            "size": 13335867,
-            "url": "https://dl.google.com/android/repository/platform-tools_r35.0.2-darwin.zip"
-          },
-          {
-            "arch": "all",
-            "os": "windows",
-            "sha1": "6d204cdff21bce8a39c1d2367084e6174f854c2c",
-            "size": 6700829,
-            "url": "https://dl.google.com/android/repository/platform-tools_r35.0.2-win.zip"
-          }
-        ],
-        "displayName": "Android SDK Platform-Tools",
-        "last-available-day": 20237,
-        "license": "android-sdk-license",
-        "name": "platform-tools",
-        "path": "platform-tools",
-        "revision": "35.0.2",
-        "revision-details": {
-          "major:0": "35",
-          "micro:2": "2",
-          "minor:1": "0"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "36.0.0": {
-        "archives": [
-          {
-            "arch": "all",
-            "os": "linux",
-            "sha1": "ddb0cd76d952d9a1f4c8a32e4ec0e73d7a8bebb8",
-            "size": 7904253,
-            "url": "https://dl.google.com/android/repository/platform-tools_r36.0.0-linux.zip"
-          },
-          {
-            "arch": "all",
-            "os": "macosx",
-            "sha1": "69ffc978ad66667c6b2eb7979a09f5af20f83aaa",
-            "size": 14186137,
-            "url": "https://dl.google.com/android/repository/platform-tools_r36.0.0-darwin.zip"
-          },
-          {
-            "arch": "all",
-            "os": "windows",
-            "sha1": "18bb505f9fbfbdf1e44fca4d794e74e01b63d30e",
-            "size": 7138784,
-            "url": "https://dl.google.com/android/repository/platform-tools_r36.0.0-win.zip"
-          }
-        ],
-        "displayName": "Android SDK Platform-Tools",
-        "last-available-day": 20429,
-        "license": "android-sdk-license",
-        "name": "platform-tools",
-        "path": "platform-tools",
-        "revision": "36.0.0",
-        "revision-details": {
-          "major:0": "36",
-          "micro:2": "0",
-          "minor:1": "0"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "36.0.1": {
-        "archives": [
-          {
-            "arch": "all",
-            "os": "linux",
-            "sha1": "5ea5ed0ce3734d4f7dfed7f91eeda090101c3411",
-            "size": 8128518,
-            "url": "https://dl.google.com/android/repository/platform-tools_r36.0.1-linux.zip"
-          },
-          {
-            "arch": "all",
-            "os": "macosx",
-            "sha1": "96dd111d89fb1e6c8f3a78781102dad7366fe9cc",
-            "size": 14597016,
-            "url": "https://dl.google.com/android/repository/platform-tools_r36.0.1-darwin.zip"
-          },
-          {
-            "arch": "all",
-            "os": "windows",
-            "sha1": "0a700d028bca11fbf5be6fc2187e9a8820f2d942",
-            "size": 7316031,
-            "url": "https://dl.google.com/android/repository/platform-tools_r36.0.1-win.zip"
-          }
-        ],
-        "displayName": "Android SDK Platform-Tools",
-        "last-available-day": 20369,
-        "license": "android-sdk-preview-license",
-        "name": "platform-tools",
-        "path": "platform-tools",
-        "revision": "36.0.1",
-        "revision-details": {
-          "major:0": "36",
-          "micro:2": "1",
-          "minor:1": "0"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "36.0.2": {
-        "archives": [
-          {
-            "arch": "all",
-            "os": "linux",
-            "sha1": "3c5c54a14f51a2da59d7c4874372619a42deb94d",
-            "size": 8785200,
-            "url": "https://dl.google.com/android/repository/platform-tools_r36.0.2-linux.zip"
-          },
-          {
-            "arch": "all",
-            "os": "macosx",
-            "sha1": "5998b371cd55fbd3807632ac36f1b3a62558d46d",
-            "size": 15711207,
-            "url": "https://dl.google.com/android/repository/platform-tools_r36.0.2-darwin.zip"
-          },
-          {
-            "arch": "all",
-            "os": "windows",
-            "sha1": "970632ccb7a364767d64d9eec3d143f5d2adcc3c",
-            "size": 7708640,
-            "url": "https://dl.google.com/android/repository/platform-tools_r36.0.2-win.zip"
-          }
-        ],
-        "displayName": "Android SDK Platform-Tools",
-        "last-available-day": 20429,
-        "license": "android-sdk-preview-license",
-        "name": "platform-tools",
-        "path": "platform-tools",
-        "revision": "36.0.2",
-        "revision-details": {
-          "major:0": "36",
-          "micro:2": "2",
-          "minor:1": "0"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "37.0.0": {
-        "archives": [
-          {
-            "arch": "all",
-            "os": "linux",
-            "sha1": "bcf323933980a59dccc3f14c339aed5fb2171163",
-            "size": 9167924,
-            "url": "https://dl.google.com/android/repository/platform-tools_r37.0.0-linux.zip"
-          },
-          {
-            "arch": "all",
-            "os": "macosx",
-            "sha1": "8c4c926d0ca192376b2a04b0318484724319e67c",
-            "size": 16442240,
-            "url": "https://dl.google.com/android/repository/platform-tools_r37.0.0-darwin.zip"
-          },
-          {
-            "arch": "all",
-            "os": "windows",
-            "sha1": "f29bfb58d0d6f9a57d7dbcba6cc259f9ca6f58f1",
-            "size": 8092164,
-            "url": "https://dl.google.com/android/repository/platform-tools_r37.0.0-win.zip"
-          }
-        ],
-        "displayName": "Android SDK Platform-Tools",
-        "last-available-day": 20656,
-        "license": "android-sdk-license",
-        "name": "platform-tools",
-        "path": "platform-tools",
-        "revision": "37.0.0",
-        "revision-details": {
-          "major:0": "37",
-          "micro:2": "0",
-          "minor:1": "0"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
       "37.0.1": {
         "archives": [
           {
@@ -28230,7 +22549,7 @@
           }
         ],
         "displayName": "Android SDK Platform-Tools",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platform-tools",
         "path": "platform-tools",
@@ -28259,7 +22578,7 @@
           }
         ],
         "displayName": "Android SDK Platform 10",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-10",
@@ -28273,11 +22592,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "4"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -28297,7 +22611,7 @@
           }
         ],
         "displayName": "Android SDK Platform 11",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-11",
@@ -28311,11 +22625,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "4"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -28335,7 +22644,7 @@
           }
         ],
         "displayName": "Android SDK Platform 12",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-12",
@@ -28349,11 +22658,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "4"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -28373,7 +22677,7 @@
           }
         ],
         "displayName": "Android SDK Platform 13",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-13",
@@ -28387,11 +22691,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "4"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -28411,7 +22710,7 @@
           }
         ],
         "displayName": "Android SDK Platform 14",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-14",
@@ -28425,11 +22724,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "12"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -28449,7 +22743,7 @@
           }
         ],
         "displayName": "Android SDK Platform 15",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-15",
@@ -28463,11 +22757,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "12"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -28487,7 +22776,7 @@
           }
         ],
         "displayName": "Android SDK Platform 16",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-16",
@@ -28501,11 +22790,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "12"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -28525,7 +22809,7 @@
           }
         ],
         "displayName": "Android SDK Platform 17",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-17",
@@ -28539,11 +22823,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "12"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -28563,7 +22842,7 @@
           }
         ],
         "displayName": "Android SDK Platform 18",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-18",
@@ -28577,11 +22856,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "12"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -28601,7 +22875,7 @@
           }
         ],
         "displayName": "Android SDK Platform 19",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-19",
@@ -28615,11 +22889,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "12"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -28653,7 +22922,7 @@
           }
         ],
         "displayName": "Android SDK Platform 2",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -28668,11 +22937,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "4"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -28692,7 +22956,7 @@
           }
         ],
         "displayName": "Android SDK Platform 20",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-20",
@@ -28706,11 +22970,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "12"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -28730,7 +22989,7 @@
           }
         ],
         "displayName": "Android SDK Platform 21",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-21",
@@ -28744,11 +23003,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "12"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -28768,7 +23022,7 @@
           }
         ],
         "displayName": "Android SDK Platform 22",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-22",
@@ -28782,11 +23036,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "14"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -28806,7 +23055,7 @@
           }
         ],
         "displayName": "Android SDK Platform 23",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-23",
@@ -28820,11 +23069,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "16"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -28844,7 +23088,7 @@
           }
         ],
         "displayName": "Android SDK Platform 24",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-24",
@@ -28858,11 +23102,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "16"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -28882,7 +23121,7 @@
           }
         ],
         "displayName": "Android SDK Platform 25",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-25",
@@ -28896,11 +23135,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "16"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -28920,7 +23154,7 @@
           }
         ],
         "displayName": "Android SDK Platform 26",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-26",
@@ -28934,11 +23168,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "15"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -28958,7 +23187,7 @@
           }
         ],
         "displayName": "Android SDK Platform 27",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-27",
@@ -28972,11 +23201,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "15"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -28996,7 +23220,7 @@
           }
         ],
         "displayName": "Android SDK Platform 28",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-28",
@@ -29010,11 +23234,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "15"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -29034,7 +23253,7 @@
           }
         ],
         "displayName": "Android SDK Platform 29",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-29",
@@ -29048,11 +23267,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "15"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -29086,7 +23300,7 @@
           }
         ],
         "displayName": "Android SDK Platform 3",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -29101,11 +23315,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "4"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -29125,7 +23334,7 @@
           }
         ],
         "displayName": "Android SDK Platform 30",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-30",
@@ -29139,11 +23348,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "15"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -29163,7 +23367,7 @@
           }
         ],
         "displayName": "Android SDK Platform 31",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-31",
@@ -29177,11 +23381,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "15"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -29201,7 +23400,7 @@
           }
         ],
         "displayName": "Android SDK Platform 32",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-32",
@@ -29215,11 +23414,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "15"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -29239,7 +23433,7 @@
           }
         ],
         "displayName": "Android SDK Platform 33",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-33",
@@ -29255,11 +23449,6 @@
             "xsi:type": "ns11:platformDetailsType"
           },
           "extension-level:2": "3",
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "15"
-            }
-          },
           "layoutlib:4": {
             "element-attributes": {
               "api": "15"
@@ -29278,7 +23467,7 @@
           }
         ],
         "displayName": "Android SDK Platform 33-ext5",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-33-ext5",
@@ -29312,7 +23501,7 @@
           }
         ],
         "displayName": "Android SDK Platform 34",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -29329,16 +23518,6 @@
             "xsi:type": "ns11:platformDetailsType"
           },
           "extension-level:2": "7",
-          "layoutlib:1": {
-            "element-attributes": {
-              "api": "15"
-            }
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "15"
-            }
-          },
           "layoutlib:4": {
             "element-attributes": {
               "api": "15"
@@ -29357,7 +23536,7 @@
           }
         ],
         "displayName": "Android SDK Platform 34-ext12",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-34-ext12",
@@ -29390,7 +23569,7 @@
           }
         ],
         "displayName": "Android SDK Platform 35",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-35",
@@ -29405,11 +23584,6 @@
             "xsi:type": "ns11:platformDetailsType"
           },
           "extension-level:1": "13",
-          "layoutlib:1": {
-            "element-attributes": {
-              "api": "15"
-            }
-          },
           "layoutlib:3": {
             "element-attributes": {
               "api": "15"
@@ -29428,7 +23602,7 @@
           }
         ],
         "displayName": "Android SDK Platform 35-ext15",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-35-ext15",
@@ -29461,7 +23635,7 @@
           }
         ],
         "displayName": "Android SDK Platform 36",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-36",
@@ -29494,7 +23668,7 @@
           }
         ],
         "displayName": "Android SDK Platform 36.1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-36.1",
@@ -29527,7 +23701,7 @@
           }
         ],
         "displayName": "Android SDK Platform 36-ext19",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-36-ext19",
@@ -29560,7 +23734,7 @@
           }
         ],
         "displayName": "Android SDK Platform 37.0",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-37.0",
@@ -29594,7 +23768,7 @@
           }
         ],
         "displayName": "Android SDK Platform 37.1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-37.1",
@@ -29642,7 +23816,7 @@
           }
         ],
         "displayName": "Android SDK Platform 4",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -29657,11 +23831,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "4"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -29695,7 +23864,7 @@
           }
         ],
         "displayName": "Android SDK Platform 5",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -29710,11 +23879,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "4"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -29748,7 +23912,7 @@
           }
         ],
         "displayName": "Android SDK Platform 6",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -29763,11 +23927,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "4"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -29787,7 +23946,7 @@
           }
         ],
         "displayName": "Android SDK Platform 7",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-7",
@@ -29801,11 +23960,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "4"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -29825,7 +23979,7 @@
           }
         ],
         "displayName": "Android SDK Platform 8",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-8",
@@ -29839,11 +23993,6 @@
           "codename:1": {},
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "4"
-            }
           },
           "layoutlib:3": {
             "element-attributes": {
@@ -29863,7 +24012,7 @@
           }
         ],
         "displayName": "Android SDK Platform 9",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-9",
@@ -29878,48 +24027,9 @@
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
           },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "4"
-            }
-          },
           "layoutlib:3": {
             "element-attributes": {
               "api": "4"
-            }
-          }
-        }
-      },
-      "Baklava": {
-        "archives": [
-          {
-            "arch": "all",
-            "os": "all",
-            "sha1": "7842268e95c0538a9d59ab813f39a5ee69bdbb86",
-            "size": 66332697,
-            "url": "https://dl.google.com/android/repository/platform-36.0-Baklava-ext19_r01.zip"
-          }
-        ],
-        "displayName": "Android SDK Platform Baklava-ext19",
-        "last-available-day": 20621,
-        "license": "android-sdk-license",
-        "name": "platforms",
-        "path": "platforms/android-Baklava-ext19",
-        "revision": "Baklava",
-        "revision-details": {
-          "major:0": "1"
-        },
-        "type-details": {
-          "api-level:0": "36.0x",
-          "base-extension:3": "false",
-          "codename:1": "Baklava",
-          "element-attributes": {
-            "xsi:type": "ns11:platformDetailsType"
-          },
-          "extension-level:2": "19",
-          "layoutlib:4": {
-            "element-attributes": {
-              "api": "15"
             }
           }
         }
@@ -29929,19 +24039,19 @@
           {
             "arch": "all",
             "os": "all",
-            "sha1": "579bed8e6d9f9759efbf10dfc93c876bb226bdee",
-            "size": 67761167,
-            "url": "https://dl.google.com/android/repository/platform-CANARY_r14.zip"
+            "sha1": "f67f277643ae1aebc7971e7f81d2a3cd99cc0a7f",
+            "size": 67921587,
+            "url": "https://dl.google.com/android/repository/platform-CANARY_r15.zip"
           }
         ],
         "displayName": "Android SDK Platform CANARY",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-CANARY",
         "revision": "CANARY",
         "revision-details": {
-          "major:0": "14"
+          "major:0": "15"
         },
         "type-details": {
           "api-level:0": "37.1",
@@ -29969,7 +24079,7 @@
           }
         ],
         "displayName": "Android SDK Platform 37.2-beta1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-37.2-beta1",
@@ -29992,31 +24102,34 @@
           }
         }
       },
-      "TiramisuPrivacySandbox": {
+      "DEV": {
         "archives": [
           {
+            "arch": "all",
             "os": "all",
-            "sha1": "6bc5e85cd2ea54df4dae036ff20fb0e889a6835e",
-            "size": 67663071,
-            "url": "https://dl.google.com/android/repository/platform-TiramisuPrivacySandbox_r09.zip"
+            "sha1": "e27443b95492f41c4ef8fea7ec69f6fd6c662204",
+            "size": 67757684,
+            "url": "https://dl.google.com/android/repository/platform-37.2-beta2_r02.zip"
           }
         ],
-        "displayName": "Android SDK Platform TiramisuPrivacySandbox",
-        "last-available-day": 19954,
+        "displayName": "Android SDK Platform 37.2-beta2",
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
-        "path": "platforms/android-TiramisuPrivacySandbox",
-        "revision": "TiramisuPrivacySandbox",
+        "path": "platforms/android-37.2-beta2",
+        "revision": "DEV",
         "revision-details": {
-          "major:0": "9"
+          "major:0": "2"
         },
         "type-details": {
-          "api-level:0": "33",
-          "codename:1": "TiramisuPrivacySandbox",
+          "api-level:0": "37.1",
+          "base-extension:3": "true",
+          "codename:1": "DEV",
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
           },
-          "layoutlib:2": {
+          "extension-level:2": "23",
+          "layoutlib:4": {
             "element-attributes": {
               "api": "15"
             }
@@ -30034,7 +24147,7 @@
           }
         ],
         "displayName": "Android SDK Platform UpsideDownCake",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -30051,74 +24164,7 @@
             "xsi:type": "ns11:platformDetailsType"
           },
           "extension-level:2": "6",
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "15"
-            }
-          },
           "layoutlib:4": {
-            "element-attributes": {
-              "api": "15"
-            }
-          }
-        }
-      },
-      "UpsideDownCakePrivacySandbox": {
-        "archives": [
-          {
-            "os": "all",
-            "sha1": "693beff31fe890c670efe34498c761ebe425ac8f",
-            "size": 64049813,
-            "url": "https://dl.google.com/android/repository/platform-UpsideDownCakePrivacySandbox_r03.zip"
-          }
-        ],
-        "displayName": "Android SDK Platform UpsideDownCakePrivacySandbox",
-        "last-available-day": 19954,
-        "license": "android-sdk-license",
-        "name": "platforms",
-        "path": "platforms/android-UpsideDownCakePrivacySandbox",
-        "revision": "UpsideDownCakePrivacySandbox",
-        "revision-details": {
-          "major:0": "3"
-        },
-        "type-details": {
-          "api-level:0": "34",
-          "codename:1": "UpsideDownCakePrivacySandbox",
-          "element-attributes": {
-            "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "15"
-            }
-          }
-        }
-      },
-      "VanillaIceCream": {
-        "archives": [
-          {
-            "os": "all",
-            "sha1": "593df928592daf8e8b904a1680f54be715b32e98",
-            "size": 64462100,
-            "url": "https://dl.google.com/android/repository/platform-VanillaIceCream_r04.zip"
-          }
-        ],
-        "displayName": "Android SDK Platform VanillaIceCream",
-        "last-available-day": 19954,
-        "license": "android-sdk-license",
-        "name": "platforms",
-        "path": "platforms/android-VanillaIceCream",
-        "revision": "VanillaIceCream",
-        "revision-details": {
-          "major:0": "4"
-        },
-        "type-details": {
-          "api-level:0": "34",
-          "codename:1": "VanillaIceCream",
-          "element-attributes": {
-            "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
             "element-attributes": {
               "api": "15"
             }
@@ -30152,95 +24198,13 @@
           }
         ],
         "displayName": "Layout Inspector image server for API S",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "skiaparser",
         "path": "skiaparser/2",
         "revision": "3",
         "revision-details": {
           "major:0": "3"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "4": {
-        "archives": [
-          {
-            "os": "linux",
-            "sha1": "caafe27824ceb1c69691766984ab287354104b50",
-            "size": 6433967,
-            "url": "https://dl.google.com/android/repository/skiaparser-11591181-linux-x64.zip"
-          },
-          {
-            "os": "macosx",
-            "sha1": "8043d8f669fec8a3785f95c3e22a7b753cc70c3d",
-            "size": 2933536,
-            "url": "https://dl.google.com/android/repository/skiaparser-11591181-darwin-x64.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "b1b2ca27aa2f2783dda3a7d73bb4f039513a9500",
-            "size": 2920006,
-            "url": "https://dl.google.com/android/repository/skiaparser-11591181-win-x64.zip"
-          }
-        ],
-        "displayName": "Layout Inspector image server for API 31-35",
-        "last-available-day": 19954,
-        "license": "android-sdk-license",
-        "name": "skiaparser",
-        "path": "skiaparser/3",
-        "revision": "4",
-        "revision-details": {
-          "major:0": "4"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "5": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "f1f9acd490c2a94402fa5fc0a548f529acab91b1",
-            "size": 9059335,
-            "url": "https://dl.google.com/android/repository/skiaparser-12616120-linux-x64.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "d320af2c33979fce796d436e6e68351a9d1a02d2",
-            "size": 2932763,
-            "url": "https://dl.google.com/android/repository/skiaparser-12616120-darwin-x64.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "b40c1615bacc6b8c27563c2f5dd8d1a856f20c50",
-            "size": 2598750,
-            "url": "https://dl.google.com/android/repository/skiaparser-12616120-darwin-aarch64.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "afd28844313af84f7245cef5d5be8d9a9de848e1",
-            "size": 2952673,
-            "url": "https://dl.google.com/android/repository/skiaparser-12616120-win-x64.zip"
-          }
-        ],
-        "displayName": "Layout Inspector image server for API 31-36",
-        "last-available-day": 20131,
-        "license": "android-sdk-license",
-        "name": "skiaparser",
-        "path": "skiaparser/3",
-        "revision": "5",
-        "revision-details": {
-          "major:0": "5"
         },
         "type-details": {
           "element-attributes": {
@@ -30273,59 +24237,13 @@
           }
         ],
         "displayName": "Layout Inspector image server for API 29-30",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "skiaparser",
         "path": "skiaparser/1",
         "revision": "6",
         "revision-details": {
           "major:0": "6"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "7": {
-        "archives": [
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "bb1f92866924dc64e035516d36866f6d851c5f6d",
-            "size": 9075303,
-            "url": "https://dl.google.com/android/repository/skiaparser-13188227-linux-x64.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "a4a0037269a48d8eca8cdb8bc289e7b35b829b45",
-            "size": 2939258,
-            "url": "https://dl.google.com/android/repository/skiaparser-13188227-darwin-x64.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "44c55cb986abfb8d5dc2293db3a625b8d81dc1f6",
-            "size": 2601969,
-            "url": "https://dl.google.com/android/repository/skiaparser-13188227-darwin-aarch64.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "9c47bdff5f0bb8947426d766d28b35a6f3bba988",
-            "size": 2956517,
-            "url": "https://dl.google.com/android/repository/skiaparser-13188227-win-x64.zip"
-          }
-        ],
-        "displayName": "Layout Inspector image server for API 31-36",
-        "last-available-day": 20318,
-        "license": "android-sdk-license",
-        "name": "skiaparser",
-        "path": "skiaparser/3",
-        "revision": "7",
-        "revision-details": {
-          "major:0": "7"
         },
         "type-details": {
           "element-attributes": {
@@ -30365,7 +24283,7 @@
           }
         ],
         "displayName": "Layout Inspector image server for API 31-36",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "skiaparser",
         "path": "skiaparser/3",
@@ -30392,7 +24310,7 @@
           }
         ],
         "displayName": "Sources for Android 14",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "sources",
         "obsolete": "true",
@@ -30421,7 +24339,7 @@
           }
         ],
         "displayName": "Sources for Android 15",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-15",
@@ -30449,7 +24367,7 @@
           }
         ],
         "displayName": "Sources for Android 16",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-16",
@@ -30477,7 +24395,7 @@
           }
         ],
         "displayName": "Sources for Android 17",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-17",
@@ -30505,7 +24423,7 @@
           }
         ],
         "displayName": "Sources for Android 18",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-18",
@@ -30533,7 +24451,7 @@
           }
         ],
         "displayName": "Sources for Android 19",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-19",
@@ -30561,7 +24479,7 @@
           }
         ],
         "displayName": "Sources for Android 20",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-20",
@@ -30589,7 +24507,7 @@
           }
         ],
         "displayName": "Sources for Android 21",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-21",
@@ -30617,7 +24535,7 @@
           }
         ],
         "displayName": "Sources for Android 22",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-22",
@@ -30645,7 +24563,7 @@
           }
         ],
         "displayName": "Sources for Android 23",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-23",
@@ -30673,7 +24591,7 @@
           }
         ],
         "displayName": "Sources for Android 24",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-24",
@@ -30701,7 +24619,7 @@
           }
         ],
         "displayName": "Sources for Android 25",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-25",
@@ -30729,7 +24647,7 @@
           }
         ],
         "displayName": "Sources for Android 26",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-26",
@@ -30757,7 +24675,7 @@
           }
         ],
         "displayName": "Sources for Android 27",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-27",
@@ -30785,7 +24703,7 @@
           }
         ],
         "displayName": "Sources for Android 28",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-28",
@@ -30813,7 +24731,7 @@
           }
         ],
         "displayName": "Sources for Android 29",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-29",
@@ -30841,7 +24759,7 @@
           }
         ],
         "displayName": "Sources for Android 30",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-30",
@@ -30869,7 +24787,7 @@
           }
         ],
         "displayName": "Sources for Android 31",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-31",
@@ -30897,7 +24815,7 @@
           }
         ],
         "displayName": "Sources for Android 32",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-32",
@@ -30925,7 +24843,7 @@
           }
         ],
         "displayName": "Sources for Android 33",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-33",
@@ -30954,7 +24872,7 @@
           }
         ],
         "displayName": "Sources for Android 34",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-34",
@@ -30983,7 +24901,7 @@
           }
         ],
         "displayName": "Sources for Android 35",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-35",
@@ -31012,7 +24930,7 @@
           }
         ],
         "displayName": "Sources for Android 36",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-36",
@@ -31040,7 +24958,7 @@
           }
         ],
         "displayName": "Sources for Android 36.1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-36.1",
@@ -31068,7 +24986,7 @@
           }
         ],
         "displayName": "Sources for Android 37.0",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-37.0",
@@ -31097,7 +25015,7 @@
           }
         ],
         "displayName": "Sources for Android 37.1",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-37.1",
@@ -31146,26 +25064,10 @@
             "element-attributes": {
               "path": "emulator"
             }
-          },
-          "dependency:1": {
-            "element-attributes": {
-              "path": "platform-tools"
-            },
-            "min-revision:0": {
-              "major:0": "20"
-            }
-          },
-          "dependency:2": {
-            "element-attributes": {
-              "path": "platform-tools"
-            },
-            "min-revision:0": {
-              "major:0": "20"
-            }
           }
         },
         "displayName": "Android SDK Tools",
-        "last-available-day": 20665,
+        "last-available-day": 20676,
         "license": "android-sdk-license",
         "name": "tools",
         "obsolete": "true",

--- a/pkgs/development/mobile/androidenv/update.rb
+++ b/pkgs/development/mobile/androidenv/update.rb
@@ -158,7 +158,7 @@ def package_revision package
   when 'sys-img:sysImgDetailsType'
     codename = text type_details.at_css('> codename')
     api_level = text type_details.at_css('> api-level')
-    id = text type_details.at_css('> tag > id')
+    _, _, id, _ = package['path'].split(';')
     abi = text type_details.at_css('> abi')
 
     revision = ''
@@ -342,7 +342,7 @@ def parse_package_xml doc
   [licenses, packages, extras]
 end
 
-def parse_image_xml doc
+def parse_image_xml loc, doc
   licenses = get_licenses doc
   images = {}
 
@@ -357,7 +357,7 @@ def parse_image_xml doc
     obsolete &&= package['obsolete']
     type_details = to_json_collector package.at_css('> type-details')
     revision_details = to_json_collector package.at_css('> revision')
-    archives = package_archives(package) {|url| image_url url, components[-2]}
+    archives = package_archives(package) {|url| image_url url, loc}
     dependencies_xml = package.at_css('> dependencies')
     dependencies = to_json_collector dependencies_xml if dependencies_xml
 
@@ -503,7 +503,8 @@ opts[:packages].each do |filename|
 end
 
 opts[:images].each do |filename|
-  licenses, images = parse_image_xml(Nokogiri::XML(get(filename)) { |conf| conf.noblanks })
+  loc = URI.parse(filename).host
+  licenses, images = parse_image_xml(loc, Nokogiri::XML(get(filename)) { |conf| conf.noblanks })
   merge result['licenses'], licenses
   merge result['images'], images
 end


### PR DESCRIPTION
Because a single abi such as x86_64 can have multiple variants which are not distinguished by checking only the first tag. Due to package ordering in the source metadata that prevented using non-16kb memory page images for at least Android API 36.1.

Also sorts the tags alphanumericly to avoid cases where Google are not consistent.

This does result in additional `systemImageTypes` such as `google_apis_playstore-page_size_16kb` however I don't see where these are documented outside the repo.json.

For some reason when creating or editing a virtual device the system image shows as the "Pre-Release 16KB Page Size" for 36.1 even though it is displayed correctly in the SDK Manager and can be confirmed as a 4kb by running
```
adb shell getconf PAGE_SIZE
```

`repo.json` has been regenerated based on `6ff5d4adb863` as that was the last commit before the tagging changes appear to have been an issue. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
