### PR TITLE
brltty: initrd support; optional bluetooth/python/tcl

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -110,6 +110,8 @@
 - `temporal` has been updated to the 1.31 release line. Always consult the [upstream upgrade
   notes](https://docs.temporal.io/self-hosted-guide/upgrade-server) before upgrading between versions.
 
+- [services.brltty.initrd](#opt-services.brltty.initrd.enable) has been added, which runs BRLTTY inside the initrd so that a braille display is usable during early boot and in the initrd emergency shell. It is enabled by default whenever [services.brltty](#opt-services.brltty.enable) and systemd-in-initrd are both enabled.
+
 - The `shell_interact()` function on interactive runs of NixOS VM tests has been deprecated. Use the SSH backdoor instead.
 
 - [services.netbox](#opt-services.netbox.enable) has received a number of updates:

--- a/nixos/modules/services/hardware/brltty.nix
+++ b/nixos/modules/services/hardware/brltty.nix
@@ -33,32 +33,197 @@ in
       description = "Whether to enable the BRLTTY daemon.";
     };
 
+    services.brltty.initrd = {
+
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = cfg.enable && config.boot.initrd.systemd.enable;
+        defaultText = lib.literalExpression "config.services.brltty.enable && config.boot.initrd.systemd.enable";
+        description = ''
+          Whether to run BRLTTY in the initrd, so that a braille display is
+          usable during early boot and in the initrd emergency shell.
+
+          Defaults to enabled whenever BRLTTY and systemd-in-initrd
+          ([](#opt-boot.initrd.systemd.enable), on by default) are both enabled,
+          since a braille user almost always wants access as early as possible.
+          Setting it explicitly requires systemd in the initrd.
+        '';
+      };
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.brltty.override {
+          alsaSupport = false;
+          bluetoothSupport = false;
+          polkitSupport = false;
+          pythonSupport = false;
+          systemdSupport = false;
+          tclSupport = false;
+        };
+        defaultText = lib.literalExpression ''
+          pkgs.brltty.override {
+            alsaSupport = false;
+            bluetoothSupport = false;
+            polkitSupport = false;
+            pythonSupport = false;
+            systemdSupport = false;
+            tclSupport = false;
+          }
+        '';
+        description = ''
+          The BRLTTY package to use in the initrd.
+
+          The default disables everything that is not needed to drive a display
+          there. Only `bin/brltty`, the drivers and the tables are copied into
+          the initrd, and with these options those reference nothing but glibc,
+          so the initrd grows by a few megabytes rather than by BRLTTY's full
+          closure.
+
+          Note that Bluetooth is disabled: supporting it in the initrd would
+          require copying the link keys of all paired devices into the image.
+        '';
+      };
+
+      kernelModules = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [
+          "hid_generic"
+          "uinput"
+          "usbhid"
+        ];
+        example = [
+          "ftdi_sio"
+          "cp210x"
+        ];
+        description = ''
+          Kernel modules to load in the initrd.
+
+          `uinput` is what BRLTTY uses to inject keystrokes, so it is required
+          for typing on the braille display's own keyboard. `usbhid` and
+          `hid_generic` bind USB HID displays, which are what most current
+          displays are.
+
+          These cannot be left to [](#opt-boot.initrd.availableKernelModules):
+          `nixos-generate-config` only adds a USB device's driver there if it is
+          mass storage or a HID *boot keyboard*, and a braille display is
+          neither, so its module is generally not detected at install time.
+
+          A **USB-serial display** (still common) instead needs its USB-serial
+          converter's driver, and it must be added here explicitly — the same
+          detection gap applies. Which driver depends on the converter, e.g.
+          `ftdi_sio`, `cp210x`, `ch341` or `pl2303`; `lsusb`/`dmesg` with the
+          display plugged in on a running system will show which one binds. Old
+          real RS-232 (`/dev/ttyS*`) displays need no extra module.
+
+          `pcspkr` is not included by default because it only provides BRLTTY's
+          alert tones and many machines have no PC speaker; add it here if you
+          want them.
+        '';
+      };
+
+    };
+
   };
 
-  config = lib.mkIf cfg.enable {
-    users.users.brltty = {
-      description = "BRLTTY daemon user";
-      group = "brltty";
-      isSystemUser = true;
-    };
-    users.groups = {
-      brltty = { };
-      brlapi = { };
-    };
+  config = lib.mkMerge [
 
-    systemd.services."brltty@".serviceConfig = {
-      ExecStartPre = "!${genApiKey}";
-    };
+    (lib.mkIf cfg.enable {
+      users.users.brltty = {
+        description = "BRLTTY daemon user";
+        group = "brltty";
+        isSystemUser = true;
+      };
+      users.groups = {
+        brltty = { };
+        brlapi = { };
+      };
 
-    # Install all upstream-provided files
-    systemd.packages = [ pkgs.brltty ];
-    systemd.tmpfiles.packages = [ pkgs.brltty ];
-    services.udev.packages = [ pkgs.brltty ];
-    environment.systemPackages = [ pkgs.brltty ];
+      systemd.services."brltty@".serviceConfig = {
+        ExecStartPre = "!${genApiKey}";
+      };
 
-    # Add missing WantedBys (see issue #81138)
-    systemd.paths.brltty.wantedBy = targets;
-    systemd.paths."brltty@".wantedBy = targets;
-  };
+      # Install all upstream-provided files
+      systemd.packages = [ pkgs.brltty ];
+      systemd.tmpfiles.packages = [ pkgs.brltty ];
+      services.udev.packages = [ pkgs.brltty ];
+      environment.systemPackages = [ pkgs.brltty ];
+
+      # Add missing WantedBys (see issue #81138)
+      systemd.paths.brltty.wantedBy = targets;
+      systemd.paths."brltty@".wantedBy = targets;
+    })
+
+    (lib.mkIf cfg.initrd.enable {
+      assertions = [
+        {
+          assertion = config.boot.initrd.systemd.enable;
+          message = ''
+            services.brltty.initrd.enable requires boot.initrd.systemd.enable.
+          '';
+        }
+      ];
+
+      boot.initrd.kernelModules = cfg.initrd.kernelModules;
+
+      boot.initrd.systemd.storePaths = [
+        "${cfg.initrd.package}/bin/brltty"
+        "${cfg.initrd.package}/lib/brltty"
+        "${cfg.initrd.package}/etc/brltty"
+      ];
+
+      # /dev/bus/usb is not populated this early, so BRLTTY falls back to
+      # mounting its own usbfs and needs somewhere it is allowed to create
+      # device nodes. /run is mounted nodev, but a submount need not be.
+      boot.initrd.systemd.mounts = [
+        {
+          what = "tmpfs";
+          where = "/run/brltty";
+          type = "tmpfs";
+          options = "dev,mode=755";
+          unitConfig.DefaultDependencies = false;
+        }
+      ];
+
+      boot.initrd.systemd.services.brltty = {
+        description = "Braille Device Support (initrd)";
+        # Also emergency and rescue: initrd.target is never reached when
+        # booting into those, which are precisely the situations where a
+        # braille display is needed most.
+        wantedBy = [
+          "initrd.target"
+          "emergency.target"
+          "rescue.target"
+        ];
+        after = [
+          "systemd-udevd.service"
+          "run-brltty.mount"
+        ];
+        requires = [ "run-brltty.mount" ];
+        unitConfig.DefaultDependencies = false;
+        environment = {
+          # The Linux console screen driver; nothing else is usable here.
+          BRLTTY_SCREEN_DRIVER = "lx";
+          # Speech drivers behave poorly in an initrd, and this build has no
+          # sound support anyway.
+          BRLTTY_SPEECH_DRIVER = "no";
+          # Allow typing on the display's own keyboard, so the initrd
+          # emergency shell can actually be used.
+          BRLTTY_OVERRIDE_PREFERENCE = "braille-keyboard-enabled=yes,braille-input-mode=text";
+          BRLTTY_WRITABLE_DIRECTORY = "/run/brltty";
+          BRLTTY_PID_FILE = "/run/brltty/brltty.pid";
+        };
+        serviceConfig = {
+          Type = "simple";
+          # -E: honour the environment above. -n: stay in the foreground.
+          ExecStart = "${cfg.initrd.package}/bin/brltty -E -n";
+          # Release the display before switch-root so that the BRLTTY instance
+          # of the booted system can claim it.
+          ExecStop = "${cfg.initrd.package}/bin/brltty -E -C";
+          Restart = "no";
+        };
+      };
+    })
+
+  ];
 
 }

