### PR TITLE
lib.makeScopeWithSplicing':  fix `overideScope` with spliced `newScope`

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -738,6 +738,16 @@ rec {
       # ```
       extra ? (_spliced0: { }),
       f,
+      fExplicit ?
+        {
+          selfBuildBuild,
+          selfBuildHost,
+          selfBuildTarget,
+          selfHostHost,
+          selfHostTarget,
+          selfTargetTarget,
+        }:
+        { },
     }:
     let
       splicePackages' =
@@ -755,8 +765,9 @@ rec {
             pkgsHostTarget = self; # Not `otherSplices.selfHostTarget`;
             pkgsTargetTarget = otherSplices.selfTargetTarget // splitSelves.targetTarget;
           };
+          explicitSelves = lib.renameCrossIndexTo "self" splitSelves;
         in
-        extra spliced0 // spliced0 // keep self;
+        extra spliced0 // spliced0 // fExplicit explicitSelves // keep self;
       getSelf =
         {
           newScope,

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -748,6 +748,8 @@ rec {
           selfTargetTarget,
         }:
         { },
+      spliceOutput ? false,
+      splicedPackagesAttrName ? null,
     }:
     let
       splicePackages' =
@@ -792,10 +794,25 @@ rec {
           overrideScope =
             g:
             (makeScopeWithSplicing' { inherit splicePackages newScope; } {
-              inherit otherSplices keep extra;
+              inherit
+                otherSplices
+                keep
+                extra
+                spliceOutput
+                splicedPackagesAttrName
+                ;
               f = extends g f;
             });
           packages = f;
+          ${splicedPackagesAttrName} =
+            splicePackages (
+              renameCrossIndexTo "pkgs" (
+                mapCrossIndex (as: removeAttrs as [ splicedPackagesAttrName ]) splitSelves
+              )
+            )
+            // {
+              ${splicedPackagesAttrName} = self.${splicedPackagesAttrName};
+            };
         };
       otherSplicesLower = renameCrossIndexFrom "self" otherSplices;
       splitSpliced = lib.mapAttrs (
@@ -859,8 +876,12 @@ rec {
           ;
         spliced = splitSpliced.hostTarget;
       };
+      splicedSelf = splicePackages (renameCrossIndexTo "pkgs" splitSelves);
+      explicitPackages = fExplicit (lib.renameCrossIndexTo "self" splitSelves);
+      keptPackages = keep self;
+      splicedOutput = splicedSelf // explicitPackages // keptPackages;
     in
-    self;
+    if spliceOutput then splicedOutput else self;
 
   /**
     Define a `mkDerivation`-like function based on another `mkDerivation`-like function.

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -717,7 +717,14 @@ rec {
       isNewScopeSpliced = removeAttrs (newScope.__spliced or { }) [ "hostTarget" ] != { };
     in
     {
-      otherSplices,
+      otherSplices ? {
+        selfBuildBuild = { };
+        selfBuildHost = { };
+        selfBuildTarget = { };
+        selfHostHost = { };
+        selfHostTarget = { };
+        selfTargetTarget = { };
+      },
       # Attrs from `self` which won't be spliced.
       # Avoid using keep, it's only used for a python hook workaround, added in PR #104201.
       # ex: `keep = (self: { inherit (self) aAttr; })`

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -16,16 +16,21 @@ let
     optionalAttrs
     attrNames
     filter
+    filterAttrs
     elemAt
+    concatMap
     concatStringsSep
     sortOn
     take
+    toLower
     length
     head
     pipe
+    range
     isDerivation
     listToAttrs
     mapAttrs
+    nameValuePair
     seq
     flatten
     deepSeq
@@ -700,10 +705,17 @@ rec {
     ```
   */
   makeScopeWithSplicing' =
+    let
+      # Workaround setFunctionArgs's neglecting other attributes of a callable set.
+      toCallableSet = f: if isAttrs f then f else mirrorFunctionArgs f f;
+    in
     {
       splicePackages,
       newScope,
     }:
+    let
+      isNewScopeSpliced = removeAttrs (newScope.__spliced or { }) [ "hostTarget" ] != { };
+    in
     {
       otherSplices,
       # Attrs from `self` which won't be spliced.
@@ -728,27 +740,113 @@ rec {
       f,
     }:
     let
-      spliced0 = splicePackages {
-        pkgsBuildBuild = otherSplices.selfBuildBuild;
-        pkgsBuildHost = otherSplices.selfBuildHost;
-        pkgsBuildTarget = otherSplices.selfBuildTarget;
-        pkgsHostHost = otherSplices.selfHostHost;
-        pkgsHostTarget = self; # Not `otherSplices.selfHostTarget`;
-        pkgsTargetTarget = otherSplices.selfTargetTarget;
-      };
-      spliced = extra spliced0 // spliced0 // keep self;
-      self = f self // {
-        newScope = scope: newScope (spliced // scope);
-        callPackage = newScope spliced; # == self.newScope {};
-        # N.B. the other stages of the package set spliced in are *not*
-        # overridden.
-        overrideScope =
-          g:
-          (makeScopeWithSplicing' { inherit splicePackages newScope; } {
-            inherit otherSplices keep extra;
-            f = extends g f;
-          });
-        packages = f;
+      splicePackages' =
+        {
+          otherSplices,
+          self,
+          splitSelves,
+        }:
+        let
+          spliced0 = splicePackages {
+            pkgsBuildBuild = otherSplices.selfBuildBuild // splitSelves.buildBuild;
+            pkgsBuildHost = otherSplices.selfBuildHost // splitSelves.buildHost;
+            pkgsBuildTarget = otherSplices.selfBuildTarget // splitSelves.buildTarget;
+            pkgsHostHost = otherSplices.selfHostHost // splitSelves.hostHost;
+            pkgsHostTarget = self; # Not `otherSplices.selfHostTarget`;
+            pkgsTargetTarget = otherSplices.selfTargetTarget // splitSelves.targetTarget;
+          };
+        in
+        extra spliced0 // spliced0 // keep self;
+      getSelf =
+        {
+          newScope,
+          otherSplices,
+          self,
+          spliced,
+          splitSelves,
+        }:
+        f self
+        // {
+          # Fancy way to write `newScope = scope: newScope (spliced // scope)`
+          newScope = {
+            __functor = _: scope: newScope (spliced // scope);
+            ${if isNewScopeSpliced then "__spliced" else null} = filterAttrs (_: value: value != null) (
+              mapAttrs (name: _: splitSelves.${name}.newScope or null) newScope.__spliced or { }
+            );
+          };
+          callPackage = newScope spliced; # == self.newScope {};
+          # NOTE:
+          # If newScope.__spliced does not exist or doesn't provide all six cross indexes,
+          # some of the other stages of the package set spliced in may *not* be overridden.
+          overrideScope =
+            g:
+            (makeScopeWithSplicing' { inherit splicePackages newScope; } {
+              inherit otherSplices keep extra;
+              f = extends g f;
+            });
+          packages = f;
+        };
+      otherSplicesLower = renameCrossIndexFrom "self" otherSplices;
+      splitSpliced = lib.mapAttrs (
+        name1: value1:
+        splicePackages' {
+          otherSplices = mapAttrs (name2: value2: otherSplicesLower.${value2}) (
+            lib.renameCrossIndexTo "self" value1
+          );
+          splitSelves = mapAttrs (name2: value2: splitSelves.${value2}) value1;
+          self = splitSelves.${name1};
+        }
+      ) crossIndexSelection;
+      splitSelves =
+        lib.mapAttrs (
+          name1: value1:
+          if newScope ? __spliced.${name1} then
+            getSelf {
+              newScope = splitNewScopes.${name1};
+              otherSplices = mapAttrs (name2: value2: otherSplicesLower.${value2}) (
+                lib.renameCrossIndexTo "self" value1
+              );
+              splitSelves = mapAttrs (name2: value2: splitSelves.${value2}) value1;
+              self = splitSelves.${name1};
+              spliced = splitSpliced.${name1};
+            }
+          else
+            { }
+        ) (removeAttrs crossIndexSelection [ "hostTarget" ])
+        // {
+          hostTarget = self;
+        };
+      splitNewScopes =
+        lib.mapAttrs (
+          name1: value1:
+          toCallableSet newScope.__spliced.${name1}
+          // {
+            __spliced = filterAttrs (name2: value2: value2 != null) (
+              mapAttrs (name2: value2: splitNewScopes.${value2} or null) value1
+            );
+          }
+        ) (intersectAttrs newScope.__spliced or { } (removeAttrs crossIndexSelection [ "hostTarget" ]))
+        // {
+          hostTarget =
+            if newScope ? __spliced then
+              newScope
+              // {
+                __spliced = {
+                  inherit (splitNewScopes) hostTarget;
+                }
+                // newScope.__spliced or { };
+              }
+            else
+              newScope;
+        };
+      self = getSelf {
+        inherit
+          otherSplices
+          splitSelves
+          newScope
+          self
+          ;
+        spliced = splitSpliced.hostTarget;
       };
     in
     self;
