### PR TITLE
gphoto2fs: 0.5.0 -> 1.0; modernize

### DIFF
--- a/pkgs/by-name/gp/gphoto2fs/package.nix
+++ b/pkgs/by-name/gp/gphoto2fs/package.nix
@@ -1,39 +1,61 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  libtool,
+  fetchFromGitHub,
+  autoreconfHook,
   pkg-config,
+  gettext,
+  libtool,
   libgphoto2,
-  fuse,
+  fuse3,
   glib,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gphoto2fs";
-  version = "0.5.0";
-  src = fetchurl {
-    url = "mirror://sourceforge/gphoto/gphotofs/${finalAttrs.version}/gphotofs-0.5.tar.bz2";
-    hash = "sha256-Z27E3mmoHBk//DG9x7WHrCosw3gLFPDnycTApRezQ8w=";
+  version = "1.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "gphoto";
+    repo = "gphotofs";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-3DdL4FQzLEzvREhoZYfZlzZvyow/EATN/Q0HtOmdWKA=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    gettext
+    libtool
+    glib
+  ];
+
   buildInputs = [
     libgphoto2
-    fuse
+    fuse3
     glib
-    libtool
   ];
+
+  # gphotofs_init() still declares the FUSE 2 callback signature, which GCC 14 rejects
+  env = lib.optionalAttrs stdenv.cc.isGNU {
+    NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
+  };
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/gphotofs --help > /dev/null
+  '';
 
   meta = {
     description = "Fuse FS to mount a digital camera";
     mainProgram = "gphotofs";
     homepage = "http://www.gphoto.org/";
+    changelog = "https://github.com/gphoto/gphotofs/releases/tag/${finalAttrs.src.tag}";
     maintainers = [ lib.maintainers.raskin ];
     platforms = lib.platforms.linux;
-    license = with lib.licenses; [
-      lgpl2
-      gpl2
-    ];
+    license = lib.licenses.gpl2Only;
   };
 })


### PR DESCRIPTION
Related https://github.com/NixOS/nixpkgs/issues/526161

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
