### PR TITLE
trilium-{desktop,server}: 0.103.0 -> 0.104.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -154,3 +154,5 @@
   - If [`system.stateVersion`](#opt-system.stateVersion) is >=26.05, `pkgs.nextcloud33` will be installed by default.
   - If [`system.stateVersion`](#opt-system.stateVersion) is >=25.11, `pkgs.nextcloud32` will be installed by default.
   - Please note that Nextcloud prohibits skipping major versions while upgrading. You can upgrade to specific versions by declaring `services.nextcloud.package = pkgs.nextcloud33;`.
+
+  - `trilium-desktop` and `trilium-server` have been updated to 0.104.0. This release includes security hardening fixes that may break functionality. [See upstream release note for details](https://github.com/TriliumNext/Trilium/releases/tag/v0.104.0).

--- a/pkgs/by-name/tr/trilium-desktop/package.nix
+++ b/pkgs/by-name/tr/trilium-desktop/package.nix
@@ -5,7 +5,7 @@
   fetchurl,
   makeBinaryWrapper,
   # use specific electron since it has to load a compiled module
-  electron_41,
+  electron_42,
   autoPatchelfHook,
   makeDesktopItem,
   copyDesktopItems,
@@ -15,7 +15,7 @@
 
 let
   pname = "trilium-desktop";
-  version = "0.103.0";
+  version = "0.104.0";
 
   triliumSource = os: arch: hash: {
     url = "https://github.com/TriliumNext/Trilium/releases/download/v${version}/TriliumNotes-v${version}-${os}-${arch}.zip";
@@ -26,9 +26,9 @@ let
   darwinSource = triliumSource "macos";
 
   # exposed like this for update.sh
-  x86_64-linux.hash = "sha256-1d6nYhj83LWzglkWoOtAj6lNPkik1qXY5lVpr1iG7No=";
-  aarch64-linux.hash = "sha256-LQMNgj1Ml8gShlPS0qgD/a+Fw4SjvvHrw6XAcSLN7q4=";
-  aarch64-darwin.hash = "sha256-dMlgJgDuxZH1jnvLalmgDUMVCdWQ8AviGt86aeMbGVY=";
+  x86_64-linux.hash = "sha256-VVYBXjKBo5GNKrIiSjvLw3Md26NEO2Fgot2421PDr0k=";
+  aarch64-linux.hash = "sha256-iHFzCiqNajETgJm4jk6NdrCybM1SG9qThBwEaGJMeqM=";
+  aarch64-darwin.hash = "sha256-zVV7lJhl/DNDfvbyCCdTSeDvhyzQLF8pxfnr2QYKeas=";
 
   sources = {
     x86_64-linux = linuxSource "x64" x86_64-linux.hash;
@@ -109,7 +109,7 @@ let
       asar pack $tmp/ $out/share/trilium/resources/app.asar
       rm -rf $tmp
 
-      makeWrapper ${lib.getExe electron_41} $out/bin/trilium \
+      makeWrapper ${lib.getExe electron_42} $out/bin/trilium \
         "''${gappsWrapperArgs[@]}" \
         --set-default ELECTRON_IS_DEV 0 \
         --add-flags $out/share/trilium/resources/app.asar

--- a/pkgs/by-name/tr/trilium-server/package.nix
+++ b/pkgs/by-name/tr/trilium-server/package.nix
@@ -7,12 +7,12 @@
 }:
 
 let
-  version = "0.103.0";
+  version = "0.104.0";
 
   serverSource_x64.url = "https://github.com/TriliumNext/Trilium/releases/download/v${version}/TriliumNotes-Server-v${version}-linux-x64.tar.xz";
-  serverSource_x64.hash = "sha256-+PmlEevacif9xP8y7KrMMCwMQ0jGmT9yVhMrQ1SYG58=";
+  serverSource_x64.hash = "sha256-lrZL0c9ijvjYUQlN6BN1BhHR2KacFG6h6KzIlkIKLGk=";
   serverSource_arm64.url = "https://github.com/TriliumNext/Trilium/releases/download/v${version}/TriliumNotes-Server-v${version}-linux-arm64.tar.xz";
-  serverSource_arm64.hash = "sha256-RjnHCvVIR/ExZ9lC8ukGr2M8X1Hnj5ZeVMmQHUvZTKY=";
+  serverSource_arm64.hash = "sha256-EgqYA7IBSt9tZ12MgktIKhJ9/ww/prTCE5Z7enMUk7Q=";
 
   serverSource =
     if stdenv.hostPlatform.isx86_64 then


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updated with `trilium-desktop.updateScript`

https://github.com/TriliumNext/Trilium/releases/tag/v0.104.0

Breaking changes:
- Backend scripting is now disabled by default
- SQL console access is disabled by default
- The Desktop application has been hardened against potential RCE attacks
- The desktop application now no longer opens its port on the local
  network by default
- OMPL v1 export was dropped from this release

I have included a change to the release note since it seems like the right thing to do. Please let me know if that needs to be removed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
