### PR TITLE
divinemc: init at 26.2

### DIFF
--- a/pkgs/by-name/di/divinemc/generic.nix
+++ b/pkgs/by-name/di/divinemc/generic.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  makeBinaryWrapper,
+  jdk17_headless,
+  jdk21_headless,
+  jdk25_headless,
+  udev,
+  nixosTests,
+  version,
+  build,
+  channel,
+  java,
+  url,
+  hash,
+}:
+
+let
+  jdksByVersion = {
+    "17" = jdk17_headless;
+    "21" = jdk21_headless;
+    "25" = jdk25_headless;
+  };
+  available = lib.sort lib.lessThan (map lib.toInt (builtins.attrNames jdksByVersion));
+  minimum = if java == null then lib.head available else java;
+  chosen = lib.findFirst (v: v >= minimum) (lib.last available) available;
+  jre = jdksByVersion.${toString chosen};
+in
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "divinemc";
+  inherit version;
+
+  src = fetchurl { inherit url hash; };
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  dontUnpack = true;
+  preferLocalBuild = true;
+  allowSubstitutes = false;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D $src $out/share/divinemc/divinemc.jar
+
+    makeWrapper ${lib.getExe jre} "$out/bin/minecraft-server" \
+      --append-flags "-jar $out/share/divinemc/divinemc.jar nogui" \
+      ${lib.optionalString stdenvNoCC.hostPlatform.isLinux "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ udev ]}"}
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    inherit build channel;
+    javaVersion = chosen;
+    updateScript = {
+      command = [ ./update.py ];
+      attrPath = "divinemc";
+      supportedFeatures = [ "commit" ];
+    };
+    tests = { inherit (nixosTests) minecraft-server; };
+  };
+
+  meta = {
+    description = "Multi-functional fork of Purpur focused on flexibility and optimization (Minecraft ${version})";
+    homepage = "https://github.com/BX-Team/DivineMC";
+    changelog = "https://bxteam.org/downloads/divinemc";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
+      nonplay
+      wiyba
+    ];
+    mainProgram = "minecraft-server";
+  };
+})

