### PR TITLE
tine: init at 0.6.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8951,6 +8951,12 @@
     githubId = 62179193;
     name = "Francesco Carmelo Capria";
   };
+  fcosanabria = {
+    email = "fsanabria@mm.st";
+    github = "fcosanabria";
+    githubId = 37163970;
+    name = "Francisco Sanabria";
+  };
   fd = {
     email = "simon.menke@gmail.com";
     github = "fd";

--- a/pkgs/by-name/ti/tine/package.nix
+++ b/pkgs/by-name/ti/tine/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  cargo-tauri,
+  nodejs,
+  npmHooks,
+  pkg-config,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tine";
+  version = "0.6.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "martinkoutecky";
+    repo = "tine";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-EP1tU1RNACpY3frS+5oNPKwrZ5mBszJx2yawnhia9Mg=";
+  };
+
+  cargoHash = "sha256-/zKrnBVN8O4uCWQ7Sz5dg3XY/BqrrViNHcadjWsTZPE=";
+
+  npmDeps = fetchNpmDeps {
+    name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
+    inherit (finalAttrs) src;
+    hash = "sha256-6hyzr7Tpc7PM+E6YYAdcnvwA+d5LUc9/RqNE0JuCoXw=";
+  };
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    nodejs
+    npmHooks.npmConfigHook
+    pkg-config
+  ];
+
+  buildAndTestSubdir = "src-tauri";
+
+  tauriBuildFlags = [ "--no-bundle" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/tine $out/bin/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Fast, local, Logseq-compatible outliner";
+    homepage = "https://github.com/martinkoutecky/tine";
+    license = lib.licenses.agpl3Only;
+    mainProgram = "tine";
+    maintainers = with lib.maintainers; [ fcosanabria ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Description of the package: Tine is a fast, local, Logseq-compatible outliner built with Tauri 2 + SolidJS.

Homepage: https://github.com/martinkoutecky/tine

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

## Notes

- Uses `--no-bundle` via `tauriBuildFlags` because upstream has signing configured (public key in `tauri.conf.json`) but we don't need to sign bundles for nixpkgs. The binary is copied directly to `$out/bin/`.
- All 106 upstream unit tests pass during `checkPhase`.