### PR TITLE
rkward: init at 0.8.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1411,6 +1411,12 @@
     githubId = 30437811;
     name = "Alex Andrews";
   };
+  aliheidary1381 = {
+    email = "aliheidary1381@gmail.com";
+    github = "aliheidary1381";
+    githubId = 31212739;
+    name = "Ali Heydari";
+  };
   alikindsys = {
     email = "alice@blocovermelho.org";
     github = "alikindsys";

--- a/pkgs/by-name/rk/rkward/package.nix
+++ b/pkgs/by-name/rk/rkward/package.nix
@@ -1,0 +1,111 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  cmake,
+  pkg-config,
+  gettext,
+  rWrapper,
+  rPackages,
+  pandoc,
+  kdePackages,
+  qt6,
+  kdsingleapplication,
+  shared-mime-info,
+  rEnv ? rWrapper.override {
+    packages = with rPackages; [
+      R2HTML
+      rmarkdown
+    ];
+  },
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "rkward";
+  version = "0.8.3";
+
+  src = fetchurl {
+    url = "mirror://kde/stable/rkward/${finalAttrs.version}/rkward-${finalAttrs.version}.tar.gz";
+    hash = "sha256-QNKmtt3HfLImzNlwNzUCNcoS06Qi8xsfmuPAG+Qn9eU=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    shared-mime-info
+    kdePackages.extra-cmake-modules
+    gettext
+    kdePackages.kdoctools
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    rEnv
+    kdePackages.qtbase
+    kdePackages.qtdeclarative
+    kdePackages.qtwebengine
+    kdePackages.qtwebview
+    kdePackages.qtsvg
+    kdePackages.breeze-icons
+    kdePackages.karchive
+    kdePackages.kcompletion
+    kdePackages.kconfig
+    kdePackages.kconfigwidgets
+    kdePackages.kcoreaddons
+    kdePackages.kcrash
+    kdePackages.ki18n
+    kdePackages.kio
+    kdePackages.kjobwidgets
+    kdePackages.knotifications
+    kdePackages.kparts
+    kdePackages.kservice
+    kdePackages.ktexteditor
+    kdePackages.kwidgetsaddons
+    kdePackages.kwindowsystem
+    kdePackages.kxmlgui
+    kdsingleapplication
+  ];
+
+  cmakeFlags = [
+    "-DDLOPEN_RLIB=OFF"
+    "-DR_EXECUTABLE=${lib.getExe rEnv}"
+  ];
+
+  qtWrapperArgs = [
+    "--prefix"
+    "PATH"
+    ":"
+    "${lib.makeBinPath [ pandoc ]}"
+    # Also missing KBibTeX as runtime dep, but it's deprecated in NixOS
+  ];
+
+  meta = {
+    description = "Easily extensible and easy-to-use IDE/GUI for R";
+    longDescription = ''
+      RKWard aims to become an easy to use, transparent frontend to R,
+      a powerful system for statistical computation and graphics.
+      Besides a convenient GUI for the most important statistical functions,
+      future versions will also provide seamless integration with an office-suite.
+    '';
+    homepage = "https://rkward.kde.org/";
+    license =
+      with lib.licenses;
+      OR [
+        gpl2Plus
+        (AND [
+          gpl2Plus
+          lgpl21Plus
+          mit
+          bsd3
+          cc0
+          fdl12Plus
+        ])
+      ];
+    maintainers = [ lib.maintainers.aliheidary1381 ];
+    mainProgram = "rkward";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[RKWard](https://rkward.kde.org/) is an R IDE by KDE. It's not available at release-services, so it shouldn't be in kdePackages.

There was also dmg files in the [official release](https://download.kde.org/stable/rkward/0.8.3/) page, but I don't have a aarch64-darwin device, and I'm unable to test or build anything from it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
