### PR TITLE
python3Packages.grip: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/grip/default.nix
+++ b/pkgs/development/python-modules/grip/default.nix
@@ -16,15 +16,17 @@
   tabulate,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "grip";
   version = "4.6.1";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "joeyespo";
     repo = "grip";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-CHL2dy0H/i0pLo653F7aUHFvZHTeZA6jC/rwn1KrEW4=";
   };
 
@@ -59,6 +61,8 @@ buildPythonPackage rec {
     py.test -xm "not assumption"
   '';
 
+  pythonImportsCheck = [ "grip" ];
+
   meta = {
     description = "Preview GitHub Markdown files like Readme locally before committing them";
     mainProgram = "grip";
@@ -66,4 +70,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ koral ];
   };
-}
+})

--- a/pkgs/development/python-modules/grip/default.nix
+++ b/pkgs/development/python-modules/grip/default.nix
@@ -4,6 +4,7 @@
   fetchpatch,
   # Python bits:
   buildPythonPackage,
+  setuptools,
   pytest,
   responses,
   docopt,
@@ -18,7 +19,7 @@
 buildPythonPackage rec {
   pname = "grip";
   version = "4.6.1";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "joeyespo";
@@ -36,12 +37,14 @@ buildPythonPackage rec {
     })
   ];
 
+  build-system = [ setuptools ];
+
   nativeCheckInputs = [
     pytest
     responses
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     docopt
     flask
     markdown


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
