### PR TITLE
Kanbn: init at 0.6.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1712,6 +1712,7 @@
   ./services/web-apps/isso.nix
   ./services/web-apps/jirafeau.nix
   ./services/web-apps/jitsi-meet.nix
+  ./services/web-apps/kanbn.nix
   ./services/web-apps/kanboard.nix
   ./services/web-apps/karakeep.nix
   ./services/web-apps/kasmweb/default.nix

--- a/nixos/modules/services/web-apps/kanbn.nix
+++ b/nixos/modules/services/web-apps/kanbn.nix
@@ -1,0 +1,230 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.kanbn;
+
+  # Build the environment passed to both the migrate and web units. Only
+  # variables that are non-null are forwarded; everything else is left to
+  # the (optional) environmentFile so secrets can be kept out of the store.
+  baseEnv = {
+    PORT = toString cfg.port;
+    HOSTNAME = cfg.host;
+    NODE_ENV = "production";
+    NEXT_PUBLIC_BASE_URL = cfg.baseUrl;
+  }
+  // lib.optionalAttrs (cfg.database.url != null) {
+    POSTGRES_URL = cfg.database.url;
+  }
+  // cfg.extraEnvironment;
+
+  environmentFiles = lib.optional (cfg.environmentFile != null) cfg.environmentFile;
+in
+{
+  options.services.kanbn = {
+    enable = lib.mkEnableOption "kanbn, an open source Trello/Jira alternative";
+
+    package = lib.mkPackageOption pkgs "kanbn" { };
+
+    host = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      description = "Address the kanbn web server should bind to.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 3000;
+      description = "TCP port the kanbn web server should listen on.";
+    };
+
+    baseUrl = lib.mkOption {
+      type = lib.types.str;
+      example = "https://kanbn.example.com";
+      description = ''
+        Public base URL kanbn is reachable at. Forwarded as
+        `NEXT_PUBLIC_BASE_URL`.
+      '';
+    };
+
+    database = {
+      createLocally = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Whether to provision a local PostgreSQL database and user for
+          kanbn. When enabled, {option}`services.kanbn.database.url` is
+          set automatically to a unix-socket connection string.
+        '';
+      };
+
+      url = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "postgres://kanbn@localhost/kanbn";
+        description = ''
+          PostgreSQL connection URL passed as `POSTGRES_URL`. If null and
+          {option}`createLocally` is true, a unix-socket URL is generated
+          automatically. For secret credentials prefer
+          {option}`environmentFile`.
+        '';
+      };
+    };
+
+    environmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/run/secrets/kanbn.env";
+      description = ''
+        Path to an EnvironmentFile read by both kanbn services. Use this
+        to provide secrets such as `BETTER_AUTH_SECRET`, OAuth client
+        credentials or `POSTGRES_URL` without putting them into the
+        Nix store.
+      '';
+    };
+
+    extraEnvironment = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          NEXT_PUBLIC_DISABLE_SIGN_UP = "true";
+          LOG_LEVEL = "info";
+        }
+      '';
+      description = ''
+        Extra environment variables passed to the kanbn services. See the
+        upstream documentation and `docker-compose.yml` for the full list
+        of supported variables.
+      '';
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "kanbn";
+      description = "User the kanbn services run as.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "kanbn";
+      description = "Group the kanbn services run as.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        # kanbn cannot start without a database. POSTGRES_URL may also arrive
+        # through environmentFile (whose contents we cannot inspect), so only
+        # assert when no possible source is configured.
+        assertion =
+          cfg.database.createLocally
+          || cfg.database.url != null
+          || cfg.environmentFile != null
+          || cfg.extraEnvironment ? POSTGRES_URL;
+        message = ''
+          services.kanbn needs a PostgreSQL connection. Enable
+          services.kanbn.database.createLocally, set
+          services.kanbn.database.url, or provide POSTGRES_URL through
+          services.kanbn.environmentFile or services.kanbn.extraEnvironment.
+        '';
+      }
+    ];
+
+    # When createLocally is on, default POSTGRES_URL to a peer-auth socket
+    # connection (only if the user did not set one explicitly).
+    services.kanbn.database.url = lib.mkIf cfg.database.createLocally (
+      lib.mkDefault "postgres://${cfg.user}@localhost/kanbn?host=/run/postgresql"
+    );
+
+    services.postgresql = lib.mkIf cfg.database.createLocally {
+      enable = true;
+      ensureDatabases = [ "kanbn" ];
+      ensureUsers = [
+        {
+          name = cfg.user;
+          ensureDBOwnership = true;
+        }
+      ];
+    };
+
+    users.users.${cfg.user} = lib.mkIf (cfg.user == "kanbn") {
+      isSystemUser = true;
+      group = cfg.group;
+      description = "kanbn service user";
+    };
+    users.groups.${cfg.group} = lib.mkIf (cfg.group == "kanbn") { };
+
+    systemd.services.kanbn-migrate = {
+      description = "kanbn database migrations";
+      wantedBy = [ "multi-user.target" ];
+      before = [ "kanbn.service" ];
+      after = lib.optional cfg.database.createLocally "postgresql.target";
+      requires = lib.optional cfg.database.createLocally "postgresql.target";
+      environment = baseEnv // {
+        # drizzle-kit tries to create ~/.local/share/drizzle-studio.
+        HOME = "/tmp";
+      };
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        User = cfg.user;
+        Group = cfg.group;
+        EnvironmentFile = environmentFiles;
+        ExecStart = "${cfg.package}/bin/kanbn-migrate";
+        PrivateTmp = true;
+      };
+    };
+
+    systemd.services.kanbn = {
+      description = "kanbn web server";
+      wantedBy = [ "multi-user.target" ];
+      after = [
+        "network.target"
+        "kanbn-migrate.service"
+      ]
+      ++ lib.optional cfg.database.createLocally "postgresql.target";
+      requires = [ "kanbn-migrate.service" ];
+      environment = baseEnv;
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        EnvironmentFile = environmentFiles;
+        # bootstrap.cjs writes apps/web/public/__ENV.js at startup with the
+        # current NEXT_PUBLIC_* values, so the web tree must be writable.
+        # Copy the read-only store tree into RuntimeDirectory before starting.
+        ExecStartPre = "${pkgs.coreutils}/bin/cp -a --no-preserve=mode,ownership ${cfg.package}/lib/kanbn/web/. /run/kanbn/";
+        ExecStart = "${lib.getExe pkgs.nodejs_24} /run/kanbn/bootstrap.cjs";
+        Restart = "on-failure";
+        RestartSec = 5;
+
+        RuntimeDirectory = "kanbn";
+        RuntimeDirectoryMode = "0750";
+        StateDirectory = "kanbn";
+        WorkingDirectory = "/run/kanbn";
+
+        # Hardening
+        PrivateTmp = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictSUIDSGID = true;
+        LockPersonality = true;
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    abcsds
+    mkg20001
+  ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -868,6 +868,7 @@ in
   };
   kafka = handleTest ./kafka { };
   kaidan = runTest ./kaidan;
