### PR TITLE
luarocks-packages-updater: support initial maintainer

### DIFF
--- a/doc/languages-frameworks/lua.section.md
+++ b/doc/languages-frameworks/lua.section.md
@@ -167,8 +167,11 @@ To add a new package without updating all packages, run
 ```sh
 
 nix-shell -p luarocks-packages-updater
-luarocks-packages-updater add <package-name>
+luarocks-packages-updater add [--maintainers "<maintainer>"] <package-name>
 ```
+
+The optional `--maintainers` argument accepts a space-separated list of nixpkgs maintainer names.
+When omitted, the package is added without maintainers.
 
 [luarocks2nix](https://github.com/nix-community/luarocks) is a tool capable of generating nix derivations from both rockspec and src.rock (and favors the src.rock).
 The automation only goes so far though and some packages need to be customized.

--- a/pkgs/by-name/lu/luarocks-packages-updater/updater.py
+++ b/pkgs/by-name/lu/luarocks-packages-updater/updater.py
@@ -182,6 +182,13 @@ class LuaEditor(nixpkgs_plugin_update.Editor):
         parser.set_defaults(proc=1, update_only=None)
         return parser
 
+    def configure_add_parser(self, parser):
+        parser.add_argument(
+            "--maintainers",
+            default="",
+            help="Space-separated nixpkgs maintainer names to add to each package",
+        )
+
     def get_current_plugins(self, _config: FetchConfig, _nixpkgs: str):
         return []
 
@@ -340,7 +347,7 @@ class LuaEditor(nixpkgs_plugin_update.Editor):
                 "server": "",
                 "version": "",
                 "luaversion": "",
-                "maintainers": "",
+                "maintainers": args.maintainers,
             }
             existing_entries.append(new_entry)
 

--- a/pkgs/by-name/lu/luarocks-packages-updater/updater.py
+++ b/pkgs/by-name/lu/luarocks-packages-updater/updater.py
@@ -72,7 +72,7 @@ LICENSE_NORMALIZATION = {
     "Apache 2.0": "lib.licenses.asl20",
     "Apache-2.0": "lib.licenses.asl20",
     "Apache License Version 2": "lib.licenses.asl20",
-    "BSD": "lib.licenses.free", # Too unspecific
+    "BSD": "lib.licenses.free",  # Too unspecific
     "BSD-2-Clause": "lib.licenses.bsd2",
     "BSD-3-Clause": "lib.licenses.bsd3",
     "GPL-2+": "lib.licenses.gpl2Plus",
@@ -85,7 +85,7 @@ LICENSE_NORMALIZATION = {
     "GPL-3.0-or-later": "lib.licenses.gpl3Plus",
     "GPLv3+ and other free licenses": "lib.licenses.AND [ lib.licenses.gpl3Plus lib.licenses.free ]",
     "ISC": "lib.licenses.isc",
-    "LGPL": "lib.licenses.free", # Too unspecific
+    "LGPL": "lib.licenses.free",  # Too unspecific
     "LGPL-2.0": "lib.licenses.lgpl2Only",
     "LGPL-2.1": "lib.licenses.lgpl21Only",
     "LGPL-3.0": "lib.licenses.lgpl3Only",
@@ -99,7 +99,7 @@ LICENSE_NORMALIZATION = {
     "2-clause BSD": "lib.licenses.bsd2",
     "Two-clause BSD": "lib.licenses.bsd2",
     "Public domain": "lib.licenses.publicDomain",
-    "UNKNOWN": "lib.licenses.unfree"
+    "UNKNOWN": "lib.licenses.unfree",
 }
 
 LICENSE_FULL_NAME_RE = re.compile(r'(?P<indent>\s*)license\.fullName = "(?P<license>[^"]+)";')
@@ -217,11 +217,7 @@ class LuaEditor(nixpkgs_plugin_update.Editor):
         specs = sorted(specs, key=lambda v: v.name.lower())
 
         if args.update_only:
-            specs = [
-                p
-                for p in specs
-                if p.normalized_name in args.update_only or p.name in args.update_only
-            ]
+            specs = [p for p in specs if p.normalized_name in args.update_only or p.name in args.update_only]
 
         if not specs:
             log.error("No matching Lua packages to update")

--- a/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/src/nixpkgs_plugin_update/__init__.py
+++ b/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/src/nixpkgs_plugin_update/__init__.py
@@ -1037,6 +1037,9 @@ class Editor:
     def rewrite_input(self, *args, **kwargs):
         return rewrite_input(*args, **kwargs)
 
+    def configure_add_parser(self, _parser: argparse.ArgumentParser) -> None:
+        """Add updater-specific arguments to the add subcommand."""
+
     def create_parser(self):
         common = argparse.ArgumentParser(
             add_help=False,
@@ -1122,6 +1125,7 @@ class Editor:
             nargs="+",
             help=f"Plugin to add to {self.attr_path} from Github in the form owner/repo",
         )
+        self.configure_add_parser(padd)
 
         pupdate = subparsers.add_parser(
             "update",


### PR DESCRIPTION
Allow passing `--maintainers` to add the maintainers for a new package creation.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
