### PR TITLE
nagiosPlugins.check_interfaces: fix compiler error

### DIFF
--- a/pkgs/servers/monitoring/nagios-plugins/check_interfaces/default.nix
+++ b/pkgs/servers/monitoring/nagios-plugins/check_interfaces/default.nix
@@ -15,9 +15,19 @@ stdenv.mkDerivation rec {
     hash = "sha256-sQ2lee2gxyrl455tumMJ4EbKc8mYEDXl18Wik6daf5Q=";
   };
 
-  buildInputs = [ net-snmp ];
+  buildInputs = [
+    net-snmp
+  ];
 
-  configureFlags = [ "--libexecdir=${placeholder "out"}/bin" ];
+  configureFlags = [
+    "CFLAGS=-std=gnu17"
+    "--libexecdir=${placeholder "out"}/bin"
+  ];
+
+  postConfigure = ''
+    substituteInPlace Makefile \
+      --replace-fail "-Werror=declaration-after-statement" ""
+  '';
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
nagiosPlugins.check_interfaces currently fails to build to a compiler error:

```
       last 25 log lines:
       >   741 |         bool errorflag = false;
       >       |         ^~~~
       > check_interfaces.c: In function 'fetch_interface_aliases':
       > check_interfaces.c:979:17: error: ISO C90 forbids mixed declarations and code [-Werror=declaration-after-statement]
       >   979 |                 int status;
       >       |                 ^~~
       > check_interfaces.c: In function 'fetch_interface_names':
       > check_interfaces.c:1105:17: error: ISO C90 forbids mixed declarations and code [-Werror=declaration-after-statement]
       >  1105 |                 int status = snmp_synch_response(snmp_session, pdu, &response);
       >       |                 ^~~
       > check_interfaces.c: In function 'parse_and_check_commandline':
       > check_interfaces.c:1205:9: error: ISO C90 forbids mixed declarations and code [-Werror=declaration-after-statement]
       >  1205 |         static struct option longopts[] = {{"aliases", no_argument, NULL, 'a'},
       >       |         ^~~~~~
       > check_interfaces.c:1353:9: error: ISO C90 forbids mixed declarations and code [-Werror=declaration-after-statement]
       >  1353 |         struct addrinfo *addr_list;
       >       |         ^~~~~~
       > check_interfaces.c:1375:9: error: ISO C90 forbids mixed declarations and code [-Werror=declaration-after-statement]
       >  1375 |         int status;
       >       |         ^~~
       > cc1: some warnings being treated as errors
       > make: *** [Makefile:421: utils.o] Error 1
       > make: *** Waiting for unfinished jobs....
       > cc1: some warnings being treated as errors
       > make: *** [Makefile:421: check_interfaces.o] Error 1
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
