### PR TITLE
flatten-references-graph: add reorder DSL primitive for explicit flatten order

### DIFF
--- a/pkgs/by-name/fl/flatten-references-graph/src/flatten_references_graph/lib.py
+++ b/pkgs/by-name/fl/flatten-references-graph/src/flatten_references_graph/lib.py
@@ -327,3 +327,25 @@ def remove_paths(paths, graph):
 @curry
 def reverse(iterator):
     return reversed(list(iterator))
+
+
+@curry
+def reorder(keys, graph):
+    """Reorder the keys of a dict of graphs, controlling the traversal order
+    when followed by flatten(). Keys absent from the graph are ignored;
+    keys present in the graph but not in `keys` are appended at the end in
+    their original insertion order.
+
+    Example: after subcomponent_out the result is {"main": ..., "rest": ...}
+    and flatten() yields main before rest. Use reorder(["rest", "main"]) to
+    put rest-layers first without the double-reverse workaround.
+
+    Also works for split_paths which returns {"main", "common", "rest"}:
+    reorder(["rest", "common", "main"]) puts shared deps (common) before the
+    split-off paths (main).
+    """
+    if not isinstance(graph, dict):
+        return graph
+    ordered = {k: graph[k] for k in keys if k in graph}
+    remainder = {k: v for k, v in graph.items() if k not in ordered}
+    return {**ordered, **remainder}

--- a/pkgs/by-name/fl/flatten-references-graph/src/flatten_references_graph/lib_test.py
+++ b/pkgs/by-name/fl/flatten-references-graph/src/flatten_references_graph/lib_test.py
@@ -10,7 +10,8 @@ from .lib import (
     limit_layers,
     pick_keys,
     references_graph_to_igraph,
-    reference_graph_node_keys_to_keep
+    reference_graph_node_keys_to_keep,
+    reorder
 )
 
 if __name__ == "__main__":
@@ -197,3 +198,45 @@ class TestLib(unittest.TestCase, th.CustomAssertions):
         )
 
         self.assertGraphEqual(graph, result_list[0])
+
+
+class TestReorder(unittest.TestCase):
+
+    def test_reorder_two_keys_swaps_main_and_rest(self):
+        g1 = directed_graph([], ["A"])
+        g2 = directed_graph([], ["B"])
+        d = {"main": g1, "rest": g2}
+        result = reorder(["rest", "main"], d)
+        self.assertEqual(list(result.keys()), ["rest", "main"])
+        self.assertIs(result["rest"], g2)
+        self.assertIs(result["main"], g1)
+
+    def test_reorder_three_keys_split_paths_order(self):
+        g_main   = directed_graph([], ["A"])
+        g_common = directed_graph([], ["B"])
+        g_rest   = directed_graph([], ["C"])
+        d = {"main": g_main, "common": g_common, "rest": g_rest}
+        result = reorder(["rest", "common", "main"], d)
+        self.assertEqual(list(result.keys()), ["rest", "common", "main"])
+
+    def test_reorder_missing_keys_are_ignored(self):
+        g1 = directed_graph([], ["A"])
+        g2 = directed_graph([], ["B"])
+        d = {"main": g1, "rest": g2}
+        # "common" is not in dict — should be silently skipped
+        result = reorder(["rest", "common", "main"], d)
+        self.assertEqual(list(result.keys()), ["rest", "main"])
+
+    def test_reorder_extra_keys_appended_in_original_order(self):
+        g1 = directed_graph([], ["A"])
+        g2 = directed_graph([], ["B"])
+        g3 = directed_graph([], ["C"])
+        g4 = directed_graph([], ["D"])
+        d = {"main": g1, "rest": g2, "extra1": g3, "extra2": g4}
+        result = reorder(["rest", "main"], d)
+        self.assertEqual(list(result.keys()), ["rest", "main", "extra1", "extra2"])
+
+    def test_reorder_non_dict_passthrough(self):
+        graphs = [directed_graph([], ["A"]), directed_graph([], ["B"])]
+        result = reorder(["rest", "main"], graphs)
+        self.assertIs(result, graphs)

--- a/pkgs/by-name/fl/flatten-references-graph/src/flatten_references_graph/pipe.py
+++ b/pkgs/by-name/fl/flatten-references-graph/src/flatten_references_graph/pipe.py
@@ -20,7 +20,8 @@ funcs = tlz.merge(
             "split_every",
             "limit_layers",
             "remove_paths",
-            "reverse"
+            "reverse",
+            "reorder"
         ],
         lib
     ),

