### PR TITLE
spidermonkey_140: 140.11.0 -> 140.13.0

### DIFF
--- a/pkgs/development/interpreters/spidermonkey/140.nix
+++ b/pkgs/development/interpreters/spidermonkey/140.nix
@@ -1,4 +1,4 @@
 import ./common.nix {
-  version = "140.11.0";
-  hash = "sha512-0GrbPvTeEyTj1hhy1w3jGrCKwBPzOQNUm+0oxuvMW03ulLs2OIKCwZNdd9GlZAefOtvwjWu4AoSomcuz2GEwDA==";
+  version = "140.13.0";
+  hash = "sha512-k3pBA9ccXh5L8FGCFyn26nC1wY1ESTCkh2lcwj10cSoBNARySPasAjBeAb7LcFQmpVudiXOfAqAe2gHs9bwn8Q==";
 }


### PR DESCRIPTION
https://github.com/mozilla-firefox/firefox/commits/FIREFOX_140_13_0esr_RELEASE/js/src/build
https://github.com/mozilla-firefox/firefox/commits/FIREFOX_140_13_0esr_RELEASE/build

Security advisories:
- 140.12.0: https://www.mozilla.org/en-US/security/advisories/mfsa2026-58/
- 140.13.0: https://www.mozilla.org/en-US/security/advisories/mfsa2026-70/

Fixes: CVE-2026-12315, CVE-2026-15718, CVE-2026-16355, CVE-2026-16363, CVE-2026-16368, CVE-2026-16369 (from cross-referencing bugzilla IDs and CVE ids).

for testing, we ran `spidermonkey_140.tests` as well as building all direct dependents (`gjs`, `cjs`, `plowshare`, `libpeas2`) with no issues.

this should probably be backported to staging-26.05, but #544210 will need to be merged first

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
