### PR TITLE
openfx: 1.4 -> 1.5.1

### DIFF
--- a/pkgs/by-name/op/openfx/package.nix
+++ b/pkgs/by-name/op/openfx/package.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation {
   pname = "openfx";
-  version = "1.4";
+  version = "1.5.1";
 
   src = fetchFromGitHub {
     owner = "AcademySoftwareFoundation";
     repo = "openfx";
-    rev = "OFX_Release_1_4_TAG";
-    sha256 = "0k9ggzr6bisn77mipjfvawg3mv4bz50b63v8f7w1jhldi1sfy548";
+    rev = "OFX_Release_1.5.1";
+    hash = "sha256-qiY5klmGDiU9cqjfNdFsCcNqSBwV0dVZB2ZIsElRBD4=";
   };
 
   outputs = [


### PR DESCRIPTION
See
https://github.com/AcademySoftwareFoundation/openfx/releases#release-OFX_Release_1.5.1 for release notes

## Things done

Updated OpenFX from 1.4 to 1.5.1. The change is simple because OpenFX is just a bunch of header files, not a binary or anything.

No AI/LLM was involved in the creation of this change.

Tested by building the derivation.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (N/A)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