--- a/pkgs/by-name/fl/flatten-references-graph/src/flatten_references_graph/pipe_test.py
+++ b/pkgs/by-name/fl/flatten-references-graph/src/flatten_references_graph/pipe_test.py
@@ -151,3 +151,62 @@ class Test(
                 ([], ["A", "B"])
             ]
         )
+
+    def test_reorder_rest_before_main(self):
+        # Verify that ["reorder" ["rest" "main"]] puts the rest-graph layers
+        # before the main (split-off) layers, equivalent to the double-reverse
+        # workaround but expressed directly.
+        #
+        # Graph: Root -> A -> B -> D
+        #                  -> C
+        # Split off B and its deps; rest should come first.
+        graph = directed_graph(
+            [
+                ("Root", "A"),
+                ("A", "B"),
+                ("A", "C"),
+                ("B", "D"),
+            ]
+        )
+
+        # Without reorder: main (B+D) comes before rest (Root, A, C)
+        result_without = list(pipe(
+            [
+                ["subcomponent_out", ["B"]],
+                ["flatten"],
+            ],
+            graph
+        ))
+        # main graph contains B and D
+        main_names = set(result_without[0].vs["name"])
+        self.assertIn("B", main_names)
+
+        # With reorder: rest (Root, A, C) comes before main (B+D)
+        result_with = list(pipe(
+            [
+                ["subcomponent_out", ["B"]],
+                ["reorder", ["rest", "main"]],
+                ["flatten"],
+            ],
+            graph
+        ))
+        rest_names = set(result_with[0].vs["name"])
+        self.assertIn("A", rest_names)
+        self.assertNotIn("B", rest_names)
+
+    def test_reorder_three_keys_split_paths(self):
+        # split_paths returns {"main", "common", "rest"} — verify reorder
+        # can express "rest, common, main" ordering for stable shared layers first.
+        graph = make_test_graph()
+        result = list(pipe(
+            [
+                ["split_paths", ["B"]],
+                ["reorder", ["rest", "common", "main"]],
+                ["flatten"],
+                ["limit_layers", 3],
+            ],
+            graph
+        ))
+        # rest should be first: contains Root1, A, C (no B or its exclusive deps)
+        first_names = set(result[0].vs["name"])
+        self.assertNotIn("B", first_names)


### PR DESCRIPTION
### Problem

The subcomponent_out, subcomponent_in, and split_paths operations return a dict with a fixed key insertion order (`{"main": ..., "rest": ...}` or `{"main": ..., "common": ..., "rest": ...}`). Since flatten() iterates dict values in insertion order, main always comes out first - meaning the split-off paths always land in earlier layers than the remainder. This was also mentioned within https://github.com/NixOS/nixpkgs/pull/122608.

For use cases where the remainder (rest) should come first - e.g. placing stable shared dependencies in early layers and the split-off large derivations in later layers - there is currently no direct way to express this in the pipeline DSL. The only workaround is a pair of pre-inversions on each branch followed by an outer reversal:

### Current workaround to get rest-before-main:
```
  ["subcomponent_out", packages]
  ["over", "main", ["pipe", (last ++ [["flatten"]["reverse"]])]]
  ["over", "rest",  ["pipe", (next ++ [["flatten"]["reverse"]])]]
  ["flatten"]
  ["reverse"]
```

This pattern requires four load-bearing reverse operations whose purpose is non-obvious without a detailed comment. The same problem applies to split_paths which returns three keys (main, common, rest) - there is no way to express rest → common → main ordering without the same double-reverse gymnastics, extended further.

### Solution

Add a reorder function to lib.py and register it as a DSL primitive in pipe.py. It reorders the keys of a dict-of-graphs before flatten() is applied, directly controlling which branch's layers appear first:
```
  ["subcomponent_out", packages]
  ["reorder", ["rest", "main"]]
  ["over", "main", ["pipe", last]]
  ["over", "rest",  ["pipe", next]]
  ["flatten"]
```

Keys absent from the graph are silently ignored; keys present but not listed are appended in their original order, so reorder is safe to use with both two-key (subcomponent_*) and three-key (split_paths)  results.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
