### PR TITLE
Darwin linux-builder drop-in solution with Rosetta support

### DIFF
--- a/doc/packages/darwin-builder.section.md
+++ b/doc/packages/darwin-builder.section.md
@@ -83,6 +83,57 @@ $ sudo launchctl kickstart -k system/org.nixos.nix-daemon
 
 Note that if the builder is running and you have created the above ssh conf file, you can ssh into the builder with `sudo ssh builder@linux-builder`.
 
+## Using the Virtualization.framework backend {#sec-darwin-builder-vz}
+
+`darwin.linux-builder-vz` is a variant of `darwin.linux-builder` that runs the same
+NixOS guest on Apple's Virtualization.framework (via `pkgs.vzvm`) instead of QEMU.
+Instead of emulating x86_64, it exposes Rosetta to the guest, so `x86_64-linux`
+builds are translated rather than emulated, which is substantially faster. It
+requires an Apple silicon host (`aarch64-darwin`) running macOS 13 or newer, with
+Rosetta installed:
+
+```ShellSession
+$ softwareupdate --install-rosetta --agree-to-license
+```
+
+The builder refuses to start when Rosetta is missing, rather than silently dropping
+`x86_64-linux` support; set `virtualisation.vz.rosetta.enable = false` to run
+without it.
+
+It is a drop-in replacement: it listens on the same host port (31022) and presents
+the same host key as the QEMU builder, so the `nix.conf` and SSH configuration
+described above apply unchanged; only the transport behind the port changes, from
+TCP forwarding to vsock. Since a single builder VM handles both architectures
+through Rosetta, list both systems in your `builders` entry
+(`aarch64-linux,x86_64-linux`), or with nix-darwin:
+
+```nix
+{
+  nix.linux-builder = {
+    enable = true;
+    package = pkgs.darwin.linux-builder-vz;
+    systems = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+  };
+}
+```
+
+When switching an existing QEMU builder over, delete its data disk first (e.g.
+`sudo rm /var/lib/linux-builder/nixos.qcow2`): the vz builder reuses the file name
+but writes a raw image, and refuses to misread a genuine qcow2 left behind.
+
+The guest console goes to the macOS unified log by default; read it with:
+
+```ShellSession
+$ /usr/bin/log show --last 5m --predicate 'subsystem == "systems.applicative.vzvm"'
+```
+
+The `virtualisation.vz.*` NixOS options configure the backend further, e.g.
+`virtualisation.vz.nestedVirtualization` gives the guest a working `/dev/kvm` for
+running NixOS integration tests on the builder (macOS 15+, M3 or newer).
+
 ## Example flake usage {#sec-darwin-builder-example-flake}
 
 ```nix

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -440,6 +440,9 @@
   "sec-darwin-availability-checks": [
     "index.html#sec-darwin-availability-checks"
   ],
+  "sec-darwin-builder-vz": [
+    "index.html#sec-darwin-builder-vz"
+  ],
   "sec-darwin-libcxx-deployment-targets": [
     "index.html#sec-darwin-libcxx-deployment-targets"
   ],

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -112,6 +112,8 @@
 
 - The `shell_interact()` function on interactive runs of NixOS VM tests has been deprecated. Use the SSH backdoor instead.
 
+- `darwin.linux-builder-vz` has been added: a variant of `darwin.linux-builder` that runs the builder guest on Apple's Virtualization.framework via the new `vzvm` package, translating `x86_64-linux` builds with Rosetta instead of emulating them. Apple silicon hosts only. As part of this, the `nixos/modules/profiles/nix-builder-vm.nix` profile has been split into the backend-neutral `nixos/modules/profiles/nix-builder.nix` and a QEMU-specific part. Existing imports of `nix-builder-vm.nix` keep working unchanged.
+
 - [services.netbox](#opt-services.netbox.enable) has received a number of updates:
   - Default settings can now be introspected at [](#opt-services.netbox.settings).
   - Environment files can now be passed at [](#opt-services.netbox.environmentFiles).

--- a/nixos/lib/erofs-store-image.nix
+++ b/nixos/lib/erofs-store-image.nix
@@ -1,0 +1,30 @@
+# Shell-script fragment that packs a Nix store closure into a read-only erofs
+# image, built on the host when the VM starts. Shared by the VM backends
+# `qemu-vm.nix` and `vz-vm.nix`
+{
+  hostPkgs,
+  # path to a file listing the store paths to pack, one per line
+  storePaths,
+  # filesystem label of the image
+  label,
+  # shell word the image is written to
+  destination,
+}:
+''
+  ${hostPkgs.gnutar}/bin/tar --create \
+    --absolute-names \
+    --verbatim-files-from \
+    --transform 'flags=rSh;s|/nix/store/||' \
+    --transform 'flags=rSh;s|~nix~case~hack~[[:digit:]]\+||g' \
+    --files-from ${storePaths} \
+    | ${hostPkgs.erofs-utils}/bin/mkfs.erofs \
+      --quiet \
+      --force-uid=0 \
+      --force-gid=0 \
+      -L ${label} \
+      -U eb176051-bd15-49b7-9e6b-462e0b467019 \
+      -T 0 \
+      --hard-dereference \
+      --tar=f \
+      ${destination}
+''

--- a/nixos/modules/profiles/nix-builder-vm.nix
+++ b/nixos/modules/profiles/nix-builder-vm.nix
@@ -3,118 +3,19 @@
   which can be used to build packages for Linux on other operating systems;
   primarily macOS.
 
-  It contains both the relevant guest settings as well as an installer script
-  that manages it as a QEMU virtual machine on the host.
+  It combines the backend-neutral remote-builder profile (./nix-builder.nix)
+  with the QEMU VM backend (../virtualisation/qemu-vm.nix), which provides the
+  `config.system.build.vm` runner that the installer script launches.
 */
-{
-  config,
-  lib,
-  options,
-  ...
-}:
-
-let
-  keysDirectory = "/var/keys";
-
-  user = "builder";
-
-  keyType = "ed25519";
-
-  cfg = config.virtualisation.darwin-builder;
-
-in
+{ config, ... }:
 
 {
   imports = [
+    ./nix-builder.nix
     ../virtualisation/qemu-vm.nix
-
-    # Avoid a dependency on stateVersion
-    {
-      disabledModules = [
-        ../virtualisation/nixos-containers.nix
-        ../services/x11/desktop-managers/xterm.nix
-      ];
-      # swraid's default depends on stateVersion
-      config.boot.swraid.enable = false;
-      options.boot.isContainer = lib.mkOption {
-        default = false;
-        internal = true;
-      };
-      options.boot.isNspawnContainer = lib.mkOption {
-        default = false;
-        internal = true;
-      };
-    }
   ];
 
-  options.virtualisation.darwin-builder = with lib; {
-    diskSize = mkOption {
-      default = 20 * 1024;
-      type = types.int;
-      example = 30720;
-      description = "The maximum disk space allocated to the runner in MiB (1024×1024 bytes).";
-    };
-    memorySize = mkOption {
-      default = 3 * 1024;
-      type = types.int;
-      example = 8192;
-      description = "The runner's memory in MiB (1024×1024 bytes).";
-    };
-    min-free = mkOption {
-      default = 1024 * 1024 * 1024;
-      type = types.int;
-      example = 1073741824;
-      description = ''
-        The threshold (in bytes) of free disk space left at which to
-        start garbage collection on the runner
-      '';
-    };
-    max-free = mkOption {
-      default = 3 * 1024 * 1024 * 1024;
-      type = types.int;
-      example = 3221225472;
-      description = ''
-        The threshold (in bytes) of free disk space left at which to
-        stop garbage collection on the runner
-      '';
-    };
-    workingDirectory = mkOption {
-      default = ".";
-      type = types.str;
-      example = "/var/lib/darwin-builder";
-      description = ''
-        The working directory to use to run the script. When running
-        as part of a flake will need to be set to a non read-only filesystem.
-      '';
-    };
-    hostPort = mkOption {
-      default = 31022;
-      type = types.port;
-      example = 22;
-      description = ''
-        The localhost host port to forward TCP to the guest port.
-      '';
-    };
-  };
-
   config = {
-    # The builder is not intended to be used interactively
-    documentation.enable = false;
-
-    environment.etc = {
-      "ssh/ssh_host_ed25519_key" = {
-        mode = "0600";
-
-        source = ./keys/ssh_host_ed25519_key;
-      };
-
-      "ssh/ssh_host_ed25519_key.pub" = {
-        mode = "0644";
-
-        source = ./keys/ssh_host_ed25519_key.pub;
-      };
-    };
-
     # DNS fails for QEMU user networking (SLiRP) on macOS.  See:
     #
     # https://github.com/utmapp/UTM/issues/2353
@@ -123,174 +24,18 @@ in
     # server that QEMU provides (normally 10.0.2.3)
     networking.nameservers = [ "8.8.8.8" ];
 
-    # The linux builder is a lightweight VM for remote building; not evaluation.
-    nix.channel.enable = false;
-
-    # Deployment is by image.
-    # TODO system.switch.enable = false;?
-    system.disableInstallerTools = true;
-
-    # Allow the system derivation to be substituted, so that
-    # users are less likely to run into a state where they need
-    # the builder running to build the builder if they just want
-    # to make a tweak that only affects the macOS side of things,
-    # like changing the QEMU args.
-    #
-    # TODO(winter): Move to qemu-vm? Trying it here for now as a
-    # low impact change that'll probably improve people's experience.
-    system.systemBuilderArgs.allowSubstitutes = true;
-
-    nix.settings = {
-      min-free = cfg.min-free;
-
-      max-free = cfg.max-free;
-
-      trusted-users = [ user ];
-    };
-
-    services = {
-      getty.autologinUser = user;
-
-      openssh = {
-        enable = true;
-
-        authorizedKeysFiles = [ "${keysDirectory}/%u_${keyType}.pub" ];
-      };
-    };
-
-    system.build.macos-builder-installer =
-      let
-        privateKey = "/etc/nix/${user}_${keyType}";
-
-        publicKey = "${privateKey}.pub";
-
-        # This installCredentials script is written so that it's as easy as
-        # possible for a user to audit before confirming the `sudo`
-        installCredentials = hostPkgs.writeShellScript "install-credentials" ''
-          set -euo pipefail
-
-          KEYS="''${1}"
-          INSTALL=${hostPkgs.coreutils}/bin/install
-          "''${INSTALL}" -g nixbld -m 600 "''${KEYS}/${user}_${keyType}" ${privateKey}
-          "''${INSTALL}" -g nixbld -m 644 "''${KEYS}/${user}_${keyType}.pub" ${publicKey}
-        '';
-
-        hostPkgs = config.virtualisation.host.pkgs;
-
-        add-keys = hostPkgs.writeShellScriptBin "add-keys" (
-          ''
-            set -euo pipefail
-          ''
-          +
-            # When running as non-interactively as part of a DarwinConfiguration the working directory
-            # must be set to a writeable directory.
-            (
-              if cfg.workingDirectory != "." then
-                ''
-                  ${hostPkgs.coreutils}/bin/mkdir --parent "${cfg.workingDirectory}"
-                  cd "${cfg.workingDirectory}"
-                ''
-              else
-                ""
-            )
-          + ''
-            KEYS="''${KEYS:-./keys}"
-            ${hostPkgs.coreutils}/bin/mkdir --parent "''${KEYS}"
-            PRIVATE_KEY="''${KEYS}/${user}_${keyType}"
-            PUBLIC_KEY="''${PRIVATE_KEY}.pub"
-            if [ ! -e "''${PRIVATE_KEY}" ] || [ ! -e "''${PUBLIC_KEY}" ]; then
-                ${hostPkgs.coreutils}/bin/rm --force -- "''${PRIVATE_KEY}" "''${PUBLIC_KEY}"
-                ${hostPkgs.openssh}/bin/ssh-keygen -q -f "''${PRIVATE_KEY}" -t ${keyType} -N "" -C 'builder@localhost'
-            fi
-            if ! ${hostPkgs.diffutils}/bin/cmp "''${PUBLIC_KEY}" ${publicKey}; then
-              (set -x; sudo --reset-timestamp ${installCredentials} "''${KEYS}")
-            fi
-          ''
-        );
-
-        run-builder = hostPkgs.writeShellScriptBin "run-builder" ''
-          set -euo pipefail
-          KEYS="''${KEYS:-./keys}"
-          KEYS="$(${hostPkgs.nix}/bin/nix-store --add "$KEYS")" ${lib.getExe config.system.build.vm}
-        '';
-
-      in
-      hostPkgs.writeTextFile {
-        name = "create-builder";
-        executable = true;
-        destination = "/bin/create-builder";
-        text = ''
-          #!${hostPkgs.runtimeShell}
-          set -euo pipefail
-          export KEYS="''${KEYS:-./keys}"
-          ${lib.getExe add-keys}
-          ${lib.getExe run-builder}
-        '';
-        checkPhase = ''
-          ${hostPkgs.stdenv.shellDryRun} "$target"
-        '';
-        meta = {
-          mainProgram = "create-builder";
-          description = "Create a Linux builder VM for macOS";
-          platforms = lib.platforms.darwin;
-        };
-        passthru = {
-          # Let users in the repl inspect the config
-          nixosConfig = config;
-          nixosOptions = options;
-
-          inherit add-keys run-builder;
-        };
-      };
-
-    system = {
-      # To prevent gratuitous rebuilds on each change to Nixpkgs
-      nixos.revision = null;
-
-      # To prevent channels and Git checkouts resulting in different system drvs
-      nixos.versionSuffix = "";
-
-      # to be updated by module maintainers, see nixpkgs#325610
-      stateVersion = "24.05";
-    };
-
-    users.users."${user}" = {
-      isNormalUser = true;
-    };
-
-    security.polkit.enable = true;
-
-    security.polkit.extraConfig = ''
-      polkit.addRule(function(action, subject) {
-        if (action.id === "org.freedesktop.login1.power-off" && subject.user === "${user}") {
-          return "yes";
-        } else {
-          return "no";
-        }
-      })
-    '';
-
     virtualisation = {
-      diskSize = cfg.diskSize;
-
-      memorySize = cfg.memorySize;
-
       forwardPorts = [
         {
           from = "host";
           guest.port = 22;
-          host.port = cfg.hostPort;
+          host.port = config.virtualisation.darwin-builder.hostPort;
         }
       ];
 
       # Disable graphics for the builder since users will likely want to run it
       # non-interactively in the background.
       graphics = false;
-
-      sharedDirectories.keys = {
-        source = "\"$KEYS\"";
-        target = keysDirectory;
-      };
 
       # If we don't enable this option then the host will fail to delegate builds
       # to the guest, because:
@@ -303,18 +48,6 @@ in
       # Snapshotting the host's /nix/store as an image isolates the guest VM's
       # /nix/store from the host's /nix/store, preventing this problem.
       useNixStoreImage = true;
-
-      # Obviously the /nix/store needs to be writable on the guest in order for it
-      # to perform builds.
-      writableStore = true;
-
-      # This ensures that anything built on the guest isn't lost when the guest is
-      # restarted.
-      writableStoreUseTmpfs = false;
-
-      # Pass certificates from host to the guest otherwise when custom CA certificates
-      # are required we can't use the cached builder.
-      useHostCerts = true;
     };
   };
 }

--- a/nixos/modules/profiles/nix-builder-vz-vm.nix
+++ b/nixos/modules/profiles/nix-builder-vz-vm.nix
@@ -1,0 +1,87 @@
+/*
+  The Linux remote-builder profile, on Apple's Virtualization.framework.
+
+  The vzvm counterpart to `./nix-builder-vm.nix`:
+
+  - Backend-neutral half lives in `./nix-builder.nix`.
+  - everything below is what differs from the QEMU backend.
+
+  Main differences:
+
+  - `networking.nameservers = [ "8.8.8.8" ]` is not needed.
+    vz uses the host's NAT, which provides working DNS.
+  - `virtualisation.graphics = false`: no display support in vz
+  - `virtualisation.useNixStoreImage`: vz only supports nix store image
+*/
+{
+  config,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.virtualisation.darwin-builder;
+
+  keysDirectory = "/var/keys";
+  keysMountUnit = "var-keys.mount";
+in
+
+{
+  imports = [
+    ./nix-builder.nix
+    ../virtualisation/vz-vm.nix
+  ];
+
+  config = {
+    virtualisation.vz.forwardPorts = [
+      {
+        host.address = "127.0.0.1";
+        host.port = cfg.hostPort;
+        # Must track the port the guest serves SSH on, or the host forwards nowhere.
+        guest.port = config.virtualisation.vz.vsockSSH.port;
+      }
+    ];
+
+    # The guest console belongs where a Mac user looks for service logs. Switch to `file`
+    # for a complete record: the unified log drops messages under bursts.
+    virtualisation.vz.console = lib.mkDefault "log";
+    virtualisation.vz.consoleLog = lib.mkDefault "./console.log";
+
+    # Our raw image must keep the `.qcow2` name nix-darwin's `ephemeral` wipes; vzvm checks
+    # the magic bytes and refuses a genuine leftover qcow2 rather than misreading it.
+    virtualisation.vz.diskImage = "./${config.networking.hostName}.qcow2";
+
+    # authorized keys come via virtiofs. fix uid and mode for sshd's ownership checks.
+    systemd.services.copy-builder-keys = {
+      description = "Stage builder SSH keys where sshd will accept them";
+      wantedBy = [ "multi-user.target" ];
+      requires = [ keysMountUnit ];
+      after = [ keysMountUnit ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
+      script = ''
+        install -d -m 0755 -o root -g root /run/builder-keys
+        for key in ${keysDirectory}/*.pub; do
+          [ -e "$key" ] || continue
+          install -m 0444 -o root -g root "$key" /run/builder-keys/
+        done
+      '';
+    };
+
+    # The dependency belongs on the per-connection service, not on the socket.
+    systemd.services."vzvm-ssh@" = {
+      requires = [ "copy-builder-keys.service" ];
+      wants = [ "network-online.target" ];
+      after = [
+        "copy-builder-keys.service"
+        "network-online.target"
+      ];
+    };
+
+    services.openssh.authorizedKeysFiles = lib.mkForce [
+      "/run/builder-keys/%u_ed25519.pub"
+    ];
+  };
+}

--- a/nixos/modules/profiles/nix-builder-vz-vm.nix
+++ b/nixos/modules/profiles/nix-builder-vz-vm.nix
@@ -37,8 +37,8 @@ in
       {
         host.address = "127.0.0.1";
         host.port = cfg.hostPort;
-        # Must track the port the guest serves SSH on, or the host forwards nowhere.
-        guest.port = config.virtualisation.vz.vsockSSH.port;
+        # `systemd-ssh-generator` serves SSH on vsock port 22 in the guest.
+        guest.port = 22;
       }
     ];
 
@@ -71,8 +71,11 @@ in
     };
 
     # The dependency belongs on the per-connection service, not on the socket.
-    systemd.services."vzvm-ssh@" = {
+    systemd.services."sshd-vsock@" = {
+      overrideStrategy = "asDropin";
       requires = [ "copy-builder-keys.service" ];
+      # ssh works before DHCP finishes
+      # don't accept build requests when substitution would still fail
       wants = [ "network-online.target" ];
       after = [
         "copy-builder-keys.service"

--- a/nixos/modules/profiles/nix-builder.nix
+++ b/nixos/modules/profiles/nix-builder.nix
@@ -1,0 +1,288 @@
+/*
+  Backend-neutral half of the profile that uses NixOS to create a remote
+  builder VM to build Linux packages, which can be used to build packages for
+  Linux on other operating systems; primarily macOS.
+
+  It contains the relevant guest settings as well as an installer script that
+  manages the VM on the host, but no VM backend. A backend module provides
+  `config.system.build.vm`, which the installer script launches; see
+  ./nix-builder-vm.nix for the QEMU-based composition.
+*/
+{
+  config,
+  lib,
+  options,
+  ...
+}:
+
+let
+  keysDirectory = "/var/keys";
+
+  user = "builder";
+
+  keyType = "ed25519";
+
+  cfg = config.virtualisation.darwin-builder;
+
+in
+
+{
+  imports = [
+    # Avoid a dependency on stateVersion
+    {
+      disabledModules = [
+        ../virtualisation/nixos-containers.nix
+        ../services/x11/desktop-managers/xterm.nix
+      ];
+      # swraid's default depends on stateVersion
+      config.boot.swraid.enable = false;
+      options.boot.isContainer = lib.mkOption {
+        default = false;
+        internal = true;
+      };
+      options.boot.isNspawnContainer = lib.mkOption {
+        default = false;
+        internal = true;
+      };
+    }
+  ];
+
+  options.virtualisation.darwin-builder = with lib; {
+    diskSize = mkOption {
+      default = 20 * 1024;
+      type = types.int;
+      example = 30720;
+      description = "The maximum disk space allocated to the runner in MiB (1024×1024 bytes).";
+    };
+    memorySize = mkOption {
+      default = 3 * 1024;
+      type = types.int;
+      example = 8192;
+      description = "The runner's memory in MiB (1024×1024 bytes).";
+    };
+    min-free = mkOption {
+      default = 1024 * 1024 * 1024;
+      type = types.int;
+      example = 1073741824;
+      description = ''
+        The threshold (in bytes) of free disk space left at which to
+        start garbage collection on the runner
+      '';
+    };
+    max-free = mkOption {
+      default = 3 * 1024 * 1024 * 1024;
+      type = types.int;
+      example = 3221225472;
+      description = ''
+        The threshold (in bytes) of free disk space left at which to
+        stop garbage collection on the runner
+      '';
+    };
+    workingDirectory = mkOption {
+      default = ".";
+      type = types.str;
+      example = "/var/lib/darwin-builder";
+      description = ''
+        The working directory to use to run the script. When running
+        as part of a flake will need to be set to a non read-only filesystem.
+      '';
+    };
+    hostPort = mkOption {
+      default = 31022;
+      type = types.port;
+      example = 22;
+      description = ''
+        The localhost host port to forward TCP to the guest port.
+      '';
+    };
+  };
+
+  config = {
+    # The builder is not intended to be used interactively
+    documentation.enable = false;
+
+    environment.etc = {
+      "ssh/ssh_host_ed25519_key" = {
+        mode = "0600";
+
+        source = ./keys/ssh_host_ed25519_key;
+      };
+
+      "ssh/ssh_host_ed25519_key.pub" = {
+        mode = "0644";
+
+        source = ./keys/ssh_host_ed25519_key.pub;
+      };
+    };
+
+    # The linux builder is a lightweight VM for remote building; not evaluation.
+    nix.channel.enable = false;
+
+    # Deployment is by image.
+    # TODO system.switch.enable = false;?
+    system.disableInstallerTools = true;
+
+    # Allow the system derivation to be substituted, so that
+    # users are less likely to run into a state where they need
+    # the builder running to build the builder if they just want
+    # to make a tweak that only affects the macOS side of things,
+    # like changing the QEMU args.
+    #
+    # TODO(winter): Move to qemu-vm? Trying it here for now as a
+    # low impact change that'll probably improve people's experience.
+    system.systemBuilderArgs.allowSubstitutes = true;
+
+    nix.settings = {
+      min-free = cfg.min-free;
+
+      max-free = cfg.max-free;
+
+      trusted-users = [ user ];
+    };
+
+    services = {
+      getty.autologinUser = user;
+
+      openssh = {
+        enable = true;
+
+        authorizedKeysFiles = [ "${keysDirectory}/%u_${keyType}.pub" ];
+      };
+    };
+
+    system.build.macos-builder-installer =
+      let
+        privateKey = "/etc/nix/${user}_${keyType}";
+
+        publicKey = "${privateKey}.pub";
+
+        # This installCredentials script is written so that it's as easy as
+        # possible for a user to audit before confirming the `sudo`
+        installCredentials = hostPkgs.writeShellScript "install-credentials" ''
+          set -euo pipefail
+
+          KEYS="''${1}"
+          INSTALL=${hostPkgs.coreutils}/bin/install
+          "''${INSTALL}" -g nixbld -m 600 "''${KEYS}/${user}_${keyType}" ${privateKey}
+          "''${INSTALL}" -g nixbld -m 644 "''${KEYS}/${user}_${keyType}.pub" ${publicKey}
+        '';
+
+        hostPkgs = config.virtualisation.host.pkgs;
+
+        add-keys = hostPkgs.writeShellScriptBin "add-keys" (
+          ''
+            set -euo pipefail
+          ''
+          +
+            # When running as non-interactively as part of a DarwinConfiguration the working directory
+            # must be set to a writeable directory.
+            (
+              if cfg.workingDirectory != "." then
+                ''
+                  ${hostPkgs.coreutils}/bin/mkdir --parent "${cfg.workingDirectory}"
+                  cd "${cfg.workingDirectory}"
+                ''
+              else
+                ""
+            )
+          + ''
+            KEYS="''${KEYS:-./keys}"
+            ${hostPkgs.coreutils}/bin/mkdir --parent "''${KEYS}"
+            PRIVATE_KEY="''${KEYS}/${user}_${keyType}"
+            PUBLIC_KEY="''${PRIVATE_KEY}.pub"
+            if [ ! -e "''${PRIVATE_KEY}" ] || [ ! -e "''${PUBLIC_KEY}" ]; then
+                ${hostPkgs.coreutils}/bin/rm --force -- "''${PRIVATE_KEY}" "''${PUBLIC_KEY}"
+                ${hostPkgs.openssh}/bin/ssh-keygen -q -f "''${PRIVATE_KEY}" -t ${keyType} -N "" -C 'builder@localhost'
+            fi
+            if ! ${hostPkgs.diffutils}/bin/cmp "''${PUBLIC_KEY}" ${publicKey}; then
+              (set -x; sudo --reset-timestamp ${installCredentials} "''${KEYS}")
+            fi
+          ''
+        );
+
+        run-builder = hostPkgs.writeShellScriptBin "run-builder" ''
+          set -euo pipefail
+          KEYS="''${KEYS:-./keys}"
+          KEYS="$(${hostPkgs.nix}/bin/nix-store --add "$KEYS")" ${lib.getExe config.system.build.vm}
+        '';
+
+      in
+      hostPkgs.writeTextFile {
+        name = "create-builder";
+        executable = true;
+        destination = "/bin/create-builder";
+        text = ''
+          #!${hostPkgs.runtimeShell}
+          set -euo pipefail
+          export KEYS="''${KEYS:-./keys}"
+          ${lib.getExe add-keys}
+          ${lib.getExe run-builder}
+        '';
+        checkPhase = ''
+          ${hostPkgs.stdenv.shellDryRun} "$target"
+        '';
+        meta = {
+          mainProgram = "create-builder";
+          description = "Create a Linux builder VM for macOS";
+          platforms = lib.platforms.darwin;
+        };
+        passthru = {
+          # Let users in the repl inspect the config
+          nixosConfig = config;
+          nixosOptions = options;
+
+          inherit add-keys run-builder;
+        };
+      };
+
+    system = {
+      # To prevent gratuitous rebuilds on each change to Nixpkgs
+      nixos.revision = null;
+
+      # To prevent channels and Git checkouts resulting in different system drvs
+      nixos.versionSuffix = "";
+
+      # to be updated by module maintainers, see nixpkgs#325610
+      stateVersion = "24.05";
+    };
+
+    users.users."${user}" = {
+      isNormalUser = true;
+    };
+
+    security.polkit.enable = true;
+
+    security.polkit.extraConfig = ''
+      polkit.addRule(function(action, subject) {
+        if (action.id === "org.freedesktop.login1.power-off" && subject.user === "${user}") {
+          return "yes";
+        } else {
+          return "no";
+        }
+      })
+    '';
+
+    virtualisation = {
+      diskSize = cfg.diskSize;
+
+      memorySize = cfg.memorySize;
+
+      sharedDirectories.keys = {
+        source = "\"$KEYS\"";
+        target = keysDirectory;
+      };
+
+      # Obviously the /nix/store needs to be writable on the guest in order for it
+      # to perform builds.
+      writableStore = true;
+
+      # This ensures that anything built on the guest isn't lost when the guest is
+      # restarted.
+      writableStoreUseTmpfs = false;
+
+      # Pass certificates from host to the guest otherwise when custom CA certificates
+      # are required we can't use the cached builder.
+      useHostCerts = true;
+    };
+  };
+}

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -172,30 +172,19 @@ let
     ${lib.optionalString (cfg.useNixStoreImage) ''
       echo "Creating Nix store image..."
 
-      ${hostPkgs.gnutar}/bin/tar --create \
-        --absolute-names \
-        --verbatim-files-from \
-        --transform 'flags=rSh;s|/nix/store/||' \
-        --transform 'flags=rSh;s|~nix~case~hack~[[:digit:]]\+||g' \
-        --files-from ${
+      ${import ../../lib/erofs-store-image.nix {
+        inherit hostPkgs;
+        storePaths = "${
           hostPkgs.closureInfo {
             rootPaths = [
               config.system.build.toplevel
               regInfo
             ];
           }
-        }/store-paths \
-        | ${hostPkgs.erofs-utils}/bin/mkfs.erofs \
-          --quiet \
-          --force-uid=0 \
-          --force-gid=0 \
-          -L ${nixStoreFilesystemLabel} \
-          -U eb176051-bd15-49b7-9e6b-462e0b467019 \
-          -T 0 \
-          --hard-dereference \
-          --tar=f \
-          "$TMPDIR"/store.img
-
+        }/store-paths";
+        label = nixStoreFilesystemLabel;
+        destination = ''"$TMPDIR"/store.img'';
+      }}
       echo "Created Nix store image."
     ''}
 

--- a/nixos/modules/virtualisation/vm-base.nix
+++ b/nixos/modules/virtualisation/vm-base.nix
@@ -1,0 +1,204 @@
+# Backend-neutral pieces of running a NixOS guest in a VM.
+#
+# `qemu-vm.nix` still carries its own copies of these options: the two modules are
+# never imported together because a configuration has exactly one VM backend, so
+# the duplicated declarations cannot collide.
+# Deduping `qemu-vm.nix` onto this module is a refactor left for later.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.virtualisation;
+in
+{
+  options = {
+
+    virtualisation.memorySize = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 1024;
+      description = ''
+        The memory size in megabytes of the virtual machine.
+      '';
+    };
+
+    virtualisation.cores = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 1;
+      description = ''
+        Specify the number of cores the guest is permitted to use.
+        The number can be higher than the available cores on the
+        host system.
+      '';
+    };
+
+    # `virtualisation.diskSize` comes from `disk-size-option.nix` in the default module list.
+
+    virtualisation.additionalPaths = lib.mkOption {
+      type = lib.types.listOf lib.types.path;
+      default = [ ];
+      description = ''
+        A list of paths whose closure should be made available to the VM.
+
+        The closure is copied into the VM's Nix store image and registered in
+        the guest's Nix database.
+      '';
+    };
+
+    virtualisation.writableStore = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        If enabled, the Nix store in the VM is made writable by layering an
+        overlay filesystem on top of the (read-only) store image.
+      '';
+    };
+
+    virtualisation.writableStoreUseTmpfs = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Use a tmpfs for the writable store instead of writing to a disk image.
+
+        Turning this off makes store writes survive a reboot, at the cost of
+        needing a disk to put them on.
+      '';
+    };
+
+    virtualisation.useHostCerts = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        If enabled, when `NIX_SSL_CERT_FILE` is set on the host,
+        pass the CA certificates from the host to the VM.
+      '';
+    };
+
+    virtualisation.sharedDirectories = lib.mkOption {
+      type = lib.types.attrsOf (
+        lib.types.submodule (
+          { name, ... }:
+          {
+            options.source = lib.mkOption {
+              type = lib.types.str;
+              description = "The path of the directory to share, can be a shell variable";
+            };
+            options.target = lib.mkOption {
+              type = lib.types.path;
+              description = "The mount point of the directory inside the virtual machine";
+            };
+            options.tag = lib.mkOption {
+              type = lib.types.str;
+              default = name;
+              description = ''
+                The tag the guest mounts this share by. Defaults to the attribute
+                name. Backends impose their own length limits on tags.
+              '';
+            };
+          }
+        )
+      );
+      default = { };
+      example = {
+        my-share = {
+          source = "/path/to/be/shared";
+          target = "/mnt/shared";
+        };
+      };
+      description = ''
+        An attribute set of directories that will be shared with the virtual
+        machine. The attribute name is used as the mount tag.
+      '';
+    };
+
+    virtualisation.host.pkgs = lib.mkOption {
+      type = lib.types.pkgs;
+      default = pkgs;
+      defaultText = lib.literalExpression "pkgs";
+      example = lib.literalExpression ''
+        import pkgs.path { system = "aarch64-darwin"; }
+      '';
+      description = ''
+        Package set to use for the host-side tooling that launches the VM.
+
+        This is not the guest's package set: the host may well be a different
+        platform than the guest, which is the entire point of running a VM.
+      '';
+    };
+  };
+
+  config = {
+
+    # Passed on the kernel command line: a direct reference would make the closure self-referential.
+    systemd.services.register-nix-paths = lib.mkIf config.nix.enable {
+      # Runs early so the store DB is populated first; `--load-db` needs no daemon.
+      unitConfig.DefaultDependencies = false;
+      wantedBy = [ "sysinit.target" ];
+      before = [
+        "sysinit.target"
+        "shutdown.target"
+        "nix-daemon.socket"
+        "nix-daemon.service"
+      ];
+      after = [ "local-fs.target" ];
+      conflicts = [ "shutdown.target" ];
+      restartIfChanged = false;
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        User = lib.mkIf (config.nix.daemonUser != "root") config.nix.daemonUser;
+        Group = lib.mkIf (config.nix.daemonGroup != "root") config.nix.daemonGroup;
+      };
+      script = ''
+        if [[ "$(cat /proc/cmdline)" =~ regInfo=([^ ]*) ]]; then
+          ${lib.getExe' config.nix.package.out "nix-store"} --load-db < "''${BASH_REMATCH[1]}"
+        fi
+      '';
+    };
+
+    virtualisation.additionalPaths = [ config.system.build.toplevel ];
+
+    # Read-only erofs store, overlaid when writable. Override per entry: `mkVMOverride` on
+    # the whole set would drop other modules' filesystems, including the Rosetta share.
+    fileSystems = {
+      "/nix/.ro-store" = lib.mkVMOverride {
+        device = "/dev/disk/by-label/nix-store";
+        fsType = "erofs";
+        neededForBoot = true;
+        options = [ "ro" ];
+      };
+      "/nix/store" = lib.mkVMOverride (
+        if cfg.writableStore then
+          {
+            overlay = {
+              lowerdir = [ "/nix/.ro-store" ];
+              upperdir = "/nix/.rw-store/upper";
+              workdir = "/nix/.rw-store/work";
+            };
+          }
+        else
+          {
+            device = "/nix/.ro-store";
+            fsType = "none";
+            options = [ "bind" ];
+          }
+      );
+      "/nix/.rw-store" = lib.mkIf (cfg.writableStore && cfg.writableStoreUseTmpfs) (
+        lib.mkVMOverride {
+          fsType = "tmpfs";
+          options = [ "mode=0755" ];
+          neededForBoot = true;
+        }
+      );
+    };
+
+    swapDevices = lib.mkVMOverride [ ];
+    boot.initrd.luks.devices = lib.mkVMOverride { };
+
+    # The host keeps time for us.
+    services.timesyncd.enable = false;
+  };
+}

--- a/nixos/modules/virtualisation/vz-vm.nix
+++ b/nixos/modules/virtualisation/vz-vm.nix
@@ -1,0 +1,452 @@
+# Runs a NixOS guest on Apple's Virtualization.framework with `vzvm`: Rosetta, and a
+# lighter hypervisor than QEMU.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.virtualisation;
+  vzCfg = cfg.vz;
+
+  hostPkgs = cfg.host.pkgs;
+
+  regInfo = hostPkgs.closureInfo { rootPaths = cfg.additionalPaths; };
+
+  # Host-built erofs store image, named by closure hash so only a changed guest rebuilds it.
+  # A derivation is not an option: it would need the Linux builder this VM provides.
+  storeClosureInfo = hostPkgs.closureInfo {
+    rootPaths = [
+      config.system.build.toplevel
+      regInfo
+    ];
+  };
+  storeImageName = "store-${lib.head (lib.splitString "-" (baseNameOf (toString storeClosureInfo)))}.img";
+
+  toplevel = config.system.build.toplevel;
+
+  kernelParams = [
+    # Virtualization.framework offers a virtio console
+    "console=hvc0"
+    "init=${toplevel}/init"
+    "regInfo=${regInfo}/registration"
+  ]
+  ++ config.boot.kernelParams;
+
+  forwards = map (forward: {
+    listen = "${forward.host.address}:${toString forward.host.port}";
+    vsockPort = forward.guest.port;
+  }) vzCfg.forwardPorts;
+
+  # The builder profile passes the keys directory as `"$KEYS"`; the runner resolves it.
+  shareFragment = lib.concatMapStrings (share: ''
+    shares=$(${lib.getExe hostPkgs.jq} -n --argjson shares "$shares" \
+      --arg tag ${lib.escapeShellArg share.tag} --arg path ${share.source} \
+      '$shares + [{tag: $tag, path: $path}]')
+  '') (lib.attrValues cfg.sharedDirectories);
+
+  staticConfig = {
+    cpuCount = cfg.cores;
+    memorySizeMiB = cfg.memorySize;
+    kernel = "${toplevel}/kernel";
+    initrd = "${toplevel}/initrd";
+    cmdline = toString kernelParams;
+    vsock.forwards = forwards;
+    rosetta = vzCfg.rosetta.enable;
+    inherit (vzCfg) nestedVirtualization;
+    # Only `file` carries a path; dispatch rather than fall through, so a new mode cannot
+    # silently be emitted as `file`.
+    console =
+      if vzCfg.console == "file" then
+        {
+          mode = "file";
+          path = vzCfg.consoleLog;
+        }
+      else
+        { mode = vzCfg.console; };
+  }
+  // vzCfg.extraConfig;
+
+  staticConfigFile = hostPkgs.writeText "vzvm-config.json" (builtins.toJSON staticConfig);
+in
+{
+  imports = [ ./vm-base.nix ];
+
+  options = {
+
+    virtualisation.vz.package = lib.mkPackageOption hostPkgs "vzvm" { };
+
+    virtualisation.vz.rosetta = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Expose Rosetta to the guest, so that it can execute x86_64 binaries.
+
+          Rosetta must be installed on the host; the VM refuses to start
+          otherwise rather than quietly losing the ability to build for
+          x86_64-linux. Install it with:
+
+          ```
+          softwareupdate --install-rosetta --agree-to-license
+          ```
+        '';
+      };
+
+    };
+
+    virtualisation.vz.nestedVirtualization = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Boot the guest at EL2 so it gets a working `/dev/kvm`, which the Nix
+        daemon inside then advertises as the `kvm` system feature — required
+        for running NixOS integration tests on the builder.
+
+        Needs macOS 15+ and an M3 or newer chip; the VM refuses to start
+        otherwise rather than quietly advertising a `kvm` it does not have.
+      '';
+    };
+
+    virtualisation.vz.forwardPorts = lib.mkOption {
+      type = lib.types.listOf (
+        lib.types.submodule {
+          options.host.address = lib.mkOption {
+            type = lib.types.str;
+            default = "127.0.0.1";
+            description = "Host address to listen on.";
+          };
+          options.host.port = lib.mkOption {
+            type = lib.types.port;
+            description = "Host port to listen on.";
+          };
+          options.guest.port = lib.mkOption {
+            type = lib.types.port;
+            description = "Guest *vsock* port that connections are forwarded to.";
+          };
+        }
+      );
+      default = [ ];
+      example = lib.literalExpression ''
+        [ { host.port = 2222; guest.port = 22; } ]
+      '';
+      description = ''
+        Forward host TCP ports into guest over vsock.
+
+        Going via vsock relieves us from having to find a stable inbound address
+        in the NAT network setup.
+      '';
+    };
+
+    virtualisation.vz.console = lib.mkOption {
+      type = lib.types.enum [
+        "stdio"
+        "file"
+        "log"
+      ];
+      default = "stdio";
+      description = ''
+        Where the guest console goes.
+
+        - `stdio`: standard output, which is interactive but goes nowhere under launchd.
+        - `file`: the path in {option}`virtualisation.vz.consoleLog`. The only complete
+          record: the unified log rate-limits chatty sources and drops under bursts.
+        - `log`: macOS unified logging, alongside vzvm's own diagnostics. Read it with
+          `log show --predicate 'subsystem == "systems.applicative.vzvm"'`, and narrow to
+          the guest with `AND category == "guest"`.
+      '';
+    };
+
+    virtualisation.vz.consoleLog = lib.mkOption {
+      type = lib.types.str;
+      default = "./console.log";
+      description = ''
+        Console log file, used when {option}`virtualisation.vz.console` is `file`.
+        Relative paths are resolved against working directory.
+      '';
+    };
+
+    virtualisation.vz.diskImage = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = "./${config.system.name}.img";
+      defaultText = lib.literalExpression ''"./''${config.system.name}.img"'';
+      description = ''
+        Path to the raw data disk backing the writable store, created on first
+        start. Set to `null` to run without one, which requires
+        {option}`virtualisation.writableStoreUseTmpfs`.
+      '';
+    };
+
+    virtualisation.vz.vsockSSH = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = config.services.openssh.enable;
+        defaultText = lib.literalExpression "config.services.openssh.enable";
+        description = ''
+          Serve SSH on a vsock port in addition to any TCP listeners.
+
+          Inbound connections arrive over vsock rather than TCP because NAT
+          networking gives the guest no stable inbound address. Each connection
+          is handed to its own `sshd -i`, same way a socket-activated `sshd`
+          works over TCP.
+        '';
+      };
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 22;
+        description = "vsock port that SSH is served on.";
+      };
+    };
+
+    virtualisation.vz.extraConfig = lib.mkOption {
+      type = lib.types.attrs;
+      default = { };
+      description = ''
+        Additional attributes merged into the generated `vzvm` JSON configuration.
+      '';
+    };
+  };
+
+  config = lib.mkMerge [
+    {
+      assertions = [
+        {
+          assertion = hostPkgs.stdenv.hostPlatform.system == "aarch64-darwin";
+          message = ''
+            virtualisation.vz only runs on aarch64-darwin hosts, but
+            `virtualisation.host.pkgs` is ${hostPkgs.stdenv.hostPlatform.system}.
+          '';
+        }
+        {
+          assertion = pkgs.stdenv.hostPlatform.isAarch64;
+          message = ''
+            virtualisation.vz cannot emulate a foreign architecture: the guest
+            (${pkgs.stdenv.hostPlatform.system}) must be aarch64. x86_64 guest
+            binaries run through Rosetta instead, not through emulation.
+          '';
+        }
+        {
+          assertion = vzCfg.diskImage != null || cfg.writableStoreUseTmpfs;
+          message = ''
+            virtualisation.vz.diskImage is null, so there is nowhere to put the
+            writable store. Enable virtualisation.writableStoreUseTmpfs.
+          '';
+        }
+      ];
+
+      boot.loader.grub.enable = false;
+
+      boot.initrd.availableKernelModules = [
+        "virtio_pci"
+        "virtio_blk"
+        "virtio_console"
+        "virtiofs"
+        "erofs"
+        "overlay"
+      ];
+
+      # All inbound connections go via vsock
+      boot.kernelModules = [ "vmw_vsock_virtio_transport" ];
+
+      boot.initrd.systemd.enable = lib.mkDefault true;
+
+      system.requiredKernelConfig = with config.lib.kernelConfig; [
+        (isEnabled "VIRTIO_BLK")
+        (isEnabled "VIRTIO_PCI")
+        (isEnabled "VIRTIO_CONSOLE")
+        (isEnabled "VIRTIO_NET")
+        (isYes "BLK_DEV_INITRD")
+        (isEnabled "FUSE_FS")
+        (isEnabled "VIRTIO_FS")
+        (isEnabled "EROFS_FS")
+        (isEnabled "OVERLAY_FS")
+        (isEnabled "VSOCKETS")
+        (isEnabled "VIRTIO_VSOCKETS")
+      ];
+
+      # Override per entry and not as a whole: see note in vm-base.nix.
+      fileSystems = {
+        "/" = lib.mkVMOverride {
+          device = "tmpfs";
+          fsType = "tmpfs";
+          neededForBoot = true;
+          options = [ "mode=0755" ];
+        };
+      }
+      // lib.optionalAttrs (!cfg.writableStoreUseTmpfs && vzCfg.diskImage != null) {
+        # Second disk, hence /dev/vdb: store image is always first.
+        "/nix/.rw-store" = lib.mkVMOverride {
+          device = "/dev/vdb";
+          fsType = "ext4";
+          autoFormat = true;
+          neededForBoot = true;
+        };
+      }
+      // lib.mapAttrs' (
+        _: share:
+        lib.nameValuePair share.target (
+          lib.mkVMOverride {
+            device = share.tag;
+            fsType = "virtiofs";
+          }
+        )
+      ) cfg.sharedDirectories;
+
+      # DHCP and DNS come from host NAT
+      networking.useDHCP = lib.mkDefault true;
+
+      virtualisation.rosetta.enable = lib.mkIf vzCfg.rosetta.enable true;
+      # Must agree with the tag vzvm shares Rosetta under, which is fixed.
+      virtualisation.rosetta.mountTag = lib.mkIf vzCfg.rosetta.enable "rosetta";
+
+      system.build.vm =
+        hostPkgs.runCommand "nixos-vm"
+          {
+            preferLocalBuild = true;
+            meta.mainProgram = "run-${config.system.name}-vm";
+          }
+          ''
+            mkdir -p $out/bin
+            ln -s ${config.system.build.toplevel} $out/system
+            ln -s ${hostPkgs.writeShellScript "run-${config.system.name}-vm" ''
+              set -eu
+
+              # nix-darwin runs this with a working directory it owns
+              imageDir="''${VZVM_STATE_DIR:-$PWD}"
+              mkdir -p "$imageDir"
+
+              if [ -z "''${TMPDIR:-}" ]; then
+                # GNU mktemp needs the XXXXXX placeholder; only reachable when TMPDIR is unset.
+                TMPDIR=$(${hostPkgs.coreutils}/bin/mktemp -d -t vzvm.XXXXXX)
+              fi
+              export TMPDIR
+
+              ${lib.optionalString cfg.useHostCerts ''
+                mkdir -p "$TMPDIR/certs"
+                if [ -e "''${NIX_SSL_CERT_FILE:-}" ]; then
+                  ${hostPkgs.coreutils}/bin/install -m 0644 \
+                    "$NIX_SSL_CERT_FILE" "$TMPDIR/certs/ca-certificates.crt"
+                else
+                  echo "vzvm: NIX_SSL_CERT_FILE is unset or missing; guest gets no host CA certificates" >&2
+                  : > "$TMPDIR/certs/ca-certificates.crt"
+                fi
+              ''}
+
+              storeImage="$imageDir/${storeImageName}"
+
+              if [ ! -f "$storeImage" ]; then
+                echo "Building Nix store image, this can take a minute on first boot..." >&2
+
+                # Build into a temp file so an interrupted run leaves no truncated image behind.
+                storeImageTmp="$storeImage.tmp.$$"
+                # shellcheck disable=SC2064
+                trap "rm -f '$storeImageTmp'" EXIT
+
+                ${hostPkgs.gnutar}/bin/tar --create \
+                  --absolute-names \
+                  --verbatim-files-from \
+                  --transform 'flags=rSh;s|/nix/store/||' \
+                  --transform 'flags=rSh;s|~nix~case~hack~[[:digit:]]\+||g' \
+                  --files-from ${storeClosureInfo}/store-paths \
+                  | ${hostPkgs.erofs-utils}/bin/mkfs.erofs \
+                    --quiet \
+                    --force-uid=0 \
+                    --force-gid=0 \
+                    -L nix-store \
+                    -U eb176051-bd15-49b7-9e6b-462e0b467019 \
+                    -T 0 \
+                    --hard-dereference \
+                    --tar=f \
+                    "$storeImageTmp"
+
+                mv "$storeImageTmp" "$storeImage"
+                trap - EXIT
+
+                # Images from previous generations are dead weight and cheap to rebuild.
+                find "$imageDir" -maxdepth 1 -name 'store-*.img' ! -name ${lib.escapeShellArg storeImageName} -delete
+              fi
+
+              disks=$(${lib.getExe hostPkgs.jq} -n --arg store "$storeImage" \
+                '[{path: $store, readOnly: true}]')
+
+              shares='[]'
+              ${shareFragment}
+
+              ${lib.optionalString (vzCfg.diskImage != null) ''
+                dataDisk="${vzCfg.diskImage}"
+                case "$dataDisk" in
+                  /*) ;;
+                  *) dataDisk="$imageDir/''${dataDisk#./}" ;;
+                esac
+
+                if [ ! -f "$dataDisk" ]; then
+                  echo "Creating ${toString cfg.diskSize}M data disk at $dataDisk..." >&2
+                  ${hostPkgs.coreutils}/bin/dd if=/dev/zero of="$dataDisk" bs=1M count=0 \
+                     seek=${toString cfg.diskSize}
+                fi
+
+                disks=$(${lib.getExe hostPkgs.jq} -n --argjson disks "$disks" --arg data "$dataDisk" \
+                  '$disks + [{path: $data, readOnly: false}]')
+              ''}
+
+              config="$imageDir/vzvm.json"
+              ${lib.getExe hostPkgs.jq} --argjson disks "$disks" --argjson shares "$shares" \
+                '.disks = $disks | .shares = $shares' ${staticConfigFile} > "$config"
+
+              exec ${lib.getExe vzCfg.package} "$config"
+            ''} $out/bin/run-${config.system.name}-vm
+          '';
+    }
+
+    (lib.mkIf vzCfg.vsockSSH.enable {
+      # sshd has no vsock listener, so systemd owns the socket and hands it each connection.
+      systemd.sockets.vzvm-ssh = {
+        description = "SSH vsock socket";
+        wantedBy = [ "sockets.target" ];
+        socketConfig = {
+          ListenStream = "vsock::${toString vzCfg.vsockSSH.port}";
+          Accept = true;
+
+          # The default 64 suits interactive logins, not `ssh-ng://`; past the limit systemd
+          # stops accepting and connections hang without a banner or a log line anywhere.
+          MaxConnections = 512;
+
+          # stop the socket unit outright once exceeded
+          TriggerLimitIntervalSec = 0;
+        };
+      };
+
+      # vsock delivers no RST, so without keepalives a session whose peer vanished never dies.
+      services.openssh.settings = {
+        ClientAliveInterval = lib.mkDefault 60;
+        ClientAliveCountMax = lib.mkDefault 3;
+      };
+
+      systemd.services."vzvm-ssh@" = {
+        description = "SSH per-connection daemon (vsock)";
+        after = [ "sshd-keygen.service" ];
+        serviceConfig = {
+          ExecStart = "-${lib.getExe' config.services.openssh.package "sshd"} -i -f /etc/ssh/sshd_config";
+          StandardInput = "socket";
+          StandardOutput = "socket";
+          StandardError = "journal";
+
+          # Not `KillMode = "process"`: sshd's `nix-daemon` child would outlive the connection
+          # and leak instances against MaxConnections until the guest stops accepting SSH.
+          TimeoutStopSec = 10;
+        };
+      };
+    })
+
+    (lib.mkIf cfg.useHostCerts {
+      virtualisation.sharedDirectories.certs = {
+        source = "$TMPDIR/certs";
+        target = "/etc/ssl/certs";
+      };
+      security.pki.installCACerts = false;
+    })
+  ];
+}

