### PR TITLE
radicle-explorer: decouple src from radicle-httpd; radicle-httpd: 0.25.0 -> 0.26.0

### DIFF
--- a/pkgs/by-name/ra/radicle-explorer/package.nix
+++ b/pkgs/by-name/ra/radicle-explorer/package.nix
@@ -1,9 +1,12 @@
 {
   lib,
   buildNpmPackage,
+  fetchFromRadicle,
   fetchFromGitHub,
-  radicle-httpd,
   writers,
+  _experimental-update-script-combinators,
+  unstableGitUpdater,
+  nix-update-script,
 }:
 
 let
@@ -20,18 +23,16 @@ in
 
 buildNpmPackage (finalAttrs: {
   pname = "radicle-explorer";
-  inherit (radicle-httpd) version;
+  version = "0-unstable-2026-07-16";
 
-  # radicle-explorer uses the radicle-httpd API, and they are developed in the
-  # same repo. For this reason we pin the sources to each other, but due to
-  # radicle-httpd using a more limited sparse checkout we need to carry a
-  # separate hash.
-  src = radicle-httpd.src.override {
-    hash = "sha256-cnQsPWkRChC8yPrICRoUpGW2GGLB2TK9+3v8ZRGe3x0=";
-    sparseCheckout = [ ];
+  src = fetchFromRadicle {
+    seed = "seed.radicle.dev";
+    repo = "z4V1sjrXqjvFdnCUbxPFqd5p4DtH5";
+    rev = "3c2935704f5767d60b3caf609ef772948bbecb10";
+    hash = "sha256-EpHKuFNgRLwCVdDDRKjPJEvfDpS9qka75B2fQEVc1ns=";
   };
 
-  npmDepsHash = "sha256-8vmAs788PjdUTaQ5E8YLX0KiIPymJbH51oNaGZACe6I=";
+  npmDepsHash = "sha256-74r7cyggbuva9XpW++HdAHHFqEBJ6BgNuJJUR+8HE4c=";
 
   postPatch = ''
     patchShebangs --build ./scripts
@@ -73,6 +74,11 @@ buildNpmPackage (finalAttrs: {
   passthru.withConfig =
     config:
     finalAttrs.finalPackage.overrideAttrs { configFile = writers.writeJSON "config.json" config; };
+
+  passthru.updateScript = _experimental-update-script-combinators.sequence [
+    (unstableGitUpdater { hardcodeZeroVersion = true; })
+    (nix-update-script { extraArgs = [ "--version=skip" ]; })
+  ];
 
   meta = {
     description = "Web frontend for Radicle";

--- a/pkgs/by-name/ra/radicle-httpd/package.nix
+++ b/pkgs/by-name/ra/radicle-httpd/package.nix
@@ -19,7 +19,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   env.RADICLE_VERSION = finalAttrs.version;
 
-  # You must update the radicle-explorer source hash when changing this.
   src = fetchFromRadicle {
     seed = "seed.radicle.dev";
     repo = "z4V1sjrXqjvFdnCUbxPFqd5p4DtH5";

--- a/pkgs/by-name/ra/radicle-httpd/package.nix
+++ b/pkgs/by-name/ra/radicle-httpd/package.nix
@@ -15,7 +15,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "radicle-httpd";
-  version = "0.25.0";
+  version = "0.26.0";
 
   env.RADICLE_VERSION = finalAttrs.version;
 
@@ -23,13 +23,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
     seed = "seed.radicle.dev";
     repo = "z4V1sjrXqjvFdnCUbxPFqd5p4DtH5";
     tag = "releases/${finalAttrs.version}";
-    sparseCheckout = [ "radicle-httpd" ];
-    hash = "sha256-gejNiCQ511OGGItmqXoyB+TmsUw+ozoEmOWooBXBkQ8=";
+    nonConeMode = true;
+    sparseCheckout = [
+      "/crates"
+      "/Cargo.toml"
+      "/Cargo.lock"
+    ];
+    hash = "sha256-zSU8B5IwOEUS9d4Y/UWJ6eD0p3zvp0nWVgJmZ/kVB1Q=";
   };
 
-  sourceRoot = "${finalAttrs.src.name}/radicle-httpd";
-
-  cargoHash = "sha256-Oawin/2R5dZ46pf3SarwNgILF9dXSkw02Z4gYQ4HtzE=";
+  cargoHash = "sha256-rdW+WLkQ4UEn6hRZfgJhJkJWb7A26MayXVnVwAlLAG8=";
 
   nativeBuildInputs = [
     asciidoctor
@@ -77,7 +80,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       repositories on a Radicle node via their web browser.
     '';
     homepage = "https://radicle.dev";
-    changelog = "https://radicle.network/nodes/seed.radicle.dev/rad:z4V1sjrXqjvFdnCUbxPFqd5p4DtH5/tree/radicle-httpd/CHANGELOG.md";
+    changelog = "https://radicle.network/nodes/seed.radicle.dev/rad:z4V1sjrXqjvFdnCUbxPFqd5p4DtH5/tree/CHANGELOG.md";
     # cargo.toml says MIT and asl20, LICENSE file says GPL3
     license = with lib.licenses; [
       gpl3Only

--- a/pkgs/by-name/ra/radicle-httpd/update.sh
+++ b/pkgs/by-name/ra/radicle-httpd/update.sh
@@ -3,4 +3,3 @@
 
 version=$(list-git-tags | grep -oP '^releases/\K\d+\.\d+\.\d+$' | sort -rV | head -1)
 nix-update --version="$version" radicle-httpd
-nix-update --version=skip radicle-explorer


### PR DESCRIPTION
Changelog: https://radicle.network/nodes/seed.radicle.dev/rad:z4V1sjrXqjvFdnCUbxPFqd5p4DtH5/tree/CHANGELOG.md

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
