### PR TITLE
duckdb: fix formatting

### DIFF
--- a/pkgs/by-name/du/duckdb/package.nix
+++ b/pkgs/by-name/du/duckdb/package.nix
@@ -157,8 +157,7 @@ stdenv.mkDerivation (finalAttrs: {
       runHook preInstallCheck
       (($(ulimit -n) < 1024)) && ulimit -n 1024
 
-      HOME="$(mktemp -d)" ${LD_LIBRARY_PATH}="$lib/lib" ./test/unittest ${toString excludes}${
-        lib.optionalString stdenv.hostPlatform.isx86_64 " >/dev/null" }
+      HOME="$(mktemp -d)" ${LD_LIBRARY_PATH}="$lib/lib" ./test/unittest ${toString excludes}${lib.optionalString stdenv.hostPlatform.isx86_64 " >/dev/null"}
 
       runHook postInstallCheck
     '';


### PR DESCRIPTION
Bad formatting was introduced in https://github.com/NixOS/nixpkgs/commit/4f1b1fac3d3d16854a998e3f2171f2f42e18dbae. I noticed this because CI failed when trying to merge https://github.com/NixOS/nixpkgs/pull/543647 ([logs](https://github.com/NixOS/nixpkgs/actions/runs/29751373427/job/88382507271)).

The problem originated on `staging-next`, so I guess it would make the most sense to fix it there first and then merge into `staging`, which happens periodically anyway.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
