### PR TITLE
instantview: init at 2.24.8.0

### DIFF
--- a/nixos/modules/hardware/video/instantview.nix
+++ b/nixos/modules/hardware/video/instantview.nix
@@ -1,0 +1,94 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.hardware.instantview;
+
+  enabled = cfg.enable || lib.elem "instantview" config.services.xserver.videoDrivers;
+
+  evdi = config.boot.kernelPackages.evdi;
+
+  instantview = pkgs.instantview.override {
+    inherit evdi;
+  };
+in
+{
+  options.hardware.instantview.enable = lib.mkEnableOption ''
+    Silicon Motion SM76x InstantView USB display support (EVDI + SMIUSBDisplayManager).
+    Works at the DRM layer for Wayland and X11; compositor support for EVDI
+    connectors varies (niri is known to pick them up; some KWin versions do not)
+  '';
+
+  config = lib.mkIf enabled {
+    boot.extraModulePackages = [ evdi ];
+    boot.kernelModules = [ "evdi" ];
+    boot.extraModprobeConfig = ''
+      options evdi initial_device_count=4
+    '';
+
+    services.udev.packages = [ instantview ];
+
+    # Proprietary manager hardcodes /opt/siliconmotion for firmware and debug
+    # dumps; keep that tree writable and symlink firmware from the store.
+    systemd.tmpfiles.rules =
+      let
+        fw = "${instantview}/lib/instantview";
+      in
+      [
+        "d /opt 0755 root root -"
+        "d /opt/siliconmotion 0755 root root -"
+        "d /opt/siliconmotion/pic 0755 root root -"
+        "L+ /opt/siliconmotion/Bootloader0.bin - - - - ${fw}/Bootloader0.bin"
+        "L+ /opt/siliconmotion/Bootloader1.bin - - - - ${fw}/Bootloader1.bin"
+        "L+ /opt/siliconmotion/firmware0.bin - - - - ${fw}/firmware0.bin"
+        "L+ /opt/siliconmotion/USBDisplay.bin - - - - ${fw}/USBDisplay.bin"
+        "L+ /opt/siliconmotion/USBDisplay770.bin - - - - ${fw}/USBDisplay770.bin"
+      ];
+
+    # Optional X11 helper (not required for Wayland). Gated so Wayland-only
+    # sessions are not forced into xrandr sessionCommands.
+    services.xserver.externallyConfiguredDrivers = lib.mkIf config.services.xserver.enable [
+      "instantview"
+    ];
+
+    environment.etc."X11/xorg.conf.d/40-instantview.conf" = lib.mkIf config.services.xserver.enable {
+      text = ''
+        Section "OutputClass"
+          Identifier  "InstantView"
+          MatchDriver "evdi"
+          Driver      "modesetting"
+          Option      "TearFree" "true"
+          Option      "AccelMethod" "none"
+        EndSection
+      '';
+    };
+
+    systemd.services.instantview = {
+      description = "Silicon Motion InstantView USB Display Manager";
+      after = [
+        "systemd-tmpfiles-setup.service"
+        "systemd-udev-settle.service"
+        "modprobe@evdi.service"
+      ];
+      wants = [ "modprobe@evdi.service" ];
+      # Udev SYSTEMD_WANTS starts this on device add; also allow manual enable.
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        # Prefer current-system so a switch without reboot can still load
+        # newly added out-of-tree modules (booted-system lags until reboot).
+        ExecStartPre = "${pkgs.kmod}/bin/modprobe -d /run/current-system/kernel-modules evdi";
+        ExecStart = "${instantview}/bin/SMIUSBDisplayManager";
+        # Matches vendor/AUR layout; absolute firmware paths use /opt/siliconmotion.
+        WorkingDirectory = "/opt/siliconmotion";
+        Restart = "always";
+        RestartSec = 5;
+        LogsDirectory = "instantview";
+      };
+    };
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -122,6 +122,7 @@
   ./hardware/video/bumblebee.nix
   ./hardware/video/capture/mwprocapture.nix
   ./hardware/video/displaylink.nix
+  ./hardware/video/instantview.nix
   ./hardware/video/intel-gpu-tools.nix
   ./hardware/video/nvidia.nix
   ./hardware/video/switcheroo-control.nix

--- a/pkgs/by-name/in/instantview/99-instantview.rules
+++ b/pkgs/by-name/in/instantview/99-instantview.rules
@@ -1,0 +1,12 @@
+# Silicon Motion USB Display (SM76x InstantView), e.g. 090c:0768
+ACTION=="add", SUBSYSTEM=="usb", DRIVERS=="usb", \
+ ATTR{idVendor}=="090c", IMPORT{builtin}="usb_id", \
+ ATTR{bDeviceClass}=="ef", \
+ ENV{SMIUSBDISPLAY_DEVNAME}="$env{DEVNAME}", \
+ ENV{SMIUSBDISPLAY_DEVICE_ID}="$env{ID_BUS}-$env{BUSNUM}-$env{DEVNUM}-$env{ID_SERIAL}", \
+ TAG+="systemd", ENV{SYSTEMD_WANTS}="instantview.service", \
+ RUN+="@smiUdev@ add $root $env{SMIUSBDISPLAY_DEVICE_ID} $env{SMIUSBDISPLAY_DEVNAME}"
+
+ACTION=="remove", ENV{DEVNAME}!="", \
+ ENV{PRODUCT}=="90c/*", \
+ RUN+="@smiUdev@ remove $root $env{DEVNAME}"

--- a/pkgs/by-name/in/instantview/package.nix
+++ b/pkgs/by-name/in/instantview/package.nix
@@ -1,0 +1,108 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  unzip,
+  libusb1,
+  linuxPackages,
+  evdi ? linuxPackages.evdi,
+  makeBinaryWrapper,
+  patchelf,
+}:
+
+let
+  sources = lib.importJSON ./sources.json;
+
+  libPath = lib.makeLibraryPath [
+    stdenv.cc.cc
+    libusb1
+    evdi
+  ];
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "instantview";
+  inherit (sources) version;
+
+  src = fetchurl {
+    inherit (sources) url hash;
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    unzip
+    makeBinaryWrapper
+    patchelf
+  ];
+
+  buildInputs = [
+    libusb1
+    evdi
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+    unzip "$src"
+    chmod +x SMIUSBDisplay-driver.${finalAttrs.version}.run
+    ./SMIUSBDisplay-driver.${finalAttrs.version}.run --target . --noexec
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 x64/SMIUSBDisplayManager $out/bin/SMIUSBDisplayManager
+
+    install -d $out/lib/instantview
+    install -m644 \
+      Bootloader0.bin Bootloader1.bin firmware0.bin \
+      USBDisplay.bin USBDisplay770.bin \
+      $out/lib/instantview/
+
+    # Binary DT_NEEDED is libevdi.so.1; nixpkgs evdi installs libevdi.so
+    ln -s ${lib.getLib evdi}/lib/libevdi.so $out/lib/instantview/libevdi.so.1
+
+    install -Dm755 ${./smi-udev.sh} $out/lib/instantview/smi-udev.sh
+    install -d $out/lib/udev/rules.d
+    substitute ${./99-instantview.rules} $out/lib/udev/rules.d/99-instantview.rules \
+      --subst-var-by smiUdev "$out/lib/instantview/smi-udev.sh"
+
+    patchelf \
+      --set-interpreter "$(cat ${stdenv.cc}/nix-support/dynamic-linker)" \
+      --set-rpath "$out/lib/instantview:${libPath}" \
+      $out/bin/SMIUSBDisplayManager
+
+    wrapProgram $out/bin/SMIUSBDisplayManager \
+      --chdir "$out/lib/instantview"
+
+    patchShebangs $out/lib/instantview
+
+    runHook postInstall
+  '';
+
+  dontStrip = true;
+  dontPatchELF = true;
+
+  passthru = {
+    inherit sources;
+    updateScript = {
+      command = [ ./update.sh ];
+      supportedFeatures = [ "commit" ];
+    };
+  };
+
+  meta = {
+    description = "Silicon Motion SM76x InstantView USB display driver for Linux";
+    homepage = "https://www.siliconmotion.com/events/instantview/";
+    changelog = sources.releaseNotes;
+    # EVDI creates DRM devices; Wayland compositors may or may not expose them
+    # (test per host). Packaging does not require X11.
+    license = lib.licenses.unfree;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    maintainers = with lib.maintainers; [ aspauldingcode ];
+    platforms = [ "x86_64-linux" ];
+    hydraPlatforms = [ ];
+    mainProgram = "SMIUSBDisplayManager";
+  };
+})

