### PR TITLE
python314Packages.ctranslate2: explicitly set library_dirs through build system env

### DIFF
--- a/pkgs/development/python-modules/ctranslate2/default.nix
+++ b/pkgs/development/python-modules/ctranslate2/default.nix
@@ -37,12 +37,12 @@ buildPythonPackage rec {
     setuptools
   ];
 
-  buildInputs = [ ctranslate2-cpp ];
-
   dependencies = [
     numpy
     pyyaml
   ];
+
+  env.CTRANSLATE2_ROOT = "${ctranslate2-cpp}";
 
   cmakeFlags = [ "-DCMAKE_POLICY_VERSION_MINIMUM=3.5" ];
 


### PR DESCRIPTION
In high core/load environments ctranslate2 could fail to link like:

```
...
running build_ext
building 'ctranslate2._ext' extension
creating build/temp.linux-x86_64-cpython-314/cpp
g++ -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -I/nix/store/ijyd6j5zv846q20zh9q5dk5dk9smn5h0-python3.14-pybind11-3.0.4/lib/python3.14/site-packages/pybind11/include -I/nix/store/jxyrvv4gbpnp3ap5iy7wxwl1sg4x2x88-python3-3.14.6/include/python3.14 -c cpp/encoder.cc -o build/temp.linux-x86_64-cpython-314/cpp/encoder.o -std=c++17 -fvisibility=hidden -fPIC
g++ -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -I/nix/store/ijyd6j5zv846q20zh9q5dk5dk9smn5h0-python3.14-pybind11-3.0.4/lib/python3.14/site-packages/pybind11/include -I/nix/store/jxyrvv4gbpnp3ap5iy7wxwl1sg4x2x88-python3-3.14.6/include/python3.14 -c cpp/logging.cc -o build/temp.linux-x86_64-cpython-314/cpp/logging.o -std=c++17 -fvisibility=hidden -fPIC
g++ -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -I/nix/store/ijyd6j5zv846q20zh9q5dk5dk9smn5h0-python3.14-pybind11-3.0.4/lib/python3.14/site-packages/pybind11/include -I/nix/store/jxyrvv4gbpnp3ap5iy7wxwl1sg4x2x88-python3-3.14.6/include/python3.14 -c cpp/translation_result.cc -o build/temp.linux-x86_64-cpython-314/cpp/translation_result.o -std=c++17 -fvisibility=hidden -fPIC
g++ -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -I/nix/store/ijyd6j5zv846q20zh9q5dk5dk9smn5h0-python3.14-pybind11-3.0.4/lib/python3.14/site-packages/pybind11/include -I/nix/store/jxyrvv4gbpnp3ap5iy7wxwl1sg4x2x88-python3-3.14.6/include/python3.14 -c cpp/wav2vec2.cc -o build/temp.linux-x86_64-cpython-314/cpp/wav2vec2.o -std=c++17 -fvisibility=hidden -fPIC
g++ -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -I/nix/store/ijyd6j5zv846q20zh9q5dk5dk9smn5h0-python3.14-pybind11-3.0.4/lib/python3.14/site-packages/pybind11/include -I/nix/store/jxyrvv4gbpnp3ap5iy7wxwl1sg4x2x88-python3-3.14.6/include/python3.14 -c cpp/execution_stats.cc -o build/temp.linux-x86_64-cpython-314/cpp/execution_stats.o -std=c++17 -fvisibility=hidden -fPIC
g++ -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -I/nix/store/ijyd6j5zv846q20zh9q5dk5dk9smn5h0-python3.14-pybind11-3.0.4/lib/python3.14/site-packages/pybind11/include -I/nix/store/jxyrvv4gbpnp3ap5iy7wxwl1sg4x2x88-python3-3.14.6/include/python3.14 -c cpp/mpi.cc -o build/temp.linux-x86_64-cpython-314/cpp/mpi.o -std=c++17 -fvisibility=hidden -fPIC
g++ -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -I/nix/store/ijyd6j5zv846q20zh9q5dk5dk9smn5h0-python3.14-pybind11-3.0.4/lib/python3.14/site-packages/pybind11/include -I/nix/store/jxyrvv4gbpnp3ap5iy7wxwl1sg4x2x88-python3-3.14.6/include/python3.14 -c cpp/generator.cc -o build/temp.linux-x86_64-cpython-314/cpp/generator.o -std=c++17 -fvisibility=hidden -fPIC
g++ -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -I/nix/store/ijyd6j5zv846q20zh9q5dk5dk9smn5h0-python3.14-pybind11-3.0.4/lib/python3.14/site-packages/pybind11/include -I/nix/store/jxyrvv4gbpnp3ap5iy7wxwl1sg4x2x88-python3-3.14.6/include/python3.14 -c cpp/module.cc -o build/temp.linux-x86_64-cpython-314/cpp/module.o -std=c++17 -fvisibility=hidden -fPIC
g++ -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -I/nix/store/ijyd6j5zv846q20zh9q5dk5dk9smn5h0-python3.14-pybind11-3.0.4/lib/python3.14/site-packages/pybind11/include -I/nix/store/jxyrvv4gbpnp3ap5iy7wxwl1sg4x2x88-python3-3.14.6/include/python3.14 -c cpp/translator.cc -o build/temp.linux-x86_64-cpython-314/cpp/translator.o -std=c++17 -fvisibility=hidden -fPIC
g++ -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -I/nix/store/ijyd6j5zv846q20zh9q5dk5dk9smn5h0-python3.14-pybind11-3.0.4/lib/python3.14/site-packages/pybind11/include -I/nix/store/jxyrvv4gbpnp3ap5iy7wxwl1sg4x2x88-python3-3.14.6/include/python3.14 -c cpp/whisper.cc -o build/temp.linux-x86_64-cpython-314/cpp/whisper.o -std=c++17 -fvisibility=hidden -fPIC
g++ -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -I/nix/store/ijyd6j5zv846q20zh9q5dk5dk9smn5h0-python3.14-pybind11-3.0.4/lib/python3.14/site-packages/pybind11/include -I/nix/store/jxyrvv4gbpnp3ap5iy7wxwl1sg4x2x88-python3-3.14.6/include/python3.14 -c cpp/generation_result.cc -o build/temp.linux-x86_64-cpython-314/cpp/generation_result.o -std=c++17 -fvisibility=hidden -fPIC
g++ -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -I/nix/store/ijyd6j5zv846q20zh9q5dk5dk9smn5h0-python3.14-pybind11-3.0.4/lib/python3.14/site-packages/pybind11/include -I/nix/store/jxyrvv4gbpnp3ap5iy7wxwl1sg4x2x88-python3-3.14.6/include/python3.14 -c cpp/storage_view.cc -o build/temp.linux-x86_64-cpython-314/cpp/storage_view.o -std=c++17 -fvisibility=hidden -fPIC
g++ -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -I/nix/store/ijyd6j5zv846q20zh9q5dk5dk9smn5h0-python3.14-pybind11-3.0.4/lib/python3.14/site-packages/pybind11/include -I/nix/store/jxyrvv4gbpnp3ap5iy7wxwl1sg4x2x88-python3-3.14.6/include/python3.14 -c cpp/wav2vec2bert.cc -o build/temp.linux-x86_64-cpython-314/cpp/wav2vec2bert.o -std=c++17 -fvisibility=hidden -fPIC
g++ -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -I/nix/store/ijyd6j5zv846q20zh9q5dk5dk9smn5h0-python3.14-pybind11-3.0.4/lib/python3.14/site-packages/pybind11/include -I/nix/store/jxyrvv4gbpnp3ap5iy7wxwl1sg4x2x88-python3-3.14.6/include/python3.14 -c cpp/scoring_result.cc -o build/temp.linux-x86_64-cpython-314/cpp/scoring_result.o -std=c++17 -fvisibility=hidden -fPIC
g++ -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -shared -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-bzip2-1.0.8/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-libffi-3.5.2/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-util-linux-minimal-2.42.2-lib/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-ncurses-6.6/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-xz-5.8.3/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-zlib-1.3.2/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-openssl-3.6.3/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-sqlite-3.53.1/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-mpdecimal-4.0.1/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-expat-2.8.2/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-zstd-1.5.7/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-bluez-headers-5.86/lib -L/nix/store/bzzvmj6wh8a7mqvq9i54fmvpsdxz4zqj-tzdata-2026b/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gdbm-1.26-lib/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-readline-8.3p3/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-bzip2-1.0.8/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-libffi-3.5.2/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-util-linux-minimal-2.42.2-lib/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-ncurses-6.6/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-xz-5.8.3/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-zlib-1.3.2/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-openssl-3.6.3/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-sqlite-3.53.1/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-mpdecimal-4.0.1/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-expat-2.8.2/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-zstd-1.5.7/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-bluez-headers-5.86/lib -L/nix/store/bzzvmj6wh8a7mqvq9i54fmvpsdxz4zqj-tzdata-2026b/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gdbm-1.26-lib/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-readline-8.3p3/lib build/temp.linux-x86_64-cpython-314/cpp/encoder.o build/temp.linux-x86_64-cpython-314/cpp/execution_stats.o build/temp.linux-x86_64-cpython-314/cpp/generation_result.o build/temp.linux-x86_64-cpython-314/cpp/generator.o build/temp.linux-x86_64-cpython-314/cpp/logging.o build/temp.linux-x86_64-cpython-314/cpp/module.o build/temp.linux-x86_64-cpython-314/cpp/mpi.o build/temp.linux-x86_64-cpython-314/cpp/scoring_result.o build/temp.linux-x86_64-cpython-314/cpp/storage_view.o build/temp.linux-x86_64-cpython-314/cpp/translation_result.o build/temp.linux-x86_64-cpython-314/cpp/translator.o build/temp.linux-x86_64-cpython-314/cpp/wav2vec2.o build/temp.linux-x86_64-cpython-314/cpp/wav2vec2bert.o build/temp.linux-x86_64-cpython-314/cpp/whisper.o -L/nix/store/jxyrvv4gbpnp3ap5iy7wxwl1sg4x2x88-python3-3.14.6/lib -lctranslate2 -o build/lib.linux-x86_64-cpython-314/ctranslate2/_ext.cpython-314-x86_64-linux-gnu.so -Wl,-rpath,/usr/local/lib64:/usr/local/lib
/nix/store/ddk8rvjihg4vhh1k6x9rc65y1zb1kx34-binutils-2.46/bin/ld.bfd: cannot find -lctranslate2: No such file or directory
collect2: error: ld returned 1 exit status
error: command '/nix/store/vdaz6sk455r8sbpi7wzaf9vlz5i9yyvx-gcc-wrapper-15.2.0/bin/g++' failed with exit code 1
ERROR Backend subprocess exited when trying to invoke build_wheel
...
```

