### PR TITLE
neuropil: init at 1.0.2

### DIFF
--- a/pkgs/by-name/ms/msgpack-cmp/package.nix
+++ b/pkgs/by-name/ms/msgpack-cmp/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "msgpack-cmp";
+  version = "20";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "camgunz";
+    repo = "cmp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-K42M6QhGrZgVWANSoVu62iC/uYfUjOKwgLS3m7U8Qu0=";
+  };
+
+  env.CMPCFLAGS = "-std=c99 -o libcmp.so";
+
+  buildPhase = ''
+    runHook preBuild
+
+    $CC $CFLAGS $CMPCFLAGS -g -I. -c cmp.c
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{lib,obj,include}/cmp
+    cp ./libcmp.so "$out/lib/libcmp.so"
+    cp ./cmp.h "$out/include/cmp/cmp.h"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Implementation of the MessagePack serialization format in C";
+    homepage = "https://github.com/camgunz/cmp";
+    changelog = "https://github.com/camgunz/cmp/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/by-name/ne/neuropil/0001-Remove-duplicate-QCBOR_Int64ToUInt16.patch
+++ b/pkgs/by-name/ne/neuropil/0001-Remove-duplicate-QCBOR_Int64ToUInt16.patch
@@ -1,0 +1,28 @@
+Since it's already defined when building with system qcbor.
+---
+ src/util/s11n_impl/np_serialize_qcbor.c | 9 ---------
+ 1 file changed, 9 deletions(-)
+
+diff --git a/src/util/s11n_impl/np_serialize_qcbor.c b/src/util/s11n_impl/np_serialize_qcbor.c
+index 903554d8..1f8863d1 100644
+--- a/src/util/s11n_impl/np_serialize_qcbor.c
++++ b/src/util/s11n_impl/np_serialize_qcbor.c
+@@ -37,15 +37,6 @@ static void AppendCBORHeadWithSize(QCBOREncodeContext *me,
+   UsefulOutBuf_AppendUsefulBuf(&(me->OutBuf), EncodedHead);
+ }
+ 
+-static inline int QCBOR_Int64ToUInt16(int64_t src, uint16_t *dest) {
+-  if (src > UINT16_MAX || src < 0) {
+-    return -1;
+-  } else {
+-    *dest = (uint16_t)src;
+-  }
+-  return 0;
+-}
+-
+ uint8_t __np_tree_serialize_read_type_dhkey(QCBORDecodeContext *qcbor_ctx,
+                                             np_treeval_t       *target) {
+ 
+-- 
+2.54.0
+

--- a/pkgs/by-name/ne/neuropil/0002-Disable-vendord-qcbor.patch
+++ b/pkgs/by-name/ne/neuropil/0002-Disable-vendord-qcbor.patch
@@ -1,0 +1,19 @@
+---
+ SConstruct | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/SConstruct b/SConstruct
+index b95491cc..962ab7f1 100755
+--- a/SConstruct
++++ b/SConstruct
+@@ -225,7 +225,6 @@ default_env.Append(
+         os.path.join(project_root_path, "include"),
+         os.path.join(project_root_path, "framework"),
+         os.path.join(project_root_path, "ext_tools"),
+-        os.path.join(project_root_path, "ext_tools", "qcbor", "inc"),
+         os.path.join(project_root_path, "build", "ext_tools", "libsodium", "include"),
+     ]
+ )
+-- 
+2.54.0
+