@@ -1037,4 +1135,38 @@ rec {
       hostTarget = f hostTarget;
       targetTarget = f targetTarget;
     };
+
+  crossIndexSelection =
+    let
+      names = [
+        "Build"
+        "Host"
+        "Target"
+      ];
+    in
+    listToAttrs (
+      concatMap (
+        i:
+        (map (j: {
+          name = toLower (elemAt names i) + elemAt names j;
+          value =
+            let
+              indices = [
+                0
+                i
+                j
+              ];
+            in
+            listToAttrs (
+              concatMap (
+                k:
+                map (l: {
+                  name = toLower (elemAt names k) + elemAt names l;
+                  value = toLower (elemAt names (elemAt indices k)) + elemAt names (elemAt indices l);
+                }) (range k 2)
+              ) (range 0 2)
+            );
+        }) (range i 2))
+      ) (range 0 2)
+    );
 }

--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -61,6 +61,8 @@ let
         # on to splice them together.
         if lib.isDerivation defaultValue then
           augmentedValue // lib.genAttrs outputNames (out: outputSplice.${out})
+        else if defaultValue ? __functor then
+          augmentedValue // spliceReal value'
         else if lib.isAttrs defaultValue then
           spliceReal value'
         else

--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -123,7 +123,10 @@ in
 
   callPackages = lib.callPackagesWith pkgsForCall;
 
-  newScope = extra: lib.callPackageWith (pkgsForCall // extra);
+  # `newScope = extra: ...` but as a callable set that could be spliced
+  newScope = {
+    __functor = _: extra: lib.callPackageWith (pkgsForCall // extra);
+  };
 
   pkgs = if actuallySplice then splicedPackages // { recurseForDerivations = false; } else pkgs;
 


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
