### PR TITLE
imagemagick: Generic GCC arch

### DIFF
--- a/pkgs/by-name/im/imagemagick/package.nix
+++ b/pkgs/by-name/im/imagemagick/package.nix
@@ -67,26 +67,6 @@
 assert libXtSupport -> libX11Support;
 assert libraqmSupport -> freetypeSupport;
 
-let
-  arch =
-    if stdenv.hostPlatform.system == "i686-linux" then
-      "i686"
-    else if
-      stdenv.hostPlatform.system == "x86_64-linux" || stdenv.hostPlatform.system == "x86_64-darwin"
-    then
-      "x86-64"
-    else if stdenv.hostPlatform.system == "armv7l-linux" then
-      "armv7l"
-    else if
-      stdenv.hostPlatform.system == "aarch64-linux" || stdenv.hostPlatform.system == "aarch64-darwin"
-    then
-      "aarch64"
-    else if stdenv.hostPlatform.system == "powerpc64le-linux" then
-      "ppc64le"
-    else
-      null;
-in
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "imagemagick";
   version = "7.1.2-27";
@@ -113,7 +93,7 @@ stdenv.mkDerivation (finalAttrs: {
     "MVDelegate=${lib.getExe' coreutils "mv"}"
     "RMDelegate=${lib.getExe' coreutils "rm"}"
     "--with-frozenpaths"
-    (lib.withFeatureAs (arch != null) "gcc-arch" arch)
+    "--with-gcc-arch=generic"
     (lib.withFeature librsvgSupport "rsvg")
     (lib.withFeature librsvgSupport "pango")
     (lib.withFeature liblqr1Support "lqr")


### PR DESCRIPTION
The architectures for `x86_64` and `aarch64` have been deprecated.

[This comment](https://github.com/NixOS/nixpkgs/pull/195766#issuecomment-1478981292) suggests doing so, and I've found that `--with-gcc-arch=generic` is already used, whilst `--without-gcc-arch` isn't used.
Closes https://github.com/NixOS/nixpkgs/pull/195766

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