+  kanbn = runTest ./web-apps/kanbn.nix;
   kanboard = runTest ./web-apps/kanboard.nix;
   kanidm = runTest ./kanidm.nix;
   kanidm-provisioning = runTest ./kanidm-provisioning.nix;

--- a/nixos/tests/web-apps/kanbn.nix
+++ b/nixos/tests/web-apps/kanbn.nix
@@ -1,0 +1,109 @@
+{ lib, ... }:
+let
+  port = 3000;
+  domain = "kanban.localhost";
+in
+{
+  name = "kanbn";
+  meta.maintainers = with lib.maintainers; [
+    abcsds
+    mkg20001
+  ];
+
+  nodes.kanbn =
+    { pkgs, ... }:
+    {
+      networking.firewall.allowedTCPPorts = [
+        80
+        port
+      ];
+      # Make `kanban.localhost` resolve on the VM itself so curl can hit
+      # nginx by name (matches what an end user does in a browser).
+      networking.hosts."127.0.0.1" = [ domain ];
+
+      services.kanbn = {
+        enable = true;
+        host = "127.0.0.1";
+        inherit port;
+        baseUrl = "http://${domain}";
+        extraEnvironment = {
+          # Required by better-auth; the test does not depend on the value.
+          BETTER_AUTH_SECRET = "test-secret-test-secret-test-secret-32b";
+          # Allow email/password sign-up so the test can create a user.
+          NEXT_PUBLIC_ALLOW_CREDENTIALS = "true";
+          NEXT_PUBLIC_DISABLE_EMAIL = "true";
+          LOG_LEVEL = "info";
+        };
+      };
+
+      services.nginx = {
+        enable = true;
+        recommendedProxySettings = true;
+        virtualHosts.${domain} = {
+          locations."/" = {
+            proxyPass = "http://127.0.0.1:${toString port}";
+            proxyWebsockets = true;
+          };
+        };
+      };
+    };
+
+  testScript = ''
+    import json
+
+    kanbn.wait_for_unit("postgresql.target")
+    kanbn.wait_for_unit("kanbn-migrate.service")
+    kanbn.wait_for_unit("kanbn.service")
+    kanbn.wait_for_unit("nginx.service")
+    kanbn.wait_for_open_port(${toString port})
+    kanbn.wait_for_open_port(80)
+
+    # The landing page should render via nginx.
+    kanbn.wait_until_succeeds(
+        "curl -sSf -o /dev/null http://${domain}/",
+        timeout=120,
+    )
+
+    # Regression: kanbn's middleware redirects "/" to "/login" for self-hosted
+    # installs. The redirect must respect NEXT_PUBLIC_BASE_URL and NOT leak the
+    # internal listen address (127.0.0.1:${toString port}) back to the client,
+    # i.e. the Location header must be an absolute URL anchored at the public
+    # base URL (http://${domain}/login), regardless of which Host header the
+    # client used.
+    def location_for(url):
+        headers = kanbn.succeed(f"curl -sSI {url}")
+        for line in headers.splitlines():
+            if line.lower().startswith("location:"):
+                return line.split(":", 1)[1].strip()
+        raise AssertionError(f"no Location header for {url}: {headers}")
+
+    for url in [
+        "http://${domain}/",
+        # Bypass nginx and hit the upstream directly via Host header to make
+        # sure the redirect still points at the public origin even if the
+        # client connected to the internal listener.
+        "-H 'Host: ${domain}' http://127.0.0.1:${toString port}/",
+        "http://127.0.0.1:${toString port}/",
+    ]:
+        loc = location_for(url)
+        assert loc == "http://${domain}/login", (
+            f"redirect for {url!r} does not honor NEXT_PUBLIC_BASE_URL: {loc}"
+        )
+
+    # Sign up a user via better-auth and confirm we get back a session.
+    payload = json.dumps({
+        "email": "test@example.com",
+        "password": "hunter22hunter22",
+        "name": "Test User",
+    })
+    resp = kanbn.succeed(
+        "curl -sSf -X POST "
+        "-H 'Content-Type: application/json' "
+        f"-d {json.dumps(payload)} "
+        "http://${domain}/api/auth/sign-up/email"
+    )
+    data = json.loads(resp)
+    assert "user" in data, f"sign-up did not return a user: {data}"
+    assert data["user"]["email"] == "test@example.com", data
+  '';
+}

