### PR TITLE
textext: fix GUI library (GTK3) detection

### DIFF
--- a/pkgs/applications/graphics/inkscape/extensions/textext/default.nix
+++ b/pkgs/applications/graphics/inkscape/extensions/textext/default.nix
@@ -109,6 +109,20 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
     # Include gobject-introspection typelibs in the wrapper.
     makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+
+    # TexText probes for a GUI toolkit by spawning a subprocess
+    # (`sys.executable -c "import gi; gi.require_version('Gtk', '3.0'); ..."`)
+    # instead of importing in-process. The Python wrapper makes runtime
+    # dependencies importable via a site.addsitedir preamble and deliberately
+    # does not export PYTHONPATH, so the spawned probe interpreter cannot import
+    # gi and TexText aborts with "Neither GTK nor TkInter has been found".
+    # Export PYTHONPATH so the probe subprocess inherits the dependencies too.
+    # See https://github.com/NixOS/nixpkgs/issues/384042
+    makeWrapperArgs+=(--prefix PYTHONPATH : "${
+      lib.makeSearchPath python3.sitePackages (
+        finalAttrs.propagatedBuildInputs ++ [ python3.pkgs.pycairo ]
+      )
+    }")
   '';
 
   postFixup = ''


### PR DESCRIPTION
Fixes TexText failing to launch inside Inkscape with "Neither GTK nor TkInter
has been found", even though GTK3 and its GObject-introspection bindings are
present.

TexText's requirements checker probes for a GUI toolkit by spawning a *subprocess* (roughly `import gi; gi.require_version('Gtk', '3.0'); from gi.repository import Gtk`) rather than importing in-process. The nixpkgs Python wrapper makes runtime dependencies importable via a `site.addsitedir` preamble and deliberately does not export `PYTHONPATH`, so the freshly spawned probe interpreter starts bare, cannot import `gi`, and the check fails. The real GUI imports `gi` in-process, so only this gatekeeping probe was broken.

This exports `PYTHONPATH` on the wrapper so the probe subprocess inherits the runtime dependencies too. The search path is derived from the package's own `propagatedBuildInputs` (plus `pycairo`) to avoid duplicating the dependency list.

(cc @raboof)

Resolves #384042

### Testing

- Built `textext` 1.13.0 from source on x86_64-linux.
- Reproduced the bug and verified the fix by running TexText's exact GTK
  detection probe against the built wrapper:
  - **before:** `ModuleNotFoundError: No module named 'gi'` (the reported failure)
  - **after:** imports succeed
- `nixpkgs-review`: 1 package built (`inkscape-extensions.textext`), 0 failed; no reverse dependencies are affected (textext is consumed only via `inkscape-with-extensions.override`).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test