--- a/nixos/modules/virtualisation/vz-vm.nix
+++ b/nixos/modules/virtualisation/vz-vm.nix
@@ -323,23 +323,12 @@ in
                 # shellcheck disable=SC2064
                 trap "rm -f '$storeImageTmp'" EXIT
 
-                ${hostPkgs.gnutar}/bin/tar --create \
-                  --absolute-names \
-                  --verbatim-files-from \
-                  --transform 'flags=rSh;s|/nix/store/||' \
-                  --transform 'flags=rSh;s|~nix~case~hack~[[:digit:]]\+||g' \
-                  --files-from ${storeClosureInfo}/store-paths \
-                  | ${hostPkgs.erofs-utils}/bin/mkfs.erofs \
-                    --quiet \
-                    --force-uid=0 \
-                    --force-gid=0 \
-                    -L nix-store \
-                    -U eb176051-bd15-49b7-9e6b-462e0b467019 \
-                    -T 0 \
-                    --hard-dereference \
-                    --tar=f \
-                    "$storeImageTmp"
-
+                ${import ../../lib/erofs-store-image.nix {
+                  inherit hostPkgs;
+                  storePaths = "${storeClosureInfo}/store-paths";
+                  label = "nix-store";
+                  destination = ''"$storeImageTmp"'';
+                }}
                 mv "$storeImageTmp" "$storeImage"
                 trap - EXIT
 

