### PR TITLE
nixos/misskey: map vhost via lib.mkDefault

### DIFF
--- a/nixos/modules/services/web-apps/misskey.nix
+++ b/nixos/modules/services/web-apps/misskey.nix
@@ -388,9 +388,9 @@ in
     services.caddy = lib.mkIf (cfg.reverseProxy.enable && cfg.reverseProxy.webserver ? caddy) {
       enable = true;
       virtualHosts.${cfg.settings.url} = lib.mkMerge [
-        cfg.reverseProxy.webserver.caddy
+        (lib.mapAttrsRecursive (_: lib.mkDefault) cfg.reverseProxy.webserver.caddy)
         {
-          hostName = lib.mkDefault cfg.settings.url;
+          hostName = lib.mkForce cfg.settings.url;
           extraConfig = ''
             reverse_proxy localhost:${toString cfg.settings.port}
           '';
@@ -401,15 +401,15 @@ in
     services.nginx = lib.mkIf (cfg.reverseProxy.enable && cfg.reverseProxy.webserver ? nginx) {
       enable = true;
       virtualHosts.${cfg.reverseProxy.host} = lib.mkMerge [
-        cfg.reverseProxy.webserver.nginx
+        (lib.mapAttrsRecursive (_: lib.mkDefault) cfg.reverseProxy.webserver.nginx)
         {
           locations."/" = {
-            proxyPass = lib.mkDefault "http://localhost:${toString cfg.settings.port}";
-            proxyWebsockets = lib.mkDefault true;
-            recommendedProxySettings = lib.mkDefault true;
+            proxyPass = "http://localhost:${toString cfg.settings.port}";
+            proxyWebsockets = true;
+            recommendedProxySettings = true;
           };
         }
-        (lib.mkIf (cfg.reverseProxy.ssl != null) { forceSSL = lib.mkDefault cfg.reverseProxy.ssl; })
+        (lib.mkIf (cfg.reverseProxy.ssl != null) { forceSSL = cfg.reverseProxy.ssl; })
       ];
     };
   };


### PR DESCRIPTION
the code itself has very redundant definitions. I applied this fix as well in #543983

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
