### PR TITLE
python3Packages.libvirt-python: rename from libvirt

### DIFF
--- a/pkgs/by-name/bu/bumblebee-status/plugins.nix
+++ b/pkgs/by-name/bu/bumblebee-status/plugins.nix
@@ -118,7 +118,7 @@ in
   };
   # NOTE: Yes, there is also a plugin named `layout-xkbswitch` with a dash.
   layout_xkbswitch.propagatedBuildInputs = [ pkgs.xkb-switch ];
-  libvirtvms.propagatedBuildInputs = [ py.libvirt ];
+  libvirtvms.propagatedBuildInputs = [ py.libvirt-python ];
   load.propagatedBuildInputs = [ pkgs.gnome-system-monitor ];
   memory.propagatedBuildInputs = [ pkgs.gnome-system-monitor ];
   messagereceiver = { };

--- a/pkgs/by-name/fd/fdroidserver/package.nix
+++ b/pkgs/by-name/fd/fdroidserver/package.nix
@@ -60,7 +60,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     defusedxml
     gitpython
     libcloud
-    libvirt
+    libvirt-python
     magic
     mwclient
     oscrypto

--- a/pkgs/by-name/li/libvirt/package.nix
+++ b/pkgs/by-name/li/libvirt/package.nix
@@ -419,7 +419,7 @@ stdenv.mkDerivation rec {
     libvirtVersion=$(curl https://gitlab.com/api/v4/projects/192693/repository/tags | jq -r '.[].name|select(. | contains("rc") | not)' | head -n1 | sed "s/v//g")
     sysvirtVersion=$(curl https://gitlab.com/api/v4/projects/192677/repository/tags | jq -r '.[].name|select(. | contains("rc") | not)' | head -n1 | sed "s/v//g")
     update-source-version ${pname} "$libvirtVersion"
-    update-source-version python3Packages.${pname} "$libvirtVersion"
+    update-source-version python3Packages.libvirt-python "$libvirtVersion"
     update-source-version perlPackages.SysVirt "$sysvirtVersion" --file="pkgs/top-level/perl-packages.nix"
   '';
 

--- a/pkgs/by-name/vi/virt-manager/package.nix
+++ b/pkgs/by-name/vi/virt-manager/package.nix
@@ -28,7 +28,7 @@
 let
   pythonDependencies = with python3.pkgs; [
     pygobject3
-    libvirt
+    libvirt-python
     libxml2
     requests
   ];

--- a/pkgs/by-name/vi/virtnbdbackup/package.nix
+++ b/pkgs/by-name/vi/virtnbdbackup/package.nix
@@ -22,7 +22,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   ];
 
   dependencies = with python3Packages; [
-    libvirt
+    libvirt-python
     tqdm
     libnbd
     lz4

--- a/pkgs/development/python-modules/libvirt-python/default.nix
+++ b/pkgs/development/python-modules/libvirt-python/default.nix
@@ -11,7 +11,7 @@
 }:
 
 buildPythonPackage rec {
-  pname = "libvirt";
+  pname = "libvirt-python";
   version = "12.4.0";
   pyproject = true;
 

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -347,6 +347,7 @@ mapAliases {
   libclang = clang; # added 2026-06-18
   libgpiod = gpiod; # added 2026-03-30
   libpyfoscam = throw "libpyfoscam was removed because Home Assistant switched to libpyfoscamcgi"; # added 2025-07-03
+  libvirt = libvirt-python; # added 2026-07-20
   line_profiler = throw "'line_profiler' has been renamed to/replaced by 'line-profiler'"; # Converted to throw 2025-10-29
   linear-garage-door = throw "'linear-garage-door' has been superseded by 'nice-go'"; # Added 2025-11-16
   linear_operator = throw "'linear_operator' has been renamed to/replaced by 'linear-operator'"; # Converted to throw 2025-10-29

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9445,7 +9445,9 @@ self: super: with self; {
 
   libversion = callPackage ../development/python-modules/libversion { inherit (pkgs) libversion; };
 
-  libvirt = callPackage ../development/python-modules/libvirt { inherit (pkgs) libvirt; };
+  libvirt-python = callPackage ../development/python-modules/libvirt-python {
+    inherit (pkgs) libvirt;
+  };
 
   libxc = callPackage ../by-name/li/libxc/python.nix {
     libxc = pkgs.libxc_7;


### PR DESCRIPTION
The project name (e.g. on PyPI) is libvirt-python.

see https://github.com/NixOS/nixpkgs/pull/541843#issuecomment-5024708726
cc @spiage

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
