### PR TITLE
vigra: split output `dev`

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -53,6 +53,9 @@
 - `services.mysql` now sets `root@localhost` authentication to `auth_socket` when used with `mysql` or `percona-server`.
   Existing deployments will also be adjusted if possible. See the [security advisory GHSA-6qxx-6rg8-c4p8](https://github.com/NixOS/nixpkgs/security/advisories/GHSA-6qxx-6rg8-c4p8) for more information.
 
+- `vigra` now has a split output `dev`, and its `bin/vigra-config` now belongs to the `dev` output.
+  Overriding with `outputs = [ "out" ]` is still supported.
+
 - `zerofs` has been updated from `1.x` to `2.x` which is a breaking change. Volumes created by earlier releases are refused at open with a clear error. There is no migration tool; older volumes remain readable and writable by the release that created them.
 
 - `keycloak.plugins.keycloak-metrics-spi` has been removed. Keycloak exposes Prometheus metrics natively on its management interface; enable them with the `metrics-enabled` setting (and `event-metrics-user-enabled` for login and event counters). See [Gaining insights with metrics](https://www.keycloak.org/observability/configuration-metrics).

--- a/pkgs/by-name/vi/vigra/package.nix
+++ b/pkgs/by-name/vi/vigra/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   boost,
   cmake,
+  doxygen,
   fftw,
   fftwSinglePrec,
   hdf5,
@@ -79,10 +80,39 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
+    doc =
+      (finalAttrs.overrideAttrs (
+        finalAttrs: previousAttrs: {
+          outputs = [
+            "out"
+            "doc"
+          ];
+          cmakeFlags = [
+            (lib.cmakeBool "BUILD_DOCS" true)
+            (lib.cmakeBool "CMAKE_SKIP_INSTALL_ALL_DEPENDENCY" true)
+          ];
+          postPatch = previousAttrs.postPatch or "" + ''
+            substituteInPlace src/impex/CMakeLists.txt \
+              --replace-fail "INSTALL(TARGETS vigraimpex" "INSTALL(TARGETS vigraimpex OPTIONAL"
+          '';
+          nativeBuildInputs = previousAttrs.nativeBuildInputs ++ [
+            doxygen
+            python3
+          ];
+          buildInputs = [
+            python3
+          ];
+          buildFlags = [
+            "doc"
+          ];
+          passthru = removeAttrs previousAttrs.passthru [ "doc" ];
+        }
+      )).doc;
     tests = {
       check = finalAttrs.overrideAttrs (previousAttrs: {
         doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
       });
+      inherit (finalAttrs.passthru) doc;
     };
     updateScript = writeShellScript "update-vigra" ''
       latestVersion=$(curl ''${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} --fail --silent https://api.github.com/repos/ukoethe/vigra/releases/latest | ${lib.getExe jq} --raw-output .tag_name | sed -E 's/Version-([0-9]+)-([0-9]+)-([0-9]+)/\1.\2.\3/')

--- a/pkgs/by-name/vi/vigra/package.nix
+++ b/pkgs/by-name/vi/vigra/package.nix
@@ -23,7 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "vigra";
   version = "1.12.3";
 
-  outputs = [ "out" ];
+  outputs = [
+    "out"
+    "dev"
+  ];
 
   src = fetchFromGitHub {
     owner = "ukoethe";

--- a/pkgs/by-name/vi/vigra/package.nix
+++ b/pkgs/by-name/vi/vigra/package.nix
@@ -17,9 +17,6 @@
   nix-update,
 }:
 
-let
-  python = python3.withPackages (py: with py; [ numpy ]);
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "vigra";
   version = "1.12.3";
@@ -49,7 +46,6 @@ stdenv.mkDerivation (finalAttrs: {
     libpng
     libtiff
     openexr
-    python
   ];
 
   postPatch = ''
@@ -59,7 +55,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     "-DWITH_OPENEXR=1"
-    "-DVIGRANUMPY_INSTALL_DIR=${placeholder "out"}/${python.sitePackages}"
   ]
   ++ lib.optionals (stdenv.hostPlatform.system == "x86_64-linux") [
     "-DCMAKE_CXX_FLAGS=-fPIC"
@@ -67,6 +62,21 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   enableParallelBuilding = true;
+
+  postInstall = ''
+    mkdir -p "$out/bin"
+    # vigra builds vigra-config unconditionally,
+    # but somehow won't install vigra-config without the presence of Python3 and NumPy at build time.
+    # Let's install it manually as needed.
+    if [[ ! -e "''$out/bin/vigra-config" ]] && [[ ! -e "''${!outputDev}/bin/vigra-config" ]]; then
+      install -m755 bin/vigra-config "$out/bin/vigra-config"
+    fi
+  '';
+
+  preFixup = ''
+    moveToOutput bin/vigra-config "''${!outputDev}"
+    patchShebangs --build "''${!outputDev}/bin/vigra-config"
+  '';
 
   passthru = {
     tests = {

--- a/pkgs/by-name/vi/vigra/package.nix
+++ b/pkgs/by-name/vi/vigra/package.nix
@@ -24,6 +24,8 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "vigra";
   version = "1.12.3";
 
+  outputs = [ "out" ];
+
   src = fetchFromGitHub {
     owner = "ukoethe";
     repo = "vigra";

--- a/pkgs/by-name/vi/vigra/package.nix
+++ b/pkgs/by-name/vi/vigra/package.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests = {
-      check = finalAttrs.finalPackage.overrideAttrs (previousAttrs: {
+      check = finalAttrs.overrideAttrs (previousAttrs: {
         doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
       });
     };

--- a/pkgs/by-name/vi/vigra/package.nix
+++ b/pkgs/by-name/vi/vigra/package.nix
@@ -13,6 +13,7 @@
   libtiff,
   openexr,
   python3,
+  versionCheckHook,
   writeShellScript,
   jq,
   nix-update,
@@ -76,7 +77,25 @@ stdenv.mkDerivation (finalAttrs: {
 
   preFixup = ''
     moveToOutput bin/vigra-config "''${!outputDev}"
+    # In case python3 is available
     patchShebangs --build "''${!outputDev}/bin/vigra-config"
+  '';
+
+  doInstallCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  preInstallCheck = ''
+    vigraConfigInstallPath="''${!outputDev}/bin/vigra-config"
+    if command -v python3; then
+      # Take this opportunity to test vigra-config
+      versionCheckProgram=$vigraConfigInstallPath
+      versionCheckProgramArg=--version
+    else
+      versionCheckProgram=$(command -v cat)
+      versionCheckProgramArg=$vigraConfigInstallPath
+    fi
   '';
 
   passthru = {

--- a/pkgs/by-name/vi/vigra/package.nix
+++ b/pkgs/by-name/vi/vigra/package.nix
@@ -53,6 +53,12 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     chmod +x config/run_test.sh.in
     patchShebangs --build config/run_test.sh.in
+
+    substituteInPlace vigranumpy/CMakeLists.txt  \
+      --replace-fail "''${CMAKE_INSTALL_PREFIX}/include" "''${CMAKE_INSTALL_INCLUDEDIR}"
+
+    substituteInPlace config/vigra-config.in \
+      --replace-fail "@CMAKE_INSTALL_PREFIX@/include" "@CMAKE_INSTALL_INCLUDEDIR@"
   '';
 
   cmakeFlags = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`vigra` now has a split output `dev`, and its `bin/vigra-config` now belongs to the `dev` output.

Overriding with `outputs = [ "out" ]` is still supported.

This PR depends on the following PRs:
- PR #543907

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
