### PR TITLE
cantor: fix dependencies

### DIFF
--- a/pkgs/kde/gear/cantor/default.nix
+++ b/pkgs/kde/gear/cantor/default.nix
@@ -1,18 +1,51 @@
 {
+  lib,
   mkKdeDerivation,
-
   pkg-config,
   shared-mime-info,
+  pcre2,
 
   qtsvg,
   qttools,
   qtwebengine,
 
-  libqalculate,
   libspectre,
-  luajit,
   poppler,
+  texliveSmall, # Override with: cantor.override { texliveSmall = texliveFull; } if you want.
+
+  withQalculate ? true,
+  withR ? true,
+  withPython ? true,
+  withJulia ? true,
+  withLua ? true,
+  withMaxima ? false,
+  withOctave ? false,
+  withScilab ? false,
+  withSage ? false,
+
+  libqalculate,
+  R, # Override with: cantor.override { R = pkgs.rWrapper.override { packages = with pkgs.rPackages; [ ggplot2 ]; }; } if you want.
+  python3, # Override with: cantor.override { python3 = python3.withPackages (ps: with ps; [ matplotlib plotly bokeh ]); }
+  julia, # Override with: cantor.override { julia = julia.withPackages [ "GR" "Plots" "PyPlot" "Gadfly" ]; }
+  luajit,
+  maxima,
+  octave,
+  scilab-bin,
+  sage,
 }:
+let
+  runtimeDeps =
+    lib.optional withMaxima maxima
+    ++ lib.optional withOctave octave
+    ++ lib.optional withScilab scilab-bin
+    ++ lib.optional withSage sage
+    ++ lib.optional withQalculate libqalculate
+    ++ lib.optional withLua luajit
+    ++ lib.optional withJulia julia
+    ++ lib.optional withPython python3
+    ++ lib.optional withR R
+    ++ [ texliveSmall ];
+in
 mkKdeDerivation {
   pname = "cantor";
 
@@ -20,15 +53,38 @@ mkKdeDerivation {
     pkg-config
     shared-mime-info
   ];
+
   extraBuildInputs = [
+    pcre2
     qtsvg
     qttools
     qtwebengine
 
-    libqalculate
     libspectre
-    luajit
     poppler
-    # FIXME: can't find R, Julia - if anyone needs this, feel free to investigate
+  ]
+  ++ lib.optional withQalculate libqalculate
+  ++ lib.optional withLua luajit
+  ++ lib.optional withJulia julia
+  ++ lib.optional withPython python3
+  ++ lib.optional withR R;
+
+  extraCmakeFlags = [
+    "-DCMAKE_EXE_LINKER_FLAGS=-Wl,-rpath-link,${lib.getLib pcre2}/lib"
+  ]
+  ++ lib.optional withR "-DR_EXECUTABLE=${lib.getExe R}"
+  ++ lib.optional withJulia "-DJULIA_EXECUTABLE=${lib.getExe julia}"
+  ++ lib.optional withPython "-DPython3_EXECUTABLE=${lib.getExe python3}"
+  ++ lib.optional withPython "-DPython3_ROOT_DIR=${python3}"
+  ++ lib.optional withPython "-DPython3_FIND_STRATEGY=LOCATION";
+
+  preFixup = ''
+    ${lib.optionalString withR ''
+      patchelf --add-rpath "${lib.getLib R}/lib/R/lib" "$out/bin/cantor_rserver"
+    ''}
+  '';
+
+  qtWrapperArgs = [
+    "--prefix PATH : ${lib.makeBinPath runtimeDeps}"
   ];
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
The current cantor derivation had two missing backends (R and Julia), runtime dependencies, and some optional packages. This PR fixes them all.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
