### PR TITLE
pidginPackages.pidgin-libnotify: init at 0.14.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/default.nix
@@ -30,6 +30,8 @@ lib.makeScope newScope (
 
     pidgin-xmpp-receipts = callPackage ./pidgin-xmpp-receipts { };
 
+    pidgin-libnotify = callPackage ./pidgin-libnotify { };
+
     pidgin-otr = callPackage ./otr { };
 
     pidgin-osd = callPackage ./pidgin-osd { };

--- a/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/pidgin-libnotify/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/pidgin-libnotify/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  libotr,
+  pidgin,
+  intltool,
+  fetchFromGitHub,
+  libnotify,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pidgin-libnotify";
+  version = "0.14.1";
+  src = fetchFromGitHub {
+    owner = "qhga";
+    repo = "pidgin-libnotify";
+    rev = version;
+    sha256 = "sha256-orKYYCa+382Ha5IuYOfBUVPUJZk1l4eQCEFDdR/WPTM=";
+  };
+
+  nativeBuildInputs = [
+    intltool
+  ];
+
+  buildInputs = [
+    pidgin
+    libnotify
+  ];
+
+  makeFlags = [
+    "gddir=${placeholder "out"}/lib/purple-2"
+  ];
+
+  meta = {
+    homepage = "https://github.com/qhga/pidgin-libnotify";
+    description = "Plugin for Pidgin 2.x which implements libnotify notification support";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+    maintainers = [ ];
+  };
+}


### PR DESCRIPTION
I needed libnotify based notifications for pidgin. Thus, I "forked" the original `pidgin-libnotify` package from https://gaim-libnotify.sourceforge.net/ to https://github.com/qhga/pidgin-libnotify and fixed a build error. I tried to align the module to the structure of the other pidgin-plugins.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