--- a/nixos/modules/virtualisation/vz-vm.nix
+++ b/nixos/modules/virtualisation/vz-vm.nix
@@ -179,28 +179,6 @@ in
       '';
     };
 
-    virtualisation.vz.vsockSSH = {
-      enable = lib.mkOption {
-        type = lib.types.bool;
-        default = config.services.openssh.enable;
-        defaultText = lib.literalExpression "config.services.openssh.enable";
-        description = ''
-          Serve SSH on a vsock port in addition to any TCP listeners.
-
-          Inbound connections arrive over vsock rather than TCP because NAT
-          networking gives the guest no stable inbound address. Each connection
-          is handed to its own `sshd -i`, same way a socket-activated `sshd`
-          works over TCP.
-        '';
-      };
-
-      port = lib.mkOption {
-        type = lib.types.port;
-        default = 22;
-        description = "vsock port that SSH is served on.";
-      };
-    };
-
     virtualisation.vz.extraConfig = lib.mkOption {
       type = lib.types.attrs;
       default = { };
@@ -248,8 +226,8 @@ in
         "overlay"
       ];
 
-      # All inbound connections go via vsock
-      boot.kernelModules = [ "vmw_vsock_virtio_transport" ];
+      # Inbound connections go via vsock; loaded in the initrd so `systemd-ssh-generator` finds `/dev/vsock`.
+      boot.initrd.kernelModules = [ "vmw_vsock_virtio_transport" ];
 
       boot.initrd.systemd.enable = lib.mkDefault true;
 