--- a/pkgs/by-name/di/divinemc/package.nix
+++ b/pkgs/by-name/di/divinemc/package.nix
@@ -1,0 +1,9 @@
+{
+  lib,
+  callPackage,
+}:
+
+let
+  data = lib.importJSON ./versions.json;
+in
+callPackage ./generic.nix ({ version = data.latest; } // data.versions.${data.latest})

--- a/pkgs/by-name/di/divinemc/update.py
+++ b/pkgs/by-name/di/divinemc/update.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i python3 -p python3
+
+"""Regenerate versions.json for divinemc.
+
+DivineMC is distributed through the BX Team API, which already exposes a
+direct download URL and the SHA-256 checksum for every build, plus the minimum
+Java version each Minecraft version requires. That means we never have to
+download a jar to hash it and we can pick the right
+JRE per version automatically. This script only reshapes that metadata into the
+SRI form Nix wants.
+"""
+
+import base64
+import json
+import os
+import sys
+import urllib.request
+
+API = "https://api.bxteam.org/atlas/projects/divinemc"
+
+
+def fetch(path: str) -> dict:
+    request = urllib.request.Request(f"{API}{path}", headers={"User-Agent": "nixpkgs-divinemc-updater"})
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.load(response)
+
+
+def to_sri(hex_digest: str) -> str:
+    """Convert a hex SHA-256 (as served by the API) to an SRI hash."""
+    return "sha256-" + base64.b64encode(bytes.fromhex(hex_digest)).decode()
+
+
+def version_keys(project: dict) -> list[str]:
+    """Flatten the API's version_groups into a plain list of version keys."""
+    return [key for group in project["version_groups"].values() for key in group]
+
+
+def build_version(version: str) -> dict:
+    info = fetch(f"/versions/{version}")["version"]
+    java = info.get("java", {}).get("version", {}).get("minimum")
+
+    build = fetch(f"/versions/{version}/builds/latest")
+    application = build["downloads"]["application"]
+
+    return {
+        "build": build["id"],
+        "channel": build["channel"],
+        "java": java,
+        "url": application["url"],
+        "hash": to_sri(application["checksums"]["sha256"]),
+    }
+
+
+def main() -> None:
+    # `GET /projects/divinemc` returns {"project": ..., "version_groups": ...}
+    root = fetch("")
+    latest = root["project"]["latestVersion"]
+
+    versions = {}
+    for version in version_keys(root):
+        print(f"fetching {version} ...", file=sys.stderr)
+        versions[version] = build_version(version)
+
+    out = {"latest": latest, "versions": versions}
+
+    target = os.path.join(os.path.dirname(os.path.realpath(__file__)), "versions.json")
+    with open(target) as handle:
+        old = json.load(handle)
+
+    # `supportedFeatures = [ "commit" ]` requires the list of commits to create on
+    # stdout, so everything else this script says has to go to stderr.
+    if old == out:
+        print("[]")
+        return
+
+    with open(target, "w") as handle:
+        json.dump(out, handle, indent=2)
+        handle.write("\n")
+
+    print(f"wrote {len(versions)} versions to {target}", file=sys.stderr)
+
+    commit = {
+        "attrPath": "divinemc",
+        "oldVersion": old["latest"],
+        "newVersion": latest,
+        "files": [target],
+    }
+    if old["latest"] == latest:
+        commit["commitMessage"] = "divinemc: update builds"
+
+    print(json.dumps([commit]))
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/by-name/di/divinemc/update.py
+++ b/pkgs/by-name/di/divinemc/update.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i python3 -p python3
+
+"""Regenerate versions.json for divinemc.
+
+DivineMC is distributed through the BX Team API, which already exposes a
+direct download URL and the SHA-256 checksum for every build, plus the minimum
+Java version each Minecraft version requires. That means we never have to
+download a jar to hash it and we can pick the right
+JRE per version automatically. This script only reshapes that metadata into the
+SRI form Nix wants.
+"""
+
+import base64
+import json
+import os
+import sys
+import urllib.request
+
+API = "https://api.bxteam.org/v1"
+PROJECT = "divinemc"
+
+
+def fetch(path: str):
+    request = urllib.request.Request(f"{API}{path}", headers={"User-Agent": "nixpkgs-divinemc-updater"})
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.load(response)
+
+
+def to_sri(hex_digest: str) -> str:
+    """Convert a hex SHA-256 (as served by the API) to an SRI hash."""
+    return "sha256-" + base64.b64encode(bytes.fromhex(hex_digest)).decode()
+
+
+def build_version(summary: dict) -> dict:
+    version = summary["version"]
+    build = fetch(f"/builds/{PROJECT}/{version}/latest")
+    application = build["downloads"]["application"]
+
+    return {
+        "build": build["build"],
+        "channel": build["channel"],
+        "java": summary["java_min"],
+        "url": application["url"],
+        "hash": to_sri(application["sha256"]),
+    }
+
+
+def main() -> None:
+    latest = fetch(f"/projects/{PROJECT}")["latest"]
+
+    versions = {}
+    for summary in fetch(f"/builds/{PROJECT}"):
+        if summary["latest_build"] is None:
+            continue
+        print(f"fetching {summary['version']} ...", file=sys.stderr)
+        versions[summary["version"]] = build_version(summary)
+
+    out = {"latest": latest, "versions": versions}
+
+    target = os.path.join(os.path.dirname(os.path.realpath(__file__)), "versions.json")
+    with open(target) as handle:
+        old = json.load(handle)
+
+    # `supportedFeatures = [ "commit" ]` requires the list of commits to create on
+    # stdout, so everything else this script says has to go to stderr.
+    if old == out:
+        print("[]")
+        return
+
+    with open(target, "w") as handle:
+        json.dump(out, handle, indent=2)
+        handle.write("\n")
+
+    print(f"wrote {len(versions)} versions to {target}", file=sys.stderr)
+
+    commit = {
+        "attrPath": "divinemc",
+        "oldVersion": old["latest"],
+        "newVersion": latest,
+        "files": [target],
+    }
+    if old["latest"] == latest:
+        commit["commitMessage"] = "divinemc: update builds"
+
+    print(json.dumps([commit]))
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/by-name/di/divinemc/versions.json
+++ b/pkgs/by-name/di/divinemc/versions.json
@@ -1,0 +1,124 @@
+{
+  "latest": "26.2",
+  "versions": {
+    "26.2": {
+      "build": 7,
+      "channel": "STABLE",
+      "java": 25,
+      "url": "https://files.bxteam.org/divinemc/versions/26.2/7/divinemc-26.2-7.jar",
+      "hash": "sha256-gxtcXzfrQpCIezipCK1oLqwM+HZMIMWHtKwr27w94Xo="
+    },
+    "26.1.2": {
+      "build": 14,
+      "channel": "STABLE",
+      "java": 25,
+      "url": "https://files.bxteam.org/divinemc/versions/26.1.2/14/divinemc-26.1.2-14.jar",
+      "hash": "sha256-eU6CuW0ucBY3r9cx+fLIJk/LACYEJpP4wF/sOYjZfdM="
+    },
+    "1.21.11": {
+      "build": 29,
+      "channel": "STABLE",
+      "java": 21,
+      "url": "https://files.bxteam.org/divinemc/versions/1.21.11/29/divinemc-1.21.11-29.jar",
+      "hash": "sha256-37HP3rj3PmWmMpyXbhu6RyCZ84ffEcy5/Zi96ERn3Xs="
+    },
+    "1.21.10": {
+      "build": 29,
+      "channel": "STABLE",
+      "java": 21,
+      "url": "https://files.bxteam.org/divinemc/versions/1.21.10/29/divinemc-1.21.10-29.jar",
+      "hash": "sha256-autdMD3oOQ1GfV5fA+9I8Nl4zIKAhDSK/lJGu6VdTYc="
+    },
+    "1.21.8": {
+      "build": 33,
+      "channel": "STABLE",
+      "java": 21,
+      "url": "https://files.bxteam.org/divinemc/versions/1.21.8/33/divinemc-1.21.8-33.jar",
+      "hash": "sha256-Egt2dwEJFTgH8sUwHWAvYBqbm3Y5/oean+x/4K5g70s="
+    },
+    "1.21.7": {
+      "build": 11,
+      "channel": "STABLE",
+      "java": 21,
+      "url": "https://files.bxteam.org/divinemc/versions/1.21.7/11/divinemc-1.21.7-11.jar",
+      "hash": "sha256-ZXL3JcDaZY05ZEfUSZLagYu05ghebbSbbrcUeInnywY="
+    },
+    "1.21.6": {
+      "build": 9,
+      "channel": "STABLE",
+      "java": 21,
+      "url": "https://files.bxteam.org/divinemc/versions/1.21.6/9/divinemc-1.21.6-9.jar",
+      "hash": "sha256-Q+9erABlnLbLHMn03WQ4GY/Fjyij96ljYoWktHJPXgI="
+    },
+    "1.21.5": {
+      "build": 26,
+      "channel": "STABLE",
+      "java": 21,
+      "url": "https://files.bxteam.org/divinemc/versions/1.21.5/26/divinemc-1.21.5-26.jar",
+      "hash": "sha256-J1R+zI85Stv3mc951vV4/QNKSCPMeJbcXMLavZCfsoM="
+    },
+    "1.21.4": {
+      "build": 476,
+      "channel": "STABLE",
+      "java": 21,
+      "url": "https://files.bxteam.org/divinemc/versions/1.21.4/476/divinemc-1.21.4-476.jar",
+      "hash": "sha256-s2Ohs73LKTwH09D7XoLx2QAgXZSQw0DajHeiuHcKCEE="
+    },
+    "1.21.3": {
+      "build": 418,
+      "channel": "STABLE",
+      "java": 21,
+      "url": "https://files.bxteam.org/divinemc/versions/1.21.3/418/DivineMC-paperclip-1.21.3-R0.1-SNAPSHOT-reobf.jar",
+      "hash": "sha256-5VaRqL0kixoA2XJ9t0v2z7IwF+Y3QTskPyqZz75h9Sg="
+    },
+    "1.21.1": {
+      "build": 413,
+      "channel": "STABLE",
+      "java": 21,
+      "url": "https://files.bxteam.org/divinemc/versions/1.21.1/413/DivineMC-paperclip-1.21.1-R0.1-SNAPSHOT-reobf.jar",
+      "hash": "sha256-sNq8IenGpD+3/aYfKelFyCKEbT6XH1d9I5ULPDz6BQc="
+    },
+    "1.21": {
+      "build": 400,
+      "channel": "STABLE",
+      "java": 21,
+      "url": "https://files.bxteam.org/divinemc/versions/1.21/400/DivineMC-paperclip-1.21-R0.1-SNAPSHOT-reobf.jar",
+      "hash": "sha256-5O/kWfKZpbuAzsvRHHXZZUcV7jlE8yNZmTZEBe13xXA="
+    },
+    "1.20.6": {
+      "build": 364,
+      "channel": "STABLE",
+      "java": 21,
+      "url": "https://files.bxteam.org/divinemc/versions/1.20.6/364/DivineMC-paperclip-1.20.6-R0.1-SNAPSHOT-reobf.jar",
+      "hash": "sha256-vAuBhkotfFjzHb+28nQKpj4OG3EMWkRU0Dbg4c1dvdg="
+    },
+    "1.20.4": {
+      "build": 325,
+      "channel": "STABLE",
+      "java": 17,
+      "url": "https://files.bxteam.org/divinemc/versions/1.20.4/325/DivineMC-paperclip-1.20.4-R0.1-SNAPSHOT-reobf.jar",
+      "hash": "sha256-uCVKv+Yu9qQt35EcJFMGDcqebs86FmzHp0GUY7scqhM="
+    },
+    "1.20.2": {
+      "build": 244,
+      "channel": "STABLE",
+      "java": 17,
+      "url": "https://files.bxteam.org/divinemc/versions/1.20.2/244/DivineMC-paperclip-1.20.2-R0.1-SNAPSHOT-reobf.jar",
+      "hash": "sha256-PREmQ7MplCgozpOKQ1egHnWRUsqWGG13UZEccnYwUlc="
+    },
+    "1.20.1": {
+      "build": 214,
+      "channel": "STABLE",
+      "java": 17,
+      "url": "https://files.bxteam.org/divinemc/versions/1.20.1/214/DivineMC-paperclip-1.20.1-R0.1-SNAPSHOT-reobf.jar",
+      "hash": "sha256-oPdDilgkTeydpkJCl8j4SRnrMu78GTFmd/f80pPEzns="
+    },
+    "1.20": {
+      "build": 160,
+      "channel": "STABLE",
+      "java": 17,
+      "url": "https://files.bxteam.org/divinemc/versions/1.20/160/DivineMC-paperclip-1.20-R0.1-SNAPSHOT-reobf.jar",
+      "hash": "sha256-U/d1o0yx59+6DRxd8nXmL0kRkwM8/erjzerf8wx0zxM="
+    }
+  }
+}

--- a/pkgs/by-name/di/divinemc/versions.json
+++ b/pkgs/by-name/di/divinemc/versions.json
@@ -1,0 +1,124 @@
+{
+  "latest": "26.2",
+  "versions": {
+    "26.2": {
+      "build": 13,
+      "channel": "stable",
+      "java": 25,
+      "url": "https://files.bxteam.org/divinemc/versions/26.2/13/divinemc-26.2-13.jar",
+      "hash": "sha256-Sad3gIVL1wCcgMouzwyISyjTrZIWtIriEBotvlP6kIU="
+    },
+    "26.1.2": {
+      "build": 14,
+      "channel": "stable",
+      "java": 25,
+      "url": "https://files.bxteam.org/divinemc/versions/26.1.2/14/divinemc-26.1.2-14.jar",
+      "hash": "sha256-eU6CuW0ucBY3r9cx+fLIJk/LACYEJpP4wF/sOYjZfdM="
+    },
+    "1.21.11": {
+      "build": 30,
+      "channel": "stable",
+      "java": 21,
+      "url": "https://files.bxteam.org/divinemc/versions/1.21.11/30/divinemc-1.21.11-30.jar",
+      "hash": "sha256-UF9q/WnvK1VZd9v6fDfqEJiFEVMcjKG94bNbiLMkH3k="
+    },
+    "1.21.10": {
+      "build": 29,
+      "channel": "stable",
+      "java": 21,
+      "url": "https://files.bxteam.org/divinemc/versions/1.21.10/29/divinemc-1.21.10-29.jar",
+      "hash": "sha256-autdMD3oOQ1GfV5fA+9I8Nl4zIKAhDSK/lJGu6VdTYc="
+    },
+    "1.21.8": {
+      "build": 33,
+      "channel": "stable",
+      "java": 21,
+      "url": "https://files.bxteam.org/divinemc/versions/1.21.8/33/divinemc-1.21.8-33.jar",
+      "hash": "sha256-Egt2dwEJFTgH8sUwHWAvYBqbm3Y5/oean+x/4K5g70s="
+    },
+    "1.21.7": {
+      "build": 11,
+      "channel": "stable",
+      "java": 21,
+      "url": "https://files.bxteam.org/divinemc/versions/1.21.7/11/divinemc-1.21.7-11.jar",
+      "hash": "sha256-ZXL3JcDaZY05ZEfUSZLagYu05ghebbSbbrcUeInnywY="
+    },
+    "1.21.6": {
+      "build": 9,
+      "channel": "stable",
+      "java": 21,
+      "url": "https://files.bxteam.org/divinemc/versions/1.21.6/9/divinemc-1.21.6-9.jar",
+      "hash": "sha256-Q+9erABlnLbLHMn03WQ4GY/Fjyij96ljYoWktHJPXgI="
+    },
+    "1.21.5": {
+      "build": 26,
+      "channel": "stable",
+      "java": 21,
+      "url": "https://files.bxteam.org/divinemc/versions/1.21.5/26/divinemc-1.21.5-26.jar",
+      "hash": "sha256-J1R+zI85Stv3mc951vV4/QNKSCPMeJbcXMLavZCfsoM="
+    },
+    "1.21.4": {
+      "build": 476,
+      "channel": "stable",
+      "java": 21,
+      "url": "https://files.bxteam.org/divinemc/versions/1.21.4/476/divinemc-1.21.4-476.jar",
+      "hash": "sha256-s2Ohs73LKTwH09D7XoLx2QAgXZSQw0DajHeiuHcKCEE="
+    },
+    "1.21.3": {
+      "build": 418,
+      "channel": "stable",
+      "java": 21,
+      "url": "https://files.bxteam.org/divinemc/versions/1.21.3/418/DivineMC-paperclip-1.21.3-R0.1-SNAPSHOT-reobf.jar",
+      "hash": "sha256-5VaRqL0kixoA2XJ9t0v2z7IwF+Y3QTskPyqZz75h9Sg="
+    },
+    "1.21.1": {
+      "build": 413,
+      "channel": "stable",
+      "java": 21,
+      "url": "https://files.bxteam.org/divinemc/versions/1.21.1/413/DivineMC-paperclip-1.21.1-R0.1-SNAPSHOT-reobf.jar",
+      "hash": "sha256-sNq8IenGpD+3/aYfKelFyCKEbT6XH1d9I5ULPDz6BQc="
+    },
+    "1.21": {
+      "build": 400,
+      "channel": "stable",
+      "java": 21,
+      "url": "https://files.bxteam.org/divinemc/versions/1.21/400/DivineMC-paperclip-1.21-R0.1-SNAPSHOT-reobf.jar",
+      "hash": "sha256-5O/kWfKZpbuAzsvRHHXZZUcV7jlE8yNZmTZEBe13xXA="
+    },
+    "1.20.6": {
+      "build": 364,
+      "channel": "stable",
+      "java": 21,
+      "url": "https://files.bxteam.org/divinemc/versions/1.20.6/364/DivineMC-paperclip-1.20.6-R0.1-SNAPSHOT-reobf.jar",
+      "hash": "sha256-vAuBhkotfFjzHb+28nQKpj4OG3EMWkRU0Dbg4c1dvdg="
+    },
+    "1.20.4": {
+      "build": 325,
+      "channel": "stable",
+      "java": 17,
+      "url": "https://files.bxteam.org/divinemc/versions/1.20.4/325/DivineMC-paperclip-1.20.4-R0.1-SNAPSHOT-reobf.jar",
+      "hash": "sha256-uCVKv+Yu9qQt35EcJFMGDcqebs86FmzHp0GUY7scqhM="
+    },
+    "1.20.2": {
+      "build": 244,
+      "channel": "stable",
+      "java": 17,
+      "url": "https://files.bxteam.org/divinemc/versions/1.20.2/244/DivineMC-paperclip-1.20.2-R0.1-SNAPSHOT-reobf.jar",
+      "hash": "sha256-PREmQ7MplCgozpOKQ1egHnWRUsqWGG13UZEccnYwUlc="
+    },
+    "1.20.1": {
+      "build": 214,
+      "channel": "stable",
+      "java": 17,
+      "url": "https://files.bxteam.org/divinemc/versions/1.20.1/214/DivineMC-paperclip-1.20.1-R0.1-SNAPSHOT-reobf.jar",
+      "hash": "sha256-oPdDilgkTeydpkJCl8j4SRnrMu78GTFmd/f80pPEzns="
+    },
+    "1.20": {
+      "build": 160,
+      "channel": "stable",
+      "java": 17,
+      "url": "https://files.bxteam.org/divinemc/versions/1.20/160/DivineMC-paperclip-1.20-R0.1-SNAPSHOT-reobf.jar",
+      "hash": "sha256-U/d1o0yx59+6DRxd8nXmL0kRkwM8/erjzerf8wx0zxM="
+    }
+  }
+}

--- a/pkgs/by-name/di/divinemc/versions.nix
+++ b/pkgs/by-name/di/divinemc/versions.nix
@@ -1,0 +1,16 @@
+{
+  lib,
+  callPackage,
+}:
+
+let
+  data = lib.importJSON ./versions.json;
+
+  escapeVersion = builtins.replaceStrings [ "." ] [ "_" ];
+in
+lib.recurseIntoAttrs (
+  lib.mapAttrs' (version: meta: {
+    name = "divinemc-${escapeVersion version}";
+    value = callPackage ./generic.nix ({ inherit version; } // meta);
+  }) data.versions
+)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9912,6 +9912,8 @@ with pkgs;
 
   ddnet-server = ddnet.override { buildClient = false; };
 
+  divinemcServers = callPackage ../by-name/di/divinemc/versions.nix { };
+
   dwarf-fortress-packages = recurseIntoAttrs (callPackage ../games/dwarf-fortress { });
 
   inherit (dwarf-fortress-packages) dwarf-fortress dwarf-fortress-full dwarf-therapist;


### PR DESCRIPTION
Adds **DivineMC**, a multi-functional fork of the Purpur Minecraft server focused on server flexibility and optimization - https://github.com/BX-Team/DivineMC. DivineMC's API exposes a direct download URL and SHA-256 for every build, so the derivation fetches by URL/hash directly instead of reconstructing URLs, and update script never has to download a JAR file to hash it. The API also reports the minimum Java version per Minecraft version, so each derivation automatically selects the smallest headless JDK.

The package lives entirely in `pkgs/by-name/di/divinemc`, so that [it can be merged by `nixpkgs-merge-bot`](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#how-to-merge-pull-requests-yourself) in the future. `package.nix` resolves the latest version out of `versions.json` and is what `pkgs.divinemc` points at; `versions.nix` builds every version the API still serves and is exposed as `pkgs.divinemcServers` from `all-packages.nix`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
