### PR TITLE
lib.setFunctionArgs: preserve existing callable set attributes

### DIFF
--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -1083,10 +1083,21 @@ in
     f: args:
     # TODO: Should we add call-time "type" checking like built in?
     if isAttrs f then
-      f // { __functionArgs = args; }
+      if
+        removeAttrs f [
+          "__functor"
+          "__functionArgs"
+        ] != { }
+      then
+        f // { __functionArgs = args; }
+      else
+        {
+          inherit (f) __functor;
+          __functionArgs = args;
+        }
     else
       {
-        __functor = f.__functor or (self: f);
+        __functor = self: f;
         __functionArgs = args;
       };
 
@@ -1187,7 +1198,18 @@ in
     in
     g:
     if isAttrs g then
-      g // { __functionArgs = fArgs; }
+      if
+        removeAttrs g [
+          "__functor"
+          "__functionArgs"
+        ] != { }
+      then
+        g // { __functionArgs = fArgs; }
+      else
+        {
+          inherit (g) __functor;
+          __functionArgs = fArgs;
+        }
     else
       {
         __functor = self: g;

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -15,6 +15,7 @@ let
   inherit (lib)
     foldr
     fromJSON
+    isAttrs
     isString
     readFile
     ;
@@ -1078,11 +1079,16 @@ in
     setFunctionArgs : (a -> b) -> { [String] :: Bool } -> (a -> b)
     ```
   */
-  setFunctionArgs = f: args: {
+  setFunctionArgs =
+    f: args:
     # TODO: Should we add call-time "type" checking like built in?
-    __functor = self: f;
-    __functionArgs = args;
-  };
+    if isAttrs f then
+      f // { __functionArgs = args; }
+    else
+      {
+        __functor = f.__functor or (self: f);
+        __functionArgs = args;
+      };
 
   /**
     Extract the expected function arguments from a function.
@@ -1179,10 +1185,14 @@ in
     let
       fArgs = functionArgs f;
     in
-    g: {
-      __functor = self: g;
-      __functionArgs = fArgs;
-    };
+    g:
+    if isAttrs g then
+      g // { __functionArgs = fArgs; }
+    else
+      {
+        __functor = self: g;
+        __functionArgs = fArgs;
+      };
 
   /**
     Turns any non-callable values into constant functions.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Callable sets could carry nontrivial attributes aside from `__functor` and `functionArgs`, e.g., `<function>.override` and `fetchgit.getRevWithTag`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
