### PR TITLE
at: substituteInPlace replace with replace-fail

### DIFF
--- a/pkgs/by-name/at/at/package.nix
+++ b/pkgs/by-name/at/at/package.nix
@@ -32,17 +32,16 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     # Remove chown commands and setuid bit
     substituteInPlace Makefile.in \
-      --replace ' -o root ' ' ' \
-      --replace ' -g root ' ' ' \
-      --replace ' -o $(DAEMON_USERNAME) ' ' ' \
-      --replace ' -o $(DAEMON_GROUPNAME) ' ' ' \
-      --replace ' -g $(DAEMON_GROUPNAME) ' ' ' \
-      --replace '$(DESTDIR)$(etcdir)' "$out/etc" \
-      --replace '$(DESTDIR)$(ATJOB_DIR)' "$out/var/spool/atjobs" \
-      --replace '$(DESTDIR)$(ATSPOOL_DIR)' "$out/var/spool/atspool" \
-      --replace '$(DESTDIR)$(LFILE)' "$out/var/spool/atjobs/.SEQ" \
-      --replace 'chown' '# skip chown' \
-      --replace '6755' '0755'
+      --replace-fail ' -o root ' ' ' \
+      --replace-fail ' -g root ' ' ' \
+      --replace-fail ' -o $(DAEMON_USERNAME) ' ' ' \
+      --replace-fail ' -g $(DAEMON_GROUPNAME) ' ' ' \
+      --replace-fail '$(DESTDIR)$(etcdir)' "$out/etc" \
+      --replace-fail '$(DESTDIR)$(ATJOB_DIR)' "$out/var/spool/atjobs" \
+      --replace-fail '$(DESTDIR)$(ATSPOOL_DIR)' "$out/var/spool/atspool" \
+      --replace-fail '$(DESTDIR)$(LFILE)' "$out/var/spool/atjobs/.SEQ" \
+      --replace-fail 'chown' '# skip chown' \
+      --replace-fail '6755' '0755'
   '';
 
   nativeBuildInputs = [
@@ -57,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
     export SENDMAIL=${sendmailPath}
     # Purity: force atd.pid to be placed in /var/run regardless of
     # whether it exists now.
-    substituteInPlace ./configure --replace "test -d /var/run" "true"
+    substituteInPlace ./configure --replace-fail "test -d /var/run" "true"
   '';
 
   configureFlags = [


### PR DESCRIPTION
Per https://github.com/NixOS/nixpkgs/issues/356002

Removed substitution that was making the build fail when replaced.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
