### PR TITLE
python3Packages.rapidyaml: init at 0.15.2

### DIFF
--- a/pkgs/development/python-modules/rapidyaml/default.nix
+++ b/pkgs/development/python-modules/rapidyaml/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  swig,
+  cmake-build-extension,
+  setuptools,
+  setuptools-git,
+  setuptools-scm,
+  deprecation,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "rapidyaml";
+  version = "0.15.2";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "biojppm";
+    repo = "rapidyaml-python";
+    fetchSubmodules = true;
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-lTLVcB6LJKY2gIg2l8/B/hrl0Cu2Ia5d/I1z6jyZ2KM=";
+  };
+
+  build-system = [
+    setuptools
+    cmake-build-extension
+    setuptools-scm
+    setuptools-git
+    swig
+  ];
+
+  postPatch = ''
+    # pyproject.toml lists "swig" as a Python build requirement (for PyPI installs),
+    # but in Nix swig is a system binary on PATH, not a Python package. Remove it so
+    # pypa/build's dependency check doesn't fail when using --no-isolation.
+    substituteInPlace pyproject.toml \
+      --replace-fail '"swig"' ""
+  '';
+
+  # cmake-build-extension drives the CMake configure step
+  dontUseCmakeConfigure = true;
+
+  dependencies = [ deprecation ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "ryml" ];
+
+  meta = {
+    description = "Parse and emit YAML, and do it fast. Python wrapper for the C++ library";
+    homepage = "https://github.com/biojppm/rapidyaml-python";
+    changelog = "https://github.com/biojppm/rapidyaml-python/blob/master/changelog/${finalAttrs.version}.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jherland ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17380,6 +17380,8 @@ self: super: with self; {
 
   rapidocr-onnxruntime = callPackage ../development/python-modules/rapidocr-onnxruntime { };
 
+  rapidyaml = callPackage ../development/python-modules/rapidyaml { };
+
   rapt-ble = callPackage ../development/python-modules/rapt-ble { };
 
   rarfile = callPackage ../development/python-modules/rarfile { inherit (pkgs) libarchive; };


### PR DESCRIPTION
Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
