### PR TITLE
cudaPackages.nvbandwidth: 0.9 -> 0.10.0

### DIFF
--- a/pkgs/development/cuda-modules/packages/nvbandwidth/package.nix
+++ b/pkgs/development/cuda-modules/packages/nvbandwidth/package.nix
@@ -9,7 +9,7 @@
   cuda_nvcc,
 
   # buildInputs
-  boost,
+  argparse,
   cuda_cudart,
   cuda_nvml_dev,
 
@@ -21,7 +21,7 @@
 }:
 backendStdenv.mkDerivation (finalAttrs: {
   pname = "nvbandwidth";
-  version = "0.9";
+  version = "0.10.0";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -30,7 +30,7 @@ backendStdenv.mkDerivation (finalAttrs: {
     owner = "NVIDIA";
     repo = "nvbandwidth";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-j1bKWXHIkjsE/M+w5rRF0UGjkj1gLA2yi+5hc1sWl/A=";
+    hash = "sha256-bmE9EEe4mPzgo2QQucs+gof/NYN0rkvV/4ZxPWP1mMs=";
   };
 
   patches = [
@@ -49,7 +49,7 @@ backendStdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    boost
+    argparse
     cuda_cudart # cuda_runtime.h, libcuda stub
     cuda_nvml_dev # libnvidia-ml
   ];

--- a/pkgs/development/cuda-modules/packages/nvbandwidth/use-cuda-imported-targets.patch
+++ b/pkgs/development/cuda-modules/packages/nvbandwidth/use-cuda-imported-targets.patch
@@ -1,4 +1,4 @@
-Use CMake imported targets and disable the static Boost build.
+Use CMake imported targets and a system argparse instead of FetchContent.
 
 The upstream link command `target_link_libraries(... ${NVML_LIB_NAME} cuda)`
 expands to plain `-lnvidia-ml -lcuda`, which forces the linker to look up
@@ -8,40 +8,41 @@ build fails. Switching to the `CUDA::nvml` / `CUDA::cuda_driver` imported
 targets exposed by `find_package(CUDAToolkit)` makes CMake link against the
 absolute stub paths it discovers via `CUDAToolkit_ROOT` instead.
 
-The static-Boost branch is also dropped: it dispatches on `/etc/os-release`,
-which doesn't exist in the Nix sandbox, and we want a dynamic build anyway.
+The `FetchContent` argparse dependency is also dropped in favour of the
+`argparse` package from Nixpkgs (pinned to the same v3.2 upstream requests):
+`FetchContent` downloads a tarball over the network, which isn't available in
+the Nix sandbox.
 ---
- CMakeLists.txt | 11 +++--------
- 1 file changed, 3 insertions(+), 8 deletions(-)
+ CMakeLists.txt | 12 +++---------
+ 1 file changed, 3 insertions(+), 9 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -43,16 +43,11 @@
+@@ -76,14 +76,8 @@
      set(CMAKE_BUILD_TYPE "Release")
  endif()
 
--if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
--    file(READ "/etc/os-release" OS_RELEASE_CONTENT)
--    # Skip static libs on Fedora - https://github.com/NVIDIA/nvbandwidth/issues/4
--    if(NOT OS_RELEASE_CONTENT MATCHES "ID=.*fedora|azurelinux")
--        set(Boost_USE_STATIC_LIBS ON)
--    endif()
--else()
-+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
-     set(Boost_USE_STATIC_LIBS ON)
- endif()
- find_package(Boost COMPONENTS program_options REQUIRED)
+-include(FetchContent)
+-FetchContent_Declare(
+-        argparse
+-        URL https://github.com/p-ranav/argparse/archive/refs/tags/v3.2.tar.gz
+-        URL_HASH SHA256=9dcb3d8ce0a41b2a48ac8baa54b51a9f1b6a2c52dd374e28cc713bab0568ec98
+-        # Pinned version - provides .flag(), .store_into(), .choices()
+-)
+-FetchContent_MakeAvailable(argparse)
++find_package(argparse REQUIRED)
 +find_package(CUDAToolkit REQUIRED)
 
  set(src
-     environment.cpp
-@@ -85,7 +80,7 @@
-
- add_executable(nvbandwidth ${src})
- target_include_directories(nvbandwidth PRIVATE ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES} .)
--target_link_libraries(nvbandwidth Boost::program_options ${NVML_LIB_NAME} cuda)
-+target_link_libraries(nvbandwidth Boost::program_options CUDA::nvml CUDA::cuda_driver)
-
- if (MULTINODE)
-     find_package(MPI REQUIRED)
+     cuda_version_check.cpp
+@@ -107,7 +101,7 @@
+ target_include_directories(nvbandwidth PRIVATE
+     ${CMAKE_CURRENT_BINARY_DIR}
+     ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}
+     .)
+-target_link_libraries(nvbandwidth argparse ${NVML_LIB_NAME} cuda)
++target_link_libraries(nvbandwidth argparse::argparse CUDA::nvml CUDA::cuda_driver)
+ if(NOT WIN32)
+     target_link_libraries(nvbandwidth dl)
+ endif()


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/NVIDIA/nvbandwidth/compare/v0.9...v0.10.0
Changelog: https://github.com/NVIDIA/nvbandwidth/blob/v0.10.0/CHANGELOG.md

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test