### PR TITLE
vivaldi-ffmpeg-codecs: use stdenvNoCC and fix path for aarch64

### DIFF
--- a/pkgs/by-name/vi/vivaldi-ffmpeg-codecs/package.nix
+++ b/pkgs/by-name/vi/vivaldi-ffmpeg-codecs/package.nix
@@ -2,7 +2,7 @@
   fetchurl,
   lib,
   squashfsTools,
-  stdenv,
+  stdenvNoCC,
 }:
 
 # This derivation roughly follows the update-ffmpeg script that ships with the official Vivaldi
@@ -20,22 +20,31 @@ let
     };
   };
 in
-stdenv.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "chromium-codecs-ffmpeg-extra";
 
   version = "2026-05-18";
 
-  src = sources."${stdenv.hostPlatform.system}";
+  src = sources."${stdenvNoCC.hostPlatform.system}";
 
-  buildInputs = [ squashfsTools ];
+  nativeBuildInputs = [ squashfsTools ];
 
   unpackPhase = ''
     unsquashfs -dest . $src
   '';
 
-  installPhase = ''
-    install -vD chromium-ffmpeg-git-${finalAttrs.version}/chromium-ffmpeg/libffmpeg.so $out/lib/libffmpeg.so
-  '';
+  # arm64 and x86_64 snaps may ship different ffmpeg versions.
+  installPhase =
+    let
+      ffmpegData =
+        if stdenvNoCC.hostPlatform.system == "x86_64-linux" then
+          "chromium-ffmpeg-git-2026-05-18"
+        else
+          "chromium-ffmpeg-git-2026-03-16";
+    in
+    ''
+      install -vD ${ffmpegData}/chromium-ffmpeg/libffmpeg.so $out/lib/libffmpeg.so
+    '';
 
   passthru = {
     inherit sources;


### PR DESCRIPTION
- Switch from stdenv to stdenvNoCC to avoid pulling in a C toolchain
- Handle different ffmpeg version directories per architecture in installPhase, since arm64 and x86_64 snaps may ship different versions


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
