### PR TITLE
opencamlib: Fix build failing on deprecated flag

### DIFF
--- a/pkgs/development/python-modules/opencamlib/01-build-verbose.patch
+++ b/pkgs/development/python-modules/opencamlib/01-build-verbose.patch
@@ -1,0 +1,12 @@
+diff --git i/pyproject.toml w/pyproject.toml
+index 20be73f..3773051 100644
+--- i/pyproject.toml
++++ w/pyproject.toml
+@@ -36,7 +36,7 @@ requires = ["scikit-build-core"]
+ build-backend = "scikit_build_core.build"
+
+ [tool.scikit-build]
+-cmake.verbose = true
++build.verbose = true
+ logging.level = "DEBUG"
+ wheel.packages = ["src/pythonlib/opencamlib"]

--- a/pkgs/development/python-modules/opencamlib/default.nix
+++ b/pkgs/development/python-modules/opencamlib/default.nix
@@ -23,6 +23,11 @@ buildPythonPackage rec {
     hash = "sha256-pUj71PdWo902dqF9O6SLnpvFooFU2OfLBv8hAVsH/iA=";
   };
 
+  patches = [
+    # Upstream status: https://github.com/aewallin/opencamlib/pull/180
+    ./01-build-verbose.patch
+  ];
+
   build-system = [
     scikit-build-core
   ];


### PR DESCRIPTION
Adds a patch to set a build flag that fixes the build from failing.

Attempt to get this fixes upstream: https://github.com/aewallin/opencamlib/pull/180

This package is a dependency of freecad.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
