### PR TITLE
rgp: 2.6.1 -> 2.7

### DIFF
--- a/pkgs/by-name/rg/rgp/package.nix
+++ b/pkgs/by-name/rg/rgp/package.nix
@@ -28,15 +28,15 @@
 }:
 
 let
-  buildNum = "2025-12-08-1746";
+  buildNum = "2026-05-28-1806";
 in
 stdenv.mkDerivation {
   pname = "rgp";
-  version = "2.6.1";
+  version = "2.7";
 
   src = fetchurl {
     url = "https://gpuopen.com/download/RadeonDeveloperToolSuite-${buildNum}.tgz";
-    hash = "sha256-rfFZPA8DzgP5axSHToEBvhRTgWAejn/z0WlLMectya0=";
+    hash = "sha256-hMUAo72JVfDEv8Rp0/0YZDXX7p8ioVH40WtK/PQnRb8=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Changelog: https://github.com/GPUOpen-Tools/radeon_gpu_profiler/releases/tag/v2.7

Tested that opening a trace with RGP works.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
