### PR TITLE
syncplay: apply TLS fix patch

### DIFF
--- a/pkgs/by-name/sy/syncplay/package.nix
+++ b/pkgs/by-name/sy/syncplay/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   python3Packages,
   qt6,
   enableGUI ? true,
@@ -22,6 +23,13 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   patches = [
     ./trusted_certificates.patch
+    # https://github.com/Syncplay/syncplay/pull/775
+    # Remove next update
+    (fetchpatch {
+      name = "pyopenssl_fix.patch";
+      url = "https://patch-diff.githubusercontent.com/raw/Syncplay/syncplay/pull/775.patch";
+      hash = "sha256-6bJZtWgb9e7ZK51xjkghloIVQRdLI2UJiVa4fyxDa5w=";
+    })
   ];
 
   buildInputs = lib.optionals enableGUI [


### PR DESCRIPTION
Applied patch Syncplay/syncplay#775 which fixes incompatibility with newer versions of pyOpenSSL and is not available on a release yet. 
Fixes #543881.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
