### PR TITLE
python3Packages.skggm: init at 0.2.8-unstable-2025-06-14

### DIFF
--- a/pkgs/development/python-modules/skggm/default.nix
+++ b/pkgs/development/python-modules/skggm/default.nix
@@ -1,0 +1,128 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  python,
+  cython,
+  joblib,
+  lapack,
+  nilearn,
+  numpy,
+  scikit-learn,
+  scipy,
+  seaborn,
+  tabulate,
+  nix-update-script,
+  pytestCheckHook,
+  flaky,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "skggm";
+  version = "0.2.8-unstable-2025-06-14";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "skggm";
+    repo = "skggm";
+    rev = "6792fe7d0079bb7c62e701921e37782a209234cb";
+    hash = "sha256-+9XxvmcWo4GMv4n+/NV/3J+pQbMkktEoy5U1c19DsEg=";
+  };
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace-fail "numpy>=1.12.1, <2.0" "numpy>=1.12.1" \
+      --replace-fail "scikit-learn>=1.1.13" "scikit-learn>=1.1.3" \
+      --replace-fail "pytest>=2.9.2" "" \
+      --replace-fail "nose>=1.3.6" "" \
+      --replace-fail "tabulate==0.7.5" "tabulate>=0.7.5"
+
+    substituteInPlace setup.cfg \
+      --replace-fail "description-file = README.md" "description_file = README.md"
+
+  ''
+  + lib.optionalString stdenv.hostPlatform.isAarch64 ''
+    substituteInPlace setup.py \
+      --replace-fail "'-msse2', " ""
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    cython
+    joblib
+    lapack
+    nilearn
+    numpy
+    scikit-learn
+    scipy
+    seaborn
+    tabulate
+  ];
+
+  # Run tests against the installed package, including the compiled pyquic
+  # extension, by copying the installed package and source tests into a
+  # temporary merged tree.
+  #
+  # Several upstream test modules are incompatible with modern scikit-learn
+  # (>=1.8) and fail at import/collection time. In particular they still do
+  # `from sklearn.utils._testing import assert_raises`, which was removed
+  # upstream. skggm has not been updated for this, so the affected
+  # test files are disabled
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    flaky
+  ];
+
+  preCheck = ''
+    sitePackages=$(echo "$out"/${python.sitePackages})
+    testRoot="$TMPDIR/test-root"
+
+    mkdir -p "$testRoot"
+    cp -r "$sitePackages/inverse_covariance" "$testRoot/"
+    cp -r inverse_covariance/tests "$testRoot/tests"
+    cp -r inverse_covariance/profiling/tests "$testRoot/profiling-tests"
+    chmod -R +w "$testRoot"
+
+    export PYTHONPATH="$testRoot:$PYTHONPATH"
+    cd "$testRoot"
+  '';
+
+  enabledTests = [
+    "tests"
+    "profiling-tests"
+  ];
+
+  disabledTestPaths = [
+    "tests/quic_graph_lasso_test.py"
+    "tests/adaptive_graph_lasso_test.py"
+    "tests/common_test.py"
+    "tests/model_average_test.py"
+    "profiling-tests/monte_carlo_profile_test.py"
+  ];
+
+  disabledTests = [
+    "integration_quic_graphical_lasso_ebic"
+    "test_has_approx_support"
+  ];
+
+  pythonImportsCheck = [ "inverse_covariance" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = "Gaussian graphical models using the scikit-learn API";
+    homepage = "https://github.com/skggm/skggm";
+    changelog = "https://github.com/skggm/skggm/commits/${finalAttrs.src.rev}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jlesquembre ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18683,6 +18683,8 @@ self: super: with self; {
 
   skein = callPackage ../development/python-modules/skein { };
 
+  skggm = callPackage ../development/python-modules/skggm { };
+
   skia-pathops = callPackage ../development/python-modules/skia-pathops { };
 
   skidl = callPackage ../development/python-modules/skidl { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
