### PR TITLE
libbde: fuse -> fuse3

### DIFF
--- a/pkgs/by-name/li/libbde/package.nix
+++ b/pkgs/by-name/li/libbde/package.nix
@@ -2,7 +2,9 @@
   lib,
   stdenv,
   fetchurl,
-  fuse,
+  fuse3,
+  macfuse-stubs,
+  pkg-config,
   ncurses,
   python3,
   nix-update-script,
@@ -17,10 +19,12 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-La6rzBOfyBIXDn78vXb8GUt8jgQkzsqM38kRZ7t3Fp0=";
   };
 
+  nativeBuildInputs = [ pkg-config ];
+
   buildInputs = [
-    fuse
     ncurses
     python3
+    (if stdenv.hostPlatform.isDarwin then macfuse-stubs else fuse3)
   ];
 
   preInstall = ''


### PR DESCRIPTION
libbde already gained fuse3 support in 20240502 https://github.com/libyal/libbde/commit/e71dedddb5a6ec15e03e48ad067c2036e9e66d20

Related https://github.com/NixOS/nixpkgs/issues/526161

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
