### PR TITLE
python3Packages: opentype-feature-freezer: 1.0.1 -> 1.32.3

### DIFF
--- a/pkgs/development/python-modules/opentype-feature-freezer/default.nix
+++ b/pkgs/development/python-modules/opentype-feature-freezer/default.nix
@@ -5,25 +5,29 @@
   gitUpdater,
   pytestCheckHook,
   fonttools,
+  hatch-vcs,
   hatchling,
   biplist,
 }:
 
 buildPythonPackage rec {
   pname = "opentype-feature-freezer";
-  version = "1.0.1";
+  version = "1.32.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "twardoch";
     repo = "fonttools-opentype-feature-freezer";
     tag = "v${version}";
-    hash = "sha256-8aJYQyUpcEOyzVHZ0LXfGJ1Tsxe5HICcfkFUdsI+/GI=";
+    hash = "sha256-uwU9lsTK6XlKwar46DLTzjwtD/zQDJnC+Kq/sVNCNE0=";
   };
 
   build-system = [
+    hatch-vcs
     hatchling
   ];
+
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   dependencies = [ fonttools ];
 
@@ -39,15 +43,6 @@ buildPythonPackage rec {
     "app/dmgbuild_settings.py"
     # Missing module
     "app/OTFeatureFreezer.py"
-  ];
-
-  disabledTests = [
-    # File not found
-    "test_freeze"
-    # AssertionError: assert '' == '# Scripts an...m,pnum,tnum\n'
-    "test_report"
-    # assert False
-    "test_warn_substituting_glyphs_without_unicode"
   ];
 
   passthru.updateScript = gitUpdater { rev-prefix = "v"; };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
