### PR TITLE
hyprlandPlugins.hyprcapture: init at 0.2.6-0.56.0

### DIFF
--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/default.nix
@@ -39,6 +39,7 @@ let
     { hy3 = import ./hy3.nix; }
     { hypr-darkwindow = import ./hypr-darkwindow.nix; }
     { hypr-dynamic-cursors = import ./hypr-dynamic-cursors.nix; }
+    { hyprcapture = import ./hyprcapture.nix; }
     { hyprfocus = import ./hyprfocus.nix; }
     { hyprgrass = import ./hyprgrass.nix; }
     { hyprspace = import ./hyprspace.nix; }

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprcapture.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprcapture.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  mkHyprlandPlugin,
+  fetchFromGitHub,
+  cmake,
+  qt6,
+  kdePackages,
+  nlohmann_json,
+  hyprland,
+  nix-update-script,
+}:
+
+mkHyprlandPlugin (finalAttrs: {
+  pluginName = "hyprcapture";
+  version = "0.2.6-0.56.0";
+
+  src = fetchFromGitHub {
+    owner = "gfhdhytghd";
+    repo = "HyprCapture";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-a3xTocd0xCYqSQAByjotOa8M2PscdGQFDIlkTp/kFRo=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qt6.qtsvg
+    kdePackages.layer-shell-qt
+    nlohmann_json
+  ];
+
+  cmakeFlags = [
+    "-DHYPRCAPTURE_DEFAULT_HELPER_PATH=${placeholder "out"}/bin/hyprcapture-ui"
+    "-DHYPRCAPTURE_TRUSTED_BIN_DIRS=${hyprland}"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Hyprland-only screenshot and recording tool";
+    homepage = "https://github.com/gfhdhytghd/HyprCapture";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ anninzy ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Hyprland screenshot & recording plugin
https://github.com/gfhdhytghd/HyprCapture

Supersedes https://github.com/NixOS/nixpkgs/pull/524137

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
