### PR TITLE
sssd: enable __structuredAttrs, strictDeps

### DIFF
--- a/pkgs/by-name/ss/sssd/package.nix
+++ b/pkgs/by-name/ss/sssd/package.nix
@@ -7,6 +7,7 @@
   glibc,
   adcli,
   augeas,
+  bashNonInteractive,
   dnsutils,
   c-ares,
   curl,
@@ -67,6 +68,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "sssd";
   version = "2.13.1";
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   src = fetchFromGitHub {
     owner = "SSSD";
     repo = "sssd";
@@ -91,11 +95,17 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   separateDebugInfo = true;
 
-  # Something is looking for <libxml/foo.h> instead of <libxml2/libxml/foo.h>
-  env.NIX_CFLAGS_COMPILE = toString [
-    "-DRENEWAL_PROG_PATH=\"${adcli}/bin/adcli\""
-    "-I${libxml2.dev}/include/libxml2"
-  ];
+  env = {
+    # Something is looking for <libxml/foo.h> instead of <libxml2/libxml/foo.h>
+    NIX_CFLAGS_COMPILE = toString [
+      "-DRENEWAL_PROG_PATH=\"${adcli}/bin/adcli\""
+      "-I${libxml2.dev}/include/libxml2"
+    ];
+    KRB5_CONFIG = lib.getExe' (lib.getDev libkrb5) "krb5-config";
+    NSUPDATE = lib.getExe' dnsutils "nsupdate";
+    XMLLINT = lib.getExe' libxml2 "xmllint";
+    XSLTPROC = lib.getExe' libxslt "xsltproc";
+  };
 
   preConfigure = ''
     export SGML_CATALOG_FILES="${docbookFiles}"
@@ -134,10 +144,18 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper
     pkg-config
     doxygen
+    (python3.withPackages (
+      p: with p; [
+        setuptools
+        distutils
+        python-ldap
+      ]
+    ))
   ];
 
   buildInputs = [
     augeas
+    bashNonInteractive
     dnsutils
     c-ares
     curl
@@ -150,13 +168,6 @@ stdenv.mkDerivation (finalAttrs: {
     samba
     nfs-utils
     p11-kit
-    (python3.withPackages (
-      p: with p; [
-        setuptools
-        distutils
-        python-ldap
-      ]
-    ))
     popt
     talloc
     tdb

--- a/pkgs/by-name/ss/sssd/package.nix
+++ b/pkgs/by-name/ss/sssd/package.nix
@@ -96,10 +96,8 @@ stdenv.mkDerivation (finalAttrs: {
   separateDebugInfo = true;
 
   env = {
-    # Something is looking for <libxml/foo.h> instead of <libxml2/libxml/foo.h>
     NIX_CFLAGS_COMPILE = toString [
       "-DRENEWAL_PROG_PATH=\"${adcli}/bin/adcli\""
-      "-I${libxml2.dev}/include/libxml2"
     ];
     KRB5_CONFIG = lib.getExe' (lib.getDev libkrb5) "krb5-config";
     NSUPDATE = lib.getExe' dnsutils "nsupdate";


### PR DESCRIPTION
#178468 

## Things done

Checked output is equivalent using diffoscope

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
