### PR TITLE
[Backport release-26.05] lemmy: 0.19.18 -> 0.19.19, use pnpm_11

### DIFF
--- a/pkgs/servers/web-apps/lemmy/pin.json
+++ b/pkgs/servers/web-apps/lemmy/pin.json
@@ -4,5 +4,5 @@
   "serverHash": "sha256-JcJV1dEWlFsbv9eH2yQMGYEZEFB/Pe1xtL1UNtKI6c4=",
   "serverCargoHash": "sha256-cwmz8Gf7T1IsCRyxo3ap+byX+Aj7+iCTHmZ/IeMN2no=",
   "uiHash": "sha256-67OMwzOGl+dMX5YNPPBG/QwKOVerkSa7ICbrQl4YBp4=",
-  "uiPNPMDepsHash": "sha256-T7vHfeewwT8fCH6AM6u2GFRkd+KWsp4lKj5I7I+yJAo="
+  "uiPNPMDepsHash": "sha256-50IUUymGyaCAeMnWbYJlBytcULr9lvuY9kLVSEqHGL0="
 }

--- a/pkgs/servers/web-apps/lemmy/pin.json
+++ b/pkgs/servers/web-apps/lemmy/pin.json
@@ -1,8 +1,8 @@
 {
-  "serverVersion": "0.19.18",
-  "uiVersion": "0.19.18",
-  "serverHash": "sha256-NUr96dsH3Gd+1ouOAgPheU0hnDI37a87EN642u482Sg=",
-  "serverCargoHash": "sha256-oI8o+29kqjkAP2DIoSopPMQb5YlZNja1hV1bVmfMIvU=",
-  "uiHash": "sha256-7WcPujev7VrkoX5vvGUvS0hUVJnCZjsceO5zK36jPbw=",
-  "uiPNPMDepsHash": "sha256-dRUD/R7Qtlfy2saX7grfdi5qBDP8gc3L3+C2m7ro1CU="
+  "serverVersion": "0.19.19",
+  "uiVersion": "0.19.19",
+  "serverHash": "sha256-JcJV1dEWlFsbv9eH2yQMGYEZEFB/Pe1xtL1UNtKI6c4=",
+  "serverCargoHash": "sha256-cwmz8Gf7T1IsCRyxo3ap+byX+Aj7+iCTHmZ/IeMN2no=",
+  "uiHash": "sha256-67OMwzOGl+dMX5YNPPBG/QwKOVerkSa7ICbrQl4YBp4=",
+  "uiPNPMDepsHash": "sha256-T7vHfeewwT8fCH6AM6u2GFRkd+KWsp4lKj5I7I+yJAo="
 }

--- a/pkgs/servers/web-apps/lemmy/ui.nix
+++ b/pkgs/servers/web-apps/lemmy/ui.nix
@@ -3,7 +3,7 @@
   stdenvNoCC,
   libsass,
   nodejs,
-  pnpm_9,
+  pnpm_11,
   fetchPnpmDeps,
   pnpmConfigHook,
   fetchFromGitHub,
@@ -31,7 +31,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
-    pnpm_9
+    pnpm_11
   ];
 
   buildInputs = [
@@ -42,8 +42,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   extraBuildInputs = [ libsass ];
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
+    pnpm = pnpm_11;
+    fetcherVersion = 4;
     hash = pinData.uiPNPMDepsHash;
   };
 


### PR DESCRIPTION
Manual backport of https://github.com/NixOS/nixpkgs/pull/531402 + https://github.com/NixOS/nixpkgs/pull/535914.

**Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).**

Even as a non-committer, if you find that it is not acceptable, leave a comment.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
