### PR TITLE
nixos/headscale: align settings with upstream config schema

### DIFF
--- a/nixos/modules/services/networking/headscale.nix
+++ b/nixos/modules/services/networking/headscale.nix
@@ -97,6 +97,7 @@ in
           lib.showWarnings settings.warnings (
             (lib.removeAttrs settings [
               "assertions"
+              "ephemeral_node_inactivity_timeout"
               "warnings"
             ])
             // {
@@ -114,6 +115,10 @@ in
           imports = [
             ../../misc/assertions.nix
             (lib.mkRenamedOptionModule [ "dns" "split" ] [ "dns" "nameservers" "split" ])
+            (lib.mkRenamedOptionModule
+              [ "ephemeral_node_inactivity_timeout" ]
+              [ "node" "ephemeral" "inactivity_timeout" ]
+            )
           ];
 
           options = {
@@ -217,7 +222,7 @@ in
               };
             };
 
-            ephemeral_node_inactivity_timeout = lib.mkOption {
+            node.ephemeral.inactivity_timeout = lib.mkOption {
               type = lib.types.str;
               default = "30m";
               description = ''
@@ -627,7 +632,7 @@ in
     )
     (mkRenamedOptionModule
       [ "services" "headscale" "ephemeralNodeInactivityTimeout" ]
-      [ "services" "headscale" "settings" "ephemeral_node_inactivity_timeout" ]
+      [ "services" "headscale" "settings" "node" "ephemeral" "inactivity_timeout" ]
     )
     (mkRenamedOptionModule
       [ "services" "headscale" "logLevel" ]

--- a/nixos/modules/services/networking/headscale.nix
+++ b/nixos/modules/services/networking/headscale.nix
@@ -92,6 +92,17 @@ in
       };
 
       settings = lib.mkOption {
+        apply =
+          settings:
+          lib.showWarnings settings.warnings (
+            (lib.removeAttrs settings [
+              "assertions"
+              "warnings"
+            ])
+            // {
+              dns = lib.removeAttrs settings.dns [ "split" ];
+            }
+          );
         description = ''
           Overrides to {file}`config.yaml` as a Nix attribute set.
           Check the [example config](https://github.com/juanfont/headscale/blob/main/config-example.yaml)
@@ -99,6 +110,11 @@ in
         '';
         type = lib.types.submodule {
           freeformType = settingsFormat.type;
+
+          imports = [
+            ../../misc/assertions.nix
+            (lib.mkRenamedOptionModule [ "dns" "split" ] [ "dns" "nameservers" "split" ])
+          ];
 
           options = {
             server_url = lib.mkOption {
@@ -346,17 +362,17 @@ in
                     List of nameservers to pass to Tailscale clients.
                   '';
                 };
-              };
 
-              split = lib.mkOption {
-                type = lib.types.attrsOf (lib.types.listOf lib.types.str);
-                default = { };
-                description = ''
-                  Split DNS configuration (map of domains and which DNS server to use for each).
-                  See <https://tailscale.com/kb/1054/dns/>.
-                '';
-                example = {
-                  "foo.bar.com" = [ "1.1.1.1" ];
+                split = lib.mkOption {
+                  type = lib.types.attrsOf (lib.types.listOf lib.types.str);
+                  default = { };
+                  description = ''
+                    Split DNS configuration (map of domains and which DNS server to use for each).
+                    See <https://tailscale.com/kb/1054/dns/>.
+                  '';
+                  example = {
+                    "foo.bar.com" = [ "1.1.1.1" ];
+                  };
                 };
               };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Align the Headscale module options with the configuration schema used by the packaged Headscale 0.29.2:

- Move split DNS configuration from `dns.split` to `dns.nameservers.split`.
- Move `ephemeral_node_inactivity_timeout` to `node.ephemeral.inactivity_timeout`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Assisted-by: OpenAI Codex (GPT-5)