### PR TITLE
vscode: fix darwin ripgrep path for VS Code >= 1.129

### DIFF
--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -419,7 +419,11 @@ stdenv.mkDerivation (
         let
           nodeModulesPath =
             if stdenv.hostPlatform.isDarwin then
-              if lib.versionAtLeast vscodeVersion "1.94.0" then
+              # 1.129 moved node_modules back into app.asar, shipping native
+              # binaries in the asar.unpacked directory like before 1.94
+              if lib.versionAtLeast vscodeVersion "1.129.0" then
+                "Contents/Resources/app/node_modules.asar.unpacked"
+              else if lib.versionAtLeast vscodeVersion "1.94.0" then
                 "Contents/Resources/app/node_modules"
               else
                 "Contents/Resources/app/node_modules.asar.unpacked"


### PR DESCRIPTION
VS Code 1.129 changed the darwin app layout: `node_modules` moved back into `app.asar`, with native binaries shipped in `node_modules.asar.unpacked/` (the pre-1.94 layout). `generic.nix` still chmods the bundled ripgrep at the old `node_modules/` path, so vscode 1.129.1 fails to build on darwin:

```
chmod: cannot access 'Contents/Resources/app/node_modules/@vscode/ripgrep-universal/bin/darwin-arm64/rg': No such file or directory
```

The layout change was verified against the central-directory listings of the official `darwin-arm64` zips from update.code.visualstudio.com:

| version | ripgrep path |
| ------- | ------------ |
| 1.128.0, 1.128.1 | `node_modules/@vscode/ripgrep-universal/bin/darwin-arm64/rg` |
| 1.129.0, 1.129.1 | `node_modules.asar.unpacked/@vscode/ripgrep-universal/bin/darwin-arm64/rg` |

so the new path is gated on `lib.versionAtLeast vscodeVersion "1.129.0"`. Linux is unaffected: its asar is already extracted by the existing save-as-root fixup, so `resources/app/node_modules` stays valid there.

With the fix, vscode 1.129.1 builds on aarch64-darwin and the bundled `rg` ends up with its executable bit set (`-r-xr-xr-x`). The equivalent change has been running as a local overlay on the submitter's machine (aarch64-darwin, macOS 27 beta).

**Automation/AI disclosure:** this change was prepared with the assistance of Claude Code (model: Claude Fable 5); the submitter reviewed the diff and the build/functionality evidence above. The commit carries the corresponding `Assisted-by:` trailer.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test