### PR TITLE
tabby-terminal: init at 1.0.230

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1411,6 +1411,12 @@
     githubId = 30437811;
     name = "Alex Andrews";
   };
+  aliheidary1381 = {
+    email = "aliheidary1381@gmail.com";
+    github = "aliheidary1381";
+    githubId = 31212739;
+    name = "Ali Heydari";
+  };
   alikindsys = {
     email = "alice@blocovermelho.org";
     github = "alikindsys";

--- a/pkgs/by-name/ta/tabby-terminal/package.nix
+++ b/pkgs/by-name/ta/tabby-terminal/package.nix
@@ -1,0 +1,153 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  dpkg,
+  autoPatchelfHook,
+  wrapGAppsHook3,
+  glib,
+  gtk3,
+  gsettings-desktop-schemas,
+  nss,
+  nspr,
+  dbus,
+  at-spi2-atk,
+  cups,
+  cairo,
+  pango,
+  atk,
+  libdrm,
+  mesa,
+  libglvnd,
+  libxkbcommon,
+  alsa-lib,
+  expat,
+  libnotify,
+  libsecret,
+  libappindicator-gtk3,
+  libx11,
+  libxcomposite,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxrandr,
+  libxcb,
+  libxtst,
+}:
+
+let
+  version = "1.0.230";
+
+  platformInfo = {
+    "x86_64-linux" = {
+      url = "https://github.com/Eugeny/tabby/releases/download/v${version}/tabby-${version}-linux-x64.deb";
+      hash = "sha256-ZDyUIADOS2vvfRX485ae7Q7fhtGG24vsDRRMnlAqnQk=";
+    };
+    "aarch64-linux" = {
+      url = "https://github.com/Eugeny/tabby/releases/download/v${version}/tabby-${version}-linux-arm64.deb";
+      hash = "sha256-HjSW9oaFVI7Pb+dYX0Yd6wFQX9DkZ6nKic3KZ+6RSmQ=";
+    };
+  };
+
+  selectedPlatform =
+    platformInfo.${stdenv.hostPlatform.system}
+      or (throw "Unsupported platform: ${stdenv.hostPlatform.system}");
+in
+
+stdenv.mkDerivation {
+  pname = "tabby";
+  inherit version;
+
+  src = fetchurl {
+    url = selectedPlatform.url;
+    hash = selectedPlatform.hash;
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    gsettings-desktop-schemas
+    nss
+    nspr
+    dbus
+    at-spi2-atk
+    cups
+    cairo
+    pango
+    atk
+    libdrm
+    mesa
+    libglvnd
+    libxkbcommon
+    alsa-lib
+    expat
+    libnotify
+    libsecret
+    libappindicator-gtk3
+    libx11
+    libxcomposite
+    libxdamage
+    libxext
+    libxfixes
+    libxrandr
+    libxcb
+    libxtst
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+    dpkg-deb -x $src .
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/opt
+    cp -r opt/Tabby $out/opt/
+
+    mkdir -p $out/share
+    cp -r usr/share/applications $out/share/
+    cp -r usr/share/icons $out/share/
+
+    mkdir -p $out/bin
+    ln -s $out/opt/Tabby/tabby $out/bin/tabby
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    rm $out/opt/Tabby/resources/app.asar.unpacked/node_modules/@serialport/bindings-cpp/prebuilds/linux-x64/node.napi.musl.node
+    substituteInPlace $out/share/applications/tabby.desktop --replace "/opt/Tabby/tabby" "tabby"
+  '';
+
+  gappsWrapperArgs = [
+    "--prefix LD_LIBRARY_PATH : ${
+      lib.makeLibraryPath [
+        mesa
+        libglvnd
+      ]
+    }"
+  ];
+
+  meta = {
+    description = "Terminal for a modern age";
+    homepage = "https://tabby.sh/";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.aliheidary1381 ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    mainProgram = "tabby";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Tabby](https://tabby.sh/) is a modern FOSS terminal emulator built with Electron. Plugins are available for better integration with AI tools. I'm using it for some time now, and haven't noticed any runtime issues with the build. https://github.com/NixOS/nixpkgs/pull/425256 builds the electron package from source, but hasn't seen progress for more than a year.

Note: I haven't tested Tabby for arm64. Tho the x64 build is working fine on my device. There's also dmg packages in the release page, but I don't know how to use them. Any help from anyone who knows how to make a aarch64-darwin derivation using dmg or zip prebuilt packages is appreciated.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux **NOTE**
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
