### PR TITLE
pleroma-bot: 0.8.6 -> 1.2.0 (and modernize)

### DIFF
--- a/pkgs/development/python-modules/pleroma-bot/default.nix
+++ b/pkgs/development/python-modules/pleroma-bot/default.nix
@@ -8,21 +8,24 @@
   requests-oauthlib,
   requests,
   pyaml,
+  setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pleroma-bot";
   version = "0.8.6";
-  format = "setuptools";
+  pyproject = true;
+  build-system = [ setuptools ];
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "robertoszek";
     repo = "pleroma-bot";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-vJxblpf3NMSyYMHeWG7vHP5AeluTtMtVxOsHgvGDHeA=";
   };
 
-  propagatedBuildInputs = [
+  dependencies = [
     pyaml
     requests
     requests-oauthlib
@@ -43,4 +46,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ robertoszek ];
   };
-}
+})

--- a/pkgs/development/python-modules/pleroma-bot/default.nix
+++ b/pkgs/development/python-modules/pleroma-bot/default.nix
@@ -9,11 +9,15 @@
   requests,
   pyaml,
   setuptools,
+  feedparser,
+  beautifulsoup4,
+  tqdm,
+  python,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "pleroma-bot";
-  version = "0.8.6";
+  version = "1.2.0";
   pyproject = true;
   build-system = [ setuptools ];
   __structuredAttrs = true;
@@ -22,7 +26,7 @@ buildPythonPackage (finalAttrs: {
     owner = "robertoszek";
     repo = "pleroma-bot";
     tag = finalAttrs.version;
-    hash = "sha256-vJxblpf3NMSyYMHeWG7vHP5AeluTtMtVxOsHgvGDHeA=";
+    hash = "sha256-my42szvkiUg6vGG6yGjDqN5LlDaertj+yA/pIcjdaLk=";
   };
 
   dependencies = [
@@ -30,11 +34,25 @@ buildPythonPackage (finalAttrs: {
     requests
     requests-oauthlib
     oauthlib
+    feedparser
+    beautifulsoup4
+    tqdm
   ];
+
+  postPatch = ''
+    substituteInPlace pleroma_bot/tests/test_{exceptions,logger}.py --replace-fail 'return' 'assert'
+  '';
 
   nativeCheckInputs = [
     pytestCheckHook
     requests-mock
+  ];
+
+  disabledTestPaths = [
+    # Tries to connect to api.twitter.com
+    "pleroma_bot/tests/test_run.py::test_tweet_order"
+    # Tries to connect to api.twitter.com and pbs.twimg.com
+    "pleroma_bot/tests/test_run.py::test_main"
   ];
 
   pythonImportsCheck = [ "pleroma_bot" ];
@@ -45,5 +63,6 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://robertoszek.github.io/pleroma-bot/";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ robertoszek ];
+    broken = python.pythonAtLeast "3.15";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- Modernized package per https://github.com/NixOS/nixpkgs/issues/515974
- Upgraded to latest version.
- Disabled failing tests, patched some warnings out via `substituteInPlae`, and added a `meta.broken` to automatically stop to build the package after Python 3.15, since `locale.getdefaultlocale` is deprecated and will be removed by then.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
