### PR TITLE
nixos/fedimintd: map vhost via lib.mkDefault

### DIFF
--- a/nixos/modules/services/networking/fedimintd.nix
+++ b/nixos/modules/services/networking/fedimintd.nix
@@ -13,7 +13,6 @@ let
     mkEnableOption
     mkIf
     mkOption
-    mkOverride
     mkPackageOption
     nameValuePair
     recursiveUpdate
@@ -351,13 +350,11 @@ in
         fedimintdName: cfg:
         (nameValuePair cfg.nginx.fqdn (
           lib.mkMerge [
-            cfg.nginx.config
+            (lib.mapAttrsRecursive (_: lib.mkDefault) cfg.nginx.config)
 
             {
-              # Note: we want by default to enable OpenSSL, but it seems anything 100 and above is
-              # overridden by default value from vhost-options.nix
-              enableACME = mkOverride 99 true;
-              forceSSL = mkOverride 99 true;
+              enableACME = true;
+              forceSSL = true;
               locations.${cfg.nginx.path_ws} = {
                 proxyPass = "http://127.0.0.1:${toString cfg.api_ws.port}/";
                 proxyWebsockets = true;


### PR DESCRIPTION
I have the feeling you tried to fix the same thing I did in #543983

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
