### PR TITLE
ripgrep: fix cross build Linux to FreeBSD

### DIFF
--- a/pkgs/by-name/ri/ripgrep/package.nix
+++ b/pkgs/by-name/ri/ripgrep/package.nix
@@ -50,15 +50,17 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   doInstallCheck = true;
-  installCheckPhase = ''
-    file="$(mktemp)"
-    echo "abc\nbcd\ncde" > "$file"
-    ${rg} -N 'bcd' "$file"
-    ${rg} -N 'cd' "$file"
-  ''
-  + lib.optionalString withPCRE2 ''
-    echo '(a(aa)aa)' | ${rg} -P '\((a*|(?R))*\)'
-  '';
+  installCheckPhase = lib.optionalString canRunRg (
+    ''
+      file="$(mktemp)"
+      echo "abc\nbcd\ncde" > "$file"
+      ${rg} -N 'bcd' "$file"
+      ${rg} -N 'cd' "$file"
+    ''
+    + lib.optionalString withPCRE2 ''
+      echo '(a(aa)aa)' | ${rg} -P '\((a*|(?R))*\)'
+    ''
+  );
 
   meta = {
     description = "Utility that combines the usability of The Silver Searcher with the raw speed of grep";


### PR DESCRIPTION
ripgrep was evaluating the emulator for a cross-test, even without `canRunRg`. This failed when there is no emulator.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Stop the package from evaluating the emulator when there is none available.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
