### PR TITLE
python3Packages.grip: use pytestCheckHook

### DIFF
--- a/pkgs/development/python-modules/grip/default.nix
+++ b/pkgs/development/python-modules/grip/default.nix
@@ -5,7 +5,6 @@
   # Python bits:
   buildPythonPackage,
   setuptools,
-  pytest,
   responses,
   docopt,
   flask,
@@ -14,6 +13,8 @@
   pygments,
   requests,
   tabulate,
+  addBinToPathHook,
+  pytestCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -41,11 +42,6 @@ buildPythonPackage (finalAttrs: {
 
   build-system = [ setuptools ];
 
-  nativeCheckInputs = [
-    pytest
-    responses
-  ];
-
   dependencies = [
     docopt
     flask
@@ -56,12 +52,15 @@ buildPythonPackage (finalAttrs: {
     tabulate
   ];
 
-  checkPhase = ''
-    export PATH="$PATH:$out/bin"
-    py.test -xm "not assumption"
-  '';
-
   pythonImportsCheck = [ "grip" ];
+
+  nativeCheckInputs = [
+    responses
+    pytestCheckHook
+    addBinToPathHook
+  ];
+
+  enabledTestMarks = [ "not assumption" ];
 
   meta = {
     description = "Preview GitHub Markdown files like Readme locally before committing them";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- https://github.com/NixOS/nixpkgs/pull/543835

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
