### PR TITLE
python3Packages.vegafusion: patch failing tests

### DIFF
--- a/pkgs/development/python-modules/vegafusion/default.nix
+++ b/pkgs/development/python-modules/vegafusion/default.nix
@@ -37,6 +37,10 @@ buildPythonPackage rec {
     hash = "sha256-yiECw9WGd+03KFOWa+bwR10gQFqzx4Riy6uw2zwdc3s=";
   };
 
+  patches = [
+    ./fix-test_transformer.patch
+  ];
+
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";

--- a/pkgs/development/python-modules/vegafusion/fix-test_transformer.patch
+++ b/pkgs/development/python-modules/vegafusion/fix-test_transformer.patch
@@ -1,0 +1,47 @@
+From 5ba473229913031b2b3053371db7887d23b45ff8 Mon Sep 17 00:00:00 2001
+From: Mario <191101255+wariuccio@users.noreply.github.com>
+Date: Tue, 14 Jul 2026 20:10:05 +0100
+Subject: [PATCH] Relax data type checks in `test_transformer.py`
+
+https://github.com/vega/vegafusion/issues/591
+---
+ vegafusion-python/tests/test_transformer.py | 14 ++++++++++----
+ 1 file changed, 10 insertions(+), 4 deletions(-)
+
+diff --git a/vegafusion-python/tests/test_transformer.py b/vegafusion-python/tests/test_transformer.py
+index 8852bb068..fe7f87e1e 100644
+--- a/vegafusion-python/tests/test_transformer.py
++++ b/vegafusion-python/tests/test_transformer.py
+@@ -17,7 +17,7 @@ def test_to_arrow_expands_categoricals():
+ 
+     # Check that pyarrow type is String (not Dictionary)
+     b_type = pa_table.column("b").type
+-    assert b_type == pa.string()
++    assert b_type == pa.string() or b_type == pa.large_string()
+ 
+ 
+ def test_to_table_converts_decimals():
+@@ -45,7 +45,7 @@ def test_to_table_with_mixed_string_int_column():
+ 
+     # Check that pyarrow type is float64 (not Decimal128)
+     b_type = pa_table.column("b").type
+-    assert b_type == pa.string()
++    assert b_type == pa.string() or b_type == pa.large_string()
+ 
+ 
+ def test_to_table_with_all_conversions():
+@@ -68,6 +68,12 @@ def test_to_table_with_all_conversions():
+     pa_table = to_arrow_table(df)
+ 
+     # Check pyarrow types
+-    assert pa_table.column("b").type == pa.string()
++    assert (
++        pa_table.column("b").type == pa.string()
++        or pa_table.column("b").type == pa.large_string()
++    )
+     assert pa_table.column("c").type == pa.float64()
+-    assert pa_table.column("d").type == pa.string()
++    assert (
++        pa_table.column("d").type == pa.string()
++        or pa_table.column("d").type == pa.large_string()
++    )


### PR DESCRIPTION
I noticed that the package fails to build on NixOS because of changes on an underlying library. I am trying to upstream the fix https://github.com/vega/vegafusion/pull/592 but in the meantime we can fix the package by applying as a patch the content of the PR I opened.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
