### PR TITLE
jetbrains.jdk: don't inherit version string from base JDK

### DIFF
--- a/pkgs/development/compilers/jetbrains-jdk/common.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/common.nix
@@ -102,6 +102,10 @@ jdk.overrideAttrs (oldAttrs: {
         --host=*)
           # intentionally omit flag
           ;;
+        --with-version-string=*)
+          # The base JDK pins its own upstream version, which may differ from the
+          # JBR sources; let configure read the version from version-numbers.conf
+          ;;
         ${lib.optionalString (vendorVersionString != null) ''
           --with-vendor-version-string=*)
             # Replace the flag from the JDK to include that it is JBR and the package version, so it passes the installation tests


### PR DESCRIPTION
`java --version` currently reports:

```
openjdk 25.0.4 2026-04-21
OpenJDK Runtime Environment nix/JBR-25.0.3-b508.4-jcef (build 25.0.4+1-b508.4)
OpenJDK 64-Bit Server VM nix/JBR-25.0.3-b508.4-jcef (build 25.0.4+1-b508.4, mixed mode, sharing)
```

This is because `common.nix` reuses the base OpenJDK's configureFlags, which include `--with-version-string` set to the nixpkgs OpenJDK version. This patch fixes the issue. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