@@ -401,43 +379,31 @@ in
           '';
     }
 
-    (lib.mkIf vzCfg.vsockSSH.enable {
-      # sshd has no vsock listener, so systemd owns the socket and hands it each connection.
-      systemd.sockets.vzvm-ssh = {
-        description = "SSH vsock socket";
-        wantedBy = [ "sockets.target" ];
+    (lib.mkIf config.services.openssh.enable {
+      # `systemd-ssh-generator` serves SSH on vsock:22; retune its socket for `ssh-ng://` build traffic.
+      systemd.sockets.sshd-vsock = {
+        overrideStrategy = "asDropin";
         socketConfig = {
-          ListenStream = "vsock::${toString vzCfg.vsockSSH.port}";
-          Accept = true;
-
-          # The default 64 suits interactive logins, not `ssh-ng://`; past the limit systemd
-          # stops accepting and connections hang without a banner or a log line anywhere.
+          # past the default 64 concurrent connections, systemd stops accepting and ssh hangs silently
           MaxConnections = 512;
 
-          # stop the socket unit outright once exceeded
+          # don't stop the socket unit outright when connections arrive in bursts
           TriggerLimitIntervalSec = 0;
         };
+      };
+
+      systemd.services."sshd-vsock@" = {
+        overrideStrategy = "asDropin";
+        # don't race host key generation on first boot
+        wants = [ "sshd-keygen.service" ];
+        after = [ "sshd-keygen.service" ];
+        serviceConfig.TimeoutStopSec = 10;
       };
 
       # vsock delivers no RST, so without keepalives a session whose peer vanished never dies.
       services.openssh.settings = {
         ClientAliveInterval = lib.mkDefault 60;
         ClientAliveCountMax = lib.mkDefault 3;
-      };
-
-      systemd.services."vzvm-ssh@" = {
-        description = "SSH per-connection daemon (vsock)";
-        after = [ "sshd-keygen.service" ];
-        serviceConfig = {
-          ExecStart = "-${lib.getExe' config.services.openssh.package "sshd"} -i -f /etc/ssh/sshd_config";
-          StandardInput = "socket";
-          StandardOutput = "socket";
-          StandardError = "journal";
-
-          # Not `KillMode = "process"`: sshd's `nix-daemon` child would outlive the connection
-          # and leak instances against MaxConnections until the guest stops accepting SSH.
-          TimeoutStopSec = 10;
-        };
       };
     })
 

--- a/pkgs/by-name/vz/vzvm/package.nix
+++ b/pkgs/by-name/vz/vzvm/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  fetchFromGitHub,
+  darwin,
+  swift,
+  swiftPackages,
+  nix-update-script,
+}:
+
+swiftPackages.stdenv.mkDerivation (finalAttrs: {
+  pname = "vzvm";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "applicative-systems";
+    repo = "vzvm";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-wAozYULlBYelKH5Z35uOWm6nzu9gpMCV6G5WhWL8GKk=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/vzvm";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    darwin.sigtool
+    swift
+  ];
+
+  # No external deps: avoids need for swiftpm2nix and `swift build` (network fetches)
+  buildPhase = ''
+    runHook preBuild
+
+    swiftc -O -o vzvm Sources/vzvm/*.swift
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 vzvm $out/bin/vzvm
+
+    runHook postInstall
+  '';
+
+  # Virtualization.framework can't create VMs without this entitlement
+  postFixup = ''
+    codesign --entitlements ${finalAttrs.src}/vzvm/vzvm.entitlements -f -s - $out/bin/vzvm
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Minimal Linux VM monitor built on Apple's Virtualization.framework";
+    longDescription = ''
+      vzvm boots a Linux guest from a kernel and initrd on Apple's
+      Virtualization.framework, configured from a JSON file. It supports
+      Rosetta directory shares for running x86_64 binaries on Apple silicon, and
+      forwards host TCP ports into the guest over vsock, so inbound connections need
+      no guest IP discovery. Highly specialized for use as linux-builder.
+    '';
+    homepage = "https://github.com/applicative-systems/vzvm";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tfc ];
+    platforms = [ "aarch64-darwin" ];
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
+    mainProgram = "vzvm";
+  };
+})

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -177,6 +177,31 @@ makeScopeWithSplicing' {
       linux-builder-x86_64 = self.linux-builder.override {
         modules = [ { nixpkgs.hostPlatform = "x86_64-linux"; } ];
       };
+
+      # Like `linux-builder`, but runs the guest on Apple's Virtualization.framework
+      # via `vzvm`, translating x86_64-linux builds with Rosetta instead of emulating
+      # them. See doc/packages/darwin-builder.section.md
+      linux-builder-vz = lib.makeOverridable (
+        { modules }:
+        let
+          nixos = import ../../nixos {
+            configuration = {
+              imports = [
+                ../../nixos/modules/profiles/nix-builder-vz-vm.nix
+              ]
+              ++ modules;
+
+              virtualisation.host = { inherit pkgs; };
+
+              # aarch64-darwin is the only supported host, so the guest is fixed too.
+              nixpkgs.hostPlatform = lib.mkDefault "aarch64-linux";
+            };
+
+            system = null;
+          };
+        in
+        nixos.config.system.build.macos-builder-installer
+      ) { modules = [ ]; };
     }
   );
 }


### PR DESCRIPTION
This PR introduces a Linux builder for macOS that makes `x86_64-linux` builds ~2.5× faster by running the NixOS guest on Apple's native Virtualization.framework with Rosetta. It also has a smaller closure than the qemu build by offloading a lot to the apple framework.

This is designed as a ~one-line drop-in swap for `darwin.linux-builder`.

The PR consists of:

- `pkgs.vzvm`, an Apple Virtualization.framework based VMM. It is minimized for the projected use case as a linux-builder drop-in replacement with Rosetta support. Forwards ssh TCP connects via vsock to get around the NAT setup from outside.
- split up the linux-builder NixOS module to a qemu-agnostic part
- Add the vzvm-specific linux-builder module next to the qemu-specific one
- made sure that the qemu-vm module split did NOT change the qemu-vm derivation hash that we have right now.

The following nix-darwin configuration snippet can be used to run it:

```nix
{ pkgs, ... }:
{
  nix.linux-builder = {
    enable = true;

    package = pkgs.darwin.linux-builder-vz; # new
    systems = [
      "aarch64-linux"
      "x86_64-linux" # new
    ];

    ephemeral = true; # wipe the data disk on every start
    maxJobs = 4;
    supportedFeatures = [
      "kvm" # requires nestedVirtualization below (OPTIONAL)
      "benchmark"
      "big-parallel"
      "nixos-test"
    ];

    config = {
      virtualisation = {
        darwin-builder = {
          diskSize = 40 * 1024; # MiB
          memorySize = 8 * 1024; # MiB
        };
        cores = 8;

        # OPTIONAL:
        # Real /dev/kvm in the guest, for running NixOS VM tests on the
        # builder. Needs macOS 15+ and an M3 or newer chip.
        vz.nestedVirtualization = true; # new
      };
    };
  };
}
```

Regarding the AI policy: The upstream project has been developed with some LLM help but human-maintained and 110% human-reviewed and tested. All code in *this PR* is hand-written, but i let an LLM correct my sometimes bad english (not a native speaker).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
