### PR TITLE
varia: fix dependencies & 2025.10.14-1 -> 2026.3.27

### DIFF
--- a/pkgs/by-name/va/varia/package.nix
+++ b/pkgs/by-name/va/varia/package.nix
@@ -2,6 +2,8 @@
   lib,
   python3Packages,
   fetchFromGitHub,
+  makeWrapper,
+  appstream,
   aria2,
   meson,
   ninja,
@@ -11,18 +13,19 @@
   desktop-file-utils,
   libadwaita,
   ffmpeg,
+  p7zip,
+  deno,
 }:
-
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "varia";
-  version = "2025.10.14-1";
+  version = "2026.3.27";
   pyproject = false;
 
   src = fetchFromGitHub {
     owner = "giantpinkrobots";
     repo = "varia";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Spx9boNNeOXGr82uVKSpHCbimflKKjbjur+aKsNZFhY=";
+    hash = "sha256-9BH9LL7eSGtjYJKveiJTuC/kWFGmEjNU4qy6JEGpG/4=";
   };
 
   nativeBuildInputs = [
@@ -32,6 +35,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
     gobject-introspection
     wrapGAppsHook4
     desktop-file-utils
+    makeWrapper
+    appstream
   ];
 
   buildInputs = [
@@ -43,23 +48,32 @@ python3Packages.buildPythonApplication (finalAttrs: {
     aria2p
     yt-dlp
     emoji-country-flag
+    dbus-next
   ];
 
   postInstall = ''
     rm $out/bin/varia
-    mv $out/bin/varia-py.py $out/bin/varia
   '';
 
   dontWrapGApps = true;
 
-  # This replaces original varia wrapper
   preFixup = ''
-    makeWrapperArgs+=(
-      "''${gappsWrapperArgs[@]}"
-      --add-flag "${lib.getExe aria2}"
-      --add-flag "${lib.getExe ffmpeg}"
-      --add-flag "NOSNAP"
-    )
+    makeWrapper "$out/bin/varia-py.py" "$out/bin/varia" \
+      ''${gappsWrapperArgs[@]} \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          aria2
+          ffmpeg
+          p7zip
+          deno
+        ]
+      } \
+      --add-flags "${lib.getExe aria2}" \
+      --add-flags "${lib.getExe ffmpeg}" \
+      --add-flags "${lib.getExe p7zip}" \
+      --add-flags "deno" \
+      --add-flags "${lib.getExe deno}" \
+      --add-flags "NOSNAP"
   '';
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The current version of varia fails to communicate with D-Bus, because the dbus-next python lib is missing as a runtime dependency. I've also bumped the version to 2026.3.27, which also has added deno and 7zip as runtime dependencies.
This PR would also fix this draft: [#480013](https://github.com/NixOS/nixpkgs/pull/480013)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
