### PR TITLE
python3Packages.shaperglot: 0.6.4 -> 1.2.1

### DIFF
--- a/pkgs/development/python-modules/shaperglot/default.nix
+++ b/pkgs/development/python-modules/shaperglot/default.nix
@@ -2,66 +2,46 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  gflanguages,
-  num2words,
-  protobuf,
   pytestCheckHook,
-  pyyaml,
-  setuptools-scm,
-  setuptools,
-  strictyaml,
-  termcolor,
-  ufo2ft,
-  vharfbuzz,
-  youseedee,
+  rustPlatform,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "shaperglot";
-  version = "0.6.4";
+  version = "1.2.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "googlefonts";
     repo = "shaperglot";
-    tag = "v${version}";
-    hash = "sha256-O6z7TJpC54QkqX5/G1HKSvaDYty7B9BnCQ4FpsLsEMs=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-g8f8Q2DvYNvm8i6S+9K/jhhUiuGw366dht0Khx3/INg=";
   };
 
-  env.PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION = "python";
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-ivl3Zq0HRn4yP9JKfbjSaaERjbQ3SAEWhHk6toFp8dE=";
+  };
 
   postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail "setuptools>=75.0.0" "setuptools"
+    cd shaperglot-py
   '';
 
-  build-system = [
-    setuptools
-    setuptools-scm
-  ];
+  cargoRoot = "..";
 
-  dependencies = [
-    gflanguages
-    num2words
-    protobuf
-    pyyaml
-    strictyaml
-    termcolor
-    ufo2ft
-    vharfbuzz
-    youseedee
+  nativeBuildInputs = with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
   ];
-
-  nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "shaperglot" ];
 
   meta = {
     description = "Tool to test OpenType fonts for language support";
     homepage = "https://github.com/googlefonts/shaperglot";
-    changelog = "https://github.com/googlefonts/shaperglot/releases/tag/v${version}";
+    changelog = "https://github.com/googlefonts/shaperglot/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ danc86 ];
     mainProgram = "shaperglot";
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/googlefonts/shaperglot/compare/v0.6.4...v1.2.1

Changelog: https://github.com/googlefonts/shaperglot/releases/tag/v1.2.1

fixes https://github.com/NixOS/nixpkgs/issues/543959
cc @andrewmoise
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
