### PR TITLE
adl: various

### DIFF
--- a/pkgs/by-name/ad/adl/package.nix
+++ b/pkgs/by-name/ad/adl/package.nix
@@ -3,13 +3,18 @@
   stdenvNoCC,
   fetchFromGitHub,
   makeWrapper,
+  versionCheckHook,
   animdl,
+  bashNonInteractive,
+  coreutils,
   frece,
   fzf,
+  getopt,
+  gnused,
   mpv,
   perl,
   trackma,
-  ueberzug,
+  ueberzugpp,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "adl";
@@ -26,23 +31,37 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   # https://github.com/RaitaroH/adl#requirements
   buildInputs = [
-    animdl
-    frece
-    fzf
-    mpv
-    perl
-    trackma
-    ueberzug
+    bashNonInteractive
   ];
 
   dontBuild = true;
 
   installPhase = ''
+    runHook postInstall
+
     mkdir -p $out/bin
     cp $src/adl $out/bin
     wrapProgram $out/bin/adl \
-      --prefix PATH : ${lib.makeBinPath finalAttrs.buildInputs}
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          animdl
+          frece
+          fzf
+          getopt
+          gnused
+          mpv
+          perl
+          trackma
+          ueberzugpp
+        ]
+      }
+
+    runHook preInstall
   '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   meta = {
     homepage = "https://github.com/RaitaroH/adl";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
I took a look inside this package because of #287962, and noticed a few other things while I was here.

Changes:
<details>
<summary>
switch ueberzug->ueberzugpp
</summary>

>Done as part of #287962 
</details>

<details>
<summary>
add `runHooks` {pre,post}Install
</summary>

>Just for good measure
</details>

<details>
<summary>
move old `buildInputs` to `makeWrapper` call
</summary>

>Self-explanatory
</details>

<details>
<summary>
add `pkgs.coreutils`, `pkgs.getopt`, and `pkgs.gnused` to `makeWrapper` PATH prefix
</summary>

> `pkgs.coreutils` because the bash script calls `mktemp --dry-run`, which is a GNU-specific option, so if your `$PATH` contains a different version, it will fail.  The other two are called by the main script (and are easy to miss because they're on just about everyone's `$PATH` already). 
</details>

<details>
<summary>
add `pkgs.bashNonInteractive` as buildInput (for `patchShebangs`)
</summary>

>The main script calls `/usr/bin/env bash`, but `patchShebangs` will catch this as long as `pkgs.bash` (in this case `pkgs.bashNonInteractive`) is a `buildInput`.
</details>

<details>
<summary>
enable `installCheck`
</summary>

>To make sure the resulting script at least runs.
</details>

<details>
<summary>
add `versionCheckHook` as a `nativeInstallChecklInputs`
</summary>

>To make `installCheck` do something.
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
