### PR TITLE
headlamp-server: also update headlamp-frontend and headlamp hashes in updateScript

### DIFF
--- a/pkgs/by-name/he/headlamp-server/package.nix
+++ b/pkgs/by-name/he/headlamp-server/package.nix
@@ -2,6 +2,8 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  nix-update,
+  writeShellScript,
 }:
 
 buildGoModule rec {
@@ -36,6 +38,14 @@ buildGoModule rec {
 
   postInstall = ''
     mv $out/bin/cmd $out/bin/headlamp-server
+  '';
+
+  # headlamp-frontend and headlamp inherit src (and version) from here, update their hashes aswell
+  passthru.updateScript = writeShellScript "headlamp-update" ''
+    set -euo pipefail
+    ${lib.getExe nix-update} headlamp-server
+    ${lib.getExe nix-update} --version=skip --no-src headlamp-frontend
+    ${lib.getExe nix-update} --version=skip --no-src headlamp
   '';
 
   meta = {


### PR DESCRIPTION
tested by running

```
nix-shell maintainers/scripts/update.nix --argstr package headlamp-server
```

and verifying that it produces the same output as #544250

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
