### PR TITLE
gitignore: add AGENTS.md and CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ tags
 .mypy_cache
 __pycache__
 
+/AGENTS.md
+/CLAUDE.md
+
 /pkgs/development/libraries/qt-5/*/tmp/
 /pkgs/desktops/kde-5/*/tmp/
 /pkgs/development/mobile/androidenv/xml/*


### PR DESCRIPTION
Alternative to #534657.

I'd like to share some reasons why I believe this is preferable over including an AGENTS.md by default.

## If LLMs are tooling, they should be treated as such

In the comments of the original PR, @wolfgangwalther mentioned:

> I suggest to add both CLAUDE.md and AGENTS.md to .gitignore. This would be 100% in line with "tolerate, but don't encourage".

He also wrote in a separate reply:

> I'd like to point out that there is precedent for this already in https://github.com/NixOS/nixpkgs/pull/322512, https://github.com/NixOS/nixpkgs/pull/322650 and finally https://github.com/NixOS/nixpkgs/pull/325793. A controversy about tooling, which ended up adding the relevant file to .gitignore.

One of the lines I hear most in discussions about LLMs is "it's just a tool". I typically find this rhetoric frustrating, but I think there's actually some value in taking it seriously. Great. Use it as a tool on your end. But we don't ship other tooling-specific files - `.envrc`, `.vscode`, `.helix`, and `.idea` are all gitignored. I don't think we need to make an exception for LLMs.

## LLM assistance is accepted, vibe coding is not

In times like these, it's helpful to take a look at what's actually on paper. As stated in the nixpkgs AI policy:

> Everyone who submits a contribution to Nixpkgs is responsible for it, regardless of the use of automated tooling.
Before submission, they must establish a reasonable level of understanding of the contribution and expectation of its correctness.

Nixpkgs, just like other prominent open-source repositories, has seen an influx of vibe coders who simply paste output from the LLM without any human review. To mitigate this while still accepting PRs made with LLM assistance, our policy focuses on ensuring there's a "human at the wheel". I think shipping an AGENTS.md by default is counter to this. 

@shellhazard put it wonderfully in the original thread:

> I am struggling to understand who this helps. I don't think people who are so hands off that they are unable to provide meaningful guidance to an agent (even as limited as "find and read the contributor docs") should be encouraged further to contribute by the presence of this file.

## An AGENTS.md is controversial in itself

Including an AGENTS.md has become a social signal for how friendly a project is to AI contributions. Several long-time contributors have expressed that they would feel less interested in contributing to nixpkgs if the project began to "signal" in this way. What's more, even if we _did_ accept the file, the exact contents are controversial, as demonstrated by the multiple PRs and suggested changes. If individual contributors find value in an AGENTS.md, gitignoring it allows them to include it themselves.

## Things done 

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
