### PR TITLE
nixos/bentopdf: map vhost via lib.mkDefault

### DIFF
--- a/nixos/modules/services/web-apps/bentopdf.nix
+++ b/nixos/modules/services/web-apps/bentopdf.nix
@@ -60,7 +60,7 @@ in
     services.nginx = lib.mkIf cfg.nginx.enable {
       enable = lib.mkDefault true;
       virtualHosts."${cfg.domain}" = lib.mkMerge [
-        cfg.nginx.virtualHost
+        (lib.mapAttrsRecursive (_: lib.mkDefault) cfg.nginx.virtualHost)
         {
           root = lib.mkForce "${cfg.package}";
 
@@ -82,7 +82,7 @@ in
     services.caddy = lib.mkIf cfg.caddy.enable {
       enable = lib.mkDefault true;
       virtualHosts."${cfg.domain}" = lib.mkMerge [
-        cfg.caddy.virtualHost
+        (lib.mapAttrsRecursive (_: lib.mkDefault) cfg.caddy.virtualHost)
         {
           hostName = lib.mkForce cfg.domain;
           extraConfig = ''


### PR DESCRIPTION
fixes #535407

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
