### PR TITLE
{tor,mullvad}-browser: 15.0.18 -> 15.0.19

### DIFF
--- a/pkgs/by-name/mu/mullvad-browser/package.nix
+++ b/pkgs/by-name/mu/mullvad-browser/package.nix
@@ -97,7 +97,7 @@ let
     ++ lib.optionals mediaSupport [ ffmpeg_7 ]
   );
 
-  version = "15.0.18";
+  version = "15.0.19";
 
   sources = {
     x86_64-linux = fetchurl {
@@ -109,7 +109,7 @@ let
         "https://tor.eff.org/dist/mullvadbrowser/${version}/mullvad-browser-linux-x86_64-${version}.tar.xz"
         "https://tor.calyxinstitute.org/dist/mullvadbrowser/${version}/mullvad-browser-linux-x86_64-${version}.tar.xz"
       ];
-      hash = "sha256-hvLft1HDj/5NgAfQb1igYdhJN5H/jZ2+7s/JKKLf4Gs=";
+      hash = "sha256-9Vbv7A8JarYtT0Ll1bveQmwif7/IViq6geMxMqeF+S4=";
     };
   };
 

--- a/pkgs/by-name/to/tor-browser/package.nix
+++ b/pkgs/by-name/to/tor-browser/package.nix
@@ -102,7 +102,7 @@ let
     ++ lib.optionals mediaSupport [ ffmpeg_7 ]
   );
 
-  version = "15.0.18";
+  version = "15.0.19";
 
   sources = {
     x86_64-linux = fetchurl {
@@ -112,7 +112,7 @@ let
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux-x86_64-${version}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux-x86_64-${version}.tar.xz"
       ];
-      hash = "sha256-4e7G8M/iKU65ECMVhxGjaJwHfwVZ49RD7ro6YJT43v0=";
+      hash = "sha256-LrSrQx9JIcpjsSO2+fRFoHP797ZfGI9FpXfVdusr4s8=";
     };
 
     i686-linux = fetchurl {
@@ -122,7 +122,7 @@ let
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux-i686-${version}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux-i686-${version}.tar.xz"
       ];
-      hash = "sha256-lLShsQQ2thSSp4PRK9Fhza6e01Myj2mUP4qqCeyilXo=";
+      hash = "sha256-N+TjpJrHg8cB6vwCqrTWnz4/dwzu2/r55kNmkLemWvU=";
     };
   };
 


### PR DESCRIPTION
tb changelog: https://gitlab.torproject.org/tpo/applications/tor-browser-build/-/raw/tbb-15.0.19-build1/projects/browser/Bundle-Data/Docs-TBB/ChangeLog.txt
mb changelog: https://gitlab.torproject.org/tpo/applications/tor-browser-build/-/raw/mb-15.0.19-build1/projects/browser/Bundle-Data/Docs-MB/ChangeLog.txt
firefox esr: https://www.firefox.com/en-US/firefox/140.13.0/releasenotes/
firefox security advisories: https://www.mozilla.org/en-US/security/advisories/mfsa2026-70/

this may be one of the last 15.0 releases. 16.0 stable is tentatively scheduled for 2026-08-18 as per morganava on irc.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
