### PR TITLE
turnstile: init at 0.1.11

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29770,6 +29770,12 @@
     githubId = 59029586;
     name = "Vitor Pavan";
   };
+  vitrial = {
+    email = "111700bh@gmail.com";
+    github = "xZecora";
+    githubId = 63205921;
+    name = "Bryant Collins";
+  };
   vizid = {
     email = "mail@vizqq.cc";
     github = "ViZiD";

--- a/pkgs/by-name/tu/turnstile/package.nix
+++ b/pkgs/by-name/tu/turnstile/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  scdoc,
+  meson,
+  ninja,
+  pam,
+  dinitSupport ? true,
+  dinit,
+  runitSupport ? true,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "turnstile";
+  version = "0.1.11";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "chimera-linux";
+    repo = "turnstile";
+    tag = "v${finalAttrs.version}";
+    sha256 = "sha256-94J+w0RHxzw7wS70LcpEzMvgevAqAwl0EtiANUmdRYU=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    scdoc
+    meson
+    ninja
+  ];
+
+  buildInputs = [
+    scdoc
+    pam
+  ];
+
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace-fail "get_option('prefix'), get_option('sysconfdir'), 'turnstile'" "'/etc', 'turnstile'"
+  ''
+  + lib.optionalString dinitSupport ''
+    substituteInPlace backend/dinit \
+      --replace-fail '/usr/bin/dinit-monitor' '${lib.getExe' dinit "dinit-monitor"}'
+  '';
+
+  mesonFlags = [
+    "-Dlocalstatedir=/var"
+    "-Dpam_moddir=${placeholder "out"}/lib/security"
+    (lib.mesonEnable "dinit" dinitSupport)
+    (lib.mesonEnable "runit" runitSupport)
+  ];
+
+  meta = {
+    homepage = "https://github.com/chimera-linux/turnstile";
+    description = "This program waits for user logins and then runs the associated user-service manager";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ vitrial ];
+    mainProgram = "turnstiled";
+  };
+
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Turnstile](https://github.com/chimera-linux/turnstile) is a session manager from Chimera Linux that runs user level service managers when a user logs in and closes them safely when that user logs out. It natively provides two backends for `dinit` and `runit`. This is latest tagged release.

@aanderse requested that I upstream this package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
