### PR TITLE
spidermonkey: add update script

### DIFF
--- a/pkgs/development/interpreters/spidermonkey/common.nix
+++ b/pkgs/development/interpreters/spidermonkey/common.nix
@@ -166,11 +166,15 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s $out/bin/js${lib.versions.major version} $out/bin/js
   '';
 
-  passthru.tests.run = callPackage ./test.nix {
-    spidermonkey = finalAttrs.finalPackage;
+  passthru = {
+    tests.run = callPackage ./test.nix {
+      spidermonkey = finalAttrs.finalPackage;
+    };
+    updateScript = lib.getExe (callPackage ./update.nix { version = lib.versions.major version; });
   };
 
   meta = {
+    changelog = "https://www.firefox.com/en-US/firefox/${version}/releasenotes/";
     description = "Mozilla's JavaScript engine written in C/C++";
     homepage = "https://spidermonkey.dev/";
     license = lib.licenses.mpl20;

--- a/pkgs/development/interpreters/spidermonkey/update.nix
+++ b/pkgs/development/interpreters/spidermonkey/update.nix
@@ -1,0 +1,39 @@
+{
+  writeShellApplication,
+  common-updater-scripts,
+  xidel,
+  baseUrl ? "https://archive.mozilla.org/pub/firefox/releases/",
+  version ? "",
+}:
+writeShellApplication {
+  name = "update-spidermonkey_${version}";
+  runtimeInputs = [
+    common-updater-scripts
+    xidel
+  ];
+
+  text = ''
+    set -eux
+
+    HOME=$(mktemp -d)
+    GNUPGHOME=$(mktemp -d)
+    export GNUPGHOME
+
+    curl https://keys.openpgp.org/vks/v1/by-fingerprint/09BEED63F3462A2DFFAB3B875ECB6497C1A20256 | gpg --import -
+
+    version=$(xidel --trace -s "${baseUrl}" --extract "//a" | \
+     grep "^${version}[0-9.]*esr/$" | \
+     sed s/[/]$// | \
+     sort --version-sort | \
+     tail -n 1)
+
+    curl --silent --show-error -o "$HOME"/shasums "${baseUrl}$version/SHA512SUMS"
+    curl --silent --show-error -o "$HOME"/shasums.asc "${baseUrl}$version/SHA512SUMS.asc"
+    gpgv --keyring="$GNUPGHOME"/pubring.kbx "$HOME"/shasums.asc "$HOME"/shasums
+
+    hash=$(grep '\.source\.tar\.xz$' "$HOME"/shasums | grep '^[^ ]*' -o)
+    sri_hash=$(nix hash convert --hash-algo sha512 --to sri "$hash")
+    update-source-version --file=pkgs/development/interpreters/spidermonkey/${version}.nix \
+      "spidermonkey_${version}" "''${version%esr}" "$sri_hash"
+  '';
+}


### PR DESCRIPTION
partially based on https://github.com/NixOS/nixpkgs/blob/6f31c2529024d14916da3ea3e84d886ef67d3084/pkgs/applications/networking/browsers/firefox/update.nix. tested with 140.13.0.

should be helpful for keeping up to date, especially with firefox picking up biweekly releases (instead of every four weeks) in september.

## Things done

- Built on platform:
  - [x] x86_64-linux (i guess it counts as building?)
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
