### PR TITLE
nixos/account-utils: support config file

### DIFF
--- a/nixos/modules/security/account-utils.nix
+++ b/nixos/modules/security/account-utils.nix
@@ -6,6 +6,7 @@
 }:
 let
   cfg = config.security.account-utils;
+  format = pkgs.formats.ini { };
 in
 {
   options.security.account-utils = {
@@ -24,6 +25,16 @@ in
         This is passed to both pwupdd and pwaccessd, which support identical flags.
         :::
       '';
+    };
+    pwaccessd.settings = lib.mkOption {
+      description = ''
+        Options for pwaccessd.
+        See {manpage}`pwaccessd.conf(5)` for available options.
+      '';
+      type = lib.types.submodule {
+        freeformType = format.type;
+      };
+      default = { };
     };
   };
 
@@ -44,6 +55,8 @@ in
     };
 
     environment.systemPackages = [ cfg.package ];
+    environment.etc."account-utils/pwaccessd.conf".source =
+      format.generate "pwaccessd.conf" cfg.pwaccessd.settings;
 
     security.pam.services = {
       pwupd-passwd = { };

--- a/nixos/tests/login-nosuid.nix
+++ b/nixos/tests/login-nosuid.nix
@@ -11,7 +11,12 @@
     {
       security.enableWrappers = false;
       systemd.settings.Manager.NoNewPrivileges = true;
-      security.account-utils.enable = true;
+      security.account-utils = {
+        enable = true;
+        pwaccessd.settings = {
+          ExpiredCheck.SpMin = true;
+        };
+      };
       users.mutableUsers = true;
       security.account-utils.extraArgs = [
         "-v"
@@ -45,6 +50,9 @@
         passwd_path = machine.succeed("realpath $(which passwd)")
         print(f"passwd path is: {passwd_path}")
         assert "account-utils" in passwd_path
+
+    with subtest("config file exists"):
+        machine.succeed("ls /etc/account-utils/pwaccessd.conf")
 
     with subtest("create user"):
         machine.succeed("useradd -m alice")


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
