### PR TITLE
ld64 workaround reverts

### DIFF
--- a/pkgs/by-name/pa/pango/package.nix
+++ b/pkgs/by-name/pa/pango/package.nix
@@ -25,8 +25,6 @@
   buildPackages,
   gobject-introspection,
   testers,
-  # TODO: Clean up on `staging`.
-  llvmPackages,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -60,10 +58,6 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals withIntrospection [
     gi-docgen
     gobject-introspection
-  ]
-  # TODO: Clean up on `staging`.
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    llvmPackages.lld
   ];
 
   buildInputs = [
@@ -89,17 +83,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # Fontconfig error: Cannot load default config file
-  env = {
-    FONTCONFIG_FILE = makeFontsConf {
-      fontDirectories = [ freefont_ttf ];
-    };
-  }
-  // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
-    # workaround for ld64 hardening issue
-    #
-    # TODO: Clean up on `staging`
-    CC_LD = "lld";
-    OBJC_LD = "lld";
+  env.FONTCONFIG_FILE = makeFontsConf {
+    fontDirectories = [ freefont_ttf ];
   };
 
   # Run-time dependency gi-docgen found: NO (tried pkgconfig and cmake)

--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -112,8 +112,6 @@
   guiSupport ? false,
   gst-plugins-bad,
   apple-sdk_gstreamer,
-  # TODO: Clean up on `staging`.
-  llvmPackages,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -158,10 +156,6 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals (gst-plugins-base.waylandEnabled && stdenv.hostPlatform.isLinux) [
     wayland-scanner
-  ]
-  # TODO: Clean up on `staging`.
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    llvmPackages.lld
   ];
 
   buildInputs = [
@@ -413,9 +407,6 @@ stdenv.mkDerivation (finalAttrs: {
   # This package has some `_("string literal")` string formats
   # that trip up clang with format security enabled.
   hardeningDisable = [ "format" ];
-
-  # TODO: Clean up on `staging`.
-  env.NIX_CFLAGS_LINK = "-fuse-ld=lld";
 
   doCheck = false; # fails 20 out of 58 tests, expensive
 

--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -415,7 +415,7 @@ stdenv.mkDerivation (finalAttrs: {
   hardeningDisable = [ "format" ];
 
   # TODO: Clean up on `staging`.
-  env.NIX_CFLAGS_LINK = lib.optionalString stdenv.hostPlatform.isDarwin "-fuse-ld=lld";
+  env.NIX_CFLAGS_LINK = "-fuse-ld=lld";
 
   doCheck = false; # fails 20 out of 58 tests, expensive
 

--- a/pkgs/development/libraries/qt-5/modules/qtmultimedia.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtmultimedia.nix
@@ -9,8 +9,6 @@
   gst_all_1,
   libpulseaudio,
   wayland,
-  # TODO: Clean up on `staging`.
-  llvmPackages,
 }:
 
 qtModule {
@@ -19,13 +17,7 @@ qtModule {
     qtbase
     qtdeclarative
   ];
-  nativeBuildInputs = [
-    pkg-config
-  ]
-  # TODO: Clean up on `staging`.
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    llvmPackages.lld
-  ];
+  nativeBuildInputs = [ pkg-config ];
   buildInputs =
     with gst_all_1;
     [
@@ -46,7 +38,5 @@ qtModule {
   qmakeFlags = [ "GST_VERSION=1.0" ];
   env = lib.optionalAttrs (stdenv.hostPlatform.isDarwin) {
     NIX_LDFLAGS = "-lobjc";
-    # TODO: Clean up on `staging`.
-    NIX_CFLAGS_LINK = "-fuse-ld=lld";
   };
 }

--- a/pkgs/development/libraries/qt-6/modules/qtdeclarative/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtdeclarative/default.nix
@@ -11,8 +11,6 @@
   pkgsBuildBuild,
   replaceVars,
   fetchpatch,
-  # TODO: Clean up on `staging`.
-  llvmPackages,
 }:
 
 qtModule {
@@ -29,8 +27,6 @@ qtModule {
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     darwin.sigtool
-    # TODO: Clean up on `staging`.
-    llvmPackages.lld
   ];
 
   patches = [
@@ -72,11 +68,6 @@ qtModule {
   ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
     "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
   ];
-
-  env = lib.optionalAttrs (stdenv.hostPlatform.isDarwin) {
-    # TODO: Clean up on `staging`.
-    NIX_CFLAGS_LINK = "-fuse-ld=lld";
-  };
 
   meta.maintainers = with lib.maintainers; [
     nickcao

--- a/pkgs/development/libraries/qt-6/modules/qtmultimedia/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtmultimedia/default.nix
@@ -24,19 +24,11 @@
   libunwind,
   orc,
   pkgsBuildBuild,
-  # TODO: Clean up on `staging`.
-  llvmPackages,
 }:
 
 qtModule {
   pname = "qtmultimedia";
-  nativeBuildInputs = [
-    pkg-config
-  ]
-  # TODO: Clean up on `staging`.
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    llvmPackages.lld
-  ];
+  nativeBuildInputs = [ pkg-config ];
   buildInputs = [
     ffmpeg
   ]
@@ -80,8 +72,6 @@ qtModule {
 
   env = {
     NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-include AudioToolbox/AudioToolbox.h";
-    # TODO: Clean up on `staging`.
-    NIX_CFLAGS_LINK = lib.optionalString stdenv.hostPlatform.isDarwin "-fuse-ld=lld";
     NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-framework AudioToolbox";
   };
 }

--- a/pkgs/development/libraries/tk/generic.nix
+++ b/pkgs/development/libraries/tk/generic.nix
@@ -9,8 +9,6 @@
   zlib,
   patches ? [ ],
   enableAqua ? stdenv.hostPlatform.isDarwin,
-  # TODO: Clean up on `staging`.
-  llvmPackages,
   ...
 }:
 
@@ -76,10 +74,6 @@ tcl.mkTclDerivation {
   ++ lib.optionals (lib.versionAtLeast tcl.version "9.0") [
     # Only used to detect the presence of zlib. Could be replaced with a stub.
     zip
-  ]
-  # TODO: Clean up on `staging`.
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    llvmPackages.lld
   ];
   buildInputs = lib.optionals (lib.versionAtLeast tcl.version "9.0") [
     zlib
@@ -95,16 +89,9 @@ tcl.mkTclDerivation {
 
   inherit tcl;
 
-  env =
-    lib.optionalAttrs (lib.versionOlder tcl.version "8.6") {
-      NIX_CFLAGS_COMPILE = "-std=gnu17";
-    }
-    // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
-      # workaround for ld64 hardening issue
-      #
-      # TODO: Clean up on `staging`
-      NIX_CFLAGS_COMPILE = "-fuse-ld=lld";
-    };
+  env = lib.optionalAttrs (lib.versionOlder tcl.version "8.6") {
+    NIX_CFLAGS_COMPILE = "-std=gnu17";
+  };
 
   passthru = rec {
     inherit (tcl) release version;

--- a/pkgs/development/python-modules/pyobjc-framework-Cocoa/default.nix
+++ b/pkgs/development/python-modules/pyobjc-framework-Cocoa/default.nix
@@ -5,9 +5,6 @@
   lib,
   pyobjc-core,
   setuptools,
-  # TODO: Clean up on `staging`.
-  stdenv,
-  llvmPackages,
 }:
 
 buildPythonPackage rec {
@@ -28,10 +25,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     darwin.DarwinTools # sw_vers
-  ]
-  # TODO: Clean up on `staging`.
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    llvmPackages.lld
   ];
 
   # See https://github.com/ronaldoussoren/pyobjc/pull/641. Unfortunately, we
@@ -50,8 +43,6 @@ buildPythonPackage rec {
     "-I${darwin.libffi.dev}/include"
     "-Wno-error=unused-command-line-argument"
   ];
-  # TODO: Clean up on `staging`.
-  env.NIX_CFLAGS_LINK = "-fuse-ld=lld";
 
   pythonImportsCheck = [
     "Cocoa"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