--- a/pkgs/by-name/br/brltty/package.nix
+++ b/pkgs/by-name/br/brltty/package.nix
@@ -7,6 +7,8 @@
   bluez,
   tcl,
   acl,
+  polkitSupport ? lib.meta.availableOn stdenv.hostPlatform polkit,
+  polkit,
   kmod,
   coreutils,
   shadow,
@@ -42,6 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     tcl # For TCL bindings
   ]
   ++ lib.optional alsaSupport alsa-lib
+  ++ lib.optional polkitSupport polkit
   ++ lib.optional systemdSupport systemdMinimal;
 
   doInstallCheck = true;
@@ -76,6 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-writable-directory=/run/brltty"
     "--with-updatable-directory=/var/lib/brltty"
     "--with-api-socket-path=/var/lib/BrlAPI"
+    (lib.enableFeature polkitSupport "polkit")
   ];
   installFlags = [
     "install-systemd"

--- a/pkgs/by-name/br/brltty/package.nix
+++ b/pkgs/by-name/br/brltty/package.nix
@@ -3,8 +3,11 @@
   stdenv,
   fetchurl,
   pkg-config,
+  pythonSupport ? true,
   python3,
+  bluetoothSupport ? stdenv.hostPlatform.isLinux,
   bluez,
+  tclSupport ? true,
   tcl,
   acl,
   polkitSupport ? lib.meta.availableOn stdenv.hostPlatform polkit,
@@ -33,19 +36,21 @@ stdenv.mkDerivation (finalAttrs: {
 
   depsBuildBuild = [ pkg-config ];
   nativeBuildInputs = [
+    tcl # One of the build scripts requires tclsh, regardless of tclSupport
+    udevCheckHook
+  ]
+  ++ lib.optionals pythonSupport [
     python3.pkgs.cython
     python3.pkgs.setuptools
-    tcl # One of build scripts require tclsh
-    udevCheckHook
   ];
   buildInputs = [
-    bluez
     ncurses.dev
-    tcl # For TCL bindings
   ]
   ++ lib.optional alsaSupport alsa-lib
+  ++ lib.optional bluetoothSupport bluez
   ++ lib.optional polkitSupport polkit
-  ++ lib.optional systemdSupport systemdMinimal;
+  ++ lib.optional systemdSupport systemdMinimal
+  ++ lib.optional tclSupport tcl; # For TCL bindings
 
   doInstallCheck = true;
 
@@ -64,7 +69,6 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   makeFlags = [
-    "PYTHON_PREFIX=$(out)"
     "SYSTEMD_UNITS_DIRECTORY=$(out)/lib/systemd/system"
     "SYSTEMD_USERS_DIRECTORY=$(out)/lib/sysusers.d"
     "SYSTEMD_FILES_DIRECTORY=$(out)/lib/tmpfiles.d"
@@ -73,14 +77,30 @@ stdenv.mkDerivation (finalAttrs: {
     "UDEV_RULES_TYPE=all"
     "POLKIT_POLICY_DIR=$(out)/share/polkit-1/actions"
     "POLKIT_RULE_DIR=$(out)/share/polkit-1/rules.d"
-    "TCL_DIR=$(out)/lib"
-  ];
+  ]
+  ++ lib.optional pythonSupport "PYTHON_PREFIX=$(out)"
+  ++ lib.optional tclSupport "TCL_DIR=$(out)/lib";
   configureFlags = [
     "--with-writable-directory=/run/brltty"
     "--with-updatable-directory=/var/lib/brltty"
     "--with-api-socket-path=/var/lib/BrlAPI"
     (lib.enableFeature polkitSupport "polkit")
+    (lib.enableFeature pythonSupport "python-bindings")
+    (lib.enableFeature tclSupport "tcl-bindings")
+    (lib.withFeature bluetoothSupport "bluetooth-package")
   ];
+
+  # latex-access is an executable contraction table implemented in Python, so
+  # it cannot work without Python — and shipping it would keep a reference to
+  # python3 (~200 MiB) in the closure of an otherwise Python-free build.
+  postFixup = lib.optionalString (!pythonSupport) ''
+    rm -f $out/etc/brltty/Contraction/latex-access.ctb
+  '';
+
+  # Enforce the "Python-free closure" guarantee above: if a future upstream
+  # table (or a rename of latex-access.ctb) reintroduces a python3 reference,
+  # fail the build rather than silently pulling ~200 MiB back in.
+  disallowedReferences = lib.optionals (!pythonSupport) [ python3 ];
   installFlags = [
     "install-systemd"
     "install-udev"


### PR DESCRIPTION
Two related changes: make BRLTTY's heavy optional dependencies actually optional, then use that to run BRLTTY in the initrd.

### `brltty: make bluetooth, python and tcl support optional`

BRLTTY's closure is **374 MiB**, almost none of which is BRLTTY itself (`$out` is ~5 MiB). It is dominated by references pulled in by features that are not always wanted:

| Reference | Size | Pulled in by |
|---|---|---|
| python3 | 208 MiB | installed bindings + `latex-access.ctb`, an executable contraction table implemented in Python |
| bluez | 163 MiB | `libbluetooth` (drags in libical, icu4c, dbus) |
| tcl | | installed bindings |

This adds `bluetoothSupport`, `pythonSupport` and `tclSupport`, mirroring the package's existing `alsaSupport`/`systemdSupport` toggles. Defaults are unchanged. With all three off, `bin/brltty` and the drivers reference nothing but glibc (measured: 137 MiB closure, entirely from the systemd/udev/helper-script files, none of which the initrd copies).

`--disable-python-bindings` also requires removing `latex-access.ctb`, since it is a Python program and would otherwise keep a dangling python3 reference.

### `nixos/brltty: add initrd support`

Adds `services.brltty.initrd.enable`, which runs BRLTTY inside the initrd so a braille display works during early boot and — the real motivation — **in the initrd emergency shell**, where a blind user otherwise has no way to tell what went wrong (e.g. a root filesystem that fails to mount).

It **defaults to enabled** whenever `services.brltty.enable` and `boot.initrd.systemd.enable` (itself on by default) are both on — a braille user who turns BRLTTY on almost always wants it as early as possible. The default is guarded on systemd-in-initrd so that enabling BRLTTY on a scripted-initrd system does not start failing an assertion on upgrade; an explicit `initrd.enable = true` there still does. Nothing in-tree sets `services.brltty.enable`, so no profiles or images are affected.

Only `bin/brltty`, the drivers and the tables are copied in via file-level `storePaths` (the same approach as `initrd-ssh`/`initrd-openvpn`), and the default package disables everything not needed there, so those files reference only glibc. **A minimal initrd grows from 28M to 29M.**

Three details are load-bearing, each found by testing on real hardware (HumanWare Brailliant BI 40X):

* `/run` is mounted `nodev`, and `/dev/bus/usb` is not populated this early, so BRLTTY falls back to mounting its own usbfs and must be able to create device nodes. A `dev`-capable submount at `/run/brltty` fixes this; without it BRLTTY never reaches the display no matter how long it probes.
* The service is also `wantedBy` `emergency.target` and `rescue.target`. `initrd.target` is never reached when booting into those — precisely the situations this exists for.
* BRLTTY is stopped with `-C` before switch-root, so the booted system's instance can claim the display.

The design follows BRLTTY's own dracut module (`Initramfs/Dracut` in the source tarball): screen driver `lx`, speech disabled, braille keyboard input enabled, and `uinput` in the default kernel modules (BRLTTY injects keystrokes through it). Braille-display USB modules can't be left to `boot.initrd.availableKernelModules`, because `nixos-generate-config` only detects USB mass-storage and HID *boot-keyboard* devices, and a braille display is neither; USB-serial displays likewise need their converter's driver added explicitly, which the option documents.

### Testing

- `brltty` builds on x86_64-linux, default and with the new flags in all combinations.
- Built a NixOS initrd with `services.brltty.initrd.enable` on and off: 29M vs 28M, brltty present in the initrd derivation.
- Verified the `boot.initrd.systemd.enable` assertion fires.
- The initrd service itself (display binding, keyboard input, `-C` handoff at switch-root) was verified on real hardware during development; the equivalent config runs on my laptop.

No automated NixOS test is included. Exercising the braille path would mean emulating a display via QEMU's `-chardev braille`, which is served by QEMU's own BrlAPI — built from the very package under test — so such a test would be largely circular. `nixpkgs-review` was not run locally: any change to `brltty` rebuilds `qemu` (BrlAPI) and therefore every NixOS test, which is also why this targets `staging-nixos`.

### Note

This is stacked on #544333 (`brltty: add polkit support`); the first commit here is that PR. It will show a clean two-commit diff once #544333 merges into `staging-nixos`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Disclosure per the automation/AI policy: these changes and this pull request summary were prepared with Claude Code (Claude Opus 4.8, `claude-opus-4-8`). Both commits carry the required `Assisted-by:` trailer. I have reviewed the diff and verified the behaviour, including on real hardware.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
