### PR TITLE
python3Packages.greek-accentuation: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/greek-accentuation/default.nix
+++ b/pkgs/development/python-modules/greek-accentuation/default.nix
@@ -4,20 +4,27 @@
   fetchPypi,
   setuptools,
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "greek-accentuation";
   version = "1.2.0";
   pyproject = true;
+
+  __structuredAttrs = true;
+
   src = fetchPypi {
-    inherit pname version;
+    pname = "greek-accentuation";
+    inherit (finalAttrs) version;
     hash = "sha256-l2HZXdqlLubvy2bWhhZVYGMpF0DXVKTDFehkcGF5xdk=";
   };
 
   build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "greek_accentuation" ];
+
   meta = {
     description = "Python 3 library for accenting (and analyzing the accentuation of) Ancient Greek words";
     homepage = "https://github.com/jtauber/greek-accentuation";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ kmein ];
   };
-}
+})

--- a/pkgs/development/python-modules/greek-accentuation/default.nix
+++ b/pkgs/development/python-modules/greek-accentuation/default.nix
@@ -2,15 +2,18 @@
   buildPythonPackage,
   lib,
   fetchPypi,
+  setuptools,
 }:
 buildPythonPackage rec {
   pname = "greek-accentuation";
   version = "1.2.0";
-  format = "setuptools";
+  pyproject = true;
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-l2HZXdqlLubvy2bWhhZVYGMpF0DXVKTDFehkcGF5xdk=";
   };
+
+  build-system = [ setuptools ];
   meta = {
     description = "Python 3 library for accenting (and analyzing the accentuation of) Ancient Greek words";
     homepage = "https://github.com/jtauber/greek-accentuation";


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
