### PR TITLE
flacon: 12.0.0 -> 13.0.2

### DIFF
--- a/pkgs/by-name/fl/flacon/package.nix
+++ b/pkgs/by-name/fl/flacon/package.nix
@@ -5,7 +5,7 @@
   cmake,
   libuchardet,
   pkg-config,
-  shntool,
+  faac,
   flac,
   opus-tools,
   vorbis-tools,
@@ -17,53 +17,67 @@
   monkeys-audio,
   sox,
   gtk3,
-  libsForQt5,
+  qt6,
+  ttaenc,
+  withFaac ? false,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "flacon";
-  version = "12.0.0";
+  version = "13.0.2";
 
   src = fetchFromGitHub {
     owner = "flacon";
     repo = "flacon";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-r9SdQg6JTMoGxO2xUtkkBe5F5cajnsndZEq20BjJGuU=";
+    hash = "sha256-7UcZJ/npoAYRUUYUUkq/TisCDWShWcjalXACwCOsOmc=";
   };
 
   nativeBuildInputs = [
     cmake
     pkg-config
-    libsForQt5.wrapQtAppsHook
+    qt6.wrapQtAppsHook
   ];
   buildInputs = [
-    libsForQt5.qtbase
-    libsForQt5.qttools
+    qt6.qtbase
+    qt6.qttools
     libuchardet
     taglib
   ];
 
-  bin_path = lib.makeBinPath [
-    shntool
-    flac
-    opus-tools
-    vorbis-tools
-    mp3gain
-    lame
-    wavpack
-    monkeys-audio
-    vorbisgain
-    sox
-  ];
+  bin_path = lib.makeBinPath (
+    [
+      flac
+      opus-tools
+      vorbis-tools
+      mp3gain
+      lame
+      ttaenc
+      wavpack
+      monkeys-audio
+      vorbisgain
+      sox
+    ]
+    ++ lib.optional withFaac faac
+  );
 
-  postInstall = ''
-    wrapProgram $out/bin/flacon \
-      --suffix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}" \
-      --prefix PATH : "$bin_path";
-  '';
+  qtWrapperArgs = [
+    "--suffix XDG_DATA_DIRS : ${gtk3}/share/gsettings-schemas/${gtk3.name}"
+    "--prefix PATH : ${finalAttrs.bin_path}"
+  ];
 
   meta = {
     description = "Extracts audio tracks from an audio CD image to separate tracks";
+    longDescription = ''
+      Flacon extracts individual tracks from one big audio file containing the
+      entire album of music and saves them as separate audio files. To do this,
+      it uses information from the appropriate CUE file. Besides, Flacon makes
+      it possible to conveniently revise or specify tags both for all tracks
+      at once or for each tag separately.
+
+      Supported input formats: WAV, FLAC, APE, WavPack, True Audio (TTA)
+      Supported output formats: FLAC, WAV, WavPack, AAC, OGG or MP3
+    '';
     mainProgram = "flacon";
     homepage = "https://flacon.github.io/";
     license = lib.licenses.lgpl21;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The new flacon version has migrated to qt6. I also fixed some of the missing runtime dependencies. faac is unfree, so I made it optional.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
