### PR TITLE
brltty: add polkit support

### DIFF
--- a/pkgs/by-name/br/brltty/package.nix
+++ b/pkgs/by-name/br/brltty/package.nix
@@ -7,6 +7,8 @@
   bluez,
   tcl,
   acl,
+  polkitSupport ? lib.meta.availableOn stdenv.hostPlatform polkit,
+  polkit,
   kmod,
   coreutils,
   shadow,
@@ -42,6 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     tcl # For TCL bindings
   ]
   ++ lib.optional alsaSupport alsa-lib
+  ++ lib.optional polkitSupport polkit
   ++ lib.optional systemdSupport systemdMinimal;
 
   doInstallCheck = true;
@@ -76,6 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-writable-directory=/run/brltty"
     "--with-updatable-directory=/var/lib/brltty"
     "--with-api-socket-path=/var/lib/BrlAPI"
+    (lib.enableFeature polkitSupport "polkit")
   ];
   installFlags = [
     "install-systemd"


### PR DESCRIPTION
BRLTTY enables Polkit support by default (`--enable-polkit`), but detects it solely via `pkg-config --exists polkit-gobject-1`. Since `polkit` was not in `buildInputs`, detection silently failed and BRLTTY was built without Polkit support — while still installing its Polkit policy (`org.a11y.brlapi.policy`).

The user-visible effect is that BrlAPI clients such as Orca cannot authorize against BRLTTY, so a braille display is unusable from the desktop. Fixes #540757.

Polkit is Linux-only, so this follows the existing `alsaSupport`/`systemdSupport` pattern and gates on `lib.meta.availableOn`. The configure flag is now passed explicitly rather than relying on pkg-config detection, so the feature can no longer be dropped silently if the dependency goes missing again.

Before:

```
$ ldd result/bin/brltty | grep -c polkit
0
```

After:

```
   polkit: yes                                   # configure summary

$ ldd result/bin/brltty | grep polkit
	libpolkit-gobject-1.so.0 => /nix/store/...-polkit-127/lib/libpolkit-gobject-1.so.0
```

Platform gating verified by eval:

```
x86_64-linux    polkit in buildInputs: true
aarch64-darwin  polkit in buildInputs: false
```

Tested with a real braille display (HumanWare Brailliant BI 40X) and Orca on NixOS: with the equivalent change applied as an overlay, Orca drives the display over BrlAPI; without it, it cannot.

### Branch target

This targets `staging-nixos` rather than `master` because CI assigns the `10.rebuild-nixos-tests` label, per [Changes rebuilding all NixOS tests](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-rebuilding-all-nixos-tests). The cause is that `qemu` takes `brltty` as a build input for BrlAPI (`--enable-brlapi`), so any change to brltty rebuilds qemu and therefore every NixOS test. The package rebuild count itself is small (`10.rebuild-linux: 11-100`).

Rebased onto the merge base of `master` and `staging-nixos` as described in CONTRIBUTING, so the branch contains only this commit.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

`nixpkgs-review` was attempted locally but not completed: the reverse-dependency set is the qemu-driven NixOS test scaffolding described above (551 derivations), and the run exhausted memory during evaluation on a 16 GB machine (14.9 GB peak). Since that set rebuilds identically for any brltty change — including a plain version bump — and exercises nothing specific to this patch, it is left to CI. `brltty` itself builds and was verified as shown above.

Disclosure per the automation/AI policy: this change and this pull request summary were prepared with Claude Code (Claude Opus 4.8, `claude-opus-4-8`). The commit carries the required `Assisted-by:` trailer. I have reviewed the diff and verified the behaviour, including against real hardware.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
