### PR TITLE
trurl: fix tests with curl 8.21.0

### DIFF
--- a/pkgs/by-name/tr/trurl/package.nix
+++ b/pkgs/by-name/tr/trurl/package.nix
@@ -64,7 +64,10 @@ stdenv.mkDerivation rec {
     homepage = "https://curl.se/trurl";
     changelog = "https://github.com/curl/trurl/releases/tag/trurl-${version}";
     license = lib.licenses.curl;
-    maintainers = with lib.maintainers; [ christoph-heiss ];
+    maintainers = with lib.maintainers; [
+      christoph-heiss
+      diogotcorreia
+    ];
     platforms = lib.platforms.all;
     mainProgram = "trurl";
   };

--- a/pkgs/by-name/tr/trurl/package.nix
+++ b/pkgs/by-name/tr/trurl/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
       url = "https://github.com/curl/trurl/commit/f22a2c45956f35702e437fb83ac05376f1956ec5.patch";
       hash = "sha256-7CkUs5tMk77WKc7SlgE2NslHtU5cViKSGhHj3IBlpWo=";
     })
-    # https://github.com/curl/trurl/pull/441
+    # https://github.com/curl/trurl/pull/441 + fix for more tests
     ./tests-uppercase-hex.patch
   ];
 

--- a/pkgs/by-name/tr/trurl/tests-uppercase-hex.patch
+++ b/pkgs/by-name/tr/trurl/tests-uppercase-hex.patch
@@ -1,6 +1,36 @@
+diff --git a/tests.json b/tests.json
+index 891271c..c8606b0 100644
 --- a/tests.json
 +++ b/tests.json
-@@ -749,6 +749,7 @@
+@@ -473,12 +473,27 @@
+                 "https://example.com/#%2e%61%13%Fa"
+             ]
+         },
++        "excludes": ["uppercase-hex"],
+         "expected": {
+             "stdout": "https://example.com/#.a%13%fa\n",
+             "stderr": "",
+             "returncode": 0
+         }
+     },
++    {
++        "input": {
++            "arguments": [
++                "--url",
++                "https://example.com/#%2e%61%13%Fa"
++            ]
++        },
++        "required": ["uppercase-hex"],
++        "expected": {
++            "stdout": "https://example.com/#.a%13%FA\n",
++            "stderr": "",
++            "returncode": 0
++        }
++    },
+     {
+         "input": {
+             "arguments": [
+@@ -749,12 +764,29 @@
                  "query=user=me"
              ]
          },
@@ -8,10 +38,15 @@
          "expected": {
              "stdout": "https://curl.se/hello?user%3dme\n",
              "stderr": "",
-@@ -761,6 +762,22 @@
-                 "--url",
-                 "https://curl.se/hello",
-                 "--set",
+             "returncode": 0
+         }
+     },
++    {
++        "input": {
++            "arguments": [
++                "--url",
++                "https://curl.se/hello",
++                "--set",
 +                "query=user=me"
 +            ]
 +        },
@@ -22,16 +57,10 @@
 +            "returncode": 0
 +        }
 +    },
