### PR TITLE
xmlrpc_c: enable __structuredAttrs, strictDeps

### DIFF
--- a/pkgs/by-name/xm/xmlrpc_c/package.nix
+++ b/pkgs/by-name/xm/xmlrpc_c/package.nix
@@ -4,6 +4,7 @@
   fetchurl,
   fetchDebianPatch,
   pkg-config,
+  bashNonInteractive,
   curl,
   libxml2,
 }:
@@ -11,6 +12,9 @@
 stdenv.mkDerivation rec {
   pname = "xmlrpc-c";
   version = "1.60.05";
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchurl {
     url = "mirror://sourceforge/xmlrpc-c/xmlrpc-c-${version}.tgz";
@@ -31,6 +35,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [
+    bashNonInteractive
     pkg-config
   ];
 
@@ -43,12 +48,24 @@ stdenv.mkDerivation rec {
     "--enable-libxml2-backend"
   ];
 
+  preConfigure = ''
+    export PATH="${
+      lib.makeBinPath [
+        (lib.getDev curl)
+        (lib.getDev libxml2)
+      ]
+    }:$PATH"
+  '';
+
   # Build and install the "xmlrpc" tool (like the Debian package)
   postInstall = ''
     (cd tools/xmlrpc && make && make install)
+    patchShebangs --build $out/bin/xmlrpc-c-config
   '';
 
-  enableParallelBuilding = true;
+  # parallel make sometimes fails with:
+  # ln: failed to create symbolic link 'libxmlrpc_util.so.4': File exists
+  enableParallelBuilding = false;
 
   # ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-error=implicit-function-declaration";

--- a/pkgs/by-name/xm/xmlrpc_c/package.nix
+++ b/pkgs/by-name/xm/xmlrpc_c/package.nix
@@ -73,6 +73,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Lightweight RPC library based on XML and HTTP";
     homepage = "https://xmlrpc-c.sourceforge.net/";
+    changelog = "https://xmlrpc-c.sourceforge.io/change.html";
     # <xmlrpc-c>/doc/COPYING also lists "ABYSS Web Server License" and "Python 1.5.2 License"
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;


### PR DESCRIPTION
Also disable parallel building (fails randomly), enable __structuredAttrs, strictDeps (#178468)

I didn't update to the latest release because it breaks `tlf`.

## Things done

Checked output is equivalent using diffoscope.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
