### PR TITLE
claude-swap: init at 0.22.0

### DIFF
--- a/pkgs/by-name/cl/claude-swap/package.nix
+++ b/pkgs/by-name/cl/claude-swap/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "claude-swap";
+  version = "0.22.0";
+  disabled = python3Packages.pythonOlder "3.12";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "realiti4";
+    repo = "claude-swap";
+    tag = "v${version}";
+    hash = "sha256-jRiICzOXSiLRxM24NEj+RCqzcDgCsLtLEc6Ge+1UpPQ=";
+  };
+
+  build-system = with python3Packages; [
+    hatchling
+  ];
+
+  dependencies = with python3Packages; [
+    keyring
+    textual
+    truststore
+  ];
+
+  pythonImportsCheck = [ "claude_swap" ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+    pytest-asyncio
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Switch between multiple Claude Code accounts, with automatic rate-limit rotation, usage dashboard, and parallel sessions";
+    homepage = "https://github.com/realiti4/claude-swap";
+    changelog = "https://github.com/realiti4/claude-swap/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    mainProgram = "cswap";
+    maintainers = [ lib.maintainers.abcsds ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
https://github.com/realiti4/claude-swap
Multi-account switcher for Claude Code with automatic rate-limit rotation, a usage dashboard, and parallel per-account sessions.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
