### PR TITLE
zenroom: enable tests

### DIFF
--- a/pkgs/by-name/ze/zenroom/package.nix
+++ b/pkgs/by-name/ze/zenroom/package.nix
@@ -14,15 +14,23 @@
 
   # tests
   callPackage,
+  jq,
+  meson,
+  ninja,
 }:
+
+let
+  inherit (stdenv.hostPlatform)
+    isDarwin
+    isLinux
+    isMusl
+    isUnix
+    ;
+in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "zenroom";
   version = "5.37.2";
-
-  __structuredAttrs = true;
-  dontUseCmakeConfigure = true; # cmake is a dependency, but we use make to build
-  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "dyne";
@@ -38,8 +46,21 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   postPatch = ''
-    patchShebangs build/embed-lualibs
+    patchShebangs build/{embed-lualibs,meson_version.sh}
+    patchShebangs test/
   '';
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  # cmake is required to build dependencies, not the main package
+  dontUseCmakeConfigure = true;
+
+  # manually invoken while testing
+  dontUseMesonConfigure = true;
+  dontUseNinjaBuild = true;
+  dontUseNinjaCheck = true;
+  dontUseNinjaInstall = true;
 
   nativeBuildInputs = [
     cmake
@@ -51,23 +72,27 @@ stdenv.mkDerivation (finalAttrs: {
     readline
   ];
 
-  buildFlags =
-    with stdenv.hostPlatform;
-    lib.optionals (isLinux && !isMusl) [
-      "linux-lib"
-      "linux-exe"
-    ]
-    ++ lib.optionals (isLinux && isMusl) [
-      "musl"
-    ]
-    ++ lib.optionals isDarwin [
-      "osx-lib"
-      "osx-exe"
-    ]
-    ++ lib.optionals (isUnix && !isLinux && !isDarwin) [
-      "posix-lib"
-      "posix-exe"
-    ];
+  buildFlags = [
+    "VERSION=${finalAttrs.version}"
+    "COMMIT=0000000"
+    "BRANCH=master"
+    "CURRENT_YEAR=1970" # unix epoch
+  ]
+  ++ lib.optionals (isLinux && !isMusl) [
+    "linux-lib"
+    "linux-exe"
+  ]
+  ++ lib.optionals (isLinux && isMusl) [
+    "musl"
+  ]
+  ++ lib.optionals isDarwin [
+    "osx-lib"
+    "osx-exe"
+  ]
+  ++ lib.optionals (isUnix && !isLinux && !isDarwin) [
+    "posix-lib"
+    "posix-exe"
+  ];
 
   hardeningDisable = [ "format" ]; # -Werror=format-security
 
@@ -82,11 +107,30 @@ stdenv.mkDerivation (finalAttrs: {
     install -D libzenroom${stdenv.hostPlatform.extensions.sharedLibrary} -t $out/lib
   '';
 
+  nativeCheckInputs = [
+    jq
+    meson
+    ninja
+  ];
+
+  doCheck = true;
+  checkTarget = "check" + lib.optionalString isDarwin "-osx";
+
+  preCheck =
+    lib.optionalString isDarwin # sh
+      ''
+        # on darwin, we're using GNU base64
+        substituteInPlace test/zencode/cookbook_{hash_pdf,ecdh_encrypt_json}.bats \
+          --replace-fail \
+            'cmd_base64="base64 -b 0"' \
+            'cmd_base64="base64 -w 0"'
+      '';
+
   passthru.updateScript = nix-update-script { };
   passthru.tests = callPackage ./tests { zenroom = finalAttrs.finalPackage; };
 
   meta = {
-    description = "no-code cryptographic virtual machine";
+    description = "No-code cryptographic virtual machine";
     longDescription = ''
       Zenroom is a tiny, portable, and fully isolated crypto VM for building
       privacy-preserving applications, smart contracts, and secure data


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
