### PR TITLE
wawa: init at 0.1.0

### DIFF
--- a/pkgs/by-name/wa/wawa/package.nix
+++ b/pkgs/by-name/wa/wawa/package.nix
@@ -1,0 +1,52 @@
+{
+  stdenv,
+  fetchFromCodeberg,
+  lib,
+  pkg-config,
+  wayland-scanner,
+  wayland,
+  wayland-protocols,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "wawa";
+  version = "0.1.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromCodeberg {
+    owner = "sewn";
+    repo = "wawa";
+    rev = finalAttrs.version;
+    hash = "sha256-F7nPXi1zBnfNKSeZ2oQnGlfoJmKeSictPylpDBJtSRw=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    wayland
+    wayland-protocols
+  ];
+
+  env.NIX_CFLAGS_COMPILE = "-O3 -Wno-error=incompatible-pointer-types";
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "WAYLAND_SCANNER=wayland-scanner"
+  ];
+
+  meta = {
+    description = "Distinctive simpler wlroots wallpaper setter";
+    longDescription = ''
+      A simple, hackable, and distinctive Wayland wallpaper setter utilizing stb_image that targets wlr-layer-shell supported compositors, featuring tiling, spreading across monitors, along with fill, fit and stretching the wallpaper, with less SLOC than your average wallpaper setter.
+    '';
+    homepage = "https://codeberg.org/sewn/wawa";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ vavakado ];
+    mainProgram = "wawa";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

A simple and minimal wayland wallpaper setter.

https://codeberg.org/sewn/wawa

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