--- a/pkgs/by-name/in/instantview/smi-udev.sh
+++ b/pkgs/by-name/in/instantview/smi-udev.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Udev helper for Silicon Motion USB Display (adapted from vendor/AUR bootstrap).
+# Service start/stop is handled via SYSTEMD_WANTS=instantview.service in udev rules.
+
+create_siliconmotion_symlink() {
+  root=$1
+  device_id=$2
+  devnode=$3
+  mkdir -p "${root}/siliconmotion/by-id"
+  ln -sf "$devnode" "${root}/siliconmotion/by-id/$device_id"
+}
+
+unlink_siliconmotion_symlink() {
+  root=$1
+  devname=$2
+  dir="${root}/siliconmotion/by-id"
+  [ -d "$dir" ] || return 0
+  for f in "$dir"/*; do
+    [ -e "$f" ] || [ -L "$f" ] || continue
+    if [ ! -e "$f" ] || { [ -L "$f" ] && [ "$f" -ef "$devname" ]; }; then
+      unlink "$f" 2>/dev/null || true
+    fi
+  done
+  rmdir -p --ignore-fail-on-non-empty "$dir" 2>/dev/null || true
+}
+
+main() {
+  action=$1
+  root=$2
+  case "$action" in
+  add)
+    device_id=$3
+    devnode=$4
+    create_siliconmotion_symlink "$root" "$device_id" "$devnode"
+    ;;
+  remove)
+    devname=$3
+    unlink_siliconmotion_symlink "$root" "$devname"
+    ;;
+  esac
+}
+
+main "$@"

--- a/pkgs/by-name/in/instantview/sources.json
+++ b/pkgs/by-name/in/instantview/sources.json
@@ -1,0 +1,6 @@
+{
+  "version": "2.24.8.0",
+  "url": "https://www.siliconmotion.com/downloads/SMI-USB-Display-for-Linux-v2.24.8.0.zip",
+  "hash": "sha256-uyJFi1Jkcbea9Bh0cSJHrhLf3K78pjjR4seBA3Uf4H8=",
+  "releaseNotes": "https://www.siliconmotion.com/downloads/Release%20Notes/SiliconMotion%20USB%20Graphics%20Software%20for%20Ubuntu%20release%20note.txt"
+}

--- a/pkgs/by-name/in/instantview/update.sh
+++ b/pkgs/by-name/in/instantview/update.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq coreutils nix ripgrep
+# shellcheck shell=bash
+set -euo pipefail
+
+cd -- "$(dirname "${BASH_SOURCE[0]}")"
+
+INDEX_URL="https://www.siliconmotion.com/downloads/index.html"
+LINUX_NOTES_URL="https://www.siliconmotion.com/downloads/Release%20Notes/SiliconMotion%20USB%20Graphics%20Software%20for%20Ubuntu%20release%20note.txt"
+UA="nixpkgs#instantview update.sh"
+
+CURL=(curl --fail --silent --show-error --proto "=https" --tlsv1.2 -H "User-Agent: ${UA}")
+
+html=$("${CURL[@]}" "$INDEX_URL")
+notes=$("${CURL[@]}" "$LINUX_NOTES_URL")
+
+# Authoritative version from release notes head, e.g. "InstantView release  V2.24.8.0"
+linux_ver=$(rg -o 'InstantView release\s+V([0-9]+(?:\.[0-9]+)+)' -r '$1' <<<"$notes" | head -n1)
+if [[ -z $linux_ver ]]; then
+  echo "update.sh: failed to parse InstantView version from Linux release notes" >&2
+  exit 1
+fi
+
+# Artifact URL from downloads index (first Linux zip)
+linux_url=$(rg -o 'https://www\.siliconmotion\.com/downloads/SMI-USB-Display-for-Linux-v[^"[:space:]]+\.zip' <<<"$html" | head -n1)
+if [[ -z $linux_url ]]; then
+  linux_url=$(rg -o 'SMI-USB-Display-for-Linux-v[^"[:space:]]+\.zip' <<<"$html" | head -n1)
+  if [[ -n $linux_url ]]; then
+    linux_url="https://www.siliconmotion.com/downloads/${linux_url}"
+  fi
+fi
+if [[ -z $linux_url ]]; then
+  linux_url="https://www.siliconmotion.com/downloads/SMI-USB-Display-for-Linux-v${linux_ver}.zip"
+fi
+
+url_ver=$(rg -o 'SMI-USB-Display-for-Linux-v([0-9.]+)\.zip' -r '$1' <<<"$linux_url" || true)
+if [[ -n $url_ver && $url_ver != "$linux_ver" ]]; then
+  echo "update.sh: version mismatch: notes=${linux_ver} url=${url_ver}" >&2
+  exit 1
+fi
+
+"${CURL[@]}" -I -o /dev/null "$linux_url"
+
+current=$(jq -r .version sources.json)
+attrPath="${UPDATE_NIX_ATTR_PATH:-instantview}"
+
+if [[ $linux_ver == "$current" ]]; then
+  echo "Already up to date (linux=${linux_ver})" >&2
+  echo '[]'
+  exit 0
+fi
+
+echo "Updating ${attrPath}: ${current} -> ${linux_ver}" >&2
+echo "Prefetching ${linux_url}" >&2
+
+{
+  read -r hash
+  read -r _path
+} < <(nix-prefetch-url --print-path "$linux_url")
+sri=$(nix hash to-sri --type sha256 "$hash" 2>/dev/null || nix-hash --type sha256 --to-sri "$hash")
+
+jq -n \
+  --arg v "$linux_ver" \
+  --arg u "$linux_url" \
+  --arg h "$sri" \
+  --arg n "$LINUX_NOTES_URL" \
+  '{ version: $v, url: $u, hash: $h, releaseNotes: $n }' >sources.json
+
+pkgDir=$(pwd)
+echo "[{\"attrPath\":\"${attrPath}\",\"oldVersion\":\"${current}\",\"newVersion\":\"${linux_ver}\",\"files\":[\"${pkgDir}/sources.json\"],\"commitBody\":\"Release notes: ${LINUX_NOTES_URL}\"}]"


### PR DESCRIPTION
## Summary
- Add `instantview` (Silicon Motion SM76x Linux userspace + firmware) under `pkgs/os-specific/linux/`
- Add `hardware.instantview.enable` NixOS module (EVDI, udev, systemd)

## Test plan
- [x] `NIXPKGS_ALLOW_UNFREE=1 nix-build -A instantview` (`x86_64-linux`)
- [x] `./pkgs/os-specific/linux/instantview/update.sh` (already current)
- [x] NixOS: `hardware.instantview.enable = true` on local host