### PR TITLE
minimal-boostrap.mes: use vendored ldexpl.c

### DIFF
--- a/pkgs/os-specific/linux/minimal-bootstrap/mes/libc.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/mes/libc.nix
@@ -8,7 +8,6 @@ in
   ln-boot,
   mes,
   buildPlatform,
-  fetchurl,
 }:
 let
   pname = "mes-libc";
@@ -24,18 +23,16 @@ let
   sources = sourcesJson."${arch}.linux.gcc";
   inherit (sources) libtcc1_SOURCES libc_gnu1_SOURCES libc_gnu2_SOURCES;
 
-  ldexpl = fetchurl {
-    url = "https://gitlab.com/janneke/mes/-/raw/c837abed8edb341d4e56913729fbe9803b4de47c/lib/math/ldexpl.c";
-    hash = "sha256-3QoFZZIqVmlMUosEqOdYIMEHzYgQ7GJ7Hz0Bf/1iIig=";
-  };
-
   # Concatenate all source files into a convenient bundle
   # "gcc" variants of source files (eg. "lib/linux/x86-mes-gcc") can also be
   # compiled by tinycc
   #
   # Passing this many arguments is too much for kaem so we need to split
   # the operation in two
-  firstLibc = libc_gnu1_SOURCES + " ${ldexpl}";
+  #
+  # We also vendor a copy of ldexpl. We do not `fetchurl` it as the mes GitLab
+  # often has force pushes and links are thus unstable.
+  firstLibc = libc_gnu1_SOURCES + " " + ./ldexpl.c;
   lastLibc = libc_gnu2_SOURCES;
 in
 kaem.runCommand "${pname}-${version}"


### PR DESCRIPTION
fixes https://github.com/NixOS/nixpkgs/issues/541875. this was initially introduced in https://github.com/NixOS/nixpkgs/pull/494801 but reverted in https://github.com/NixOS/nixpkgs/pull/519568.

originally opened as #543877 but i failed to git :upside_down_face: 

~~ci will fail until #543886 hits `staging` via periodic merges in a few hours.~~ it was run, rebased onto a new commit. should be good now.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
