### PR TITLE
minimega: init at 3.0.1

### DIFF
--- a/pkgs/by-name/mi/minimega/package.nix
+++ b/pkgs/by-name/mi/minimega/package.nix
@@ -1,0 +1,105 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+  makeWrapper,
+  libpcap,
+  libnl,
+}:
+buildGoModule (finalAttrs: {
+  pname = "minimega";
+  version = "3.0.1";
+
+  # For version.go
+  rev = "1fe073faa4eceb6056de1bc400fd782c0e40c164";
+
+  src = fetchFromGitHub {
+    owner = "sandia-minimega";
+    repo = "minimega";
+    tag = finalAttrs.version;
+    hash = "sha256-i+xIUyWrOCv5DvcRBSwRQM3+XYPMvUKO2n/wsSJR2ms=";
+  };
+
+  __structuredAttrs = true;
+
+  strictDeps = true;
+
+  vendorHash = null;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  buildInputs = [
+    libpcap
+    libnl
+  ];
+
+  subPackages = [
+    "cmd/..."
+  ];
+
+  excludedPackages = [
+    "cmd/plumbing"
+  ];
+
+  postPatch = ''
+    # Link libnl for static builds
+    substituteInPlace vendor/github.com/google/gopacket/pcap/pcap_unix.go \
+      --replace-fail "-lpcap" "-lpcap -lnl-genl-3 -lnl-3"
+  '';
+
+  preBuild = ''
+    # Create the version.go file for minimega (see scripts/build.bash in src)
+    echo "package version
+
+    var (
+      Version  = \"${finalAttrs.version}\"
+      Revision = \"${finalAttrs.rev}\"
+      Date     = \"$(date -d @$SOURCE_DATE_EPOCH --rfc-3339=date)\"
+    )" > internal/version/version.go
+  '';
+
+  postBuild = ''
+    # Generate API docs for minimega and minirouter
+    $GOPATH/bin/apigen -bin $GOPATH/bin/minimega \
+                -template doc/content_templates/minimega_api.template \
+                -sections .,mesh,vm,host \
+                > doc/content/articles/api.article
+    $GOPATH/bin/apigen -bin $GOPATH/bin/minirouter \
+                -template doc/content_templates/minirouter_api.template \
+                -sections . \
+                > doc/content/articles/minirouter_api.article
+  '';
+
+  postInstall = ''
+    # Copy out the docs for minidoc
+    mkdir $out/doc
+    cp -r doc/* $out/doc/
+
+    # Copy out the assets for miniweb
+    mkdir -p $out/share/web
+    cp -r web/* $out/share/web
+  '';
+
+  postFixup = ''
+    # Wrap miniweb to pass the webroot
+    wrapProgram $out/bin/miniweb \
+      --add-flags "-root $out/share/web"
+
+    # Wrap minidoc to pass the base and root paths
+    wrapProgram $out/bin/minidoc \
+      --add-flags "-base $out/share/doc/template" \
+      --add-flags "-root $out/share/doc/content"
+  '';
+
+  meta = {
+    description = "Tool for launching and managing virtual machines";
+    homepage = "https://www.sandia.gov/minimega";
+    changelog = "https://github.com/sandia-minimega/minimega/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ tbaldwin ];
+    mainProgram = "minimega";
+  };
+})

--- a/pkgs/development/python-modules/minimega/default.nix
+++ b/pkgs/development/python-modules/minimega/default.nix
@@ -1,0 +1,36 @@
+{
+  buildPythonPackage,
+  setuptools,
+  minimega,
+  lib,
+}:
+buildPythonPackage (finalAttrs: {
+  inherit (minimega) pname version src;
+  pyproject = true;
+
+  sourceRoot = "${finalAttrs.src.name}/lib";
+
+  build-system = [
+    setuptools
+  ];
+
+  nativeBuildInputs = [
+    minimega
+  ];
+
+  preBuild = ''
+    # Generate minimega bindings from custom program
+    pyapigen -out minimega.py minimega
+    cp ../README.md .
+    cp ../VERSION .
+  '';
+
+  meta = {
+    description = "Python bindings for minimega";
+    homepage = "https://www.sandia.gov/minimega/";
+    changelog = "https://github.com/sandia-minimega/minimega/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ tbaldwin ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10493,6 +10493,8 @@ self: super: with self; {
 
   minimal-snowplow-tracker = callPackage ../development/python-modules/minimal-snowplow-tracker { };
 
+  minimega = callPackage ../development/python-modules/minimega { minimega = pkgs.minimega; };
+
   minimock = callPackage ../development/python-modules/minimock { };
 
   mininet-python = (toPythonModule (pkgs.mininet.override { python3 = python; })).py;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Init minimega from Sandia National Labs. This package wraps `qemu` and allows for dynamically spinning up vms and networks easily. This is a prerequisit to adding Phenix which is a platform for running experiments across many vms.

This PR adds:
- minimega program and associated tools (miniccc, minidoc, miniweb, etc)
- minimega python bindings
- minimega NixOS Module (WIP)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [X] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