-+    {
-+        "input": {
-+            "arguments": [
-+                "--url",
-+                "https://curl.se/hello",
-+                "--set",
-                 "fragment= hello"
-             ]
-         },
-@@ -2132,6 +2149,7 @@
+     {
+         "input": {
+             "arguments": [
+@@ -2132,12 +2164,33 @@
                  "query:=a&b&a%26b"
              ]
          },
@@ -39,10 +68,12 @@
          "expected": {
              "stdout": "http://localhost/ABC%5c%5c?a&b&a%26b\n",
              "returncode": 0,
-@@ -2141,6 +2159,26 @@
-     {
-         "input": {
-             "arguments": [
+             "stderr": ""
+         }
+     },
++    {
++        "input": {
++            "arguments": [
 +                "-s",
 +                "scheme:=http",
 +                "-s",
@@ -60,13 +91,37 @@
 +            "stderr": ""
 +        }
 +    },
+     {
+         "input": {
+             "arguments": [
+@@ -2811,12 +2864,26 @@
+                 "https://example.com/one/t%61o/%2F%42/"
+             ]
+         },
++        "excludes": ["uppercase-hex"],
+         "expected": {
+             "stdout": "https://example.com/one/tao/%2fB/\n",
+             "stderr": "",
+             "returncode": 0
+         }
+     },
 +    {
 +        "input": {
 +            "arguments": [
-                 "-g",
-                 "{query:b}\\t{query-all:a}\\n{:query:b}\\t{:query-all:a}",
-                 "https://example.org/foo?a=1&b=%23&a=%26#hello"
-@@ -2825,11 +2863,27 @@
++                "https://example.com/one/t%61o/%2F%42/"
++            ]
++        },
++        "required": ["uppercase-hex"],
++        "expected": {
++            "stdout": "https://example.com/one/tao/%2FB/\n",
++            "stderr": "",
++            "returncode": 0
++        }
++    },
+     {
+         "input": {
+             "arguments": [
+@@ -2825,12 +2892,28 @@
                  "path=%61"
              ]
          },
@@ -76,7 +131,7 @@
              "stderr": "",
              "returncode": 0
          }
-+    },
+     },
 +    {
 +        "input": {
 +            "arguments": [
@@ -91,6 +146,115 @@
 +            "stderr": "",
 +            "returncode": 0
 +        }
-     },
++    },
      {
          "input": {
+             "arguments": [
+@@ -2991,36 +3074,78 @@
+                 "http://example.com/?a=%5D"
+             ]
+         },
++        "excludes": ["uppercase-hex"],
+         "expected": {
+             "stdout": "http://example.com/?a=%5d\n",
+             "stderr": "",
+             "returncode": 0
+         }
+     },
++    {
++        "input": {
++            "arguments": [
++                "http://example.com/?a=%5D"
++            ]
++        },
++        "required": ["uppercase-hex"],
++        "expected": {
++            "stdout": "http://example.com/?a=%5D\n",
++            "stderr": "",
++            "returncode": 0
++        }
++    },
+     {
+         "input": {
+             "arguments": [
+                 "http://example.com/?a=%5D&b=%5D"
+             ]
+         },
++        "excludes": ["uppercase-hex"],
+         "expected": {
+             "stdout": "http://example.com/?a=%5d&b=%5d\n",
+             "stderr": "",
+             "returncode": 0
+         }
+     },
++    {
++        "input": {
++            "arguments": [
++                "http://example.com/?a=%5D&b=%5D"
++            ]
++        },
++        "required": ["uppercase-hex"],
++        "expected": {
++            "stdout": "http://example.com/?a=%5D&b=%5D\n",
++            "stderr": "",
++            "returncode": 0
++        }
++    },
+     {
+         "input": {
+             "arguments": [
+                 "sftp://us%65r:pwd;giraffe@odd"
+             ]
+         },
++        "excludes": ["uppercase-hex"],
+         "expected": {
+             "stdout": "sftp://user:pwd%3bgiraffe@odd/\n",
+             "stderr": "",
+             "returncode": 0
+         }
+     },
++    {
++        "input": {
++            "arguments": [
++                "sftp://us%65r:pwd;giraffe@odd"
++            ]
++        },
++        "required": ["uppercase-hex"],
++        "expected": {
++            "stdout": "sftp://user:pwd%3Bgiraffe@odd/\n",
++            "stderr": "",
++            "returncode": 0
++        }
++    },
+     {
+         "input": {
+             "arguments": [
+@@ -3055,12 +3180,28 @@
+                 "[:password]"
+             ]
+         },
++        "excludes": ["uppercase-hex"],
+         "expected": {
+             "stdout": "pwd%3bgiraffe\n",
+             "stderr": "",
+             "returncode": 0
+         }
+     },
++    {
++        "input": {
++            "arguments": [
++                "sftp://us%65r:pwd;giraffe@odd",
++                "--get",
++                "[:password]"
++            ]
++        },
++        "required": ["uppercase-hex"],
++        "expected": {
++            "stdout": "pwd%3Bgiraffe\n",
++            "stderr": "",
++            "returncode": 0
++        }
++    },
+     {
+         "input": {
+             "arguments": [


### PR DESCRIPTION
Fixes #543817

I also added myself as maintainer, if you don't mind @christoph-heiss 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
