### PR TITLE
python3Packages.epc: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/epc/default.nix
+++ b/pkgs/development/python-modules/epc/default.nix
@@ -3,19 +3,22 @@
   buildPythonPackage,
   fetchPypi,
   sexpdata,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "epc";
   version = "0.0.5";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "a14d2ea74817955a20eb00812e3a4630a132897eb4d976420240f1152c0d7d25";
   };
 
-  propagatedBuildInputs = [ sexpdata ];
+  build-system = [ setuptools ];
+
+  dependencies = [ sexpdata ];
   doCheck = false;
 
   meta = {

--- a/pkgs/development/python-modules/epc/default.nix
+++ b/pkgs/development/python-modules/epc/default.nix
@@ -4,6 +4,7 @@
   fetchPypi,
   sexpdata,
   setuptools,
+  pytestCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -19,7 +20,17 @@ buildPythonPackage (finalAttrs: {
   build-system = [ setuptools ];
 
   dependencies = [ sexpdata ];
-  doCheck = false;
+
+  pythonImportsCheck = [ "epc" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTestPaths = [
+    # imports nose
+    "epc/tests/test_py2py.py"
+  ];
+
+  __darwinAllowLocalNetworking = true;
 
   meta = {
     description = "EPC (RPC stack for Emacs Lisp) implementation in Python";

--- a/pkgs/development/python-modules/epc/default.nix
+++ b/pkgs/development/python-modules/epc/default.nix
@@ -6,14 +6,14 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "epc";
   version = "0.0.5";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "a14d2ea74817955a20eb00812e3a4630a132897eb4d976420240f1152c0d7d25";
+    inherit (finalAttrs) pname version;
+    hash = "sha256-oU0up0gXlVog6wCBLjpGMKEyiX602XZCAkDxFSwNfSU=";
   };
 
   build-system = [ setuptools ];
@@ -26,4 +26,4 @@ buildPythonPackage rec {
     homepage = "https://github.com/tkf/python-epc";
     license = lib.licenses.gpl3;
   };
-}
+})

--- a/pkgs/development/python-modules/epc/default.nix
+++ b/pkgs/development/python-modules/epc/default.nix
@@ -24,6 +24,6 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "EPC (RPC stack for Emacs Lisp) implementation in Python";
     homepage = "https://github.com/tkf/python-epc";
-    license = lib.licenses.gpl3;
+    license = lib.licenses.gpl3Only;
   };
 })


### PR DESCRIPTION
## Things done

- https://github.com/NixOS/nixpkgs/issues/515974

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
