### PR TITLE
nixos/test-driver: read test script from store instead of env var

### DIFF
--- a/nixos/lib/testing/driver.nix
+++ b/nixos/lib/testing/driver.nix
@@ -68,9 +68,11 @@ let
         ++ lib.optionals (!config.skipTypeCheck) [ hostPkgs.ty ]
         ++ lib.optionals (!config.skipLint) [ hostPkgs.ruff ];
         buildInputs = [ testDriver ];
-        testScript = config.testScriptString;
         preferLocalBuild = true;
-        passthru = config.passthru;
+        passthru = config.passthru // {
+          # testScript used to be a part of the derivation attributes, kept for backwards compat.
+          testScript = config.testScriptString;
+        };
         meta = config.meta // {
           mainProgram = "nixos-test-driver";
         };
@@ -82,7 +84,7 @@ let
           # prepend type hints so the test script can be type checked with ty
           cat "${../test-script-prepend.py}" >> testScriptWithTypes
           echo "${toString typeHints}" >> testScriptWithTypes
-          echo -n "$testScript" >> testScriptWithTypes
+          cat "${config.driverConfiguration.test_script}" >> testScriptWithTypes
         ''}
 
         ${lib.optionalString (!config.skipTypeCheck) ''


### PR DESCRIPTION
The env var approach caps out at 128K which makes large test scripts fail checks with:
```
error: executing '.../bin/bash': Argument list too long
```

The script already exists in the store, let's use that.


To reproduce:

- Write a large test (>128k) from a Python repl
  `import string, random; open('./nixos/tests/pam/test_chfn.py', 'a').write("# " + "".join(random.choices(string.ascii_letters + string.digits, k=256*1024)))`
- `nix-build ./. -A nixosTests.pam-file-contents`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
