### PR TITLE
ci/pinned: bump nixpkgs

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -53,7 +53,8 @@ jobs:
             ci/github-script
 
       - name: Install dependencies
-        run: npm install @actions/artifact@6.2.1 bottleneck@2.19.5
+        run: npm ci --package-lock-only=false @actions/artifact bottleneck
+        working-directory: ci/github-script
 
       # Use a GitHub App, because it has much higher rate limits: 12,500 instead of 5,000 req / hour.
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -51,7 +51,8 @@ jobs:
             ci/github-script
 
       - name: Install dependencies
-        run: npm install bottleneck@2.19.5
+        run: npm ci --package-lock-only=false bottleneck
+        working-directory: trusted/ci/github-script
 
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         if: github.event_name != 'pull_request' && vars.NIXPKGS_COMMIT_CHECK_CLIENT_ID

--- a/.github/workflows/teams.yml
+++ b/.github/workflows/teams.yml
@@ -38,7 +38,8 @@ jobs:
             maintainers/github-teams.json
 
       - name: Install dependencies
-        run: npm install bottleneck@2.19.5
+        run: npm ci --package-lock-only=false bottleneck
+        working-directory: ci/github-script
 
       - name: Synchronise teams
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/ci/github-script/package-lock.json
+++ b/ci/github-script/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "github-script",
       "dependencies": {
         "@actions/artifact": "6.2.1",
         "@actions/core": "1.10.1",

--- a/ci/github-script/package.json
+++ b/ci/github-script/package.json
@@ -2,9 +2,7 @@
   "private": true,
   "//": [
     "Keep `@actions/core` and `@actions/github` in sync with",
-    "https://github.com/actions/github-script/blob/main/package.json.",
-    "Keep `@actions/artifact` and `bottleneck` in sync with",
-    "`.github/workflows/bot.yml`."
+    "https://github.com/actions/github-script/blob/main/package.json."
   ],
   "dependencies": {
     "@actions/artifact": "6.2.1",

--- a/ci/pinned.json
+++ b/ci/pinned.json
@@ -9,9 +9,9 @@
       },
       "branch": "nixpkgs-unstable",
       "submodules": false,
-      "revision": "6edbf1a6a03e75886a6609c088801a0856449e88",
-      "url": "https://github.com/NixOS/nixpkgs/archive/6edbf1a6a03e75886a6609c088801a0856449e88.tar.gz",
-      "hash": "sha256-0lkauQbtrljJqwtzTCILPAiHAJyMvn6XDo264moDv30="
+      "revision": "421eebfd0ec7bccd4abe826ce62d7e6e83129493",
+      "url": "https://github.com/NixOS/nixpkgs/archive/421eebfd0ec7bccd4abe826ce62d7e6e83129493.tar.gz",
+      "hash": "sha256:1lxfhfgiv1sz2v7fg43gny57sa6wf59n98q7ldsyb2p06f4sal7w"
     }
   },
   "version": 8


### PR DESCRIPTION
Make nixdoc 3.1.0 -> 3.2.0 avilable. Required for iterating on docs tooling.

Used the (at this time) latest commit from https://github.com/NixOS/nixpkgs/tree/nixpkgs-unstable


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
