### PR TITLE
python3Packages.helpdev: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/helpdev/default.nix
+++ b/pkgs/development/python-modules/helpdev/default.nix
@@ -5,6 +5,8 @@
   importlib-metadata,
   psutil,
   setuptools,
+  pip,
+  pytestCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -19,13 +21,17 @@ buildPythonPackage (finalAttrs: {
 
   build-system = [ setuptools ];
 
+  postPatch = ''
+    substituteInPlace helpdev/__init__.py \
+      --replace-fail "'pip'," "'${lib.getExe pip}',"
+  '';
+
   dependencies = [
     importlib-metadata
     psutil
   ];
 
-  # No tests included in archive
-  doCheck = false;
+  nativeCheckInputs = [ pytestCheckHook ];
 
   meta = {
     description = "Extracts information about the Python environment easily";

--- a/pkgs/development/python-modules/helpdev/default.nix
+++ b/pkgs/development/python-modules/helpdev/default.nix
@@ -7,14 +7,14 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "helpdev";
   version = "0.7.1";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "0gfvj28i82va7c264jl2p4cdsl3lpf9fpb9cyjnis55crfdafqmv";
+    inherit (finalAttrs) pname version;
+    hash = "sha256-u2KnmsusFB2t9Cyt65K7dFDdGLmCSmIEO2oLFJGQ2z0=";
   };
 
   build-system = [ setuptools ];
@@ -32,4 +32,4 @@ buildPythonPackage rec {
     mainProgram = "helpdev";
     license = lib.licenses.mit;
   };
-}
+})

--- a/pkgs/development/python-modules/helpdev/default.nix
+++ b/pkgs/development/python-modules/helpdev/default.nix
@@ -4,19 +4,22 @@
   fetchPypi,
   importlib-metadata,
   psutil,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "helpdev";
   version = "0.7.1";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "0gfvj28i82va7c264jl2p4cdsl3lpf9fpb9cyjnis55crfdafqmv";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     importlib-metadata
     psutil
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- https://github.com/NixOS/nixpkgs/issues/515974

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
