### PR TITLE
lesscpy: fix build after pkg_resources removal

### DIFF
--- a/pkgs/by-name/le/lesscpy/package.nix
+++ b/pkgs/by-name/le/lesscpy/package.nix
@@ -2,6 +2,7 @@
   lib,
   python3Packages,
   fetchPypi,
+  fetchpatch,
 }:
 
 python3Packages.buildPythonPackage rec {
@@ -13,6 +14,14 @@ python3Packages.buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-EEXRepj2iGRsp1jf8lTm6cA3RWSOBRoIGwOVw7d8gkw=";
   };
+
+  patches = [
+    # remove use of pkg_resources (drop on next release)
+    (fetchpatch {
+      url = "https://github.com/lesscpy/lesscpy/commit/bd8949579713c9d4ff9e15799a26fcecdf73530e.patch";
+      hash = "sha256-U1VDqZqHYaUmND5qCkARyU/eDv2QRhGcCDzuN4+XTbo=";
+    })
+  ];
 
   build-system = with python3Packages; [ setuptools ];
 


### PR DESCRIPTION


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
