### PR TITLE
python3Packages.ttconv, ttconv: init at 1.2.2

### DIFF
--- a/pkgs/by-name/tt/ttconv/package.nix
+++ b/pkgs/by-name/tt/ttconv/package.nix
@@ -1,0 +1,3 @@
+{ python3Packages }:
+
+python3Packages.toPythonApplication python3Packages.ttconv

--- a/pkgs/development/python-modules/ttconv/default.nix
+++ b/pkgs/development/python-modules/ttconv/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "ttconv";
+  version = "1.2.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "sandflow";
+    repo = "ttconv";
+    tag = finalAttrs.version;
+    hash = "sha256-2kBEkDX612+H6W0BdtlDScgsgXl/sHRi+jo1vDxTJ7k=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "ttconv" ];
+
+  # No version is embedded, but we still check if the executable can run
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $out/bin/tt -h
+
+    runHook postInstallCheck
+  '';
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Timed Text Conversion";
+    longDescription = ''
+      A library and command line application written in pure Python
+      for converting between timed text formats
+      used in the presentations of captions, subtitles, karaoke, etc.
+    '';
+    homepage = "https://github.com/sandflow/ttconv";
+    changelog = "https://github.com/sandflow/ttconv/releases/tag/${finalAttrs.version}";
+    mainProgram = "tt";
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.sfrijters ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20774,6 +20774,8 @@ self: super: with self; {
 
   ttach = callPackage ../development/python-modules/ttach { };
 
+  ttconv = callPackage ../development/python-modules/ttconv { };
+
   ttfautohint-py = callPackage ../development/python-modules/ttfautohint-py { };
 
   ttkbootstrap = callPackage ../development/python-modules/ttkbootstrap { };


### PR DESCRIPTION
This package can be used as a library (https://github.com/sandflow/ttconv#library), but it also contains an executable for standalone use.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
