### PR TITLE
gomuks-desktop: init at 26.07

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16270,6 +16270,19 @@
     github = "i-am-logger";
     githubId = 1440852;
   };
+  logn = {
+    name = "Logan Devine";
+    github = "thetayloredman";
+    githubId = 26350849;
+
+    email = "nixpkgs@zirco.dev";
+    matrix = "@logn:zirco.dev";
+    keys = [
+      {
+        fingerprint = "67FA AA65 5DBD 691E 7957  E095 1594 E544 D8F8 F21E";
+      }
+    ];
+  };
   logo = {
     email = "logo4poop@protonmail.com";
     matrix = "@logo4poop:matrix.org";

--- a/pkgs/by-name/go/gomuks-desktop/gomuks-binary-path.patch
+++ b/pkgs/by-name/go/gomuks-desktop/gomuks-binary-path.patch
@@ -1,0 +1,12 @@
+diff --git a/forge.config.ts b/forge.config.ts
+index 198cdcc0..9997b4c8 100644
+--- a/forge.config.ts
++++ b/forge.config.ts
+@@ -87,6 +87,7 @@ const config: ForgeConfig = {
+ 			}
+ 		},
+ 		packageAfterCopy: async (_forgeConfig, buildPath, _electronVersion, platform, _arch) => {
++			return;
+ 			const binaryName = platform === "win32" ? "gomuks.exe" : "gomuks"
+ 			const resourcesDir = path.resolve(buildPath, "..")
+ 			const dest = path.join(resourcesDir, binaryName)

--- a/pkgs/by-name/go/gomuks-desktop/package.nix
+++ b/pkgs/by-name/go/gomuks-desktop/package.nix
@@ -1,0 +1,114 @@
+{
+  lib,
+  stdenv,
+  buildNpmPackage,
+  makeDesktopItem,
+  copyDesktopItems,
+
+  electron_42,
+  zip,
+  makeWrapper,
+
+  gomuks-web,
+}:
+let
+  electron = electron_42;
+in
+buildNpmPackage (finalAttrs: {
+  pname = "gomuks-desktop";
+
+  __structuredAttrs = true;
+
+  inherit (gomuks-web) version src;
+  sourceRoot = "${finalAttrs.src.name}/desktop";
+
+  npmBuildScript = "package";
+
+  npmDepsFetcherVersion = 2;
+  npmDepsHash = "sha256-m3T9aPBuknyDIySa2fJagj0xeQmcJ/RgkzlDCsvfTKs=";
+
+  patches = [
+    ./gomuks-binary-path.patch # fix location of gomuks-web binary at build-time
+    ./resources-path.patch # allow specifying location of icons
+  ];
+
+  nativeBuildInputs = [
+    zip
+    makeWrapper
+    copyDesktopItems
+  ];
+
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+    # electron-forge's console output is squeezed into one narrow column if unset
+    CI = "1";
+  };
+
+  postConfigure = ''
+    # electron files need to be writable on Darwin
+    cp -r ${electron.dist} electron-dist
+    chmod -R u+w electron-dist
+
+    pushd electron-dist
+    zip -0Xqr ../electron.zip .
+    popd
+
+    rm -r electron-dist
+
+    # force @electron/packager to use our electron instead of downloading it, even if it is a different version
+    substituteInPlace node_modules/@electron/packager/dist/packager.js \
+        --replace-fail 'await this.getElectronZipPath(downloadOpts)' '"electron.zip"'
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/gomuks-desktop
+    cp -r out/gomuks-desktop-*/resources $out/share/gomuks-desktop
+
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    cp $src/desktop/icon.png $out/share/icons/hicolor/512x512/apps/gomuks-desktop.png
+
+    makeWrapper ${lib.getExe electron} $out/bin/gomuks-desktop \
+      --add-flags $out/share/gomuks-desktop/resources/app.asar \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+      --set-default GOMUKS_DESKTOP_BINARY_PATH ${gomuks-web}/bin/gomuks-web \
+      --set-default GOMUKS_DESKTOP_RESOURCES_PATH $out/share/gomuks-desktop/resources/ \
+      --inherit-argv0
+
+    runHook copyDesktopItems
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "gomuks-desktop";
+      comment = "Matrix client written in Go (Electron frontend)";
+      genericName = "Matrix Client";
+      desktopName = "Gomuks";
+      exec = "gomuks-desktop %u";
+      terminal = false;
+      type = "Application";
+      icon = "gomuks-desktop";
+      categories = [
+        "Network"
+        "InstantMessaging"
+        "Chat"
+      ];
+      mimeTypes = [ "x-scheme-handler/matrix" ];
+    })
+  ];
+
+  meta = {
+    homepage = "https://maunium.net/go/gomuks/";
+    description = "${gomuks-web.meta.description} (Electron frontend)";
+    mainProgram = "gomuks-desktop";
+    inherit (gomuks-web.meta) license;
+    maintainers = with lib.maintainers; [
+      logn
+      xaltsc
+    ];
+    platforms = with lib.platforms; linux ++ darwin ++ windows;
+    broken = stdenv.hostPlatform.isDarwin;
+  };
+})

--- a/pkgs/by-name/go/gomuks-desktop/resources-path.patch
+++ b/pkgs/by-name/go/gomuks-desktop/resources-path.patch
@@ -1,0 +1,34 @@
+diff --git a/forge.config.ts b/forge.config.ts
+index 4fda2d92..16581c55 100644
+--- a/forge.config.ts
++++ b/forge.config.ts
+@@ -61,7 +61,7 @@ const config: ForgeConfig = {
+ 		} : undefined,
+ 		appBundleId: "app.gomuks.desktop",
+ 		appCategoryType: "public.app-category.social-networking",
+-		extraResource: ["tray@2x.png", "trayTemplate@2x.png"],
++		extraResource: ["tray@2x.png", "trayTemplate@2x.png", "icon.png"],
+ 	},
+ 	hooks: {
+ 		readPackageJson: async (_forgeConfig, packageJSON) => {
+diff --git a/src/mainwindow.ts b/src/mainwindow.ts
+index da649371..94b52173 100644
+--- a/src/mainwindow.ts
++++ b/src/mainwindow.ts
+@@ -56,7 +56,7 @@ export class GomuksWindow {
+ 
+ 	createTray() {
+ 		const trayIconPath = path.join(
+-			app.isPackaged ? process.resourcesPath : app.getAppPath(),
++			process.env.GOMUKS_DESKTOP_RESOURCES_PATH,
+ 			process.platform === "darwin" ? "trayTemplate@2x.png" : "tray@2x.png",
+ 		)
+ 		this.tray = new Tray(nativeImage.createFromPath(trayIconPath))
+@@ -136,6 +136,7 @@ export class GomuksWindow {
+ 			width: 1280,
+ 			height: 720,
+ 			autoHideMenuBar: true,
++			icon: path.join(process.env.GOMUKS_DESKTOP_RESOURCES_PATH, "icon.png")
+ 		})
+ 		newWindow.on("close", () => {
+ 			if (this.window === newWindow) {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
