### PR TITLE
python3Packages.torchao: prevent +git from being appended to version metadata during build

### DIFF
--- a/pkgs/development/python-modules/torchao/default.nix
+++ b/pkgs/development/python-modules/torchao/default.nix
@@ -83,6 +83,8 @@ buildPythonPackage (finalAttrs: {
 
   env = {
     USE_SYSTEM_LIBS = true;
+    # if this is unset, build script will append '+git' to the version number
+    VERSION_SUFFIX = "";
   };
 
   # Otherwise, the tests are loading the python module from the source instead of the installed one


### PR DESCRIPTION
Build error:
```sh
> Executing pythonMetadataCheckPhase
> The 'torchao' derivation has version '0.17.0' but .dist-info/METADATA specifies version '0.17.0+git'.
> This usually means that the wrong version is hardcoded in pyproject.toml or setup.{py,cfg}.
> Use the pyprojectVersionPatchHook or patch the version manually so that the project metadata matches the derivation's version.
```

`pyprojectVersionPatchHook` doesn't help as the suffix is being added by the build script, see https://github.com/pytorch/ao/blob/5f17fde9fc575435a4211fbe9c8ea4c0fba012d2/setup.py#L84-L87

Fix: Build script looks for `env.VERSION_SUFFIX` to be undefined. Set it to an empty string instead.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
