### PR TITLE
logo-ls-modernized: init at 1.3.7

### DIFF
--- a/pkgs/by-name/lo/logo-ls-modernized/package.nix
+++ b/pkgs/by-name/lo/logo-ls-modernized/package.nix
@@ -7,6 +7,7 @@
 buildGoModule {
   pname = "logo-ls-modernized";
   version = "1.3.7";
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "orhnk";

--- a/pkgs/by-name/lo/logo-ls-modernized/package.nix
+++ b/pkgs/by-name/lo/logo-ls-modernized/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "logo-ls-modernized";
+  version = "1.3.7";
+
+  src = fetchFromGitHub {
+    owner = "orhnk";
+    repo = "logo-ls-modernized";
+    rev = "7bf4721811c2b7f08e2dfb7a1b5d40de39a315fa";
+    hash = "sha256-javdn2UODcMXe094qn0KYs/oMTjtMWZCo9bUNH9Bb9c=";
+  };
+
+  proxyVendor = true;
+
+  subPackages = [ "." ];
+
+  vendorHash = "sha256-yEj0A3LLv/l8Iqnvj/H+TA6UPzETr+ph5Y9QcX4nmjw=";
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Modern ls command with beautiful icons and git integrations written in Go";
+    homepage = "https://github.com/orhnk/logo-ls-modernized";
+    license = licenses.mit;
+    mainProgram = "logo-ls";
+    maintainers = [ ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/by-name/lo/logo-ls-modernized/package.nix
+++ b/pkgs/by-name/lo/logo-ls-modernized/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
 }:
 
-buildGoModule rec {
+buildGoModule {
   pname = "logo-ls-modernized";
   version = "1.3.7";
 


### PR DESCRIPTION
## Things done

Added `logo-ls-modernized`, a modern replacement for `ls` written in Go. It provides file listings with icons, colors, and git integration.

Homepage: https://github.com/orhnk/logo-ls-modernized

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin

- Tested, as applicable:
  - [x] Ran `nixpkgs-review wip` on this PR.
  - [x] Tested basic functionality of the binary in `./result/bin/`.

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.