This can be avoided by setting library_dirs explicitly through an env in
the upstream build system https://github.com/OpenNMT/CTranslate2/blob/v4.8.1/python/setup.py#L31-L42
and with that the lib directory is given explicitly and the linker can
always find it:

```
python3.14-ctranslate2> g++ -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -shared -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-bzip2-1.0.8/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-libffi-3.5.2/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-util-linux-minimal-2.42.2-lib/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-ncurses-6.6/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-xz-5.8.3/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-zlib-1.3.2/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-openssl-3.6.3/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-sqlite-3.53.1/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-mpdecimal-4.0.1/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-expat-2.8.2/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-zstd-1.5.7/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-bluez-headers-5.86/lib -L/nix/store/bzzvmj6wh8a7mqvq9i54fmvpsdxz4zqj-tzdata-2026b/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gdbm-1.26-lib/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-readline-8.3p3/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-bzip2-1.0.8/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-libffi-3.5.2/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-util-linux-minimal-2.42.2-lib/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-ncurses-6.6/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-xz-5.8.3/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-zlib-1.3.2/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-openssl-3.6.3/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-sqlite-3.53.1/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-mpdecimal-4.0.1/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-expat-2.8.2/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-zstd-1.5.7/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-bluez-headers-5.86/lib -L/nix/store/bzzvmj6wh8a7mqvq9i54fmvpsdxz4zqj-tzdata-2026b/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gdbm-1.26-lib/lib -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-readline-8.3p3/lib build/temp.linux-x86_64-cpython-314/cpp/encoder.o build/temp.linux-x86_64-cpython-314/cpp/execution_stats.o build/temp.linux-x86_64-cpython-314/cpp/generation_result.o build/temp.linux-x86_64-cpython-314/cpp/generator.o build/temp.linux-x86_64-cpython-314/cpp/logging.o build/temp.linux-x86_64-cpython-314/cpp/module.o build/temp.linux-x86_64-cpython-314/cpp/mpi.o build/temp.linux-x86_64-cpython-314/cpp/scoring_result.o build/temp.linux-x86_64-cpython-314/cpp/storage_view.o build/temp.linux-x86_64-cpython-314/cpp/translation_result.o build/temp.linux-x86_64-cpython-314/cpp/translator.o build/temp.linux-x86_64-cpython-314/cpp/wav2vec2.o build/temp.linux-x86_64-cpython-314/cpp/wav2vec2bert.o build/temp.linux-x86_64-cpython-314/cpp/whisper.o -L/nix/store/xiqxnqx0w0aaq35mh3x4pjh2mv9w0xg3-ctranslate2-4.8.1/lib -L/nix/store/jxyrvv4gbpnp3ap5iy7wxwl1sg4x2x88-python3-3.14.6/lib -lctranslate2 -o build/lib.linux-x86_64-cpython-314/ctranslate2/_ext.cpython-314-x86_64-linux-gnu.so -Wl,-rpath,/usr/local/lib64:/usr/local/lib
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
