### PR TITLE
python3Packages.numpy_2: fix for test failure on i686

### DIFF
--- a/pkgs/development/python-modules/numpy/2.nix
+++ b/pkgs/development/python-modules/numpy/2.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   python,
   pythonAtLeast,
   buildPythonPackage,
@@ -51,6 +52,16 @@ buildPythonPackage (finalAttrs: {
     fetchSubmodules = true;
     hash = "sha256-IriSrnGAZHvJ7m97s12BydNQZDZunCVtRgj/iSgw5Vc=";
   };
+
+  patches = [
+    # Fix for test failure on i686. Remove with next release.
+    # Upstream report: https://github.com/numpy/numpy/issues/32060
+    # Upstream PR: https://github.com/numpy/numpy/pull/32064
+    (fetchpatch {
+      url = "https://github.com/numpy/numpy/commit/0e1dce62e27f79be9d6552487787a19b7f95cfbf.patch";
+      hash = "sha256-mQjf6y/mLSgx9+G70/r9U3VJg5zIrl/6ANQhpP2LGmg=";
+    })
+  ];
 
   postPatch = ''
     # remove needless reference to full Python path stored in built wheel


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

```
> FAILED lib/python3.14/site-packages/numpy/lib/tests/test_polynomial.py::TestPolynomial::test_poly_int_overflow - AssertionError:
> Arrays are not almost equal to 7 decimals
>
> Mismatched elements: 2 / 21 (9.52%)
> Mismatch at indices:
>  [14]: 1.2066478037803732e+18 (ACTUAL), 1.2066478037803735e+18 (DESIRED)
>  [15]: -3.599979517947607e+18 (ACTUAL), -3.5999795179476076e+18 (DESIRED)
> Max absolute difference among violations: 512.
> Max relative difference among violations: 2.12158013e-16
>  ACTUAL: array([ 1.0000000e+00, -2.1000000e+02,  2.0615000e+04, -1.2568500e+06,
>         5.3327946e+07, -1.6722808e+09,  4.0171772e+10, -7.5611118e+11,
>         1.1310277e+13, -1.3558518e+14,  1.3075350e+15, -1.0142300e+16,...
>  DESIRED: array([ 1.0000000e+00, -2.1000000e+02,  2.0615000e+04, -1.2568500e+06,
>         5.3327946e+07, -1.6722808e+09,  4.0171772e+10, -7.5611118e+11,
>         1.1310277e+13, -1.3558518e+14,  1.3075350e+15, -1.0142300e+16,...
> = 1 failed, 47072 passed, 1058 skipped, 31 xfailed, 2 xpassed, 555 warnings in 30.74s =
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
