### PR TITLE
headlamp{-server,-frontend,}: 0.42.0 -> 0.43.0

### DIFF
--- a/pkgs/by-name/he/headlamp-frontend/package.nix
+++ b/pkgs/by-name/he/headlamp-frontend/package.nix
@@ -12,7 +12,7 @@ buildNpmPackage {
 
   sourceRoot = "${headlamp-server.src.name}/frontend";
 
-  npmDepsHash = "sha256-73xc/GK1Cvz67D6ftYVRe5GARNgG5qD86CGK6uhoyWA=";
+  npmDepsHash = "sha256-v8aMlOk2JD2DzcUMWTK+2QP44n1Nl0LQPcIry7W51vg=";
 
   postPatch = ''
     chmod -R u+w ../app

--- a/pkgs/by-name/he/headlamp-server/package.nix
+++ b/pkgs/by-name/he/headlamp-server/package.nix
@@ -6,7 +6,7 @@
 
 buildGoModule rec {
   pname = "headlamp-server";
-  version = "0.42.0";
+  version = "0.43.0";
 
   strictDeps = true;
   __structuredAttrs = true;
@@ -15,12 +15,12 @@ buildGoModule rec {
     owner = "kubernetes-sigs";
     repo = "headlamp";
     tag = "v${version}";
-    hash = "sha256-SBPSh6dsKvMw1C80THri0mNPoTMgcrjONk455S/g9v0=";
+    hash = "sha256-6TGKBKR0WR4Xv7lGCgMFVG/nc19oMOP5cJcgT0bw6Ag=";
   };
 
   modRoot = "backend";
 
-  vendorHash = "sha256-dBU053QtUEMWjzkOEHzELH3j7PJOKuoBZCVZFmZ5z7E=";
+  vendorHash = "sha256-U0H1Dj38ajRGFqcWszveWckxenaKa4nrPg81GyIpS0U=";
 
   # Don't embed frontend - Electron serves it directly. This also prevents
   # the server from auto-opening a browser window.

--- a/pkgs/by-name/he/headlamp/package.nix
+++ b/pkgs/by-name/he/headlamp/package.nix
@@ -17,7 +17,7 @@ buildNpmPackage {
 
   sourceRoot = "${headlamp-server.src.name}/app";
 
-  npmDepsHash = "sha256-k7rABbEmYY24k/obKm1GZUnM0Udjtyv2bhrVEvc0ebc=";
+  npmDepsHash = "sha256-gZr+ni3dmrjqHDwoFxgGM0/Kf3R1Qy2SZetLtGtDY+0=";
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 


### PR DESCRIPTION
release notes: https://github.com/kubernetes-sigs/headlamp/releases/tag/v0.43.0

supersedes #532519

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
