### PR TITLE
rPackages.{RFIF,gridmicrotex}: fix build

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -441,6 +441,7 @@ let
     RAppArmor = [ pkgs.pkg-config ];
     RCurl = [ pkgs.curl ]; # for curl-config
     RDieHarder = [ pkgs.gsl ]; # for gsl-config
+    RFIF = [ pkgs.pkg-config ];
     RGtk2 = [ pkgs.pkg-config ];
     RJMCMCNucleosomes = [ pkgs.gsl ]; # for gsl-config
     RKHSMetaMod = [ pkgs.gsl ]; # for gsl-config via RcppGSL
@@ -670,6 +671,7 @@ let
     ];
     git2r = [ pkgs.pkg-config ];
     glpkAPI = [ pkgs.glpk ]; # detects prefix from glpsol binary
+    gridmicrotex = [ pkgs.pkg-config ];
     gsl = [ pkgs.gsl ]; # for gsl-config
     gslnls = [ pkgs.gsl ]; # for gsl-config
     h3o = with pkgs; [
@@ -1019,6 +1021,7 @@ let
       freetype
     ];
     RAppArmor = lib.optionals stdenv.hostPlatform.isLinux [ pkgs.libapparmor ];
+    RFIF = [ pkgs.fftw ];
     RGtk2 = [ pkgs.gtk2 ];
     RITCH = [ pkgs.zlib ];
     RKHSMetaMod = [ pkgs.gsl ];
@@ -1278,6 +1281,7 @@ let
     gpg = [ pkgs.gpgme ];
     gpuMagic = [ pkgs.ocl-icd ];
     gridGraphics = [ pkgs.which ];
+    gridmicrotex = [ pkgs.freetype ];
     h5vc = with pkgs; [
       zlib
       bzip2


### PR DESCRIPTION
Targeting https://github.com/NixOS/nixpkgs/pull/539315

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
