### PR TITLE
rPackages.opencv: drop opencv override

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -1432,6 +1432,7 @@ let
     nloptr = [ pkgs.nlopt ];
     odbc = [ pkgs.unixodbc ];
     oligo = [ pkgs.zlib ];
+    opencv = [ pkgs.opencv ];
     otelsdk = with pkgs; [
       curl
       protobuf
@@ -2544,16 +2545,6 @@ let
     oligo = old.oligo.overrideAttrs (_: {
       hardeningDisable = [ "format" ];
     });
-
-    opencv =
-      let
-        opencvGtk = pkgs.opencv.override (old: {
-          enableGtk2 = true;
-        });
-      in
-      old.opencv.overrideAttrs (attrs: {
-        buildInputs = attrs.buildInputs ++ [ opencvGtk ];
-      });
 
     openssl = old.openssl.overrideAttrs (attrs: {
       env = (attrs.env or { }) // {


### PR DESCRIPTION
Targeting https://github.com/NixOS/nixpkgs/pull/539315

*SURELY* the package no longer needs opencv to be built with GTK2.
I have no idea why it was added, and I haven't tested it beyond running `opencv::ocv_version()`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