--- a/pkgs/by-name/ne/neuropil/package.nix
+++ b/pkgs/by-name/ne/neuropil/package.nix
@@ -1,0 +1,137 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  nix-update-script,
+
+  # build-time
+  fixDarwinDylibNames,
+  git,
+  python3,
+  scons,
+
+  # run-time
+  criterion,
+  libsodium,
+  msgpack-cmp,
+  ncurses,
+  parson,
+  sqlite,
+  qcbor,
+
+  withDebug ? true,
+  withSystemMsgpackCmp ? true,
+  withSystemQcbor ? true,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "neuropil";
+  version = "1.0.2";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitLab {
+    owner = "pi-lar";
+    repo = "neuropil";
+    tag = "neuropil_${finalAttrs.version}";
+    hash = "sha256-NQU3dL/4ftV730i9snW+K9wdnRsirYnOgHw6F5VuR7w=";
+    fetchSubmodules = true;
+  };
+
+  patches = lib.optionals withSystemQcbor [
+    ./0001-Remove-duplicate-QCBOR_Int64ToUInt16.patch
+    ./0002-Disable-vendord-qcbor.patch
+  ];
+
+  postPatch = ''
+    # Replace non-breaking spaces with standard spaces across all C files,
+    # else the build fails
+    find . \
+      -name '*.c' \
+      -exec sed -i 's#\xc2\xa0# #g' {} +
+  '';
+
+  nativeBuildInputs = [
+    git
+    scons
+    finalAttrs.passthru.customPython
+  ]
+  ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
+
+  buildInputs = [
+    criterion
+    libsodium
+    ncurses
+    parson
+    sqlite
+  ]
+  ++ lib.optional withSystemMsgpackCmp msgpack-cmp
+  ++ lib.optional withSystemQcbor qcbor;
+
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-Wno-implicit-function-declaration"
+    "-Wno-incompatible-pointer-types"
+    "-Wno-unused-variable"
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    mkdir build
+    scons -C build -f ../SConstruct
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{include,lib,bin}
+    cp -r include/neuropil* $out/include
+    cp -r build/neuropil/lib/* $out/lib
+    cp -r build/neuropil/bin/* $out/bin
+
+    runHook postInstall
+  '';
+
+  dontStrip = withDebug;
+
+  passthru.updateScript = nix-update-script { };
+  passthru.customPython = python3.withPackages (p: [
+    p.requests
+  ]);
+
+  meta = {
+    description = "Secure & distributed M2M cybersecurity mesh";
+    # https://pi-lar.gitlab.io/neuropil/intro.html#introduction
+    longDescription = ''
+      Neuropil is a small c-library which by default adds two layers of
+      encryption to communication channels.
+
+      It allows you to address identities (a device, an application, a service
+      or a person) worldwide without compromise for privacy or security
+      requirements.
+
+      The project embraces modern concepts like named-data networks,
+      self-sovereign identities, zero trust architectures and attributes based
+      access control to increase the cybersecurity level of its users beyond
+      the current state-of-technology.
+
+      In effect its users will benefit from the new way of secure, scalable and
+      souvereign data integration to easily comply with legal, organizational,
+      operational and compliance regulations and requirements.
+    '';
+    homepage = "https://gitlab.com/pi-lar/neuropil";
+    mainProgram = "neuropil";
+    platforms = lib.platforms.all;
+    license = with lib.licenses; [
+      osl3
+      # src/ext_tools
+      bsd2
+      gpl2Plus
+      x11
+    ];
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/by-name/qc/qcbor/package.nix
+++ b/pkgs/by-name/qc/qcbor/package.nix
@@ -5,7 +5,7 @@
   cmake,
   nix-update-script,
 
-  disableFeatures ? true,
+  disableFeatures ? false,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS" disableFeatures)
     (lib.cmakeBool "QCBOR_DISABLE_INDEFINITE_LENGTH_ARRAYS" disableFeatures)
     (lib.cmakeBool "QCBOR_DISABLE_PREFERRED_FLOAT" disableFeatures)
-    (lib.cmakeFeature "BUILD_QCBOR_TEST" "APP")
+    (lib.cmakeFeature "BUILD_QCBOR_TEST" (if finalAttrs.doCheck then "APP" else "OFF"))
   ];
 
   doCheck = true;
@@ -42,7 +42,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "CBOR encoder/decoder";
     homepage = "https://github.com/laurencelundblade/QCBOR";
     changelog = "https://github.com/laurencelundblade/QCBOR/releases/tag/${finalAttrs.src.tag}";
-    mainProgram = "qcbor";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ eljamm ];

--- a/pkgs/by-name/qc/qcbor/package.nix
+++ b/pkgs/by-name/qc/qcbor/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  nix-update-script,
+
+  disableFeatures ? true,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qcbor";
+  version = "1.6.1";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "laurencelundblade";
+    repo = "QCBOR";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-tpCW0YjTipdpYwgFVVV0pSb4OH3QoJSbhbb48/WhTFw=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  cmakeFlags = [
+    # https://github.com/laurencelundblade/QCBOR#disabling-features
+    (lib.cmakeBool "QCBOR_DISABLE_ENCODE_USAGE_GUARDS" disableFeatures)
+    (lib.cmakeBool "QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS" disableFeatures)
+    (lib.cmakeBool "QCBOR_DISABLE_INDEFINITE_LENGTH_ARRAYS" disableFeatures)
+    (lib.cmakeBool "QCBOR_DISABLE_PREFERRED_FLOAT" disableFeatures)
+    (lib.cmakeFeature "BUILD_QCBOR_TEST" "APP")
+  ];
+
+  doCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CBOR encoder/decoder";
+    homepage = "https://github.com/laurencelundblade/QCBOR";
+    changelog = "https://github.com/laurencelundblade/QCBOR/releases/tag/${finalAttrs.src.tag}";
+    mainProgram = "qcbor";
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})


### PR DESCRIPTION
Neuropil is a secure & distributed M2M cybersecurity mesh (see the [project documentation](https://pi-lar.gitlab.io/neuropil/intro.html#introduction) for more information).

Tracking: https://github.com/ngi-nix/projects/issues/601

> [!NOTE]
> - work done as part of the [Nix@NGI](https://nixos.org/community/teams/ngi/) packaging effort
> - some derivations were adapted and improved from [upstream's Nix code](https://gitlab.com/pi-lar/neuropil/-/tree/85223b0ddccfcd492075d2368e761a6fb27f9d5f/scripts/nix)
> - this PR was assisted-by `DeepSeek V4 Flash Free`, which figured out the non-breaking spaces fix and how to use the system qcbor over the vendored one

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
