### PR TITLE
sleek-grub-theme: unstable-2024-08-11 -> 0-unstable-2025-05-21

### DIFF
--- a/pkgs/by-name/sl/sleek-grub-theme/package.nix
+++ b/pkgs/by-name/sl/sleek-grub-theme/package.nix
@@ -15,13 +15,13 @@ assert builtins.elem withStyle [
 
 stdenv.mkDerivation {
   pname = "sleek-grub-theme";
-  version = "unstable-2024-08-11";
+  version = "0-unstable-2025-05-21";
 
   src = fetchFromGitHub {
     owner = "sandesh236";
     repo = "sleek--themes";
-    rev = "0c47e645ccc2d72aa165e9d994f9d09f58de9f6d";
-    hash = "sha256-H4s4CSR8DaH8RT9w40hkguNNcC0U8gHKS2FLt+FApeA=";
+    rev = "e103aa4cd655be6a38dbab37b1911c6ed9ef7765";
+    hash = "sha256-E3DSOZlszBRy2F172L7ZSSsDlkk3n9jGXl4hRWv2WF8=";
   };
 
   installPhase = ''


### PR DESCRIPTION
- Conform to the version scheme. (#541820)
- Upgrade to newest commit, the older version would have been 0-unstable-2024-08-11.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
