### PR TITLE
ziglint: init at 0.5.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30858,6 +30858,11 @@
     githubId = 106241330;
     name = "Success Kingsley";
   };
+  xqtc161 = {
+    github = "xqtc161";
+    githubId = 65857432;
+    name = "tila";
+  };
   xrelkd = {
     github = "xrelkd";
     githubId = 46590321;

--- a/pkgs/by-name/zi/ziglint/package.nix
+++ b/pkgs/by-name/zi/ziglint/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  zig_0_16,
+  versionCheckHook,
+}:
+
+let
+  zig = zig_0_16;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ziglint";
+  version = "0.5.3";
+
+  src = fetchFromGitHub {
+    owner = "rockorager";
+    repo = "ziglint";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-kLcUIFMDJHuCA0rn3l5a3h/E6TUwNWA5mWRADCDB1cw=";
+  };
+
+  postPatch = ''
+    substituteInPlace build.zig \
+      --replace-fail "getVersion(b)" '"${finalAttrs.version}"'
+  '';
+
+  nativeBuildInputs = [ zig.hook ];
+
+  strictDeps = true;
+
+  __structuredAttrs = true;
+
+  doCheck = true;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    homepage = "https://github.com/rockorager/ziglint";
+    description = "Linter for Zig source code";
+    changelog = "https://github.com/rockorager/ziglint/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ xqtc161 ];
+    mainProgram = "ziglint";
+    inherit (zig.meta) platforms;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^
-->

Adds [ziglint](https://github.com/rockorager/ziglint) at version 0.5.3.

The upstream build.zig derives the version string from a `git describe`, so a `postPatch` substitutes the packaged version in (so `ziglint --version` and `versionCheckHook` report 0.5.3). The package has no external Zig dependencies.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at passthru.tests.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran nixpkgs-review on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in ./result/bin/.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test