### PR TITLE
tree-sitter-grammars.tree-sitter-odoc: init at 0.1.1

### DIFF
--- a/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
+++ b/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
@@ -1851,6 +1851,16 @@
     };
   };
 
+  odoc = rec {
+    version = "0.1.1";
+    url = "github:tmcgilchrist/tree-sitter-odoc?ref=${version}";
+    rev = "c98439dc63d25f29304a20693cbcb6fea7152183";
+    hash = "sha256-FaaH9+OS/teC1JiCaMmswTaba2AeXeBneOyk/hWOPBA=";
+    meta = {
+      license = lib.licenses.mit;
+    };
+  };
+
   ohm = {
     version = "0-unstable-2025-12-12";
     url = "github:novusnota/tree-sitter-ohm";


### PR DESCRIPTION
Tree-sitter grammar for the `odoc` language, which can be injected in `comment` and `doc_comment` nodes for the `ocaml` language.

https://github.com/tmcgilchrist/tree-sitter-odoc

## Things done

Manual testing: Loaded the `odoc` parser as an injection in a different language's comment node type, and validated that the injection worked properly in Neovim.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