--- a/pkgs/by-name/ka/kanbn/package.nix
+++ b/pkgs/by-name/ka/kanbn/package.nix
@@ -1,0 +1,154 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  nixosTests,
+  nodejs_24,
+  pnpm_10,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  makeWrapper,
+  plus-jakarta-sans,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "kanbn";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "kanbn";
+    repo = "kan";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-I3jcCfvqSCTxbi3mfFb/ocRchz2jSBP/hQYUwtyYF+c=";
+  };
+
+  patches = [
+    ./respect-base-url-in-login-redirect.patch
+    ./use-local-plus-jakarta-sans.patch
+  ];
+
+  postPatch = ''
+    # use-local-plus-jakarta-sans.patch switches _app.tsx from next/font/google
+    # to next/font/local; drop the TTF it references next to the source.
+    mkdir -p apps/web/src/fonts
+    cp ${plus-jakarta-sans}/share/fonts/truetype/PlusJakartaSans-Regular.ttf \
+      apps/web/src/fonts/PlusJakartaSans.ttf
+
+    # Widen engines.pnpm ("^9.14.2") so the bundled pnpm (>=10) is accepted;
+    # the v9 lockfile is read unchanged. Mirrors fetchPnpmDeps.prePnpmInstall.
+    sed -i -E 's/("pnpm": ")\^?[0-9][^"]*(")/\1>=9\2/' package.json
+  '';
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    nodejs_24
+    pnpm_10
+    pnpmConfigHook
+    makeWrapper
+  ];
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm_10;
+    fetcherVersion = 3;
+    # Upstream pins engines.pnpm to "^9.14.2"; nixpkgs only ships supported
+    # (non-EOL) pnpm from 10 onwards, which reads the v9 lockfile fine. Widen
+    # the engine range so install does not hard-fail on the major mismatch.
+    prePnpmInstall = ''
+      sed -i -E 's/("pnpm": ")\^?[0-9][^"]*(")/\1>=9\2/' package.json
+    '';
+    hash = "sha256-usaG3PaEB8J5adutSGM0u3RVbN6UyacebNQYnkhDMaM=";
+  };
+
+  env = {
+    # Force the standalone Next.js output, matching the upstream Dockerfile.
+    NEXT_PUBLIC_USE_STANDALONE_OUTPUT = "true";
+    NEXT_PUBLIC_APP_VERSION = finalAttrs.version;
+    CI = "true";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    pushd apps/web
+    pnpm exec next build --turbopack
+    popd
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/doc/kanbn
+    cp README.md LICENSE $out/share/doc/kanbn/ || true
+
+    LIB=$out/lib/kanbn
+    mkdir -p $LIB
+
+    # --- Web (Next.js standalone) -------------------------------------------
+    # Layout matches what apps/web/bootstrap.cjs expects: it requires
+    # ./apps/web/server.js relative to its own location and writes to
+    # ./apps/web/public/__ENV.js .
+    mkdir -p $LIB/web
+    cp -a apps/web/.next/standalone/. $LIB/web/
+    mkdir -p $LIB/web/apps/web/.next
+    cp -a apps/web/.next/static $LIB/web/apps/web/.next/static
+    cp -a apps/web/public $LIB/web/apps/web/public
+    cp apps/web/bootstrap.cjs $LIB/web/bootstrap.cjs
+
+    # --- DB migrations ------------------------------------------------------
+    # Ship the drizzle config + migrations together with the relevant
+    # node_modules so `drizzle-kit migrate` can run at deploy time.
+    mkdir -p $LIB/db
+    cp packages/db/drizzle.config.ts $LIB/db/
+    cp -a packages/db/migrations $LIB/db/migrations
+    cp -a packages/db/src $LIB/db/src
+    cp -a node_modules $LIB/db/node_modules
+
+    # --- Wrappers -----------------------------------------------------------
+    mkdir -p $out/bin
+
+    makeWrapper ${lib.getExe nodejs_24} $out/bin/kanbn \
+      --add-flags "$LIB/web/bootstrap.cjs" \
+      --set-default HOSTNAME "0.0.0.0" \
+      --set-default PORT "3000" \
+      --set NODE_ENV "production"
+
+    makeWrapper ${lib.getExe nodejs_24} $out/bin/kanbn-migrate \
+      --add-flags "$LIB/db/node_modules/.bin/drizzle-kit" \
+      --add-flags "migrate" \
+      --chdir "$LIB/db"
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    # Drop large build-only dependencies that are not needed at runtime by
+    # the standalone server.
+    rm -rf $out/lib/kanbn/db/node_modules/{@next,next,@swc,turbo,@turbo} || true
+    # Remove broken symlinks left over from pruning.
+    find $out/lib/kanbn -type l ! -exec test -e {} \; -delete
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = { inherit (nixosTests) kanbn; };
+  };
+
+  meta = {
+    description = "Open source alternative to Trello, Asana and Jira";
+    homepage = "https://kan.bn";
+    changelog = "https://github.com/kanbn/kan/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [
+      abcsds
+      mkg20001
+    ];
+    mainProgram = "kanbn";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/ka/kanbn/respect-base-url-in-login-redirect.patch
+++ b/pkgs/by-name/ka/kanbn/respect-base-url-in-login-redirect.patch
@@ -1,0 +1,22 @@
+Anchor the "/" -> "/login" redirect on NEXT_PUBLIC_BASE_URL when it is set.
+
+Upstream builds the redirect URL from `request.url`, which yields a *relative*
+`Location` header. Browsers then resolve that against whatever host the client
+typed (often localhost), so a request via the public hostname can end up on
+localhost behind a reverse proxy. When NEXT_PUBLIC_BASE_URL is set we always
+emit an absolute URL pointing at the configured public origin.
+
+--- a/apps/web/src/middleware.ts
++++ b/apps/web/src/middleware.ts
+@@ -5,7 +5,10 @@
+ export function middleware(request: NextRequest) {
+   if (request.nextUrl.pathname === "/") {
+     if (env("NEXT_PUBLIC_KAN_ENV") !== "cloud") {
+-      const loginUrl = new URL("/login", request.url);
++      const loginUrl = new URL(
++        "/login",
++        env("NEXT_PUBLIC_BASE_URL") ?? request.url,
++      );
+       return NextResponse.redirect(loginUrl);
+     }
+   }

--- a/pkgs/by-name/ka/kanbn/use-local-plus-jakarta-sans.patch
+++ b/pkgs/by-name/ka/kanbn/use-local-plus-jakarta-sans.patch
@@ -1,0 +1,29 @@
+Load Plus Jakarta Sans from a local TTF instead of next/font/google.
+
+The Nix build sandbox has no network access, so the default `next/font/google`
+call fails during `next build`. Swap it for `next/font/local` and reference a
+TTF that the package's postPatch drops into `apps/web/src/fonts/` from the
+plus-jakarta-sans nixpkg.
+
+--- a/apps/web/src/pages/_app.tsx
++++ b/apps/web/src/pages/_app.tsx
+@@ -4,7 +4,7 @@
+ import type { NextPage, Viewport } from "next";
+ import type { AppProps, AppType } from "next/app";
+ import type { ReactElement, ReactNode } from "react";
+-import { Plus_Jakarta_Sans } from "next/font/google";
++import localFont from "next/font/local";
+ import Script from "next/script";
+ import { env } from "next-runtime-env";
+ import { ThemeProvider } from "next-themes";
+@@ -19,8 +19,8 @@
+ import { PopupProvider } from "~/providers/popup";
+ import { api } from "~/utils/api";
+
+-const jakarta = Plus_Jakarta_Sans({
+-  subsets: ["latin"],
++const jakarta = localFont({
++  src: "../fonts/PlusJakartaSans.ttf",
+   display: "swap",
+ });
+


### PR DESCRIPTION
Adds Kan (github.com/kanbn/kan), an open-source, self-hostable Trello/Asana/Jira alternative written in TypeScript and built as a Next.js + tRPC standalone server backed by PostgreSQL (AGPL-3.0).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
