### PR TITLE
WIP: nixos/test-driver: expose as a python library

### DIFF
--- a/nixos/lib/test-driver/default.nix
+++ b/nixos/lib/test-driver/default.nix
@@ -11,6 +11,7 @@
   ptpython,
   pydantic,
   python,
+  pythonOlder,
   ovmfvartool,
   remote-pdb,
   ruff,
@@ -28,6 +29,7 @@
 
   enableNspawn ? false,
   enableOCR ? false,
+  enableRuntimeDeps ? true,
   extraPythonPackages ? (_: [ ]),
 }:
 
@@ -35,6 +37,8 @@ buildPythonApplication {
   pname = "nixos-test-driver";
   version = "1.1";
   pyproject = true;
+
+  disabled = pythonOlder "3.13";
 
   src = ./src;
 
@@ -44,25 +48,31 @@ buildPythonApplication {
 
   dependencies = [
     colorama
-    ipython
     junit-xml
-    ptpython
     pydantic
     ovmfvartool
     remote-pdb
+  ]
+  ++ lib.optionals enableRuntimeDeps [
+    ipython
+    ptpython
   ]
   ++ extraPythonPackages python.pkgs;
 
   propagatedBuildInputs = [
     coreutils
-    netpbm
-    socat
-    util-linux
-    vde2
   ]
-  ++ lib.optionals stdenv.isLinux [
-    vhost-device-vsock
-  ]
+  ++ lib.optionals enableRuntimeDeps (
+    [
+      netpbm
+      socat
+      util-linux
+      vde2
+    ]
+    ++ lib.optionals stdenv.isLinux [
+      vhost-device-vsock
+    ]
+  )
   ++ lib.optionals enableNspawn [
     systemd
   ]
@@ -74,7 +84,7 @@ buildPythonApplication {
   # containers test requires extra nix features that are not available in ofborg.
   passthru.tests = removeAttrs nixosTests.nixos-test-driver [ "containers" ];
 
-  doCheck = true;
+  doCheck = enableRuntimeDeps;
 
   nativeCheckInputs = [
     ruff

--- a/nixos/lib/test-driver/src/pyproject.toml
+++ b/nixos/lib/test-driver/src/pyproject.toml
@@ -5,6 +5,17 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "nixos-test-driver"
 version = "0.0.0"
+requires-python = ">=3.13"
+dependencies = [
+  "colorama",
+  "junit-xml",
+  "ovmfvartool",
+  "pydantic",
+  "remote-pdb",
+]
+
+[project.optional-dependencies]
+interactive = ["ipython", "ptpython"]
 
 [project.scripts]
 nixos-test-driver = "test_driver:main"

--- a/nixos/lib/test-driver/src/test_driver/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/__init__.py
@@ -5,8 +5,6 @@ import time
 import warnings
 from pathlib import Path
 
-import ptpython.ipython
-import ptpython.repl
 from colorama import Fore, Style
 
 from test_driver.debug import Debug, DebugAbstract, DebugNop
@@ -173,6 +171,9 @@ def main() -> None:
         if driver.config.enable_ssh_backdoor:
             driver.dump_machine_ssh()
         if args.interactive:
+            import ptpython.ipython
+            import ptpython.repl
+
             history_dir = os.getcwd()
             history_path = os.path.join(history_dir, ".nixos-test-history")
             ptpython.repl.enable_deprecation_warnings()

--- a/nixos/lib/testing/driver.nix
+++ b/nixos/lib/testing/driver.nix
@@ -20,6 +20,7 @@ let
   # the respective qemu version and with or without ocr support
   testDriver = config.pythonTestDriverPackage.override {
     inherit (config) enableOCR extraPythonPackages;
+    enableRuntimeDeps = true;
     enableNspawn = config.containers != { };
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11753,6 +11753,10 @@ self: super: with self; {
     nixl = pkgs.nixl.override { python3Packages = self; };
   };
 
+  nixos-test-driver = toPythonModule (
+    callPackage ../../nixos/lib/test-driver { enableRuntimeDeps = false; }
+  );
+
   nixpkgs-plugin-update = callPackage ../development/python-modules/nixpkgs-plugin-update { };
 
   nixpkgs-pytools = callPackage ../development/python-modules/nixpkgs-pytools { };


### PR DESCRIPTION
Expose the NixOS test-driver as its own python library.

This allows us to use it in a python module as well as python files,
which makes integrations into editors, lsp's, linters, and typecheckers easier/feasible.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
