### PR TITLE
teleport_18: 18.9.2 -> 18.10.0; teleport_17: 17.7.25 -> 17.7.26

### DIFF
--- a/pkgs/by-name/te/teleport_17/package.nix
+++ b/pkgs/by-name/te/teleport_17/package.nix
@@ -7,11 +7,11 @@
 }:
 
 buildTeleport {
-  version = "17.7.25";
-  hash = "sha256-IrelrkTvOBcTkO7cHf572MU5KkOQq3we53dgFsDCSRo=";
-  vendorHash = "sha256-ERwCdWdp230wkqsRUCnd1hbO4PqXo+gDPsoGbxQqt04=";
+  version = "17.7.26";
+  hash = "sha256-JwPW+w2ZS4jGWxf0GZgf3UMUrxKcIthnvZT8nImtE2c=";
+  vendorHash = "sha256-YX0HC+cU3YpAdToALJa/FeCc8ANEq7E+zExzX42lk9c=";
   cargoHash = "sha256-BE/TBZoOaB3Th14E+t3qJ+0Uww56TtRA1sRQ+usFo+Y=";
-  pnpmHash = "sha256-TARwHswSWbKk2eoyynuaOm7pvt2CwbjtklqnM+9/YXM=";
+  pnpmHash = "sha256-oVQF+Ba7zLCr86pPzFydVOBzA3GSzvtIfoggtiO2oFQ=";
 
   wasm-bindgen-cli = wasm-bindgen-cli_0_2_95;
   inherit buildGoModule withRdpClient extPatches;

--- a/pkgs/by-name/te/teleport_18/package.nix
+++ b/pkgs/by-name/te/teleport_18/package.nix
@@ -7,11 +7,11 @@
 }:
 
 buildTeleport {
-  version = "18.9.2";
-  hash = "sha256-w6qCH57L2rwClbSpZeG01eekzj3JRNijwSdfl+wx8v8=";
-  vendorHash = "sha256-LJmpFHvFsBsneq1Cl3vvqxBGB94gSjaikNDZtQfwNjM=";
-  pnpmHash = "sha256-8tKVv5SPJlS89EsHhF8qpThkh4n47qRBbHDCgX17Cdg=";
-  cargoHash = "sha256-+B5fGIzCpiYmqVcM4iy+PTIdtvuvtufQiXMHNzHTDlQ=";
+  version = "18.10.0";
+  hash = "sha256-df2VEtMTsnB72WIQj7iButC3b/U7tpv2e6dQEZm5zVA=";
+  vendorHash = "sha256-5uTZuWOSgL4319iUg8QuIqY4rACr4xBUHzdLXyG6Xo0=";
+  pnpmHash = "sha256-Fvp2ROOcr7g0yqjQheiLTaBEMysmyLLyzir6pYh09SQ=";
+  cargoHash = "sha256-cjks+Gv4CdlqWaJFFeyFsIuc3KsE7A/1MEDQB36pTkk=";
 
   wasm-bindgen-cli = wasm-bindgen-cli_0_2_122;
   buildGoModule = buildGo125Module;


### PR DESCRIPTION
Changelog: https://github.com/gravitational/teleport/releases/tag/v18.10.0
Diff: https://github.com/gravitational/teleport/compare/v18.9.2...v18.10.0

Changelog: https://github.com/gravitational/teleport/releases/tag/v17.7.26
Diff: https://github.com/gravitational/teleport/compare/v17.7.25...v17.7.26

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
