### PR TITLE
practrand: init at 0.96

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7884,6 +7884,12 @@
     github = "edlimerkaj";
     githubId = 71988351;
   };
+  edoars = {
+    name = "Edoardo Signorini";
+    email = "mail@edoars.me";
+    github = "edoars";
+    githubId = 44139791;
+  };
   edrex = {
     email = "ericdrex@gmail.com";
     github = "edrex";

--- a/pkgs/by-name/pr/practrand/package.nix
+++ b/pkgs/by-name/pr/practrand/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  unzip,
+  nix-update-script,
+  programPrefix ? "PractRand-",
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "practrand";
+  version = "0.96";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchurl {
+    url = "mirror://sourceforge/pracrand/PractRand_${finalAttrs.version}.zip";
+    hash = "sha256-5Mr3/amLLFl7vaO1dnU89aD2BHqrg3yCvjcKt5imcuE=";
+  };
+
+  nativeBuildInputs = [ unzip ];
+
+  env.NIX_CFLAGS_COMPILE = "-O3";
+
+  buildPhase = ''
+    runHook preBuild
+
+    $CXX -Iinclude -pthread -c src/*.cpp src/RNGs/*.cpp src/RNGs/other/*.cpp
+    $AR rcs libPractRand.a ./*.o
+
+    for tool in RNG_test RNG_benchmark RNG_output; do
+      $CXX -Iinclude -Itools -pthread -o "$tool" "tools/$tool.cpp" libPractRand.a
+    done
+
+    runHook postBuild
+  '';
+
+  doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+
+    ./RNG_test --self_test
+
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    for tool in RNG_test RNG_benchmark RNG_output; do
+      install -Dm755 "$tool" "$out/bin/${programPrefix}$tool"
+    done
+    install -Dm644 libPractRand.a -t "$dev/lib"
+    mkdir -p "$dev/include" "$out/share/doc/practrand"
+    cp -r include/. "$dev/include/"
+    cp -r doc/. "$out/share/doc/practrand/"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Suite of statistical tests and pseudo-random number generators";
+    homepage = "https://sourceforge.net/projects/pracrand/";
+    license = lib.licenses.cc0;
+    maintainers = with lib.maintainers; [ edoars ];
+    platforms = lib.intersectLists lib.platforms.unix lib.platforms.x86;
+  };
+})


### PR DESCRIPTION
Add PractRand 0.96, a C++ suite of statistical tests and pseudo-random number generators.

The package installs the `RNG_test`, `RNG_benchmark`, and `RNG_output` tools, together with the static library, headers, and documentation. The build also runs PractRand's upstream self-test.

Upstream homepage: https://sourceforge.net/projects/pracrand/

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
