### PR TITLE
python3Packages.android-backup: migrate to pyproject, use tag

### DIFF
--- a/pkgs/development/python-modules/android-backup/default.nix
+++ b/pkgs/development/python-modules/android-backup/default.nix
@@ -5,6 +5,7 @@
   pycrypto,
   python,
   setuptools,
+  pytestCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -23,9 +24,9 @@ buildPythonPackage (finalAttrs: {
 
   dependencies = [ pycrypto ];
 
-  checkPhase = ''
-    ${python.interpreter} -m android_backup.tests
-  '';
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  enabledTestPaths = [ "android_backup/tests/__main__.py" ];
 
   pythonImportsCheck = [ "android_backup" ];
 

--- a/pkgs/development/python-modules/android-backup/default.nix
+++ b/pkgs/development/python-modules/android-backup/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "bluec0re";
     repo = "android-backup-tools";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-fONMfy1SQTRuGO/VRZ28iex4tflH3XO0zLg1YjY0gzA=";
   };
 

--- a/pkgs/development/python-modules/android-backup/default.nix
+++ b/pkgs/development/python-modules/android-backup/default.nix
@@ -4,21 +4,24 @@
   fetchFromGitHub,
   pycrypto,
   python,
+  setuptools,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "android-backup";
   version = "0.2.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "bluec0re";
     repo = "android-backup-tools";
     rev = "v${finalAttrs.version}";
-    sha256 = "0c436hv64ddqrjs77pa7z6spiv49pjflbmgg31p38haj5mzlrqvw";
+    hash = "sha256-fONMfy1SQTRuGO/VRZ28iex4tflH3XO0zLg1YjY0gzA=";
   };
 
-  propagatedBuildInputs = [ pycrypto ];
+  build-system = [ setuptools ];
+
+  dependencies = [ pycrypto ];
 
   checkPhase = ''
     ${python.interpreter} -m android_backup.tests


### PR DESCRIPTION
- #515974
- use `tag` instead of `rev`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
