### PR TITLE
kanban: update homepage URL to kanban.rs

### DIFF
--- a/pkgs/by-name/ka/kanban/package.nix
+++ b/pkgs/by-name/ka/kanban/package.nix
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       built with Rust. Features include file persistence, keyboard-driven
       navigation, multi-select capabilities, and sprint management.
     '';
-    homepage = "https://kanban.yoon.se";
+    homepage = "https://kanban.rs";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fulsomenko ];
     mainProgram = "kanban";


### PR DESCRIPTION
## Summary
- Updated homepage URL from the old landing page (https://kanban.yoon.se) to the project's current site (https://kanban.rs)

## Test plan
- Verified the URL is accessible