### PR TITLE
git-recent: 2.0.4 -> 2.1.0

### DIFF
--- a/pkgs/by-name/gi/git-recent/package.nix
+++ b/pkgs/by-name/gi/git-recent/package.nix
@@ -3,39 +3,56 @@
   stdenv,
   fetchFromGitHub,
   makeBinaryWrapper,
+  bash,
   gitMinimal,
-  less,
-  util-linuxMinimal,
+  delta,
+  fzf,
+  coreutils,
+  gnugrep,
+  gnused,
+  gawk,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "git-recent";
-  version = "2.0.4";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "paulirish";
     repo = "git-recent";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-b6AWLEXCOza+lIHlvyYs3M6yHGr2StYXzl7OsA9gv/k=";
+    hash = "sha256-qE6UNNuFfB2n3MuR+9gCRQCJKe0jOgW8ZwzlBZwvkrs=";
   };
 
   nativeBuildInputs = [ makeBinaryWrapper ];
+  buildInputs = [ bash ];
 
+  __structuredAttrs = true;
+  strictDeps = true;
   dontBuild = true;
 
   installPhase = ''
     runHook preInstall
 
-    install -D -m755 -t $out/bin git-recent
+    install -Dm755 -t $out/bin git-recent
 
+    patchShebangs $out/bin/git-recent
+
+    # git-recent treats delta as optional and probes PATH at runtime
+    # (`delta || diff-so-fancy`), so keep it after the user's PATH to prefer
+    # any user-provided diff pager.
     wrapProgram $out/bin/git-recent \
       --prefix PATH : "${
         lib.makeBinPath [
           gitMinimal
-          less
-          util-linuxMinimal
+          fzf
+          coreutils
+          gnugrep
+          gnused
+          gawk
         ]
-      }"
+      }" \
+      --suffix PATH : "${lib.makeBinPath [ delta ]}"
 
     runHook postInstall
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
I'm also updating the runtime dependencies 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
