### PR TITLE
ld64 workaround reverts

### DIFF
--- a/pkgs/by-name/co/concord-tui/package.nix
+++ b/pkgs/by-name/co/concord-tui/package.nix
@@ -7,8 +7,6 @@
   opus,
   lib,
   stdenv,
-  # TODO: Clean up on `staging`
-  lld,
   nix-update-script,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -33,20 +31,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeBuildInputs = [
     pkg-config
     cmake
-  ]
-  # TODO: Clean up on `staging`
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    lld
   ];
 
   __darwinAllowLocalNetworking = true;
 
   __structuredAttrs = true;
-
-  # TODO: Clean up on `staging`
-  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
-    NIX_CFLAGS_LINK = "-fuse-ld=${lib.getExe' lld "ld64.lld"}";
-  };
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/sk/sketchybar/package.nix
+++ b/pkgs/by-name/sk/sketchybar/package.nix
@@ -5,7 +5,6 @@
   nix-update-script,
   apple-sdk_15,
   versionCheckHook,
-  llvmPackages,
 }:
 
 let
@@ -22,19 +21,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-5tyc/yYzdV/3JTtujuj7le/14XkC7TlN/nZg7tOZsNg=";
   };
 
-  nativeBuildInputs = [
-    # TODO: Remove once #536365 reaches this branch
-    llvmPackages.lld
-  ];
-
   buildInputs = [
     apple-sdk_15
   ];
 
   makeFlags = [ "arm64" ];
-
-  # TODO: Remove once #536365 reaches this branch
-  env.NIX_CFLAGS_LINK = "-fuse-ld=lld";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/vf/vfkit/package.nix
+++ b/pkgs/by-name/vf/vfkit/package.nix
@@ -5,7 +5,6 @@
   darwin,
   fetchFromGitHub,
   fetchpatch2,
-  llvmPackages,
   nix-update-script,
   testers,
   vfkit,
@@ -34,16 +33,11 @@ buildGoModule rec {
 
   nativeBuildInputs = [
     darwin.sigtool
-    # TODO: Remove this when NixOS/nixpkgs#536365 reaches master.
-    llvmPackages.lld
   ];
 
   buildInputs = [
     apple-sdk_15
   ];
-
-  # TODO: Remove this when NixOS/nixpkgs#536365 reaches master.
-  env.NIX_CFLAGS_LINK = "-fuse-ld=${lib.getExe' llvmPackages.lld "ld64.lld"}";
 
   postFixup = ''
     codesign --entitlements vf.entitlements -f -s - $out/bin/vfkit


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
