### PR TITLE
ocamlPackages.{ppx_css,bonsai}: unbreak the Jane Street 0.17 web stack

### DIFF
--- a/pkgs/development/ocaml-modules/janestreet/0.17.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.17.nix
@@ -375,7 +375,10 @@ with self;
       async_extra
       async_rpc_websocket
       babel
-      cohttp-async
+      # bonsai.opam requires cohttp-async < 6.0.0; also avoids mixing both
+      # cohttp lines in one closure (async_rpc_websocket pulls in
+      # cohttp_async_websocket, which uses cohttp-async_5_3)
+      cohttp-async_5_3
       core_bench
       fuzzy_match
       incr_dom

--- a/pkgs/development/ocaml-modules/janestreet/0.17.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.17.nix
@@ -9,6 +9,12 @@
 }:
 
 let
+  # Jane Street 0.17 targets the js_of_ocaml 5.x API (virtual_dom and
+  # bonsai v0.17.0 declare js_of_ocaml >= 5.1.1 & < 5.7.0); 5.9.1 is the
+  # last release before 6.x. It declares ocaml < 5.4 and its ppx breaks
+  # with ppxlib >= 0.36 (three-argument Pexp_function), so this part of
+  # the scope only builds on package sets whose ppxlib is older, i.e.
+  # OCaml <= 5.2 (see the virtual_dom and async_js broken markers).
   js_of_ocaml-compiler = self.js_of_ocaml-compiler.override { version = "5.9.1"; };
   js_of_ocaml = self.js_of_ocaml.override { inherit js_of_ocaml-compiler; };
   gen_js_api = self.gen_js_api.override {

--- a/pkgs/development/ocaml-modules/janestreet/0.17.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.17.nix
@@ -1181,6 +1181,8 @@ with self;
   ppx_css = janePackage {
     pname = "ppx_css";
     hash = "sha256-mzLMVtNTy9NrVaNgsRa+oQynxXnh2qlHJCfr3FLFJ2I=";
+    # sedlex ≥ 3.5 rejects non-ASCII character-literal intervals
+    patches = [ ./ppx_css_sedlex_3_5.patch ];
     meta.description = "PPX that takes in css strings and produces a module for accessing the unique names defined within";
     propagatedBuildInputs = [
       async
@@ -1193,7 +1195,6 @@ with self;
       sedlex
       virtual_dom
     ];
-    meta.broken = true; # Not compatible with sedlex > 3.4
   };
 
   ppx_csv_conv = janePackage {

--- a/pkgs/development/ocaml-modules/janestreet/ppx_css_sedlex_3_5.patch
+++ b/pkgs/development/ocaml-modules/janestreet/ppx_css_sedlex_3_5.patch
@@ -1,0 +1,24 @@
+Make the vendored CSS lexer compatible with sedlex >= 3.5.
+
+sedlex 3.5 restricts character-literal intervals to ASCII endpoints
+(https://github.com/ocaml-community/sedlex/pull/127, commit
+c7605dab330cee27b66a3546b97ae98be0bdcbb7, released in 3.5):
+'\160' .. '\255' is now rejected with
+"this pattern is not a valid ASCII interval regexp".  Respell the
+interval using code points, which sedlex accepts for any range and
+which denotes exactly the same character set.
+
+Upstream ppx_css master (unreleased) has restructured the vendored
+parser and defines non_ascii as the complement of the ASCII range
+instead; this minimal respelling keeps v0.17.0 semantics unchanged.
+
+--- a/vendor/css_parser/src/lexer.ml
++++ b/vendor/css_parser/src/lexer.ml
+@@ -93,7 +93,7 @@
+ let ws = [%sedlex.regexp? Star white_space]
+ let hex_digit = [%sedlex.regexp? '0' .. '9' | 'a' .. 'f' | 'A' .. 'F']
+ let digit = [%sedlex.regexp? '0' .. '9']
+-let non_ascii = [%sedlex.regexp? '\160' .. '\255']
++let non_ascii = [%sedlex.regexp? 0xA0 .. 0xFF]
+ let up_to_6_hex_digits = [%sedlex.regexp? Rep (hex_digit, 1 .. 6)]
+ let unicode = [%sedlex.regexp? '\\', up_to_6_hex_digits, Opt white_space]


### PR DESCRIPTION
Unbreaks `ocamlPackages.ppx_css` — and with it `bonsai`: a one-line patch
to ppx_css's vendored CSS lexer for sedlex ≥ 3.5, a one-line cohttp-async_5_3
fix for bonsai's closure (completing #411517), and a comment documenting
why the scope pins js_of_ocaml 5.9.1.

Verified on x86_64-linux at c2b4dd086cfddacf79cd1394f72c9ef9906dfd9b:

```
nix-build -A ocaml-ng.ocamlPackages_5_2.ppx_css   # builds; result/bin/css_inliner runs
nix-build -A ocaml-ng.ocamlPackages_5_2.bonsai    # builds
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy]: prepared with LLM assistance (Claude Code; model
  Claude Fable 5), `Assisted-by:` trailers on the commits; build-verified as above and
  reviewed by the submitting human.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test