### PR TITLE
emacs: bump elisp packages

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
@@ -5492,10 +5492,10 @@
     elpaBuild {
       pname = "lisp-ts-mode";
       ename = "lisp-ts-mode";
-      version = "0.2.1.0.20260711.3";
+      version = "0.3.0.0.20260720.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/lisp-ts-mode-0.2.1.0.20260711.3.tar";
-        sha256 = "1ihjb14qz1kmz02p7zpvr0vq75f28lp6win60xw0d6y12gks60f9";
+        url = "https://elpa.gnu.org/devel/lisp-ts-mode-0.3.0.0.20260720.0.tar";
+        sha256 = "09xnsw5rsvkwx8dvxw9m60fc3pwk21r0iydm0r55bj7sksb6z7id";
       };
       packageRequires = [
         compat

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
@@ -9,10 +9,10 @@
     elpaBuild {
       pname = "a68-mode";
       ename = "a68-mode";
-      version = "1.3.0.20260614.1";
+      version = "1.3.0.20260710.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/a68-mode-1.3.0.20260614.1.tar";
-        sha256 = "1b51c2v7sx8g4mm2irm43rgb741syphji6cglpv1r3j9wvcpj58k";
+        url = "https://elpa.gnu.org/devel/a68-mode-1.3.0.20260710.2.tar";
+        sha256 = "10qxsr316kv8317zfjwixj7pmsrqykycwf6pmw0wiv8w0vq0v9jr";
       };
       packageRequires = [ ];
       meta = {
@@ -74,10 +74,10 @@
     elpaBuild {
       pname = "activities";
       ename = "activities";
-      version = "0.80.20251118.222434";
+      version = "0.8pre0.20251118.85";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/activities-0.80.20251118.222434.tar";
-        sha256 = "19h5c1cpmxl1j0k6yicy3gw10wcnc3likb1q0frwchw8vnp7bx96";
+        url = "https://elpa.gnu.org/devel/activities-0.8pre0.20251118.85.tar";
+        sha256 = "0v0s5vlfd2dv4shbmxqn37mcvfmfszdk0nwi1y184hwsp0bkvzqx";
       };
       packageRequires = [ persist ];
       meta = {
@@ -461,10 +461,10 @@
     elpaBuild {
       pname = "auctex";
       ename = "auctex";
-      version = "14.1.2.0.20260623.43";
+      version = "14.1.2.0.20260710.47";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/auctex-14.1.2.0.20260623.43.tar";
-        sha256 = "0csk0k8njms3dn2ijbsvm9g78k6yvdxgcdcibj79acllzslhnwis";
+        url = "https://elpa.gnu.org/devel/auctex-14.1.2.0.20260710.47.tar";
+        sha256 = "0vlx2mi7fvch1h6s2cyjrwk88zib8l5cmzwh9z0i0z6pgnx5d7nq";
       };
       packageRequires = [ ];
       meta = {
@@ -505,10 +505,10 @@
     elpaBuild {
       pname = "auctex-label-numbers";
       ename = "auctex-label-numbers";
-      version = "0.2.0.20241019.12742";
+      version = "0.3.0.20260714.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/auctex-label-numbers-0.2.0.20241019.12742.tar";
-        sha256 = "0y4y8267r3bmwshcb5qkfrpnaxs1zwy1rwdhngjci005n68bslk9";
+        url = "https://elpa.gnu.org/devel/auctex-label-numbers-0.3.0.20260714.1.tar";
+        sha256 = "1bqw342873z0cpjg6lg3inscbjilwrgm0dgd9bhc7bb8mas7hkaj";
       };
       packageRequires = [ auctex ];
       meta = {
@@ -740,10 +740,10 @@
     elpaBuild {
       pname = "bicep-ts-mode";
       ename = "bicep-ts-mode";
-      version = "0.1.4.0.20260619.82";
+      version = "0.1.4.0.20260720.83";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/bicep-ts-mode-0.1.4.0.20260619.82.tar";
-        sha256 = "0rf10gab6vfrmiwcvm6b6cb0a3vlaydc4cgfpq34na9czqn760r0";
+        url = "https://elpa.gnu.org/devel/bicep-ts-mode-0.1.4.0.20260720.83.tar";
+        sha256 = "19k83fn4i2vvvad6pz865ns165vpd9msa1cnjhmlcfv5cxsa7wk3";
       };
       packageRequires = [ ];
       meta = {
@@ -902,10 +902,10 @@
     elpaBuild {
       pname = "breadcrumb";
       ename = "breadcrumb";
-      version = "1.0.1.0.20260507.73535";
+      version = "1.0.1.0.20260630.15";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/breadcrumb-1.0.1.0.20260507.73535.tar";
-        sha256 = "1ccx08zczmkgdm9xb1bnz0v4a4yrf3zy5nnfyax57anw3m8yliz2";
+        url = "https://elpa.gnu.org/devel/breadcrumb-1.0.1.0.20260630.15.tar";
+        sha256 = "12l1bi4gynmgfffbj7w6za21a3n6776iqixm33rh7zkbzfhafvxl";
       };
       packageRequires = [ project ];
       meta = {
@@ -1106,10 +1106,10 @@
     elpaBuild {
       pname = "cape";
       ename = "cape";
-      version = "2.7.0.20260519.102137";
+      version = "2.7.0.20260628.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/cape-2.7.0.20260519.102137.tar";
-        sha256 = "1ilx7ka6vx2xv0xfmc4sbjf8nqsgxd4vzj5r417ckmpfb4vnpa18";
+        url = "https://elpa.gnu.org/devel/cape-2.7.0.20260628.1.tar";
+        sha256 = "1hbwh1752p1rjh4csn6vs4k9bv2qxa0ms6s914aclx72slqa2qvj";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1414,10 +1414,10 @@
     elpaBuild {
       pname = "company";
       ename = "company";
-      version = "1.0.2.0.20260618.138";
+      version = "1.0.2.0.20260718.178";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/company-1.0.2.0.20260618.138.tar";
-        sha256 = "072y63bvpq6falkg3yqv8smhkba2nqlw6crm5809pqrihfm8ybii";
+        url = "https://elpa.gnu.org/devel/company-1.0.2.0.20260718.178.tar";
+        sha256 = "15ymhxywy9kh33rpjrbnn6h545hkwgqcc7mbjpjp7p2kghh1xndj";
       };
       packageRequires = [ posframe ];
       meta = {
@@ -1509,10 +1509,10 @@
     elpaBuild {
       pname = "compat";
       ename = "compat";
-      version = "31.0.0.1.0.20260606.2";
+      version = "31.0.0.2.0.20260716.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/compat-31.0.0.1.0.20260606.2.tar";
-        sha256 = "1bziwppgl138pf65q9jbw3c8xsarik9617fnqw3wnp3hlkg39b4m";
+        url = "https://elpa.gnu.org/devel/compat-31.0.0.2.0.20260716.2.tar";
+        sha256 = "179w1zim5nfj1crvc2qm9ipvwwh2yr9q3rs8wjffcvsfjipnym5d";
       };
       packageRequires = [ ];
       meta = {
@@ -1573,10 +1573,10 @@
     elpaBuild {
       pname = "consult";
       ename = "consult";
-      version = "3.6.0.20260607.1";
+      version = "3.6.0.20260716.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/consult-3.6.0.20260607.1.tar";
-        sha256 = "02z3cdzf2lyis0a5kc8vcyas8ycz8gfli7hiahx6zc7dyd94mi9s";
+        url = "https://elpa.gnu.org/devel/consult-3.6.0.20260716.5.tar";
+        sha256 = "1hn04wqdbdbrim1idbcqj9b0lkicghhyaba0jpw7zdw682hfjcaf";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1596,10 +1596,10 @@
     elpaBuild {
       pname = "consult-denote";
       ename = "consult-denote";
-      version = "0.5.0.0.20260520.122738";
+      version = "0.5.1.0.20260704.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/consult-denote-0.5.0.0.20260520.122738.tar";
-        sha256 = "19y5vd4j1ndnxr5z7fz8ghxs5ra0y9d0qca2npglcmzy5l6zsaga";
+        url = "https://elpa.gnu.org/devel/consult-denote-0.5.1.0.20260704.0.tar";
+        sha256 = "0bfy6gzznxg356s1nqrv5ma26rlb9njf12dbkma6glpr8l7gpavv";
       };
       packageRequires = [
         consult
@@ -1686,10 +1686,10 @@
     elpaBuild {
       pname = "corfu";
       ename = "corfu";
-      version = "2.10.0.20260519.105314";
+      version = "2.10.0.20260719.16";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/corfu-2.10.0.20260519.105314.tar";
-        sha256 = "15ajzvqjw61rqp6gb275x81d4bl8dsj04lzl84cjj8khf3m1jrcp";
+        url = "https://elpa.gnu.org/devel/corfu-2.10.0.20260719.16.tar";
+        sha256 = "0h3mjsfk8zsviqcqccql4pcj87ja0am78ag3q2w8jw77bqvk5s4a";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1903,10 +1903,10 @@
     elpaBuild {
       pname = "cursory";
       ename = "cursory";
-      version = "1.2.0.0.20260424.102447";
+      version = "1.2.0.0.20260701.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/cursory-1.2.0.0.20260424.102447.tar";
-        sha256 = "14yaa5bay9asyvhkq8bj3fhbzrhry6pc87vhw4gm64ixm9k499g5";
+        url = "https://elpa.gnu.org/devel/cursory-1.2.0.0.20260701.4.tar";
+        sha256 = "0087hsy0qzzlhj7zsasmc6x41w6gnh21sb0in7zyahy2x0qrqwi4";
       };
       packageRequires = [ ];
       meta = {
@@ -1967,10 +1967,10 @@
     elpaBuild {
       pname = "dape";
       ename = "dape";
-      version = "0.27.1.0.20260602.5";
+      version = "0.27.1.0.20260719.8";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dape-0.27.1.0.20260602.5.tar";
-        sha256 = "0vy4b8p9wys1rj7rra87p9yld9d8szlg0y77ls1hnq2lqnsxvyqd";
+        url = "https://elpa.gnu.org/devel/dape-0.27.1.0.20260719.8.tar";
+        sha256 = "08y9z6l5qirz812v0wz1y3fklsqj9b0476scl2ziq8mvjdkv37bq";
       };
       packageRequires = [ jsonrpc ];
       meta = {
@@ -2101,10 +2101,10 @@
     elpaBuild {
       pname = "denote";
       ename = "denote";
-      version = "4.2.3.0.20260611.3";
+      version = "4.2.3.0.20260707.7";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-4.2.3.0.20260611.3.tar";
-        sha256 = "0cg6zk2sz6dbss0z6is17xri4mzqkx7m1pbxr4f2fzhh59wk93ww";
+        url = "https://elpa.gnu.org/devel/denote-4.2.3.0.20260707.7.tar";
+        sha256 = "0yrqdz1znd5nkrwqiwrzgsgb7d1yysqmy1lr05r2yj3rlfzhcnvi";
       };
       packageRequires = [ ];
       meta = {
@@ -2277,10 +2277,10 @@
     elpaBuild {
       pname = "denote-silo";
       ename = "denote-silo";
-      version = "0.3.0.0.20260520.122913";
+      version = "0.3.2.0.20260705.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-silo-0.3.0.0.20260520.122913.tar";
-        sha256 = "0dx6nhjga8mq5g0db24jjzlvdy218bh2yszasjls101nf9ksc3hy";
+        url = "https://elpa.gnu.org/devel/denote-silo-0.3.2.0.20260705.4.tar";
+        sha256 = "08zgg8jll6kdmzqrzx2j0q0g35sk6sfbp6qxd687sc8p9n9bx4yg";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2363,10 +2363,10 @@
     elpaBuild {
       pname = "dicom";
       ename = "dicom";
-      version = "1.5.0.20260605.1";
+      version = "1.5.0.20260704.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dicom-1.5.0.20260605.1.tar";
-        sha256 = "1lasbqwkgd74jck88525nx76da7535s2m15c47awjpr2hhbwra89";
+        url = "https://elpa.gnu.org/devel/dicom-1.5.0.20260704.4.tar";
+        sha256 = "0b5mm81wfskhls44w951igz2y5yf4lx3g61fswyk9hjhm4sccgz5";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2413,10 +2413,10 @@
     elpaBuild {
       pname = "diff-hl";
       ename = "diff-hl";
-      version = "1.10.0.0.20260624.182";
+      version = "1.10.0.0.20260627.186";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/diff-hl-1.10.0.0.20260624.182.tar";
-        sha256 = "1gppg1sqc4gwc9szl83zbaw1hk140zqw9sy275cl85v7bd4wdvja";
+        url = "https://elpa.gnu.org/devel/diff-hl-1.10.0.0.20260627.186.tar";
+        sha256 = "0anq2hcihzsm3ff0g0smk8w72x5fi3frqymbm1dci679ssx4316v";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -2710,10 +2710,10 @@
     elpaBuild {
       pname = "doc-view-follow";
       ename = "doc-view-follow";
-      version = "0.3.2.0.20250427.143824";
+      version = "0.3.2.0.20260708.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/doc-view-follow-0.3.2.0.20250427.143824.tar";
-        sha256 = "04jk93rkv682w6zcfr283gpwgi5fiq5w3xdpv49zkwddx783crfa";
+        url = "https://elpa.gnu.org/devel/doc-view-follow-0.3.2.0.20260708.1.tar";
+        sha256 = "0xyd9w7fqaj22dp43788gm5i7rzbhch2sh2mmarhyw4xp9a7j83w";
       };
       packageRequires = [ ];
       meta = {
@@ -2752,10 +2752,10 @@
     elpaBuild {
       pname = "doric-themes";
       ename = "doric-themes";
-      version = "1.1.0.0.20260618.8";
+      version = "1.2.1.0.20260716.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/doric-themes-1.1.0.0.20260618.8.tar";
-        sha256 = "11ck5y66zh9lwiiqmxfh1w4s5k8irvncmd6zsanhh8wb2fd9wms8";
+        url = "https://elpa.gnu.org/devel/doric-themes-1.2.1.0.20260716.2.tar";
+        sha256 = "00jysh555i53hx32drdfwc25bf09jq4hm0q6w2q9h2pzrk8wmk85";
       };
       packageRequires = [ ];
       meta = {
@@ -2774,10 +2774,10 @@
     elpaBuild {
       pname = "drepl";
       ename = "drepl";
-      version = "0.4.0.20260520.140843";
+      version = "0.4.0.20260715.8";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/drepl-0.4.0.20260520.140843.tar";
-        sha256 = "0apa8fi1j1wkjnjxfsyyf8k21na4q7fvlg6baz2y2aaqisfykqlh";
+        url = "https://elpa.gnu.org/devel/drepl-0.4.0.20260715.8.tar";
+        sha256 = "01gbl3gqrlz2gimmjsk0nb6zyps8a89z96bwrxqfjph6w13d33gw";
       };
       packageRequires = [ comint-mime ];
       meta = {
@@ -3004,10 +3004,10 @@
     elpaBuild {
       pname = "eglot";
       ename = "eglot";
-      version = "1.23.0.20260622.30";
+      version = "1.24.0.20260623.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/eglot-1.23.0.20260622.30.tar";
-        sha256 = "0ignlpfdlxjk0z66z8gq2paffm2r874wajf94b1r61xa1mmf63nn";
+        url = "https://elpa.gnu.org/devel/eglot-1.24.0.20260623.0.tar";
+        sha256 = "16zcxb2xfxfxppkr0l00h72q5wgww6bi66zqf76h1j84k295mjwv";
       };
       packageRequires = [
         eldoc
@@ -3080,10 +3080,10 @@
     elpaBuild {
       pname = "eldoc";
       ename = "eldoc";
-      version = "1.16.0.0.20260514.100530";
+      version = "1.16.0.0.20260709.6";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/eldoc-1.16.0.0.20260514.100530.tar";
-        sha256 = "00pmjqjljxwr5n69h8pqc4yxsdl9pq1d2djlzbvs0cl99xgn7sjb";
+        url = "https://elpa.gnu.org/devel/eldoc-1.16.0.0.20260709.6.tar";
+        sha256 = "0i3bls6iq0lm03w09vrillqygx8xx9xpf2ixr8k2q3my4g8kszqx";
       };
       packageRequires = [ ];
       meta = {
@@ -3178,10 +3178,10 @@
     elpaBuild {
       pname = "ellama";
       ename = "ellama";
-      version = "1.27.2.0.20260605.1";
+      version = "1.30.0.0.20260712.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ellama-1.27.2.0.20260605.1.tar";
-        sha256 = "1vklfqrrygamgyr2f9ndnrwyxxvgai2431bvywxiwwgh8lk937hg";
+        url = "https://elpa.gnu.org/devel/ellama-1.30.0.0.20260712.1.tar";
+        sha256 = "0gn0jgi3li4ycqwjk2bbfwp47awxkr5pscyxpnxyy1qbjlv77s4d";
       };
       packageRequires = [
         compat
@@ -3247,10 +3247,10 @@
     elpaBuild {
       pname = "emacs-lisp-intro-nl";
       ename = "emacs-lisp-intro-nl";
-      version = "0.0.20260529.43";
+      version = "0.0.20260702.44";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/emacs-lisp-intro-nl-0.0.20260529.43.tar";
-        sha256 = "1aisy3awq830i3bwzyd508w96vcr8igy0gcv9j2mvfa8fzzh0m56";
+        url = "https://elpa.gnu.org/devel/emacs-lisp-intro-nl-0.0.20260702.44.tar";
+        sha256 = "1xsnp0pfsvs20wscbqcqsigl56ig5vacmkl86f3ljp338ka90d5f";
       };
       packageRequires = [ ];
       meta = {
@@ -3325,10 +3325,10 @@
     elpaBuild {
       pname = "ement";
       ename = "ement";
-      version = "0.180.20251117.191748";
+      version = "0.18pre0.20251117.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ement-0.180.20251117.191748.tar";
-        sha256 = "12464sywsxwnhc0mpkcqy0wsvjig5q6g2pqa985vnk3vygx7w9gz";
+        url = "https://elpa.gnu.org/devel/ement-0.18pre0.20251117.1.tar";
+        sha256 = "0d5cgm00qq6rclpq63jkn8677kkhbql79xg6isij39d7nhrkfyp1";
       };
       packageRequires = [
         map
@@ -3446,10 +3446,10 @@
     elpaBuild {
       pname = "erc";
       ename = "erc";
-      version = "5.70.20260605.12";
+      version = "5.7snapshot0.20260630.20";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/erc-5.70.20260605.12.tar";
-        sha256 = "0nxvjbmy9lf4px6p4ndkwxn32540s841byn5zb8vnc238al8h2k5";
+        url = "https://elpa.gnu.org/devel/erc-5.7snapshot0.20260630.20.tar";
+        sha256 = "0b8nibq9xrs6y0ia99fvf2vxx8wkvkj4vygzswb7130fdf7s3r5l";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3609,10 +3609,10 @@
     elpaBuild {
       pname = "exwm";
       ename = "exwm";
-      version = "0.34.0.20260623.71";
+      version = "0.35.0.20260718.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/exwm-0.34.0.20260623.71.tar";
-        sha256 = "1mwi57r477xv3wg8ninlsf7k1jdl4f38i85p55r8xqa54hsgmr8s";
+        url = "https://elpa.gnu.org/devel/exwm-0.35.0.20260718.3.tar";
+        sha256 = "1kk9ggm9q32rz5dld2w2znpifwpjcncn7ih19rkw3bfd2q8bgirg";
       };
       packageRequires = [
         compat
@@ -3655,10 +3655,10 @@
     elpaBuild {
       pname = "ffs";
       ename = "ffs";
-      version = "0.2.30.20260522.94521";
+      version = "0.2.3snapshot0.20260522.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ffs-0.2.30.20260522.94521.tar";
-        sha256 = "0y8rsj2b6sjs9pai9swk18g72ms71lvv28zaw55v69dl1wjchvfc";
+        url = "https://elpa.gnu.org/devel/ffs-0.2.3snapshot0.20260522.1.tar";
+        sha256 = "1csx6sxdi4aa68ajjbgfymb1y2l3n6w1ig566n1lhxkpn2mh5xji";
       };
       packageRequires = [ ];
       meta = {
@@ -3764,10 +3764,10 @@
     elpaBuild {
       pname = "flymake";
       ename = "flymake";
-      version = "1.4.5.0.20260512.154242";
+      version = "1.4.5.0.20260702.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/flymake-1.4.5.0.20260512.154242.tar";
-        sha256 = "1wsfb33ybn6kiqn7mbnpr3vwgf68vszi9566jpl9vn8vhjq8xvkd";
+        url = "https://elpa.gnu.org/devel/flymake-1.4.5.0.20260702.3.tar";
+        sha256 = "1fddbgjlqkdr6kml7mbwhv1y6imkp5a73v6ynqhr7wkjh65vhryg";
       };
       packageRequires = [
         eldoc
@@ -3831,10 +3831,10 @@
     elpaBuild {
       pname = "flymake-proselint";
       ename = "flymake-proselint";
-      version = "0.3.0.0.20230325.160756";
+      version = "0.3.0.0.20260704.11";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/flymake-proselint-0.3.0.0.20230325.160756.tar";
-        sha256 = "1p3jpsv6w4hask7bk07dmafwgymbw3xl6i0vx0sjd0i5aa0xs9vz";
+        url = "https://elpa.gnu.org/devel/flymake-proselint-0.3.0.0.20260704.11.tar";
+        sha256 = "0n619yab8s9lr00b7zcbgywvm5phwrh19iww8rwm0sf1qhmg3azf";
       };
       packageRequires = [ ];
       meta = {
@@ -3852,10 +3852,10 @@
     elpaBuild {
       pname = "fontaine";
       ename = "fontaine";
-      version = "3.0.1.0.20260424.102702";
+      version = "3.1.0.0.20260629.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/fontaine-3.0.1.0.20260424.102702.tar";
-        sha256 = "01nnyx1hy869yd2x3vhzp13qzy90c6rhsj8r8jkyyd5ycfzrkdnn";
+        url = "https://elpa.gnu.org/devel/fontaine-3.1.0.0.20260629.0.tar";
+        sha256 = "1d4jf8y02xp09c9gwa0rnp5c941rzpkpf9npk9zs07c6k1612j34";
       };
       packageRequires = [ ];
       meta = {
@@ -3874,10 +3874,10 @@
     elpaBuild {
       pname = "forgejo";
       ename = "forgejo";
-      version = "0.2.3.0.20260619.16";
+      version = "0.2.3.0.20260715.17";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/forgejo-0.2.3.0.20260619.16.tar";
-        sha256 = "1ywj3k0syc09qx267dyj313qhdm583jij2raacz6q9vrh53wwrsz";
+        url = "https://elpa.gnu.org/devel/forgejo-0.2.3.0.20260715.17.tar";
+        sha256 = "12vg44zkpr8s8i4wal2z3b6ii9gigdw674p10dx3zpj7zibjglry";
       };
       packageRequires = [ keymap-popup ];
       meta = {
@@ -4180,10 +4180,10 @@
     elpaBuild {
       pname = "gnosis";
       ename = "gnosis";
-      version = "0.10.6.0.20260508.2618";
+      version = "0.10.6.0.20260707.26";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/gnosis-0.10.6.0.20260508.2618.tar";
-        sha256 = "04rsg495ldyj739spfk4xwrylfzh27ffkjam9rn86c43rip2arvm";
+        url = "https://elpa.gnu.org/devel/gnosis-0.10.6.0.20260707.26.tar";
+        sha256 = "1s3mf539ri3d7rq0b9w6f6kla2ybkxrzwkqzq2mi92vzvypjmbv0";
       };
       packageRequires = [
         compat
@@ -4391,10 +4391,10 @@
     elpaBuild {
       pname = "greader";
       ename = "greader";
-      version = "0.19.4.0.20260608.0";
+      version = "0.19.5.0.20260627.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/greader-0.19.4.0.20260608.0.tar";
-        sha256 = "1pzblg6k9acx8nmpg9mzb42wi7invlip6zfchy03rq8f3gbk9vwy";
+        url = "https://elpa.gnu.org/devel/greader-0.19.5.0.20260627.0.tar";
+        sha256 = "1c37viwmwvhha7hra6zraim58yy3mf68ds738xky448ddbimrvl0";
       };
       packageRequires = [
         compat
@@ -4459,10 +4459,10 @@
     elpaBuild {
       pname = "guess-language";
       ename = "guess-language";
-      version = "0.0.1.0.20260529.147";
+      version = "0.0.1.0.20260625.150";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/guess-language-0.0.1.0.20260529.147.tar";
-        sha256 = "05dcakya74m9q459kywfdy1qyvlpdxwhg7fhphqqahj9pwa85yd9";
+        url = "https://elpa.gnu.org/devel/guess-language-0.0.1.0.20260625.150.tar";
+        sha256 = "0g3cvp1p1bpbf2h5vwrjcghj4bkhcpx00jqsivvrmyighpmgpxzs";
       };
       packageRequires = [
         cl-lib
@@ -4653,10 +4653,10 @@
     elpaBuild {
       pname = "hyperbole";
       ename = "hyperbole";
-      version = "9.0.20.20260622.1172";
+      version = "9.0.2pre0.20260712.1235";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/hyperbole-9.0.20.20260622.1172.tar";
-        sha256 = "0590d8ww3yq2p9x85m6435acrsmnnwg7njz96jg7wrkbnadjkyx1";
+        url = "https://elpa.gnu.org/devel/hyperbole-9.0.2pre0.20260712.1235.tar";
+        sha256 = "0ca3kpkv2rzydn7rxqvn4dw8dgk72q51mdpvdbwdk9a18pjp0fam";
       };
       packageRequires = [ ];
       meta = {
@@ -4674,10 +4674,10 @@
     elpaBuild {
       pname = "ibuffer-sidebar";
       ename = "ibuffer-sidebar";
-      version = "0.0.1.0.20260612.36";
+      version = "1.0.0.0.20260718.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ibuffer-sidebar-0.0.1.0.20260612.36.tar";
-        sha256 = "0r6wpdcn6fqrlgvmxihiwxp6lzhijjvwzikgv8nbh25x0gmz2nqm";
+        url = "https://elpa.gnu.org/devel/ibuffer-sidebar-1.0.0.0.20260718.2.tar";
+        sha256 = "1l9wk75nqbl0n8k0zbqjvkd7fb2j6b2zsag62khk9zpya50gsap7";
       };
       packageRequires = [ ];
       meta = {
@@ -5028,10 +5028,10 @@
     elpaBuild {
       pname = "javaimp";
       ename = "javaimp";
-      version = "0.9.2.0.20260619.6";
+      version = "0.9.2.0.20260715.9";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/javaimp-0.9.2.0.20260619.6.tar";
-        sha256 = "0axf8n0ymm80gswwf8hj20rzzdln04is1qy9ri8bd1iw689lvdgd";
+        url = "https://elpa.gnu.org/devel/javaimp-0.9.2.0.20260715.9.tar";
+        sha256 = "1fv10bx8f7y5f85zkyavav6ylkwxlznhfwbf4w4mybfj1p61mwha";
       };
       packageRequires = [ ];
       meta = {
@@ -5072,10 +5072,10 @@
     elpaBuild {
       pname = "jinx";
       ename = "jinx";
-      version = "2.8.0.20260519.104155";
+      version = "2.8.0.20260628.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/jinx-2.8.0.20260519.104155.tar";
-        sha256 = "0npksm6qrjnlsjrsl0szdvgim2xjbqj1az4ar7gli4s4z0pl0bkk";
+        url = "https://elpa.gnu.org/devel/jinx-2.8.0.20260628.1.tar";
+        sha256 = "0rgmkdiw7x0xknp9ndwzz1jvnkl9pyymzm7wrlzsigf5mzvx9n79";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5116,10 +5116,10 @@
     elpaBuild {
       pname = "js2-mode";
       ename = "js2-mode";
-      version = "20231224.0.20241205.14012";
+      version = "20231224.0.20260627.14";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/js2-mode-20231224.0.20241205.14012.tar";
-        sha256 = "0kcxgkib56fjgv9c2ancr046ag3nwr6zw5x2dzw9gbnlma5w3x66";
+        url = "https://elpa.gnu.org/devel/js2-mode-20231224.0.20260627.14.tar";
+        sha256 = "1cjccwswizryk0wn6ps40clmbjgf1h2amfw1hp6akmzsq4hs9abi";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -5158,10 +5158,10 @@
     elpaBuild {
       pname = "jsonrpc";
       ename = "jsonrpc";
-      version = "1.0.28.0.20260504.104721";
+      version = "1.0.29.0.20260623.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/jsonrpc-1.0.28.0.20260504.104721.tar";
-        sha256 = "1p33407vls4hfa109zl9z2jqp7iya7flzy0j2rc6cxi8k5m6ls3m";
+        url = "https://elpa.gnu.org/devel/jsonrpc-1.0.29.0.20260623.0.tar";
+        sha256 = "08l1xicms32yagpv20yi0b626nkyc5xwaljq4fda7ygndkhlm5a2";
       };
       packageRequires = [ ];
       meta = {
@@ -5200,10 +5200,10 @@
     elpaBuild {
       pname = "keymap-popup";
       ename = "keymap-popup";
-      version = "0.3.1.0.20260530.4";
+      version = "0.4.0.0.20260715.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/keymap-popup-0.3.1.0.20260530.4.tar";
-        sha256 = "1k6aqp65x3azbipj2pwdg15pip045cawx4im04s84kbk91fx0fxs";
+        url = "https://elpa.gnu.org/devel/keymap-popup-0.4.0.0.20260715.2.tar";
+        sha256 = "02077lc09shc76y1gzh7gk9ij2ap0hkgqx40m6bsg79n25i55zgz";
       };
       packageRequires = [ ];
       meta = {
@@ -5481,6 +5481,32 @@
       };
     }
   ) { };
+  lisp-ts-mode = callPackage (
+    {
+      compat,
+      cond-star,
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "lisp-ts-mode";
+      ename = "lisp-ts-mode";
+      version = "0.2.1.0.20260711.3";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/lisp-ts-mode-0.2.1.0.20260711.3.tar";
+        sha256 = "1ihjb14qz1kmz02p7zpvr0vq75f28lp6win60xw0d6y12gks60f9";
+      };
+      packageRequires = [
+        compat
+        cond-star
+      ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/lisp-ts-mode.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   listen = callPackage (
     {
       elpaBuild,
@@ -5545,10 +5571,10 @@
     elpaBuild {
       pname = "llm";
       ename = "llm";
-      version = "0.31.1.0.20260624.0";
+      version = "0.31.2.0.20260718.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/llm-0.31.1.0.20260624.0.tar";
-        sha256 = "0cakiavkq25axdvpnpsj57qfwppb3g14aww0vxzdpb8w80wzf1h1";
+        url = "https://elpa.gnu.org/devel/llm-0.31.2.0.20260718.2.tar";
+        sha256 = "0zhf1a7n0x58hf56ln1lpf61pjfn2bj8mmy940w5k3kp8y3zyxz7";
       };
       packageRequires = [
         compat
@@ -5785,10 +5811,10 @@
     elpaBuild {
       pname = "marginalia";
       ename = "marginalia";
-      version = "2.11.0.20260519.104425";
+      version = "2.11.0.20260628.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/marginalia-2.11.0.20260519.104425.tar";
-        sha256 = "11n680dghiyzm5sk3b4s8adxdj457lm50nac1khkr8vfbqfdd7j6";
+        url = "https://elpa.gnu.org/devel/marginalia-2.11.0.20260628.1.tar";
+        sha256 = "1kya2x33xbp0ghjv46484jjy7qhqsh7xkcr0pnvi6m4dgcxrg6al";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5912,10 +5938,10 @@
     elpaBuild {
       pname = "mct";
       ename = "mct";
-      version = "1.1.0.0.20260424.102720";
+      version = "1.1.1.0.20260629.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/mct-1.1.0.0.20260424.102720.tar";
-        sha256 = "1413vjnlm12s65yalna2lqb26a77als5h3pyxlpjaf8rb9lpgchw";
+        url = "https://elpa.gnu.org/devel/mct-1.1.1.0.20260629.0.tar";
+        sha256 = "1dff7gm1cw1ljvsdw7j43laamhpck598c7f5r6679gf9zqm3bdfv";
       };
       packageRequires = [ ];
       meta = {
@@ -6177,10 +6203,10 @@
     elpaBuild {
       pname = "modus-themes";
       ename = "modus-themes";
-      version = "5.3.0.0.20260623.1";
+      version = "5.3.0.0.20260717.26";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/modus-themes-5.3.0.0.20260623.1.tar";
-        sha256 = "03cj2sgr1p1xkygxqfx00z13lnpzndn44niymipccds8rb8ipsri";
+        url = "https://elpa.gnu.org/devel/modus-themes-5.3.0.0.20260717.26.tar";
+        sha256 = "0a3gd5cww0bifh9j3hxnsjb4csik7qlifa3i306l0lmj00sls1hl";
       };
       packageRequires = [ ];
       meta = {
@@ -6198,10 +6224,10 @@
     elpaBuild {
       pname = "mpdired";
       ename = "mpdired";
-      version = "40.20250502.114712";
+      version = "4pre0.20250502.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/mpdired-40.20250502.114712.tar";
-        sha256 = "1dzvv4q13xad0940yg5qc3mbznkkslh3kjcy8br6jfq9qfp85gh0";
+        url = "https://elpa.gnu.org/devel/mpdired-4pre0.20250502.1.tar";
+        sha256 = "1hrp0q5dql57hd40q838vbdrlbbyd1g7kfvf5w3zvhziq0dj61gx";
       };
       packageRequires = [ ];
       meta = {
@@ -6582,10 +6608,10 @@
     elpaBuild {
       pname = "oauth2";
       ename = "oauth2";
-      version = "0.19.10.20260526.1";
+      version = "0.19.1snapshot0.20260526.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/oauth2-0.19.10.20260526.1.tar";
-        sha256 = "1i1sndnrjgyrfzhll2wjhc2n0n0wyfpswwnfc5p8097jda1q27hk";
+        url = "https://elpa.gnu.org/devel/oauth2-0.19.1snapshot0.20260526.1.tar";
+        sha256 = "0fxrg7ypj642mxdpn06g31ynlb96w64na99fakpdcf9wa0a5ir2s";
       };
       packageRequires = [ ];
       meta = {
@@ -6711,10 +6737,10 @@
     elpaBuild {
       pname = "orderless";
       ename = "orderless";
-      version = "1.7.0.20260519.103644";
+      version = "1.7.0.20260628.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/orderless-1.7.0.20260519.103644.tar";
-        sha256 = "0l5ylzvnlgbswlnr7nqaqrrzm88j7hya69rwawp8m9nyar10mj7q";
+        url = "https://elpa.gnu.org/devel/orderless-1.7.0.20260628.2.tar";
+        sha256 = "12xwkskpbwh6aav9zpl1f8alkv0bsh7aaw9q3hciab6ai6v6x723";
       };
       packageRequires = [ compat ];
       meta = {
@@ -6732,10 +6758,10 @@
     elpaBuild {
       pname = "org";
       ename = "org";
-      version = "10.0.20260622.360";
+      version = "10.0pre0.20260715.383";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-10.0.20260622.360.tar";
-        sha256 = "1fizzj0vsv78sg7hivsicxvkvksyl7lw0iah0djnp1sfvl54gxf8";
+        url = "https://elpa.gnu.org/devel/org-10.0pre0.20260715.383.tar";
+        sha256 = "0dys9gg55z0bn7p9g7f2rw01v1my3ba3qmm3555g7xhpmy7gcfd6";
       };
       packageRequires = [ ];
       meta = {
@@ -6803,10 +6829,10 @@
     elpaBuild {
       pname = "org-gnosis";
       ename = "org-gnosis";
-      version = "0.2.2.0.20260224.203152";
+      version = "0.2.2.0.20260711.6";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-gnosis-0.2.2.0.20260224.203152.tar";
-        sha256 = "1ls3wnd4brn3aadafyfn4m4lkav5v5sm77irlijnm90rg2jdk7xc";
+        url = "https://elpa.gnu.org/devel/org-gnosis-0.2.2.0.20260711.6.tar";
+        sha256 = "0zh6wl8qcxx1av1x8pp6756wcdqnwa2h2yv6i8742l8rqi5xfybg";
       };
       packageRequires = [
         compat
@@ -6879,10 +6905,10 @@
     elpaBuild {
       pname = "org-modern";
       ename = "org-modern";
-      version = "1.14.0.20260519.104634";
+      version = "1.14.0.20260707.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-modern-1.14.0.20260519.104634.tar";
-        sha256 = "0q4iqgv18a24fhwsxrhz6f7awik0v5jxvq19brnp7k83zssw5gdj";
+        url = "https://elpa.gnu.org/devel/org-modern-1.14.0.20260707.5.tar";
+        sha256 = "1hd30siq6jnqnxmkrgibp86cn3kjma1ifa216mw9fkl3bg8js506";
       };
       packageRequires = [
         compat
@@ -7059,10 +7085,10 @@
     elpaBuild {
       pname = "osm";
       ename = "osm";
-      version = "2.3.0.20260623.1";
+      version = "2.4.0.20260705.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/osm-2.3.0.20260623.1.tar";
-        sha256 = "07a7vwcpqjrq5vrvsb0bmmx0vjsdxq3449pfcsnnyamws3qhrwa1";
+        url = "https://elpa.gnu.org/devel/osm-2.4.0.20260705.0.tar";
+        sha256 = "0s9m0j1r3hxllwmzarbg3k3yqfqrfnz93nqphpnf1p7lbwzk5v1c";
       };
       packageRequires = [ compat ];
       meta = {
@@ -7378,10 +7404,10 @@
     elpaBuild {
       pname = "plz";
       ename = "plz";
-      version = "0.100.20250318.183534";
+      version = "0.10pre0.20250318.18";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/plz-0.100.20250318.183534.tar";
-        sha256 = "0ai10h4fhavrb2nxcp5a59g32cf95q99cia7ck9chw6dznb73vpj";
+        url = "https://elpa.gnu.org/devel/plz-0.10pre0.20250318.18.tar";
+        sha256 = "0lsaxls0dgj1hqm6fc03ns67k0wdp6jp688n9galiczk7zzllvpg";
       };
       packageRequires = [ ];
       meta = {
@@ -7400,10 +7426,10 @@
     elpaBuild {
       pname = "plz-event-source";
       ename = "plz-event-source";
-      version = "0.1.40.20250413.93107";
+      version = "0.1.4pre0.20250413.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/plz-event-source-0.1.40.20250413.93107.tar";
-        sha256 = "0fm2rdsrfcw0hdwycpgcwgkikl6w5ldicr3zwhqwq4vxzfzaflb6";
+        url = "https://elpa.gnu.org/devel/plz-event-source-0.1.4pre0.20250413.0.tar";
+        sha256 = "12f9ava513hiwb9cighnnliq7nn3d1kfy2hjg6npl89nhii82g5f";
       };
       packageRequires = [ plz-media-type ];
       meta = {
@@ -7422,10 +7448,10 @@
     elpaBuild {
       pname = "plz-media-type";
       ename = "plz-media-type";
-      version = "0.2.50.20250412.100044";
+      version = "0.2.5pre0.20250412.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/plz-media-type-0.2.50.20250412.100044.tar";
-        sha256 = "1dglmb2vaznrz3c4l6nrdwfs8zqz2pj3js5d1zkbw3ld2q01m9rv";
+        url = "https://elpa.gnu.org/devel/plz-media-type-0.2.5pre0.20250412.0.tar";
+        sha256 = "1agd1m6pxmqd7vkqvrv382fg76wx0kz9dxkbz0pwpf5p9dlpl6mm";
       };
       packageRequires = [ plz ];
       meta = {
@@ -7612,10 +7638,10 @@
     elpaBuild {
       pname = "pq";
       ename = "pq";
-      version = "0.2.0.20240317.135839";
+      version = "0.2.0.20240911.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/pq-0.2.0.20240317.135839.tar";
-        sha256 = "0hva6d8iqqdvnllm7cssxrmn21alcb2aa4d6874bqdfqjij2hw1z";
+        url = "https://elpa.gnu.org/devel/pq-0.2.0.20240911.1.tar";
+        sha256 = "07033s0lrns0ibmpvm7n02xfp1dwzkrb08vlsv5fj3lx7v0dk5g6";
       };
       packageRequires = [ ];
       meta = {
@@ -7655,10 +7681,10 @@
     elpaBuild {
       pname = "preview-auto";
       ename = "preview-auto";
-      version = "0.4.2.0.20260617.3";
+      version = "0.5.0.0.20260708.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/preview-auto-0.4.2.0.20260617.3.tar";
-        sha256 = "1p518f3b78lxsjbq3q4vkj25hy04yrm9xk1srk9clr3jx3i8gbvr";
+        url = "https://elpa.gnu.org/devel/preview-auto-0.5.0.0.20260708.0.tar";
+        sha256 = "1f4y9mrv7g46cvzjiygn703nfc293zha0ivsbkbj6qd6r78hklpf";
       };
       packageRequires = [ auctex ];
       meta = {
@@ -7699,10 +7725,10 @@
     elpaBuild {
       pname = "project";
       ename = "project";
-      version = "0.11.2.0.20260612.29";
+      version = "0.12.0.0.20260716.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/project-0.11.2.0.20260612.29.tar";
-        sha256 = "19bb3v47ikpf445zz4pgxlnynkwyjacydws15lgsc853npca1df1";
+        url = "https://elpa.gnu.org/devel/project-0.12.0.0.20260716.0.tar";
+        sha256 = "0iaqw9ci3sbq3y3ry7r3pyv4ydlbx8b01p7chqq3b3h55vdi3i1d";
       };
       packageRequires = [ xref ];
       meta = {
@@ -8533,6 +8559,27 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/sed-mode.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  sendai-theme = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "sendai-theme";
+      ename = "sendai-theme";
+      version = "0.1.1snapshot0.20260701.2";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/sendai-theme-0.1.1snapshot0.20260701.2.tar";
+        sha256 = "08xpcxs280mbipllcjl06hmrxmpdzrwkfzcrvq6n9k2dv62x1cki";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/sendai-theme.html";
         license = lib.licenses.free;
       };
     }
@@ -9471,10 +9518,10 @@
     elpaBuild {
       pname = "taxy";
       ename = "taxy";
-      version = "0.110.20251129.62050";
+      version = "0.11pre0.20251129.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/taxy-0.110.20251129.62050.tar";
-        sha256 = "0nvrwsz87rmwnyafd1291kmxg8f4k62l9jm207my7dnyq5ks0b19";
+        url = "https://elpa.gnu.org/devel/taxy-0.11pre0.20251129.2.tar";
+        sha256 = "1y4k68h5z1xc7x0rc3lx1cyvbpniirqglr2gik08m1m1570r6w4x";
       };
       packageRequires = [ ];
       meta = {
@@ -9540,10 +9587,10 @@
     elpaBuild {
       pname = "tempel";
       ename = "tempel";
-      version = "1.13.0.20260609.1";
+      version = "1.14.0.20260705.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tempel-1.13.0.20260609.1.tar";
-        sha256 = "1n423dfaij4ixss5w8nm519kdainipswdr38gx3qhcb59l0pywhd";
+        url = "https://elpa.gnu.org/devel/tempel-1.14.0.20260705.0.tar";
+        sha256 = "0bxj1qkxy9sd5js36rnvjlgxhvb8nza38l4ccbnnrj4p7h72n9hl";
       };
       packageRequires = [ compat ];
       meta = {
@@ -9820,10 +9867,10 @@
     elpaBuild {
       pname = "tramp";
       ename = "tramp";
-      version = "2.8.1.5.0.20260530.0";
+      version = "2.8.2.0.20260720.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tramp-2.8.1.5.0.20260530.0.tar";
-        sha256 = "1d4ksg9cw8a9kqbwpa8jafjwb29g5f8640nd5v6chd6a5lv1z9sf";
+        url = "https://elpa.gnu.org/devel/tramp-2.8.2.0.20260720.2.tar";
+        sha256 = "01a6riczx8wvy72x9v56p314r37xnr7i8z6394li307xw3gkznzd";
       };
       packageRequires = [ ];
       meta = {
@@ -9930,10 +9977,10 @@
     elpaBuild {
       pname = "transient";
       ename = "transient";
-      version = "0.13.4.0.20260617.1";
+      version = "0.13.5.0.20260701.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/transient-0.13.4.0.20260617.1.tar";
-        sha256 = "1y96c432kviy2xnijzp5y49fyazjfab49i8jyysgf87pbxjpylsl";
+        url = "https://elpa.gnu.org/devel/transient-0.13.5.0.20260701.0.tar";
+        sha256 = "0hhb042jacadfz01fgc9dpjqcz441vpwn3gw0g7qyqaqjhh1i5ci";
       };
       packageRequires = [
         compat
@@ -9956,10 +10003,10 @@
     elpaBuild {
       pname = "transient-cycles";
       ename = "transient-cycles";
-      version = "2.0.0.20250625.85410";
+      version = "2.1.0.20260625.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/transient-cycles-2.0.0.20250625.85410.tar";
-        sha256 = "1782gr8hwidfxilggb83s2v9wzkvyhcxbv3nj8f4aylhcdahfzf8";
+        url = "https://elpa.gnu.org/devel/transient-cycles-2.1.0.20260625.0.tar";
+        sha256 = "1jadhnszdnc9hj6992bpdmdrqcrig0r172dis8cwxksfrcb0qpgs";
       };
       packageRequires = [ ];
       meta = {
@@ -10176,10 +10223,10 @@
     elpaBuild {
       pname = "urgrep";
       ename = "urgrep";
-      version = "0.6.10.20260619.3";
+      version = "0.6.1snapshot0.20260619.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/urgrep-0.6.10.20260619.3.tar";
-        sha256 = "1cakwsfi1caz1z30d3dshsjq348ghzh6s9z474zwcdycay94037i";
+        url = "https://elpa.gnu.org/devel/urgrep-0.6.1snapshot0.20260619.3.tar";
+        sha256 = "0aks8nan0rjavz72s34c1d6wq4031z2wf2rbi73kr4sfq944yiss";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10528,10 +10575,10 @@
     elpaBuild {
       pname = "vertico";
       ename = "vertico";
-      version = "2.10.0.20260605.0";
+      version = "2.10.0.20260709.7";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vertico-2.10.0.20260605.0.tar";
-        sha256 = "0c7fj7issnnz4m0hm9c4ggpl4siic3y67pvgjfkil9zd1z7jnh0s";
+        url = "https://elpa.gnu.org/devel/vertico-2.10.0.20260709.7.tar";
+        sha256 = "0jq13xdfbgrdf6b48sd70znax4mvcbf2p0h17mbc8vg006fs3xih";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10941,10 +10988,10 @@
     elpaBuild {
       pname = "with-command-redo";
       ename = "with-command-redo";
-      version = "0.1.0.20260504.211611";
+      version = "0.2.0.20260710.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/with-command-redo-0.1.0.20260504.211611.tar";
-        sha256 = "1k37zdj23p606mxinaics0djp8n2rdylc7k4p03sacxmjiw34fid";
+        url = "https://elpa.gnu.org/devel/with-command-redo-0.2.0.20260710.0.tar";
+        sha256 = "0zk18x8bplbishpxwy8r3m51i3kcai4crc6d4pipg927qdymry7z";
       };
       packageRequires = [ ];
       meta = {
@@ -11047,10 +11094,10 @@
     elpaBuild {
       pname = "xelb";
       ename = "xelb";
-      version = "0.22.0.20260623.5";
+      version = "0.23.0.20260627.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/xelb-0.22.0.20260623.5.tar";
-        sha256 = "0v5rwk9m76zy1irg7ii84slfwb360fy5h3kacnzdrgxlwk7aw6rj";
+        url = "https://elpa.gnu.org/devel/xelb-0.23.0.20260627.0.tar";
+        sha256 = "0q5z5mvdfgc411nqxqf9qi8gw43pdf3yqsg48riv67w58nnx11bv";
       };
       packageRequires = [ compat ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -484,10 +484,10 @@
     elpaBuild {
       pname = "auctex-label-numbers";
       ename = "auctex-label-numbers";
-      version = "0.2";
+      version = "0.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/auctex-label-numbers-0.2.tar";
-        sha256 = "1cd68yvpm061r9k4x6rvy3g2wdynv5gbjg2dyp06nkrgvakdb00x";
+        url = "https://elpa.gnu.org/packages/auctex-label-numbers-0.3.tar";
+        sha256 = "10dgq2jnzxd2w10a9raz9gj6nzlmyk048fzlv839sf5m73pjq89s";
       };
       packageRequires = [ auctex ];
       meta = {
@@ -1484,10 +1484,10 @@
     elpaBuild {
       pname = "compat";
       ename = "compat";
-      version = "31.0.0.1";
+      version = "31.0.0.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/compat-31.0.0.1.tar";
-        sha256 = "1lraq5i8jk0wsrnkv66q6lxv314fm8c09hrfvm0gj2lpn8126f20";
+        url = "https://elpa.gnu.org/packages/compat-31.0.0.2.tar";
+        sha256 = "0f0gig6imlf5gx8qykvwajvhr66v52v7hsifqwh8nzq820x6kn27";
       };
       packageRequires = [ ];
       meta = {
@@ -1571,10 +1571,10 @@
     elpaBuild {
       pname = "consult-denote";
       ename = "consult-denote";
-      version = "0.5.0";
+      version = "0.5.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/consult-denote-0.5.0.tar";
-        sha256 = "1qmfwmm4hi0z2lqn6ryfwckrivrlvy16y42w729q6pk0nd21j48k";
+        url = "https://elpa.gnu.org/packages/consult-denote-0.5.1.tar";
+        sha256 = "0if1qfma6ssb4ciwviz5avm68k1yivj23sg2m2fmb9asry9zrvjd";
       };
       packageRequires = [
         consult
@@ -2231,10 +2231,10 @@
     elpaBuild {
       pname = "denote-silo";
       ename = "denote-silo";
-      version = "0.3.0";
+      version = "0.3.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/denote-silo-0.3.0.tar";
-        sha256 = "1pwhn1k8cdb4n6v1l6d6ld5zm4gfzb5vl9fp1myqlfkjx756lglj";
+        url = "https://elpa.gnu.org/packages/denote-silo-0.3.2.tar";
+        sha256 = "14qbzf336n62s5wp2v67fp8das28aa8a0ahv3nxg5w3fbdxdf03b";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2684,10 +2684,10 @@
     elpaBuild {
       pname = "doric-themes";
       ename = "doric-themes";
-      version = "1.1.0";
+      version = "1.2.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/doric-themes-1.1.0.tar";
-        sha256 = "12rm5swbhn52yh4nvngqqbaiy8j97bi86a0k7swdb08vxmgp5kzh";
+        url = "https://elpa.gnu.org/packages/doric-themes-1.2.1.tar";
+        sha256 = "0p7qvn8g0hw7h1r3b0m2iif5f4739jmkqn0zih90qw5lbbjf4i86";
       };
       packageRequires = [ ];
       meta = {
@@ -2936,10 +2936,10 @@
     elpaBuild {
       pname = "eglot";
       ename = "eglot";
-      version = "1.23";
+      version = "1.24";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/eglot-1.23.tar";
-        sha256 = "1l83c90rdamlk576bd859jkg6406hgxi7w4c6ixlw509c66qr3s6";
+        url = "https://elpa.gnu.org/packages/eglot-1.24.tar";
+        sha256 = "0fi10gxw33lh15xvwv5bfqzv81wp7k3yibqc2mzbn59kwrja94gc";
       };
       packageRequires = [
         eldoc
@@ -3110,10 +3110,10 @@
     elpaBuild {
       pname = "ellama";
       ename = "ellama";
-      version = "1.27.2";
+      version = "1.30.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/ellama-1.27.2.tar";
-        sha256 = "09l22c29vv8bd70vq681ashvlyqcq3ajk37nmdkcj7j4ik53l4bh";
+        url = "https://elpa.gnu.org/packages/ellama-1.30.0.tar";
+        sha256 = "0xfyli6mzv5rdw6ddzy7q4w7332z4vniz1dmxlyr4r0dczyjq0pk";
       };
       packageRequires = [
         compat
@@ -3520,10 +3520,10 @@
     elpaBuild {
       pname = "exwm";
       ename = "exwm";
-      version = "0.34";
+      version = "0.35";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/exwm-0.34.tar";
-        sha256 = "1hp2ni9c6bn627275x37n6zhcismvni6vqp7cpdn3cx292n7sx6z";
+        url = "https://elpa.gnu.org/packages/exwm-0.35.tar";
+        sha256 = "05sfgprmsy3yc82qqm2ysg091yw91d0vb74cd612bqxyi3ifqa19";
       };
       packageRequires = [
         compat
@@ -3761,10 +3761,10 @@
     elpaBuild {
       pname = "fontaine";
       ename = "fontaine";
-      version = "3.0.1";
+      version = "3.1.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/fontaine-3.0.1.tar";
-        sha256 = "0bgfg6pkw724id1d3igiw4g0204wnjwsbnabfy2rq6nrf99z1qwr";
+        url = "https://elpa.gnu.org/packages/fontaine-3.1.0.tar";
+        sha256 = "066q3pys9f4d7jkvm52yrj0df12jz8z22gv2f4jpb47g1iapkp9f";
       };
       packageRequires = [ ];
       meta = {
@@ -4300,10 +4300,10 @@
     elpaBuild {
       pname = "greader";
       ename = "greader";
-      version = "0.19.4";
+      version = "0.19.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/greader-0.19.4.tar";
-        sha256 = "1wg25481rdzfjshsjhaf2747hsy964gn1zc5gbmqak8y1vmsjb6h";
+        url = "https://elpa.gnu.org/packages/greader-0.19.5.tar";
+        sha256 = "1kzm63xp0fzryha5msyl0f4gdhhacz4ys0b0z1wf5phy832bc1w1";
       };
       packageRequires = [
         compat
@@ -4574,6 +4574,27 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/hyperbole.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  ibuffer-sidebar = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "ibuffer-sidebar";
+      ename = "ibuffer-sidebar";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/ibuffer-sidebar-1.0.0.tar";
+        sha256 = "00wgka7g7gndk8vczrm3pvx09l46mv93yc0i4w3xlma30z0clivw";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/ibuffer-sidebar.html";
         license = lib.licenses.free;
       };
     }
@@ -5050,10 +5071,10 @@
     elpaBuild {
       pname = "jsonrpc";
       ename = "jsonrpc";
-      version = "1.0.28";
+      version = "1.0.29";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/jsonrpc-1.0.28.tar";
-        sha256 = "13zdm9ss1sfpw55lwr8nrv1ha30qcj7v10m1ql8r9cbdxxkzxp8f";
+        url = "https://elpa.gnu.org/packages/jsonrpc-1.0.29.tar";
+        sha256 = "1cjxdzckxffiw2cjp68rf382iaf7qpg9iqkxm0yrz0rmw3vk3gcq";
       };
       packageRequires = [ ];
       meta = {
@@ -5092,10 +5113,10 @@
     elpaBuild {
       pname = "keymap-popup";
       ename = "keymap-popup";
-      version = "0.3.1";
+      version = "0.4.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/keymap-popup-0.3.1.tar";
-        sha256 = "0m44s8618n7g5pajxiv4k1dfx6l58gr01a3ga26fxc51j1d05q8b";
+        url = "https://elpa.gnu.org/packages/keymap-popup-0.4.0.tar";
+        sha256 = "0hdzppwrq78hzamr05jjj3nmdsv0fxbv93gs94gmwbc07jiq0937";
       };
       packageRequires = [ ];
       meta = {
@@ -5373,6 +5394,32 @@
       };
     }
   ) { };
+  lisp-ts-mode = callPackage (
+    {
+      compat,
+      cond-star,
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "lisp-ts-mode";
+      ename = "lisp-ts-mode";
+      version = "0.2.1";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/lisp-ts-mode-0.2.1.tar";
+        sha256 = "0sdyziagjcq29n10yygd28n1i99wsrd33i8g1h9ahfm9imr215jy";
+      };
+      packageRequires = [
+        compat
+        cond-star
+      ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/lisp-ts-mode.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   listen = callPackage (
     {
       elpaBuild,
@@ -5437,10 +5484,10 @@
     elpaBuild {
       pname = "llm";
       ename = "llm";
-      version = "0.31.1";
+      version = "0.31.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/llm-0.31.1.tar";
-        sha256 = "1395rh5jk3c0hfszzvn9xp3qyyi48nvz1x1v3vljgx4qzzcakgh3";
+        url = "https://elpa.gnu.org/packages/llm-0.31.2.tar";
+        sha256 = "08lc058w1xhiv3cxfkbcjaszplvwhmdyxpcwqkzw3x2sb11pn7rj";
       };
       packageRequires = [
         compat
@@ -5802,10 +5849,10 @@
     elpaBuild {
       pname = "mct";
       ename = "mct";
-      version = "1.1.0";
+      version = "1.1.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/mct-1.1.0.tar";
-        sha256 = "0kv0j37bdsmc2jv7adpx5m48cp4h0kvjq2jfwv7d8nzpk5kk2d2p";
+        url = "https://elpa.gnu.org/packages/mct-1.1.1.tar";
+        sha256 = "18kwrm93vmkhm8l6gim1r3daizrj6k65lsq8xmja55a1jr60j1xi";
       };
       packageRequires = [ ];
       meta = {
@@ -6598,10 +6645,10 @@
     elpaBuild {
       pname = "org";
       ename = "org";
-      version = "9.8.6";
+      version = "9.8.7";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/org-9.8.6.tar";
-        sha256 = "0qc9c49k8fcaa8c947wb7knn5lbm2bigvzxkbx8cdbyrj15pra4j";
+        url = "https://elpa.gnu.org/packages/org-9.8.7.tar";
+        sha256 = "1y7sf3p9jqkfw8k6wddy2p9hfskiq4a5hkx8sq39dgb4sri6v03d";
       };
       packageRequires = [ ];
       meta = {
@@ -6925,10 +6972,10 @@
     elpaBuild {
       pname = "osm";
       ename = "osm";
-      version = "2.3";
+      version = "2.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/osm-2.3.tar";
-        sha256 = "0x08qbdk7y05cm8kc35f2i6k5xnd9iyyhr0f0fyi489kbvd3n1nh";
+        url = "https://elpa.gnu.org/packages/osm-2.4.tar";
+        sha256 = "1w270bjnxxlwi3vbgfb0aih6lkr8bgs872yrwfpl423x9wkrk48j";
       };
       packageRequires = [ compat ];
       meta = {
@@ -7479,10 +7526,10 @@
     elpaBuild {
       pname = "preview-auto";
       ename = "preview-auto";
-      version = "0.4.2";
+      version = "0.5.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/preview-auto-0.4.2.tar";
-        sha256 = "1fg4nxzqjk13q9yvhrjmm9qqrszf9xd2n9jfji2v31f0rphlkc3p";
+        url = "https://elpa.gnu.org/packages/preview-auto-0.5.0.tar";
+        sha256 = "1d8rm22aqvgyg46r4vdf2w3ywxmqiny46y0p030i9q26xc2xq7my";
       };
       packageRequires = [ auctex ];
       meta = {
@@ -7523,10 +7570,10 @@
     elpaBuild {
       pname = "project";
       ename = "project";
-      version = "0.11.2";
+      version = "0.12.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/project-0.11.2.tar";
-        sha256 = "0gyjdqxsblsmh2higkr2a6vfl051hpqzm0pxrzwsg2766xmldgqk";
+        url = "https://elpa.gnu.org/packages/project-0.12.0.tar";
+        sha256 = "0g7in5lzv21j4mrmqp60bl02gwrh2mrs6fw1ysj6pwaqlza9hw4w";
       };
       packageRequires = [ xref ];
       meta = {
@@ -8338,6 +8385,27 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/sed-mode.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  sendai-theme = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "sendai-theme";
+      ename = "sendai-theme";
+      version = "0.1.0";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/sendai-theme-0.1.0.tar";
+        sha256 = "0c8k19pj5l148g34isi6w309msrq6q3z65427ilky47xzs067faz";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/sendai-theme.html";
         license = lib.licenses.free;
       };
     }
@@ -9278,10 +9346,10 @@
     elpaBuild {
       pname = "tempel";
       ename = "tempel";
-      version = "1.13";
+      version = "1.14";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/tempel-1.13.tar";
-        sha256 = "1sxyxz799nw56wqrm7hsr0dq2yaxckr9a1rynw2jsrfhbzcxpbfp";
+        url = "https://elpa.gnu.org/packages/tempel-1.14.tar";
+        sha256 = "1m2zy53drrpcjqky7a2pfhrnrynhj7hdksl68kfz8r6lp5id6xf3";
       };
       packageRequires = [ compat ];
       meta = {
@@ -9558,10 +9626,10 @@
     elpaBuild {
       pname = "tramp";
       ename = "tramp";
-      version = "2.8.1.5";
+      version = "2.8.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/tramp-2.8.1.5.tar";
-        sha256 = "04rhm5ijx3qs386ffxvp2117a4xn7zw6z5cqci77f6q07i5921zw";
+        url = "https://elpa.gnu.org/packages/tramp-2.8.2.tar";
+        sha256 = "1d9mki1ik8ck891jq7kzkf93aqalfm0i9vqdbm5km8g317wqpaqn";
       };
       packageRequires = [ ];
       meta = {
@@ -9662,19 +9730,21 @@
       elpaBuild,
       fetchurl,
       lib,
+      llama,
       seq,
     }:
     elpaBuild {
       pname = "transient";
       ename = "transient";
-      version = "0.13.4";
+      version = "0.13.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/transient-0.13.4.tar";
-        sha256 = "02142xcxv50bycshbl6qj47q6s9gi6sbagrnyjqi5ma74509zq6h";
+        url = "https://elpa.gnu.org/packages/transient-0.13.5.tar";
+        sha256 = "15mdg6q6ns6sqyrikvxvn4l76dxz5gai9a9hqvf61vgk35vkgz47";
       };
       packageRequires = [
         compat
         cond-let
+        llama
         seq
       ];
       meta = {
@@ -9692,10 +9762,10 @@
     elpaBuild {
       pname = "transient-cycles";
       ename = "transient-cycles";
-      version = "2.0";
+      version = "2.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/transient-cycles-2.0.tar";
-        sha256 = "0cq2k77rgbw3fx84a2d33nbb75wqxynrc1mx4gb32a9ysm0sa4s3";
+        url = "https://elpa.gnu.org/packages/transient-cycles-2.1.tar";
+        sha256 = "12g22ajwf3lsqi3c9bajqq30n1aaq96r15mfd1z2bbzpn1gfahkf";
       };
       packageRequires = [ ];
       meta = {
@@ -10671,6 +10741,27 @@
       };
     }
   ) { };
+  with-command-redo = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "with-command-redo";
+      ename = "with-command-redo";
+      version = "0.2";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/with-command-redo-0.2.tar";
+        sha256 = "1da6xklk9yf9xazspr9d987rsfxl8m2y556g99cnf3cj6bx8npa3";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/with-command-redo.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   wpuzzle = callPackage (
     {
       elpaBuild,
@@ -10765,10 +10856,10 @@
     elpaBuild {
       pname = "xelb";
       ename = "xelb";
-      version = "0.22";
+      version = "0.23";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/xelb-0.22.tar";
-        sha256 = "0vd0dsigr2lvwvvm32kf20dyg5bvafinb2xhz491f8wj2w99fjx4";
+        url = "https://elpa.gnu.org/packages/xelb-0.23.tar";
+        sha256 = "1fsqs06g2hx248sngp7lqkx1m63m96jvmdks28xcamw1j1p8h0v0";
       };
       packageRequires = [ compat ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -5405,10 +5405,10 @@
     elpaBuild {
       pname = "lisp-ts-mode";
       ename = "lisp-ts-mode";
-      version = "0.2.1";
+      version = "0.3.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/lisp-ts-mode-0.2.1.tar";
-        sha256 = "0sdyziagjcq29n10yygd28n1i99wsrd33i8g1h9ahfm9imr215jy";
+        url = "https://elpa.gnu.org/packages/lisp-ts-mode-0.3.0.tar";
+        sha256 = "0dh15bdmjgn4jmdc8xdf0wddj1zkbpi9xqw32m724h1y5511whh2";
       };
       packageRequires = [
         compat

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -1703,6 +1703,9 @@ let
 
           shampoo = ignoreCompilationError super.shampoo; # elisp error
 
+          # missing optional dependencies
+          shexc-ts-mode = addPackageRequires super.shexc-ts-mode [ self.yaml ];
+
           # missing optional dependencies and one of them (mew) is not on any ELPA
           shimbun = ignoreCompilationError (
             addPackageRequires super.shimbun [

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-generated.nix
@@ -75,10 +75,10 @@
     elpaBuild {
       pname = "aidermacs";
       ename = "aidermacs";
-      version = "1.7.0.20260521.153004";
+      version = "1.9.0.20260719.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/aidermacs-1.7.0.20260521.153004.tar";
-        sha256 = "11pw6absa9nj0ps8n17jzsqdnajk1cdz7rv6lnp2ibfyfg6vr03c";
+        url = "https://elpa.nongnu.org/nongnu-devel/aidermacs-1.9.0.20260719.1.tar";
+        sha256 = "1rian9r2vvdnrk0hqmrgpsp2lbi7ci5gr8jzg9ghgpkz7bjsa8w1";
       };
       packageRequires = [
         compat
@@ -269,10 +269,10 @@
     elpaBuild {
       pname = "auto-dim-other-buffers";
       ename = "auto-dim-other-buffers";
-      version = "2.2.1.0.20250116.140242";
+      version = "2.2.2.0.20260624.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/auto-dim-other-buffers-2.2.1.0.20250116.140242.tar";
-        sha256 = "07v5n7d3whk79by6xwd1gak1m73k4zpcscwfminfidj3f6rmkj92";
+        url = "https://elpa.nongnu.org/nongnu-devel/auto-dim-other-buffers-2.2.2.0.20260624.0.tar";
+        sha256 = "1kpglnqss61dx9px0v2agbnfnjymjynslr31mpc73p6qjv0fqgcv";
       };
       packageRequires = [ ];
       meta = {
@@ -333,10 +333,10 @@
     elpaBuild {
       pname = "bash-completion";
       ename = "bash-completion";
-      version = "3.2.10.20260325.162703";
+      version = "3.2.1snapshot0.20260325.20";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/bash-completion-3.2.10.20260325.162703.tar";
-        sha256 = "0jfad1l564dz5w9n980d0yvf7ivbp570vapwx451h74f3g9xdcx1";
+        url = "https://elpa.nongnu.org/nongnu-devel/bash-completion-3.2.1snapshot0.20260325.20.tar";
+        sha256 = "1ircxf1kgdjbrkx1i16z3lv62vbdsspyhl6hh589827031lsz0sj";
       };
       packageRequires = [ ];
       meta = {
@@ -543,10 +543,10 @@
     elpaBuild {
       pname = "caml";
       ename = "caml";
-      version = "4.100.20250227.123439";
+      version = "4.10snapshot0.20250227.11";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/caml-4.100.20250227.123439.tar";
-        sha256 = "0niymrn7d4gh5bd7wgrpbfh8r7d8i455ihr0i4lgs2v7xrgzc5ci";
+        url = "https://elpa.nongnu.org/nongnu-devel/caml-4.10snapshot0.20250227.11.tar";
+        sha256 = "06r646gvwkqmsiiln434c6x6w17f8in0rqaymxpgyfhrxmx6skbb";
       };
       packageRequires = [ ];
       meta = {
@@ -566,10 +566,10 @@
     elpaBuild {
       pname = "casual";
       ename = "casual";
-      version = "2.16.2.0.20260609.0";
+      version = "2.17.1.0.20260718.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/casual-2.16.2.0.20260609.0.tar";
-        sha256 = "1n3br77c56psicqs394kdgzlmsxbzzbm5w7bm0g3pkz5kq1jh5bh";
+        url = "https://elpa.nongnu.org/nongnu-devel/casual-2.17.1.0.20260718.0.tar";
+        sha256 = "031vpnhf498lic2ngh9bmg0917561dsnrn3apsdv0id3rl7vsd35";
       };
       packageRequires = [
         csv-mode
@@ -619,10 +619,10 @@
     elpaBuild {
       pname = "cider";
       ename = "cider";
-      version = "1.23.0.20260624.34";
+      version = "2.0.1snapshot0.20260718.7";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/cider-1.23.0.20260624.34.tar";
-        sha256 = "0p56g5ni3w6rlajqp368zi6gw4jp0c0s5786fh04iv0kyqipw60p";
+        url = "https://elpa.nongnu.org/nongnu-devel/cider-2.0.1snapshot0.20260718.7.tar";
+        sha256 = "1y5bp14z67xky44nv419hwjry2n0md2ff54pi8mnfffcd0ikvp97";
       };
       packageRequires = [
         clojure-mode
@@ -649,10 +649,10 @@
     elpaBuild {
       pname = "clojure-mode";
       ename = "clojure-mode";
-      version = "5.23.0.0.20260615.3";
+      version = "5.23.0.0.20260709.7";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/clojure-mode-5.23.0.0.20260615.3.tar";
-        sha256 = "03sfdnyp7m9mvz55mdvp62wkjklp5nr4xrmrac5z5gvjwviqhcva";
+        url = "https://elpa.nongnu.org/nongnu-devel/clojure-mode-5.23.0.0.20260709.7.tar";
+        sha256 = "0rw17p4kgifzyxz393say6dbv5m5csvfwbyj9l96cyi9x71llz19";
       };
       packageRequires = [ ];
       meta = {
@@ -670,10 +670,10 @@
     elpaBuild {
       pname = "clojure-ts-mode";
       ename = "clojure-ts-mode";
-      version = "0.6.0.0.20260616.45";
+      version = "0.6.0.0.20260709.48";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/clojure-ts-mode-0.6.0.0.20260616.45.tar";
-        sha256 = "01vnjim6l8c6b6h6sgbznwssyqzr183j983i2p9s5gwpphcwi3qz";
+        url = "https://elpa.nongnu.org/nongnu-devel/clojure-ts-mode-0.6.0.0.20260709.48.tar";
+        sha256 = "0ia909an1q6zig3ysvnjf6nrv0gyz7jm7k3xzqfnqb0idm0sllx7";
       };
       packageRequires = [ ];
       meta = {
@@ -712,10 +712,10 @@
     elpaBuild {
       pname = "cond-let";
       ename = "cond-let";
-      version = "1.1.2.0.20260601.0";
+      version = "1.1.3.0.20260701.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/cond-let-1.1.2.0.20260601.0.tar";
-        sha256 = "0yqnwc5xv7aqazrr3g921lclrc6pnbaf1h3qv1qm8qxbvz7z76vd";
+        url = "https://elpa.nongnu.org/nongnu-devel/cond-let-1.1.3.0.20260701.0.tar";
+        sha256 = "1swmpvpx2437js3vn93vnfj5aqnwaf1xxw1ynyr0i2g4nr27qc7s";
       };
       packageRequires = [ ];
       meta = {
@@ -735,10 +735,10 @@
     elpaBuild {
       pname = "consult-flycheck";
       ename = "consult-flycheck";
-      version = "1.2.0.20260605.0";
+      version = "1.2.0.20260628.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/consult-flycheck-1.2.0.20260605.0.tar";
-        sha256 = "0kyhr3wzcdzjacda9hf07h0lrgayzacv8ly3hpnrvxq0gyjk9sk8";
+        url = "https://elpa.nongnu.org/nongnu-devel/consult-flycheck-1.2.0.20260628.1.tar";
+        sha256 = "0vffihzsnpnjcfkj2gc9qyx4hh274zhfq3nsgddygsl7dcbjv8xp";
       };
       packageRequires = [
         consult
@@ -785,10 +785,10 @@
     elpaBuild {
       pname = "crux";
       ename = "crux";
-      version = "0.6.0.20260315.62204";
+      version = "0.6.0snapshot0.20260315.12";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/crux-0.6.0.20260315.62204.tar";
-        sha256 = "0sbv5m22fgn5444ck8j0l9zvi8m8x7jv46z2zl06r6139s8m4l81";
+        url = "https://elpa.nongnu.org/nongnu-devel/crux-0.6.0snapshot0.20260315.12.tar";
+        sha256 = "09anj5a7p0waqyg0cng6x8231078xk4p6ig0ayancspbgyi9yp4d";
       };
       packageRequires = [ ];
       meta = {
@@ -914,10 +914,10 @@
     elpaBuild {
       pname = "datetime";
       ename = "datetime";
-      version = "0.10.30.20250203.204701";
+      version = "0.10.3snapshot0.20250203.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/datetime-0.10.30.20250203.204701.tar";
-        sha256 = "07c2wr4wdfp94hdiaxfzpcic80yckw32db9ay83gb21jy2rvys91";
+        url = "https://elpa.nongnu.org/nongnu-devel/datetime-0.10.3snapshot0.20250203.0.tar";
+        sha256 = "0d3vi2fg17rv4id78jdq9xv44skc1ndkajq9plf6x9bsgbbf3mcz";
       };
       packageRequires = [ extmap ];
       meta = {
@@ -978,10 +978,10 @@
     elpaBuild {
       pname = "devil";
       ename = "devil";
-      version = "0.7.3.0.20240129.2809";
+      version = "0.7.0beta3.0.20240129.11";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/devil-0.7.3.0.20240129.2809.tar";
-        sha256 = "0gqmp1x6li3g7fvy3aydm1smlx587g59d9fwv5ci3z5ik8cb98h8";
+        url = "https://elpa.nongnu.org/nongnu-devel/devil-0.7.0beta3.0.20240129.11.tar";
+        sha256 = "174wkr002wif8h62dlj34c5h7a1a52zs097n8flncm014l6m3y3i";
       };
       packageRequires = [ ];
       meta = {
@@ -999,10 +999,10 @@
     elpaBuild {
       pname = "diff-ansi";
       ename = "diff-ansi";
-      version = "0.2.0.20260524.93804";
+      version = "0.2.0.20260713.62";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/diff-ansi-0.2.0.20260524.93804.tar";
-        sha256 = "1wjvyhs8lfq5fszxlmrjwpw3spa3qq9dn7wmh0m0ilavmnql492v";
+        url = "https://elpa.nongnu.org/nongnu-devel/diff-ansi-0.2.0.20260713.62.tar";
+        sha256 = "0gxf2cjk96c5kx80qsn4w9ckg738zis2hhvbp26dgzkppmwxdwyk";
       };
       packageRequires = [ ];
       meta = {
@@ -1021,10 +1021,10 @@
     elpaBuild {
       pname = "dirvish";
       ename = "dirvish";
-      version = "2.3.0.0.20250504.80741";
+      version = "2.3.0.0.20260716.9";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/dirvish-2.3.0.0.20250504.80741.tar";
-        sha256 = "0h8ap8bnqy2czvgkc71l49ms3kwk8lciz0ydzi2yy5xgh5pvs71k";
+        url = "https://elpa.nongnu.org/nongnu-devel/dirvish-2.3.0.0.20260716.9.tar";
+        sha256 = "0yr5x846v1zynyacfpgn8zhhrzsw5qw3fqnr1w9cscljzfwlajs8";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1084,10 +1084,10 @@
     elpaBuild {
       pname = "dracula-theme";
       ename = "dracula-theme";
-      version = "1.8.3.0.20260519.113056";
+      version = "1.8.3.0.20260701.10";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/dracula-theme-1.8.3.0.20260519.113056.tar";
-        sha256 = "0jw288i092zgfkkazxsmx60va9fbklb2y7awcq2fwpbph7k14w4r";
+        url = "https://elpa.nongnu.org/nongnu-devel/dracula-theme-1.8.3.0.20260701.10.tar";
+        sha256 = "0m26r1swffj2ax3rl3yikgqi2rq796y8vwazisfsb1lsx06hwyyn";
       };
       packageRequires = [ ];
       meta = {
@@ -1307,10 +1307,10 @@
     elpaBuild {
       pname = "elfeed";
       ename = "elfeed";
-      version = "4.0.1.0.20260623.15";
+      version = "4.1.0.0.20260714.9";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/elfeed-4.0.1.0.20260623.15.tar";
-        sha256 = "1l9zizafja49r9kmn85qv3sfwh4kpp44yvz33b6gfrj06gn1mppf";
+        url = "https://elpa.nongnu.org/nongnu-devel/elfeed-4.1.0.0.20260714.9.tar";
+        sha256 = "05y0j3hmz1ch2fsv4gryf6d4ygk1xc5vh6zi5fn7ydyxkp49pnqr";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1331,10 +1331,10 @@
     elpaBuild {
       pname = "elfeed-web";
       ename = "elfeed-web";
-      version = "4.0.0.0.20260623.3";
+      version = "4.0.0.0.20260628.4";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/elfeed-web-4.0.0.0.20260623.3.tar";
-        sha256 = "18sqr02xn2vzfajysbz8i0f2m6vqq39c2vhazs8bi638vjk4irc0";
+        url = "https://elpa.nongnu.org/nongnu-devel/elfeed-web-4.0.0.0.20260628.4.tar";
+        sha256 = "0vwd5k1h47xcj6jz5wqcppm9cv2ywiliq4x3mszbharqklw83wmx";
       };
       packageRequires = [
         compat
@@ -1546,6 +1546,28 @@
       packageRequires = [ evil ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/evil-args.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  evil-collection = callPackage (
+    {
+      elpaBuild,
+      evil,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "evil-collection";
+      ename = "evil-collection";
+      version = "3.0.0.0.20260719.2";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu-devel/evil-collection-3.0.0.0.20260719.2.tar";
+        sha256 = "0xccbmkxzqdw5nqzaink8yab4ga3j0cg7djgiqrzdcd2cc44vqgx";
+      };
+      packageRequires = [ evil ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu-devel/evil-collection.html";
         license = lib.licenses.free;
       };
     }
@@ -1894,10 +1916,10 @@
     elpaBuild {
       pname = "extmap";
       ename = "extmap";
-      version = "1.3.10.20250203.193959";
+      version = "1.3.1snapshot0.20250203.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/extmap-1.3.10.20250203.193959.tar";
-        sha256 = "1xp7y64zi0pik02r78ks90zydddx583h3f4689n4ldif5zz3wd2k";
+        url = "https://elpa.nongnu.org/nongnu-devel/extmap-1.3.1snapshot0.20250203.2.tar";
+        sha256 = "07davhhx3nq15b3i7mfckxy9cnsq12y5cds8m0m4bw61sz8svxvi";
       };
       packageRequires = [ ];
       meta = {
@@ -2037,10 +2059,10 @@
     elpaBuild {
       pname = "flycheck";
       ename = "flycheck";
-      version = "36.0.0.20260604.57";
+      version = "37.0.0.20260720.8";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/flycheck-36.0.0.20260604.57.tar";
-        sha256 = "1rkpzjy998x346sc7ka2nvhavlam0d9klpgccsandacywdps1imq";
+        url = "https://elpa.nongnu.org/nongnu-devel/flycheck-37.0.0.20260720.8.tar";
+        sha256 = "1d7pb6kqz5s862d43l0ywzvhcd15xj2y8ixgc9zy42yz3rwnqlbj";
       };
       packageRequires = [ seq ];
       meta = {
@@ -2238,10 +2260,10 @@
     elpaBuild {
       pname = "geiser";
       ename = "geiser";
-      version = "0.33.1.0.20260523.150214";
+      version = "0.33.1.0.20260718.4";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/geiser-0.33.1.0.20260523.150214.tar";
-        sha256 = "1k0x34c6w0bnrbbkc01frn5h2kbn9pr02i80clr9vfixjv7zar9b";
+        url = "https://elpa.nongnu.org/nongnu-devel/geiser-0.33.1.0.20260718.4.tar";
+        sha256 = "14sipclbj37v0f0yc1pk0fl1p704f1gzpd3r21zyh3wkgfj2vjf5";
       };
       packageRequires = [ project ];
       meta = {
@@ -2282,10 +2304,10 @@
     elpaBuild {
       pname = "geiser-chibi";
       ename = "geiser-chibi";
-      version = "0.17.0.20240521.155242";
+      version = "0.17.0.20260706.3";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/geiser-chibi-0.17.0.20240521.155242.tar";
-        sha256 = "0xiaikj274ypfj546snxpi6h30jlc9hifhnw8ljj1zxsafr1wzqq";
+        url = "https://elpa.nongnu.org/nongnu-devel/geiser-chibi-0.17.0.20260706.3.tar";
+        sha256 = "08rhpfr9zsgdmz8j4f8va07ww7lk9kbxcpnm3wxjl940n56nhji9";
       };
       packageRequires = [ geiser ];
       meta = {
@@ -2608,10 +2630,10 @@
     elpaBuild {
       pname = "gnuplot";
       ename = "gnuplot";
-      version = "0.12.0.20260623.2";
+      version = "0.12.0.20260628.3";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/gnuplot-0.12.0.20260623.2.tar";
-        sha256 = "0w38z2cmrrnc0bh6pdsqyrhsipz59lknfrkcyahybpbi80x0cgl8";
+        url = "https://elpa.nongnu.org/nongnu-devel/gnuplot-0.12.0.20260628.3.tar";
+        sha256 = "1gmivwm8xv4x3gab3xnlxnjsqxivb9xdkk6gb8nc6a3rl87py19w";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2715,10 +2737,10 @@
     elpaBuild {
       pname = "gptel";
       ename = "gptel";
-      version = "0.9.9.5.0.20260620.44";
+      version = "0.9.9.5.0.20260715.65";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/gptel-0.9.9.5.0.20260620.44.tar";
-        sha256 = "1j9ij8z4hyd4rbz96gk99myrw39x8fd907imnvarqq9xl42m9hrj";
+        url = "https://elpa.nongnu.org/nongnu-devel/gptel-0.9.9.5.0.20260715.65.tar";
+        sha256 = "0ax0i8v68ibx4mh6pyz8lqjrkjw7zz9chwkricmjkcn7kha3l6l2";
       };
       packageRequires = [
         compat
@@ -2912,10 +2934,10 @@
     elpaBuild {
       pname = "helm";
       ename = "helm";
-      version = "4.0.7.0.20260624.21";
+      version = "4.0.7.0.20260716.25";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/helm-4.0.7.0.20260624.21.tar";
-        sha256 = "13kprv1v1snk018m4ccjiyj8ndmc9jf7f5saw896kq16rdiwq72p";
+        url = "https://elpa.nongnu.org/nongnu-devel/helm-4.0.7.0.20260716.25.tar";
+        sha256 = "0g3qmffjwfyrw3iqwrp2ai8pm7q6wan2x0w62vlbacvkziqy7vgf";
       };
       packageRequires = [
         helm-core
@@ -2937,10 +2959,10 @@
     elpaBuild {
       pname = "helm-core";
       ename = "helm-core";
-      version = "4.0.7.0.20260624.21";
+      version = "4.0.7.0.20260716.25";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/helm-core-4.0.7.0.20260624.21.tar";
-        sha256 = "1w3xdawc6br7i0300544rc6c35yrbck2rkd0d667fv4c79nhvix3";
+        url = "https://elpa.nongnu.org/nongnu-devel/helm-core-4.0.7.0.20260716.25.tar";
+        sha256 = "0qrcc87av7s3xmrl9290rsjljlh68hdh4wyrfjk0g988kpdpbyqx";
       };
       packageRequires = [ async ];
       meta = {
@@ -3070,10 +3092,10 @@
     elpaBuild {
       pname = "hyperdrive";
       ename = "hyperdrive";
-      version = "0.60.20251120.145618";
+      version = "0.6pre0.20251120.26";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/hyperdrive-0.60.20251120.145618.tar";
-        sha256 = "0m4ns20mfcbxqy68qdlbyy9ywvwvhrlrz34dr7g35cz836740a2v";
+        url = "https://elpa.nongnu.org/nongnu-devel/hyperdrive-0.6pre0.20251120.26.tar";
+        sha256 = "0j8zglxc2bjvbfdzw9lzy5lksda6hq6xjwcmiyg489yfrx1n5gk5";
       };
       packageRequires = [
         compat
@@ -3327,10 +3349,10 @@
     elpaBuild {
       pname = "jabber";
       ename = "jabber";
-      version = "0.11.0.0.20260619.11";
+      version = "0.12.2.0.20260715.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/jabber-0.11.0.0.20260619.11.tar";
-        sha256 = "0gjjbl93l0x9sqlmxabrpirkkw5c514pbja74znmdh3j89b7x5zs";
+        url = "https://elpa.nongnu.org/nongnu-devel/jabber-0.12.2.0.20260715.2.tar";
+        sha256 = "1d07y9qax62hgyxmcyfdk8w30y0p7qn4x0al2qzh1k0slvw12yjy";
       };
       packageRequires = [
         fsm
@@ -3533,10 +3555,10 @@
     elpaBuild {
       pname = "logview";
       ename = "logview";
-      version = "0.19.40.20260218.201306";
+      version = "0.19.4snapshot0.20260218.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/logview-0.19.40.20260218.201306.tar";
-        sha256 = "0nzhy8g714gy2w7dd9wyiwx9my2asbl9d1ps7k6m9g44xbvb2y0s";
+        url = "https://elpa.nongnu.org/nongnu-devel/logview-0.19.4snapshot0.20260218.1.tar";
+        sha256 = "1z9qplw6gbkvq5dmh2pwiwjva36bzy2dcfc4xrc79l1m0c0nffks";
       };
       packageRequires = [
         compat
@@ -3562,10 +3584,10 @@
     elpaBuild {
       pname = "loopy";
       ename = "loopy";
-      version = "0.16.0.0.20260622.0";
+      version = "0.16.1.0.20260718.10";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/loopy-0.16.0.0.20260622.0.tar";
-        sha256 = "1s534lm9ysk8q0z4ndlb4zxns1mzpffy1p11zf4qy54qsh0brj9x";
+        url = "https://elpa.nongnu.org/nongnu-devel/loopy-0.16.1.0.20260718.10.tar";
+        sha256 = "1gcw2if57rf30n0clxjfg372zb41nkrbx2q1ygh792l1cxlhbr51";
       };
       packageRequires = [
         compat
@@ -3590,10 +3612,10 @@
     elpaBuild {
       pname = "loopy-dash";
       ename = "loopy-dash";
-      version = "0.13.0.0.20260312.12155";
+      version = "0.13.0.0.20260718.11";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/loopy-dash-0.13.0.0.20260312.12155.tar";
-        sha256 = "1rg98wgrh5s6slafz8g8piazz04pa6fwiymgpic6hcrmf842fgpy";
+        url = "https://elpa.nongnu.org/nongnu-devel/loopy-dash-0.13.0.0.20260718.11.tar";
+        sha256 = "0ph9w0505yljnaiykmas8hjfj0d4rnbxv7xdw3j5aglffshl626z";
       };
       packageRequires = [
         dash
@@ -3689,10 +3711,10 @@
     elpaBuild {
       pname = "magit";
       ename = "magit";
-      version = "4.5.0.0.20260622.306";
+      version = "4.6.0.0.20260718.46";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/magit-4.5.0.0.20260622.306.tar";
-        sha256 = "07r0zjz7n6vy7fywmqf577vh7mx801104ph7302m4icawqbrk1gd";
+        url = "https://elpa.nongnu.org/nongnu-devel/magit-4.6.0.0.20260718.46.tar";
+        sha256 = "1ln6p4y19z2j2x9hj63v4p5d9kl83vzw993bwirbljf59gwn60qz";
       };
       packageRequires = [
         compat
@@ -3722,10 +3744,10 @@
     elpaBuild {
       pname = "magit-section";
       ename = "magit-section";
-      version = "4.5.0.0.20260622.306";
+      version = "4.6.0.0.20260718.46";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/magit-section-4.5.0.0.20260622.306.tar";
-        sha256 = "017345kx3wpfipy6pas53cyrhg4qx9pjl8ja7kram2g1hra3hm3z";
+        url = "https://elpa.nongnu.org/nongnu-devel/magit-section-4.6.0.0.20260718.46.tar";
+        sha256 = "02glfja6slz17qv3qzrwjz32a5j3yqj135z430nm2bz015c4k2gv";
       };
       packageRequires = [
         compat
@@ -3748,10 +3770,10 @@
     elpaBuild {
       pname = "markdown-mode";
       ename = "markdown-mode";
-      version = "2.90.20260425.95459";
+      version = "2.9alpha0.20260425.11";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/markdown-mode-2.90.20260425.95459.tar";
-        sha256 = "1xdszi0kjn3dg9nrn004hcb7ib7adh3vf6a8aznkaz4zhhqs420m";
+        url = "https://elpa.nongnu.org/nongnu-devel/markdown-mode-2.9alpha0.20260425.11.tar";
+        sha256 = "0gfaxz089cm7rzwdz9dva4kz8i1cndlq67svcb0fnyca03p6lgkr";
       };
       packageRequires = [ ];
       meta = {
@@ -3846,10 +3868,10 @@
     elpaBuild {
       pname = "meow";
       ename = "meow";
-      version = "1.5.0.0.20260619.66";
+      version = "1.5.0.0.20260714.67";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/meow-1.5.0.0.20260619.66.tar";
-        sha256 = "1m4ymrg1q8d87zxg72na8a272852qhw443na1g2lf0i01sqijsr8";
+        url = "https://elpa.nongnu.org/nongnu-devel/meow-1.5.0.0.20260714.67.tar";
+        sha256 = "1w91jlbpp37p4c11z15njvn8icd78hhwkldx70d6y28ngk14q9g3";
       };
       packageRequires = [ ];
       meta = {
@@ -4084,10 +4106,10 @@
     elpaBuild {
       pname = "opam-switch-mode";
       ename = "opam-switch-mode";
-      version = "1.80.20230802.91729";
+      version = "1.8snapshot0.20230802.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/opam-switch-mode-1.80.20230802.91729.tar";
-        sha256 = "1wp7h0p0mfa5gpwbn9sh43a7zy2yaslb9db9k54ylapqn8d8zapx";
+        url = "https://elpa.nongnu.org/nongnu-devel/opam-switch-mode-1.8snapshot0.20230802.1.tar";
+        sha256 = "11nvx2rp6zc4m78nkf5c9gbpfyrg68rkrwfvg6iqsga4aw4mr5z8";
       };
       packageRequires = [ ];
       meta = {
@@ -4266,10 +4288,10 @@
     elpaBuild {
       pname = "org-transclusion-http";
       ename = "org-transclusion-http";
-      version = "0.50.20240630.140904";
+      version = "0.5pre0.20240630.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/org-transclusion-http-0.50.20240630.140904.tar";
-        sha256 = "0kgq58mr7r9jlsc68nm6z6fm3wb0y1kjayj0qp7pbipqj9dx6b9z";
+        url = "https://elpa.nongnu.org/nongnu-devel/org-transclusion-http-0.5pre0.20240630.1.tar";
+        sha256 = "06cnyym38nrli2hb74g8qpwaajy3brg64sfkfr5rmbrqyqwlqspp";
       };
       packageRequires = [
         org-transclusion
@@ -4316,10 +4338,10 @@
     elpaBuild {
       pname = "orgit";
       ename = "orgit";
-      version = "2.1.3.0.20260623.18";
+      version = "2.2.0.0.20260701.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/orgit-2.1.3.0.20260623.18.tar";
-        sha256 = "0cpi9xzs79jbysj127z72611x82wpbzhfgz603ww454x9qiyb9fa";
+        url = "https://elpa.nongnu.org/nongnu-devel/orgit-2.2.0.0.20260701.0.tar";
+        sha256 = "143w8vvgn9qfyfrdd8ccs4grpgnksbvjby9sb077ciqjnzimnx5d";
       };
       packageRequires = [
         compat
@@ -4429,10 +4451,10 @@
     elpaBuild {
       pname = "paredit";
       ename = "paredit";
-      version = "270.20241103.213959";
+      version = "27beta0.20241103.20";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/paredit-270.20241103.213959.tar";
-        sha256 = "11fbgw18934ddrba1z5fz6c42m2b7jdmrg2lnzlracxfgk9gfp8p";
+        url = "https://elpa.nongnu.org/nongnu-devel/paredit-27beta0.20241103.20.tar";
+        sha256 = "0dmqfcir64pb9nw577wqnh0g0d6kvvzc4v8hca4bcl17ipa0wjkz";
       };
       packageRequires = [ ];
       meta = {
@@ -4566,10 +4588,10 @@
     elpaBuild {
       pname = "pg";
       ename = "pg";
-      version = "0.67.0.20260610.2";
+      version = "0.68.0.20260719.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/pg-0.67.0.20260610.2.tar";
-        sha256 = "16014aqcz3pj31pbwgyaw9qsqz5rfmmscdah6qvppg2dg17lwfhg";
+        url = "https://elpa.nongnu.org/nongnu-devel/pg-0.68.0.20260719.0.tar";
+        sha256 = "1awd1rsb95vka0raf8pdgpyj1mmx8s3nqqhgqcxs4h44v8fppyc6";
       };
       packageRequires = [ peg ];
       meta = {
@@ -4587,10 +4609,10 @@
     elpaBuild {
       pname = "php-mode";
       ename = "php-mode";
-      version = "1.26.1.0.20251112.64638";
+      version = "1.26.1.0.20260719.80";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/php-mode-1.26.1.0.20251112.64638.tar";
-        sha256 = "1vh7ynpbpps46jw5g9qwzzhyb4kll0dpppj5493kpjj3d87xclir";
+        url = "https://elpa.nongnu.org/nongnu-devel/php-mode-1.26.1.0.20260719.80.tar";
+        sha256 = "0wsid2y7lybyzk6kf61k9jc80vk3qz3bqsr2rgqy6hln5rv8g5q8";
       };
       packageRequires = [ ];
       meta = {
@@ -4672,10 +4694,10 @@
     elpaBuild {
       pname = "projectile";
       ename = "projectile";
-      version = "2.10.0.20260620.133";
+      version = "3.3.0snapshot0.20260720.5";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/projectile-2.10.0.20260620.133.tar";
-        sha256 = "1l2m7v59jx8myiaswyrwrm2z60hkk8vqnfl7bnzzvjcs10jafl82";
+        url = "https://elpa.nongnu.org/nongnu-devel/projectile-3.3.0snapshot0.20260720.5.tar";
+        sha256 = "1n26lg4i2k8nh5sw3yxjrjdmqdylmf0wdbijc0gkqzlafa3nh6qg";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4693,10 +4715,10 @@
     elpaBuild {
       pname = "proof-general";
       ename = "proof-general";
-      version = "4.60.20260622.265";
+      version = "4.6snapshot0.20260622.265";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/proof-general-4.60.20260622.265.tar";
-        sha256 = "1b9qv3dv173aqx5k0drkysk017g1ycrzy25kzdhkxg8280kz3v5k";
+        url = "https://elpa.nongnu.org/nongnu-devel/proof-general-4.6snapshot0.20260622.265.tar";
+        sha256 = "1w3xbgzq9ibhdb4b06f658lvg79c0gyacicmaljp8pz3548dcly8";
       };
       packageRequires = [ ];
       meta = {
@@ -4737,10 +4759,10 @@
     elpaBuild {
       pname = "racket-mode";
       ename = "racket-mode";
-      version = "1.0.20260303.123213";
+      version = "1.0.20260626.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/racket-mode-1.0.20260303.123213.tar";
-        sha256 = "1iqbrsy5sivv9mm6sk48vj1mv4magh7bg7346i1a02plr0hg8qml";
+        url = "https://elpa.nongnu.org/nongnu-devel/racket-mode-1.0.20260626.0.tar";
+        sha256 = "19lbiv2wd1fs1jzr4j9q89j41hbhvlgfg9h48bjxki8dqs96d668";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4928,10 +4950,10 @@
     elpaBuild {
       pname = "rubocop";
       ename = "rubocop";
-      version = "0.7.0.20210309.124149";
+      version = "0.7.0snapshot0.20210309.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/rubocop-0.7.0.20210309.124149.tar";
-        sha256 = "0akmidx76zrrfcax7397cs1plwnr3dm83npakbpkssihf08b13aq";
+        url = "https://elpa.nongnu.org/nongnu-devel/rubocop-0.7.0snapshot0.20210309.1.tar";
+        sha256 = "0bggy6nc2wsng83df3vrqw8ygs5ys87i09511kl5d9xfhds7fx4j";
       };
       packageRequires = [ ];
       meta = {
@@ -4997,10 +5019,10 @@
     elpaBuild {
       pname = "scad-mode";
       ename = "scad-mode";
-      version = "99.0.0.20260519.103934";
+      version = "99.0.0.20260628.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/scad-mode-99.0.0.20260519.103934.tar";
-        sha256 = "1rh44ifrfihh1jiy1g8fj5gln6ycdimpszilfhzy9fawxwlqhrqk";
+        url = "https://elpa.nongnu.org/nongnu-devel/scad-mode-99.0.0.20260628.1.tar";
+        sha256 = "0pwx9vknh5w1m3cqp1081dq07061qwn7y292y0x85cvisak8hkcs";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5102,10 +5124,10 @@
     elpaBuild {
       pname = "sesman";
       ename = "sesman";
-      version = "0.3.30.20260616.21";
+      version = "0.3.3snapshot0.20260616.21";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/sesman-0.3.30.20260616.21.tar";
-        sha256 = "0px5lb4xqv8j1n4qran31ra5cq7l1adgfsghm63hwd2sqb999337";
+        url = "https://elpa.nongnu.org/nongnu-devel/sesman-0.3.3snapshot0.20260616.21.tar";
+        sha256 = "1nc2h58dcjwvi9kjqgmw79cvdc9i1ja8xkxs69hjhyq7y0wp85kf";
       };
       packageRequires = [ ];
       meta = {
@@ -5145,10 +5167,10 @@
     elpaBuild {
       pname = "simple-httpd";
       ename = "simple-httpd";
-      version = "1.6.0.20260623.1";
+      version = "1.6.0.20260709.3";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/simple-httpd-1.6.0.20260623.1.tar";
-        sha256 = "1npss5lv7r2nzvbhzh5jr7w53n2hx6w9pws554srh25hw68v3zd4";
+        url = "https://elpa.nongnu.org/nongnu-devel/simple-httpd-1.6.0.20260709.3.tar";
+        sha256 = "0fyl4r8x0k074cb5h7agfm9zdpny68n0sm24wb9mc089fx9j9q5c";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5167,10 +5189,10 @@
     elpaBuild {
       pname = "slime";
       ename = "slime";
-      version = "2.320.20260612.49";
+      version = "2.32snapshot0.20260719.53";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/slime-2.320.20260612.49.tar";
-        sha256 = "196g2sc1v84013nk3c8my3w2r3aqvg9sjix2ca64vvrarfamb0ck";
+        url = "https://elpa.nongnu.org/nongnu-devel/slime-2.32snapshot0.20260719.53.tar";
+        sha256 = "06isvwjq37vzf636ci5jb8fkzc926fnjzwx0fszlfax4hy00mlqf";
       };
       packageRequires = [ macrostep ];
       meta = {
@@ -5231,10 +5253,10 @@
     elpaBuild {
       pname = "solarized-theme";
       ename = "solarized-theme";
-      version = "2.1.0.0.20260610.7";
+      version = "2.1.0.0.20260703.8";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/solarized-theme-2.1.0.0.20260610.7.tar";
-        sha256 = "1phh2qqjf68ap6giid63zpnggx41y1zvn9q2c60igx01fv7xnykd";
+        url = "https://elpa.nongnu.org/nongnu-devel/solarized-theme-2.1.0.0.20260703.8.tar";
+        sha256 = "0iqgpdjxn6an3vn0pmy7iya5xs1ihjc9rj0kiyk6xlfswzc5pyfk";
       };
       packageRequires = [ ];
       meta = {
@@ -5443,10 +5465,10 @@
     elpaBuild {
       pname = "symbol-overlay";
       ename = "symbol-overlay";
-      version = "4.3.0.20260423.145452";
+      version = "4.3.0.20260703.4";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/symbol-overlay-4.3.0.20260423.145452.tar";
-        sha256 = "16gm3gj84wd7v6qhf3p0sz2jgbbyi60kqwkb41rfiz7n79qlijpg";
+        url = "https://elpa.nongnu.org/nongnu-devel/symbol-overlay-4.3.0.20260703.4.tar";
+        sha256 = "1mg02vrf7lhqiqkqlnl9czd11aw9i3gsa00f53fbn80vy123hixb";
       };
       packageRequires = [ seq ];
       meta = {
@@ -5739,7 +5761,6 @@
   ) { };
   tuareg = callPackage (
     {
-      caml,
       elpaBuild,
       fetchurl,
       lib,
@@ -5747,12 +5768,12 @@
     elpaBuild {
       pname = "tuareg";
       ename = "tuareg";
-      version = "3.0.20.20260617.40";
+      version = "3.1.1snapshot0.20260626.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/tuareg-3.0.20.20260617.40.tar";
-        sha256 = "0xmfvmxnk50pymajgmymwzmhjs8x5ac9dg1r7mx4iwsv15x13m4f";
+        url = "https://elpa.nongnu.org/nongnu-devel/tuareg-3.1.1snapshot0.20260626.1.tar";
+        sha256 = "0y1ygn4d8dcw0zgq0y2f65kmx64id5dcv2d23kvk2sddr53qya8f";
       };
-      packageRequires = [ caml ];
+      packageRequires = [ ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/tuareg.html";
         license = lib.licenses.free;
@@ -5789,10 +5810,10 @@
     elpaBuild {
       pname = "typst-ts-mode";
       ename = "typst-ts-mode";
-      version = "0.12.2.0.20260415.103532";
+      version = "0.12.2.0.20260624.24";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/typst-ts-mode-0.12.2.0.20260415.103532.tar";
-        sha256 = "190jabvm3p74cd96rrbj45y68myg32zvlxjrq01zvi3jv29xbpf6";
+        url = "https://elpa.nongnu.org/nongnu-devel/typst-ts-mode-0.12.2.0.20260624.24.tar";
+        sha256 = "13amyfg5zkbxwp1gipnyn01wpwpyv0p0w4sv97xpfiyazhs5w4bn";
       };
       packageRequires = [ ];
       meta = {
@@ -5937,10 +5958,10 @@
     elpaBuild {
       pname = "vm";
       ename = "vm";
-      version = "8.3.30.20260610.33";
+      version = "8.3.3snapshot0.20260716.51";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/vm-8.3.30.20260610.33.tar";
-        sha256 = "0194px4dg5q2rgddvqwylcywymjx39s3ih16kh6d8whvlk1xcm6p";
+        url = "https://elpa.nongnu.org/nongnu-devel/vm-8.3.3snapshot0.20260716.51.tar";
+        sha256 = "04pq2a39czffcj4rwv0c7bg53vc95mjyk4jqqp25blk4v4l9ygs2";
       };
       packageRequires = [ vcard ];
       meta = {
@@ -6005,10 +6026,10 @@
     elpaBuild {
       pname = "wfnames";
       ename = "wfnames";
-      version = "1.2.0.20260105.45812";
+      version = "1.2.0.20260706.4";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/wfnames-1.2.0.20260105.45812.tar";
-        sha256 = "116d5j1sqb0fbqlfaxxiaraw8c6mg69nw5mn412zwrvbq4vgpp4c";
+        url = "https://elpa.nongnu.org/nongnu-devel/wfnames-1.2.0.20260706.4.tar";
+        sha256 = "1gzypbg4nkf7yyscyq8p9n5ckclg0rcks5s8rilsljb0csnx35nz";
       };
       packageRequires = [ ];
       meta = {
@@ -6071,10 +6092,10 @@
     elpaBuild {
       pname = "with-editor";
       ename = "with-editor";
-      version = "3.5.1.0.20260623.3";
+      version = "3.5.2.0.20260701.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/with-editor-3.5.1.0.20260623.3.tar";
-        sha256 = "16mfh41zkdylbk92cizm4ia69lwirq58mb8rms9v448s41w2wvka";
+        url = "https://elpa.nongnu.org/nongnu-devel/with-editor-3.5.2.0.20260701.0.tar";
+        sha256 = "067x2q0ykrp9llva4gn1cjyxwnhb0yh1cxr6ghdd4yccbfdi4y85";
       };
       packageRequires = [
         compat
@@ -6185,10 +6206,10 @@
     elpaBuild {
       pname = "xah-fly-keys";
       ename = "xah-fly-keys";
-      version = "28.11.20260416140940.0.20260416.141130";
+      version = "28.11.20260712150256.0.20260712.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/xah-fly-keys-28.11.20260416140940.0.20260416.141130.tar";
-        sha256 = "0mrfn3z60jgk2f9lccb3qcaa52rvh366ys97ypz5lgjlxal1sr5r";
+        url = "https://elpa.nongnu.org/nongnu-devel/xah-fly-keys-28.11.20260712150256.0.20260712.0.tar";
+        sha256 = "0g4lfqm81kpszwlkapvr25c8c0b4rmg00zrr62ziz16bplvgy3ky";
       };
       packageRequires = [ ];
       meta = {
@@ -6292,10 +6313,10 @@
     elpaBuild {
       pname = "zenburn-theme";
       ename = "zenburn-theme";
-      version = "2.10.0.0.20260601.0";
+      version = "2.10.0.0.20260704.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/zenburn-theme-2.10.0.0.20260601.0.tar";
-        sha256 = "0li865y8wp8gsim2xiscxhmpfnwd394ag9x9kpff082yg2q4j2ww";
+        url = "https://elpa.nongnu.org/nongnu-devel/zenburn-theme-2.10.0.0.20260704.2.tar";
+        sha256 = "17wp8z3nycqr3rva4npq3gi8ddv93fwzqh45bfgcr6a0zv4pfxp4";
       };
       packageRequires = [ ];
       meta = {
@@ -6314,10 +6335,10 @@
     elpaBuild {
       pname = "zig-mode";
       ename = "zig-mode";
-      version = "0.0.8.0.20251128.25646";
+      version = "0.0.8.0.20260717.49";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/zig-mode-0.0.8.0.20251128.25646.tar";
-        sha256 = "03nqzy5xyqsr7ax1m0sprk75ygkyspj824vixgkrflqnrhyj5b2s";
+        url = "https://elpa.nongnu.org/nongnu-devel/zig-mode-0.0.8.0.20260717.49.tar";
+        sha256 = "182rhhax10ldn763fraa5fc2vqlglzm9iq2yq2rvndgklqlf5bsc";
       };
       packageRequires = [ reformatter ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
@@ -75,10 +75,10 @@
     elpaBuild {
       pname = "aidermacs";
       ename = "aidermacs";
-      version = "1.7";
+      version = "1.9";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/aidermacs-1.7.tar";
-        sha256 = "17l7dlg218j63zwzi51wdczamvxlv54l0ivkip3h3kll386lkcm6";
+        url = "https://elpa.nongnu.org/nongnu/aidermacs-1.9.tar";
+        sha256 = "05ff2kfy97870qgvv89ysrk8cwnr3zxh1f01lvp7rk7siln0w10d";
       };
       packageRequires = [
         compat
@@ -269,10 +269,10 @@
     elpaBuild {
       pname = "auto-dim-other-buffers";
       ename = "auto-dim-other-buffers";
-      version = "2.2.1";
+      version = "2.2.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/auto-dim-other-buffers-2.2.1.tar";
-        sha256 = "00x0niv1zd47b2xl19k3fi0xxskdndiabns107cxzwb7pnkp4f0m";
+        url = "https://elpa.nongnu.org/nongnu/auto-dim-other-buffers-2.2.2.tar";
+        sha256 = "1464kwsdkzh4v0w2y8sv2v5w1s552a2pq1q81jpbfwh2md47ais2";
       };
       packageRequires = [ ];
       meta = {
@@ -566,10 +566,10 @@
     elpaBuild {
       pname = "casual";
       ename = "casual";
-      version = "2.16.2";
+      version = "2.17.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/casual-2.16.2.tar";
-        sha256 = "0aqkxxds4paicn1r4hy13f71cl4qllf9dfijpl4mp5zizyx8a8a2";
+        url = "https://elpa.nongnu.org/nongnu/casual-2.17.1.tar";
+        sha256 = "0wnr7lqb3c6wzcbjh19cj00jdh3rhplzyxq2khk009pfld861pa3";
       };
       packageRequires = [
         csv-mode
@@ -619,10 +619,10 @@
     elpaBuild {
       pname = "cider";
       ename = "cider";
-      version = "1.22.2";
+      version = "2.0.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/cider-1.22.2.tar";
-        sha256 = "0a7mcg1lazn1xyl3sxy0qpwd4qipf0ix56891ydjcv7i9yhggnpc";
+        url = "https://elpa.nongnu.org/nongnu/cider-2.0.0.tar";
+        sha256 = "1i8drgg7fbj4l4y7mgh47fw94bajwd5sdacfkvii0d6pc8sda2if";
       };
       packageRequires = [
         clojure-mode
@@ -735,10 +735,10 @@
     elpaBuild {
       pname = "cond-let";
       ename = "cond-let";
-      version = "1.1.2";
+      version = "1.1.3";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/cond-let-1.1.2.tar";
-        sha256 = "04p2jf8nm1q00439r26vvg9549hld4spcabghwsgmf89gqjiv8mm";
+        url = "https://elpa.nongnu.org/nongnu/cond-let-1.1.3.tar";
+        sha256 = "0zxirrq3rps48irxab1m1hkvbxjfahibfaynl4qb0lrz0bv8dzcf";
       };
       packageRequires = [ ];
       meta = {
@@ -1331,10 +1331,10 @@
     elpaBuild {
       pname = "elfeed";
       ename = "elfeed";
-      version = "4.0.1";
+      version = "4.1.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/elfeed-4.0.1.tar";
-        sha256 = "1az6lj58j1kkxzpa7ik8irl3z2b9f7yxsm92pfqlcwplsnm2q8q2";
+        url = "https://elpa.nongnu.org/nongnu/elfeed-4.1.0.tar";
+        sha256 = "0bwmhba975rsj9pk3s6wq7lsa38v4s0737hvhhdbzx1i66z45hmx";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1564,6 +1564,28 @@
       packageRequires = [ evil ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu/evil-args.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  evil-collection = callPackage (
+    {
+      elpaBuild,
+      evil,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "evil-collection";
+      ename = "evil-collection";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu/evil-collection-3.0.0.tar";
+        sha256 = "1a347yznrgw8b5y8jwj4rbryidr24c7g8c2is9pd4470v5h7jnfd";
+      };
+      packageRequires = [ evil ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu/evil-collection.html";
         license = lib.licenses.free;
       };
     }
@@ -2055,10 +2077,10 @@
     elpaBuild {
       pname = "flycheck";
       ename = "flycheck";
-      version = "36.0";
+      version = "37.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/flycheck-36.0.tar";
-        sha256 = "0172y6qzkys77cbvdla1iiiznpxpscjzmsdr66m66s8g4bf7f1p2";
+        url = "https://elpa.nongnu.org/nongnu/flycheck-37.0.tar";
+        sha256 = "0x565wcnxkmdsf87dzv555r6m86lmlwz4c16isgac8dn1qp7l5jb";
       };
       packageRequires = [ seq ];
       meta = {
@@ -3344,10 +3366,10 @@
     elpaBuild {
       pname = "jabber";
       ename = "jabber";
-      version = "0.11.0";
+      version = "0.12.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/jabber-0.11.0.tar";
-        sha256 = "1wikfd8iqj9r1qrh6cd593vgbkjndfpm9f12ilsdwxwh0nx3cpd7";
+        url = "https://elpa.nongnu.org/nongnu/jabber-0.12.2.tar";
+        sha256 = "0klii5m93g5dva7wrf7v0habb9pghrpa6kw63c5x1ym2w7sh8v6q";
       };
       packageRequires = [
         fsm
@@ -3579,10 +3601,10 @@
     elpaBuild {
       pname = "loopy";
       ename = "loopy";
-      version = "0.16.0";
+      version = "0.16.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/loopy-0.16.0.tar";
-        sha256 = "0bav318gimpv42y0ww9c0gm90pkma3ri0xp9mfimz9yriw2bjzyv";
+        url = "https://elpa.nongnu.org/nongnu/loopy-0.16.1.tar";
+        sha256 = "17p5km90v2pwwqr66x39h2ca6dx47xig1rkpvk1m4nlw32nqv1dh";
       };
       packageRequires = [
         compat
@@ -3706,10 +3728,10 @@
     elpaBuild {
       pname = "magit";
       ename = "magit";
-      version = "4.5.0";
+      version = "4.6.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/magit-4.5.0.tar";
-        sha256 = "080hc0y9pah86g7nw1x1gh2issap54r8dg9vzpm2l923cxy9jnbp";
+        url = "https://elpa.nongnu.org/nongnu/magit-4.6.0.tar";
+        sha256 = "0m7n3jvdf8d40wzglz67addk1nwwbvb7wkm0nq1mjpayqvwqyjml";
       };
       packageRequires = [
         compat
@@ -3739,10 +3761,10 @@
     elpaBuild {
       pname = "magit-section";
       ename = "magit-section";
-      version = "4.5.0";
+      version = "4.6.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/magit-section-4.5.0.tar";
-        sha256 = "1k63g8ayvg152r16ml5ph8q07qs5a424vs4i5q32icvl78v6cn2z";
+        url = "https://elpa.nongnu.org/nongnu/magit-section-4.6.0.tar";
+        sha256 = "085fr4fnk2wcd9z5l4ks20q69r501sx96abhyw80lshbd9rzj59z";
       };
       packageRequires = [
         compat
@@ -4333,20 +4355,22 @@
       elpaBuild,
       fetchurl,
       lib,
+      llama,
       magit,
       org,
     }:
     elpaBuild {
       pname = "orgit";
       ename = "orgit";
-      version = "2.1.3";
+      version = "2.2.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/orgit-2.1.3.tar";
-        sha256 = "1brwy6jx7jxb8jlkr8jq8hsdzmizqs41hkb3p14rmqqd0m5ddapl";
+        url = "https://elpa.nongnu.org/nongnu/orgit-2.2.0.tar";
+        sha256 = "0lw6mp6war3aqsad8vbdpz33nx7kki8df39xm7gnq1ja2dkgf9ah";
       };
       packageRequires = [
         compat
         cond-let
+        llama
         magit
         org
       ];
@@ -4588,10 +4612,10 @@
     elpaBuild {
       pname = "pg";
       ename = "pg";
-      version = "0.67";
+      version = "0.68";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/pg-0.67.tar";
-        sha256 = "01q06yk011pn9pg9srilwy0k9nn8x5pl32k1mn9i54mbikf7ac5b";
+        url = "https://elpa.nongnu.org/nongnu/pg-0.68.tar";
+        sha256 = "0nnr5gz4bm0hfdwj8f0vkfwb2apbk5sv3l85q7b420nwcs7d546r";
       };
       packageRequires = [ peg ];
       meta = {
@@ -4686,6 +4710,7 @@
   ) { };
   projectile = callPackage (
     {
+      compat,
       elpaBuild,
       fetchurl,
       lib,
@@ -4693,12 +4718,12 @@
     elpaBuild {
       pname = "projectile";
       ename = "projectile";
-      version = "2.9.1";
+      version = "3.2.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/projectile-2.9.1.tar";
-        sha256 = "07icp9baa7jkyqnz4b1sxl1dg88y5vzzhiwyfb12q349flbkkkb1";
+        url = "https://elpa.nongnu.org/nongnu/projectile-3.2.1.tar";
+        sha256 = "07hfhfbig1zw1fs0k7m22n3wqdyk4fj5fbpcrg0x4q2dw05r5bbj";
       };
-      packageRequires = [ ];
+      packageRequires = [ compat ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu/projectile.html";
         license = lib.licenses.free;
@@ -4758,10 +4783,10 @@
     elpaBuild {
       pname = "racket-mode";
       ename = "racket-mode";
-      version = "1.0.20260303.123213";
+      version = "1.0.20260626.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/racket-mode-1.0.20260303.123213.tar";
-        sha256 = "1wxhdrwm2fr3rnv7ghziibnpbx99z9qdaa54zd11jzjpkjgf2jxs";
+        url = "https://elpa.nongnu.org/nongnu/racket-mode-1.0.20260626.0.tar";
+        sha256 = "0y45m019fl0rdgjdz9ap1cr5agqg0gssfi04p33xqdcjkwrf51d0";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5776,7 +5801,6 @@
   ) { };
   tuareg = callPackage (
     {
-      caml,
       elpaBuild,
       fetchurl,
       lib,
@@ -5784,12 +5808,12 @@
     elpaBuild {
       pname = "tuareg";
       ename = "tuareg";
-      version = "3.0.1";
+      version = "3.1.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/tuareg-3.0.1.tar";
-        sha256 = "04lb71cafg4bqicx3q3rb9jpxbq6hmdrzw88f52sjqxq5c4cqdkj";
+        url = "https://elpa.nongnu.org/nongnu/tuareg-3.1.0.tar";
+        sha256 = "1fhw143rmdzrfrh6y3jdsyq6yqwv1dy6m6sg4s3mbqhnhxawc9sm";
       };
-      packageRequires = [ caml ];
+      packageRequires = [ ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu/tuareg.html";
         license = lib.licenses.free;
@@ -6103,18 +6127,20 @@
       elpaBuild,
       fetchurl,
       lib,
+      llama,
     }:
     elpaBuild {
       pname = "with-editor";
       ename = "with-editor";
-      version = "3.5.1";
+      version = "3.5.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/with-editor-3.5.1.tar";
-        sha256 = "0p19n8kx9gkj87pr8rlac8b9vlrb57w7k5b62fx9dwx2m54dixh9";
+        url = "https://elpa.nongnu.org/nongnu/with-editor-3.5.2.tar";
+        sha256 = "1qibgsb67zh8k8mpk3ghy2ilmrmf3dxz75clfvn2qji5ds2qlkzq";
       };
       packageRequires = [
         compat
         cond-let
+        llama
       ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu/with-editor.html";
@@ -6220,10 +6246,10 @@
     elpaBuild {
       pname = "xah-fly-keys";
       ename = "xah-fly-keys";
-      version = "28.11.20260416140940";
+      version = "28.11.20260712150256";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/xah-fly-keys-28.11.20260416140940.tar";
-        sha256 = "0zzdwrd4h12bqlxzpj7xs4m5cdgx9nbljrnyld6qs5b19352izyl";
+        url = "https://elpa.nongnu.org/nongnu/xah-fly-keys-28.11.20260712150256.tar";
+        sha256 = "1c4xsvmc92ydil78j2kk6avgswgz4ll5fx4mrlsmrq1z57v99ca1";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -134907,14 +134907,14 @@
   "repo": "tbanel/uniline",
   "unstable": {
    "version": [
-    20260718,
-    1006
+    20260721,
+    1504
    ],
    "deps": [
     "hydra"
    ],
-   "commit": "35983966dc850cec03d37d3d98ff8fddd8f1d099",
-   "sha256": "0qmkr4a76hxxs8vm1fxrd2dahk7y6imympd8myd8m36rpx6110sn"
+   "commit": "dc31332675769a789da879608276ec7e5b964865",
+   "sha256": "1nb2slw8has9bs2xh78zdkhgadqslkgpvlc3iab89a50bpa2mdf1"
   }
  },
  {

--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -1599,11 +1599,11 @@
   "repo": "xenodium/acp.el",
   "unstable": {
    "version": [
-    20260527,
-    2132
+    20260719,
+    342
    ],
-   "commit": "3ddfa907eb7f17949a4a8e731ea5c5241e6cbcb4",
-   "sha256": "0c9bsj9qz0v788m18bqr71a13jmby61d18dvmnzgl14a8gb5rpl4"
+   "commit": "a29cb161ac95f1819f34481a98666707661c5cf8",
+   "sha256": "0mbhra3nnvfwja3bamhcg8nfgrh4l19sv5cvir452xhab0y9rs7a"
   },
   "stable": {
    "version": [
@@ -1728,11 +1728,11 @@
   "repo": "brownts/ada-ts-mode",
   "unstable": {
    "version": [
-    20260603,
-    1308
+    20260627,
+    1553
    ],
-   "commit": "95f64aec514891039d04d0158df798bec152894a",
-   "sha256": "1dj1sdlhg5wyp6q01w7n6qkj9fkcnxmpgb18hch6b9myyjdgxvgk"
+   "commit": "32fcf68dba7463902481b256cdecad08e4b5b0a7",
+   "sha256": "05qj0zv33f6f8gknfbpz1fdz4nx7c3zzpl62qdxb5zvdsrmmdj0a"
   },
   "stable": {
    "version": [
@@ -2152,14 +2152,26 @@
   "repo": "Marx-A00/agent-recall",
   "unstable": {
    "version": [
-    20260515,
-    1821
+    20260710,
+    1707
    ],
    "deps": [
     "agent-shell"
    ],
-   "commit": "89436ed83a7a77a424627479ff486ca97a009f4a",
-   "sha256": "06v7rd7m0pszjs9g23djbxv679vnijy367ja3mhcaz8013504jir"
+   "commit": "166f421bce4a6550507e0bd2b896956d0d9d4a94",
+   "sha256": "1pyzipf18sjlcrgkzldgfb8dvk0j1m9g88v28r5iha99hbglg4pk"
+  },
+  "stable": {
+   "version": [
+    0,
+    6,
+    1
+   ],
+   "deps": [
+    "agent-shell"
+   ],
+   "commit": "166f421bce4a6550507e0bd2b896956d0d9d4a94",
+   "sha256": "1pyzipf18sjlcrgkzldgfb8dvk0j1m9g88v28r5iha99hbglg4pk"
   }
  },
  {
@@ -2170,28 +2182,28 @@
   "repo": "xenodium/agent-shell",
   "unstable": {
    "version": [
-    20260621,
-    1300
+    20260719,
+    1729
    ],
    "deps": [
     "acp",
     "shell-maker"
    ],
-   "commit": "131b9bec01588488c353de1f2510dc1bd68fa850",
-   "sha256": "15mp9r4yx4amanzrbbqblkxg7wriqg4kkb09w0x8a43ssi401fc0"
+   "commit": "d5675782a24e6e6ea850d5015e6b7cacf305854c",
+   "sha256": "1l6pv6zr5630lygaf7lmbaic2pbjxbf5n873c8lzg60cfswfydnz"
   },
   "stable": {
    "version": [
     0,
-    56,
+    62,
     1
    ],
    "deps": [
     "acp",
     "shell-maker"
    ],
-   "commit": "6b3799cac0e3a224fc7486970bfbc46b78fde8b7",
-   "sha256": "15pw3hsz8abxgbzmg0r7nycmzx4fxx771alw4cyzx0zr0hfk7r53"
+   "commit": "4a4b98b008ce9dba2edf22dc3a265abd1679ab0d",
+   "sha256": "0i46dw0a1djr8yx239x51i3cqd11zqs1lcrdzi87r8gvy82bd7wk"
   }
  },
  {
@@ -2371,27 +2383,27 @@
   "repo": "tninja/ai-code-interface.el",
   "unstable": {
    "version": [
-    20260624,
-    320
+    20260719,
+    2236
    ],
    "deps": [
     "magit",
     "transient"
    ],
-   "commit": "911a0631a1bc0a56080780715b749f0423ac8a08",
-   "sha256": "0zg3ilabsxmhgqpms9cq40yml5fmdq5ghabvrcls4inzv47991y2"
+   "commit": "0a7839ccc93f9769a27aa382da581518bcbf7390",
+   "sha256": "14dfcwv0zb4hv15az1vwg6xvznxli8hfyjhl3s9g3f2l3qp5rqxf"
   },
   "stable": {
    "version": [
     1,
-    86
+    900
    ],
    "deps": [
     "magit",
     "transient"
    ],
-   "commit": "8f4ac59dfc33f9907335b5b223739662a376ddf9",
-   "sha256": "0amq0b6fv80kbjv2pcisjzm17g458ivy25w0r3iii0pijr9qbnaf"
+   "commit": "0a7839ccc93f9769a27aa382da581518bcbf7390",
+   "sha256": "14dfcwv0zb4hv15az1vwg6xvznxli8hfyjhl3s9g3f2l3qp5rqxf"
   }
  },
  {
@@ -2438,29 +2450,29 @@
   "repo": "MatthewZMD/aidermacs",
   "unstable": {
    "version": [
-    20260521,
-    1930
+    20260719,
+    1435
    ],
    "deps": [
     "compat",
     "markdown-mode",
     "transient"
    ],
-   "commit": "9772db3e1969eec1df6a53b7d3e5597d07e3337f",
-   "sha256": "0q1ya7952cl8i2xr54idp9s76zlz6n9xmdklsfymd611l3pvchfj"
+   "commit": "c548c5cf0d4a427a9c59d6e384ac1d96c285adbe",
+   "sha256": "0rk8h2vjzkrwzmqsrw2pf3hikbj10v5n6z7jjjjil8pqj146whjy"
   },
   "stable": {
    "version": [
     1,
-    7
+    8
    ],
    "deps": [
     "compat",
     "markdown-mode",
     "transient"
    ],
-   "commit": "9772db3e1969eec1df6a53b7d3e5597d07e3337f",
-   "sha256": "0q1ya7952cl8i2xr54idp9s76zlz6n9xmdklsfymd611l3pvchfj"
+   "commit": "7496878820661a950ef1b28ce8814177b3010825",
+   "sha256": "0rn0va9k69bf5021w4b8g76m5lsvp2h8ch5ch4kb0060xmdnc2gb"
   }
  },
  {
@@ -3438,11 +3450,11 @@
   "repo": "rolandwalker/anaphora",
   "unstable": {
    "version": [
-    20240120,
-    1744
+    20260720,
+    903
    ],
-   "commit": "a755afa7db7f3fa515f8dd2c0518113be0b027f6",
-   "sha256": "1mmil5ckb623wxxmvw1cfi1fycxiz7aalfjm768h7wc73xfa7ks4"
+   "commit": "d22ae8afd3b3bf6a383f6a6c27522893b57130b1",
+   "sha256": "10nn49csvxqljhj17v1qlqzhmzrx5lz7yzp5fa33xjy7gn7j1v8d"
   },
   "stable": {
    "version": [
@@ -3596,28 +3608,28 @@
   "repo": "kickingvegas/anju",
   "unstable": {
    "version": [
-    20260624,
-    510
+    20260701,
+    2139
    ],
    "deps": [
     "casual",
     "markdown-mode"
    ],
-   "commit": "eb3889778f212a69fbe40acbc4d208c0e0c9ee2c",
-   "sha256": "0l6xw9i1cis2wxp6ncj8w2v685cqqs3p0mpdplwvfar1q9gl63hn"
+   "commit": "f5d27108ffe5facb6886fab191068efd1faea39f",
+   "sha256": "0agkin9ph1mhfl3dr4p2ljs48npjgm70kpxd43vl5xgyz1dhkkfl"
   },
   "stable": {
    "version": [
     1,
-    7,
+    8,
     0
    ],
    "deps": [
     "casual",
     "markdown-mode"
    ],
-   "commit": "eb3889778f212a69fbe40acbc4d208c0e0c9ee2c",
-   "sha256": "0l6xw9i1cis2wxp6ncj8w2v685cqqs3p0mpdplwvfar1q9gl63hn"
+   "commit": "f5d27108ffe5facb6886fab191068efd1faea39f",
+   "sha256": "0agkin9ph1mhfl3dr4p2ljs48npjgm70kpxd43vl5xgyz1dhkkfl"
   }
  },
  {
@@ -3643,11 +3655,11 @@
   "repo": "anki-editor/anki-editor",
   "unstable": {
    "version": [
-    20260605,
-    551
+    20260714,
+    1156
    ],
-   "commit": "7089c15f3151e0318e3d7d801f6b87eeeb25d226",
-   "sha256": "0mmnk8dnliad97jw25ck2h61v8065qjgxl3sm1k0l60x5knwl6n3"
+   "commit": "4a55c3f937b176d31e36d484c196682cae9f9104",
+   "sha256": "02q4qh3hliah8h4648vbn13mw5xspps54kwp1k9gvxmnmz8ch85f"
   }
  },
  {
@@ -4479,11 +4491,11 @@
   "repo": "motform/arduino-cli-mode",
   "unstable": {
    "version": [
-    20250524,
-    901
+    20260628,
+    2219
    ],
-   "commit": "aa93d49dc90c54e61b70f40fe88967fc0ae04927",
-   "sha256": "1b84gaz8libqfapkgxfbbsbn5pvzxnm6b7c96vbxa0ry3jc0bd34"
+   "commit": "d5614acdca80871cf4db65843227223b5a0e3a2c",
+   "sha256": "03av4cy826kxi8lxl3asay044dxnax5wxlx3i7hbmya20rckczqh"
   }
  },
  {
@@ -4850,20 +4862,20 @@
   "repo": "SunskyXH/ast-grep.el",
   "unstable": {
    "version": [
-    20260615,
-    1001
+    20260702,
+    238
    ],
-   "commit": "8fabb5064131a1c822580e47bf35871466d469ff",
-   "sha256": "1r0i49vjrr9x86kn656l0dbbj40snvgq5k91w249cnq8xh2khh5m"
+   "commit": "28bc6e9ac21acf1d1ef58b962b6acd670c27e80f",
+   "sha256": "1li2aj2aaicpc291igzkfsvjdr85nnd27kc976389zn0ngqngyd4"
   },
   "stable": {
    "version": [
     0,
-    4,
-    1
+    6,
+    0
    ],
-   "commit": "8fabb5064131a1c822580e47bf35871466d469ff",
-   "sha256": "1r0i49vjrr9x86kn656l0dbbj40snvgq5k91w249cnq8xh2khh5m"
+   "commit": "28bc6e9ac21acf1d1ef58b962b6acd670c27e80f",
+   "sha256": "1li2aj2aaicpc291igzkfsvjdr85nnd27kc976389zn0ngqngyd4"
   }
  },
  {
@@ -5999,11 +6011,11 @@
   "repo": "mina86/auto-dim-other-buffers.el",
   "unstable": {
    "version": [
-    20250116,
-    1402
+    20260624,
+    950
    ],
-   "commit": "d8591d048f97478e75c71830fb6d7c009351c73d",
-   "sha256": "0ipx6gpgbap5jxkvhxxifllhcjyap552835jz26h9w3ppa4q1hig"
+   "commit": "cf0263073470190b85f6013066856126aac67d19",
+   "sha256": "047zvky0m51c31y6ai7g2y2y4zndrx3fv9ymvv1nlk595qc4rg4r"
   }
  },
  {
@@ -7232,11 +7244,20 @@
   "repo": "wbolster/emacs-balanced-windows",
   "unstable": {
    "version": [
-    20190903,
-    1120
+    20260706,
+    1545
    ],
-   "commit": "1da5354ad8a9235d13928e2ee0863f3642ccdd13",
-   "sha256": "1hsjg48jlfi6lc6izp9xcfqvxj7c0ivjrfsr2q3yv3s1iy2fz37l"
+   "commit": "f94f9cbe832147396bb0d67e687a9dc33ec2a2c5",
+   "sha256": "081k5qdvjp3f9swnn45azsy233x9sza9y1qj7sy85bj7xcrmz82q"
+  },
+  "stable": {
+   "version": [
+    1,
+    1,
+    0
+   ],
+   "commit": "f94f9cbe832147396bb0d67e687a9dc33ec2a2c5",
+   "sha256": "081k5qdvjp3f9swnn45azsy233x9sza9y1qj7sy85bj7xcrmz82q"
   }
  },
  {
@@ -7346,11 +7367,11 @@
   "repo": "tinted-theming/base16-emacs",
   "unstable": {
    "version": [
-    20260621,
-    406
+    20260719,
+    235
    ],
-   "commit": "93b118e5ae7477361d1120db32508cb9756eb145",
-   "sha256": "1lmzfm2yscq1f4xrf47vabaf6r8svc6hrwdn2166zfj42sf3zx2h"
+   "commit": "0fa7a37a5140cc64f44ef404309b8961d2e46562",
+   "sha256": "1ahay37adsv3givhcpc1jzl054sw9n8rslk3m786fjvqn4zn5h92"
   },
   "stable": {
    "version": [
@@ -7517,11 +7538,11 @@
   "repo": "bbatsov/batppuccin-emacs",
   "unstable": {
    "version": [
-    20260520,
-    1150
+    20260703,
+    608
    ],
-   "commit": "16a6f902cd2d9e25019b4c17a7ee41025f99b93d",
-   "sha256": "1raxr8rnfq1f1z936bl20y2yjcf7r6hh003br8y9g986gwgs0rz1"
+   "commit": "5fc17c1c403bed4b7728ee0afbb4563749fd381d",
+   "sha256": "1gg69xxdalb5ylh2h7kii0ncp5ffj2501f0vzpmcwz31w47510w1"
   },
   "stable": {
    "version": [
@@ -8004,28 +8025,28 @@
   "repo": "pastor/ben.el",
   "unstable": {
    "version": [
-    20260617,
-    1102
+    20260626,
+    1926
    ],
    "deps": [
     "inheritenv",
     "seq"
    ],
-   "commit": "259f76f83efb03220e60bd799fb17fc49bddcda0",
-   "sha256": "12qliyhk9ni10ks2hrwv74dhwakqb0jkvhip44qcfcrnhjvyacka"
+   "commit": "247054fe5da00ee4aee4607da0075935541017a9",
+   "sha256": "1rzs21l032awcpyq7alh2xy7ibkzqlhmph9jx8rbs6ml8wzyc0l6"
   },
   "stable": {
    "version": [
     0,
     12,
-    12
+    13
    ],
    "deps": [
     "inheritenv",
     "seq"
    ],
-   "commit": "c91cce703deb0cafb9f344cbc66d63791665fcb2",
-   "sha256": "05ls9sdydwnz2sifakk1jww68dkv0pinj25mpqw4j11kh48s7cm7"
+   "commit": "247054fe5da00ee4aee4607da0075935541017a9",
+   "sha256": "1rzs21l032awcpyq7alh2xy7ibkzqlhmph9jx8rbs6ml8wzyc0l6"
   }
  },
  {
@@ -8804,14 +8825,14 @@
   "repo": "eki3z/binky.el",
   "unstable": {
    "version": [
-    20250123,
-    1928
+    20260719,
+    1537
    ],
    "deps": [
     "dash"
    ],
-   "commit": "29f2492366ced8ff13802faf4a1c6df5e0c9cb07",
-   "sha256": "16qvz52lqrv3gv9fvnm8hfxghlnim7gf05y7l0i3zwgcmc2nhk3n"
+   "commit": "e24c4691d231f4b0f649e155d2c93cd83d3dc073",
+   "sha256": "1wrp3ys5lv10ny2fspg5sqbwcxlmn315q7g8icjsjnk64dbdicvs"
   },
   "stable": {
    "version": [
@@ -8926,16 +8947,16 @@
   "repo": "danielcmccarthy/bitbake-el",
   "unstable": {
    "version": [
-    20260620,
-    217
+    20260712,
+    1615
    ],
    "deps": [
     "dash",
-    "mmm-mode",
+    "polymode",
     "s"
    ],
-   "commit": "683f6e9fa1d15447eeef0415b88bd116180463d3",
-   "sha256": "0dpjsknphrwjc6hqrdfgdv18nz7dcbx6vksiibdc0jmxr0bzk558"
+   "commit": "f626d37727df0550aa2afd3f1b0ce81f38be18a3",
+   "sha256": "0jzig4hyia6zi31qygh8c62jzfas7vz7kp3nfh8s1fvqx8pj8lrk"
   }
  },
  {
@@ -9070,11 +9091,11 @@
   "repo": "gdonald/blackjack-el",
   "unstable": {
    "version": [
-    20260418,
-    1402
+    20260705,
+    2046
    ],
-   "commit": "3930d197d1f8f37de0dbb6c9875ef5279e16cdfa",
-   "sha256": "0zxpiz9kjicyf2lhq2rclj2cqaf3f518xwlm48dcrkr1hjn6yqac"
+   "commit": "7f98c9d15fa2d42abb2643235f73a9513b46c227",
+   "sha256": "0zsia1p1vch1ph24k7nq0q0cb7f4kz2dk75sywkh9rdfcs8cijgm"
   },
   "stable": {
    "version": [
@@ -9107,6 +9128,30 @@
    ],
    "commit": "87822abd1ed46411368ef91752a7f51c0ef2aee0",
    "sha256": "0n0889vsm3lzswkcdgdykgv3vz4pb9s88wwkinc5bn70vc187byp"
+  }
+ },
+ {
+  "ename": "blamee",
+  "commit": "6a860645041c1ca63437f4ce06ad73bfdd3ff356",
+  "sha256": "1hv320apk7lj7sk3yqpam33bw1b4czqqakc5m5m13x71m06c4s3v",
+  "fetcher": "github",
+  "repo": "fvi-att/blamee",
+  "unstable": {
+   "version": [
+    20260619,
+    227
+   ],
+   "commit": "60bb7e7dd29e0e0fabd172e91d362b00fac363c4",
+   "sha256": "0i5kaidka9668wiarpkkj0s9s35r7hmmp78z57nhz3nqn7nc7315"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    5
+   ],
+   "commit": "60bb7e7dd29e0e0fabd172e91d362b00fac363c4",
+   "sha256": "0i5kaidka9668wiarpkkj0s9s35r7hmmp78z57nhz3nqn7nc7315"
   }
  },
  {
@@ -9337,14 +9382,14 @@
   "repo": "lapislazuli/blue.el",
   "unstable": {
    "version": [
-    20260620,
-    951
+    20260709,
+    1248
    ],
    "deps": [
     "magit-section"
    ],
-   "commit": "ca78d0ee1f7ff9e08b46ec2e90b69a8fbd05a9ab",
-   "sha256": "1sn54gijg5x9vwjn8y0vl9d7f8ig6rink6s2fibcv11har2gazps"
+   "commit": "3668ca7f627f3497d907293f38dcfbe33fb6f4f7",
+   "sha256": "1gqcbxr3dr2wi1r0fqzm4zvgsqhw6l9zph81h5k23nzw62aryx0i"
   }
  },
  {
@@ -9781,28 +9826,28 @@
   "repo": "emacscollective/borg",
   "unstable": {
    "version": [
-    20260602,
-    2342
+    20260701,
+    1437
    ],
    "deps": [
     "epkg",
     "magit"
    ],
-   "commit": "04fc19ef58fc23965d582721cf22691e1bd91cfd",
-   "sha256": "0c98shqd1ns0ggjzkd19rgbxnzssl5iw7w1hfx28a7pzdm96rkjj"
+   "commit": "a844569c8ef24408ba0df31d5cd58be9d955efce",
+   "sha256": "1sywja538dm77p4jmd83hvymmj98hqzpvmnsg3zigrjyd0ywr28y"
   },
   "stable": {
    "version": [
     4,
     5,
-    1
+    2
    ],
    "deps": [
     "epkg",
     "magit"
    ],
-   "commit": "8269db64810cc2ff574d27311648ce3da35181f2",
-   "sha256": "0m4kzyd5vwgypykliq64530qrqq6acap0igh1dgi2q0cf35vmf33"
+   "commit": "a844569c8ef24408ba0df31d5cd58be9d955efce",
+   "sha256": "1sywja538dm77p4jmd83hvymmj98hqzpvmnsg3zigrjyd0ywr28y"
   }
  },
  {
@@ -10230,6 +10275,25 @@
   }
  },
  {
+  "ename": "browsel",
+  "commit": "d771cf4923d77a6908addf93352ddb88f24f0275",
+  "sha256": "0w6p75nnv6qyjczqs8ypibn636lwk75wl3zzb1wk0cxxjbywa1cs",
+  "fetcher": "github",
+  "repo": "dmgerman/browsel",
+  "unstable": {
+   "version": [
+    20260629,
+    542
+   ],
+   "deps": [
+    "org",
+    "websocket"
+   ],
+   "commit": "805a4162762c3a1e60ebb791007c788bde0d0be0",
+   "sha256": "0n6bb6pj9giynxkxxkr6zw6h16i4sjb9a9kh1665kp8lisk2wkdj"
+  }
+ },
+ {
   "ename": "browser-hist",
   "commit": "bc155dcf3df95ab12a305d0f2cf67a04bf4bc82a",
   "sha256": "0x6582c5sdqy63i0yn9p3d2v0n42l3a4gpr2bbs31vxl7hw4dasl",
@@ -10430,11 +10494,11 @@
   "repo": "jamescherti/buffer-guardian.el",
   "unstable": {
    "version": [
-    20260604,
-    226
+    20260715,
+    1805
    ],
-   "commit": "44a692448659e529a9b6d5a1b36b40a66601376f",
-   "sha256": "16lb8f38qgf8rnh9k9ik00g6qrilv1dx91qpsia94kld85ympwqn"
+   "commit": "e56fe46b8588dd851406e5d5264644898730ea20",
+   "sha256": "10a48yfn0x55mv56aiwpza9pchlxb8532psg0rfjzhdq3psx4rmi"
   },
   "stable": {
    "version": [
@@ -10454,27 +10518,28 @@
   "repo": "plandes/buffer-manage",
   "unstable": {
    "version": [
-    20260615,
-    1909
+    20260713,
+    121
    ],
    "deps": [
     "choice-program",
     "dash"
    ],
-   "commit": "3063b6efb9eb9e5efa27098ddb25bc12205c362f",
-   "sha256": "0hiy2smidfjhm7kibjaaz73k6pdjfysszpd94j2p79d20h8h5wjf"
+   "commit": "f32c756a261aebca0a864e41958097b30690e171",
+   "sha256": "0sq3h0r7nr2x129f5b8gcjxmq90myixrmi9xggf9q40861jqjqwp"
   },
   "stable": {
    "version": [
     1,
+    2,
     1
    ],
    "deps": [
     "choice-program",
     "dash"
    ],
-   "commit": "819bbfd9ae2f028361f484bc3b60d751623a2df5",
-   "sha256": "0g79xcq0jf8p1cpsz3fifjpyaidkr0b2zm8sf11n8li4hfqmr10d"
+   "commit": "f32c756a261aebca0a864e41958097b30690e171",
+   "sha256": "0sq3h0r7nr2x129f5b8gcjxmq90myixrmi9xggf9q40861jqjqwp"
   }
  },
  {
@@ -10568,14 +10633,14 @@
   "stable": {
    "version": [
     3,
-    7,
-    2
+    8,
+    0
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "cdc66804b8a1ec7ddf94d99c7f24b801148b64df",
-   "sha256": "0lz7bjmxzxkri6mvqk6lrl6dp58as6py3i41hkfkj9zjmjvsl589"
+   "commit": "8d67ed8c9ea182abdcf457e0c247ab44675def9e",
+   "sha256": "07rjf3j44kpgcizx0cmdhccbyf0dd9pxv7i6zic2vlq1jvhj9mci"
   }
  },
  {
@@ -10586,11 +10651,11 @@
   "repo": "jamescherti/buffer-terminator.el",
   "unstable": {
    "version": [
-    20260607,
-    157
+    20260715,
+    1822
    ],
-   "commit": "0f31cbbb1a8368f08b486525f419dc3d059f05df",
-   "sha256": "0m7l6a6dmjaxq76g2kxnx2g9ayp3h2r8v9liz8djskdllaxkxvyd"
+   "commit": "68dbf7e34babe0467886132c641c54372d369acb",
+   "sha256": "100gypdg3v9w3pmv4ryy8fjv6k79mff8r2zjx0ayx7j4q2mcm3az"
   },
   "stable": {
    "version": [
@@ -10703,20 +10768,20 @@
   "repo": "jamescherti/bufferfile.el",
   "unstable": {
    "version": [
-    20260619,
-    1542
+    20260627,
+    1319
    ],
-   "commit": "11e610d799ba4ec4355630fb0651d3cf8de9ee31",
-   "sha256": "0bfz1lp661785hl36z6vk6137rw9l52l9l3sibhh3yrzs9ykf48f"
+   "commit": "e60be7084d5395617565531efab49718fe7c1a36",
+   "sha256": "0lhcq7z61s1z3n41nskc8lkpp6k2a4766cjibbij1sjhrfhlgbj6"
   },
   "stable": {
    "version": [
     1,
     0,
-    7
+    8
    ],
-   "commit": "55dbc57268c18e8965a020c6bbdad3be6c7e019c",
-   "sha256": "0xwbigjn1i01qsn49kpvp01hf4k9bhgy3fv9mmqs2n1pxf42d2l3"
+   "commit": "e60be7084d5395617565531efab49718fe7c1a36",
+   "sha256": "0lhcq7z61s1z3n41nskc8lkpp6k2a4766cjibbij1sjhrfhlgbj6"
   }
  },
  {
@@ -11712,31 +11777,30 @@
   "repo": "beacoder/call-graph",
   "unstable": {
    "version": [
-    20260212,
-    649
+    20260713,
+    638
    ],
    "deps": [
     "beacon",
     "ivy",
     "tree-mode"
    ],
-   "commit": "38cb7a4488af63208d7ee1766a141453518e0abc",
-   "sha256": "00yn00kgski6nyfxjjqr1cxyf725dnl81v6chy0kc94mxnww8ybr"
+   "commit": "99cab0f3829632f39f0e76f4e992c7bd988203a7",
+   "sha256": "0y3lmb8232qv2gkqc35qc3ipmc8jlp1cni4dbhl1aqgvhwjma1jq"
   },
   "stable": {
    "version": [
-    0,
     1,
-    0
+    0,
+    6
    ],
    "deps": [
-    "cl-lib",
-    "hierarchy",
+    "beacon",
     "ivy",
     "tree-mode"
    ],
-   "commit": "0bbe292b1b9c7ba1d8a65ed5e475f6a53f5f9f27",
-   "sha256": "0kckjs7yg8d04nir5z3f00k05272kgma98794g0ycgfn1vrck0h0"
+   "commit": "99cab0f3829632f39f0e76f4e992c7bd988203a7",
+   "sha256": "0y3lmb8232qv2gkqc35qc3ipmc8jlp1cni4dbhl1aqgvhwjma1jq"
   }
  },
  {
@@ -11912,11 +11976,11 @@
   "stable": {
    "version": [
     1,
-    4,
+    5,
     0
    ],
-   "commit": "8b892a8a11a632f5d52b877a49728808a142379a",
-   "sha256": "17dmyq3v6xj2zphbr52rirbq7bwxw9gg0lalwsv03y8lkhw4ms0a"
+   "commit": "373e61ec89e2359f1c362e9b2eadc552f4779306",
+   "sha256": "0p6zb9icy2cjj6y8bj2ai7csghak5aix8wld3jhvddf00diwb7fq"
   }
  },
  {
@@ -12011,11 +12075,11 @@
   "repo": "peterstuart/cargo-transient",
   "unstable": {
    "version": [
-    20241204,
-    1217
+    20260718,
+    1155
    ],
-   "commit": "b75511f911189b6b6c47976dd970eeb80ccfb3ee",
-   "sha256": "1s1kjc7xg55lnwn5ngdp89hnh2qp42x10cyqlji268xiglx0xzs2"
+   "commit": "a1fac6ce76d32317fd9f6bcdcc86fca46460c709",
+   "sha256": "1k3mzxj49f680dxzla58xn1yg9s93rs1qj2ig0a9ay12z3zpr5mr"
   }
  },
  {
@@ -12202,28 +12266,28 @@
   "repo": "kickingvegas/casual",
   "unstable": {
    "version": [
-    20260609,
-    1642
+    20260718,
+    1803
    ],
    "deps": [
     "csv-mode",
     "transient"
    ],
-   "commit": "f2977bc97e0e80f5b6ea817f016e739e4f64b6e1",
-   "sha256": "0fi15hgqjxjz1z6jxsm9lwssl97zaa1ds1hhsnsihhij0hs95vny"
+   "commit": "cadbeab2ec45804e63a328202c9a82fbed2413c5",
+   "sha256": "1dr4bdxm5c69kpn0312a9jxl1ds6m66dr0x1571993qga4m67aqn"
   },
   "stable": {
    "version": [
     2,
-    16,
-    2
+    17,
+    1
    ],
    "deps": [
     "csv-mode",
     "transient"
    ],
-   "commit": "f2977bc97e0e80f5b6ea817f016e739e4f64b6e1",
-   "sha256": "0fi15hgqjxjz1z6jxsm9lwssl97zaa1ds1hhsnsihhij0hs95vny"
+   "commit": "cadbeab2ec45804e63a328202c9a82fbed2413c5",
+   "sha256": "1dr4bdxm5c69kpn0312a9jxl1ds6m66dr0x1571993qga4m67aqn"
   }
  },
  {
@@ -12845,7 +12909,7 @@
   "repo": "worr/cfn-mode",
   "unstable": {
    "version": [
-    20260621,
+    20260705,
     807
    ],
    "deps": [
@@ -12853,8 +12917,8 @@
     "s",
     "yaml-mode"
    ],
-   "commit": "fb0b04fe6c6c46ad59f8691668339f53c6d9da57",
-   "sha256": "16czlly566h70x4dcv441ckj71rlgqky6chhxj55x6cmk3sdypf0"
+   "commit": "407094bd072103d43fddb3e186077d65f4f62f26",
+   "sha256": "0igcfj6c89mbvw5wpfhqihfwjxi851k89dagj3mfchdwrbfn7xvs"
   },
   "stable": {
    "version": [
@@ -13559,26 +13623,26 @@
   "repo": "breatheoutbreathein/chordpro-mode.el",
   "unstable": {
    "version": [
-    20250814,
-    301
+    20260711,
+    623
    ],
    "deps": [
     "compat"
    ],
-   "commit": "ae6db74f2078e4ee3d6262ac1344df9c1ab87527",
-   "sha256": "03aqw9385f5xdhphhm352n66yi2fmah6n43wrnr850d3mq5485g0"
+   "commit": "9d7b242b06453aaaa3fb3d1cca438ebcd478979b",
+   "sha256": "13447a0cc0jhxxmjhazv0hshbr13vpx22r30xhxm38c4hq7rfalk"
   },
   "stable": {
    "version": [
     2,
-    6,
+    7,
     0
    ],
    "deps": [
     "compat"
    ],
-   "commit": "c4167676831c790240610cfb4b5bbef93b5ddd49",
-   "sha256": "0x0a1990fip335ajd6zs90wq6lzb89gxaxr28nniyifrix8q8cxb"
+   "commit": "7a412da298dcc290050c4c6ba3571c0975a815a9",
+   "sha256": "14cy93yzzb7qy01mig9kkwnahmr8awh5ip4fxkky0a4c16pcw4dr"
   }
  },
  {
@@ -13806,8 +13870,8 @@
   "repo": "clojure-emacs/cider",
   "unstable": {
    "version": [
-    20260624,
-    952
+    20260718,
+    1302
    ],
    "deps": [
     "clojure-mode",
@@ -13819,14 +13883,14 @@
     "spinner",
     "transient"
    ],
-   "commit": "696334fdaedea14722ee95fc916018d62d10b7bc",
-   "sha256": "0myga7bg8yix1dy81yx5p5mf8gy2lc69d06jz7lw9y0bmavdg8w6"
+   "commit": "03bffb62b7c30250979a9b4512c210f165dc36c9",
+   "sha256": "1251fs6namlghmgy581mw7lijv9fnwn68pfah6pjgn8vmqdzk041"
   },
   "stable": {
    "version": [
-    1,
-    22,
-    2
+    2,
+    0,
+    0
    ],
    "deps": [
     "clojure-mode",
@@ -13838,8 +13902,8 @@
     "spinner",
     "transient"
    ],
-   "commit": "7bba70a194fa6687274a85d17b6201201f732223",
-   "sha256": "0lfkh1q4nw3kzj3885ipkmzlnppv6nc1badzqw3p6i9cgaqjfq55"
+   "commit": "39c70c0f5f7985704c14e3254ca8a1fbd15d1088",
+   "sha256": "18i5ajdns4mhh7d8jnrg1c1im7cwmk8yq3myz4m8lbxmka7gv6g7"
   }
  },
  {
@@ -14135,17 +14199,16 @@
   "repo": "emacs-citar/citar",
   "unstable": {
    "version": [
-    20260328,
-    1759
+    20260706,
+    1221
    ],
    "deps": [
     "citeproc",
-    "compat",
     "org",
     "parsebib"
    ],
-   "commit": "58df8b9b8af8a2636b28ed5c6005eddef7f579f7",
-   "sha256": "0b7gkik5p087hp08v40lll66sryy8yhnari5wqnkq984z1qwhsad"
+   "commit": "d2289669fea76ae7b2f7ad04794fcc230d65e055",
+   "sha256": "0gnh7lajg6sirr1dyygl3bczp13zdll9wq5zimylvh7l916x03y9"
   },
   "stable": {
    "version": [
@@ -14579,20 +14642,20 @@
   "repo": "parenworks/clatter.el",
   "unstable": {
    "version": [
-    20260622,
-    343
+    20260720,
+    457
    ],
-   "commit": "8b1ae9949717da2491d4a0d869592a2c4d6ba2bf",
-   "sha256": "07c4izlp9xw1p3i8z0q367yr19rmn7jamcwpy32bjqb32r6g1apz"
+   "commit": "9b81c45c423755333929dbe4e2e204ae0246c016",
+   "sha256": "0qpwslixsbyypc8z67yjnhxz3a2v5yg66q1jii26knkqjg216x32"
   },
   "stable": {
    "version": [
     0,
-    4,
-    3
+    6,
+    0
    ],
-   "commit": "bf967054e9c81d9a1fe8bf00e53e4762e3141d93",
-   "sha256": "09azczifqhhxhh87s836mnjihjv59y71y0mwbal4r7dsjilai47k"
+   "commit": "6b1c8466d283b052e2dbba44e6df06f5fe0c16df",
+   "sha256": "1baq6i5nsqd4qzp8zdb5zl199jipnjhfwk88nq11pd3v5xskl2my"
   }
  },
  {
@@ -15027,41 +15090,38 @@
   "repo": "clojure-emacs/clj-refactor.el",
   "unstable": {
    "version": [
-    20260403,
-    830
+    20260716,
+    1545
    ],
    "deps": [
     "cider",
     "clojure-mode",
-    "hydra",
-    "inflections",
-    "multiple-cursors",
     "paredit",
     "parseedn",
+    "spinner",
+    "transient",
     "yasnippet"
    ],
-   "commit": "39c9688c79e1d00965621d04c04fe1ddde4b571f",
-   "sha256": "1im1l9910asx9bvgcdrrznmrm52kb9jrgkicb3jmplbvay2xyxzv"
+   "commit": "2805bd5f505fdb199a8c5a25fca398ec9c161e5b",
+   "sha256": "0v4j0y81m0bk3v0rp1f32imymplqd7p1i9p3k9xix254cnpq0ywg"
   },
   "stable": {
    "version": [
-    3,
-    12,
+    4,
+    0,
     0
    ],
    "deps": [
     "cider",
     "clojure-mode",
-    "hydra",
-    "inflections",
-    "multiple-cursors",
     "paredit",
     "parseedn",
-    "seq",
+    "spinner",
+    "transient",
     "yasnippet"
    ],
-   "commit": "dc1bbc8cdaa723bdbb6669ea7d280625c370755d",
-   "sha256": "0mha1wqn5hd9g8y0fp35qkhlnxlrwli62x7mbifman279h16gaml"
+   "commit": "2805bd5f505fdb199a8c5a25fca398ec9c161e5b",
+   "sha256": "0v4j0y81m0bk3v0rp1f32imymplqd7p1i9p3k9xix254cnpq0ywg"
   }
  },
  {
@@ -15337,11 +15397,11 @@
   "repo": "clojure-emacs/clojure-mode",
   "unstable": {
    "version": [
-    20260615,
-    1407
+    20260709,
+    952
    ],
-   "commit": "762674d956a4e861f46711a00921b159f96792c0",
-   "sha256": "0h43a80w222409nsp1bvrl8jgcb3rghjp8f0z2gpn4yaq4k7qzdf"
+   "commit": "38c72d3284367459a8b116deb660c3163f6653ea",
+   "sha256": "03c6a12jlg0jvq4f146d9q2iq1waw047jcaja8b8vbpchfr40hl7"
   },
   "stable": {
    "version": [
@@ -15618,16 +15678,26 @@
   "repo": "LuciusChen/clutch",
   "unstable": {
    "version": [
-    20260611,
-    1401
+    20260719,
+    1018
    ],
    "deps": [
-    "mysql",
-    "pg",
     "transient"
    ],
-   "commit": "40a6f93e14a6742dbad59e383236e3be6ec0e9e5",
-   "sha256": "06sp1wlzkagvw949rg38pg40864fqkgxss02dxwxd0xymb25f4bl"
+   "commit": "f64414e20c58a6b92255fd3f634785b0855ea8f5",
+   "sha256": "0akgrdhrbmwjwl7g4zlym5blpja3q9p55mygcck17xxqrl40z4fw"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    4
+   ],
+   "deps": [
+    "transient"
+   ],
+   "commit": "a4dfac80ebbf54df48f6fbf7936da0d6f1b6f321",
+   "sha256": "1cyjawbrfphdqcrwg10nrhcvmr45hlhjr3v1g8k0ypcgmfa7cmjs"
   }
  },
  {
@@ -15731,20 +15801,20 @@
   "url": "https://gitlab.kitware.com/cmake/cmake.git",
   "unstable": {
    "version": [
-    20260617,
-    1353
+    20260709,
+    1724
    ],
-   "commit": "c2fd48014f39786ba5c5e51b983d1cdcf05aa269",
-   "sha256": "0hrx31ljc89ij1chrn47cgsc2n9jc6szf89ycafhq7pli765ak6x"
+   "commit": "44125a9e977c834f06ac1e5fe8db55355261ef87",
+   "sha256": "1b356mjzcsdj9im4404h2y51gfphqxg83s6cmgrlnmm3bycj71bg"
   },
   "stable": {
    "version": [
     4,
-    3,
-    4
+    4,
+    0
    ],
-   "commit": "c2fd48014f39786ba5c5e51b983d1cdcf05aa269",
-   "sha256": "0hrx31ljc89ij1chrn47cgsc2n9jc6szf89ycafhq7pli765ak6x"
+   "commit": "44125a9e977c834f06ac1e5fe8db55355261ef87",
+   "sha256": "1b356mjzcsdj9im4404h2y51gfphqxg83s6cmgrlnmm3bycj71bg"
   }
  },
  {
@@ -15866,14 +15936,14 @@
   "repo": "lejicore/coc-damage-calculator",
   "unstable": {
    "version": [
-    20241104,
-    1739
+    20260629,
+    1344
    ],
    "deps": [
     "hydra"
    ],
-   "commit": "097bc2496263fc1e69a04d0528b41baf2fd08115",
-   "sha256": "0y8x197zlmg0ipbk6jjcjcwmw2ncfplbdpjhpdk4lj684hacxsr9"
+   "commit": "c5bb252b1ed39c17796ef2b4dcaf66e1202cbd89",
+   "sha256": "1ri6nym15laavfqvmzipyf3ndak9s9ymbsi7a4ilkldwz6by5wsr"
   }
  },
  {
@@ -16413,11 +16483,11 @@
   "repo": "purcell/color-theme-sanityinc-tomorrow",
   "unstable": {
    "version": [
-    20260619,
-    1157
+    20260710,
+    1606
    ],
-   "commit": "9ce4bc783acc4ebebed1b13427873cdffc1b7960",
-   "sha256": "1hmh25ib4lrc8ipp440c269w036rz4qvb30p1gs1d8zvlb4npbfm"
+   "commit": "d32469ec6529e3a7f84b45277f233497b74f5bab",
+   "sha256": "0l7jbsq3992sjrj0afldb7q746wq44ir02cdrqdfzn1d0ndm62yb"
   },
   "stable": {
    "version": [
@@ -16915,14 +16985,14 @@
   "repo": "company-mode/company-mode",
   "unstable": {
    "version": [
-    20260618,
-    1349
+    20260718,
+    1243
    ],
    "deps": [
     "posframe"
    ],
-   "commit": "04fa1b9bfe150b1f8c76cea47c3a4af3f0e1b22e",
-   "sha256": "156vlp2a67dcn9cp3w8pgkjjmq51aw1w3w929wrhhvkq1kg0v20r"
+   "commit": "24a4a6b129546a1ce2fcb3e3c5948259dff00685",
+   "sha256": "0qjqk4zh3fk1m7rhkj4sp6wdrsk3ki6jwdc5fly3gng3fjlc5lz1"
   },
   "stable": {
    "version": [
@@ -18154,28 +18224,28 @@
   "repo": "radian-software/prescient.el",
   "unstable": {
    "version": [
-    20250816,
-    19
+    20260628,
+    2243
    ],
    "deps": [
     "company",
     "prescient"
    ],
-   "commit": "87e2d2f2ddf24f591a5f70cc90d2afb4537caa18",
-   "sha256": "0f4wi8aq3yfykxfza4y4c5yhcs50cs3gpfj0qrmvfq9hvkhzj52w"
+   "commit": "5649977fa7789e4615efeca09397ed7eccd06dfc",
+   "sha256": "199150yng81f6n3kb120s37yf2dqs0i9k91f2gzkk8kjn6hvrsj8"
   },
   "stable": {
    "version": [
     6,
     3,
-    2
+    3
    ],
    "deps": [
     "company",
     "prescient"
    ],
-   "commit": "87e2d2f2ddf24f591a5f70cc90d2afb4537caa18",
-   "sha256": "0f4wi8aq3yfykxfza4y4c5yhcs50cs3gpfj0qrmvfq9hvkhzj52w"
+   "commit": "5649977fa7789e4615efeca09397ed7eccd06dfc",
+   "sha256": "199150yng81f6n3kb120s37yf2dqs0i9k91f2gzkk8kjn6hvrsj8"
   }
  },
  {
@@ -18840,11 +18910,11 @@
   "repo": "jamescherti/compile-angel.el",
   "unstable": {
    "version": [
-    20260604,
-    227
+    20260710,
+    1459
    ],
-   "commit": "a75f4fe69abc0e8b15c739e3d07bc237a974e052",
-   "sha256": "1vzs2j9xwgxd54gm6j73dpxs5si77l3ywkf3g4af5hmrqpshb6c0"
+   "commit": "fc469061a294a2a9888736d9b9c4ff9b9e6971ce",
+   "sha256": "0xcq3pbw52fbk54xk1hdq24wbcg87yl8zk3j02xhi65dqih8qj3m"
   },
   "stable": {
    "version": [
@@ -19137,20 +19207,20 @@
   "repo": "tarsius/cond-let",
   "unstable": {
    "version": [
-    20260601,
-    1457
+    20260701,
+    1237
    ],
-   "commit": "21b9e9835756ff5cd1acb971cf9eb56fff671c8b",
-   "sha256": "18507g86bz50as93cajx754nmg5y26djhmrj50ba88rm2rl8szlf"
+   "commit": "c48600dfab6372670225f046cace263700c78eab",
+   "sha256": "1d5daj00qkpyjqhdy24rng08ynpqxc44d30sv5f1y92nmlhswmdv"
   },
   "stable": {
    "version": [
     1,
     1,
-    2
+    3
    ],
-   "commit": "21b9e9835756ff5cd1acb971cf9eb56fff671c8b",
-   "sha256": "18507g86bz50as93cajx754nmg5y26djhmrj50ba88rm2rl8szlf"
+   "commit": "c48600dfab6372670225f046cace263700c78eab",
+   "sha256": "1d5daj00qkpyjqhdy24rng08ynpqxc44d30sv5f1y92nmlhswmdv"
   }
  },
  {
@@ -19399,14 +19469,14 @@
   "repo": "minad/consult",
   "unstable": {
    "version": [
-    20260605,
-    1907
+    20260716,
+    1105
    ],
    "deps": [
     "compat"
    ],
-   "commit": "9bb68cf3941eb618fff18bd7626164951c70eb8a",
-   "sha256": "02ain9sqvivhhy1fbxv7ayl6mshaiz484y2gcifvml1wjrnygwr2"
+   "commit": "8c6787edc690097ccfcf2255fecf623a8ab29c7e",
+   "sha256": "0pl4fxggmjjfmad9qwvpsjjihz86j6gcigb1xylml9q9rrnh3yf7"
   },
   "stable": {
    "version": [
@@ -20037,16 +20107,16 @@
   "repo": "mclear-tools/consult-notes",
   "unstable": {
    "version": [
-    20260222,
-    1928
+    20260706,
+    1837
    ],
    "deps": [
     "consult",
     "dash",
     "s"
    ],
-   "commit": "94e5b19ec84363438eb7114e59c059a67f3d7c59",
-   "sha256": "1cvvmk3nf3fidcfc2x8wvsb1yc98cilhhcl7kgawzlwmy8r0libr"
+   "commit": "1e095562c5d8245e9f85c043cbaa9aa4dc0b9ded",
+   "sha256": "1f5jl777akjpx0ays16wy1hiv684x33v0c4g0mzlxmb9zify65d9"
   }
  },
  {
@@ -20206,14 +20276,14 @@
   "repo": "guibor/consult-spotlight",
   "unstable": {
    "version": [
-    20260612,
-    1527
+    20260708,
+    2142
    ],
    "deps": [
     "consult"
    ],
-   "commit": "0a8a60e26fcbf15414c0f56f4c8b4a504c5c9c11",
-   "sha256": "13729iapksanf2p53a802yj8m3jkspixq5z648ysgdkjpa1kk4iw"
+   "commit": "c6d8cb34e223608708c5424e4d03d04d6d6648f7",
+   "sha256": "0fps3yhla3d9wawm3fchgfqxhd4wih48lp7ib2qzk7bj1i9yhihw"
   }
  },
  {
@@ -20377,6 +20447,36 @@
   }
  },
  {
+  "ename": "context-clues",
+  "commit": "095357945ea2d37ff4bec125c10a3d5d6e7b7738",
+  "sha256": "10mwins3ssg75sgdm3imvvlz24x4fh3id4akalmyqq1kzlbhrf1n",
+  "fetcher": "github",
+  "repo": "mrcnski/context-clues",
+  "unstable": {
+   "version": [
+    20260719,
+    2046
+   ],
+   "deps": [
+    "transient"
+   ],
+   "commit": "51fa7a434a234d64c70054dd8d99ca4792bb7ee1",
+   "sha256": "1zgk58myqh8b4nnx8r8bj77cqsdrfswwsw8yi493f0cqwasgc9vy"
+  },
+  "stable": {
+   "version": [
+    0,
+    3,
+    0
+   ],
+   "deps": [
+    "transient"
+   ],
+   "commit": "55483a68c18e4c5960bfb89c0ea95265a89db0ab",
+   "sha256": "19pps2wjzlv1ghl6nlrl9fndz8ankfyxmvkgwcl87ba7bhbm4d67"
+  }
+ },
+ {
   "ename": "context-transient",
   "commit": "eae3d8f214a0967fd5bc1d48e45e27a639f61e0d",
   "sha256": "1kgyd202db6wgkygmpjqa2w7f8qbhd4z5wymr615zvw1qal3407q",
@@ -20536,8 +20636,8 @@
   "repo": "copilot-emacs/copilot.el",
   "unstable": {
    "version": [
-    20260622,
-    2038
+    20260707,
+    516
    ],
    "deps": [
     "compat",
@@ -20545,13 +20645,13 @@
     "jsonrpc",
     "track-changes"
    ],
-   "commit": "2882a50182a6e2ca3b1ccfded22645831a85a59a",
-   "sha256": "1gyhg2lix2k2xc3g30455li3kqjgllwyhb6z8jakvnivd7gd314p"
+   "commit": "277ca357422ba34bcf7fe650cb720580994eea84",
+   "sha256": "0fj6h3v3v3h0cczs9mc728bcx5zkqlh4yi11la347wah39wdk21d"
   },
   "stable": {
    "version": [
     0,
-    6,
+    9,
     0
    ],
    "deps": [
@@ -20560,8 +20660,8 @@
     "jsonrpc",
     "track-changes"
    ],
-   "commit": "2882a50182a6e2ca3b1ccfded22645831a85a59a",
-   "sha256": "1gyhg2lix2k2xc3g30455li3kqjgllwyhb6z8jakvnivd7gd314p"
+   "commit": "15a4be6bbe13220d9781e10d6e2086c21c3bc7ee",
+   "sha256": "1skm4wnslx6y6vh83i7maswqk1i6x6gjar58n727z2qq7y3z6qn7"
   }
  },
  {
@@ -20757,14 +20857,14 @@
   "repo": "minad/corfu",
   "unstable": {
    "version": [
-    20260519,
-    1053
+    20260719,
+    2241
    ],
    "deps": [
     "compat"
    ],
-   "commit": "4a9c67da16eb64cadaa4bfcc16713188145c83da",
-   "sha256": "1qw0xzlxr6fh9iiszqnl4hfjm2h0rd08warhanq99q34nz4iviny"
+   "commit": "991224fc0387f005f4ffa896b35eca70b54c651a",
+   "sha256": "0bmbljl6xz7ml312sisy6j9sl9lsfzh7g6hk15fda4464lfx8jcl"
   },
   "stable": {
    "version": [
@@ -20815,28 +20915,28 @@
   "repo": "radian-software/prescient.el",
   "unstable": {
    "version": [
-    20250816,
-    19
+    20260628,
+    2243
    ],
    "deps": [
     "corfu",
     "prescient"
    ],
-   "commit": "87e2d2f2ddf24f591a5f70cc90d2afb4537caa18",
-   "sha256": "0f4wi8aq3yfykxfza4y4c5yhcs50cs3gpfj0qrmvfq9hvkhzj52w"
+   "commit": "5649977fa7789e4615efeca09397ed7eccd06dfc",
+   "sha256": "199150yng81f6n3kb120s37yf2dqs0i9k91f2gzkk8kjn6hvrsj8"
   },
   "stable": {
    "version": [
     6,
     3,
-    2
+    3
    ],
    "deps": [
     "corfu",
     "prescient"
    ],
-   "commit": "87e2d2f2ddf24f591a5f70cc90d2afb4537caa18",
-   "sha256": "0f4wi8aq3yfykxfza4y4c5yhcs50cs3gpfj0qrmvfq9hvkhzj52w"
+   "commit": "5649977fa7789e4615efeca09397ed7eccd06dfc",
+   "sha256": "199150yng81f6n3kb120s37yf2dqs0i9k91f2gzkk8kjn6hvrsj8"
   }
  },
  {
@@ -21228,10 +21328,10 @@
  },
  {
   "ename": "counsel-fd",
-  "commit": "b2e58e2a0bf3825d6ef43455fd3e60b33c88aaa2",
-  "sha256": "1ywyg2l1dx2rziw23b0i5m4xg4n8laarkq9wbbq80ma5pjb18ims",
+  "commit": "28dfcdf4682782b00234542bc9a06f2f57db66db",
+  "sha256": "0nhvqi3xr3pkrf1l1s6iihsk3hhjb7nrj4bi8i2m0bdgr1inwja0",
   "fetcher": "github",
-  "repo": "CsBigDataHub/counsel-fd",
+  "repo": "ChetanKoneru/counsel-fd",
   "unstable": {
    "version": [
     20221011,
@@ -21797,11 +21897,11 @@
   "repo": "ignity21/cppinsights.el",
   "unstable": {
    "version": [
-    20250519,
-    101
+    20260628,
+    722
    ],
-   "commit": "941e48a0d5c4a6aed865d8be30ebca006b5a6e3f",
-   "sha256": "0sz6bgk2i7jgr1g31pyxr1b4sknipiic3li1k5fwrfx35gs92hnm"
+   "commit": "552d959a7313e746b2a343991bffb9c2271dba47",
+   "sha256": "0rp3xbklgbaacwlzimb6hhizb4qjzhjmdgbypa0h7bkqkwv0l7fi"
   }
  },
  {
@@ -22309,31 +22409,20 @@
   "repo": "hlolli/csound-mode",
   "unstable": {
    "version": [
-    20260502,
-    1425
+    20260719,
+    833
    ],
-   "deps": [
-    "dash",
-    "highlight",
-    "multi",
-    "shut-up"
-   ],
-   "commit": "fb8152be0cfccd498c3d9f6bf4f550cfa96c416a",
-   "sha256": "1nj5drdpwpn34581x6sbgfv4zkwzgh36q6nmwqgfgnqiwv9c27az"
+   "commit": "9b12204deb8cede38dbb178f4b9c5f101e06d6a3",
+   "sha256": "0w7s3n4l1dw00j7k2f6h0q2dhbn8ydy3dqq20bp647sq2xpdihzp"
   },
   "stable": {
    "version": [
     0,
     2,
-    1
+    9
    ],
-   "deps": [
-    "highlight",
-    "multi",
-    "shut-up"
-   ],
-   "commit": "389be230aecfea03e8043e8ea6884ea21ea9230b",
-   "sha256": "1c88ak0jaj51fwiqniqxd7xyk23wjl9m57znzm8j267ld8g12znp"
+   "commit": "9b12204deb8cede38dbb178f4b9c5f101e06d6a3",
+   "sha256": "0w7s3n4l1dw00j7k2f6h0q2dhbn8ydy3dqq20bp647sq2xpdihzp"
   }
  },
  {
@@ -22797,11 +22886,11 @@
   "repo": "Anoncheg1/emacs-cui",
   "unstable": {
    "version": [
-    20260623,
-    919
+    20260715,
+    1931
    ],
-   "commit": "25ad76bd01d6e94b1eada4c19d52a6245a87bbba",
-   "sha256": "111bba10y98n0hcamnqm5s5za7gavzmxpnjmnycgvx4mm7bqh1wk"
+   "commit": "f68f1261f4618fee1d061b22a3a4155589b52259",
+   "sha256": "1spzw7c2x47axlj52a10wvzvcx0x485bsw515i78h4ggi1kf4ri6"
   },
   "stable": {
    "version": [
@@ -23339,28 +23428,28 @@
   "repo": "trevoke/dag-draw.el",
   "unstable": {
    "version": [
-    20251218,
-    1333
+    20260627,
+    2238
    ],
    "deps": [
     "dash",
     "ht"
    ],
-   "commit": "0c10afdff9f1ebfeea242e921fa22bb385cdf899",
-   "sha256": "11m2b30asrg54cysim6yyc4fhym9mgjg909yjjwja45qp8q3llin"
+   "commit": "c20b3c28781f1d768116a2cc601a4e8d0058e2ba",
+   "sha256": "0rylci9y8lpmsrac07npz0n3xkql61zxpj338qr0ffpdfd0vj8gq"
   },
   "stable": {
    "version": [
     1,
-    0,
-    4
+    1,
+    0
    ],
    "deps": [
     "dash",
     "ht"
    ],
-   "commit": "0c10afdff9f1ebfeea242e921fa22bb385cdf899",
-   "sha256": "11m2b30asrg54cysim6yyc4fhym9mgjg909yjjwja45qp8q3llin"
+   "commit": "c20b3c28781f1d768116a2cc601a4e8d0058e2ba",
+   "sha256": "0rylci9y8lpmsrac07npz0n3xkql61zxpj338qr0ffpdfd0vj8gq"
   }
  },
  {
@@ -23799,11 +23888,11 @@
   "repo": "nameiwillforget/d-emacs",
   "unstable": {
    "version": [
-    20260620,
-    1902
+    20260626,
+    1859
    ],
-   "commit": "c07ed16da91c66162d3b3dcf06ed076440445a1a",
-   "sha256": "0r3fzl7sqdi6ca71acvr73s51sa7hrzyb8arq229cq8ma2j30iyc"
+   "commit": "288211ee4789392aa1b5ea9c665c6e9fd04b3a84",
+   "sha256": "0s4s97icch04zp44ah3dfzn865xmy8ak17r0s7zhpwzssbbajdr6"
   }
  },
  {
@@ -24387,16 +24476,16 @@
   "repo": "Wilfred/deadgrep",
   "unstable": {
    "version": [
-    20241210,
-    1630
+    20260629,
+    1858
    ],
    "deps": [
     "dash",
     "s",
     "spinner"
    ],
-   "commit": "bb555790c6f404572d537e1e4adec8b4ff0515f5",
-   "sha256": "04jskm3qlxq7zvyvcn33gsjcd5312nzmrpznpkqai9gb1v2zhrd8"
+   "commit": "9ba86acdd9fa6aec55c753f4db8c3a5778941259",
+   "sha256": "1pl0cl44ygrgx527fca4sql099xc78wqazxhdlsrsd2bq6jnk1lc"
   },
   "stable": {
    "version": [
@@ -24420,11 +24509,11 @@
   "url": "https://salsa.debian.org/emacsen-team/debian-el.git",
   "unstable": {
    "version": [
-    20260324,
-    1738
+    20260703,
+    520
    ],
-   "commit": "d0f6cc8474fa0c022d738acdc159c1550188c991",
-   "sha256": "169jq55h22vpn0l0v4vryximxw3mmjxndjnqhl3knaa79yprwr0f"
+   "commit": "ce58c690e27522669eb1905e21a194ff9eb79a9b",
+   "sha256": "02ck505cswfzq8i7szbp1yvgyqkngxqxmfpb13qwqyg5q9nwkfdj"
   },
   "stable": {
    "version": [
@@ -25049,17 +25138,16 @@
   "repo": "pprevos/denote-explore",
   "unstable": {
    "version": [
-    20260525,
-    2035
+    20260719,
+    936
    ],
    "deps": [
     "dash",
     "denote",
-    "denote-regexp",
-    "denote-sequence"
+    "denote-regexp"
    ],
-   "commit": "5a6d005fbc9e2131197c20acdffca239f9cd4961",
-   "sha256": "12h94rikibs4h3qx173v5l3ljk2iylnnj1jk1p521zk1yxznv9ih"
+   "commit": "bd442d761d0ce6efe5cd3b7ce4806a86a49cf8a9",
+   "sha256": "1pfvwg1akn59jqrc829fky91kpm0j7maq8s8dsb5z0lfb8i08ksx"
   },
   "stable": {
    "version": [
@@ -25145,6 +25233,24 @@
    ],
    "commit": "dde6836a4663cb3fc23cdce8ea25834720711c8a",
    "sha256": "0rrnr3my8w76zv99wlhhym0j5c3amlgjlamv8q3raglhbk683q3g"
+  }
+ },
+ {
+  "ename": "denote-solo",
+  "commit": "35e65c9e778b25fd5a9e95db05e5feb7e63094d3",
+  "sha256": "1vwcl3kspiayw06y2l471ybl5vd5wqr3a9lx0rdhfqswmk331kcr",
+  "fetcher": "github",
+  "repo": "pavlo/denote-solo",
+  "unstable": {
+   "version": [
+    20260621,
+    1352
+   ],
+   "deps": [
+    "denote"
+   ],
+   "commit": "f6f3621b48022fe43ec54429dcff4f92a06d7c15",
+   "sha256": "1z7n9zpxfbmp49x5j4hal5797xx2hbma0zwibwvh1ang51ffhv06"
   }
  },
  {
@@ -25582,20 +25688,20 @@
  },
  {
   "ename": "dicom",
-  "commit": "879fe6f4268ea058c6b1b6380dfbd1bc05917ffa",
-  "sha256": "0ixj9mg2q4s4457sxp0qd13q9cicgi3p904x8jc0a6clyz6nlh36",
+  "commit": "4e939f55653401f55c8d31a694d7a0e4b4a6e184",
+  "sha256": "1z19fhrbfrmrymml4wg2giz3wli1z1872s1b5ssdfzr6cghdv5hg",
   "fetcher": "github",
   "repo": "minad/dicom",
   "unstable": {
    "version": [
-    20260605,
-    1901
+    20260704,
+    2150
    ],
    "deps": [
     "compat"
    ],
-   "commit": "026a12a27939b29935ea343bab9162ed27bd732e",
-   "sha256": "1bi9mrwvyw4gkxix66gf9xhars830kbfinzrai3biixfd3gkdgs2"
+   "commit": "50bfab3a34e502d6bac8ab12854cb33c8aff343c",
+   "sha256": "1821jfsirv1lph6d2amv8b8zzan0jgvb2i0zylv2mgy9irh8mi6p"
   },
   "stable": {
    "version": [
@@ -25703,11 +25809,11 @@
   "repo": "ideasman42/emacs-diff-ansi",
   "unstable": {
    "version": [
-    20260524,
-    938
+    20260713,
+    2340
    ],
-   "commit": "2edacc2c6bda60b1be7bf5dfdde006a9a7018af5",
-   "sha256": "11lk7dj0r5xdra0vg4csck6d6jd4mjjp13gjp75sl2i7vs4mf2d1"
+   "commit": "86c0b3525b2793b585b548c6e975d6fe6a2cea2a",
+   "sha256": "11h1gvm5iz2rd8ap3p745ndygmpay641ibaw9kk09rcr8rqr1cpy"
   }
  },
  {
@@ -25733,14 +25839,14 @@
   "repo": "dgutov/diff-hl",
   "unstable": {
    "version": [
-    20260624,
-    444
+    20260627,
+    208
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "23302acc331738652f6295eae9c8feb856cb021e",
-   "sha256": "1fkhdqa6apz6wvy9w29iagj3q0571ggskgf1snnfj002gydmd5n2"
+   "commit": "2d7d0714d9637f54af672987c65b6973b31e56a2",
+   "sha256": "1w6vqdcqwrbaxm70j6klhnmn3i2h4rx8b2g1ymj1dsclabw6i3rl"
   },
   "stable": {
    "version": [
@@ -26217,11 +26323,11 @@
   "repo": "jamescherti/dir-config.el",
   "unstable": {
    "version": [
-    20260314,
-    1908
+    20260710,
+    1609
    ],
-   "commit": "e2168cb2da83b36d071efec3d4e2ee42a599ed36",
-   "sha256": "10h06ssb0rjrgwh774i8hfzxy506hs5c8h2lrkxrc19lyvcl46x3"
+   "commit": "5620beabc842f5d63c02c90d28618d5c67fdf94e",
+   "sha256": "0sqja9riky1ixjns9hhqlq51ss5jjamrgflixwy2hbdlyz68mrmk"
   },
   "stable": {
    "version": [
@@ -27009,15 +27115,15 @@
   "repo": "stsquad/dired-rsync",
   "unstable": {
    "version": [
-    20260204,
-    1424
+    20260716,
+    1319
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "24ceb60b168c591d7e2d9440a7f1895880681f48",
-   "sha256": "0vrpwk91qrcnkr6cgmal7abi0cmykfr840l4cxvv5jzr8c1m1zhi"
+   "commit": "eecf700ce70b282040b87ccdb76ff4195bdba919",
+   "sha256": "102gbq4xpgwrfznys13fdjvxpfsf8v7mf6f1z9k51i3mg0fs9iyk"
   },
   "stable": {
    "version": [
@@ -27224,14 +27330,14 @@
   "repo": "Boruch-Baum/emacs-diredc",
   "unstable": {
    "version": [
-    20260616,
-    1507
+    20260714,
+    1154
    ],
    "deps": [
     "key-assist"
    ],
-   "commit": "0b826202e12d6c66ae902d71ab770693cf89c33e",
-   "sha256": "0zsgvznmqgbywfar8pxl56ig3zqqd3gaqxg1y6xvwnz27s0ngkhx"
+   "commit": "0ad972d370e63e9b81909a60c06a147986de84f2",
+   "sha256": "0shfb53i53a390yxap2dsa0bpl2bh9614xpx1gk7hrgxr29g5pin"
   },
   "stable": {
    "version": [
@@ -27323,26 +27429,26 @@
   "repo": "wbolster/emacs-direnv",
   "unstable": {
    "version": [
-    20240314,
-    715
+    20260630,
+    839
    ],
    "deps": [
     "dash"
    ],
-   "commit": "c0bf3b81c7a97e2a0d06d05495e86848254fcc1f",
-   "sha256": "1b68rz3y64afwbh5brxa9yzwmsjg1g8irgvbvdblazhciap397c3"
+   "commit": "c1f38f71184f8aa3130898932f2de638beb5ed33",
+   "sha256": "078g5x3xzsqh9j87qdxmp131fbwrazcj0hxr5c7rr2f25pih8lq4"
   },
   "stable": {
    "version": [
     2,
-    2,
+    3,
     0
    ],
    "deps": [
     "dash"
    ],
-   "commit": "bd161f38621d1a9e4d70c9bafab9b7e3520f00b2",
-   "sha256": "0cf5npgksl9a03mnfdhfdhlf46gr9qz9adjxz3dbckq9b1vl0dfc"
+   "commit": "c1f38f71184f8aa3130898932f2de638beb5ed33",
+   "sha256": "078g5x3xzsqh9j87qdxmp131fbwrazcj0hxr5c7rr2f25pih8lq4"
   }
  },
  {
@@ -27445,14 +27551,14 @@
   "repo": "alexluigit/dirvish",
   "unstable": {
    "version": [
-    20250504,
-    807
+    20260716,
+    729
    ],
    "deps": [
     "compat"
    ],
-   "commit": "d877433f957a363ad78b228e13a8e5215f2d6593",
-   "sha256": "0d9c7i3x4vfl7k4vi29zyrz1d2cx7kfdnir8slqdjbapyacrl4s0"
+   "commit": "5152c80a32de3965a3e131a9314514af4aa8aa1e",
+   "sha256": "0v6l4vxxb5fvqgbrwlzwj7kc1m492vmxp231555hcw589qk3av5y"
   },
   "stable": {
    "version": [
@@ -28218,8 +28324,8 @@
   "repo": "Silex/docker.el",
   "unstable": {
    "version": [
-    20260623,
-    746
+    20260709,
+    1426
    ],
    "deps": [
     "aio",
@@ -28228,8 +28334,8 @@
     "tablist",
     "transient"
    ],
-   "commit": "2128c0d432f4cc0feef21d1e1c11398a3ee2432b",
-   "sha256": "0nacf9zxjllkpqgvjvmj08acppm3qifvjgnrqnwxm9nc1w7brjgx"
+   "commit": "f32940100035438934d626adb99cfc63036de490",
+   "sha256": "07wsf9p7dy7qws7jdksra3xh6lwlkh0dxmjskmbzd6wz86c2vx1i"
   },
   "stable": {
    "version": [
@@ -28649,16 +28755,16 @@
   "repo": "seagle0128/doom-modeline",
   "unstable": {
    "version": [
-    20260612,
-    740
+    20260708,
+    823
    ],
    "deps": [
     "compat",
     "nerd-icons",
     "shrink-path"
    ],
-   "commit": "a9900c89409984572b514f0fcb4f336c9d5bba4b",
-   "sha256": "1sbq1hk1m3djzp78xzzbx5ggc04dkpsnb5gc9pb6kqavq4m9644w"
+   "commit": "017854c6484dd6a38e4b039dad04ce6dbec02f08",
+   "sha256": "0mvyi6r1599fsz6hfgbvq1i8z569xsh9iwwzz8pwd15c9v8i71v6"
   },
   "stable": {
    "version": [
@@ -29021,14 +29127,14 @@
   "url": "https://salsa.debian.org/emacsen-team/dpkg-dev-el.git",
   "unstable": {
    "version": [
-    20260502,
-    631
+    20260713,
+    1140
    ],
    "deps": [
     "debian-el"
    ],
-   "commit": "1392d194b3ef00e58901163081df47ba06afba24",
-   "sha256": "0js3pf8c5qsaxphxiakjfaj23xc724k87gv3j9si1lcpbmb5cz0w"
+   "commit": "74ccc3b0a227a2e71b2c69af4da09e28ae944972",
+   "sha256": "1a43p1jm5yn7v03pby62bl0dichcbqyidpa1fvksfhz3ry8289cc"
   },
   "stable": {
    "version": [
@@ -29074,11 +29180,11 @@
   "repo": "dracula/emacs",
   "unstable": {
    "version": [
-    20260224,
-    1455
+    20260701,
+    2051
    ],
-   "commit": "b1a4d87ba1cf880143f4ab2ccd942cf556887fb1",
-   "sha256": "10yy3abny8iv74pxw2m94gnnszylpsqsf85lp7rla7lslmykhqys"
+   "commit": "1acd97258258415f6a43c332475fbdcd7ceb9274",
+   "sha256": "17crkxrfn1cmkjvl5hnfnl6g86z1ipjd7i4qm30r7q2gxh0yh64y"
   },
   "stable": {
    "version": [
@@ -29391,19 +29497,19 @@
   "repo": "jscheid/dtrt-indent",
   "unstable": {
    "version": [
-    20260608,
-    1055
+    20260709,
+    2011
    ],
-   "commit": "4b71bf995b12966bbc350a32796b9a5f11d67fa6",
-   "sha256": "1xl2m790nq4yingv0fzkh223gp10l36ahrbvarlgkix0y7xq99mj"
+   "commit": "8402da6bcc288709366e0b589fa79e744e877788",
+   "sha256": "0r6fa6mim20bya2z3y0cvgrgjndcl839w01byjkb3zbjvwxc0byj"
   },
   "stable": {
    "version": [
     1,
-    27
+    28
    ],
-   "commit": "4b71bf995b12966bbc350a32796b9a5f11d67fa6",
-   "sha256": "1xl2m790nq4yingv0fzkh223gp10l36ahrbvarlgkix0y7xq99mj"
+   "commit": "8402da6bcc288709366e0b589fa79e744e877788",
+   "sha256": "0r6fa6mim20bya2z3y0cvgrgjndcl839w01byjkb3zbjvwxc0byj"
   }
  },
  {
@@ -29555,11 +29661,11 @@
   "repo": "ocaml/dune",
   "unstable": {
    "version": [
-    20260120,
-    2128
+    20260621,
+    2057
    ],
-   "commit": "ccdb380ab5714b81f1ba71f7f8acfd792e6200bf",
-   "sha256": "0b6xndnh8c27v84vbv0bl8x3062y9fvbrh92p2hm065qsaj8gr7s"
+   "commit": "47f64de764078db6edb2698958b5270a17bffb05",
+   "sha256": "1j0nqvr4njj8z8fcfhxq7c2fid4hc4c46vcx2077sj6iqd8kd02f"
   },
   "stable": {
    "version": [
@@ -29722,11 +29828,11 @@
   "repo": "xenodium/dwim-shell-command",
   "unstable": {
    "version": [
-    20260123,
-    1157
+    20260708,
+    1641
    ],
-   "commit": "a408b7826bb4535e7a14e16848ad41820d63411f",
-   "sha256": "1a30h2ly34pplfnpxhnkdjwqlsfkjchx01wcnh1cnd9zlg05sinp"
+   "commit": "3566651e24ca05fe818897f2cf31718d2bcd1c99",
+   "sha256": "1n8zfh4bibk3c99pijw5xma4sz03jj0m10557ny55wwbz7aqfzny"
   },
   "stable": {
    "version": [
@@ -30574,20 +30680,20 @@
   "repo": "jamescherti/easysession.el",
   "unstable": {
    "version": [
-    20260614,
-    1745
+    20260715,
+    1819
    ],
-   "commit": "e5264f31d1d2ca7ffe6fb836d6ab1a6a14eabc30",
-   "sha256": "02n821lh0nf418w98mnq5nmvp0dpinksf3sav892kkglj1j5qd68"
+   "commit": "a722fad8a087b7036657dc22015d0fffbd63d893",
+   "sha256": "1yafwq7cqkxawd3f2jsvbj2z6vz29ypq2bmas37q8babby4knk1n"
   },
   "stable": {
    "version": [
     1,
     2,
-    3
+    5
    ],
-   "commit": "07c24d08b02c7433d99a63d9260eb8c632e3533d",
-   "sha256": "1s1nf2hswg9pvydxj16sxky2rx85xdis46sqbcscbkv3cdpvy6l8"
+   "commit": "8a195693ccc144f48d7dedf50e136be9a76b437c",
+   "sha256": "0yakk0n7n7m9x847pbva2qf700aygyls1qpwcc1xxd53n87aigcm"
   }
  },
  {
@@ -30746,11 +30852,11 @@
   "repo": "flexibeast/ebuku",
   "unstable": {
    "version": [
-    20240921,
-    839
+    20260712,
+    308
    ],
-   "commit": "45294cedeeefdcb0193b18dc3e2254db0aa700c3",
-   "sha256": "11canjhvwpj2hy5czav2hn1hx0lzckicsbr3p8fr6pjrg3gg2bwh"
+   "commit": "dba4523f18591491c2d716442ad1da184747d879",
+   "sha256": "1vdsp873xmhm49r5cdha82halgwz5p85k9977xfw2163ldlkqigx"
   }
  },
  {
@@ -30761,8 +30867,8 @@
   "repo": "editor-code-assistant/eca-emacs",
   "unstable": {
    "version": [
-    20260622,
-    1430
+    20260716,
+    1447
    ],
    "deps": [
     "compat",
@@ -30771,8 +30877,8 @@
     "markdown-mode",
     "s"
    ],
-   "commit": "f91296cd8ddd1477700cc81c3edda0a45b1a6cd1",
-   "sha256": "0xrizvv94vrckirpdc2mwl4s5iqm2m23v020vhycryz0vcami9z7"
+   "commit": "005fbd8872ca23437e2c5e72f0f9c605bbc7360d",
+   "sha256": "1kzk07bkqdd8054441p30xj4aihh6a8b8d4q7pn1aqgk2iprld66"
   },
   "stable": {
    "version": [
@@ -30916,26 +31022,6 @@
    ],
    "commit": "39b833d2e51ae5ce66ebdec7c5425ff0d34e02d2",
    "sha256": "0xy3q68i47a3s81jwr0rdvc1722bp78ng56xm53pri05g1z0db9s"
-  }
- },
- {
-  "ename": "ede-compdb",
-  "commit": "3b70138b7d82aec2d60f4a7c0cd21e734a1fc52a",
-  "sha256": "1ypi7rxbgg2qck1b571hcw5m4ipllb48g6sindpdf180kbfbfpn7",
-  "fetcher": "github",
-  "repo": "randomphrase/ede-compdb",
-  "unstable": {
-   "version": [
-    20150920,
-    2033
-   ],
-   "deps": [
-    "cl-lib",
-    "ede",
-    "semantic"
-   ],
-   "commit": "23c91082270fcef24ea791b848f1604e36888ff0",
-   "sha256": "03xphcdw4b6z8i3dgrmq0l8m5nfpsjn0jv0y1rlabrbvxw1gpcqq"
   }
  },
  {
@@ -31693,16 +31779,16 @@
   "repo": "non-Jedi/eglot-jl",
   "unstable": {
    "version": [
-    20240911,
-    1352
+    20260705,
+    2320
    ],
    "deps": [
     "cl-generic",
     "eglot",
     "project"
    ],
-   "commit": "7c968cc61fb64016ebe6dc8ff83fd05923db4374",
-   "sha256": "1xy6lssg5x8m2d5802in2b5nl5wrcxz4pilw85kk0mc8640kg2ma"
+   "commit": "ebe4358b48827a85dd4c714bcc3db11842aa6c3c",
+   "sha256": "16bjkwsgsc9181kpav563nv9jpqzw0ycwgvzgdqjsj42c4pyajsv"
   },
   "stable": {
    "version": [
@@ -32044,30 +32130,30 @@
   "repo": "ahyatt/ekg",
   "unstable": {
    "version": [
-    20260624,
-    333
+    20260707,
+    412
    ],
    "deps": [
     "llm",
     "triples",
     "vui"
    ],
-   "commit": "2330740b43cd68063499a8e71b9b07e66dc74082",
-   "sha256": "1lirapvam5l08fql67g25478j1fiimx7ic38y8qa6cib3fmyp6ik"
+   "commit": "f1401f4189143dcfce5cd7d68231462d7a8873ec",
+   "sha256": "0xr95r48i057pjkiai4dyr6wchv7ciq0h4g2rn1qrj88zcmxhx91"
   },
   "stable": {
    "version": [
     0,
     9,
-    0
+    1
    ],
    "deps": [
     "llm",
     "triples",
     "vui"
    ],
-   "commit": "be6cc349a5054154470173af6521e569cb21bcb1",
-   "sha256": "12jkrzxk541i4d1b427zhg7klg304kqidksypikbq18dppsvdh5l"
+   "commit": "f1401f4189143dcfce5cd7d68231462d7a8873ec",
+   "sha256": "0xr95r48i057pjkiai4dyr6wchv7ciq0h4g2rn1qrj88zcmxhx91"
   }
  },
  {
@@ -32078,28 +32164,28 @@
   "repo": "ahyatt/ekg",
   "unstable": {
    "version": [
-    20260624,
-    333
+    20260717,
+    2134
    ],
    "deps": [
     "ekg",
     "futur"
    ],
-   "commit": "2330740b43cd68063499a8e71b9b07e66dc74082",
-   "sha256": "1lirapvam5l08fql67g25478j1fiimx7ic38y8qa6cib3fmyp6ik"
+   "commit": "3ea7ac9fc6f881ce63e8ab06dc71f4f383016c6f",
+   "sha256": "0ncq61rhmmmhavgdyjd4ddsvpkp47lrw2gx9qnv72nzdip05rfk5"
   },
   "stable": {
    "version": [
     0,
     9,
-    0
+    1
    ],
    "deps": [
     "ekg",
     "futur"
    ],
-   "commit": "be6cc349a5054154470173af6521e569cb21bcb1",
-   "sha256": "12jkrzxk541i4d1b427zhg7klg304kqidksypikbq18dppsvdh5l"
+   "commit": "f1401f4189143dcfce5cd7d68231462d7a8873ec",
+   "sha256": "0xr95r48i057pjkiai4dyr6wchv7ciq0h4g2rn1qrj88zcmxhx91"
   }
  },
  {
@@ -32110,28 +32196,28 @@
   "repo": "ahyatt/ekg",
   "unstable": {
    "version": [
-    20260415,
-    39
+    20260707,
+    412
    ],
    "deps": [
     "denote",
     "ekg"
    ],
-   "commit": "be6cc349a5054154470173af6521e569cb21bcb1",
-   "sha256": "12jkrzxk541i4d1b427zhg7klg304kqidksypikbq18dppsvdh5l"
+   "commit": "f1401f4189143dcfce5cd7d68231462d7a8873ec",
+   "sha256": "0xr95r48i057pjkiai4dyr6wchv7ciq0h4g2rn1qrj88zcmxhx91"
   },
   "stable": {
    "version": [
     0,
     9,
-    0
+    1
    ],
    "deps": [
     "denote",
     "ekg"
    ],
-   "commit": "be6cc349a5054154470173af6521e569cb21bcb1",
-   "sha256": "12jkrzxk541i4d1b427zhg7klg304kqidksypikbq18dppsvdh5l"
+   "commit": "f1401f4189143dcfce5cd7d68231462d7a8873ec",
+   "sha256": "0xr95r48i057pjkiai4dyr6wchv7ciq0h4g2rn1qrj88zcmxhx91"
   }
  },
  {
@@ -33073,20 +33159,20 @@
   "repo": "swflint/electric-ospl-mode",
   "unstable": {
    "version": [
-    20260108,
-    1622
+    20260701,
+    1901
    ],
-   "commit": "8599de5864e20831f2a3719f83da6690e0575c56",
-   "sha256": "0xhf52vkmilr4knc5xnjxphii0dlm8w4azqw9gbw4ypwx2rcz2jw"
+   "commit": "88ab5ca588b4cbd1ddd27757d390da19298b05bd",
+   "sha256": "0ngnb5db38vl2g8xln6ai1law92bci3mpa533k47k9rg5rbp0zbl"
   },
   "stable": {
    "version": [
     3,
     3,
-    1
+    2
    ],
-   "commit": "a17f7312ef48eba1586c7d0637336eb19aee057e",
-   "sha256": "04mp6pqxr5p01z4wqkj8wy07ys3p1n5fm9h3yzplknvr3n2djvxl"
+   "commit": "88ab5ca588b4cbd1ddd27757d390da19298b05bd",
+   "sha256": "0ngnb5db38vl2g8xln6ai1law92bci3mpa533k47k9rg5rbp0zbl"
   }
  },
  {
@@ -33184,26 +33270,26 @@
   "repo": "emacs-elfeed/elfeed",
   "unstable": {
    "version": [
-    20260623,
-    1113
+    20260714,
+    920
    ],
    "deps": [
     "compat"
    ],
-   "commit": "2c4f03158a3bf410d95c57851de284a1f88537ca",
-   "sha256": "0q3mff27id2jasz217im8xdxryl55jf7b6k746pjs99rsqlw3vvj"
+   "commit": "e18cbb8cc4bb08e1512571449623f5f03f43f94c",
+   "sha256": "1kbhzzf614dd8pz1s90vpqfx75dpv016z474i7l2rsq0an6xxb3s"
   },
   "stable": {
    "version": [
     4,
-    0,
-    1
+    1,
+    0
    ],
    "deps": [
     "compat"
    ],
-   "commit": "90470c3ff7cf215771f31e8c5e4b08fe6ad8f65b",
-   "sha256": "0sldxrvqcdf7is4x8g2dj4apix78bqq0q5pq1pzdawl6hfwdy1xw"
+   "commit": "d08bb8e3d1e57f1b3941abcd8d141ac59315a5e4",
+   "sha256": "0r207pxip8s7h4lcmrbd98p1psrs5211byvj5501n8qdcdwn199s"
   }
  },
  {
@@ -33486,15 +33572,15 @@
   "repo": "karthink/elfeed-tube",
   "unstable": {
    "version": [
-    20260522,
-    916
+    20260702,
+    1928
    ],
    "deps": [
     "aio",
     "elfeed"
    ],
-   "commit": "ae763194ad36942ccdbd9d59a40926a33bffd89b",
-   "sha256": "1s5df4z559jb805nb6b23hdhs0a72bqlyr12wvmn7858zn9p09bx"
+   "commit": "f653d5b7f27a2eace217d9e6b4f40e0e35ae88cd",
+   "sha256": "1lll43d8bd4j36ckvyrsc7fdbcxs6j8p21nk49rlngkczk12pfxy"
   },
   "stable": {
    "version": [
@@ -33542,8 +33628,8 @@
  },
  {
   "ename": "elfeed-web",
-  "commit": "4b3677dd24b0167dcd342a5367640c6ed54d1142",
-  "sha256": "1miajgc19swv2wl1pfa5xn2c80pcbwmwhq023msb3bzxadhhw9y6",
+  "commit": "1285db21b49c7d81ee9f4751aee3efc80457d3c1",
+  "sha256": "1nfpiy3fa11gibv96lr2awqbzfczq22w3hqvcx423zkg5riiq7pr",
   "fetcher": "github",
   "repo": "emacs-elfeed/elfeed-web",
   "unstable": {
@@ -33696,11 +33782,11 @@
   "repo": "ideasman42/emacs-elisp-autofmt",
   "unstable": {
    "version": [
-    20260407,
-    326
+    20260611,
+    427
    ],
-   "commit": "b1cdd8661930a35b1633ccc28b27b793145cd108",
-   "sha256": "1fpyr30aln2rpslx3n7s868cbxw20yv5cdsn8hvf0mvb2bwfmny3"
+   "commit": "fdae9054c55804def507cf7045c8460573d876a9",
+   "sha256": "1m43xcddswr7kl218w06rmix833jfhyr6car173ln00ggd5yvnf7"
   }
  },
  {
@@ -33801,14 +33887,14 @@
   "repo": "laurynas-biveinis/elisp-dev-mcp",
   "unstable": {
    "version": [
-    20260602,
-    1123
+    20260630,
+    1120
    ],
    "deps": [
     "mcp-server-lib"
    ],
-   "commit": "6120460212e03daf2f9502c3a5cebab958faa419",
-   "sha256": "02lcr7diwbrj3ij6c8wxvymr3mf9hf1bv385wyc4r3cfakjcw4gj"
+   "commit": "d70a8f38ededefb7e3d11f3e2b519bf754a54d1a",
+   "sha256": "0km6yzp3274aqv394zsafgy2vj8ljh61na53x56svaxxq46v0dzc"
   },
   "stable": {
    "version": [
@@ -34102,8 +34188,8 @@
   "repo": "s-kostyaev/ellama",
   "unstable": {
    "version": [
-    20260605,
-    1826
+    20260712,
+    1716
    ],
    "deps": [
     "compat",
@@ -34112,14 +34198,14 @@
     "transient",
     "yaml"
    ],
-   "commit": "b122f2e043313d470fa68c0c1e042e3dec536cbf",
-   "sha256": "1pv85p94w8yr81bll30mwlwyb30rsw3sx81lwznghg5jvi8bb875"
+   "commit": "b00c307c97a2e447948a589fe591e3cad2d4b93a",
+   "sha256": "16nxq115s3b70y9gj5w1wn4ihq4wfczaripwnlb283sz3waygj9m"
   },
   "stable": {
    "version": [
     1,
-    27,
-    2
+    30,
+    0
    ],
    "deps": [
     "compat",
@@ -34128,8 +34214,8 @@
     "transient",
     "yaml"
    ],
-   "commit": "b122f2e043313d470fa68c0c1e042e3dec536cbf",
-   "sha256": "1pv85p94w8yr81bll30mwlwyb30rsw3sx81lwznghg5jvi8bb875"
+   "commit": "b00c307c97a2e447948a589fe591e3cad2d4b93a",
+   "sha256": "16nxq115s3b70y9gj5w1wn4ihq4wfczaripwnlb283sz3waygj9m"
   }
  },
  {
@@ -34382,11 +34468,11 @@
   "repo": "johanwk/elot",
   "unstable": {
    "version": [
-    20260603,
-    1452
+    20260709,
+    1716
    ],
-   "commit": "aa2e0b60307ab1d06622281a9c69411b55a442b3",
-   "sha256": "093xianvfgcqd6yyk3f9nc0ccdmcny825aah3icn72phb5ws566h"
+   "commit": "d7e9b47207a16841bb5a08077e1dfcb47608f37f",
+   "sha256": "113nyv2w42mvmkkrfzxfdzsz0x57icwlfa62rmxcgxflizy2ff37"
   },
   "stable": {
    "version": [
@@ -34519,11 +34605,11 @@
   "stable": {
    "version": [
     3,
-    6,
-    6
+    7,
+    0
    ],
-   "commit": "dcdeb86f7ae633e252f9ef8a73d3458e87c1ab12",
-   "sha256": "15cgqzzfjikq4spsmf7mmhvrd6igcsv75d9mdsxl5j6zhq784hh8"
+   "commit": "d799c467a1f35934f96d33960d638ddf796f01ba",
+   "sha256": "0wzj4n8wc90mqzmd86rvq8g20mk44lvmqdvfan3pj3z3b1jnk82c"
   }
  },
  {
@@ -34549,8 +34635,8 @@
   "repo": "jorgenschaefer/elpy",
   "unstable": {
    "version": [
-    20260517,
-    631
+    20260715,
+    1747
    ],
    "deps": [
     "company",
@@ -34559,8 +34645,8 @@
     "s",
     "yasnippet"
    ],
-   "commit": "261774a6d024503a8198c020999ed54a163f85ad",
-   "sha256": "1k2rgimv0wf62jy82wgjkbakr3xz6xmayxx8sgnhgb79fl1sigf3"
+   "commit": "9cdf26dfea1cb044b3cf1dfa9755b6479bfd9a1c",
+   "sha256": "13pkr52vzz9fkp4062zrqdxh04rscka5f1anl9lk730z8c7p5f23"
   },
   "stable": {
    "version": [
@@ -35368,16 +35454,16 @@
   "repo": "martenlienen/emcp",
   "unstable": {
    "version": [
-    20260612,
-    1547
+    20260706,
+    1558
    ],
    "deps": [
     "elisp-refs",
     "http-server",
     "magit-section"
    ],
-   "commit": "19523208ee78d6548a8f8ad6aa2e296a6836d4db",
-   "sha256": "1np8g6dk1d75xa6pfa2mh6jqmr2dl665h6bnjn3f2p7llm5bw2w5"
+   "commit": "cc452a2cb8b128305c7091a4adf9435e6b227fc1",
+   "sha256": "18i0lwv057lij599y2f2hblivvc7rmiwl1ff2vbykmakcsxfncrp"
   }
  },
  {
@@ -36366,8 +36452,8 @@
   "repo": "emacscollective/epkg",
   "unstable": {
    "version": [
-    20260617,
-    1602
+    20260701,
+    1311
    ],
    "deps": [
     "closql",
@@ -36376,14 +36462,14 @@
     "emacsql",
     "llama"
    ],
-   "commit": "636490387d8fef3dc4d54b0b7cdc7ffe947663a1",
-   "sha256": "0xgjp20gr3qjkf2bry9r91cl3b49jsc7zdkzvi0zqcbwvi0gpdjh"
+   "commit": "63bf2ab384c0f96f344492d151549c5b95b6830f",
+   "sha256": "0wbx78x1knmm64kvy1rhln8hdg3qj7yvvxdk9wbpx00r9s5kh6hh"
   },
   "stable": {
    "version": [
     4,
     2,
-    1
+    2
    ],
    "deps": [
     "closql",
@@ -36392,8 +36478,8 @@
     "emacsql",
     "llama"
    ],
-   "commit": "849ce2359fcd51467e7ef00faaf6130e1017e6ce",
-   "sha256": "0cb2bqhbh60lk1s9w0aan4qkq4v9pvsqqiiijmi3kgvyhfnkcwhn"
+   "commit": "63bf2ab384c0f96f344492d151549c5b95b6830f",
+   "sha256": "0wbx78x1knmm64kvy1rhln8hdg3qj7yvvxdk9wbpx00r9s5kh6hh"
   }
  },
  {
@@ -36733,11 +36819,11 @@
   "repo": "alexmurray/erc-matterircd",
   "unstable": {
    "version": [
-    20210804,
-    504
+    20260628,
+    743
    ],
-   "commit": "e3a59267c044474f9ca066d36517e9a3d872759c",
-   "sha256": "1iqyyhaz8zypgj9ij8ivqym0xry10zzyi8qf16fzg2ppxl47bc5i"
+   "commit": "f4c8e3cac924065b2d0e43114459c45fa39cc006",
+   "sha256": "0jsw6vbhr5g10cv3sw5lkkv8nkb18gcc6x2zy4hzqp9d72y7y08h"
   }
  },
  {
@@ -37122,20 +37208,20 @@
   "repo": "erlang/otp",
   "unstable": {
    "version": [
-    20260609,
-    1424
+    20260702,
+    800
    ],
-   "commit": "36b336d7675edfb976768465c5067bc8bc16ee9a",
-   "sha256": "0xzhcwmll71048is39kqli15fx8cgi91zk7391v5a2wf63x5xnpa"
+   "commit": "40ea544c97aa8492596f35a88286ea80326510ec",
+   "sha256": "1h6gv5hakz0jw6b93c7kyadcqbgp1xai3svd18hcr9z67bxm8m3j"
   },
   "stable": {
    "version": [
     29,
     0,
-    2
+    3
    ],
-   "commit": "36b336d7675edfb976768465c5067bc8bc16ee9a",
-   "sha256": "0xzhcwmll71048is39kqli15fx8cgi91zk7391v5a2wf63x5xnpa"
+   "commit": "40ea544c97aa8492596f35a88286ea80326510ec",
+   "sha256": "1h6gv5hakz0jw6b93c7kyadcqbgp1xai3svd18hcr9z67bxm8m3j"
   }
  },
  {
@@ -38903,19 +38989,20 @@
   "repo": "beacoder/everlasting-scratch",
   "unstable": {
    "version": [
-    20250206,
-    628
+    20260713,
+    605
    ],
-   "commit": "a990e8d2261e5ac109729eb8c2c8e1947e45c8ed",
-   "sha256": "0lhyaqwxwm54rw9lvhk6vqpnz4350dx45gxc4qgm0g6qgdzn78dk"
+   "commit": "4180fd04183a24de44a920cc02ac5a3bbf23643f",
+   "sha256": "1gqarbnnq2rs8ckvisf0bbrmh9nmfhvlqv2b1a0xwlcbn6mhn6cc"
   },
   "stable": {
    "version": [
     0,
+    1,
     1
    ],
-   "commit": "509cf24422d4047b110aac8ed077b52a8011cfe7",
-   "sha256": "04snf28gk7lc9pd5ilv9w1xjm14fi3ajp6dwaz4bbq8haacm3hpz"
+   "commit": "4180fd04183a24de44a920cc02ac5a3bbf23643f",
+   "sha256": "1gqarbnnq2rs8ckvisf0bbrmh9nmfhvlqv2b1a0xwlcbn6mhn6cc"
   }
  },
  {
@@ -39128,26 +39215,26 @@
   "repo": "emacs-evil/evil-collection",
   "unstable": {
    "version": [
-    20260624,
-    327
+    20260719,
+    2207
    ],
    "deps": [
     "evil"
    ],
-   "commit": "23fa1e6eaf32d5eb8ab83861c176f866e8d8cff2",
-   "sha256": "1hl343rpxaizmal75fnmfwpp2vvjbl9bd30smlzh2j3bqvzy2mp2"
+   "commit": "03e1c04b398bc8948a21fac5f3baa4f70da1a350",
+   "sha256": "1b9nnnincpw5rvmqvlniy4hyq08vbdca9p40x0avr8r4scf7vzx2"
   },
   "stable": {
    "version": [
-    1,
+    3,
     0,
     0
    ],
    "deps": [
     "evil"
    ],
-   "commit": "4ab182ddf139f0df2b5da2e745ad0aad195fb23f",
-   "sha256": "1lq0yh7isplr8glh9f7fb1fds7dq7k3jcxzz8zrhvyj5yhl4sj3c"
+   "commit": "29acaa81d2992d9c89a4b15ead917abb3af05228",
+   "sha256": "0j89w682394fq96jx0da8scl7n0pihp8gb23sg4frkdp2l8yvl3z"
   }
  },
  {
@@ -39420,28 +39507,28 @@
   "repo": "dakra/ghostel",
   "unstable": {
    "version": [
-    20260623,
-    1940
+    20260713,
+    2022
    ],
    "deps": [
     "evil",
     "ghostel"
    ],
-   "commit": "b6d7b37353572bf92d04c8de5abced3ef68a0304",
-   "sha256": "1yv31zvyk80k2yl67hx67l1xwizm9p9257fwwz5hfav6lx0z6vm2"
+   "commit": "2191afe3049fc785c6fd2b1ab6b826daf500ffbe",
+   "sha256": "1fyqpbpv62hs3hqai1j04x30miwdqkkpqfxdh4vbxc331fhrj4dx"
   },
   "stable": {
    "version": [
     0,
-    38,
+    44,
     0
    ],
    "deps": [
     "evil",
     "ghostel"
    ],
-   "commit": "b6d7b37353572bf92d04c8de5abced3ef68a0304",
-   "sha256": "1yv31zvyk80k2yl67hx67l1xwizm9p9257fwwz5hfav6lx0z6vm2"
+   "commit": "2191afe3049fc785c6fd2b1ab6b826daf500ffbe",
+   "sha256": "1fyqpbpv62hs3hqai1j04x30miwdqkkpqfxdh4vbxc331fhrj4dx"
   }
  },
  {
@@ -39799,26 +39886,26 @@
   "repo": "redguardtoo/evil-mark-replace",
   "unstable": {
    "version": [
-    20250422,
-    242
+    20260716,
+    634
    ],
    "deps": [
     "evil"
    ],
-   "commit": "90ee84748582be05fa8f9a02872321a08b455282",
-   "sha256": "1w2f2df48hvabb750p3c9lsb2clpif4bv11z67wl9vafci53lahh"
+   "commit": "3221d2c3b304a1cb825f6c79da4d418a8233dcc2",
+   "sha256": "1fliqxyzg2sagwva618373ly83rj3xw16ri5s3s21jfm5jva73kz"
   },
   "stable": {
    "version": [
     0,
     0,
-    6
+    7
    ],
    "deps": [
     "evil"
    ],
-   "commit": "217d5b507aa11dd0b334d5c3e1f74ac1fc2f66a4",
-   "sha256": "17mn7jybnlzhb82h6jkxdhcr76p1p5dk1v7dpb74r3ccd75sqn2b"
+   "commit": "3221d2c3b304a1cb825f6c79da4d418a8233dcc2",
+   "sha256": "1fliqxyzg2sagwva618373ly83rj3xw16ri5s3s21jfm5jva73kz"
   }
  },
  {
@@ -40549,20 +40636,20 @@
   "repo": "wbolster/evil-swap-keys",
   "unstable": {
    "version": [
-    20191105,
-    1426
+    20260624,
+    2045
    ],
-   "commit": "b5ef105499f998b5667da40da30c073229a213ea",
-   "sha256": "1kawq9c64cmkdjy03sfppjn7g9anxnmds3ip7cgj1j0yym0glyfq"
+   "commit": "889672ad0d35ab062c52d9d84b22de4ac49753f3",
+   "sha256": "066qrmdxz77zmc9k7wbyzrzrgwfkr75g413r80jll9varf73y9sn"
   },
   "stable": {
    "version": [
     1,
-    0,
+    1,
     0
    ],
-   "commit": "56bc201e265a6bd482a7c41a7c81d2238341ef3a",
-   "sha256": "0n0hl0plaghz9rjssabxwfzm46kr6564hpfh6hn8lzla4rf1q5zs"
+   "commit": "889672ad0d35ab062c52d9d84b22de4ac49753f3",
+   "sha256": "066qrmdxz77zmc9k7wbyzrzrgwfkr75g413r80jll9varf73y9sn"
   }
  },
  {
@@ -40696,27 +40783,28 @@
   "repo": "wbolster/evil-text-object-python",
   "unstable": {
    "version": [
-    20191010,
-    1328
+    20260706,
+    1546
    ],
    "deps": [
     "dash",
     "evil"
    ],
-   "commit": "39d22fc524f0413763f291267eaab7f4e7984318",
-   "sha256": "0293hfgczpjghvg28s27c5r6ll1zaq466pasrhzj71sqzyvxq7ax"
+   "commit": "c8b2c6d8f5194af99f65cceec1b692f464f00a8b",
+   "sha256": "06n7p1cwb1aaj5ixr0mb8s9fmkq45jrlwwp00p447vsnc5rsjv4l"
   },
   "stable": {
    "version": [
     1,
-    0,
-    1
+    1,
+    0
    ],
    "deps": [
+    "dash",
     "evil"
    ],
-   "commit": "3b3fb01e7ad7eeeeae1143695547fe75148cc44f",
-   "sha256": "1alin2rmx1xa1w3b1nb76bplmg10il55jxxm6jj7qs6z1izzllci"
+   "commit": "c8b2c6d8f5194af99f65cceec1b692f464f00a8b",
+   "sha256": "06n7p1cwb1aaj5ixr0mb8s9fmkq45jrlwwp00p447vsnc5rsjv4l"
   }
  },
  {
@@ -42053,20 +42141,20 @@
   "repo": "mscfd/emacs-f90-ts-mode",
   "unstable": {
    "version": [
-    20260620,
-    1316
+    20260717,
+    1000
    ],
-   "commit": "2df0e82c35e3690553231370884e340a925ba158",
-   "sha256": "1572qxrxb5riqw4psjvms4k2qd1kgskjhci4wnc0xvi95xjiqh6q"
+   "commit": "e4549d68501bdef06db615b8674a9bd9f1f70a9d",
+   "sha256": "1wyfzp02brpvrxnzkjf0jdscxx1nlglk2g00bw0g5qy6xp36pzbn"
   },
   "stable": {
    "version": [
     0,
-    2,
-    2
+    3,
+    0
    ],
-   "commit": "6c3e40cad1fc459b5c4084ce21e748a0a4145612",
-   "sha256": "0r9xmshsxq9ypsfn3wnx1sc2avrlnwmpql083blpawphs6pzxm01"
+   "commit": "3fbdbf64a17b2c712552d4733b02bf9bbf9258f6",
+   "sha256": "04l6iwz33gsbp6ab4idfh7zb7b9ggq9m34w67f7k7ps85hg2fgzg"
   }
  },
  {
@@ -42255,14 +42343,14 @@
   "repo": "jrosdahl/fancy-dabbrev",
   "unstable": {
    "version": [
-    20220211,
-    633
+    20260717,
+    1243
    ],
    "deps": [
     "popup"
    ],
-   "commit": "cf4a2f7e3e43e07ab9aa9db16532a21010e9fc8c",
-   "sha256": "04z9pwvl68hsisnyf9wlxmkwk8xag36jvcchwcwp4n9vp04z8745"
+   "commit": "9a9296f0dcfe272cdff1fc2e0a6a62b8cdaf11ab",
+   "sha256": "0ix7cdcivkfxgd81hpx8bilz0dh6hgikvh5lgl0dyap9ml4y6br0"
   }
  },
  {
@@ -42789,11 +42877,11 @@
   "repo": "technomancy/fennel-mode",
   "unstable": {
    "version": [
-    20260507,
-    757
+    20260704,
+    2353
    ],
-   "commit": "1ef8ae0cff094cfba750e72b897e03eaeebbc117",
-   "sha256": "1q31ym8gy1m9xyn9w633br8kz0wxkzk4cri6373y0d5a4ic9r53c"
+   "commit": "bbc28a629405de628880d8fb485fce23ff7fab69",
+   "sha256": "1rpyp660j9shlilxgwvc4i01qpmqyz3zy3dxk10dilw2g5n6dd0q"
   },
   "stable": {
    "version": [
@@ -43780,11 +43868,11 @@
   "repo": "Prgebish/flash",
   "unstable": {
    "version": [
-    20260308,
-    621
+    20260711,
+    805
    ],
-   "commit": "42fbc5883fd802df97cae842c403deba4c433d45",
-   "sha256": "18jbcqp844s1cvra2xw9nq9fw3g3y0jwyi1bxlm4f8s8g97bfvxd"
+   "commit": "db3bfa84866f143a0665d1b5a48c3b30dc7b528f",
+   "sha256": "02z4h73018mv5hf6xzwhaamv24abnj2s6lg5daybd0qz9ncvxxrd"
   }
  },
  {
@@ -43947,15 +44035,15 @@
   "repo": "plandes/flex-compile",
   "unstable": {
    "version": [
-    20260615,
-    2248
+    20260716,
+    2144
    ],
    "deps": [
     "buffer-manage",
     "dash"
    ],
-   "commit": "2d9d805ad6d1db8d7eeedf67460e4e13c9b06528",
-   "sha256": "0qvfvxc9jb9fwfbj209srzq122z056nwfywhvv0z9pnijv6k11wx"
+   "commit": "0bd757312b0118ed55d3f4eefe4adca983f588ec",
+   "sha256": "1n71ll57wpfps1av89k63awhbhrg527anqxhgfiglswzba5970yg"
   },
   "stable": {
    "version": [
@@ -43984,6 +44072,21 @@
    ],
    "commit": "b1f7e04de762282c276343cc2709af9ff4abc9d2",
    "sha256": "0xbwrzkfv4i91qxs80p0pfjlvj5pyigvidby8m5lammm8idwx9dh"
+  }
+ },
+ {
+  "ename": "flex-x",
+  "commit": "86f02e077f9339a0eadc479fb3ff8b73440bf325",
+  "sha256": "1k6i7qpwavabfgvrx5fczcyb91wazynqjnh4a0jwq85igvb767ls",
+  "fetcher": "github",
+  "repo": "kn66/flex-x",
+  "unstable": {
+   "version": [
+    20260713,
+    1220
+   ],
+   "commit": "c5fba3d76b1eab42f9e524f0c48d6db61274aeb1",
+   "sha256": "1n4bgmd6hspc1jy8fsmscwazgahl5pqfdsp6ydya41rfhcbirbbh"
   }
  },
  {
@@ -44310,25 +44413,25 @@
   "repo": "flycheck/flycheck",
   "unstable": {
    "version": [
-    20260604,
-    2002
+    20260720,
+    531
    ],
    "deps": [
     "seq"
    ],
-   "commit": "96f1852c7e352c969393e6e66176178177e933be",
-   "sha256": "0qar882187wm4yqpabrzc8vkcgh0ybvim1dxxskc2x97zvvqf3mp"
+   "commit": "7e44b59718318abb4bf9732de2538f4e0281ce49",
+   "sha256": "1gr5b4n2ljmvd40a35g3xwsrkafg4rf4mfc294690kzh3y0lgmbz"
   },
   "stable": {
    "version": [
-    36,
+    37,
     0
    ],
    "deps": [
     "seq"
    ],
-   "commit": "ebddfd89b1eea91b8590f542908672569942fb82",
-   "sha256": "0gndi96ijxqj6k9qy5d4l0cwqh0ky7w1p27z90ipkn05xz4j3zp5"
+   "commit": "af6b60fd544c29f68c731d709a066317b8ed0628",
+   "sha256": "0s2a7qzifz25231pzaq38j8sqnzjid0cxck91kgnazhhp4gdndl7"
   }
  },
  {
@@ -45457,13 +45560,13 @@
   "stable": {
    "version": [
     2,
-    5
+    6
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "4b50d794a88d31c43023bed78f1815673f0c8890",
-   "sha256": "1bv6g3y39ifcyxynmwk619hkfl643s3pa4qrmy7m440dndfqjzxf"
+   "commit": "f822e96ef54cc8d0d9ca64ad489b915bc36f6ac0",
+   "sha256": "1vbvgh9qkvvylskk292hcgl347ygb744w2jwx8cw41fk30i2v7qc"
   }
  },
  {
@@ -46279,28 +46382,28 @@
   "repo": "emacs-php/phpstan.el",
   "unstable": {
    "version": [
-    20250930,
-    1139
+    20260717,
+    1734
    ],
    "deps": [
     "flycheck",
     "phpstan"
    ],
-   "commit": "07ef7531f2ec73b90a965ac865cca8c96086f9de",
-   "sha256": "1myzqbd00892a604kg88bxglk0w6valdvmaybsixapr5wgg2sbri"
+   "commit": "00942a5d5b28560bd08f7355d131074772bb7a01",
+   "sha256": "1hf5jxj1amvv9ac1jm5bly38xfhj5k0rmsg3sd9kd888hi95gph8"
   },
   "stable": {
    "version": [
     0,
-    9,
+    10,
     0
    ],
    "deps": [
     "flycheck",
     "phpstan"
    ],
-   "commit": "206573c8de58654384823765dcca636c9e35e909",
-   "sha256": "12qzjy3zz0lk439y0y9gl5pirzlf52li3lbyjjmq7lq6yg30qzxm"
+   "commit": "00942a5d5b28560bd08f7355d131074772bb7a01",
+   "sha256": "1hf5jxj1amvv9ac1jm5bly38xfhj5k0rmsg3sd9kd888hi95gph8"
   }
  },
  {
@@ -47148,20 +47251,20 @@
   "repo": "jamescherti/flymake-ansible-lint.el",
   "unstable": {
    "version": [
-    20260602,
-    1355
+    20260703,
+    1441
    ],
-   "commit": "8e300cc49b234a03aca90f497a69de2de8deab96",
-   "sha256": "1i0isj0ra6g330cq676lflfqks198lz589rrf0s2nnj3mvnwsvzd"
+   "commit": "bfb8148d9a1aece141d18eef484e7c0c8db79855",
+   "sha256": "1dk84j778r38lk40d9ic2ihp5pbq7z2gplzjlj18s9f0nmj241d8"
   },
   "stable": {
    "version": [
     1,
     0,
-    6
+    7
    ],
-   "commit": "8e300cc49b234a03aca90f497a69de2de8deab96",
-   "sha256": "1i0isj0ra6g330cq676lflfqks198lz589rrf0s2nnj3mvnwsvzd"
+   "commit": "bfb8148d9a1aece141d18eef484e7c0c8db79855",
+   "sha256": "1dk84j778r38lk40d9ic2ihp5pbq7z2gplzjlj18s9f0nmj241d8"
   }
  },
  {
@@ -48225,26 +48328,26 @@
   "repo": "emacs-php/phpstan.el",
   "unstable": {
    "version": [
-    20250930,
-    1139
+    20260717,
+    1734
    ],
    "deps": [
     "phpstan"
    ],
-   "commit": "07ef7531f2ec73b90a965ac865cca8c96086f9de",
-   "sha256": "1myzqbd00892a604kg88bxglk0w6valdvmaybsixapr5wgg2sbri"
+   "commit": "00942a5d5b28560bd08f7355d131074772bb7a01",
+   "sha256": "1hf5jxj1amvv9ac1jm5bly38xfhj5k0rmsg3sd9kd888hi95gph8"
   },
   "stable": {
    "version": [
     0,
-    9,
+    10,
     0
    ],
    "deps": [
     "phpstan"
    ],
-   "commit": "206573c8de58654384823765dcca636c9e35e909",
-   "sha256": "12qzjy3zz0lk439y0y9gl5pirzlf52li3lbyjjmq7lq6yg30qzxm"
+   "commit": "00942a5d5b28560bd08f7355d131074772bb7a01",
+   "sha256": "1hf5jxj1amvv9ac1jm5bly38xfhj5k0rmsg3sd9kd888hi95gph8"
   }
  },
  {
@@ -49161,6 +49264,38 @@
   }
  },
  {
+  "ename": "folio-theme",
+  "commit": "5cdf39f996aedcb54ca024b0c62bca0ecb1f8669",
+  "sha256": "1417nn8303q4r53165kj1454dbc3vjrfh4w6q0hvq4286ww0r40y",
+  "fetcher": "github",
+  "repo": "kn66/folio-theme.el",
+  "unstable": {
+   "version": [
+    20260711,
+    13
+   ],
+   "deps": [
+    "ef-themes",
+    "modus-themes"
+   ],
+   "commit": "758ca1f9674d685747d0846160e76bb6cb677a2d",
+   "sha256": "0cwnn6dwd6hvf46pyp3b0nmirh0fh85kz91i2n9q0zfyf7jc5r7d"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "deps": [
+    "ef-themes",
+    "modus-themes"
+   ],
+   "commit": "247280f0ed9d9c94614635baf69d2a3d65bf1793",
+   "sha256": "1byxrivjk6h07jqa2lzqpafyn9pxmhhyjafkd40qi55d0blsh72z"
+  }
+ },
+ {
   "ename": "font-lock-profiler",
   "commit": "b372892a29376bc3f0101ea5865efead41e1df26",
   "sha256": "089r74jgi5gwjk9w1bc600vkj0p5ac84rgcl7aqcpqfbh9ylwcp9",
@@ -49441,8 +49576,8 @@
   "repo": "magit/forge",
   "unstable": {
    "version": [
-    20260623,
-    1325
+    20260701,
+    1425
    ],
    "deps": [
     "closql",
@@ -49456,14 +49591,14 @@
     "transient",
     "yaml"
    ],
-   "commit": "0c9407833bd688f83ad496b37ea71381e758d65b",
-   "sha256": "070mfivrbxgbyzhskzq1dqwwkhazgj0nk2np45sfw9irfp2mn0ig"
+   "commit": "9628f76740aec9270e9fb31457ff4cb38d9f3f16",
+   "sha256": "1xmq50026z47imlwi6an50h2yp6b894m84kfq6bf4878qbfmfw2w"
   },
   "stable": {
    "version": [
     0,
     6,
-    6
+    7
    ],
    "deps": [
     "closql",
@@ -49474,12 +49609,11 @@
     "llama",
     "magit",
     "markdown-mode",
-    "seq",
     "transient",
     "yaml"
    ],
-   "commit": "a8af709bc15e973804af776bba66b4205540bd73",
-   "sha256": "001q4nk7dval6g6gd7cw69jldkal5k0mnimzl2vxlrhck88jqkjf"
+   "commit": "9628f76740aec9270e9fb31457ff4cb38d9f3f16",
+   "sha256": "1xmq50026z47imlwi6an50h2yp6b894m84kfq6bf4878qbfmfw2w"
   }
  },
  {
@@ -49726,11 +49860,11 @@
   "repo": "gmlarumbe/fpga",
   "unstable": {
    "version": [
-    20260407,
-    1246
+    20260715,
+    1713
    ],
-   "commit": "6b22e9e034411a03e574b00377ce0bcf5dafb1d3",
-   "sha256": "0fxn76jjalhyymhdwqvgm3s97drkm9y44dd9sivqmpbh01r2dslm"
+   "commit": "cbf972cf8700291d904f8b922f5d919295d69a67",
+   "sha256": "1xznaq4bvmmajjsd16546fkax1ww1clpb8kvskf8jw5aqdsrji8q"
   },
   "stable": {
    "version": [
@@ -49783,14 +49917,14 @@
   "repo": "colonelpanic8/frame-mode",
   "unstable": {
    "version": [
-    20230823,
-    1850
+    20260710,
+    1851
    ],
    "deps": [
     "s"
    ],
-   "commit": "ab5e568a7c7259d31c252c263458bd76490241d0",
-   "sha256": "044ppidaapay08nw4gv85ir5ivxwwbys0gdvg6mbpf142qk093hb"
+   "commit": "0435d9ed05223904cf389eea881553632e681035",
+   "sha256": "17mzw7h4f8fkrkfazsalh3mskhyp81xcfwzxz5nnhzmnbrqv6y2w"
   }
  },
  {
@@ -50844,19 +50978,49 @@
   "repo": "dangduc/fzf-native",
   "unstable": {
    "version": [
-    20260614,
-    1331
+    20260714,
+    2328
    ],
-   "commit": "ae9c747e93ca48443792a59f4f59a4cda96949f2",
-   "sha256": "1b11javzwlnb1jhvbf0bg8ayfd3wlk3a15gla5dblrj3hdc002hd"
+   "commit": "39dc386062d6ae942b4a7e8592d26ce11b73bf29",
+   "sha256": "04xhv90sbhsx79r6nlkcl71g8sdxcyw20856wd02d71qpf3zmxp4"
   },
   "stable": {
    "version": [
     2,
+    2
+   ],
+   "commit": "39dc386062d6ae942b4a7e8592d26ce11b73bf29",
+   "sha256": "04xhv90sbhsx79r6nlkcl71g8sdxcyw20856wd02d71qpf3zmxp4"
+  }
+ },
+ {
+  "ename": "fzfa",
+  "commit": "d4fc9674633431bd3122e1e69ae1e2585ba700f3",
+  "sha256": "0npg0wgxzlgrc2jxr7pkjl06iwphy2sbp2gvaqa22sp9v891liw3",
+  "fetcher": "github",
+  "repo": "jojojames/fzfa",
+  "unstable": {
+   "version": [
+    20260719,
+    1940
+   ],
+   "deps": [
+    "fzf-native"
+   ],
+   "commit": "427ff74d62abcd4ee1729d8743fde69cd1a722f9",
+   "sha256": "1jxdvhq92aa1z16s07zgy7hjkkz2ias153v4554pq2m0crav8h51"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
     1
    ],
-   "commit": "ae9c747e93ca48443792a59f4f59a4cda96949f2",
-   "sha256": "1b11javzwlnb1jhvbf0bg8ayfd3wlk3a15gla5dblrj3hdc002hd"
+   "deps": [
+    "fzf-native"
+   ],
+   "commit": "6737ba916ace7147eaa492fdbe950817beeecfd8",
+   "sha256": "1jxdvhq92aa1z16s07zgy7hjkkz2ias153v4554pq2m0crav8h51"
   }
  },
  {
@@ -51032,11 +51196,11 @@
   "repo": "godotengine/emacs-gdscript-mode",
   "unstable": {
    "version": [
-    20260615,
-    928
+    20260720,
+    923
    ],
-   "commit": "6bfea8c477cda3f300b84248b5f56c9d241e8029",
-   "sha256": "0wfcyan4qasqfhf70ilcq82f9zb05vhrk61nrb8pq9cmj7kr6xwf"
+   "commit": "5ea9bb0a2ee3b3845918084bbb422391dfcc852c",
+   "sha256": "1r2zps4x1228pz4v6q3536giiynzz0xz0r69nhmli9aqihg4nv62"
   },
   "stable": {
    "version": [
@@ -51151,14 +51315,14 @@
   "repo": "geiser/geiser",
   "unstable": {
    "version": [
-    20260523,
-    1502
+    20260718,
+    8
    ],
    "deps": [
     "project"
    ],
-   "commit": "84c25e9683a18d00387b6c16b0cee66269536c3c",
-   "sha256": "0gyr7fky3jppk3vy44mq3lfwz0n7r0k6cxim7bdfp9qy8jqw1pr8"
+   "commit": "3e506d06b34ccda8a50ac3e43c90d722c00065fe",
+   "sha256": "0yzl6hirz8x13pm3v9n7flz44pczfc0cmv8ysmxhndk93c925k17"
   },
   "stable": {
    "version": [
@@ -51210,14 +51374,14 @@
   "repo": "geiser/chibi",
   "unstable": {
    "version": [
-    20240521,
-    2252
+    20260706,
+    27
    ],
    "deps": [
     "geiser"
    ],
-   "commit": "2502fed1349c2703eea528b74bcc980ad6bceab8",
-   "sha256": "1j8vld3s653af8jyvdb3sl16ix3al4fxprawgi3r9rrvrai2wz22"
+   "commit": "98cda369db3faf7268dd3b1705bb914dd6dad56a",
+   "sha256": "0gx6r9pczy73gl0cnrv3pn1fsj2dnzffi7j340vn54gg4832bpwr"
   },
   "stable": {
    "version": [
@@ -51569,11 +51733,11 @@
   "repo": "larme/genexpr-mode",
   "unstable": {
    "version": [
-    20240930,
-    1335
+    20260701,
+    1400
    ],
-   "commit": "27d9d4d32aef1799698ddbf75e92cb71d0ce99bf",
-   "sha256": "1qwrxca7qpm3df07y8cchg3vqvgbj2nnlv942ykrkxgcvkx0j5qf"
+   "commit": "b5007dbd80b9468b7b206927791171218f2f5da1",
+   "sha256": "0sm5jfrnwl9lh6k3bcfq64p8wnz1svmrwmwrps3b9jxrzyab48bc"
   }
  },
  {
@@ -51857,15 +52021,15 @@
   "repo": "anticomputer/gh-notify",
   "unstable": {
    "version": [
-    20251209,
-    1735
+    20260701,
+    1512
    ],
    "deps": [
     "forge",
     "magit"
    ],
-   "commit": "d606d1390778cb104c28dbc5220e685293e1e687",
-   "sha256": "17mszbyl8162j0c4jn8hlyiy3a8s9b80n7q32n09vdnrs1akdg25"
+   "commit": "efecbc0ea7a1b77a48fb395ce3d5a54271974608",
+   "sha256": "1sz662vz3h1h0vmf4052i103yvbf994gp3l9wsdd0kwrjsbxkf8b"
   },
   "stable": {
    "version": [
@@ -51964,26 +52128,26 @@
   "repo": "dakra/ghostel",
   "unstable": {
    "version": [
-    20260624,
-    710
+    20260719,
+    2039
    ],
    "deps": [
     "compat"
    ],
-   "commit": "162cb0fa0fa24df2c92e4287e1307a0a6d570b8f",
-   "sha256": "06yns5qyjkb11iyxpac6lgnli78d6r5ap5x8zssrbjcqzzfk2917"
+   "commit": "af41a8b461bbd353bdf07e27c73521aea7311151",
+   "sha256": "0ch7nh8l1aqlxjknbl5n56200fnvw76xrdfhjscy9c5298daglbd"
   },
   "stable": {
    "version": [
     0,
-    38,
+    44,
     0
    ],
    "deps": [
     "compat"
    ],
-   "commit": "b6d7b37353572bf92d04c8de5abced3ef68a0304",
-   "sha256": "1yv31zvyk80k2yl67hx67l1xwizm9p9257fwwz5hfav6lx0z6vm2"
+   "commit": "2191afe3049fc785c6fd2b1ab6b826daf500ffbe",
+   "sha256": "1fyqpbpv62hs3hqai1j04x30miwdqkkpqfxdh4vbxc331fhrj4dx"
   }
  },
  {
@@ -52026,8 +52190,8 @@
   "repo": "magit/ghub",
   "unstable": {
    "version": [
-    20260603,
-    1818
+    20260701,
+    1318
    ],
    "deps": [
     "compat",
@@ -52035,14 +52199,14 @@
     "llama",
     "treepy"
    ],
-   "commit": "89cd6c5d2770fad2c4d635136e3e36643d8bbde4",
-   "sha256": "14qrds6w62ss2cca3ryr9x09f6d71maxfvd3p1jv0zn00fca120i"
+   "commit": "59d0b9b33e780d6cff5131886904ff26033dd2e6",
+   "sha256": "0xcdwm383907hxvxxdx0f1jk1ppdch2pai5csfl97wdzqdg278ah"
   },
   "stable": {
    "version": [
     5,
     2,
-    1
+    2
    ],
    "deps": [
     "compat",
@@ -52050,8 +52214,8 @@
     "llama",
     "treepy"
    ],
-   "commit": "62d3582f1e395de1cf410af1f125dae56fe1dc4d",
-   "sha256": "0s27qknrsx5b36lnamns59ijgyy2rpdf6g5i6gz7slz4iccrczh8"
+   "commit": "59d0b9b33e780d6cff5131886904ff26033dd2e6",
+   "sha256": "0xcdwm383907hxvxxdx0f1jk1ppdch2pai5csfl97wdzqdg278ah"
   }
  },
  {
@@ -52809,6 +52973,26 @@
   }
  },
  {
+  "ename": "git-overleaf",
+  "commit": "cd76e9b4c36ddec9fa3d74a43804016a112c2529",
+  "sha256": "03np77ap1yzi7jk1afy0gmqznjhli3nlxxvjkvbidbmlnlkfslyl",
+  "fetcher": "github",
+  "repo": "Jamie-Cui/git-overleaf.el",
+  "unstable": {
+   "version": [
+    20260713,
+    844
+   ],
+   "deps": [
+    "magit-section",
+    "webdriver",
+    "websocket"
+   ],
+   "commit": "2559016e1fac95889ba04a0ac9c59c85a267d176",
+   "sha256": "0vgzvi72gn4xjpc9xryjc3nningvsi9kg8qprflg0m8vp7ynkfgm"
+  }
+ },
+ {
   "ename": "git-ps1-mode",
   "commit": "ea177b5ea168828881bd8dcd29ef6b4cb81317f0",
   "sha256": "15gswi9s0m3hrsl1qqyjnjgbglsai95klbdp51h3pcq7zj22wkn6",
@@ -53060,20 +53244,20 @@
   "repo": "Justintime50/github-dark-vscode-emacs-theme",
   "unstable": {
    "version": [
-    20240716,
-    523
+    20260706,
+    2133
    ],
-   "commit": "00cac57857732999681e14d0c04fd8b8dbf3ef2d",
-   "sha256": "1lj75w4lzjk7c05mc2srjl5ciplwn6z5rd8rjj6q8ahsm5pkkd5k"
+   "commit": "b3590004a25a279a913168801142d18d2decfde0",
+   "sha256": "0pjxpnhanqvjfrpxggcj7njd9wrkh71bay8zr3z3qp6147p77syw"
   },
   "stable": {
    "version": [
     0,
-    4,
+    5,
     0
    ],
-   "commit": "00cac57857732999681e14d0c04fd8b8dbf3ef2d",
-   "sha256": "1lj75w4lzjk7c05mc2srjl5ciplwn6z5rd8rjj6q8ahsm5pkkd5k"
+   "commit": "b3590004a25a279a913168801142d18d2decfde0",
+   "sha256": "0pjxpnhanqvjfrpxggcj7njd9wrkh71bay8zr3z3qp6147p77syw"
   }
  },
  {
@@ -53297,14 +53481,14 @@
   "repo": "agzam/github-topics",
   "unstable": {
    "version": [
-    20250416,
-    2102
+    20260106,
+    1904
    ],
    "deps": [
     "ts"
    ],
-   "commit": "296cb525c5387e5242b89950d2d84d258ff82fd2",
-   "sha256": "1l5n5wgcnws0iz5ym4znbssin67dzgz3iwq3cp04jf1nssay863h"
+   "commit": "dce3530b61fe4293190e40edf835291e8542a762",
+   "sha256": "0v2c7dlky03a94nrbbpl0l2zj74sd43nyds03r2im7rg8r4ssc5p"
   }
  },
  {
@@ -55605,7 +55789,7 @@
   "stable": {
    "version": [
     0,
-    54,
+    55,
     1
    ],
    "deps": [
@@ -55614,8 +55798,8 @@
     "magit-popup",
     "s"
    ],
-   "commit": "e6cfff79a15f1c7e7a59187985132ee1685b8233",
-   "sha256": "1xyrl4f4rcpm66c7b7kcghy1zhsfznq3jxrya1h3mzlzfpi7b33y"
+   "commit": "1e372f1c01953d43fe4d573eb60f33f7e3d3aa41",
+   "sha256": "012fcyyi63r8i4f9b8hlh9bz6g89v4v6n4h3fwbcqsqb9jka25wf"
   }
  },
  {
@@ -55778,15 +55962,15 @@
   "repo": "karthink/gptel",
   "unstable": {
    "version": [
-    20260620,
-    734
+    20260715,
+    1547
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "5b2b95fee4a632be5a5845eaff33438f96b37312",
-   "sha256": "1glqcfsxaqp30aknqlz9lvycq237dp3xhd1qkbwmgqpsvhr1im2z"
+   "commit": "8701e2bd80c5d2091ce2decef5d34d6fce4a3ada",
+   "sha256": "0sy58l4ixv01g7n9ybzcp7y3mhwm3p9353aj0wn46nharji4nca5"
   },
   "stable": {
    "version": [
@@ -55811,8 +55995,8 @@
   "repo": "karthink/gptel-agent",
   "unstable": {
    "version": [
-    20260605,
-    732
+    20260717,
+    506
    ],
    "deps": [
     "compat",
@@ -55820,8 +56004,8 @@
     "orderless",
     "yaml"
    ],
-   "commit": "2853a579154cb4528082a372db79ecdec1eb17ad",
-   "sha256": "0bg8r1zg4cy5yzakvbyca0nclbi8flyflqy2pwxp60j9pwnnhk4x"
+   "commit": "e833bcaf617baf8c8075eac098231c4457386814",
+   "sha256": "165jvz2v88j9j2h76qxj4awk7x699v5ahg4vvg06p6p37zfyfzc1"
   }
  },
  {
@@ -55880,15 +56064,28 @@
   "repo": "beacoder/gptel-cpp-complete",
   "unstable": {
    "version": [
-    20260330,
-    755
+    20260715,
+    307
    ],
    "deps": [
     "eglot",
     "gptel"
    ],
-   "commit": "4a5fe7941a76f74fe277da916be2cd20e06d2b60",
-   "sha256": "0wzrc6j56zlf7yswhrfd706jnf5a8agbnpq4cdrdg2n0s2ai6q20"
+   "commit": "d1d083100a57edc467fb1adf3afe405bf0b2c258",
+   "sha256": "1vb464kplxqhnicymgz3gzkdc7422d221imwghi1qxq3i6qsyz9i"
+  },
+  "stable": {
+   "version": [
+    0,
+    3,
+    0
+   ],
+   "deps": [
+    "eglot",
+    "gptel"
+   ],
+   "commit": "650e4077dc35e5be8fc63b3c1cc1323099731ffa",
+   "sha256": "1m2n0sq68w1xjkn5bmqdl4ky6p35gx09pja35n13islchyn42knr"
   }
  },
  {
@@ -56431,28 +56628,28 @@
   "repo": "michelangelo-rodriguez/greader",
   "unstable": {
    "version": [
-    20260608,
-    1822
+    20260627,
+    1651
    ],
    "deps": [
     "compat",
     "seq"
    ],
-   "commit": "24914f0d679c6adaa7aaa0de46fefb7a11cb1094",
-   "sha256": "0wyn9z6bhp0vyv8gybw14dvaj19nz4c7k8m1j1v24naczv2dhbhc"
+   "commit": "5c304ad008d8688e4eccd9947ba5e410399bf021",
+   "sha256": "150d9jjb3famg1phvdn4gifd5xcc3zm543m6w5czfy44khps4ll0"
   },
   "stable": {
    "version": [
     0,
     19,
-    4
+    5
    ],
    "deps": [
     "compat",
     "seq"
    ],
-   "commit": "24914f0d679c6adaa7aaa0de46fefb7a11cb1094",
-   "sha256": "0wyn9z6bhp0vyv8gybw14dvaj19nz4c7k8m1j1v24naczv2dhbhc"
+   "commit": "5c304ad008d8688e4eccd9947ba5e410399bf021",
+   "sha256": "150d9jjb3famg1phvdn4gifd5xcc3zm543m6w5czfy44khps4ll0"
   }
  },
  {
@@ -56893,21 +57090,21 @@
   "repo": "wbolster/emacs-gsettings",
   "unstable": {
    "version": [
-    20210407,
-    2045
+    20260706,
+    1543
    ],
    "deps": [
     "dash",
     "gvariant",
     "s"
    ],
-   "commit": "9f9fb1fe946bbba46307c26355f355225ea7262a",
-   "sha256": "1pq18kz6dqk45ib70sch38ql63smpv7s80ik478ajjysks3882rc"
+   "commit": "e911edf0c80f3bb9599b3b628425e510f0acb63f",
+   "sha256": "1yll0lml8ilxqxy8wv18xrid040qrdgr6ahj2dicam589rhvkncs"
   },
   "stable": {
    "version": [
     1,
-    0,
+    1,
     0
    ],
    "deps": [
@@ -56915,8 +57112,8 @@
     "gvariant",
     "s"
    ],
-   "commit": "1dd9a6a3036d76d8e680b2764c35b31bf5e6aff7",
-   "sha256": "0bv6acy3b6pbjqm24yxgi7xdd3x0c2b7s5sq65sb3lxf8hy5gdf6"
+   "commit": "e911edf0c80f3bb9599b3b628425e510f0acb63f",
+   "sha256": "1yll0lml8ilxqxy8wv18xrid040qrdgr6ahj2dicam589rhvkncs"
   }
  },
  {
@@ -57067,11 +57264,11 @@
   "repo": "bormoge/guava-themes",
   "unstable": {
    "version": [
-    20260621,
-    1947
+    20260701,
+    2352
    ],
-   "commit": "550247dca3bf268d68a703affd25e1aaa72665f5",
-   "sha256": "1nggijiwazdx72ans74awrl6kha08pzykhfn5j4wbi4yb2lqamg8"
+   "commit": "49339c87d895d0726280811b325bb631f08aec69",
+   "sha256": "0svr8sa8k1w37ijv46bsshkax2zkjgd9821azr4bqq306iirin5n"
   },
   "stable": {
    "version": [
@@ -57091,14 +57288,14 @@
   "repo": "tmalsburg/guess-language.el",
   "unstable": {
    "version": [
-    20260529,
-    1228
+    20260625,
+    628
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "78508e91d60064de398e118d452c8f61180fc17f",
-   "sha256": "0n3zxny07q79802xicazsywgwqcl62b8l291nb71d73lc27g6493"
+   "commit": "f7f74d50b11e090d7543daa0dfbf273820c006c7",
+   "sha256": "00540641raakr3f1v4l09g1h7j3x5c69221y8smfr6jm0m9ghaxy"
   }
  },
  {
@@ -57173,8 +57370,8 @@
   "repo": "guix/emacs-guix",
   "unstable": {
    "version": [
-    20260310,
-    758
+    20260719,
+    1326
    ],
    "deps": [
     "bui",
@@ -57184,14 +57381,14 @@
     "magit-popup",
     "transient"
    ],
-   "commit": "43151aa6902c7122e919d3ed688fd484ec004feb",
-   "sha256": "0zj4369i667z9v9lmmhc0zyfhia7xss5127p2hspi513mg415wsn"
+   "commit": "5d41b59529548cca88c368fe7975856a49b50a7b",
+   "sha256": "00904i5kby3794lfyic80pqwbxk4v3a8p1v5v6wi59fzzpwz26kh"
   },
   "stable": {
    "version": [
     0,
-    6,
-    1
+    7,
+    0
    ],
    "deps": [
     "bui",
@@ -57201,8 +57398,8 @@
     "magit-popup",
     "transient"
    ],
-   "commit": "72833603ee54c7a8d955415869a332419680ca50",
-   "sha256": "14639wg2717yawj4qhmmzvirrvjy0s1jw2j9wgyzc21h7hl016pz"
+   "commit": "5d41b59529548cca88c368fe7975856a49b50a7b",
+   "sha256": "00904i5kby3794lfyic80pqwbxk4v3a8p1v5v6wi59fzzpwz26kh"
   }
  },
  {
@@ -57266,26 +57463,26 @@
   "repo": "wbolster/emacs-gvariant",
   "unstable": {
    "version": [
-    20210507,
-    1310
+    20260630,
+    840
    ],
    "deps": [
     "parsec"
    ],
-   "commit": "f2e87076845800cbaaeed67f175ad4e4a9c01e37",
-   "sha256": "1m6gwplzps0hykzszh0vh4rs48hcfi99vxb4i870y46lq2y8x2xb"
+   "commit": "b49a9c6623773be20e59eada9f8eab33210cc89b",
+   "sha256": "127pnhnljdbw1l74zj7b4ncr6vzpi6rpqmn6ikn14g5jj1nh2813"
   },
   "stable": {
    "version": [
     1,
-    0,
+    1,
     0
    ],
    "deps": [
     "parsec"
    ],
-   "commit": "79c34d11ee6a34f190f1641a133d34b0808a1143",
-   "sha256": "18ld0wv8r5wlbicqym8vdw33la0bn59s7bxm2fw0w97qwjka8g8k"
+   "commit": "b49a9c6623773be20e59eada9f8eab33210cc89b",
+   "sha256": "127pnhnljdbw1l74zj7b4ncr6vzpi6rpqmn6ikn14g5jj1nh2813"
   }
  },
  {
@@ -58388,20 +58585,20 @@
   "repo": "mgmarlow/helix-mode",
   "unstable": {
    "version": [
-    20260604,
-    125
+    20260629,
+    1530
    ],
-   "commit": "6b191a4fcf0e99a3a53902d6226f9963212140dc",
-   "sha256": "1yask43jhi4hxp60wg6hxsw58s4sirdl08nsxx0hw2rqivyqq144"
+   "commit": "eca52f517583a599a0a2589cdaa04f00cfc86184",
+   "sha256": "0s5dpz0jhwdfqjqyjzar38zwd1i1p33m82as6bjlz7h3hkndb5gd"
   },
   "stable": {
    "version": [
     0,
-    9,
+    10,
     0
    ],
-   "commit": "f3f724ab2c933811a779e0cd6917829ab9e2de3c",
-   "sha256": "0rbchgcg3xkmia8qxh7v3mf0ijpzs7jx3g76dcc1zcpzj2kx46h5"
+   "commit": "eca52f517583a599a0a2589cdaa04f00cfc86184",
+   "sha256": "0s5dpz0jhwdfqjqyjzar38zwd1i1p33m82as6bjlz7h3hkndb5gd"
   }
  },
  {
@@ -58427,15 +58624,15 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20260624,
-    409
+    20260716,
+    1207
    ],
    "deps": [
     "helm-core",
     "wfnames"
    ],
-   "commit": "ad104b941015294faca3fa26146bd97127df883c",
-   "sha256": "19xh761bji11kaskvfiq7jqycx099jw7qpw4ip259skfkfr4kmvx"
+   "commit": "0046ed9ab32d6fa3e60865e84b27cf62fe386b67",
+   "sha256": "0d7faxj2si3x76kmxfq2qnlhl85yrpmcgfnl2j6hybc2q402m6ni"
   },
   "stable": {
    "version": [
@@ -58610,15 +58807,15 @@
   "repo": "emacs-helm/helm-bbdb",
   "unstable": {
    "version": [
-    20190728,
-    1325
+    20260719,
+    1537
    ],
    "deps": [
     "bbdb",
     "helm"
    ],
-   "commit": "db69114ff1af8bf48b5a222242e3a8dd6e101e67",
-   "sha256": "1yfz5s83589jazyfzyrzh84iv0db2akbwj796gadpb3yhn17pl4v"
+   "commit": "3eb99e36ed18ca2809594d165664af77a02d2bd0",
+   "sha256": "0s0rkzf8v135pjk409lbihz9b3wvr8dnjhqq98qris4rvvl0d67h"
   },
   "stable": {
    "version": [
@@ -61442,28 +61639,28 @@
   "repo": "bbatsov/helm-projectile",
   "unstable": {
    "version": [
-    20250902,
-    830
+    20260708,
+    1251
    ],
    "deps": [
     "helm",
     "projectile"
    ],
-   "commit": "0ffb6b5f09c1d65d721c1111ebfa6cec0ba63234",
-   "sha256": "19zafd0l2mcd53q83bd2mxinadzsp90q5znfcm9fq0m88lpcmg94"
+   "commit": "150ab7b669f7d3000718b73fa857dfe0ad641a97",
+   "sha256": "1s1pxi6f7v23fr7iax075wq6jkn3vrnasm2rjxmf781cjkjayk09"
   },
   "stable": {
    "version": [
     1,
-    4,
+    7,
     0
    ],
    "deps": [
     "helm",
     "projectile"
    ],
-   "commit": "0ffb6b5f09c1d65d721c1111ebfa6cec0ba63234",
-   "sha256": "19zafd0l2mcd53q83bd2mxinadzsp90q5znfcm9fq0m88lpcmg94"
+   "commit": "150ab7b669f7d3000718b73fa857dfe0ad641a97",
+   "sha256": "1s1pxi6f7v23fr7iax075wq6jkn3vrnasm2rjxmf781cjkjayk09"
   }
  },
  {
@@ -63543,11 +63740,11 @@
   "repo": "bdsatish/hindu-calendar",
   "unstable": {
    "version": [
-    20260326,
-    2105
+    20260627,
+    1755
    ],
-   "commit": "118e8455e3c2c8a0b2661b41eee0df9cb07fc87d",
-   "sha256": "1crgia9fgbfmanpxzpaklvv4vjxajw4bpaynvp65f86j7y1rm53w"
+   "commit": "0868cb7548830e50d801f68a79e34fd988464f3e",
+   "sha256": "0gsp9wfrnzbqkddbpi9w5nbhsbsiyg5aq01xpbqmrc4fwdw616xc"
   }
  },
  {
@@ -63976,6 +64173,25 @@
    ],
    "commit": "a56f67a99a855ca656da1c1985e09f44509e4bbb",
    "sha256": "1abqjrzq75ijhn3sfmy0wy6acp8x7nj5gihqy34mickz4v5wqbil"
+  }
+ },
+ {
+  "ename": "hnview",
+  "commit": "6623d052596f1be181d9365cda61caca3d92afbd",
+  "sha256": "1xwh6fcbk1r8psqm8wkd5hs8n88p3gg7k2hwg74wi67yq80q9s57",
+  "fetcher": "github",
+  "repo": "LuciusChen/hnview",
+  "unstable": {
+   "version": [
+    20260720,
+    641
+   ],
+   "deps": [
+    "llm",
+    "plz"
+   ],
+   "commit": "9b835985f9513f6801109b26d2b311f90195a3b3",
+   "sha256": "0cwkvasab7js3b47is1s5xhvy4j0lk5jb697dpvfn51c6b3dvm83"
   }
  },
  {
@@ -64755,6 +64971,27 @@
   }
  },
  {
+  "ename": "hutch",
+  "commit": "17017ad00b0a010ceb735079100fc95345804ce2",
+  "sha256": "13wxpgp1l35hl2phb5f58y2whcghwp5v4ibf1qnhrvbplclwjdwv",
+  "fetcher": "github",
+  "repo": "adjaecent/magit-hutch",
+  "unstable": {
+   "version": [
+    20260630,
+    1048
+   ],
+   "deps": [
+    "gptel",
+    "magit",
+    "svg-lib",
+    "transient"
+   ],
+   "commit": "ee06a06093c66f2c4c5873434aba44b62e11bf76",
+   "sha256": "0g1h5laqwd14dvdpwn0nj3picygqf6dgvg9lcbk727v2i9qvpssm"
+  }
+ },
+ {
   "ename": "hy-mode",
   "commit": "fc9ab5cf16b61bb27559cd8ec5cf665a5aab2154",
   "sha256": "1vxrqla3p82x7s3kn7x4h33vcdfms21srxgxzidr02k37f0vi82m",
@@ -64919,11 +65156,11 @@
   "url": "https://git.savannah.gnu.org/git/hyperbole.git",
   "unstable": {
    "version": [
-    20260622,
-    756
+    20260719,
+    1833
    ],
-   "commit": "510d713b6ebef63e7c4f41fc8039e3be4da0c28d",
-   "sha256": "1yic3m59pxp9bdkfz5k9q67bsjq7zj8cqxgxi34f94bywry78l5n"
+   "commit": "a517c813cd40597a2f9ecb2370607147846e2125",
+   "sha256": "1ib3bb9p3r2kblf0pmxhdsw9f3rpxqkaprwdf8ydfmj8frhwmsyd"
   },
   "stable": {
    "version": [
@@ -65092,19 +65329,19 @@
   "repo": "precompute/hyperstitional-themes",
   "unstable": {
    "version": [
-    20260215,
-    1305
+    20260701,
+    1314
    ],
-   "commit": "b4bf851ea46ad4ddc8c45afc3c2d000d7f13bc4b",
-   "sha256": "1zqcy2zhgp2qfj4k01ns8pc7ff449gyrx4gfwlzny8cgmbv01fkd"
+   "commit": "18b5ee327f6e7e3d82fe3a274c351137e6e0cecd",
+   "sha256": "0qjp85836gv4kbq580xrqvdx92h4f0m0k2pyg8cw28nd1mwj85ma"
   },
   "stable": {
    "version": [
     3,
-    4
+    5
    ],
-   "commit": "b4bf851ea46ad4ddc8c45afc3c2d000d7f13bc4b",
-   "sha256": "1zqcy2zhgp2qfj4k01ns8pc7ff449gyrx4gfwlzny8cgmbv01fkd"
+   "commit": "18b5ee327f6e7e3d82fe3a274c351137e6e0cecd",
+   "sha256": "0qjp85836gv4kbq580xrqvdx92h4f0m0k2pyg8cw28nd1mwj85ma"
   }
  },
  {
@@ -65367,11 +65604,11 @@
   "repo": "jojojames/ibuffer-sidebar",
   "unstable": {
    "version": [
-    20260612,
-    632
+    20260718,
+    2134
    ],
-   "commit": "1330b0f156e2275acd1a9256fc13a1d22e5e3a9e",
-   "sha256": "00nc690aqywxn4rrp2fnd7jq7vik8722ds2c1prq10bwwn6n653h"
+   "commit": "b9b985f4ceb627521ed78cfdc4270305f3b0f272",
+   "sha256": "0hncjhbznkfjafhyc8nxyy0k8pja3qbkm2innalv45i5y2hli6ar"
   },
   "stable": {
    "version": [
@@ -66748,11 +66985,11 @@
   "repo": "flashcode/impostman",
   "unstable": {
    "version": [
-    20250412,
-    1521
+    20260714,
+    1545
    ],
-   "commit": "c1e764b16d32930d157e5bf2d2e6ac4dc3a23b8c",
-   "sha256": "0b0jg4kscd8n9kccqckv9zl14ymd4w4aa6krvb3bh446y7j3i1hl"
+   "commit": "afaeefd8db6e72cd3022821db5aa5e1b521549b3",
+   "sha256": "1kiwlws6m8pn42mdsq0v2077ikvj441fwwny112iqx3kkcjnpa0q"
   },
   "stable": {
    "version": [
@@ -66819,11 +67056,11 @@
   "repo": "zk-phi/indent-guide",
   "unstable": {
    "version": [
-    20260515,
-    1152
+    20260629,
+    918
    ],
-   "commit": "ab71cac290505caf6c374cb8594b0b78d5109af1",
-   "sha256": "1b0g1hw1l2r6zmij90w7a78gxxncnnpjk6zmn4mafxgnkrg8x1q8"
+   "commit": "1332f95d6f08afee35f62621793e2622b9f86f27",
+   "sha256": "0fk3qi3ncdyyqa0x07sm4y2z5fgwhmcqviicvhwmz782n8c6h8wd"
   },
   "stable": {
    "version": [
@@ -67455,11 +67692,11 @@
   "repo": "jamescherti/inhibit-mouse.el",
   "unstable": {
    "version": [
-    20260603,
-    1158
+    20260710,
+    1610
    ],
-   "commit": "86cae75bbb771ea6be6269b925c39761be12b065",
-   "sha256": "1046g96qvvsz66qnhnk6x1d4a535cgk7qbhx6bqhr44vwzg0h1h8"
+   "commit": "0bda8fe615b093b837d78ccb110d3d37e81641a8",
+   "sha256": "1rwdwmpq8xy588hbvhaids462mcph4gb2k3iik3hwr67anqxdla7"
   },
   "stable": {
    "version": [
@@ -69232,28 +69469,28 @@
   "repo": "radian-software/prescient.el",
   "unstable": {
    "version": [
-    20250816,
-    19
+    20260628,
+    2243
    ],
    "deps": [
     "ivy",
     "prescient"
    ],
-   "commit": "87e2d2f2ddf24f591a5f70cc90d2afb4537caa18",
-   "sha256": "0f4wi8aq3yfykxfza4y4c5yhcs50cs3gpfj0qrmvfq9hvkhzj52w"
+   "commit": "5649977fa7789e4615efeca09397ed7eccd06dfc",
+   "sha256": "199150yng81f6n3kb120s37yf2dqs0i9k91f2gzkk8kjn6hvrsj8"
   },
   "stable": {
    "version": [
     6,
     3,
-    2
+    3
    ],
    "deps": [
     "ivy",
     "prescient"
    ],
-   "commit": "87e2d2f2ddf24f591a5f70cc90d2afb4537caa18",
-   "sha256": "0f4wi8aq3yfykxfza4y4c5yhcs50cs3gpfj0qrmvfq9hvkhzj52w"
+   "commit": "5649977fa7789e4615efeca09397ed7eccd06dfc",
+   "sha256": "199150yng81f6n3kb120s37yf2dqs0i9k91f2gzkk8kjn6hvrsj8"
   }
  },
  {
@@ -69704,6 +69941,30 @@
    ],
    "commit": "9cc4f9b780ff40afd8dde21ab7f53a16401c3d09",
    "sha256": "1i9f61x8pdf26p640gqjh7vb9a2yiqv915immbmbgrp6rmpdh48h"
+  }
+ },
+ {
+  "ename": "jal",
+  "commit": "16eb6bd862f3dcac53b8b0badb8115c7da27e7ad",
+  "sha256": "0gal293igsxs3iygbjj5sh6ayqfg35jgw28pyr9rrdbkqqsj58hs",
+  "fetcher": "github",
+  "repo": "saulotoledo/java-agent-loader",
+  "unstable": {
+   "version": [
+    20260629,
+    1417
+   ],
+   "commit": "54cbd7a6b613dc6ac2135ada9de47130e0665d3e",
+   "sha256": "1k0n25rsv5y7aadcbz9xmny4g111km2177q7x73p6bzk7k8cwqqc"
+  },
+  "stable": {
+   "version": [
+    2,
+    0,
+    0
+   ],
+   "commit": "54cbd7a6b613dc6ac2135ada9de47130e0665d3e",
+   "sha256": "1k0n25rsv5y7aadcbz9xmny4g111km2177q7x73p6bzk7k8cwqqc"
   }
  },
  {
@@ -71074,14 +71335,14 @@
   "repo": "mooz/js2-mode",
   "unstable": {
    "version": [
-    20241205,
-    140
+    20260627,
+    1342
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "e0c302872de4d26a9c1614fac8d6b94112b96307",
-   "sha256": "1midf8yib70k6kh50a2r7g9xri2jvvglz4rchjw89wl2zqyl1p91"
+   "commit": "41d0e7f5ef51109c682016baa6fc6846e03e8517",
+   "sha256": "16y7cdjkg1q1lr1svd0g43sqlplj67yacdfbmax4iw7fv91iac66"
   },
   "stable": {
    "version": [
@@ -71748,8 +72009,8 @@
   "repo": "gcv/julia-snail",
   "unstable": {
    "version": [
-    20260516,
-    750
+    20260713,
+    1343
    ],
    "deps": [
     "dash",
@@ -71758,8 +72019,8 @@
     "s",
     "spinner"
    ],
-   "commit": "90e2278921ff4155577f97b937f375375c32a34f",
-   "sha256": "046la1mh70syq96sla8v92mk8fg5dl05w75bs0plppxkhbnjv2ky"
+   "commit": "6c545d67e93590d1155b60e79384481438cb7527",
+   "sha256": "0n9isijm9x3ansmvg4m81kd4vzrzs8xlyn6n6qia622csqjfxbw1"
   },
   "stable": {
    "version": [
@@ -72031,10 +72292,10 @@
    "version": [
     0,
     1,
-    8
+    9
    ],
-   "commit": "d7f52eab8fa3828106f80acb1e2176e5877b7191",
-   "sha256": "103jwkmg3dphmr885rpbxjp3x8xw45c0zbcvwarkv4bjhph8y4vh"
+   "commit": "b6173c7bf4d8d28e0dbd80fa41b9c75626885b4e",
+   "sha256": "1czf779akdcx72ma7x9v70kjbic73312fi1czbzvlvxr01pjpyj0"
   }
  },
  {
@@ -72050,6 +72311,15 @@
    ],
    "commit": "94f788eccb13cd3ade827af5612ffe3cad5fddf0",
    "sha256": "0rzgj007bjjlrgknhsdpk7vfhqpp9r1yxkhsj2a4ijg3rxw9s802"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    9
+   ],
+   "commit": "9dd136bc809de85fa66a4665312eb0f55b1c8094",
+   "sha256": "0gmimdy2isfmyf622926y3w0a0fxm1q98ry0lbqjjvhfq9i2h3mc"
   }
  },
  {
@@ -72429,11 +72699,11 @@
   "repo": "Fabiokleis/kanagawa-emacs",
   "unstable": {
    "version": [
-    20260522,
-    325
+    20260625,
+    2142
    ],
-   "commit": "399dff7bc7abf5726ef85f880aa70d10b433afb4",
-   "sha256": "16ya2f28z5c68pf7i0zy555nv9ly8ggsr50g2mrfycwpg5na2zim"
+   "commit": "fe06241196bf9c77df751cfd74a984b5d8a45ba4",
+   "sha256": "0g4mr3y69zdi9hvw7d3mv7k2jz7a5xggyyh4sarwibwgxckbkfrp"
   }
  },
  {
@@ -73262,20 +73532,20 @@
   "repo": "hperrey/khalel",
   "unstable": {
    "version": [
-    20250910,
-    946
+    20260709,
+    655
    ],
-   "commit": "f7cdb3246d193a518b3a4ca7381ffb6ed8087fcf",
-   "sha256": "06h5272kmg0ykf0zqdy2qwhlzszqsw176l1brk04bg8xyc3a4384"
+   "commit": "3691b4545eaef5a246f020f57bd0f843cc9c84ef",
+   "sha256": "1g9cjiyajh3j175chf5lr8z857aim0h82sxnjh757cw4jz94kfzl"
   },
   "stable": {
    "version": [
     0,
     1,
-    15
+    16
    ],
-   "commit": "f7cdb3246d193a518b3a4ca7381ffb6ed8087fcf",
-   "sha256": "06h5272kmg0ykf0zqdy2qwhlzszqsw176l1brk04bg8xyc3a4384"
+   "commit": "3691b4545eaef5a246f020f57bd0f843cc9c84ef",
+   "sha256": "1g9cjiyajh3j175chf5lr8z857aim0h82sxnjh757cw4jz94kfzl"
   }
  },
  {
@@ -73601,14 +73871,14 @@
   "repo": "benotn/kkp",
   "unstable": {
    "version": [
-    20260617,
-    1005
+    20260706,
+    858
    ],
    "deps": [
     "compat"
    ],
-   "commit": "0b77ce2fb9eefbb07ffa906f8fe2df14450a9cfc",
-   "sha256": "08whip7ghmihrc345135kwsda7wjqm85p3hfrfhclkxd1yrpv8y7"
+   "commit": "82b7443e10a2ba287467b62e90b6adb6dd93dc99",
+   "sha256": "10iwwd2jn2hy8m5pqpl9sdvx2m9s1pcjpfpqj8i7d6mfr9pjqy6z"
   }
  },
  {
@@ -74209,6 +74479,36 @@
   }
  },
  {
+  "ename": "kusanagi-theme",
+  "commit": "537d8f60b711bf9ac5523e61c5da7b857765523d",
+  "sha256": "1rc44skay54jhhlqcf75qqxw51ymsjjrf50ml29s9iyq7klv9zgp",
+  "fetcher": "github",
+  "repo": "LionyxML/kusanagi-theme",
+  "unstable": {
+   "version": [
+    20260629,
+    307
+   ],
+   "deps": [
+    "modus-themes"
+   ],
+   "commit": "9bc24e173addb206a583fcd23086d79cd3e6c360",
+   "sha256": "18xk63g63kxn7qxakjjmrpjvy6f63mjhk6z4an2wzp0011yrkxq4"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "deps": [
+    "modus-themes"
+   ],
+   "commit": "9bc24e173addb206a583fcd23086d79cd3e6c360",
+   "sha256": "18xk63g63kxn7qxakjjmrpjvy6f63mjhk6z4an2wzp0011yrkxq4"
+  }
+ },
+ {
   "ename": "kv",
   "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
   "sha256": "1dv3vbhgs7q5q92idyy5mn9gwmx2k6xigb1vchfh7p21f2is86x8",
@@ -74278,8 +74578,8 @@
   "repo": "isamert/lab.el",
   "unstable": {
    "version": [
-    20260620,
-    1757
+    20260715,
+    1437
    ],
    "deps": [
     "async-await",
@@ -74289,8 +74589,8 @@
     "request",
     "s"
    ],
-   "commit": "2be6e50e75b4372337b77d0ae5563cb8cd671352",
-   "sha256": "1d0q7ssm9ynhd1da34by6a5zwbyzq20x8bqky9hf0fk28m9xpjjh"
+   "commit": "6a23522b5d451234d5f799caaef385bab7ff7df2",
+   "sha256": "0ki2w7p3wq5prb9aidg2qni5807rvjimrgy907cn338i9kpaiw8j"
   },
   "stable": {
    "version": [
@@ -74396,16 +74696,16 @@
   "repo": "Deducteam/lambdapi",
   "unstable": {
    "version": [
-    20260624,
-    735
+    20260701,
+    916
    ],
    "deps": [
     "eglot",
     "highlight",
     "math-symbol-lists"
    ],
-   "commit": "e2e0e4a1fc921205e56dd4d78dc22d364644813d",
-   "sha256": "01jih46346wv236hvb698vmicz0m8x7lcrgqsw0nc8sq6pb73yc9"
+   "commit": "d4fcaa80d2ac820be9928e4c75a6a0ad723d2c30",
+   "sha256": "1363z64si20xa3y86vpm7dnngyyq8s388zkzc4v5cllkkicz8bav"
   },
   "stable": {
    "version": [
@@ -75147,11 +75447,11 @@
   "repo": "jixiuf/emacs-leadkey",
   "unstable": {
    "version": [
-    20260624,
-    731
+    20260706,
+    257
    ],
-   "commit": "3a0befd5a8937f8effe07da001cf8d3c765fc2ce",
-   "sha256": "1xx8flk34f99kh54x9k5872g4961x35jgrx4ia2f54qswjgdn499"
+   "commit": "a7bf4c8a5bfee908c5287ebe86dcbaddd2b0fb8d",
+   "sha256": "04d7l0gnjm92r9l8q7j9iqwhsk6w5n1vf494yysbjafhva49q6wg"
   },
   "stable": {
    "version": [
@@ -75407,11 +75707,11 @@
   "repo": "ledger/ledger-mode",
   "unstable": {
    "version": [
-    20260609,
-    609
+    20260709,
+    1534
    ],
-   "commit": "b0ee99feb2dcae5e304ad735d82d488f2191a51c",
-   "sha256": "193m7nbpbp33i79y25g09ippxskpxsb8ixiyn6v1a1il0qjhf8rf"
+   "commit": "f7761ab7070e8c0c1cfb97e571ba81c3377a7447",
+   "sha256": "1qb4lrp5f2p1gcfrpbh86xcwggc8ffz62rq4lj6v4klyjyk52h2y"
   },
   "stable": {
    "version": [
@@ -75899,20 +76199,21 @@
   "repo": "emacs-rime/liberime",
   "unstable": {
    "version": [
-    20260622,
-    955
+    20260715,
+    958
    ],
-   "commit": "8e52f3128e553a9b0cf270ead5c8cca4de2dd0d8",
-   "sha256": "0mq106yppl9kkqfyvbxma4d9k88bqpvwk6b6lcyr8kmkd2bd6n8f"
+   "commit": "64db15eca098f3d3942e9f83422e12711dbe2ecb",
+   "sha256": "1nhrxh3wawgxjky2zklkc8qnwjrxxzhsl47lv4yk7wa67k4667nb"
   },
   "stable": {
    "version": [
     0,
     0,
-    10
+    10,
+    1
    ],
-   "commit": "482b7854b04169b348f3c943891f0895bd38bc4f",
-   "sha256": "0bmp4ajczw4nvgshbkycnvr0m0pjlji14qgkk8k58qxy38zxvli2"
+   "commit": "8e52f3128e553a9b0cf270ead5c8cca4de2dd0d8",
+   "sha256": "0mq106yppl9kkqfyvbxma4d9k88bqpvwk6b6lcyr8kmkd2bd6n8f"
   }
  },
  {
@@ -76075,19 +76376,19 @@
   "repo": "tmythicator/lichess.el",
   "unstable": {
    "version": [
-    20260203,
-    1027
+    20260710,
+    914
    ],
-   "commit": "1dd8a25ede7144c5d6be1f45f4ae3d07903783cd",
-   "sha256": "157l4crbz37x367m69sxwvnd1pd8cqa6w0lcvyyvs27cm021d2gr"
+   "commit": "572a6a353e2113c8a95564b9bea1f2896e6d3dab",
+   "sha256": "1d87qjmdpizggkrzq39i9vqgvbpjf5mv97vm7zy28ksbqxmfasqa"
   },
   "stable": {
    "version": [
-    0,
-    8
+    1,
+    0
    ],
-   "commit": "1dd8a25ede7144c5d6be1f45f4ae3d07903783cd",
-   "sha256": "157l4crbz37x367m69sxwvnd1pd8cqa6w0lcvyyvs27cm021d2gr"
+   "commit": "572a6a353e2113c8a95564b9bea1f2896e6d3dab",
+   "sha256": "1d87qjmdpizggkrzq39i9vqgvbpjf5mv97vm7zy28ksbqxmfasqa"
   }
  },
  {
@@ -76122,11 +76423,19 @@
   "repo": "mickeynp/ligature.el",
   "unstable": {
    "version": [
-    20220808,
-    1225
+    20260714,
+    655
    ],
-   "commit": "89cbd67a815f61e5001f19d64d6ec1771e867742",
-   "sha256": "106p73km11kzins0bx01n6ypz8if20g56ljx0dnnq0fi6hsn87d7"
+   "commit": "5ef919d3e3e2cf2c4622cbea28e429b29e86fc97",
+   "sha256": "1pjq8bka1ppfvijhlv55bzk3rf0xdm10jy4sfslzb4094lvdd3w1"
+  },
+  "stable": {
+   "version": [
+    1,
+    0
+   ],
+   "commit": "b732c7c57d06bda30d31fa6b52758a94490d0710",
+   "sha256": "0c3wgcgvk0wxk3dwgpl7y7w0y14z68qkcck099x42qsxix57amjw"
   }
  },
  {
@@ -76470,17 +76779,17 @@
  },
  {
   "ename": "lirve",
-  "commit": "67708cb34ff0000d571b732792e7d7d82bd4084a",
-  "sha256": "160k3kpc0ldxzbqhnvd71jmslwjnbh8cmy474d07ccqjcsn8mkb0",
-  "fetcher": "github",
-  "repo": "tanrax/lirve.el",
+  "commit": "1d1a6da1f377c3b1b4a33cbc6e1183689d74cc77",
+  "sha256": "1vgq6svl2i316qbdsigwsr5mvmgzgjdmn92ksmzacl7x4mx3fh58",
+  "fetcher": "git",
+  "url": "https://git.andros.dev/andros/lirve.el",
   "unstable": {
    "version": [
-    20240419,
-    1918
+    20260708,
+    1737
    ],
-   "commit": "ff3031fa82d854411da40a32c6191d201b4abf09",
-   "sha256": "1m4bg931w83vyhrpgsmdyl6hkknnd99mmvj34g0drhb9170sx0kb"
+   "commit": "b8dfa92eb51bde15c269dede50342f0b94240a49",
+   "sha256": "1pwhbkdz6w0b40jwgr68w8mdx8wjfdmgdvfnxssfrjc1829brbkp"
   }
  },
  {
@@ -77927,11 +78236,11 @@
   "repo": "petermao/look-mode",
   "unstable": {
    "version": [
-    20250511,
-    602
+    20260712,
+    530
    ],
-   "commit": "6d82a013ede5f9ef5493801c3071bad5f6b283bb",
-   "sha256": "1hbhvj2z41sdb03srm9q88pl5f7dzvgif9y5p7sw45gpz1bmnhmf"
+   "commit": "9102caebfb266e8153e14f7462dddfcfa8ba54dd",
+   "sha256": "1vm8s0al1ydkbfgqqjjzzgfhkkws621304pr3bfllwffkn3gddz3"
   }
  },
  {
@@ -77983,14 +78292,14 @@
  },
  {
   "ename": "loopy",
-  "commit": "f43d9c8c9862f4f008af6206467c58ae4edfc4a8",
-  "sha256": "0zrib0gvzk3rnvskpwi5d3v4624lf4z7l8kg4dg944v0x5qgy8iy",
-  "fetcher": "github",
+  "commit": "c078f84e004b187ed96523ce62ef4f7fd18aea67",
+  "sha256": "0ms91lw7h349z8qh0g3vddiqy3svmx10bnrhpj64yca1fy6lmr74",
+  "fetcher": "codeberg",
   "repo": "okamsn/loopy",
   "unstable": {
    "version": [
-    20260622,
-    2352
+    20260704,
+    1904
    ],
    "deps": [
     "compat",
@@ -77998,14 +78307,14 @@
     "seq",
     "stream"
    ],
-   "commit": "09fecad848c8671902ceae7d74afecdd29a84ac5",
-   "sha256": "1bg0icla79jjjplh5ibjbcimnkxiziiw6r3s13prg2fr6mngbs1f"
+   "commit": "838e1f5d38281dde54efbf61142267224e78e494",
+   "sha256": "18hmdlv95kl2q04b8xrvs3jrqf9kpg7p9gp9p938z416ljzja5r0"
   },
   "stable": {
    "version": [
     0,
     16,
-    0
+    1
    ],
    "deps": [
     "compat",
@@ -78013,27 +78322,27 @@
     "seq",
     "stream"
    ],
-   "commit": "09fecad848c8671902ceae7d74afecdd29a84ac5",
-   "sha256": "1bg0icla79jjjplh5ibjbcimnkxiziiw6r3s13prg2fr6mngbs1f"
+   "commit": "70427df284cc0a70a75c00be221fbabc433183c5",
+   "sha256": "0pjf0h3nzlbikxwqik58qwp2qgqyai6v1vx9kw7m7y43x46nv5hq"
   }
  },
  {
   "ename": "loopy-dash",
-  "commit": "b51bc89476900ff52cfeeee5943ddee561bcb5dc",
-  "sha256": "0gqy6z8b7iyyhbqy33n1b67v839z5711x49w097phvvm5rbwi7i2",
-  "fetcher": "github",
+  "commit": "82895d2a7d7a4664d5e1dac752ac987d69011097",
+  "sha256": "00y19abkank9vkg5wjr1llfz3kgv35p3cv6jp9qan32dbbc58avh",
+  "fetcher": "codeberg",
   "repo": "okamsn/loopy-dash",
   "unstable": {
    "version": [
-    20251226,
-    2031
+    20260627,
+    112
    ],
    "deps": [
     "dash",
     "loopy"
    ],
-   "commit": "d60c4f49a640541e415e5471ad26c2d8e6886888",
-   "sha256": "0pwayqwyarbg26piwzxag13xbx3dzdx779c4n7crzjk4gj3d80fw"
+   "commit": "d7630105c7188a6e7bc23e66e0c1efb56e005d21",
+   "sha256": "1yh6xmzymp48s101syy8zgr9faxv76k69x8iqyhplzcwnrrra83k"
   },
   "stable": {
    "version": [
@@ -78558,14 +78867,14 @@
   "repo": "ltex-plus/emacs-ltex-plus",
   "unstable": {
    "version": [
-    20260614,
-    1645
+    20260626,
+    618
    ],
    "deps": [
     "lsp-mode"
    ],
-   "commit": "2dded9da2dbced4624ecad4ab51ee2ee62aa2cad",
-   "sha256": "1fwihxqhb4x94z36qvh45rrjg95sswwx4y952skxy2fvm0dl5fa0"
+   "commit": "dc617ed2a21f6453053d218601fee38d1bfd6c70",
+   "sha256": "00fnyw9s7nhkr6l4f9lv10zar13crcj5jrlq7i85py3s37xfmrbh"
   },
   "stable": {
    "version": [
@@ -78632,8 +78941,8 @@
   "repo": "emacs-lsp/lsp-mode",
   "unstable": {
    "version": [
-    20260616,
-    510
+    20260716,
+    755
    ],
    "deps": [
     "dash",
@@ -78644,8 +78953,8 @@
     "markdown-mode",
     "spinner"
    ],
-   "commit": "2a6ab7cd41e31e4a74b1a6ea670ac4e4356f4be9",
-   "sha256": "1sf9bicrsm59fw8jkcrvk91n4d7hk62kcjw89rmpl55gybz1b3v3"
+   "commit": "6bfc593d7b1bc0dd656f09ffce52cc085ebced05",
+   "sha256": "0n48qdc9y4vq5bmxfxv2gwmv7ngawq30ai280jhdn2ilzqjw4w4d"
   },
   "stable": {
    "version": [
@@ -79449,14 +79758,14 @@
   "repo": "kmontag/macher",
   "unstable": {
    "version": [
-    20260621,
-    121
+    20260718,
+    1815
    ],
    "deps": [
     "gptel"
    ],
-   "commit": "67972625ae052a5a07929043324fbd3b6b2fc08a",
-   "sha256": "0i5nhxjz5dni2x7wq45wifq47a4cx15pgzppc76plnz1y43rlx1y"
+   "commit": "b6e51cb9a01c87e36d8920d947ed171bf21c8287",
+   "sha256": "1wxa7zkwj9c8h6qq61wr36c54fq8kabhp47ij6d7b659cc9bhwbz"
   },
   "stable": {
    "version": [
@@ -79686,28 +79995,28 @@
   "repo": "roadrunner1776/magik",
   "unstable": {
    "version": [
-    20260608,
-    1331
+    20260706,
+    1226
    ],
    "deps": [
     "compat",
     "yasnippet"
    ],
-   "commit": "ba05cca022a2cc27ee655acd1f25779b245ff380",
-   "sha256": "19biw69a6zpdb930v8innsnddh2ikx9fl6g5a9mw0ayczqv5kx87"
+   "commit": "ed8e8dce0e7bb552beda9649790b8ff9a6e1ae3b",
+   "sha256": "0pij6wn1m1pvdg16plls6z64jhffq95clwsdkci1gzall0ddm7dj"
   },
   "stable": {
    "version": [
     0,
     6,
-    0
+    5
    ],
    "deps": [
     "compat",
     "yasnippet"
    ],
-   "commit": "ba05cca022a2cc27ee655acd1f25779b245ff380",
-   "sha256": "19biw69a6zpdb930v8innsnddh2ikx9fl6g5a9mw0ayczqv5kx87"
+   "commit": "95dcd634d9de45851fce911dd0fffc85822a2ecb",
+   "sha256": "07pszv4xz1j0ai19cigrmfr31qhzv1fy4a0rvz19p5pinds03lib"
   }
  },
  {
@@ -79718,8 +80027,8 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20260621,
-    1253
+    20260719,
+    948
    ],
    "deps": [
     "compat",
@@ -79730,13 +80039,13 @@
     "transient",
     "with-editor"
    ],
-   "commit": "20058311576bd47751681bdc2ae239da76dec2dc",
-   "sha256": "1k8nmx2lp48wcd6zrj12ry7p6bg2rwsshsrrmaxblbd1c8qfn499"
+   "commit": "0988e1564bbe5a08f876fa0d78eb9d587c704121",
+   "sha256": "0rnk6kd0q8wmm1n96pvd3qkc7hwkq771vs20qqpcbb9mwqg2faaw"
   },
   "stable": {
    "version": [
     4,
-    5,
+    6,
     0
    ],
    "deps": [
@@ -79748,8 +80057,8 @@
     "transient",
     "with-editor"
    ],
-   "commit": "c800f79c2061621fde847f6a53129eca0e8da728",
-   "sha256": "04yxjkv5h3arcj1s0nq9kyh3l1z4c9wml35vb67jvv1h7mslwz55"
+   "commit": "b6c512597fd66abe69883a058a2d13bcea76bf33",
+   "sha256": "0pfx2rkxpfkyfwaz759q9b1yjd8vdwgf5jbrix5i1y06i54rnazr"
   }
  },
  {
@@ -80414,8 +80723,8 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20260514,
-    937
+    20260709,
+    950
    ],
    "deps": [
     "compat",
@@ -80423,13 +80732,13 @@
     "llama",
     "seq"
    ],
-   "commit": "be5a3b0e9f7a64bcb222ba546a18e6b09922e0a9",
-   "sha256": "1cnl0558vjmbw5900g2mg1ph30301hg1zvjpi23v7rf4qkkq6xl0"
+   "commit": "cf9d129d3612c7a900a82263951310b186860834",
+   "sha256": "1ddh1s34ibd25wkyi85054dkcpz3l3xb37pinkpvx7vgsq80m90s"
   },
   "stable": {
    "version": [
     4,
-    5,
+    6,
     0
    ],
    "deps": [
@@ -80438,8 +80747,8 @@
     "llama",
     "seq"
    ],
-   "commit": "c800f79c2061621fde847f6a53129eca0e8da728",
-   "sha256": "04yxjkv5h3arcj1s0nq9kyh3l1z4c9wml35vb67jvv1h7mslwz55"
+   "commit": "b6c512597fd66abe69883a058a2d13bcea76bf33",
+   "sha256": "0pfx2rkxpfkyfwaz759q9b1yjd8vdwgf5jbrix5i1y06i54rnazr"
   }
  },
  {
@@ -80695,15 +81004,15 @@
   "repo": "hrishikeshs/magnus",
   "unstable": {
    "version": [
-    20260618,
-    36
+    20260711,
+    945
    ],
    "deps": [
     "transient",
     "vterm"
    ],
-   "commit": "58c6673d4740d98dcd1445c01c6930208341bc2c",
-   "sha256": "0450dlh4vxfm3y6dhpplc61b5spzxbqvgw85vd6nxfjhhn0pz7m2"
+   "commit": "0939004f0bf00021246b8fb62fc5e8939b8d98da",
+   "sha256": "1k921pisal7qzv7j1dd0cynx1gr6nv539hr0y35mspmvk40bihqb"
   }
  },
  {
@@ -80828,16 +81137,16 @@
   "repo": "Olivia5k/makefile-executor.el",
   "unstable": {
    "version": [
-    20230224,
-    1329
+    20260716,
+    1302
    ],
    "deps": [
     "dash",
     "f",
     "s"
    ],
-   "commit": "d1d98eaf522a767561f6c7cbd8d2526be58b3ec5",
-   "sha256": "0wm0i2m124dglwq0szp6pdh2r0dln0xpgscw2immi9cchcmgcy4f"
+   "commit": "b22e10f528def19da9b1575546f62693555e6b22",
+   "sha256": "0h9214mg9mfmpmyrya1fqa5hs4a67mv0fk2z8mp8r68p8i4w2jw8"
   }
  },
  {
@@ -81245,14 +81554,14 @@
   "repo": "plandes/mark-thing-at",
   "unstable": {
    "version": [
-    20250126,
-    2020
+    20260711,
+    1130
    ],
    "deps": [
     "choice-program"
    ],
-   "commit": "a9a6c824ede52825a1dea8d880776ad20f12f488",
-   "sha256": "1nq3f05js3zvksc43i01pavy9iyjdmvfr5rcy67r9x9ahdjs1nmm"
+   "commit": "7829d89ba7da560adb4236fd26fc6ed5813b7173",
+   "sha256": "0y62fhdsmi3da53ldrv8l3jwg756dqwa5r1av442hnxv8pmq8v7d"
   },
   "stable": {
    "version": [
@@ -82225,11 +82534,11 @@
   "repo": "laurynas-biveinis/mcp-server-lib.el",
   "unstable": {
    "version": [
-    20260613,
-    600
+    20260630,
+    1141
    ],
-   "commit": "6a33350e768af0029af224a14b526ab6246d29b4",
-   "sha256": "13qgf4v2zsn6b1435x6qa54pfrzyhj2q55p3475c7bwc5d7bhdlv"
+   "commit": "dec55e6405987250256a81efe92d65bdfa8a140c",
+   "sha256": "1hw6wj62nwvjap3yjqjm7ybkwpnh7xi2q21rg2hi36cnzarb59yd"
   },
   "stable": {
    "version": [
@@ -82379,11 +82688,11 @@
   "repo": "jojojames/media-thumbnail",
   "unstable": {
    "version": [
-    20240816,
-    458
+    20260712,
+    2348
    ],
-   "commit": "190632c1d6cc2ab94031d57e0c24412a4698faf0",
-   "sha256": "1bj4l8yb383m2b43i514044yjpgh27v69gvm71a08n7r4hhdhbpr"
+   "commit": "4cb8075ec8bc46408a6b01fc8877571d8e66e439",
+   "sha256": "0nv5cf4plgf77bvvsy6y8frz6dwv90qpvbm53h2n3qd5qjc9grmi"
   }
  },
  {
@@ -82394,20 +82703,20 @@
   "repo": "hexmode/mediawiki-el",
   "unstable": {
    "version": [
-    20260619,
-    737
+    20260708,
+    2249
    ],
-   "commit": "8002f2fea253b5c2f601325c5b4968e568a3aa2a",
-   "sha256": "0kjy0vkwnrxblwcdqs7brnc82n3dljj4d1syb3ayf8kk40rfr217"
+   "commit": "6e081439a876b3cb9a27146fd75e887997712629",
+   "sha256": "1i9jqchlbg5w8zmqbzpnyz11xgqhfriy1kyp8z8mczpyvhyz646f"
   },
   "stable": {
    "version": [
     4,
-    0,
-    1
+    1,
+    0
    ],
-   "commit": "bcee6701b474bb805d558e58e7d0e29d999dc873",
-   "sha256": "021gxmx8492gz9zi9535s09z1rhwgh6fprxw6q231nx5cdrfbi1a"
+   "commit": "6e081439a876b3cb9a27146fd75e887997712629",
+   "sha256": "1i9jqchlbg5w8zmqbzpnyz11xgqhfriy1kyp8z8mczpyvhyz646f"
   }
  },
  {
@@ -82418,11 +82727,11 @@
   "repo": "ideasman42/emacs-meep",
   "unstable": {
    "version": [
-    20260624,
-    344
+    20260716,
+    112
    ],
-   "commit": "cc2761444e652722a65e5d31db663315abc4df2f",
-   "sha256": "13ag4qfsf82a87ybf6lzv5qb0ivyv00qd06p25f4m8y4rckfkmlw"
+   "commit": "8ddd6a5b61e295e9e423708e66f28e12c6199c8b",
+   "sha256": "05xw0c03h90kn6chilin6rr8wdqfkbsvcplcl9sz2ni8rx7mssm7"
   }
  },
  {
@@ -82628,11 +82937,11 @@
   "repo": "meow-edit/meow",
   "unstable": {
    "version": [
-    20260619,
-    1030
+    20260714,
+    1200
    ],
-   "commit": "96648fa6398222e1376422d01f5249afa2a25680",
-   "sha256": "15mp09k5iy4dmmkzsg0ss7k2l5wdh5z1ncnfi5w06apg8x1nkr0a"
+   "commit": "aa8aec19e70369b547176e625f5b95c4a8565e8e",
+   "sha256": "1mgrh9yfhv0nvb0x1ab0bmyl8x7wzb6av5ywkxidnn4jllvf1n07"
   },
   "stable": {
    "version": [
@@ -83173,11 +83482,11 @@
   "repo": "kazu-yamamoto/Mew",
   "unstable": {
    "version": [
-    20260511,
-    310
+    20260707,
+    2341
    ],
-   "commit": "b905786ae1da9da4c015d69b9417a55985f07668",
-   "sha256": "1xbdix7hn6i224gglpab43qqi5mkv356zf7gs9359vnwslfm5x6n"
+   "commit": "880d4af5cadadfa3b0348c340f187aa45c0a870c",
+   "sha256": "0sl6w556znxgxy4j0simmn3kgrh0w81aspnqh00yd7iqwcf9yllw"
   },
   "stable": {
    "version": [
@@ -83715,11 +84024,20 @@
   "repo": "dheerajshenoy/minimal-dashboard.el",
   "unstable": {
    "version": [
-    20251102,
-    1952
+    20260710,
+    1120
    ],
-   "commit": "b7dbce88a19777c0d33df025e2b830094e521af8",
-   "sha256": "0qa1sgijf8qywi8zxiv2bs6j526q5aankp6790q10p1r8d1vdhdp"
+   "commit": "260a074d44eaa9e49576dca24c09cca54f1e193d",
+   "sha256": "1gjrb8hmf44vhf0dssm7pwkz4mx2w7hkxk7540xd6qiwx7xnl6gz"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    4
+   ],
+   "commit": "260a074d44eaa9e49576dca24c09cca54f1e193d",
+   "sha256": "1gjrb8hmf44vhf0dssm7pwkz4mx2w7hkxk7540xd6qiwx7xnl6gz"
   }
  },
  {
@@ -84010,6 +84328,21 @@
   }
  },
  {
+  "ename": "mise-tasks",
+  "commit": "a00cda32a35da1bb4eb33c81212a4aa5df26755e",
+  "sha256": "0nhaidc9il333v2br9ha5xzwlb3qin9l4ghjp1xgri2hsi8l5v3l",
+  "fetcher": "github",
+  "repo": "klochowicz/mise-tasks.el",
+  "unstable": {
+   "version": [
+    20260703,
+    656
+   ],
+   "commit": "76c762bd920bf1e2faac631ac990c4e2e798d321",
+   "sha256": "178apcbm3bl1fyphbi1mkd3hrfd418g4nmahz5msad145vr01z5j"
+  }
+ },
+ {
   "ename": "mistty",
   "commit": "8a66484b8aff8298222e70466f8f9b09b31bc598",
   "sha256": "1xymccwmffccf5b5a29mmhwymmllmkd4nbmxk52g7c81xrwnrcnb",
@@ -84017,11 +84350,11 @@
   "repo": "szermatt/mistty",
   "unstable": {
    "version": [
-    20260205,
-    1444
+    20260715,
+    1804
    ],
-   "commit": "bf0ddd077351001c56a4c754399d7ec025b93bab",
-   "sha256": "0j4m5ivbzkrp4jspcvbi3jy3dq4lqmm93p47pc1v9v0g54hym5nr"
+   "commit": "879abed83287ab79b6d3dbdab7df2bf3fc68769a",
+   "sha256": "1vhrsmbg6lx2ckxsxqjv5f4wnijdilbzj5qpdq47f8j2fqslw2mw"
   },
   "stable": {
    "version": [
@@ -84097,20 +84430,20 @@
   "repo": "jdtsmith/mlscroll",
   "unstable": {
    "version": [
-    20250112,
-    1440
+    20260703,
+    1544
    ],
-   "commit": "d22f5d8e6ca5054d01f06ac57419267098b709a5",
-   "sha256": "00q0s1y8y4j9qyldbp9bwd7cqd5023wizlmsm7rkns5icf42hwbm"
+   "commit": "ff698fbbfc3b7c5775944bdff2da0acfb697d162",
+   "sha256": "197k737a3dxfjakj4lzf09sasjd46nq7dk5c78bbjlzbjdpg3r53"
   },
   "stable": {
    "version": [
     0,
     2,
-    3
+    4
    ],
-   "commit": "d22f5d8e6ca5054d01f06ac57419267098b709a5",
-   "sha256": "00q0s1y8y4j9qyldbp9bwd7cqd5023wizlmsm7rkns5icf42hwbm"
+   "commit": "ff698fbbfc3b7c5775944bdff2da0acfb697d162",
+   "sha256": "197k737a3dxfjakj4lzf09sasjd46nq7dk5c78bbjlzbjdpg3r53"
   }
  },
  {
@@ -84347,20 +84680,20 @@
   "repo": "trevoke/mock-fs.el",
   "unstable": {
    "version": [
-    20260111,
-    410
+    20260708,
+    2247
    ],
-   "commit": "c1a4b1f923bed627aea5579acd782e91243e7cdc",
-   "sha256": "10cg7gsf0iba8jh9gxvykrhc0ai3rnnwwjrcc0jnasn8fxfpkyz1"
+   "commit": "b15c34281d076d6aa1ea5820368307694952e2ce",
+   "sha256": "0jdpqpzcwf2d2pwlj9car9zx7y4d2i4nm8b057fyk5klw3hk4hpq"
   },
   "stable": {
    "version": [
     0,
     10,
-    1
+    2
    ],
-   "commit": "c1a4b1f923bed627aea5579acd782e91243e7cdc",
-   "sha256": "10cg7gsf0iba8jh9gxvykrhc0ai3rnnwwjrcc0jnasn8fxfpkyz1"
+   "commit": "b15c34281d076d6aa1ea5820368307694952e2ce",
+   "sha256": "0jdpqpzcwf2d2pwlj9car9zx7y4d2i4nm8b057fyk5klw3hk4hpq"
   }
  },
  {
@@ -84473,19 +84806,19 @@
   "repo": "purcell/mode-line-bell",
   "unstable": {
    "version": [
-    20181029,
-    516
+    20260702,
+    1209
    ],
-   "commit": "4985ba42f5a19f46ddbf9b3622453a9694995ce5",
-   "sha256": "13n3di05lgqfm4f8krn3p36yika5znhymp5vr2d747x54hqmgh7y"
+   "commit": "b888963bf390b6e1d132b72b8a14041bd7afae4b",
+   "sha256": "0lbdwwb6wyqpk3kbs4bp7lvcsp2jjks6v5flx66cinl6jg20l4gj"
   },
   "stable": {
    "version": [
     0,
-    2
+    3
    ],
-   "commit": "4985ba42f5a19f46ddbf9b3622453a9694995ce5",
-   "sha256": "13n3di05lgqfm4f8krn3p36yika5znhymp5vr2d747x54hqmgh7y"
+   "commit": "6ab459f7be311f5a30679a3dfb28431e3e8d2dad",
+   "sha256": "11j0dzc8290ykcs2wwyjda3lvmxm39zrvgmig5fq1p3l2984m88b"
   }
  },
  {
@@ -84694,15 +85027,15 @@
   "repo": "deadendpl/modus-ewal-theme",
   "unstable": {
    "version": [
-    20260609,
-    1423
+    20260715,
+    906
    ],
    "deps": [
     "ewal",
     "modus-themes"
    ],
-   "commit": "2856520a2474b3d5fddae64001817d6cecf3da51",
-   "sha256": "069wcl2l194rnkkf3gf9lp4ikc2s1zx963b2nj94zz0yw8z51lxl"
+   "commit": "75f4cbe730d16407f0251d3c45297bb83d31f6db",
+   "sha256": "1dlqpbc9yn0mpm1rnmy1l1c325jz5hwlnhccsdzc9ai64f4f778d"
   }
  },
  {
@@ -84713,11 +85046,11 @@
   "repo": "protesilaos/modus-themes",
   "unstable": {
    "version": [
-    20260621,
-    1325
+    20260717,
+    1109
    ],
-   "commit": "2d044ac89f3bca7011fa2bfda003cf80ce115f70",
-   "sha256": "1xbwvw3fg1c18gs6w10vp843mzjqxrv24ks7ll2zj8y4mcig3fbm"
+   "commit": "e81c3c6ce3cdeb02266487a6fc1461cb9194c70e",
+   "sha256": "0y7c8dk5m8nn05s0gazpipvhmadn493clx7hr0dfm54cd767bz8d"
   },
   "stable": {
    "version": [
@@ -85122,6 +85455,21 @@
   }
  },
  {
+  "ename": "moonbit-ts-mode",
+  "commit": "f75f44e867a0ed35a5beb1436f8e2f46ebd97358",
+  "sha256": "0i4wbg7vd2ijmv3z86gmbv6irkaa37cxlvm8f9wg73qzlxgx8haw",
+  "fetcher": "github",
+  "repo": "moonbit-community/moonbit-ts-mode",
+  "unstable": {
+   "version": [
+    20260713,
+    229
+   ],
+   "commit": "f8ae31f506571614afea2fcd03532d872afd917b",
+   "sha256": "0nsmxrk39sh0dl2vjr9zpx0h5yngagarkcvs85iaqmk149fm0368"
+  }
+ },
+ {
   "ename": "moonscript",
   "commit": "3046afee95277024830d7d372f2f1c84a0adcb00",
   "sha256": "1fi4hg5gk5zpfkrk0hqghghkzbbi33v48piq2i085i4nc6m3imp0",
@@ -85506,20 +85854,20 @@
   "repo": "google/mozc",
   "unstable": {
    "version": [
-    20260519,
-    247
+    20260624,
+    1355
    ],
-   "commit": "324a09a905c238e15ed37b828b4a70ef2eaad2a2",
-   "sha256": "055dxly08fxmyhsa9sjimbhvhc5wqfq7cppi777spfhwfyc7d33r"
+   "commit": "76887c679e1e4f156102e4bc62ea9cf9174678a3",
+   "sha256": "18v2vlxcs0pxq84mydqdzrfn5jf7waav6ykrawd74mfhlwjp3f4v"
   },
   "stable": {
    "version": [
     3,
-    33,
-    6133
+    34,
+    6239
    ],
-   "commit": "c9163b6bb1010671781b8acd358b025c519fc1e0",
-   "sha256": "0hq5iin2fnf4y6klmlbiqkw1h0l77appyhlagn735brf2n74qaxg"
+   "commit": "76887c679e1e4f156102e4bc62ea9cf9174678a3",
+   "sha256": "18v2vlxcs0pxq84mydqdzrfn5jf7waav6ykrawd74mfhlwjp3f4v"
   }
  },
  {
@@ -85894,11 +86242,11 @@
   "repo": "xuchunyang/msgpack.el",
   "unstable": {
    "version": [
-    20200323,
-    515
+    20260706,
+    1555
    ],
-   "commit": "e2a0d76d1087bc8178c9f27222cb9b93e2e815ec",
-   "sha256": "016vjm7sjasqqhxpq0yl12fxx9pfi3dzpp48k9xhr5wldw94czqx"
+   "commit": "5353a7b2da854c843cbec4536996242001f63471",
+   "sha256": "08pr8ijvfpnzx4bxbj8cjmibk2mlx0ksjwm3dv3lzp3i6cg5mhsw"
   }
  },
  {
@@ -86119,14 +86467,14 @@
   "url": "https://repo.or.cz/mu4e-marker-icons.git",
   "unstable": {
    "version": [
-    20250228,
-    218
+    20260629,
+    815
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "13541181d5144ee91d570ab74558abce194b083f",
-   "sha256": "1lvwg0yb993j57y7663jm33g7j0x0jqbhqgf8vdy6qv198wpj5nc"
+   "commit": "2d048729ab106aebf1acb99e1ccfd002a0f2ec4a",
+   "sha256": "08p0lvlf6s1w6wd588x64jshxaqyazszmrcwq83bd242k101vvnk"
   }
  },
  {
@@ -86615,6 +86963,24 @@
   }
  },
  {
+  "ename": "musicbrainz-interactive",
+  "commit": "cf0a2b5b33488677cae50502ebdce479f9784a4c",
+  "sha256": "1vxaldmhp3crz3xsspiq1xyja7k7spsmbwk27dmmzm5lisvxhc6c",
+  "fetcher": "github",
+  "repo": "zzkt/metabrainz",
+  "unstable": {
+   "version": [
+    20260711,
+    830
+   ],
+   "deps": [
+    "musicbrainz"
+   ],
+   "commit": "6c699a9c1a8b9292a732ae1bd662b021fcd8d8b8",
+   "sha256": "0xnx60g9l523k5ckx97bv1h3n472da268acl20nq6158w7zh6ni0"
+  }
+ },
+ {
   "ename": "mustache",
   "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
   "sha256": "1qag8yv1xh65ny7gni4ncz42ij3h6ca4nzp13pbfy5bmyw9hfzlj",
@@ -87002,11 +87368,11 @@
   "repo": "LuciusChen/mysql.el",
   "unstable": {
    "version": [
-    20260617,
-    643
+    20260716,
+    1425
    ],
-   "commit": "a3a3b151687197906586464b8f9e812261673897",
-   "sha256": "1y9ggpnwxiphmlslv5mvw9wnq86raiy7ylp4jrcykvrcvg4agld8"
+   "commit": "af030703c54004d28794c9b259d8fa6c7eaeec19",
+   "sha256": "0piq2xb93x7hviip5hyaj7vfgrcwrkd190hydlwvsg1j2sw9y3na"
   }
  },
  {
@@ -87765,20 +88131,20 @@
   "repo": "bbatsov/neocaml",
   "unstable": {
    "version": [
-    20260624,
-    440
+    20260710,
+    532
    ],
-   "commit": "6acca5831d723105af361b742049cbf53d05bdf7",
-   "sha256": "0alk1dsipnb3njc08crjqcw10ljnrgbb6ciiiysmfsml7bl67ywc"
+   "commit": "32acab3624160a7d0bb04c42babaa791729ab8b5",
+   "sha256": "0jib25g15aj65jvsfb0ngkiwh85nlyz18qb6wjdd3rfmxb68wrjh"
   },
   "stable": {
    "version": [
     0,
-    9,
+    10,
     0
    ],
-   "commit": "6acca5831d723105af361b742049cbf53d05bdf7",
-   "sha256": "0alk1dsipnb3njc08crjqcw10ljnrgbb6ciiiysmfsml7bl67ywc"
+   "commit": "32acab3624160a7d0bb04c42babaa791729ab8b5",
+   "sha256": "0jib25g15aj65jvsfb0ngkiwh85nlyz18qb6wjdd3rfmxb68wrjh"
   }
  },
  {
@@ -87843,11 +88209,11 @@
   "repo": "rainstormstudio/nerd-icons.el",
   "unstable": {
    "version": [
-    20260619,
-    455
+    20260710,
+    1627
    ],
-   "commit": "a9a9177e135dd407d508609ac4d9915eb8608b4f",
-   "sha256": "0jp0pql4sns74dm6xnh21v3icb8q9411gbaryv0wh0klfrllw2id"
+   "commit": "674909974637ff0ec2b5ebf43f9a8aefa35d93e9",
+   "sha256": "14rd0nj7v29mq78gvmsqys650fz1q44hqk6ymhlr380wjhsx8jpx"
   },
   "stable": {
    "version": [
@@ -88318,8 +88684,8 @@
   "repo": "ewantown/nice-org-html",
   "unstable": {
    "version": [
-    20250608,
-    1715
+    20260625,
+    1926
    ],
    "deps": [
     "dash",
@@ -88327,8 +88693,8 @@
     "s",
     "uuidgen"
    ],
-   "commit": "bdb49bbe22dbd99489f2c65a10cb90f29d39d80d",
-   "sha256": "1gm9dr5914hgq07xng06w2myhn115ayv5x8br6s2njw9lqmj6zxz"
+   "commit": "16c9efdd92a12c78a55364f3d5e8e310585aa012",
+   "sha256": "0skahzl2ai7v92cl40p8hxs2qj82dbpf9gmq7314s2gbdibklpk3"
   }
  },
  {
@@ -88498,20 +88864,20 @@
   "repo": "mrcnski/nimbus-theme",
   "unstable": {
    "version": [
-    20260112,
-    41
+    20260719,
+    1540
    ],
-   "commit": "1ee3e643a01129263833ee5538e5df1fefb25cde",
-   "sha256": "0a4w8pvwmpjb0lflxccvp67gr16xb458hzkj7zjkm44iq7i55qy1"
+   "commit": "d755926ec6984207f63733a0fa9612954b350c34",
+   "sha256": "1vc0c3pdcrqqizf7v3nlg6dhljwsb4vycncspx9qfi1znr8cw56d"
   },
   "stable": {
    "version": [
     1,
-    3,
+    4,
     0
    ],
-   "commit": "178557148f2e132c79be25429d04c5b89f6535dd",
-   "sha256": "09lcyxd4nds79m8bpk5pq5p5brb8c6czzvniarn8njzj13lcy2g6"
+   "commit": "d8544f963463d9d2e6ae3b701c1538064d57c6df",
+   "sha256": "1adkbhs2yrmhi6nh30c2dsiamh5wd3ibg31nl4f2qyc00cpzs40j"
   }
  },
  {
@@ -88709,11 +89075,11 @@
   "repo": "nix-community/nix-ts-mode",
   "unstable": {
    "version": [
-    20260423,
-    1718
+    20260705,
+    1600
    ],
-   "commit": "50916188784786ed201a8edc70a5264eefb525e3",
-   "sha256": "14yqs2gibq7fdg79h9mcjrnxm0y6gscbvgzjlkp8gm0dmh2x8b1y"
+   "commit": "3b69aeb8d2403ea52b60a46fa452965b7b37a50e",
+   "sha256": "0br7g2py8r1xgc0hmcbcax77kiw8ljwbcp8y51ryvjpah0jrb0pf"
   },
   "stable": {
    "version": [
@@ -88891,16 +89257,16 @@
   "repo": "dickmao/nnhackernews",
   "unstable": {
    "version": [
-    20230705,
-    1359
+    20260630,
+    1255
    ],
    "deps": [
     "anaphora",
     "dash",
     "request"
    ],
-   "commit": "4c13d261bf660901d5ff63a7ee170097ebe464ed",
-   "sha256": "08z81m25lh1basmq5w8w1sg284dfck3nzlcnv1cbj4fr2qqncvyn"
+   "commit": "0cb7ff0a86c9c5b08786b6dc0591adcb25fbe3b3",
+   "sha256": "0hcvas8h5mfs7g80in9yvahvb8s18frfy6glv27f3czjaf9s1crz"
   }
  },
  {
@@ -88984,26 +89350,26 @@
   "repo": "emacscollective/no-littering",
   "unstable": {
    "version": [
-    20260605,
-    1120
+    20260706,
+    850
    ],
    "deps": [
     "compat"
    ],
-   "commit": "8e8e427f332a501b0a35b5de518d474c87c178d9",
-   "sha256": "188vcm99izdbh11vws84vpmm496ldv7kbgj3lic5jpc4a5400n17"
+   "commit": "fa0801e5a1135cdb5ba525869f578cea87e8db0e",
+   "sha256": "10mamnnayfxwa1x5ibyks8i684bhqzq6k24askzdi3galc31gpdh"
   },
   "stable": {
    "version": [
     1,
     8,
-    8
+    9
    ],
    "deps": [
     "compat"
    ],
-   "commit": "a279e2606f749e35e9af3d9f349484ee379eda84",
-   "sha256": "1b40aphl084wwi6pi0dvxihkysl67z2gvhjhi1yadd4qn3hbxy73"
+   "commit": "719c2a3773419ebc92a06e61b0fb26f6d64e750e",
+   "sha256": "1ydqwg77k8f67fa8dnmxxcg4nyyrcm459h1553j15fm1bjw0af0v"
   }
  },
  {
@@ -89443,6 +89809,30 @@
   }
  },
  {
+  "ename": "nostr-publish",
+  "commit": "280679e6f0834e6e7e936b72044e9426dcc28c01",
+  "sha256": "012yq5nhirhf01dsi34p3s2cc1xl6bp7qpf16bmzk195lccjiyz2",
+  "fetcher": "github",
+  "repo": "941design/emacs-nostr-publish",
+  "unstable": {
+   "version": [
+    20260223,
+    951
+   ],
+   "commit": "f39220f2aaff5fc39e4268d6449a1a402a69cafa",
+   "sha256": "0gmcwsbndbc0n5jkxp5cx6irnph4lslcmvp33y7cn1nb0ikghqj9"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    1
+   ],
+   "commit": "f39220f2aaff5fc39e4268d6449a1a402a69cafa",
+   "sha256": "0gmcwsbndbc0n5jkxp5cx6irnph4lslcmvp33y7cn1nb0ikghqj9"
+  }
+ },
+ {
   "ename": "nothing-theme",
   "commit": "8f69a676e9adfb45f8fbd4467e86a4cb0fbf6ae8",
   "sha256": "0w93f50sb9swgn1lwnk8pdwwa5kpizmaaz13lvbk1qhq2xipr7yp",
@@ -89657,30 +90047,30 @@
   "repo": "tarsius/notmuch-transient",
   "unstable": {
    "version": [
-    20260601,
-    1531
+    20260701,
+    1305
    ],
    "deps": [
     "compat",
     "notmuch",
     "transient"
    ],
-   "commit": "41090076ad90b579ec48058d3edd135a1b9d05b5",
-   "sha256": "0m5h7nkd52n64vyp1nhq9vbv0cknm77yxnnk85qj8cqwd9awlmra"
+   "commit": "e60942fce3cb1f6a11533500c670ca4ac22186e5",
+   "sha256": "16kkqvr4bm52vmkz0rpy7icwzk2b796v13pgk1nnpvlq2z6j364n"
   },
   "stable": {
    "version": [
     1,
     2,
-    1
+    2
    ],
    "deps": [
     "compat",
     "notmuch",
     "transient"
    ],
-   "commit": "41090076ad90b579ec48058d3edd135a1b9d05b5",
-   "sha256": "0m5h7nkd52n64vyp1nhq9vbv0cknm77yxnnk85qj8cqwd9awlmra"
+   "commit": "e60942fce3cb1f6a11533500c670ca4ac22186e5",
+   "sha256": "16kkqvr4bm52vmkz0rpy7icwzk2b796v13pgk1nnpvlq2z6j364n"
   }
  },
  {
@@ -89888,11 +90278,11 @@
   "repo": "mattfidler/nsis-mode",
   "unstable": {
    "version": [
-    20260331,
-    53
+    20260628,
+    1801
    ],
-   "commit": "0e1ec26a3943865f33e5590e26f5bc31684ad67e",
-   "sha256": "0n3hlz00yjznns4d8rshfqwf1yvynr99qhsjkhd5njnfqswfi67d"
+   "commit": "5ee283dd4da0bf8ca90cc8210da6ad94899d50b9",
+   "sha256": "0f4a2qha8lgrnw14xrfaiz2s8wzka2p7llc0jymfyln52d2m10hc"
   },
   "stable": {
    "version": [
@@ -90143,11 +90533,11 @@
   "repo": "herbertjones/nushell-ts-mode",
   "unstable": {
    "version": [
-    20230911,
-    152
+    20260705,
+    141
    ],
-   "commit": "68afe1a8275880995b4d9a122fecf4accca15183",
-   "sha256": "0kd4pqsfyjpi8wdrqnbl18hz3i64gvfs9aarmxq86v8vj519z0wd"
+   "commit": "49915cd99d62b7e743bd8cf9023a5819479d166f",
+   "sha256": "1bm9jn1laapvfqh6r47wsav47r44q7w108ysyj622fhd9d6lf022"
   }
  },
  {
@@ -92533,11 +92923,50 @@
   "repo": "swflint/ol-bible",
   "unstable": {
    "version": [
-    20250819,
-    1543
+    20260714,
+    1429
    ],
-   "commit": "b67ff8c45d51af9fa71aa44bacb4a872f6b750c6",
-   "sha256": "0ipx60r8vpjqyan40qv78xg3rbra84yf87bqndz87f6n3h52pc6g"
+   "commit": "711f9a984c23b0cc91a3a12a339e3d0ebb714a8f",
+   "sha256": "1433kbnxkhaml5zpkq64k40kyh4wribk963kj1scv7bncgsg4lgz"
+  },
+  "stable": {
+   "version": [
+    1,
+    3,
+    3
+   ],
+   "commit": "711f9a984c23b0cc91a3a12a339e3d0ebb714a8f",
+   "sha256": "1433kbnxkhaml5zpkq64k40kyh4wribk963kj1scv7bncgsg4lgz"
+  }
+ },
+ {
+  "ename": "ol-locate-file",
+  "commit": "7a34c96396078ece320d6d0a061526bb277c226c",
+  "sha256": "09dqv171lzhzzhql7pji6qb5zkpy9md8xydgvpynbvfzbwlb9qfl",
+  "fetcher": "github",
+  "repo": "p-snow/ol-locate-file",
+  "unstable": {
+   "version": [
+    20260707,
+    933
+   ],
+   "deps": [
+    "org"
+   ],
+   "commit": "30f84f72616f38975a2dd069dd9f729cb21cca32",
+   "sha256": "1zlkixv2w3hrbw1jgd6qhfllxbkliqxhv71y8ghj63508vwr34jn"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    2
+   ],
+   "deps": [
+    "org"
+   ],
+   "commit": "30f84f72616f38975a2dd069dd9f729cb21cca32",
+   "sha256": "1zlkixv2w3hrbw1jgd6qhfllxbkliqxhv71y8ghj63508vwr34jn"
   }
  },
  {
@@ -92678,14 +93107,14 @@
   "repo": "captainflasmr/ollama-buddy",
   "unstable": {
    "version": [
-    20260622,
-    1737
+    20260715,
+    1551
    ],
    "deps": [
     "transient"
    ],
-   "commit": "c87a8fd73f1fb49859da37d6ef440ae456f2c6e1",
-   "sha256": "06a1zyyyyaag5gm8mfaqhi4lgfdd0gsfp6n5na7lnh2j3phc8gam"
+   "commit": "296dd738e43b91bd877743acd7e57139d437cc97",
+   "sha256": "17qgn2dkmgp1ka3w5vwfx99snjas1xib61g165xi9ahbl26fp37m"
   },
   "stable": {
    "version": [
@@ -93747,14 +94176,14 @@
   "repo": "awth13/org-appear",
   "unstable": {
    "version": [
-    20240716,
-    1413
+    20260716,
+    2120
    ],
    "deps": [
     "org"
    ],
-   "commit": "32ee50f8fdfa449bbc235617549c1bccb503cb09",
-   "sha256": "1hfhnzhmbxrw4kz977s48x4nbq86vda5dvj00s2ima2i22b8l2z4"
+   "commit": "77d23efec5f5c25fc0798364d2b51a3ce3d8d518",
+   "sha256": "1kfgiaaq7lxjwczc693vv1yddz28zh4gfl48bf5bggka7b22n36c"
   },
   "stable": {
    "version": [
@@ -93991,28 +94420,28 @@
   "repo": "will-abb/org-aws-iam-role",
   "unstable": {
    "version": [
-    20260308,
-    1750
+    20260625,
+    102
    ],
    "deps": [
     "async",
     "promise"
    ],
-   "commit": "0175d5ac66f43f8d32db64a04421fddf57e10af7",
-   "sha256": "0p1lcchdnmkk9xa2rl1l6dz6nwsb71xq2lbk4ivblmlyqckc1l5n"
+   "commit": "2e7072a8322a95d39c0019d41eebf9b93bb4a08d",
+   "sha256": "12fdk34w3kc8w58lsqmw7f5lkblr95hv2s9hhx6q38jd42payki1"
   },
   "stable": {
    "version": [
     1,
     6,
-    6
+    7
    ],
    "deps": [
     "async",
     "promise"
    ],
-   "commit": "4c6cdde1efd1f33a4e2434db7af7617ce590e90c",
-   "sha256": "16d92ckk4dk4dgpj0wcw79wnls4r8mfkx2j6pipphp8qr8fi8xmd"
+   "commit": "49434f06ea8fe1ae3b1ea28555f435bafb6fc5f9",
+   "sha256": "12fdk34w3kc8w58lsqmw7f5lkblr95hv2s9hhx6q38jd42payki1"
   }
  },
  {
@@ -94368,11 +94797,11 @@
   "repo": "drghirlanda/org-change",
   "unstable": {
    "version": [
-    20260227,
-    224
+    20260719,
+    1721
    ],
-   "commit": "1da8d9384c42f559d41d6564e90c03c28b777387",
-   "sha256": "17h0rv7gdv3lhfw2cp8d6hqcqwh7lk5dbk1141sk55vxnh45f7l7"
+   "commit": "5ee789e00157c7cbd88ae8b97f3408f303f1878e",
+   "sha256": "1imfrwqxbffzzshqx3m6c9bsp2bdzfvs2027avkp1j1y5mszlyyh"
   }
  },
  {
@@ -94401,14 +94830,14 @@
   "repo": "swflint/org-cite-overlay",
   "unstable": {
    "version": [
-    20260619,
-    1531
+    20260630,
+    558
    ],
    "deps": [
     "citeproc"
    ],
-   "commit": "ec716f4e84d0796f652f789e4108617df4d233de",
-   "sha256": "1i9nvfwgzslyga9nakg90bf030vxhwc1y4fsrsg9xnxd67vwkfq7"
+   "commit": "40dde06e57f4b7f5335e9d5e076e7c2a2dcc7861",
+   "sha256": "05wa8apw2h4xgj5038gvfv9lvjad0db50y150a9s04frf08jy8ml"
   },
   "stable": {
    "version": [
@@ -95459,6 +95888,38 @@
   }
  },
  {
+  "ename": "org-habit-ng",
+  "commit": "7df3f295c7c16c0b0d3fb7852c3325dfb1c708aa",
+  "sha256": "0s3lxw45c606dc8r3szr9ccfm8bddr7qppmzwzb0bbhp6079zcll",
+  "fetcher": "codeberg",
+  "repo": "Trevoke/org-habit-ng",
+  "unstable": {
+   "version": [
+    20260713,
+    1625
+   ],
+   "deps": [
+    "org",
+    "transient"
+   ],
+   "commit": "8710d55411af41d5505236d33bd5b7ad05807441",
+   "sha256": "0xdm81y0ws09a4nlv76qm7zzdg30blb0xmb9ryhm8rg8i0nvjpfm"
+  },
+  "stable": {
+   "version": [
+    0,
+    7,
+    1
+   ],
+   "deps": [
+    "org",
+    "transient"
+   ],
+   "commit": "7fdd0331edbce773ca87f6544c501accd32711f9",
+   "sha256": "05hi7xig2sml8m5ayzl117rnvdx9k404mqs9mw1lznd7zwm5szwi"
+  }
+ },
+ {
   "ename": "org-habit-stats",
   "commit": "dd9fbd4b21685225c2dedafd7eee40fa58910cb1",
   "sha256": "1qr60hlv4n4wrzri3n9i516lvksg6rrn0vyaa1hqj5fm9vs7al5s",
@@ -95495,6 +95956,29 @@
    ],
    "commit": "15c8fa7fe5b15e09a751699ce780dde7edf7b5bd",
    "sha256": "1s1wlhbd0k10p1d93f7vi29jsm2kh2ws7bqwc9r2fjqd0hgcaz8x"
+  }
+ },
+ {
+  "ename": "org-history",
+  "commit": "7d3ea7283f6f1b6dde81dfb00b656855f50810e3",
+  "sha256": "1pwmzmpkgb00frw6id30ni3kcn1k85bvblz12r5lj12hvk6bb7bh",
+  "fetcher": "github",
+  "repo": "Anoncheg1/emacs-org-history",
+  "unstable": {
+   "version": [
+    20260720,
+    250
+   ],
+   "commit": "8a24e4c85c3cce0c91e6aaf37748abccd0cea3ba",
+   "sha256": "0qk21l399d6whcb8q9qrgyzffkzf3mbv7y4ljm4isy5hng3qffmj"
+  },
+  "stable": {
+   "version": [
+    0,
+    5
+   ],
+   "commit": "518040a62ee8c63e94e7c3147103b0a558c72a29",
+   "sha256": "1djjnhln4y1g7h5khd5g7n95nigaddj4h7hia4hx6pgica2pyfyx"
   }
  },
  {
@@ -95586,8 +96070,8 @@
  },
  {
   "ename": "org-incoming",
-  "commit": "abd059db58d08c881df15cc8c89fca90252771fe",
-  "sha256": "0fcrh4q5726zw4q33qh667qh0hbq9z21qchsfs0asmmj4rbmznzj",
+  "commit": "7b5d551c4669ab4e91a7a54019ec64f48b62f372",
+  "sha256": "0vwni4kbyy2fxypmanzc3dyzim4nz2bmbp0a9w71c7ffi27v25p1",
   "fetcher": "github",
   "repo": "tinloaf/org-incoming",
   "unstable": {
@@ -95803,16 +96287,30 @@
   "repo": "beacoder/org-ivy-search",
   "unstable": {
    "version": [
-    20250305,
-    159
+    20260713,
+    622
    ],
    "deps": [
     "beacon",
     "ivy",
     "org"
    ],
-   "commit": "d09472c5ae5c099bee17fb0e4f3f017ce7ebd031",
-   "sha256": "1p48k2fjiig8kfpgrnsrpcyfpyfm17gjr80p0r52bq6ijh2z53bj"
+   "commit": "5aa418961c6dae576e800df459ad6dbd7740b4b4",
+   "sha256": "03h0d83zs5qwrs7i7zi96jwwjr4idyw4rngs864vz46kz8amk6nd"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    8
+   ],
+   "deps": [
+    "beacon",
+    "ivy",
+    "org"
+   ],
+   "commit": "5aa418961c6dae576e800df459ad6dbd7740b4b4",
+   "sha256": "03h0d83zs5qwrs7i7zi96jwwjr4idyw4rngs864vz46kz8amk6nd"
   }
  },
  {
@@ -96166,19 +96664,19 @@
   "repo": "Anoncheg1/emacs-org-links",
   "unstable": {
    "version": [
-    20260605,
-    743
+    20260717,
+    1827
    ],
-   "commit": "c168b06e408adc4b3ac03163e96e3dcbaac884bc",
-   "sha256": "1nfjb6cav830d6x055hciffg7q7g1bv82r8a8mz8435fv8cjff90"
+   "commit": "d46c02edbdbd9f070b0492ffbe9f4ceea3322737",
+   "sha256": "0z5lrb25gd1yd4amja3izj5qqrh8v8pw7q5qqjz064hxkmi83xmx"
   },
   "stable": {
    "version": [
     0,
-    3
+    4
    ],
-   "commit": "c6e8cc6753d3b880b09a6e28f244ada48debfb2b",
-   "sha256": "1vnqg43f94viixlqqjj0vfrpshzj3inpn36j5ds3f3icjzg7i16z"
+   "commit": "d46c02edbdbd9f070b0492ffbe9f4ceea3322737",
+   "sha256": "0z5lrb25gd1yd4amja3izj5qqrh8v8pw7q5qqjz064hxkmi83xmx"
   }
  },
  {
@@ -96265,14 +96763,14 @@
   "repo": "laurynas-biveinis/org-mcp",
   "unstable": {
    "version": [
-    20260620,
-    1427
+    20260714,
+    1520
    ],
    "deps": [
     "mcp-server-lib"
    ],
-   "commit": "eea4942d82858297d6f31d5872bce3e3ebe8bb50",
-   "sha256": "1hkvp98jc8la6akq0lvxldnjd7xnl1pn4g6dh8727yyba8y1q08m"
+   "commit": "29a2310ed17283e379c322dbf7a1b957a6f2395c",
+   "sha256": "0djdlq4w3zc02q9kr7y4iv1v3v1ia0aq7jpngvzvrb61233fngq9"
   },
   "stable": {
    "version": [
@@ -96364,6 +96862,36 @@
   }
  },
  {
+  "ename": "org-mindmap",
+  "commit": "c7b17ab04bff23ccea6710224cb46e69c987af61",
+  "sha256": "0iknjygxiwqsr66vrid2685mbs1xdh5hi0b7lfdfv9ccjn2xq7xp",
+  "fetcher": "github",
+  "repo": "krvkir/org-mindmap",
+  "unstable": {
+   "version": [
+    20260617,
+    1609
+   ],
+   "deps": [
+    "org"
+   ],
+   "commit": "128e8fb853718bb4a04aff29703b927276a8b24c",
+   "sha256": "14658gdvk3ii4krli2gr018iwbgdwdkg9lxkpzh4hsnz28fm1v5b"
+  },
+  "stable": {
+   "version": [
+    0,
+    3,
+    0
+   ],
+   "deps": [
+    "org"
+   ],
+   "commit": "de81481bff9e33568b7df202478e95aff9e7b4af",
+   "sha256": "1i184clw6vagpd15r2v9582yvf3wfqkxarwb4x2mly01s11zzvr0"
+  }
+ },
+ {
   "ename": "org-ml",
   "commit": "95cc2843698e2341697a223a463c4d51348aec5e",
   "sha256": "013rlpq5in8mq02pnlpsl0mbgflv6bwx2cr18j0jcyd4sd1r1srz",
@@ -96423,15 +96951,15 @@
   "repo": "minad/org-modern",
   "unstable": {
    "version": [
-    20260519,
-    1046
+    20260707,
+    1016
    ],
    "deps": [
     "compat",
     "org"
    ],
-   "commit": "4855ade77ab17de7587c37bde12a0afeab342783",
-   "sha256": "18yg3bg0mnhk4hkx5402rb5d6lyy5qn9pp5m2cigwjaa3316prk9"
+   "commit": "d41bedbab849745bd10e300b8d93a17bc78a5ad6",
+   "sha256": "10yidx97sb0sk6rp4fry4dl5psspjc4mz0aqir53p84nv08y5y6j"
   },
   "stable": {
    "version": [
@@ -97471,28 +97999,28 @@
   "repo": "mrcnski/org-recur",
   "unstable": {
    "version": [
-    20230124,
-    1532
+    20260707,
+    2223
    ],
    "deps": [
     "dash",
     "org"
    ],
-   "commit": "628099883a63d219f76cd9631cc914fe6ec8a3e3",
-   "sha256": "0s2n62y3qc72ldzpaq2jz9335h532s566499n346nx21l4qsqdz6"
+   "commit": "680731635038bf453dc75242bf007e886be8c765",
+   "sha256": "1a81zah2fhflc2wcv7kl4c15m0gbhz8flwi9hk19gb5l9k8sm9m1"
   },
   "stable": {
    "version": [
     1,
-    3,
-    3
+    4,
+    0
    ],
    "deps": [
     "dash",
     "org"
    ],
-   "commit": "628099883a63d219f76cd9631cc914fe6ec8a3e3",
-   "sha256": "0s2n62y3qc72ldzpaq2jz9335h532s566499n346nx21l4qsqdz6"
+   "commit": "680731635038bf453dc75242bf007e886be8c765",
+   "sha256": "1a81zah2fhflc2wcv7kl4c15m0gbhz8flwi9hk19gb5l9k8sm9m1"
   }
  },
  {
@@ -97585,11 +98113,11 @@
   "repo": "TomoeMami/org-repeat-by-cron.el",
   "unstable": {
    "version": [
-    20260507,
-    721
+    20260718,
+    441
    ],
-   "commit": "889944d9ee09fb4f09c3f7104c133a469dd242fd",
-   "sha256": "1j2hvsfzggm7kj7w41k953vfvi3v86qbxqmlf53kfmc5b3p7742i"
+   "commit": "3009d28e434e1c44cf55490cfa54d5668107aca9",
+   "sha256": "0fc3cvcqyg7nqhfhvyy4gcwh2lavpc9af7yvsn82gqjmr8fi366m"
   },
   "stable": {
    "version": [
@@ -97803,8 +98331,8 @@
   "repo": "ahmed-shariff/org-roam-ql",
   "unstable": {
    "version": [
-    20260603,
-    2154
+    20260627,
+    2312
    ],
    "deps": [
     "dash",
@@ -97813,8 +98341,8 @@
     "s",
     "transient"
    ],
-   "commit": "35900a7a97c459b6ded44d665d60c81ba2df6cc2",
-   "sha256": "0fcyk7m4wf8ibqvfplsysfqw5l7d4sl36bs4vjyx43rrdddl1gai"
+   "commit": "89bdd60367f95309334e8804b465e80c1aab9a78",
+   "sha256": "0ywbih47j81s6zn5x6ilcjx41blx4vg91aqpdiqkhzz8kwpgwggn"
   },
   "stable": {
    "version": [
@@ -97840,8 +98368,8 @@
   "repo": "ahmed-shariff/org-roam-ql",
   "unstable": {
    "version": [
-    20260322,
-    808
+    20260627,
+    829
    ],
    "deps": [
     "org-ql",
@@ -97850,8 +98378,8 @@
     "s",
     "transient"
    ],
-   "commit": "b6b6a25029503c27c2d4e4e0ca17a0ab82611470",
-   "sha256": "1zqpr2hvxisk0lqf6j9ak79s338wwlf4xbvkqh752pm5idlia7fj"
+   "commit": "196e6cd37f3eb7418ef250664d62b2cbd67a88e3",
+   "sha256": "0bl9k29fp59ph431j2132gv3g82ca6v4wbw21cbqy3map4ac2qfv"
   },
   "stable": {
    "version": [
@@ -98310,15 +98838,15 @@
   "repo": "bohonghuang/org-srs",
   "unstable": {
    "version": [
-    20251223,
-    1556
+    20260628,
+    1143
    ],
    "deps": [
     "fsrs",
     "org"
    ],
-   "commit": "c0aff45392b1f836fd943467cc266cef50899a44",
-   "sha256": "0bvczpn93afdng9xnr3licgmv3yw4rdmsbn45206r756738capn9"
+   "commit": "e6e5fbfcb8beb520141edac647ccb76af9b71df6",
+   "sha256": "199qc0ikz9b6hbrpdpc737byqscp2rnh3syvjp71jwf2r7kwkz6h"
   }
  },
  {
@@ -99840,8 +100368,8 @@
   "repo": "magit/orgit",
   "unstable": {
    "version": [
-    20260623,
-    2148
+    20260717,
+    1740
    ],
    "deps": [
     "compat",
@@ -99850,23 +100378,24 @@
     "magit",
     "org"
    ],
-   "commit": "1aa3a27b1cb6aec913f7365caebdd6ffbe178443",
-   "sha256": "0rbj0b28dcgjcsa17wd01f1xw0psgxi4sak7c8wx55yaq8ym2i1s"
+   "commit": "47b3568fce775c756fb5bb3545c2edd48b8e2fc1",
+   "sha256": "1yd1rk4cfr7n2fxidmpcpza8zwnzmf6sayp2i0mclrx31y88nmhl"
   },
   "stable": {
    "version": [
     2,
-    1,
-    3
+    2,
+    0
    ],
    "deps": [
     "compat",
     "cond-let",
+    "llama",
     "magit",
     "org"
    ],
-   "commit": "4a4c03ee40b0e2509b49303e151ee217edaf0da4",
-   "sha256": "1gwl58mvanzbrh7lwkqbvfpmb32lz06k6dcnacan7kglvkm6mwgr"
+   "commit": "7c4827cd04953166f71eaec151ad1c50872fc680",
+   "sha256": "1730vha6pa10cnz5j5nyzf8wxnnkck6ncmi4i3sqmhfxalf901xk"
   }
  },
  {
@@ -99913,8 +100442,8 @@
   "repo": "magit/orgit-forge",
   "unstable": {
    "version": [
-    20260623,
-    2150
+    20260717,
+    1424
    ],
    "deps": [
     "compat",
@@ -99924,14 +100453,14 @@
     "org",
     "orgit"
    ],
-   "commit": "1e325a23ccc707373c13aee91c15a0bc0d1d6f41",
-   "sha256": "0c9lsjj5mpwyp4wc4kjazxdn23pldy2mbhbc88wcz7mzwbxpya8g"
+   "commit": "f812864aae188bbbc36725c87bd92909ff0dda3a",
+   "sha256": "030zdna7kx9bcrbgkn8fmkk4bx3mab6gwhly5dzh4wdf908px1d6"
   },
   "stable": {
    "version": [
     1,
     1,
-    2
+    3
    ],
    "deps": [
     "compat",
@@ -99941,8 +100470,8 @@
     "org",
     "orgit"
    ],
-   "commit": "8e4496d7f7f84fab3e36d10883386c02f43a67e7",
-   "sha256": "0fawwd2yys89kyp1q03xng9azgmbdai067m60x0agahrpvgdrysm"
+   "commit": "c421620af3fb38ab4654f745f51370471b65cf4e",
+   "sha256": "1qaq722m0sr1awdgm6fbl52h8h9qa532lisnnnrh578b8aqs3yvv"
   }
  },
  {
@@ -100124,11 +100653,11 @@
   "repo": "tbanel/orgaggregate",
   "unstable": {
    "version": [
-    20260624,
-    650
+    20260717,
+    1115
    ],
-   "commit": "84d7721b4bf8c07d121945d9a37890059d8fad1d",
-   "sha256": "0jcpk08vfr7xxz82sicxp5qxvzvps4xzqn80knzcbl82wxh75iqi"
+   "commit": "dc2fdb7149b07f0a4454a36a05b3a174efdfcb6e",
+   "sha256": "0x7g01yklayxhrsamg3av3sdsdb1077gpddy1098nflvqvsf30kn"
   }
  },
  {
@@ -100169,11 +100698,11 @@
   "repo": "tbanel/orgtbljoin",
   "unstable": {
    "version": [
-    20260624,
-    718
+    20260705,
+    1412
    ],
-   "commit": "1f00eeb9b95bd3075b67ebf5efc5e08dbdfc0361",
-   "sha256": "0im9r4gqf18k4bhbj66v6yfpb4l65nfsjfh7fhigljcid66sxz2l"
+   "commit": "cd637a44e69b8ac3bdb9d99bee5066be279da1d8",
+   "sha256": "165bb0yhx1fm11cld61lrhfivg4x4pn65r5baciqcfwblsiifxpw"
   }
  },
  {
@@ -100332,25 +100861,25 @@
   "repo": "minad/osm",
   "unstable": {
    "version": [
-    20260623,
-    1520
+    20260705,
+    1259
    ],
    "deps": [
     "compat"
    ],
-   "commit": "b0fceb1f8488abb577e5110676f50753ea35ee24",
-   "sha256": "0w4y7cpnb371h8yf45p90gks3k601z5fkxf9ladk5kgyaz7i98an"
+   "commit": "d6167ca4f99bead657ac6f7f163c1fcf9b34267f",
+   "sha256": "11nn4rvjqs8f43gfazpghf67ihd994jd53z2pwfjhk8w8dav0gc2"
   },
   "stable": {
    "version": [
     2,
-    3
+    4
    ],
    "deps": [
     "compat"
    ],
-   "commit": "a9e76ce08fb86e40a9f3efc42b38045c9b58fa95",
-   "sha256": "10237nlimmcm9n20fvwyicswm1x8kbmqck5f59y150qsns6am41p"
+   "commit": "d6167ca4f99bead657ac6f7f163c1fcf9b34267f",
+   "sha256": "11nn4rvjqs8f43gfazpghf67ihd994jd53z2pwfjhk8w8dav0gc2"
   }
  },
  {
@@ -100679,14 +101208,14 @@
   "repo": "jamescherti/outline-indent.el",
   "unstable": {
    "version": [
-    20260608,
-    1221
+    20260715,
+    1813
    ],
    "deps": [
     "kirigami"
    ],
-   "commit": "57b9f4bb9724a82f7e5e15e2a62e04373aee3d08",
-   "sha256": "0d9qm0a5vnnhfslpxvnsf5pcqv35wqqv4niqsq7m64fcn9z4lnlh"
+   "commit": "6e12bf82611644584536f87f49d51042b2ec0339",
+   "sha256": "1j340v1s8f53vbk1db81j46n13v9bxrbm2ix8qxfqmk3mqw7m965"
   },
   "stable": {
    "version": [
@@ -101418,28 +101947,28 @@
   "repo": "jlumpe/ox-json",
   "unstable": {
    "version": [
-    20250825,
-    125
+    20260629,
+    631
    ],
    "deps": [
     "org",
     "s"
    ],
-   "commit": "0f7c63b9bbbf6c8b2547e46adc7f34289869105f",
-   "sha256": "1xlqd4rb5br3illbxg7k0rbspxfns2sr5wn7w9k546sb6lg5p4i2"
+   "commit": "3fa63a260fc58b09eed5dd8c36904ae80148adbe",
+   "sha256": "0x8bbg37qcg2ckqrjns6kx61pr4sbg9la3h2ywbsivrbw5bjagg2"
   },
   "stable": {
    "version": [
     0,
-    3,
+    4,
     0
    ],
    "deps": [
     "org",
     "s"
    ],
-   "commit": "57a43e3b3e400d219b80008c51373796b844c6b8",
-   "sha256": "12fxflyh92awjwfj5gwp8frrbjc63kj7ajlwbsmzgpnp9rr43fpx"
+   "commit": "3fa63a260fc58b09eed5dd8c36904ae80148adbe",
+   "sha256": "0x8bbg37qcg2ckqrjns6kx61pr4sbg9la3h2ywbsivrbw5bjagg2"
   }
  },
  {
@@ -101563,6 +102092,24 @@
    ],
    "commit": "27c29f3fdb9181322ae56f8bace8d95e621230e5",
    "sha256": "10rw12gmg3d6fvkqijmjnk5bdpigvm8fy34435mwg7raw0gmlq75"
+  }
+ },
+ {
+  "ename": "ox-mom",
+  "commit": "00b85145e379e14c76d549732ed9426200d0e98f",
+  "sha256": "04rfcyaw9yni19y011j2ydbg1d8jzyjgwppys6pf6zwxwpbhk0i0",
+  "fetcher": "github",
+  "repo": "hinman/ox-mom",
+  "unstable": {
+   "version": [
+    20260707,
+    243
+   ],
+   "deps": [
+    "org"
+   ],
+   "commit": "40711a3681cbeb4cbcb520371297bf3d932a333b",
+   "sha256": "0yr6hy0rb46d7vyzbs6hcsiicdl4l390mc0zvr6hqi4nrlx82w8k"
   }
  },
  {
@@ -102317,23 +102864,26 @@
   "repo": "melpa/package-build",
   "unstable": {
    "version": [
-    20260608,
-    2212
+    20260701,
+    1334
    ],
    "deps": [
     "compat"
    ],
-   "commit": "47a50e7593498533e22a832160536a90acc837e5",
-   "sha256": "0kyjlj3vmkpl5bx9j6d3ila7kxpdjb8rfxlarjbaimcqz8jspmnp"
+   "commit": "f19a7f58cf4b2e573a6d551d8d3dbe265c2566b4",
+   "sha256": "00v3fi2ssq9z9z5qf40b49z2yw9dsjkhcdfzy7qk1wdgv0pjbq0h"
   },
   "stable": {
    "version": [
-    4,
+    5,
     0,
     0
    ],
-   "commit": "0598e92cd61aa5196f78576fac7675bcff4ab217",
-   "sha256": "165gbrc1h1yj764kn3qq2y1551y04lqnklfa0k87gqgd38q5v985"
+   "deps": [
+    "compat"
+   ],
+   "commit": "f19a7f58cf4b2e573a6d551d8d3dbe265c2566b4",
+   "sha256": "00v3fi2ssq9z9z5qf40b49z2yw9dsjkhcdfzy7qk1wdgv0pjbq0h"
   }
  },
  {
@@ -102744,11 +103294,11 @@
   "repo": "coldnew/pangu-spacing",
   "unstable": {
    "version": [
-    20250124,
-    142
+    20260717,
+    230
    ],
-   "commit": "6509df9c90bbdb9321a756f7ea15bb2b60ed2530",
-   "sha256": "1i52qmky0azwp5pn20nh1zrikn71m95v4hgfc3l3cgq2rqkzzm8x"
+   "commit": "72de84e999aafa753a635b14bb199fc46d322945",
+   "sha256": "0dg13cqgzw5b49gmrv7fvmji2a23z5irkv7k4plsvsi2ci435zn7"
   },
   "stable": {
    "version": [
@@ -103658,11 +104208,11 @@
   "repo": "jamescherti/pathaction.el",
   "unstable": {
    "version": [
-    20260604,
-    212
+    20260715,
+    1811
    ],
-   "commit": "19dc91a8da6574dc7f80b263cc3a909be1c300e4",
-   "sha256": "1f1bqaya4xbwqaljfqffvn3lahh4s9q3nflhj20ny86cd5zcgdaj"
+   "commit": "5d80485e7f006a827fcd9b55f40481785abf31ee",
+   "sha256": "1ri12d9w0kkzn5jkcqs1ifq391m1ddd0vshwmc87rbaj37hpblzc"
   },
   "stable": {
    "version": [
@@ -104126,14 +104676,14 @@
   "repo": "emacsomancer/pdffontetc",
   "unstable": {
    "version": [
-    20260615,
-    2141
+    20260624,
+    1756
    ],
    "deps": [
     "pdf-tools"
    ],
-   "commit": "05c25591e807eaf79d25dbcfa20ca994f1ae78e3",
-   "sha256": "1faf6x7jckd0b408hija53074n9630srqk5hkn6wab6gz7rqn9g2"
+   "commit": "063529d92f833ca4342f88a4928f6ec74826ccd0",
+   "sha256": "0pw0f1fifni6y6hy05bbbgx8s2w40as2y1n56a938jkxhmwxdi1m"
   }
  },
  {
@@ -104391,20 +104941,20 @@
   "repo": "jamescherti/persist-text-scale.el",
   "unstable": {
    "version": [
-    20260609,
-    1528
+    20260718,
+    1651
    ],
-   "commit": "27e43ba3becce78a9365ac8e5ecdfc30e08249d6",
-   "sha256": "0add2xw1s7lrakhpb5phdscy3x81vzy7p8wz017vly27l50q787q"
+   "commit": "2535c7cda4d196d2c4f6311b27cff88aefabb14f",
+   "sha256": "0qrr99ss7pcj2j3azcqy8rimbw0w7k34zc12bkaxd7ky3ah2h614"
   },
   "stable": {
    "version": [
     1,
     0,
-    6
+    7
    ],
-   "commit": "27e43ba3becce78a9365ac8e5ecdfc30e08249d6",
-   "sha256": "0add2xw1s7lrakhpb5phdscy3x81vzy7p8wz017vly27l50q787q"
+   "commit": "2535c7cda4d196d2c4f6311b27cff88aefabb14f",
+   "sha256": "0qrr99ss7pcj2j3azcqy8rimbw0w7k34zc12bkaxd7ky3ah2h614"
   }
  },
  {
@@ -104616,14 +105166,14 @@
   "repo": "nex3/perspective-el",
   "unstable": {
    "version": [
-    20260624,
-    732
+    20260717,
+    1853
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "af96b2cdaa0e10953878b17d1eef4bcd382ed6f8",
-   "sha256": "1pwn2cz8p5d7n340da64lrp7fsl0lybw4ij8dsa6f23r970ii2n3"
+   "commit": "352a06502582646c8a79d5e1a0c36f1b61b6e6cc",
+   "sha256": "02l9hhp6qk6djs1p3q5zg4yjr8m46ax7n6553had1b1kvhbxbxm5"
   },
   "stable": {
    "version": [
@@ -104747,16 +105297,16 @@
   "repo": "wyuenho/emacs-pet",
   "unstable": {
    "version": [
-    20251217,
-    2147
+    20260716,
+    2214
    ],
    "deps": [
     "f",
     "map",
     "seq"
    ],
-   "commit": "222f1da892462d7bea5c7a7bbcb6b5a5f4cb2158",
-   "sha256": "0rm2a1cs4gv30968sap84jm0r5m4mmyi9rbwmdwklfb53698x3v9"
+   "commit": "c0d856782d74d205a9359ae2f5c623d8152d20d1",
+   "sha256": "0z50piq8wp239xc5hx51q4907yyqnmijx6x325hp60rk7kdabkga"
   },
   "stable": {
    "version": [
@@ -104805,25 +105355,25 @@
   "repo": "emarsden/pg-el",
   "unstable": {
    "version": [
-    20260607,
-    1014
+    20260719,
+    1514
    ],
    "deps": [
     "peg"
    ],
-   "commit": "7426269673da42ed6706db44d2b7d1696ede95f6",
-   "sha256": "1nfbzyidzlrhxvsk2z50l67lss9lgl4fswm23iyfkzbqqxiwm3w3"
+   "commit": "6d4b528cfd1e7f776eb0e4c14d84668fa69a041b",
+   "sha256": "1v19h9q7lsiqaxpfqhlvg16iqjj47hin4h1qgmw8kngy68l6w4js"
   },
   "stable": {
    "version": [
     0,
-    67
+    68
    ],
    "deps": [
     "peg"
    ],
-   "commit": "7426269673da42ed6706db44d2b7d1696ede95f6",
-   "sha256": "1nfbzyidzlrhxvsk2z50l67lss9lgl4fswm23iyfkzbqqxiwm3w3"
+   "commit": "6d4b528cfd1e7f776eb0e4c14d84668fa69a041b",
+   "sha256": "1v19h9q7lsiqaxpfqhlvg16iqjj47hin4h1qgmw8kngy68l6w4js"
   }
  },
  {
@@ -105074,26 +105624,26 @@
   "repo": "ErikPrantare/phony.el",
   "unstable": {
    "version": [
-    20260531,
-    2312
+    20260630,
+    1002
    ],
    "deps": [
     "simulacrum"
    ],
-   "commit": "1129dd32bb51cde770e62f56b7da50acd79790a4",
-   "sha256": "1zz2yq0fxigcwhnapx97r7i5m4s1zy8bcg40dm2qxndcj17wlgni"
+   "commit": "b155ee3686c732cfe02a4bcd5f3e07fdc39dca35",
+   "sha256": "058lmswkvx22vlwk149hb3n8wmph9rp18n925ghy46w4qhvqd0s5"
   },
   "stable": {
    "version": [
     1,
     0,
-    0
+    1
    ],
    "deps": [
     "simulacrum"
    ],
-   "commit": "1129dd32bb51cde770e62f56b7da50acd79790a4",
-   "sha256": "1zz2yq0fxigcwhnapx97r7i5m4s1zy8bcg40dm2qxndcj17wlgni"
+   "commit": "b155ee3686c732cfe02a4bcd5f3e07fdc39dca35",
+   "sha256": "058lmswkvx22vlwk149hb3n8wmph9rp18n925ghy46w4qhvqd0s5"
   }
  },
  {
@@ -105180,11 +105730,11 @@
   "repo": "emacs-php/php-mode",
   "unstable": {
    "version": [
-    20250602,
-    1308
+    20260719,
+    209
    ],
-   "commit": "40b8abed3079771e060dd99a56703520dabf5be4",
-   "sha256": "0f558vrgsb354jp4q7z52s3ybpybwjw2yxr8vlj58jg7dam6smyp"
+   "commit": "6ebe4a618aa64db3e15f809b036c1b1a6d05c030",
+   "sha256": "1fcdncv959ssqnbsjkjy2ay82h4qkrr6wzr1911b39gf78s9xn0h"
   },
   "stable": {
    "version": [
@@ -105325,21 +105875,21 @@
   "repo": "emacs-php/phpstan.el",
   "unstable": {
    "version": [
-    20260218,
-    453
+    20260717,
+    1734
    ],
    "deps": [
     "compat",
     "php-mode",
     "php-runtime"
    ],
-   "commit": "77fba8fe9d63661e940b392a0e4b573e7edafb7b",
-   "sha256": "0q08wx0k7n86v4jdspkjdjn1kmjy4cf1qrkj71qi0ga943vwz11l"
+   "commit": "00942a5d5b28560bd08f7355d131074772bb7a01",
+   "sha256": "1hf5jxj1amvv9ac1jm5bly38xfhj5k0rmsg3sd9kd888hi95gph8"
   },
   "stable": {
    "version": [
     0,
-    9,
+    10,
     0
    ],
    "deps": [
@@ -105347,8 +105897,8 @@
     "php-mode",
     "php-runtime"
    ],
-   "commit": "206573c8de58654384823765dcca636c9e35e909",
-   "sha256": "12qzjy3zz0lk439y0y9gl5pirzlf52li3lbyjjmq7lq6yg30qzxm"
+   "commit": "00942a5d5b28560bd08f7355d131074772bb7a01",
+   "sha256": "1hf5jxj1amvv9ac1jm5bly38xfhj5k0rmsg3sd9kd888hi95gph8"
   }
  },
  {
@@ -105427,30 +105977,30 @@
   "repo": "dnouri/pi-coding-agent",
   "unstable": {
    "version": [
-    20260622,
-    2213
+    20260720,
+    258
    ],
    "deps": [
     "markdown-table-wrap",
     "md-ts-mode",
     "transient"
    ],
-   "commit": "536e0f6e0ec12725874600734be3af41b02d08dd",
-   "sha256": "0i5kms8l5yda98220s3g5adz9561f30xchzvk53j0rwlz26mvqxb"
+   "commit": "3e6b04514592e0a38189552a686b9dbe51453bd7",
+   "sha256": "07zl6qw3ai2z3318qp0x0rmjil9x10f0h1fashxdrv6cm57cqxbz"
   },
   "stable": {
    "version": [
     2,
-    5,
-    1
+    6,
+    0
    ],
    "deps": [
     "markdown-table-wrap",
     "md-ts-mode",
     "transient"
    ],
-   "commit": "255b5d560f2ebf0323803498f413fc79d0ae386e",
-   "sha256": "0bdkrrv1rawgikk69d9rwjvx0swdlipbkki2gr37fdba042933vc"
+   "commit": "2b6a27feb6d224aeb9b680941a925c7c42948c59",
+   "sha256": "16x82wk0rz7cvwl3y13rjvy06chbzm4301wp4zh1gal7dh7h158y"
   }
  },
  {
@@ -105769,20 +106319,20 @@
   "repo": "Anoncheg1/pinyin-isearch",
   "unstable": {
    "version": [
-    20260620,
-    2130
+    20260718,
+    1804
    ],
-   "commit": "f15976e9989cfa9e7bd2bf59f2361e0cf62fed8e",
-   "sha256": "17nyik0xfjy17ln3pq5k69r3ad5cmjrqw3rbrygd6i0y5xqrq7iw"
+   "commit": "9834cb04fb59d8cb600059f20bf297522c764deb",
+   "sha256": "0h2cg9x8hpjxhdbql9lnncdij65lq70dl0imhqx2xkc32si9v97m"
   },
   "stable": {
    "version": [
     1,
-    6,
-    9
+    7,
+    1
    ],
-   "commit": "1ed4218cb50b4de614c11dc41ab6053255271ae7",
-   "sha256": "0m9j819q7mm5q418g160c0bickjij37w5j7c0lzhwvpilhmh2cny"
+   "commit": "9834cb04fb59d8cb600059f20bf297522c764deb",
+   "sha256": "0h2cg9x8hpjxhdbql9lnncdij65lq70dl0imhqx2xkc32si9v97m"
   }
  },
  {
@@ -107296,15 +107846,15 @@
   "repo": "kn66/pomo-cat.el",
   "unstable": {
    "version": [
-    20260224,
-    2202
+    20260627,
+    147
    ],
    "deps": [
     "popon",
     "posframe"
    ],
-   "commit": "f9eab9a897598c6da713b1730739dd2e41e70fda",
-   "sha256": "0l9ad8lmxhr8ni1ivf4fwmsawwkri6rn8ms7iibs5z342jqy4bn7"
+   "commit": "499241d5277429e0d9b37f866460e93e6b1c3a02",
+   "sha256": "0g8rhjzbp6abj97xcxfwkh7343p84s8068hr04093abji36dgkdw"
   }
  },
  {
@@ -107474,20 +108024,20 @@
  },
  {
   "ename": "popterm",
-  "commit": "e4d79aed1b29079b096ae3453d874fd830b369b7",
-  "sha256": "1k0kzr7ax1mzpv60ln1ky2x06yl7psznga6x4mnh52xxgwh1f95m",
+  "commit": "166bc08a635f453e7204dc0515e0a8b3efef0159",
+  "sha256": "0sg55hmxn0hx5lmwr7r58c3d46aaxxsddg955a4vyf8pk7dkmcxg",
   "fetcher": "github",
-  "repo": "CsBigDataHub/popterm.el",
+  "repo": "ChetanKoneru/popterm.el",
   "unstable": {
    "version": [
-    20260621,
-    1534
+    20260717,
+    1502
    ],
    "deps": [
     "posframe"
    ],
-   "commit": "24b9f85226dde1e4fc18c5470ed2971a120d4f27",
-   "sha256": "1rxpb6mjpvra6pfby21c7222cpabi856r3n8mjkb41dvcfnas0vx"
+   "commit": "c3f2079bdd5d480a7509b2f28cc104ec7473ffb7",
+   "sha256": "06ddkcvji5dz091kblr5h82jipig7q3zjcb20qc1cfv1d9lv9y46"
   }
  },
  {
@@ -108140,20 +108690,20 @@
   "repo": "radian-software/prescient.el",
   "unstable": {
    "version": [
-    20250816,
-    19
+    20260628,
+    2243
    ],
-   "commit": "87e2d2f2ddf24f591a5f70cc90d2afb4537caa18",
-   "sha256": "0f4wi8aq3yfykxfza4y4c5yhcs50cs3gpfj0qrmvfq9hvkhzj52w"
+   "commit": "5649977fa7789e4615efeca09397ed7eccd06dfc",
+   "sha256": "199150yng81f6n3kb120s37yf2dqs0i9k91f2gzkk8kjn6hvrsj8"
   },
   "stable": {
    "version": [
     6,
     3,
-    2
+    3
    ],
-   "commit": "87e2d2f2ddf24f591a5f70cc90d2afb4537caa18",
-   "sha256": "0f4wi8aq3yfykxfza4y4c5yhcs50cs3gpfj0qrmvfq9hvkhzj52w"
+   "commit": "5649977fa7789e4615efeca09397ed7eccd06dfc",
+   "sha256": "199150yng81f6n3kb120s37yf2dqs0i9k91f2gzkk8kjn6hvrsj8"
   }
  },
  {
@@ -109084,23 +109634,26 @@
   "repo": "bbatsov/projectile",
   "unstable": {
    "version": [
-    20260620,
-    902
+    20260720,
+    549
    ],
    "deps": [
     "compat"
    ],
-   "commit": "1aebd4284f1cb83a4b434362c6356d06fa9d445b",
-   "sha256": "0bdclxazk6b0fzx4h6ildl846179j00ifqir61knd1gwyjsxzssc"
+   "commit": "a4a91e08d49d280c9c5c2b0820bb04da198d61db",
+   "sha256": "0lm9jw8563hly4zi9yx9f4q28jpww4hazgdw2jigcjwgf3q7zn6q"
   },
   "stable": {
    "version": [
+    3,
     2,
-    9,
     1
    ],
-   "commit": "ef17d2971bbcce13b1ac16e0e36d44fa0defca63",
-   "sha256": "15wc2ivmac0kgbdgsaaxngmcffgd3227zsb4n7inhn14cqwr6qxd"
+   "deps": [
+    "compat"
+   ],
+   "commit": "8ac2834f1f70af977f17944c7968c72ea46bf62c",
+   "sha256": "0vqigfrgakjzvm9y2zg9vvnjx3xpzcb5s218qfphs8rqi87a6hzb"
   }
  },
  {
@@ -110361,11 +110914,19 @@
   "repo": "purescript-emacs/purescript-mode",
   "unstable": {
    "version": [
-    20250613,
-    944
+    20260717,
+    1433
    ],
-   "commit": "61732e23bd33b7d0d71bc6cff84b612bd2d9dff2",
-   "sha256": "19fycmdzyipb1lwdr4p86sg4j6qjy1j2rl8raml5yrbm1cra791a"
+   "commit": "7ad5eff9bd59632d49a44f5935c65f1069e17fed",
+   "sha256": "01jpf8whcjl7awwabhj3wpbajrv7varh4n0ammsq98ymzqlyywin"
+  },
+  "stable": {
+   "version": [
+    14,
+    0
+   ],
+   "commit": "7ad5eff9bd59632d49a44f5935c65f1069e17fed",
+   "sha256": "01jpf8whcjl7awwabhj3wpbajrv7varh4n0ammsq98ymzqlyywin"
   }
  },
  {
@@ -111199,28 +111760,28 @@
   "repo": "wbolster/emacs-python-black",
   "unstable": {
    "version": [
-    20240520,
-    729
+    20260706,
+    1540
    ],
    "deps": [
     "dash",
     "reformatter"
    ],
-   "commit": "4da1519345b3d5c513d82ef0d39536dd9c626d42",
-   "sha256": "0haxkpjggf91ahy6zl4qzpv7l9chi9yd0c0a054y3kjpvn64axqd"
+   "commit": "779d49c7db54590d1fa483ef2f89eea5ef8774e1",
+   "sha256": "19wjs67yc6gdfdjdrfav8m3w0rmyhdzfwq3hi2gcy6shyykm7s0i"
   },
   "stable": {
    "version": [
     1,
-    2,
+    3,
     0
    ],
    "deps": [
     "dash",
     "reformatter"
    ],
-   "commit": "e1bbf574a952562ddeadb0caa42c44016136c2c9",
-   "sha256": "1x6b67cs7kn8711fxr3fq8y9wcpf9g71asf9wiqfrk2mrfzli6a3"
+   "commit": "779d49c7db54590d1fa483ef2f89eea5ef8774e1",
+   "sha256": "19wjs67yc6gdfdjdrfav8m3w0rmyhdzfwq3hi2gcy6shyykm7s0i"
   }
  },
  {
@@ -111246,16 +111807,30 @@
   "repo": "wbolster/emacs-python-coverage",
   "unstable": {
    "version": [
-    20250601,
-    1621
+    20260706,
+    1541
    ],
    "deps": [
     "dash",
     "s",
     "xml+"
    ],
-   "commit": "ec1789b8cbbfd58b8f4f687c2e4efb7e30429643",
-   "sha256": "0hvschfsvj6wg00nab0c1kki9m74ii4zbnzmn6a46yqvnyxjy2qc"
+   "commit": "9e7af6999077ed3f861c5813297aee13804fcfb1",
+   "sha256": "1an8c18g7fpsz8rc0ds4ff0k9yxyw7xipyz4gcwgdlm1kchkhyns"
+  },
+  "stable": {
+   "version": [
+    1,
+    1,
+    0
+   ],
+   "deps": [
+    "dash",
+    "s",
+    "xml+"
+   ],
+   "commit": "9e7af6999077ed3f861c5813297aee13804fcfb1",
+   "sha256": "1an8c18g7fpsz8rc0ds4ff0k9yxyw7xipyz4gcwgdlm1kchkhyns"
   }
  },
  {
@@ -111409,11 +111984,11 @@
   "repo": "python-mode-devs/python-mode",
   "unstable": {
    "version": [
-    20260607,
-    1902
+    20260710,
+    1059
    ],
-   "commit": "4e2edae21655cf5d0559b1d7df23057ade20272c",
-   "sha256": "1ip3zy0jv8czygp0llclz3l7gx10q18a3gp8hhwl68l5ddv4vj5a"
+   "commit": "dbbfaa9bbfa1e330f4d9ec81b3793fbb2a297ecd",
+   "sha256": "1h1im4ph5n7799z6iax5bzxmad7m1qc9apgdb1hq8b7xqa0bd9hd"
   },
   "stable": {
    "version": [
@@ -111433,31 +112008,30 @@
   "repo": "wbolster/emacs-python-pytest",
   "unstable": {
    "version": [
-    20260117,
-    2218
+    20260630,
+    859
    ],
    "deps": [
     "dash",
     "s",
     "transient"
    ],
-   "commit": "78b5ea1d19c7e365ac00649d13c733954b11f822",
-   "sha256": "1s7slp14lrb4iik847ybk6dsqvcb4r1b50hx3pv3hn63rvpwc5jq"
+   "commit": "8c0e048a771f355903a8c2ce78fa0974a077214e",
+   "sha256": "06k1509nnzrffmkzz5shikz2msk6g0bb89v56fxf9w9prpb0nna3"
   },
   "stable": {
    "version": [
     3,
-    4,
+    6,
     0
    ],
    "deps": [
     "dash",
-    "projectile",
     "s",
     "transient"
    ],
-   "commit": "46fd006462258a3366723fafacdf2db6a6ae689d",
-   "sha256": "1ahpzay6gbxrcin4ldcp1sm17fcvg94n729haj3zgcalsmhjlx90"
+   "commit": "8c0e048a771f355903a8c2ce78fa0974a077214e",
+   "sha256": "06k1509nnzrffmkzz5shikz2msk6g0bb89v56fxf9w9prpb0nna3"
   }
  },
  {
@@ -111713,11 +112287,11 @@
   "repo": "ruediger/qrencode-el",
   "unstable": {
    "version": [
-    20260109,
-    2234
+    20260628,
+    2140
    ],
-   "commit": "023c61309e8f9e7b27fd28fe4d71a2217b2f3f9d",
-   "sha256": "0ivcdr89531yps6izk7fs7xqrz00m4b02c5rrbjalz33sj06ss41"
+   "commit": "7df905c77f590278d301679db354a3d7662407c9",
+   "sha256": "1vsj6vq003anbwhaqcfl4sswkn8zl6fazwyvy6dk1xf87nll6540"
   },
   "stable": {
    "version": [
@@ -111736,11 +112310,11 @@
   "repo": "K6SM/Emacs-QSO-Logger",
   "unstable": {
    "version": [
-    20250709,
-    1505
+    20260707,
+    1515
    ],
-   "commit": "33d3211748aa7e94f1aa187570beca8b9b2093d8",
-   "sha256": "033l5pg7bfc598xqniavwwlhlq488fzl92d17603c45f51v5yvff"
+   "commit": "a3b0d1f0b103cd00e0980637d75b6e3092d07b48",
+   "sha256": "0m2g5lbwi5kp54kldm13swwrgx3q126bqdax0ik9q45fv69x3q5c"
   }
  },
  {
@@ -111974,20 +112548,20 @@
   "repo": "jamescherti/quick-fasd.el",
   "unstable": {
    "version": [
-    20260114,
-    1535
+    20260701,
+    1254
    ],
-   "commit": "7f295404a9d5f93450c071e6226d8f52e574ab8b",
-   "sha256": "1b2hkvzisxdv46iyf5b3pfyw3s99v57klm5clscpwbzh8n4dnmza"
+   "commit": "40ac0f067b8c24ab4ac8283a9bf79655e586304f",
+   "sha256": "0yvd3za47s0ypv4ffc1rgp2y3zbb5jw0xbjzyh033c0d89js5r7j"
   },
   "stable": {
    "version": [
     1,
     0,
-    1
+    2
    ],
-   "commit": "fe0d6c611ec995e2f59b23d45af3b8b28244703b",
-   "sha256": "1fsl6l67jf8fm5h6i5qxqvibzssbiyyjzchq3r5sbqry3d8yx3mk"
+   "commit": "249334222d13b5ea6d4811833326358e8d0dd30a",
+   "sha256": "0662xmvikhfgcvivxb0m9d583ir1skj904i3sl5qq1cnn2a4hgcd"
   }
  },
  {
@@ -112281,14 +112855,14 @@
   "repo": "greghendershott/racket-mode",
   "unstable": {
    "version": [
-    20260303,
-    1556
+    20260626,
+    1429
    ],
    "deps": [
     "compat"
    ],
-   "commit": "24cb8e977a05d188756284e46ff7cece2d899f75",
-   "sha256": "00zvqsaav2hr1hllvv7nxbnb4yzkz64val46qp5rb4mf217rlqnz"
+   "commit": "97d9b8b7d73a02777c0f70ce6d145a99a99b37cb",
+   "sha256": "1rcflgpnl77wlhlcg6wikwaw39wyhn0n4fr3i43gypa04q3ih9f9"
   }
  },
  {
@@ -114731,14 +115305,14 @@
   "repo": "emacsorphanage/restclient",
   "unstable": {
    "version": [
-    20251209,
-    2022
+    20260627,
+    1851
    ],
    "deps": [
     "compat"
    ],
-   "commit": "1800a4e367c250051617d0b8c16a7cbd7f47da69",
-   "sha256": "02yphcli11j0p6144rwh7l5whx4ahxm3y15nz0b7r3y04fm25w6g"
+   "commit": "d280632df39a175dac06037038105e32945624be",
+   "sha256": "1v49has9ckn2rpjhfjds86vaaa4i0wnazz9061smaasqkf28r3i3"
   }
  },
  {
@@ -115430,14 +116004,14 @@
   "repo": "emacs-rime/rimel",
   "unstable": {
    "version": [
-    20260601,
-    323
+    20260706,
+    343
    ],
    "deps": [
     "liberime"
    ],
-   "commit": "149d0094200f6781b4fffab52bec80ac6783cb8c",
-   "sha256": "11ydjchrvhblm5idn7r5ysxhaw7nxhp04vdmajnhkyfkgq57ywhd"
+   "commit": "4d7bbad3e9b70fe0755174a79d5b7e59dfb6d3f7",
+   "sha256": "19rqq53akvrzdj74ajqvgb4dz1rmiqyivs9vcpaz43s56q00sa5c"
   },
   "stable": {
    "version": [
@@ -116722,11 +117296,11 @@
   "repo": "Anoncheg/emacs-russian-calendar",
   "unstable": {
    "version": [
-    20260623,
-    1009
+    20260716,
+    2030
    ],
-   "commit": "23d222041dba8e5dad07542e0dc7dd3fc8419112",
-   "sha256": "0hwhs8qx0jp45d39zzbg7ab0nb96v6wyb86hymsahdxp32yhaing"
+   "commit": "99077f02546a1a3619c46f95be926ceada155478",
+   "sha256": "1alk0v36jr3xbd0ykdq8kil35cqdjhcfczlnmwvdkn6ydy5igv3l"
   },
   "stable": {
    "version": [
@@ -117193,11 +117767,14 @@
   "repo": "thapakrish/samskritam.el",
   "unstable": {
    "version": [
-    20250829,
-    2315
+    20260701,
+    225
    ],
-   "commit": "e84358904b93c5c03d00b62f1e6735393d2b3d53",
-   "sha256": "1k2lsgn2zz82qpbz1ym9d69a008q3w5z7szszs1i2pz2cqwp4f91"
+   "deps": [
+    "transient"
+   ],
+   "commit": "30bbd177d2664c5a0d33f17b42c07705b8473b66",
+   "sha256": "0126jqcr9gjyd8sg0dmdg2j1pcgd55i7kxmrw81ysy6x586h3h1q"
   }
  },
  {
@@ -117405,26 +117982,26 @@
   "repo": "clojure-emacs/sayid",
   "unstable": {
    "version": [
-    20220101,
-    1357
+    20260717,
+    1435
    ],
    "deps": [
     "cider"
    ],
-   "commit": "879aff586336a0ec4d46c0ed4720fb1de22082bd",
-   "sha256": "013afdzz0rvb428pla78an052jvw2q95zzqvnq9z9w16y5yd1n0c"
+   "commit": "16fe77228cb3f76eee52d1be336a505f23a31223",
+   "sha256": "13gsvd11h5gq2ppgx9sk65vlcv3cgxj45br5izm3kjy6hy9hqbrg"
   },
   "stable": {
    "version": [
     0,
-    1,
+    8,
     0
    ],
    "deps": [
     "cider"
    ],
-   "commit": "985837897ca6f9bc5f1d1b1414ad15554a60d3b3",
-   "sha256": "0vdz3dxwi02an5k956apq3ah0dpzly9zd44fhmrqlcjimxc69m7p"
+   "commit": "16fe77228cb3f76eee52d1be336a505f23a31223",
+   "sha256": "13gsvd11h5gq2ppgx9sk65vlcv3cgxj45br5izm3kjy6hy9hqbrg"
   }
  },
  {
@@ -118041,19 +118618,19 @@
   "repo": "precompute/sculpture-themes",
   "unstable": {
    "version": [
-    20260215,
-    1259
+    20260701,
+    1308
    ],
-   "commit": "e5ac2c7b72ee58eb66510937270716d25484ecd6",
-   "sha256": "0137zqir9p1lfazs6n8qz0nw4vajawh7w1104psabrqm2izwpjz2"
+   "commit": "8fa20dc87a86ea4576debb38a75d71f1ee6ae273",
+   "sha256": "1mw1wf62jxs3nb84b9d4ziyn6xqj4g8skg9n1dpyw6yiy3ycaazj"
   },
   "stable": {
    "version": [
     1,
-    10
+    11
    ],
-   "commit": "e5ac2c7b72ee58eb66510937270716d25484ecd6",
-   "sha256": "0137zqir9p1lfazs6n8qz0nw4vajawh7w1104psabrqm2izwpjz2"
+   "commit": "8fa20dc87a86ea4576debb38a75d71f1ee6ae273",
+   "sha256": "1mw1wf62jxs3nb84b9d4ziyn6xqj4g8skg9n1dpyw6yiy3ycaazj"
   }
  },
  {
@@ -118380,11 +118957,11 @@
   "repo": "captainflasmr/selected-window-accent-mode",
   "unstable": {
    "version": [
-    20260326,
-    837
+    20260630,
+    801
    ],
-   "commit": "1ab6e720ee2c34035b5d0ab855c32d471f7ca849",
-   "sha256": "0avkn256njlzkn0hkr7l1rykcsrs8zgmpahnj6zm5z789200g7c2"
+   "commit": "57dfb3b4c65943f542eca322644cfa4d0731366c",
+   "sha256": "0b2r09jkpvcsj01cdw1cwajhlfvavbqk11fnsxcph2bbkin0a7yv"
   },
   "stable": {
    "version": [
@@ -118478,28 +119055,43 @@
   "repo": "radian-software/prescient.el",
   "unstable": {
    "version": [
-    20250816,
-    19
+    20260628,
+    2243
    ],
    "deps": [
     "prescient",
     "selectrum"
    ],
-   "commit": "87e2d2f2ddf24f591a5f70cc90d2afb4537caa18",
-   "sha256": "0f4wi8aq3yfykxfza4y4c5yhcs50cs3gpfj0qrmvfq9hvkhzj52w"
+   "commit": "5649977fa7789e4615efeca09397ed7eccd06dfc",
+   "sha256": "199150yng81f6n3kb120s37yf2dqs0i9k91f2gzkk8kjn6hvrsj8"
   },
   "stable": {
    "version": [
     6,
     3,
-    2
+    3
    ],
    "deps": [
     "prescient",
     "selectrum"
    ],
-   "commit": "87e2d2f2ddf24f591a5f70cc90d2afb4537caa18",
-   "sha256": "0f4wi8aq3yfykxfza4y4c5yhcs50cs3gpfj0qrmvfq9hvkhzj52w"
+   "commit": "5649977fa7789e4615efeca09397ed7eccd06dfc",
+   "sha256": "199150yng81f6n3kb120s37yf2dqs0i9k91f2gzkk8kjn6hvrsj8"
+  }
+ },
+ {
+  "ename": "sema-mode",
+  "commit": "be69ff027d4d11a3a4d87b190aa794fea638c079",
+  "sha256": "06k9mac5cdlxpay408221m4xhljcrxc12xyllyq4gqrb5xwvmc3q",
+  "fetcher": "github",
+  "repo": "sema-lisp/emacs-sema",
+  "unstable": {
+   "version": [
+    20260713,
+    653
+   ],
+   "commit": "296c970854225ffa2f1a9944835f07e40b5cd7b0",
+   "sha256": "1m0q874nzvp4rph5dkfv0whkalcgff2jnjnwyxikfi0n7w1bvq74"
   }
  },
  {
@@ -119069,11 +119661,11 @@
   "repo": "xenodesire/sexy-theme.el",
   "unstable": {
    "version": [
-    20250312,
-    1640
+    20260708,
+    327
    ],
-   "commit": "57cca02c067ded3964de6cf1566ef08cf5130189",
-   "sha256": "0qn0h309dqdi08bjfwdm1l0rpq1r2gzv88v2azwnnrxqldk2lkzs"
+   "commit": "eb747facb5916d8cbcac3e5d086317ce5e1ff341",
+   "sha256": "0kbjmz4lv9812qxl2d3q195833zyrb641p1kbfp4wbrkvy9jpgn3"
   }
  },
  {
@@ -119378,20 +119970,20 @@
   "repo": "xenodium/shell-maker",
   "unstable": {
    "version": [
-    20260609,
-    1823
+    20260713,
+    844
    ],
-   "commit": "43ee9e1862994cbaa89715d324edb7a424181f22",
-   "sha256": "0bdicj2bclx65n1lx1kwywfksbg1sd02yi03wrklbk56j82mk4ww"
+   "commit": "071c6df3ca22a2f4c0daa689848ac9bd21bf4e2b",
+   "sha256": "1bbh53hg1j6ic6pjjprl5y6h217f4zcj7z7pyyp5d75qv7m59f0v"
   },
   "stable": {
    "version": [
     0,
     93,
-    1
+    5
    ],
-   "commit": "43ee9e1862994cbaa89715d324edb7a424181f22",
-   "sha256": "0bdicj2bclx65n1lx1kwywfksbg1sd02yi03wrklbk56j82mk4ww"
+   "commit": "071c6df3ca22a2f4c0daa689848ac9bd21bf4e2b",
+   "sha256": "1bbh53hg1j6ic6pjjprl5y6h217f4zcj7z7pyyp5d75qv7m59f0v"
   }
  },
  {
@@ -119637,15 +120229,15 @@
   "repo": "ericprud/shexc-mode-for-emacs",
   "unstable": {
    "version": [
-    20260622,
-    2327
+    20260705,
+    2334
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "06cf27aedda3fdeb44d20b78d081a3f5d696dca6",
-   "sha256": "0kfn89sr2pv4b2c9vms5vzrp1h47afv0ndk5p5rrgv80wmfzd5fz"
+   "commit": "d113ddc322a7cca2ef92ee6af95e5755af429ccb",
+   "sha256": "0xzfzcc43skcgqm8h9g6c6bnd1qbadd7q7q0sakczal66ndwvrnb"
   },
   "stable": {
    "version": [
@@ -120249,14 +120841,14 @@
   "repo": "emacs-sideline/sideline",
   "unstable": {
    "version": [
-    20260101,
-    540
+    20260716,
+    349
    ],
    "deps": [
     "ht"
    ],
-   "commit": "b4ada1ddf7da96c2e87453130f6ff7b7d577810f",
-   "sha256": "1kw3294cz43425zmayv7jsfy9q9466jirdkyfagfh27v20bcp6vy"
+   "commit": "247cd6f6a0a841c5da20b3cc179d77c118641d66",
+   "sha256": "1ab9vhak97qkprg2ayh6s9p4isbiq8glbgvgf1an768cpzlky67y"
   },
   "stable": {
    "version": [
@@ -120861,14 +121453,14 @@
   "repo": "captainflasmr/simply-annotate",
   "unstable": {
    "version": [
-    20260624,
-    534
+    20260630,
+    653
    ],
    "deps": [
     "transient"
    ],
-   "commit": "ab87e4fb0c9cf7f86af7bf63103dd81988da907b",
-   "sha256": "0za13vdjrmi207zgpcwdway2faaynq99nf9f7yqymvvpgzkf8978"
+   "commit": "330c6b4014dcb42526b7a76affed345b1aba8b89",
+   "sha256": "0xa82hl582plg47ash7ivs05l4yfhbnyax8d1k9640lr7a4nfvss"
   },
   "stable": {
    "version": [
@@ -120942,11 +121534,11 @@
   "repo": "laishulu/emacs-smart-input-source",
   "unstable": {
    "version": [
-    20251208,
-    853
+    20260711,
+    608
    ],
-   "commit": "515e1dbe0180f33c292660b4b70d02d47153be5b",
-   "sha256": "1gd9zribaif3kdaja2csbhc1a05vh6bjxqfm4qlk4bvw88ldqv0b"
+   "commit": "7ca3e115f159f22ddb4bcea85a22246ee03c422c",
+   "sha256": "1s8sy3vv55hh63rrpprd24p934lmvll2m5wspwfi2pibvx9jajkv"
   }
  },
  {
@@ -120957,8 +121549,8 @@
   "repo": "magit/sisyphus",
   "unstable": {
    "version": [
-    20260601,
-    1544
+    20260620,
+    1659
    ],
    "deps": [
     "compat",
@@ -120967,8 +121559,8 @@
     "llama",
     "magit"
    ],
-   "commit": "4c88989715f2c347714e9cad26b03789e2b68143",
-   "sha256": "0mpclwvygn28qk0xabz8fmjmiha4v8dk8k2z2vi5fgj8zrdmbm1k"
+   "commit": "dd4ae5d52c9d862c2ebeb1c72422ba0f6e22e62b",
+   "sha256": "13sgw5z0ww14ff7rnzd248a2d19rpkyhw8p222fgh59nri1n7dfm"
   },
   "stable": {
    "version": [
@@ -121227,8 +121819,8 @@
   "repo": "emacs-slack/emacs-slack",
   "unstable": {
    "version": [
-    20260611,
-    2247
+    20260716,
+    1645
    ],
    "deps": [
     "alert",
@@ -121240,8 +121832,8 @@
     "ts",
     "websocket"
    ],
-   "commit": "06a1fe9041e1aadf293692036ad522a6f808e2fc",
-   "sha256": "1zrwvk00mkx5xiy3an6j8mkpbikq7qiilh940k8y6304rrzc72dx"
+   "commit": "93be9f2a47a576e300568fb82b6d5db53b9f200b",
+   "sha256": "0var54x5r8db5vppsg7lq5badzy7sbqj87zg4cjjsks4fwmil8b6"
   }
  },
  {
@@ -121252,20 +121844,20 @@
   "repo": "abidanBrito/sleek-modeline",
   "unstable": {
    "version": [
-    20260622,
-    2257
+    20260712,
+    2128
    ],
-   "commit": "882b440a816865d8db622f9722a6fb71d5ea1e27",
-   "sha256": "1v20k8gxlrzb4g4lc92mh4qjb6q66z8jjvgh44124nh0jkdags70"
+   "commit": "e5981c02498f4922f220f16f062f91512a5c406d",
+   "sha256": "1hj0b6gyf56lf0dcambdasg068z2i6jja3w3m6fb6k01cxdppjc2"
   },
   "stable": {
    "version": [
     1,
-    0,
+    1,
     0
    ],
-   "commit": "ac3335237397d01cddc4d9534e9da682e733d849",
-   "sha256": "1q3gb61h0xkdxvvpgjmf79z9raw4fwj4xd0973l03840ava4kanb"
+   "commit": "e5981c02498f4922f220f16f062f91512a5c406d",
+   "sha256": "1hj0b6gyf56lf0dcambdasg068z2i6jja3w3m6fb6k01cxdppjc2"
   }
  },
  {
@@ -121323,14 +121915,14 @@
   "repo": "slime/slime",
   "unstable": {
    "version": [
-    20260612,
-    2309
+    20260719,
+    420
    ],
    "deps": [
     "macrostep"
    ],
-   "commit": "b38be925a128dc3d6524121692988cb900fbcbf8",
-   "sha256": "0cby3xcpzgf07miwxpvxq0gnx3gfcyfxvjkqy1y1nl3xzizbl3yn"
+   "commit": "055c1c98c2b7791162b0e8c994051a7d72208dc1",
+   "sha256": "0scijga623w7q0hx04dl9lybvd3pvp2pvz51fwfn3gxgc64ip7pd"
   },
   "stable": {
    "version": [
@@ -122231,19 +122823,19 @@
   "repo": "mickeynp/smart-scan",
   "unstable": {
    "version": [
-    20170211,
-    2033
+    20260710,
+    1518
    ],
-   "commit": "234e077145710a174c20742de792b97ed2f965f6",
-   "sha256": "1nzkgfr1w30yi88h4kwgiwq4lcd0fpm1cd50gy0csjcpbnyq6ykf"
+   "commit": "5e283b92b5c5826e194043b0314e0d6d88a94a62",
+   "sha256": "0dxbwxl3280700my2rcpxga2z4aqs1xqivinr91ia9n0w2jgad31"
   },
   "stable": {
    "version": [
     0,
-    2
+    3
    ],
-   "commit": "13c9fd6c0e38831f78dec55051e6b4a643963176",
-   "sha256": "1sd7dh9114mvr4xnp43xx4b7qmwkaj1a1fv7pwc28fhiy89d2md4"
+   "commit": "5e283b92b5c5826e194043b0314e0d6d88a94a62",
+   "sha256": "0dxbwxl3280700my2rcpxga2z4aqs1xqivinr91ia9n0w2jgad31"
   }
  },
  {
@@ -123324,11 +123916,11 @@
   "repo": "mssola/soria",
   "unstable": {
    "version": [
-    20250703,
-    508
+    20260702,
+    1424
    ],
-   "commit": "65581530155b097fc314a19b2851a7dffcfd3790",
-   "sha256": "0142sa6dxlj77f629xp8724fja1378hjqp2k5mw7zkmjfj2finj4"
+   "commit": "bd83db9f83dff1cc717f9a6b4a2feab05031458a",
+   "sha256": "1s5iz6fzbf91cabhvgdhpkbq1kr7s4cvw3gzm9l93vysbggnbgyy"
   },
   "stable": {
    "version": [
@@ -123880,11 +124472,11 @@
   "repo": "ideasman42/emacs-spatial-navigate",
   "unstable": {
    "version": [
-    20260614,
-    1125
+    20260705,
+    40
    ],
-   "commit": "8b3e31be5a16657dc875d3ea248f907c75f8244f",
-   "sha256": "0mg7vllcyjwq3v34fdrfc902riap6aiphqpwa8dz2f1zhsvc55jf"
+   "commit": "358337ddaef449ad0f1c6b9ab29f99db363ab319",
+   "sha256": "0p8arfa19jq1i7cqd6hz5cld9c976ig4zmz5zdwsvjz9hr2s0aj7"
   }
  },
  {
@@ -123925,11 +124517,11 @@
   "repo": "condy0919/spdx.el",
   "unstable": {
    "version": [
-    20260529,
-    230
+    20260717,
+    154
    ],
-   "commit": "f67824080cb48b4e54c3930319a3ed944f6a5c66",
-   "sha256": "113k0ljwmqdwcaqp3xq7qxy1m7dgjrxabycby8iz7ysdcymcfx9b"
+   "commit": "e839ca0184713dd954aba57d59c618b7afdb678e",
+   "sha256": "04k4jmxx0znh605nzlqkfr9zv2xi0djhp123zgik09zcqdh68hc6"
   }
  },
  {
@@ -124733,11 +125325,11 @@
   "repo": "srfi-explorations/emacs-srfi",
   "unstable": {
    "version": [
-    20260623,
-    2303
+    20260719,
+    56
    ],
-   "commit": "cf83bdcfabfb06e0171f5f7a83d56d5fea72fd84",
-   "sha256": "0l9gk0i1p3cbrc6hi0w8cl9r5831qnqvr382ldqiyp8b7mdj3jv2"
+   "commit": "4b8e56ce6545de9b33ddb841f535c5f1ec301e00",
+   "sha256": "0qmn8fr9d1bk0pgfsq4p9y0lw0f1209pwyi4pz37r8za7xfpyld8"
   },
   "stable": {
    "version": [
@@ -124749,6 +125341,36 @@
    ],
    "commit": "98b8b1f9edd4ce6a05eeef49bed0d1966bd7c528",
    "sha256": "1il0z6lb2jz495gdp6g7wc0n9a4z8z8ndhrrl71rnws53fah0lm3"
+  }
+ },
+ {
+  "ename": "srs",
+  "commit": "201754208a9e4d7db2ad88f8672dddb865c53fa1",
+  "sha256": "1p1grz3wy9znqw2zblqxmspx3sxzc8mqn7ja63f8p8vs9rsr8n9k",
+  "fetcher": "github",
+  "repo": "Duncan-Britt/srs.el",
+  "unstable": {
+   "version": [
+    20260716,
+    2238
+   ],
+   "deps": [
+    "transient"
+   ],
+   "commit": "72b3db068a3b7a5e0a3f02d5f24434bec984225f",
+   "sha256": "1s9pv9y2hlgnwj8yr0f2n7c99cdybg7a63c5rqm86dgfpq03lxp0"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    1
+   ],
+   "deps": [
+    "transient"
+   ],
+   "commit": "57cf956a746c2f948b801514f62a55a97fb3ef22",
+   "sha256": "02jzidpc56pw54pf2781i4rsgbw7kcbhha2m1p3a1pkrbxjjpyxz"
   }
  },
  {
@@ -124847,11 +125469,11 @@
   "repo": "peterhoeg/ssh-config-mode-el",
   "unstable": {
    "version": [
-    20260108,
-    2149
+    20260706,
+    1430
    ],
-   "commit": "f21726d6f44a0e769a15f0a94620078a326774f7",
-   "sha256": "0y8m7j2bwg4v2xbwfbdhfsxah47yfydyh61wybl5akmiwgm6101p"
+   "commit": "a171e48c3cef777556961323d4dd6172a94be0f1",
+   "sha256": "0pvm1hh3946y59xd70p687rnyl3c0qd7dxsmjy1x8fbwkqby9sd8"
   }
  },
  {
@@ -125378,28 +126000,28 @@
   "repo": "beacoder/stock-tracker",
   "unstable": {
    "version": [
-    20250206,
-    814
+    20260713,
+    303
    ],
    "deps": [
     "async",
     "dash"
    ],
-   "commit": "51963a654a1199ec23f0938c247b1411fee85c6f",
-   "sha256": "12aipdqhx2pfgas0c3m4i1z0p45vrrld4c6ahnx9qgp4nig9b2bh"
+   "commit": "d3482bf03e738d70396412e2437da534b9059176",
+   "sha256": "0872lhnya5lyv57pn530yi2gbrrbzsf4a8ihpkc905z0gzw0kh34"
   },
   "stable": {
    "version": [
     0,
-    1,
-    6
+    2,
+    0
    ],
    "deps": [
     "async",
     "dash"
    ],
-   "commit": "58018a1747273df23dec08ec5d318da1960428c1",
-   "sha256": "0jbj24pbc07gjb6zk29yzjrd80c4aaqfp2mffc4qqisws0f8gfvb"
+   "commit": "d3482bf03e738d70396412e2437da534b9059176",
+   "sha256": "0872lhnya5lyv57pn530yi2gbrrbzsf4a8ihpkc905z0gzw0kh34"
   }
  },
  {
@@ -125614,11 +126236,11 @@
   "repo": "jamescherti/stripspace.el",
   "unstable": {
    "version": [
-    20260604,
-    232
+    20260715,
+    1824
    ],
-   "commit": "c8a53e2bce4347f5d6d8ae8d3050e3bbf3f96562",
-   "sha256": "1yfc0fwzpfi08p50ymmi3g8s947hdzdf42g0kic519rp4g9bd5cg"
+   "commit": "35e6e86195a1192822ed13090b60426d4a768d95",
+   "sha256": "0b8djf24rz2dvfv6i5z2588cvnawwv60fwy97483m5iafwardk0z"
   },
   "stable": {
    "version": [
@@ -126023,8 +126645,8 @@
   "repo": "kiyoka/Sumibi",
   "unstable": {
    "version": [
-    20260612,
-    324
+    20260719,
+    559
    ],
    "deps": [
     "deferred",
@@ -126032,13 +126654,13 @@
     "popup",
     "unicode-escape"
    ],
-   "commit": "f5674b69135a49aa3d531d148609942e0b09913b",
-   "sha256": "0m2v9wj9yvrkifg953p1w7gm7hgdav4jrs4g6vsp8l3jxfac6grj"
+   "commit": "9b191439bdaa0f6a36ad95429e725d096d564096",
+   "sha256": "0rg6la4fq6m3j2blvscg4kwc32s7va7a10ar825jnsdg5cxriqn3"
   },
   "stable": {
    "version": [
     6,
-    1,
+    2,
     0
    ],
    "deps": [
@@ -126047,8 +126669,8 @@
     "popup",
     "unicode-escape"
    ],
-   "commit": "de689010700597076adad241411a19255cfcdc6d",
-   "sha256": "1fjlx9rzzvjm7jj0m9mrryzsfhii5hbja392z3sgrbd697abaw9i"
+   "commit": "9b191439bdaa0f6a36ad95429e725d096d564096",
+   "sha256": "0rg6la4fq6m3j2blvscg4kwc32s7va7a10ar825jnsdg5cxriqn3"
   }
  },
  {
@@ -126871,14 +127493,14 @@
   "repo": "wolray/symbol-overlay",
   "unstable": {
    "version": [
-    20260423,
-    1454
+    20260703,
+    1437
    ],
    "deps": [
     "seq"
    ],
-   "commit": "253b957f5082603708b469d02ae8c31c58292823",
-   "sha256": "18w7qa959na5c9rvjarrnmb3l63pdfrfv865i3nb6lx7ap6iw2jc"
+   "commit": "85d100b0cca35b70cee1b260e09af8e1fb2fcc08",
+   "sha256": "1d26wzd3bla1sqwsly1ldlzxp24z3nrr6zf8rfzxip90b6wpk3yv"
   },
   "stable": {
    "version": [
@@ -127006,6 +127628,24 @@
    ],
    "commit": "056d1a473e36992ff5881e5ce6fdc331cead975f",
    "sha256": "030bglxnvrkf1f9grbhd8n11j4c6sxpabpjdr1ryx522v01fvx8j"
+  }
+ },
+ {
+  "ename": "synaxis",
+  "commit": "07e0e048519b8bcc834c5712d3a95d03683fc5fe",
+  "sha256": "1gqd69z3vs2y86y20qyqvik3sbhfwgras54n9wdi34raxpjcgjx7",
+  "fetcher": "git",
+  "url": "https://git.thanosapollo.org/synaxis",
+  "unstable": {
+   "version": [
+    20260713,
+    1937
+   ],
+   "deps": [
+    "keymap-popup"
+   ],
+   "commit": "fd0272e9a9dde9e31d592348638f62bcb3baebfe",
+   "sha256": "163d6qb3y3vpy72616pymhsriln9rrzawv1rcdf5iaf814qv1sah"
   }
  },
  {
@@ -127633,20 +128273,20 @@
   "repo": "isamert/tabgo.el",
   "unstable": {
    "version": [
-    20250103,
-    1740
+    20260624,
+    1540
    ],
-   "commit": "23b6397fd61db31689feacb4b7df2b1f64e69572",
-   "sha256": "13d72g9h33a8gkrw76nz6dzpalj91pp17707mqwz6zn0miyyzx9d"
+   "commit": "7cf1142c3e194ded79632846830775b42830ce51",
+   "sha256": "1yzpmfggsq96nffqmxq6zzrfkdnxawrr5qngl51mixlw9pcks573"
   },
   "stable": {
    "version": [
     1,
     0,
-    1
+    2
    ],
-   "commit": "23b6397fd61db31689feacb4b7df2b1f64e69572",
-   "sha256": "13d72g9h33a8gkrw76nz6dzpalj91pp17707mqwz6zn0miyyzx9d"
+   "commit": "7cf1142c3e194ded79632846830775b42830ce51",
+   "sha256": "1yzpmfggsq96nffqmxq6zzrfkdnxawrr5qngl51mixlw9pcks573"
   }
  },
  {
@@ -127957,11 +128597,11 @@
   "repo": "saf-dmitry/taskpaper-mode",
   "unstable": {
    "version": [
-    20260517,
-    1410
+    20260715,
+    1341
    ],
-   "commit": "93a3c5fc3dde0c32f7a3b2ad313cb00d5660c5df",
-   "sha256": "0sq3mm4hf5sfmaqxnk37qd4w0d2bysm62nvi7fkkx13z0z8haai1"
+   "commit": "0f8747a8736a6e1bff6cc401144799bdef0e69ed",
+   "sha256": "0cwv9s3ss990c26ilp88hb762zv6g221xm0wjhgs4k6jbcn05bi4"
   },
   "stable": {
    "version": [
@@ -128163,15 +128803,15 @@
   "repo": "zevlg/telega.el",
   "unstable": {
    "version": [
-    20260624,
-    630
+    20260711,
+    827
    ],
    "deps": [
     "transient",
     "visual-fill-column"
    ],
-   "commit": "7cef62c2e7b9cca9467fe9da80544d0210d9c6e1",
-   "sha256": "108cgzqq7ccg8msydmbi30sy9w7ipp4lb189q7p7r1iwpf38nb15"
+   "commit": "fc6a4d1ec6edba6b3c65b3f069cce0398c2fb7a5",
+   "sha256": "1lcv7nq08llr8s0yhjbaj33lk169nyn60ldrmvjkbdra8qzy9chp"
   },
   "stable": {
    "version": [
@@ -128302,25 +128942,25 @@
   "repo": "minad/tempel",
   "unstable": {
    "version": [
-    20260609,
-    1545
+    20260705,
+    1258
    ],
    "deps": [
     "compat"
    ],
-   "commit": "0cfeac15a3c92373d41a743d00a5cb9368eaa006",
-   "sha256": "1kb873jr7664mb9i0k8y2x9akywnic3j2pk0sj9rxychzpb9f3p6"
+   "commit": "c5fdc3806b486d9d86a54c50efac3d4a141e789d",
+   "sha256": "1vy53i1rpzhx644qhwm2vbb3z4z00wrc2127zfd3i08h8dlck3r0"
   },
   "stable": {
    "version": [
     1,
-    13
+    14
    ],
    "deps": [
     "compat"
    ],
-   "commit": "ab6d67c2e8abcb9bd20bfe56cba930a5ea093ae0",
-   "sha256": "0pn9a7rl8mqyyy63r284afjv26kqj8qk2v2sk7nkvcb3d98l8qr6"
+   "commit": "c5fdc3806b486d9d86a54c50efac3d4a141e789d",
+   "sha256": "1vy53i1rpzhx644qhwm2vbb3z4z00wrc2127zfd3i08h8dlck3r0"
   }
  },
  {
@@ -128492,10 +129132,10 @@
  },
  {
   "ename": "tengo-mode",
-  "commit": "9ae2528b4322ed892d54e61a2c7c086a028aeab1",
-  "sha256": "1c1c4lmilr7d1688df0ykn1j2gjg5n2sa942pr957fr2q0vay75n",
+  "commit": "7a51fd6e6eb4485d7add6216b690c19897bbfa6a",
+  "sha256": "1bll91n7x0dgxs78r49rx8k5fpsrqi9b2dy2da2w7llmk62klsmn",
   "fetcher": "github",
-  "repo": "CsBigDataHub/tengo-mode",
+  "repo": "ChetanKoneru/tengo-mode",
   "unstable": {
    "version": [
     20260125,
@@ -129629,21 +130269,21 @@
   "repo": "facebook/fbthrift",
   "unstable": {
    "version": [
-    20260622,
-    1358
+    20260713,
+    813
    ],
-   "commit": "72ab4f622ea110381e11f8a9981d863e5cbe5735",
-   "sha256": "1y3993xznrsmqwy3jsnjv4l2cmcwbk2n310y7h9pf6m9pwbwla1d"
+   "commit": "fe08f6c48479e1f851390b0c88e6c5644a4e9ff6",
+   "sha256": "13fbxpzlysvj95y72a57hlkprkq3cmzg5if26fhzncc12359hfyq"
   },
   "stable": {
    "version": [
     2026,
-    6,
-    22,
+    7,
+    13,
     0
    ],
-   "commit": "72ab4f622ea110381e11f8a9981d863e5cbe5735",
-   "sha256": "1y3993xznrsmqwy3jsnjv4l2cmcwbk2n310y7h9pf6m9pwbwla1d"
+   "commit": "fe08f6c48479e1f851390b0c88e6c5644a4e9ff6",
+   "sha256": "13fbxpzlysvj95y72a57hlkprkq3cmzg5if26fhzncc12359hfyq"
   }
  },
  {
@@ -129725,26 +130365,26 @@
   "repo": "uzu/tidal",
   "unstable": {
    "version": [
-    20260607,
-    1559
+    20260702,
+    630
    ],
    "deps": [
     "haskell-mode"
    ],
-   "commit": "864b8cc18efc2e999e65e676a5ec1670dbd186e9",
-   "sha256": "1jflb3jqq6jafnvdj810zi37iznihf38i29y2br3pxjfwwv5265s"
+   "commit": "5ae655255d87c983a596f398a0385b21df97df3b",
+   "sha256": "0c51zyqbyly8h7zwxnxc9sbfx3md170y0ckpvrsmycq0kwgs0mm0"
   },
   "stable": {
    "version": [
     1,
     10,
-    2
+    3
    ],
    "deps": [
     "haskell-mode"
    ],
-   "commit": "864b8cc18efc2e999e65e676a5ec1670dbd186e9",
-   "sha256": "1jflb3jqq6jafnvdj810zi37iznihf38i29y2br3pxjfwwv5265s"
+   "commit": "5ae655255d87c983a596f398a0385b21df97df3b",
+   "sha256": "0c51zyqbyly8h7zwxnxc9sbfx3md170y0ckpvrsmycq0kwgs0mm0"
   }
  },
  {
@@ -129939,11 +130579,11 @@
   "repo": "xenodium/time-zones",
   "unstable": {
    "version": [
-    20260518,
-    1503
+    20260716,
+    845
    ],
-   "commit": "4ec11f912d8af920d021c6189e59ab74fd404a2d",
-   "sha256": "0b12ql9l2xp2ab83d0s1bvidw8hmcrym3xdpjxi92lyslkg8gcaa"
+   "commit": "4cc37a54ba6447dc0570cd2e42052689d94f09ee",
+   "sha256": "0xajsx2363sj6shqv8nwbvcr4z2sq6pa4j7rbncn79qlq8wr26l4"
   },
   "stable": {
    "version": [
@@ -130862,11 +131502,11 @@
   "repo": "jamescherti/tomorrow-night-deepblue-theme.el",
   "unstable": {
    "version": [
-    20260614,
-    1718
+    20260710,
+    1611
    ],
-   "commit": "ae24e3672e8832579052ce124d0c3b05ca835e16",
-   "sha256": "0jsd0p34ppl7wgyxcww0hk641h9c5jfiymqyqrhlpr4k2lv5yg46"
+   "commit": "38e601d69e5741463e6d725100234d0c6e3e5741",
+   "sha256": "04xx9dyj2ps3lb7x72i0g41ld4p59cghzb35wvgp6cp5g199ksnm"
   },
   "stable": {
    "version": [
@@ -131450,8 +132090,8 @@
   "repo": "magit/transient",
   "unstable": {
    "version": [
-    20260617,
-    1137
+    20260701,
+    1255
    ],
    "deps": [
     "compat",
@@ -131459,22 +132099,23 @@
     "llama",
     "seq"
    ],
-   "commit": "9d103f338fb9fd4506a0f1651c483209ab838f49",
-   "sha256": "1891ly16nc0fp46i4g79yz3p7is12ckcm8jbibm3ps3bbgkcqshj"
+   "commit": "3d20a780605f0a33d6360dc0a2ce9174c69a9a92",
+   "sha256": "0893jfiqqyxc54hbzspkp5mhfzj7s1nkdfdmrp590g559blcjhmg"
   },
   "stable": {
    "version": [
     0,
     13,
-    4
+    5
    ],
    "deps": [
     "compat",
     "cond-let",
+    "llama",
     "seq"
    ],
-   "commit": "1856230dc181f23dd15026b0ad21d8b299b034d1",
-   "sha256": "097fchxjs7wm0q2yngpnxk5lrscaxxbbnnkv1h19jbzysafpbgyc"
+   "commit": "3d20a780605f0a33d6360dc0a2ce9174c69a9a92",
+   "sha256": "0893jfiqqyxc54hbzspkp5mhfzj7s1nkdfdmrp590g559blcjhmg"
   }
  },
  {
@@ -131750,28 +132391,28 @@
   "repo": "tarsius/tray",
   "unstable": {
    "version": [
-    20260601,
-    1523
+    20260701,
+    1300
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "2d3368d4dd70da4f9d7c5aec8468c97054dc8234",
-   "sha256": "100n2slsccmjxaz1dppzjg93a0qm6hbmw08crwjivja6f65arp29"
+   "commit": "0e6f331dd7fcef6a591c4954808a6b262522fa40",
+   "sha256": "1cz9f22ln823zpnh0fba3nmcs3qj3wxl1sb9kdi3phmbhxyhjq38"
   },
   "stable": {
    "version": [
     0,
-    1,
-    9
+    2,
+    0
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "2d3368d4dd70da4f9d7c5aec8468c97054dc8234",
-   "sha256": "100n2slsccmjxaz1dppzjg93a0qm6hbmw08crwjivja6f65arp29"
+   "commit": "0e6f331dd7fcef6a591c4954808a6b262522fa40",
+   "sha256": "1cz9f22ln823zpnh0fba3nmcs3qj3wxl1sb9kdi3phmbhxyhjq38"
   }
  },
  {
@@ -131929,26 +132570,26 @@
   "repo": "emacs-tree-sitter/tree-sitter-langs",
   "unstable": {
    "version": [
-    20260615,
-    1631
+    20260719,
+    1913
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "b344c86eb4fb3bbe1f30e7684fea130dbcbf32a8",
-   "sha256": "15vf7p4vd1axyk31hv5nhvjmvdd3b9069bli04ggazh0xqhkb0mw"
+   "commit": "7a2b658586ad2108ff90fc978af1c4a33a44e07a",
+   "sha256": "1sik64yq1gv8rv4qhdlai40p1qck35yhb2vjvrbj8a87i2r5q97a"
   },
   "stable": {
    "version": [
     0,
     13,
-    63
+    73
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "d7473e6c322b96de95d40401dbad7841f116bedf",
-   "sha256": "1xv3lhigdma8kslw7f2z6klj695r89z125f66zwdad3rk5xd9487"
+   "commit": "7a2b658586ad2108ff90fc978af1c4a33a44e07a",
+   "sha256": "1sik64yq1gv8rv4qhdlai40p1qck35yhb2vjvrbj8a87i2r5q97a"
   }
  },
  {
@@ -132870,11 +133511,11 @@
   "repo": "wmedrano/ttx-mode",
   "unstable": {
    "version": [
-    20260504,
-    1858
+    20260628,
+    418
    ],
-   "commit": "11720c3623e38b054967653278d18ab480609213",
-   "sha256": "0yrs8x2mmlwva35g9ymj5fzlm2s318461fq2waj1a14c2vw4z7q1"
+   "commit": "58f4d4b2de51cfc47f3320c88fdb679ac8df6758",
+   "sha256": "05l1ishm3cja05dx0g6w10ilya7161cxp0fd6ng9zkxasv82jdwg"
   }
  },
  {
@@ -132885,26 +133526,20 @@
   "repo": "ocaml/tuareg",
   "unstable": {
    "version": [
-    20260617,
-    1454
+    20260626,
+    936
    ],
-   "deps": [
-    "caml"
-   ],
-   "commit": "7d4dd535e3f4bed2013bad545629302d07ba991e",
-   "sha256": "10x3zvjm81r5bk8fw8lbxq738j0p15g0yjfxgxjanms0mrbwj2bp"
+   "commit": "2d67d53a66fbf9d83c0416dba3275080b1bc6dfd",
+   "sha256": "10k810kw3mijqprnky15id39hzzwcqwlxmlyjp5m817mslmkwnii"
   },
   "stable": {
    "version": [
     3,
-    0,
-    1
+    1,
+    0
    ],
-   "deps": [
-    "caml"
-   ],
-   "commit": "4d94293cc5a7bba6cd043e29968719ce597d65f5",
-   "sha256": "1p3xpk78i8ywgdmc59w05wjjy9dg6gm5gicm08szmrlnx08v2ihm"
+   "commit": "29ed86896e24c9d9d9855cf05ab7a6166a030250",
+   "sha256": "0gmgxqy0x3318gpwb8bjr5f53mv9xy3psrcz1h9c4xqrc189lm68"
   }
  },
  {
@@ -133676,11 +134311,11 @@
   "repo": "jamescherti/ultisnips-mode.el",
   "unstable": {
    "version": [
-    20260601,
-    1617
+    20260628,
+    1957
    ],
-   "commit": "39df8b78d4a9450cec5acbd74eb82b7372e28b73",
-   "sha256": "0rynfikr47afa5nd0npk1b6q69fym7l0mqb7abivkipg2zz3ysn7"
+   "commit": "3fc59835f6407fb60bb9935a63fc0479f8807f37",
+   "sha256": "13rn768inw0mnxp75plc981dm46vi9p8c0bckb8q8p2f0iy6rdsc"
   },
   "stable": {
    "version": [
@@ -134272,14 +134907,14 @@
   "repo": "tbanel/uniline",
   "unstable": {
    "version": [
-    20260619,
-    1103
+    20260718,
+    1006
    ],
    "deps": [
     "hydra"
    ],
-   "commit": "eaff70c71f17c85d3d26dd2c1dbf466b21c6c085",
-   "sha256": "1x8lw3pyp05fqsjrnyy0yd122m1dhnw089f9rmyka32g3kwk0hjs"
+   "commit": "35983966dc850cec03d37d3d98ff8fddd8f1d099",
+   "sha256": "0qmkr4a76hxxs8vm1fxrd2dahk7y6imympd8myd8m36rpx6110sn"
   }
  },
  {
@@ -134335,11 +134970,11 @@
   "repo": "fmguerreiro/unison-ts-mode",
   "unstable": {
    "version": [
-    20260525,
-    909
+    20260720,
+    619
    ],
-   "commit": "31bbb4fbcba02075cebcdedb05d29568420bac9f",
-   "sha256": "0bip87ld0dz2l48izbhmy88bwh1fsb1j1cwj6nkpcmy0nmji0pa7"
+   "commit": "d46a659e2a884bd843da16b21b605755a2c3444f",
+   "sha256": "0nqynakmyr31am5zpnvvx4r866vxlivjxlnjrmp0nvb8ixxzybix"
   },
   "stable": {
    "version": [
@@ -135154,11 +135789,11 @@
   "repo": "kborling/uwu-theme",
   "unstable": {
    "version": [
-    20250902,
-    202
+    20260703,
+    1803
    ],
-   "commit": "430e06214e8230357bea8252e8a56c5c1aa8f3eb",
-   "sha256": "175d83yzhv84ib92dxhiy2b4dndiynis60kmcnffbwwb4j5pxra1"
+   "commit": "10b07fae92e2b28d7f3948e5feba0e3172123370",
+   "sha256": "1jc1inzs2v4m8sgxmwv06xh5ddhzy0j5y51yixnrqzygz56cswcn"
   }
  },
  {
@@ -135551,20 +136186,20 @@
   "repo": "tarsius/vcomp",
   "unstable": {
    "version": [
-    20260616,
-    2212
+    20260701,
+    1247
    ],
-   "commit": "7b3f93d1202bd9353ee6401c47fbc3cc0d6d76e3",
-   "sha256": "116h3n0j5m0mi7c4qz1axjy4yvwh833bnj2s8crhcrzc2ppr20yz"
+   "commit": "ba2d07505dc29e3128ea915bb252969b82d2af08",
+   "sha256": "133fp6fpvh8a1kp8n5iv94yybs87x2i69fk4j8nvazsaiandfs4w"
   },
   "stable": {
    "version": [
     1,
     2,
-    0
+    1
    ],
-   "commit": "2227de68c2fc4d7a029bd30d188422429bb18d28",
-   "sha256": "0w8z683sq1bq89vlypqbg5dzb5n1p6zhj0ci07flnr7gqcicg5fw"
+   "commit": "ba2d07505dc29e3128ea915bb252969b82d2af08",
+   "sha256": "133fp6fpvh8a1kp8n5iv94yybs87x2i69fk4j8nvazsaiandfs4w"
   }
  },
  {
@@ -135867,11 +136502,11 @@
   "repo": "federicotdn/verb",
   "unstable": {
    "version": [
-    20260617,
-    1912
+    20260708,
+    1918
    ],
-   "commit": "25a25456bb9ef5090d80105aaa8ad931f336a06e",
-   "sha256": "16s7va3d7wqbqipkh3nsqsw4vkpdy3bi9qq85a9w93wx113s0sqv"
+   "commit": "ef09a5804cac4816ca9a0d1fb9c71c8ed3d3df8f",
+   "sha256": "0cli080ndalc7xc96f017xk6b5b00hfz0831r64jx8ci9xscwr5a"
   },
   "stable": {
    "version": [
@@ -135996,44 +136631,42 @@
   "repo": "gmlarumbe/verilog-ext",
   "unstable": {
    "version": [
-    20260608,
-    1712
+    20260716,
+    1137
    ],
    "deps": [
-    "ag",
     "apheleia",
     "async",
     "flycheck",
     "hydra",
     "lsp-mode",
-    "ripgrep",
+    "rg",
     "verilog-mode",
     "verilog-ts-mode",
     "yasnippet"
    ],
-   "commit": "000ed01eaeca1c3001874f1c8a6835a55d7b8b71",
-   "sha256": "125awjdw2dq7ywja2z07dzmlzw4552b7y6gg589nxklmpfmfjbsn"
+   "commit": "f4c65a24724cd2d1eeb1e21ec10c9cee4bfcc385",
+   "sha256": "08nsjdiwy7znymcmddxd3jmzhmvzjvihcsyrsmggpk1y2m1qlbjf"
   },
   "stable": {
    "version": [
     0,
-    8,
+    9,
     0
    ],
    "deps": [
-    "ag",
     "apheleia",
     "async",
     "flycheck",
     "hydra",
     "lsp-mode",
-    "ripgrep",
+    "rg",
     "verilog-mode",
     "verilog-ts-mode",
     "yasnippet"
    ],
-   "commit": "fb7d629688f862e0bdb91986d72bcff2ae7c3e23",
-   "sha256": "1hgplmd9zzikp6wklx4y8svzd7n2i0rmfhphpms0f2zl74ana6c6"
+   "commit": "f4c65a24724cd2d1eeb1e21ec10c9cee4bfcc385",
+   "sha256": "08nsjdiwy7znymcmddxd3jmzhmvzjvihcsyrsmggpk1y2m1qlbjf"
   }
  },
  {
@@ -136044,26 +136677,26 @@
   "repo": "gmlarumbe/verilog-ts-mode",
   "unstable": {
    "version": [
-    20260429,
-    1857
+    20260716,
+    1249
    ],
    "deps": [
     "verilog-mode"
    ],
-   "commit": "b243ea4c78c37c8b01a06a269b1b3cd24996b00d",
-   "sha256": "1n5w8nzbkqk8c61hk9nbklp4j8saj5gba5p70q6lsigvwgci1ig7"
+   "commit": "fc19bce75747a578305130bb8ef1e7972b028def",
+   "sha256": "1qnw5lqxb7n8kvsp16ms6l6w7gdgdmdacvmd55falfj4cyjdyr1p"
   },
   "stable": {
    "version": [
     0,
-    5,
+    6,
     0
    ],
    "deps": [
     "verilog-mode"
    ],
-   "commit": "b71a15e1677060bc0a3e7dc180a11a82074a2157",
-   "sha256": "19jzdi4n8qj65wxgfr0simnsy2r90rpac5bgkc5bz7w2vfy7rhk3"
+   "commit": "088960470a3cb25537173c0619400675319c759c",
+   "sha256": "0pybfj9vdvb4nqn77mmy62iw4w5ydipgj1v381yjknfqlxlpkym5"
   }
  },
  {
@@ -136167,14 +136800,14 @@
   "repo": "minad/vertico",
   "unstable": {
    "version": [
-    20260605,
-    1903
+    20260709,
+    1303
    ],
    "deps": [
     "compat"
    ],
-   "commit": "6028bd3d32c99c28e2b938e5e5393ec3508d2424",
-   "sha256": "0hzl3p7b62f3p2419c5d7340h7y6ry2xhwdds166wfcgwpwnm7m6"
+   "commit": "99b9ef78e653422466ee14f1672af3ee7f685ca4",
+   "sha256": "0dkrgvf8j5nayl4n48i4v66r4kw569m2j25p8cmwfab5d5g10p80"
   },
   "stable": {
    "version": [
@@ -136196,30 +136829,30 @@
   "repo": "radian-software/prescient.el",
   "unstable": {
    "version": [
-    20250816,
-    19
+    20260628,
+    2243
    ],
    "deps": [
     "compat",
     "prescient",
     "vertico"
    ],
-   "commit": "87e2d2f2ddf24f591a5f70cc90d2afb4537caa18",
-   "sha256": "0f4wi8aq3yfykxfza4y4c5yhcs50cs3gpfj0qrmvfq9hvkhzj52w"
+   "commit": "5649977fa7789e4615efeca09397ed7eccd06dfc",
+   "sha256": "199150yng81f6n3kb120s37yf2dqs0i9k91f2gzkk8kjn6hvrsj8"
   },
   "stable": {
    "version": [
     6,
     3,
-    2
+    3
    ],
    "deps": [
     "compat",
     "prescient",
     "vertico"
    ],
-   "commit": "87e2d2f2ddf24f591a5f70cc90d2afb4537caa18",
-   "sha256": "0f4wi8aq3yfykxfza4y4c5yhcs50cs3gpfj0qrmvfq9hvkhzj52w"
+   "commit": "5649977fa7789e4615efeca09397ed7eccd06dfc",
+   "sha256": "199150yng81f6n3kb120s37yf2dqs0i9k91f2gzkk8kjn6hvrsj8"
   }
  },
  {
@@ -136274,38 +136907,36 @@
   "repo": "gmlarumbe/vhdl-ext",
   "unstable": {
    "version": [
-    20251118,
-    1340
+    20260716,
+    1401
    ],
    "deps": [
-    "ag",
     "async",
     "flycheck",
     "hydra",
     "lsp-mode",
-    "ripgrep",
+    "rg",
     "vhdl-ts-mode"
    ],
-   "commit": "19b5be6e3b794e848b2554ffc6f03dfb35c75c8e",
-   "sha256": "0pqfci24mbp8cjwrikvs4gvfvgf0wjqv68nzzcs7lqx41682ixpd"
+   "commit": "fd400c09de24d3c7da9aed5884b6f114f595373c",
+   "sha256": "0nznf1w67fnqk00690kdwh0q43480crdz61qdvsnx23yfx5q9i65"
   },
   "stable": {
    "version": [
     0,
-    7,
+    8,
     0
    ],
    "deps": [
-    "ag",
     "async",
     "flycheck",
     "hydra",
     "lsp-mode",
-    "ripgrep",
+    "rg",
     "vhdl-ts-mode"
    ],
-   "commit": "5a3513d2f26ace017e9fab7141754ff5bdebb0eb",
-   "sha256": "0agiamq7g8zm3blznykbr1kgr09rb133rd4mh9nfc0vfk8i5mabv"
+   "commit": "22fa38698bdf106194c02a6d2e3830d8685437fb",
+   "sha256": "1c9cfwadi18ib4psnf5xlgdjg75038fq1zhz2fxcjdp2kjwv5nwb"
   }
  },
  {
@@ -136316,20 +136947,20 @@
   "repo": "gmlarumbe/vhdl-ts-mode",
   "unstable": {
    "version": [
-    20251008,
-    2052
+    20260716,
+    1206
    ],
-   "commit": "9da613a72aa7caaa32b11f4de6f2e778bfb9376c",
-   "sha256": "0x11sjiy3j43am0clwxsbx7b38pfsl74qgypkc3czs7dh1c5xyrx"
+   "commit": "a9bfb0dffb5f994b11b7921d5e145ea40e9a68a2",
+   "sha256": "0y41cva3qknisxnskmn1s15r3ja2hcf4bbzc5nx1z9xk2ndh8rzf"
   },
   "stable": {
    "version": [
     0,
     3,
-    2
+    3
    ],
-   "commit": "9da613a72aa7caaa32b11f4de6f2e778bfb9376c",
-   "sha256": "0x11sjiy3j43am0clwxsbx7b38pfsl74qgypkc3czs7dh1c5xyrx"
+   "commit": "a9bfb0dffb5f994b11b7921d5e145ea40e9a68a2",
+   "sha256": "0y41cva3qknisxnskmn1s15r3ja2hcf4bbzc5nx1z9xk2ndh8rzf"
   }
  },
  {
@@ -136430,11 +137061,11 @@
   "repo": "jamescherti/vim-tab-bar.el",
   "unstable": {
    "version": [
-    20260601,
-    1613
+    20260710,
+    1614
    ],
-   "commit": "61290afd8c1fdef6b5b03b1588c5cf830e196ded",
-   "sha256": "1530p5qr9b53jljsv9bx7m54zri1i2jzglvcd58akrv5krs5wrp2"
+   "commit": "c2f03438f62915e71a780ca1cb05b94fe2871a71",
+   "sha256": "1v9bv8lj125sfvmqc1bm37msaw438hk1mn8gdf59kh7p2fwgv730"
   },
   "stable": {
    "version": [
@@ -137056,11 +137687,11 @@
   "repo": "akermu/emacs-libvterm",
   "unstable": {
    "version": [
-    20260528,
-    1919
+    20260706,
+    1652
    ],
-   "commit": "d8157e74339e02b70fa5dcd9d572960dd5c8214a",
-   "sha256": "15n6qhqfd9k504w1vm4abdfagzxa50a387f1kjg9azj6v84hawnb"
+   "commit": "9a32a4afce25647282bc8a8792468e41bc64adf4",
+   "sha256": "19y0vxlx90rx0sxrwa41h9rbvxwccls0lf9h7136xm4hsn5h2d9x"
   }
  },
  {
@@ -137217,20 +137848,20 @@
   "repo": "d12frosted/vui.el",
   "unstable": {
    "version": [
-    20260624,
-    801
+    20260702,
+    1513
    ],
-   "commit": "bc7add258504673a5c3e1bcd9f8341aaa104d522",
-   "sha256": "1x3viirn0c3ngmaqirnsgngkx45nxw88vcc63agnc0crj7wvfyaf"
+   "commit": "9101db52a29c4276b45f85e63924008f0e41c39c",
+   "sha256": "1xlnp9myjw4p90lir78p0kwl0shfglwm6wb3afd2wk1l3bf8882b"
   },
   "stable": {
    "version": [
     1,
-    2,
+    3,
     0
    ],
-   "commit": "bc7add258504673a5c3e1bcd9f8341aaa104d522",
-   "sha256": "1x3viirn0c3ngmaqirnsgngkx45nxw88vcc63agnc0crj7wvfyaf"
+   "commit": "9101db52a29c4276b45f85e63924008f0e41c39c",
+   "sha256": "1xlnp9myjw4p90lir78p0kwl0shfglwm6wb3afd2wk1l3bf8882b"
   }
  },
  {
@@ -137279,8 +137910,8 @@
   "repo": "d12frosted/vulpea",
   "unstable": {
    "version": [
-    20260619,
-    803
+    20260720,
+    628
    ],
    "deps": [
     "dash",
@@ -137288,13 +137919,13 @@
     "org",
     "s"
    ],
-   "commit": "0f55c96b6649872155d5486acb749710b3726e4a",
-   "sha256": "1lv0l2wq2zbvvbif5n49wa6khgx3mayi1is1igk6dv5lrxnc0h1c"
+   "commit": "f7a9e919ffd73109f545796e0b8f78f8bc3d0d1f",
+   "sha256": "1a5cwvsf4izxir1ynn4gqlkvdlvmgfx09zb8dfqr9cmd775fdw3i"
   },
   "stable": {
    "version": [
     2,
-    4,
+    6,
     0
    ],
    "deps": [
@@ -137303,8 +137934,8 @@
     "org",
     "s"
    ],
-   "commit": "0f55c96b6649872155d5486acb749710b3726e4a",
-   "sha256": "1lv0l2wq2zbvvbif5n49wa6khgx3mayi1is1igk6dv5lrxnc0h1c"
+   "commit": "66bee1cc931d70f0ee31087e5d6217d9b65bf3a6",
+   "sha256": "05x7h6d5lb0qfd29ml1haplx9fyvha2lhfri3ivnq2l2382xf0s0"
   }
  },
  {
@@ -137315,30 +137946,32 @@
   "repo": "d12frosted/vulpea-journal",
   "unstable": {
    "version": [
-    20260619,
-    1002
+    20260718,
+    532
    ],
    "deps": [
     "dash",
+    "vui",
     "vulpea",
     "vulpea-ui"
    ],
-   "commit": "eb503e67711284ef6ad95e40ad91bf723444d837",
-   "sha256": "123lr8f3b6db3pijrg1x33hbgh7hyh6w5qpab5n11hb90vdchimq"
+   "commit": "3bd4fbbae8deece4d595f39e6f629b6cfeaf888f",
+   "sha256": "0rkzbn9hp9bxyxh6wr2lkpy6dg1glfl87ah3a5r3rrh2dhhs64rv"
   },
   "stable": {
    "version": [
     1,
-    0,
+    1,
     1
    ],
    "deps": [
     "dash",
+    "vui",
     "vulpea",
     "vulpea-ui"
    ],
-   "commit": "7525fde77555d25cbe3b78fbe5cf35113b65e7cd",
-   "sha256": "0x47rvpmrpg6m2lyh7550mynkpjqqihgj7v04wbn2s85vr9gnv94"
+   "commit": "4f6b195faec8f468047efe76a74fbd60a495c32a",
+   "sha256": "0yad7qjam45myc4a2d9jfmcajjb40v9qbhr9gkgbdk82jp3jfbf5"
   }
  },
  {
@@ -137349,28 +137982,28 @@
   "repo": "d12frosted/vulpea-ui",
   "unstable": {
    "version": [
-    20260619,
-    819
+    20260708,
+    1156
    ],
    "deps": [
     "vui",
     "vulpea"
    ],
-   "commit": "0d58924bea2ad034daa3bb3b315f5357ad65666d",
-   "sha256": "0rbipglig27waflrbql44sfsn9fhsbzgcj4mn9c7v0n5s8g3lwvp"
+   "commit": "e734d083e2838250f3ca2ec6da616ce8dcbb96d8",
+   "sha256": "1lpz2pidglzxfky20ljxqvipldg54765b9allkmysy21gl37hy67"
   },
   "stable": {
    "version": [
     1,
-    1,
+    2,
     0
    ],
    "deps": [
     "vui",
     "vulpea"
    ],
-   "commit": "fdd6749cb4a252a369e09dd1c76d01f063b44d8b",
-   "sha256": "1jc8c1s8slsbs1yvyw0h14wcmzmyxrc15jpmmcvr0jibp7k45brr"
+   "commit": "54e4478cc1a0ee7036d11f91f4e378bcc57fa314",
+   "sha256": "1jvw7gryb4l6x0ljb03d4fvkh15j71pxjigb1g9sl5ygqlw6j8sj"
   }
  },
  {
@@ -137849,11 +138482,11 @@
   "repo": "gmlarumbe/wavedrom-mode",
   "unstable": {
    "version": [
-    20250720,
-    1337
+    20260715,
+    1713
    ],
-   "commit": "159767bc9e1726035c9e21ac50f2d0f7fe315fa8",
-   "sha256": "06kiv7qsfj4xw55jzzbmf1l6n4an5rn13ms9z2516x26v3sjyix7"
+   "commit": "5d59b7ca2bdf355d9d2f00d563acf4e17e8ba8b9",
+   "sha256": "0yszy0cz57sahmz7splqkq103jp68vfrwh5if9qfra81plykcml1"
   },
   "stable": {
    "version": [
@@ -138452,11 +139085,11 @@
   "repo": "thierryvolpiatto/wfnames",
   "unstable": {
    "version": [
-    20260105,
-    458
+    20260706,
+    903
    ],
-   "commit": "6ea49841ab76f44c0164b9f4722da2f9d46228da",
-   "sha256": "1agbwnhgagfrgz5w47x8b4i6x8qdvv03f08p1fi44wsld2h0xvwr"
+   "commit": "d8839fa42a24f7c781cd2d8c3f40eda31faa19be",
+   "sha256": "0ghb3y2qbkb819l81xcb6859h3yzppahbnwykmf8bcim29i3wclf"
   },
   "stable": {
    "version": [
@@ -139513,11 +140146,11 @@
   "url": "https://hg.sr.ht/~arnebab/wisp",
   "unstable": {
    "version": [
-    20251108,
-    2318
+    20260711,
+    2357
    ],
-   "commit": "cfebcd5f097f2f7bbb0f5b0c3730584313c93bac",
-   "sha256": "1pq5qiswihisym9c7161m3flh4idhmk1dagzlvak8riz0h47glm4"
+   "commit": "97cdd788b49ea385cdc423b411af37dacd3bc5f9",
+   "sha256": "1g8599h87gsa3ffskbnapvasl4sd26fgyy5rc0mhnzzlbw91zi1s"
   },
   "stable": {
    "version": [
@@ -139567,11 +140200,11 @@
   "repo": "ideasman42/emacs-with-command-redo",
   "unstable": {
    "version": [
-    20260504,
-    2116
+    20260710,
+    942
    ],
-   "commit": "d1c4be4bb3fb22dff8fcfb562912760be3a685e8",
-   "sha256": "1mlrmd4ncb4k1wbdpzrc6hja07pn0fzfcslpxkkigc4nz69r9y6l"
+   "commit": "b3e3c86e2cbeb097552a1bff000905ad28de7907",
+   "sha256": "0kn6mlim6an53kwh09fiyvjgavm42l7sdmb3nsrmw47dky2za827"
   }
  },
  {
@@ -139582,29 +140215,30 @@
   "repo": "magit/with-editor",
   "unstable": {
    "version": [
-    20260623,
-    1348
+    20260701,
+    1252
    ],
    "deps": [
     "compat",
     "cond-let",
     "llama"
    ],
-   "commit": "c319ef4d3a9dab479b4077cdc089d1ffac97d7db",
-   "sha256": "1h6r3rzif9c1jynm14z3ajlz0zb4mdbbzjclncn4ldwnsn7pxmia"
+   "commit": "45bfc6084f03e3aa7f4f8db20836d559186c5957",
+   "sha256": "12vh1p6zlqi7rv0xmd6v0mxyxyafh5izw9x990x5m9rrzxb5q306"
   },
   "stable": {
    "version": [
     3,
     5,
-    1
+    2
    ],
    "deps": [
     "compat",
-    "cond-let"
+    "cond-let",
+    "llama"
    ],
-   "commit": "cdf2ac2314042243fae385bb8c2821ec9c3888ae",
-   "sha256": "0cxmn7kgb5npvxdk1q5g0w9a1c1b8gvwkszd1b8bjrjwmli96as0"
+   "commit": "45bfc6084f03e3aa7f4f8db20836d559186c5957",
+   "sha256": "12vh1p6zlqi7rv0xmd6v0mxyxyafh5izw9x990x5m9rrzxb5q306"
   }
  },
  {
@@ -140312,14 +140946,14 @@
   "repo": "cjennings/emacs-wttrin",
   "unstable": {
    "version": [
-    20260624,
-    410
+    20260626,
+    1725
    ],
    "deps": [
     "xterm-color"
    ],
-   "commit": "efd3cdce5b3aebfdb3e02460d1ec0434cef85949",
-   "sha256": "0w204bk520jcm9qya02ag3bb9azbn3dwjar4mvap7hp86ck6bpki"
+   "commit": "ee8fdeb692d666c12ce068a2b1ee90e9451ac892",
+   "sha256": "11yri41vzsj08arxvavc6hvkcxc4mg2bgc3in3fiksvcwy20pb44"
   },
   "stable": {
    "version": [
@@ -140433,14 +141067,26 @@
   "repo": "jobbflykt/x509-mode",
   "unstable": {
    "version": [
-    20260602,
-    643
+    20260715,
+    1405
    ],
    "deps": [
     "compat"
    ],
-   "commit": "3d1a4b3973212b26774b43f7450ff320bec54afe",
-   "sha256": "1l349q7hdixp2gy8rzqk5n568zkry07ssb9q1drgi5jvcsjn2c6r"
+   "commit": "fec2f7281b3224ea950284cf39ba45a355c652f5",
+   "sha256": "0p4i7z3jhn2r60lxmva2l227xplkrsi2skqaj6vr3wyvxz18sasd"
+  },
+  "stable": {
+   "version": [
+    2,
+    0,
+    1
+   ],
+   "deps": [
+    "compat"
+   ],
+   "commit": "fec2f7281b3224ea950284cf39ba45a355c652f5",
+   "sha256": "0p4i7z3jhn2r60lxmva2l227xplkrsi2skqaj6vr3wyvxz18sasd"
   }
  },
  {
@@ -141499,11 +142145,11 @@
   "repo": "binjo/yara-mode",
   "unstable": {
    "version": [
-    20260624,
-    302
+    20260702,
+    151
    ],
-   "commit": "dc6eb93198c081c579300521d25199625e375530",
-   "sha256": "0j41lxn6krfffc6gv9a00rj2g20y4hhnslwp46gfm33vn52kcza7"
+   "commit": "2b097f685e2770d2c16e5f59e1434a8dcc38db86",
+   "sha256": "1l1v1nnl93gmj1gg5h254v1v0c417pywblifqyggkjn66jppwgwf"
   }
  },
  {
@@ -141855,15 +142501,15 @@
   "url": "https://git.thanosapollo.org/yeetube",
   "unstable": {
    "version": [
-    20260609,
-    525
+    20260713,
+    333
    ],
    "deps": [
     "compat",
     "keymap-popup"
    ],
-   "commit": "f88374d100e9a1005d62a9822a4038ff6f2d91e7",
-   "sha256": "162gs3fdlx806s1riwjkky1s2qhh0vzxlhigj05j82ldn3s8kkf4"
+   "commit": "066bc1c2c06493d10388f8a0ecd8e90f8cd28532",
+   "sha256": "0m52fkv7zjz1iicq5qjxfmz3hcns99bc165r9wxy84j83lb6mry0"
   },
   "stable": {
    "version": [
@@ -142060,6 +142706,21 @@
    ],
    "commit": "0b835f143e88c3321006a3e48ac5190d071b872c",
    "sha256": "1araszwlw53g82phwmmp9x84rq07ma2payplr68yg3k159jbmapr"
+  }
+ },
+ {
+  "ename": "youtube-music",
+  "commit": "d26ac835326a8911dbb5efae2409a33388592454",
+  "sha256": "1g9g6ddcdyz1dpdjwvn8qgxs4cy0a8yyqpbvr1x87s1kc06czkmd",
+  "fetcher": "github",
+  "repo": "cyberkm/emacs-youtube-music",
+  "unstable": {
+   "version": [
+    20260717,
+    1039
+   ],
+   "commit": "2a962d972d8a59fed718aec039c9c61ef3c0392d",
+   "sha256": "126clxww967w2fb3padiabh6qaxfpka3kcx6xfl1k9x2n56927p1"
   }
  },
  {
@@ -142836,19 +143497,19 @@
   "repo": "localauthor/zk",
   "unstable": {
    "version": [
-    20250908,
-    1240
+    20260708,
+    2048
    ],
-   "commit": "302e494324066d63f317b54c4db75d173914c521",
-   "sha256": "10qdia4w31709jk81xcvlyn1ac7zspiawvfx5spr09vff00gbljc"
+   "commit": "3ecb5ac3c56f8727c99458b6d3ad8e2c7df25348",
+   "sha256": "0nalp20qfmaj6028ncl0lqv86kv2jdil0wgvnqb1wb7jllpcgn2d"
   },
   "stable": {
    "version": [
-    0,
-    7
+    1,
+    0
    ],
-   "commit": "599be69ae1c1283935f98f9aca4ccda47063d82c",
-   "sha256": "0449zsahyzvjlhv27lkj33ybnq86j47paww779zd0qhq550hdnjs"
+   "commit": "ad82465a4a65fba7cff07da419455947507080cc",
+   "sha256": "1d00i9p391h4341q76ci0x6pxsishsh2mkxshfqivllv80gczn2c"
   }
  },
  {
@@ -142859,27 +143520,27 @@
   "repo": "localauthor/zk",
   "unstable": {
    "version": [
-    20251215,
-    1140
+    20260704,
+    2129
    ],
    "deps": [
     "consult",
     "zk"
    ],
-   "commit": "5b7fcbdd7bcfd0903e3844d0b4b28826bfb7ef5d",
-   "sha256": "0rp5q6x93r10lrhrrlrdyg2q5amylsvjgjnkb0mgdwfyh8i9fw78"
+   "commit": "ad82465a4a65fba7cff07da419455947507080cc",
+   "sha256": "1d00i9p391h4341q76ci0x6pxsishsh2mkxshfqivllv80gczn2c"
   },
   "stable": {
    "version": [
-    0,
-    7
+    1,
+    0
    ],
    "deps": [
     "consult",
     "zk"
    ],
-   "commit": "599be69ae1c1283935f98f9aca4ccda47063d82c",
-   "sha256": "0449zsahyzvjlhv27lkj33ybnq86j47paww779zd0qhq550hdnjs"
+   "commit": "ad82465a4a65fba7cff07da419455947507080cc",
+   "sha256": "1d00i9p391h4341q76ci0x6pxsishsh2mkxshfqivllv80gczn2c"
   }
  },
  {
@@ -142890,27 +143551,27 @@
   "repo": "localauthor/zk",
   "unstable": {
    "version": [
-    20250905,
-    1921
+    20260704,
+    2129
    ],
    "deps": [
     "zk",
     "zk-index"
    ],
-   "commit": "a634b6ec7af4f16a1ceed9271d2a0dbd9bca8501",
-   "sha256": "1akiid6z812sp1jfwrf3qz4wklc0mdmina4rfj9bfyphiivk4lf6"
+   "commit": "ad82465a4a65fba7cff07da419455947507080cc",
+   "sha256": "1d00i9p391h4341q76ci0x6pxsishsh2mkxshfqivllv80gczn2c"
   },
   "stable": {
    "version": [
-    0,
-    7
+    1,
+    0
    ],
    "deps": [
     "zk",
     "zk-index"
    ],
-   "commit": "599be69ae1c1283935f98f9aca4ccda47063d82c",
-   "sha256": "0449zsahyzvjlhv27lkj33ybnq86j47paww779zd0qhq550hdnjs"
+   "commit": "ad82465a4a65fba7cff07da419455947507080cc",
+   "sha256": "1d00i9p391h4341q76ci0x6pxsishsh2mkxshfqivllv80gczn2c"
   }
  },
  {
@@ -142921,25 +143582,25 @@
   "repo": "localauthor/zk",
   "unstable": {
    "version": [
-    20250908,
-    1240
+    20260708,
+    2048
    ],
    "deps": [
     "zk"
    ],
-   "commit": "302e494324066d63f317b54c4db75d173914c521",
-   "sha256": "10qdia4w31709jk81xcvlyn1ac7zspiawvfx5spr09vff00gbljc"
+   "commit": "3ecb5ac3c56f8727c99458b6d3ad8e2c7df25348",
+   "sha256": "0nalp20qfmaj6028ncl0lqv86kv2jdil0wgvnqb1wb7jllpcgn2d"
   },
   "stable": {
    "version": [
-    0,
-    7
+    1,
+    0
    ],
    "deps": [
     "zk"
    ],
-   "commit": "599be69ae1c1283935f98f9aca4ccda47063d82c",
-   "sha256": "0449zsahyzvjlhv27lkj33ybnq86j47paww779zd0qhq550hdnjs"
+   "commit": "ad82465a4a65fba7cff07da419455947507080cc",
+   "sha256": "1d00i9p391h4341q76ci0x6pxsishsh2mkxshfqivllv80gczn2c"
   }
  },
  {
@@ -142950,15 +143611,27 @@
   "repo": "localauthor/zk-luhmann",
   "unstable": {
    "version": [
-    20250406,
-    844
+    20260705,
+    1412
    ],
    "deps": [
     "zk",
     "zk-index"
    ],
-   "commit": "1fe0d9053b603037898530ae8aa6361c4e409e46",
-   "sha256": "1gphp973a4msciy0xcfpkw8nmdvn23d5chg7qjqq7a93rpyx3qir"
+   "commit": "8b34138abc432a37642d7d60f1c2d043e07bb680",
+   "sha256": "13mxca8rj56afr1rphv2bscdbpkyxvnppr6m8bc0sxzkd86h8p8y"
+  },
+  "stable": {
+   "version": [
+    1,
+    0
+   ],
+   "deps": [
+    "zk",
+    "zk-index"
+   ],
+   "commit": "8b34138abc432a37642d7d60f1c2d043e07bb680",
+   "sha256": "13mxca8rj56afr1rphv2bscdbpkyxvnppr6m8bc0sxzkd86h8p8y"
   }
  },
  {


### PR DESCRIPTION
- emacs-overlay commit: b90ebb6e171b263604fd112e6e2a47b8f12ce6da
- build failures
  - [X] emacs-lisp-ts-mode-0.2.1.drv: [upstream report](https://codeberg.org/zshaftel/lisp-ts-mode/issues/1)
  - [X] emacs-shexc-ts-mode-20260705.2334.drv
  - [x] emacs-uniline-20260718.1006.drv: [upstream report](https://github.com/tbanel/uniline/issues/21)
  - [ ] emacs-ada-mode-8.1.0.drv: [already broken](https://github.com/NixOS/nixpkgs/issues/544219) before this PR
- previous bump: #535032
- [x] test new pkgs with my Emacs configuration
  ```console
  HOME=(mktemp -d) nix run github:jian-lin/wonima#emacs --override-input nixpkgs github:NixOS/nixpkgs?ref=refs/pull/THIS-PR-NUMBER/head
  ```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
