### PR TITLE
swig: fix cross-compilation

### DIFF
--- a/pkgs/by-name/sw/swig/package.nix
+++ b/pkgs/by-name/sw/swig/package.nix
@@ -20,13 +20,14 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-jsi83v9sg0n5kUfDACqdNAS2VuLSyxv+pe2LRcO4Khc=";
   };
 
+  # It is necessary to pull in the target pcre2-config binary this way because including pcre2 in nativeBuildInputs can create linking failures with cross-compilation
+  env.PCRE2_CONFIG = "${pcre2.dev}/bin/pcre2-config";
   strictDeps = true;
   nativeBuildInputs = [
     autoconf
     automake
     libtool
     bison
-    pcre2
   ];
   buildInputs = [ pcre2 ];
 


### PR DESCRIPTION
The changes in #353232 fix cross-compilation for most platforms but there are still linking issues for certain architectures (examples include armv7l-hf-multiplatform, armv5tel-multiplatform, arc).  This patch reverts to the previous method of setting an environment variable but updates it to use `PCRE2_CONFIG` instead of `PCRE_CONFIG`.  This works across all target platforms tested.

For reference, this is an example of the error when trying to compile with pkgsCross.arc:

```
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/z0g6vswkycr6vraal9cmwbjzi9fb9y5m-source
source root is source
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
+ test -d Tools/config
+ aclocal -I Tools/config
+ autoheader
+ automake --add-missing --copy --force-missing
configure.ac:24: installing 'Tools/config/compile'
configure.ac:11: installing 'Tools/config/config.guess'
configure.ac:11: installing 'Tools/config/config.sub'
configure.ac:12: installing 'Tools/config/install-sh'
configure.ac:12: installing 'Tools/config/missing'
Source/Makefile.am: installing 'Tools/config/depcomp'
+ autoconf
+ cd CCache
+ autoreconf
patching script interpreter paths in ./configure
./configure: interpreter directive changed from "#! /bin/sh" to "/nix/store/zh1ijdhb6gng1509b1zrilb6xlzx60j6-bash-5.3p9/bin/sh"
configure flags: --disable-dependency-tracking --prefix=/nix/store/9bzxhsq16yflfh1xhnwjmmdx79zc9p9w-swig-arc-unknown-linux-gnu-4.4.1 --without-tcl --build=x86_64-unknown-linux-gnu --host=arc-unknown-linux-gnu
checking build system type... x86_64-unknown-linux-gnu
checking host system type... arc-unknown-linux-gnu
checking for a BSD-compatible install... /nix/store/sr26flm2nkfa12dkrwj2630kqsfakky4-coreutils-9.11/bin/install -c
checking whether sleep supports fractional seconds... yes
checking filesystem timestamp resolution... 0.01
checking whether build environment is sane... yes
checking for arc-unknown-linux-gnu-strip... arc-unknown-linux-gnu-strip
checking for a race-free mkdir -p... /nix/store/sr26flm2nkfa12dkrwj2630kqsfakky4-coreutils-9.11/bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking xargs -n works... yes
checking whether UID '1000' is supported by ustar format... yes
checking whether GID '100' is supported by ustar format... yes
checking how to create a ustar tar archive... gnutar
checking for arc-unknown-linux-gnu-gcc... arc-unknown-linux-gnu-gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables...
checking whether we are cross compiling... yes
checking for suffix of object files... o
checking whether the compiler supports GNU C... yes
checking whether arc-unknown-linux-gnu-gcc accepts -g... yes
checking for arc-unknown-linux-gnu-gcc option to enable C23 features... none needed
checking whether arc-unknown-linux-gnu-gcc understands -c and -o together... yes
checking whether make supports the include directive... yes (GNU style)
checking dependency style of arc-unknown-linux-gnu-gcc... none
checking CC to use for compiling... arc-unknown-linux-gnu-gcc
checking whether the compiler supports GNU C++... yes
checking whether arc-unknown-linux-gnu-g++ accepts -g... yes
checking dependency style of arc-unknown-linux-gnu-g++... none
checking CXX to use for compiling... arc-unknown-linux-gnu-g++
checking maximum warning verbosity option... -Wall -W -pedantic for C++ -Wall -W -pedantic for C
checking CFLAGS to compile SWIG executable... -g -O2 -Wall -W -pedantic
checking CXXFLAGS to compile SWIG executable... -g -O2 -Wall -W -pedantic
checking for grep that handles long lines and -e... /nix/store/w8xlvapzxcz23ba312q119p57bnc7200-gnugrep-3.12/bin/grep
checking for egrep... /nix/store/w8xlvapzxcz23ba312q119p57bnc7200-gnugrep-3.12/bin/grep -E
checking whether to enable PCRE2 support... yes
checking whether to use local PCRE2... no
checking for a sed that does not truncate output... /nix/store/0hamsiy8hsyfw1hmizbc3bf93ad7fa1v-gnused-4.9/bin/sed
checking for pcre2-config... /nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/bin/pcre2-config
checking whether to enable ccache-swig... yes

Checking packages required for SWIG developers.
Note : None of the following packages are required for users to compile and install SWIG from the distributed tarball

checking for bison... bison

Checking for installed target languages and other information in order to compile and run
the examples and test-suite invoked by 'make check'.
Note : None of the following packages are required for users to compile and install SWIG from the distributed tarball

checking for boostlib >=  (102000)... configure: We could not detect the boost libraries (version  or higher). If you have a staged boost library (still not installed) please specify $BOOST_ROOT in your environment and do not give a PATH to --with-boost option.  If you are sure you have boost installed, then check your version number looking in <boost/version.hpp>. See http://randspringer.de/boost for more documentation.
checking SO... .so
checking LDSHARED... $(CC) -shared
checking CXXSHARED... $(CC) -shared
checking TRYLINKINGWITHCXX... CXXSHARED= $(CXX) -shared
checking CCSHARED... -fPIC
checking RPATH... -Xlinker -rpath $(exec_prefix)/lib -Xlinker -rpath .
checking LINKFORSHARED... -Xlinker -export-dynamic
checking CFLAGS to use for testing (PLATCFLAGS)...
checking whether to attempt to enable C++11 and later C++ standards testing... yes
checking whether arc-unknown-linux-gnu-g++ supports C++20 features with -std=c++20... yes
checking whether C++11 to C++20 testing is enabled... yes
checking CXXFLAGS to use for testing (PLATCXXFLAGS)... -std=c++20
checking if compiler supports pre-compiled headers... yes
checking for dlopen in -ldl... no
checking for shl_load in -ldld... no
checking for main in -lieee... no
checking for arc-unknown-linux-gnu-pkg-config... no
checking for pkg-config... no
checking for android... no
checking for adb... no
checking for ant... no
checking for ndk-build... no
checking for mono-csc... no
checking for gmcs... no
checking for mcs... no
checking for cscc... no
checking for dmd... no
checking for ldmd2... no
checking for ldc2... no
checking for gdmd... no
checking for go... no
checking for gccgo... no
checking for guile-config... no
checking for java JDK... no (JAVA_HOME is not defined)
checking for java... no
checking for kaffe... no
checking for guavac... no
checking for javac... no
checking for java include file jni.h... not found
checking for node... no
checking for nodejs... no
checking for V8 Javascript v8.h... not found
checking for lua5.4... no
checking for lua5.3... no
checking for lua5.2... no
checking for lua5.1... no
checking for lua... no
checking for ocamlc... no
checking for camlp4... no
checking for ocamldlgen... no
checking for ocamlfind... no
checking for ocamlmktop... no
checking for octave-cli... no
checking for perl... no
checking for perl5... no
checking for Perl5 header files... could not figure out how to run perl5
checking for php8.3... no
checking for php8.2... no
checking for php8.1... no
checking for php8.0... no
checking for php... no
checking for python... no
checking for python2.7... no
checking for python3... no
checking for python3.15... no
checking for python3.14... no
checking for python3.13... no
checking for python3.12... no
checking for python3.11... no
checking for python3.10... no
checking for python3.9... no
checking for python3.8... no
checking for python3.7... no
checking for python3.6... no
checking for python3.5... no
checking for python3.4... no
checking for python3.3... no
checking for python... no
checking for R... no
checking for ruby... no
checking for Ruby header files... could not figure out how to run ruby
checking for scilab... no
configure: Disabling Tcl
checking for egrep -e... (cached) /nix/store/w8xlvapzxcz23ba312q119p57bnc7200-gnugrep-3.12/bin/grep -E
checking that generated files are newer than configure... done
configure: creating ./config.status
config.status: creating Makefile
config.status: creating Examples/Makefile
config.status: creating Examples/test-suite/errors/Makefile
config.status: creating Examples/test-suite/c/Makefile
config.status: creating Examples/test-suite/csharp/Makefile
config.status: creating Examples/test-suite/d/Makefile
config.status: creating Examples/test-suite/go/Makefile
config.status: creating Examples/test-suite/guile/Makefile
config.status: creating Examples/test-suite/java/Makefile
config.status: creating Examples/test-suite/javascript/Makefile
config.status: creating Examples/test-suite/lua/Makefile
config.status: creating Examples/test-suite/ocaml/Makefile
config.status: creating Examples/test-suite/octave/Makefile
config.status: creating Examples/test-suite/perl5/Makefile
config.status: creating Examples/test-suite/php/Makefile
config.status: creating Examples/test-suite/python/Makefile
config.status: creating Examples/test-suite/r/Makefile
config.status: creating Examples/test-suite/ruby/Makefile
config.status: creating Examples/test-suite/scilab/Makefile
config.status: creating Examples/test-suite/tcl/Makefile
config.status: creating Source/Makefile
config.status: creating Tools/javascript/Makefile
config.status: creating preinst-swig
config.status: creating CCache/ccache_swig_config.h
config.status: creating Source/Include/swigconfig.h
config.status: executing depfiles commands
config.status: executing Examples commands
=== configuring in CCache (/build/source/CCache)
configure: running /nix/store/zh1ijdhb6gng1509b1zrilb6xlzx60j6-bash-5.3p9/bin/bash ./configure --disable-option-checking '--prefix=/nix/store/9bzxhsq16yflfh1xhnwjmmdx79zc9p9w-swig-arc-unknown-linux-gnu-4.4.1'  '--disable-dependency-tracking' '--without-tcl' '--build=x86_64-unknown-linux-gnu' '--host=arc-unknown-linux-gnu' 'build_alias=x86_64-unknown-linux-gnu' 'host_alias=arc-unknown-linux-gnu' 'CC=arc-unknown-linux-gnu-gcc' 'CXX=arc-unknown-linux-gnu-g++' --cache-file=/dev/null --srcdir=.
configure: Configuring ccache
checking for arc-unknown-linux-gnu-gcc... arc-unknown-linux-gnu-gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables...
checking whether we are cross compiling... yes
checking for suffix of object files... o
checking whether the compiler supports GNU C... yes
checking whether arc-unknown-linux-gnu-gcc accepts -g... yes
checking for arc-unknown-linux-gnu-gcc option to enable C23 features... none needed
checking how to run the C preprocessor... arc-unknown-linux-gnu-gcc -E
checking for a BSD-compatible install... /nix/store/sr26flm2nkfa12dkrwj2630kqsfakky4-coreutils-9.11/bin/install -c
checking for dirent.h that defines DIR... yes
checking for library containing opendir... none required
checking for sys/wait.h that is POSIX.1 compatible... yes
checking for stdio.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for strings.h... yes
checking for sys/stat.h... yes
checking for sys/types.h... yes
checking for unistd.h... yes
checking for ctype.h... yes
checking for strings.h... (cached) yes
checking for stdlib.h... (cached) yes
checking for string.h... (cached) yes
checking for pwd.h... yes
checking for sys/time.h... yes
checking for realpath... yes
checking for snprintf... yes
checking for vsnprintf... yes
checking for vasprintf... yes
checking for asprintf... yes
checking for mkstemp... yes
checking for gethostname... yes
checking for getpwuid... yes
checking for utimes... yes
checking for compar_fn_t in stdlib.h... yes
checking for C99 vsnprintf... cross
checking for zlib.h... no
configure: creating ./config.status
config.status: creating config_win32.h
config.status: creating Makefile
config.status: creating config.h

The SWIG test-suite and examples are configured for the following languages:
c

Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
build flags: -j16 SHELL=/nix/store/zh1ijdhb6gng1509b1zrilb6xlzx60j6-bash-5.3p9/bin/bash
mkdir -p Lib
test -z "1" || make -C CCache
echo "/* SWIG warning codes - generated from swigwarn.h - do not edit */" > Lib/swigwarn.swg
cat Source/Include/swigwarn.h | grep "^#define WARN\|/\*.*\*/\|^[ \t]*$" | sed 's/^#define \(WARN.*[0-9][0-9]*\)\(.*\)$/%define SWIG\1 %enddef\2/' >> Lib/swigwarn.swg
make[1]: Entering directory '/build/source/CCache'
arc-unknown-linux-gnu-gcc -g -O2 -Wall -W -I.   -c -o ccache.o ccache.c
arc-unknown-linux-gnu-gcc -g -O2 -Wall -W -I.   -c -o mdfour.o mdfour.c
make[1]: Entering directory '/build/source/Source'
bison -d -Wall -Werror  --output=CParse/parser.c ./CParse/parser.y
arc-unknown-linux-gnu-gcc -g -O2 -Wall -W -I.   -c -o hash.o hash.c
arc-unknown-linux-gnu-gcc -g -O2 -Wall -W -I.   -c -o execute.o execute.c
arc-unknown-linux-gnu-gcc -g -O2 -Wall -W -I.   -c -o util.o util.c
arc-unknown-linux-gnu-gcc -g -O2 -Wall -W -I.   -c -o args.o args.c
arc-unknown-linux-gnu-gcc -g -O2 -Wall -W -I.   -c -o stats.o stats.c
arc-unknown-linux-gnu-gcc -g -O2 -Wall -W -I.   -c -o cleanup.o cleanup.c
arc-unknown-linux-gnu-gcc -g -O2 -Wall -W -I.   -c -o snprintf.o snprintf.c
arc-unknown-linux-gnu-gcc -g -O2 -Wall -W -I.   -c -o unify.o unify.c
arc-unknown-linux-gnu-gcc -g -O2 -Wall -W -I.  -o ccache-swig ccache.o mdfour.o hash.o execute.o util.o args.o stats.o cleanup.o snprintf.o unify.o
make  all-am
make[2]: Entering directory '/build/source/Source'
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o CParse/cscanner.o CParse/cscanner.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o CParse/parser.o CParse/parser.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o CParse/templ.o CParse/templ.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o CParse/util.o CParse/util.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o DOH/base.o DOH/base.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o DOH/file.o DOH/file.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o DOH/fio.o DOH/fio.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o DOH/hash.o DOH/hash.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o DOH/list.o DOH/list.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o DOH/memory.o DOH/memory.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o DOH/string.o DOH/string.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o DOH/void.o DOH/void.c
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Doxygen/csharpdoc.o Doxygen/csharpdoc.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Doxygen/doxyentity.o Doxygen/doxyentity.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Doxygen/doxyparser.o Doxygen/doxyparser.cxx
make[1]: Leaving directory '/build/source/CCache'
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Doxygen/doxytranslator.o Doxygen/doxytranslator.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Doxygen/javadoc.o Doxygen/javadoc.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Doxygen/pydoc.o Doxygen/pydoc.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/allocate.o Modules/allocate.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/contract.o Modules/contract.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/c.o Modules/c.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/csharp.o Modules/csharp.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/d.o Modules/d.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/directors.o Modules/directors.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/emit.o Modules/emit.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/go.o Modules/go.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/guile.o Modules/guile.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/interface.o Modules/interface.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/java.o Modules/java.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/javascript.o Modules/javascript.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/lang.o Modules/lang.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/lua.o Modules/lua.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/main.o Modules/main.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/nested.o Modules/nested.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/ocaml.o Modules/ocaml.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/octave.o Modules/octave.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/overload.o Modules/overload.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/perl5.o Modules/perl5.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/php.o Modules/php.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/python.o Modules/python.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/r.o Modules/r.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/ruby.o Modules/ruby.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/scilab.o Modules/scilab.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/swigmain.o Modules/swigmain.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/tcl8.o Modules/tcl8.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/typepass.o Modules/typepass.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/utils.o Modules/utils.cxx
arc-unknown-linux-gnu-g++ -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Modules/xml.o Modules/xml.cxx
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Preprocessor/cpp.o Preprocessor/cpp.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Preprocessor/expr.o Preprocessor/expr.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Swig/cwrap.o Swig/cwrap.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Swig/deprecate.o Swig/deprecate.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Swig/error.o Swig/error.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Swig/extend.o Swig/extend.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Swig/fragment.o Swig/fragment.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Swig/getopt.o Swig/getopt.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Swig/include.o Swig/include.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Swig/misc.o Swig/misc.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Swig/naming.o Swig/naming.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Swig/parms.o Swig/parms.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Swig/scanner.o Swig/scanner.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Swig/stype.o Swig/stype.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Swig/symbol.o Swig/symbol.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Swig/tree.o Swig/tree.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Swig/typemap.o Swig/typemap.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Swig/typeobj.o Swig/typeobj.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Swig/typesys.o Swig/typesys.c
arc-unknown-linux-gnu-gcc -DHAVE_CONFIG_H   -I../Source/Include -I../Source/CParse -I../Source/Include -I../Source/DOH -I../Source/CParse -I../Source/Doxygen -I../Source/Preprocessor -I../Source/Swig -I../Source/Modules -I/nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev/include  -g -O2 -Wall -W -pedantic -c -o Swig/wrapfunc.o Swig/wrapfunc.c
arc-unknown-linux-gnu-g++  -g -O2 -Wall -W -pedantic   -o eswig CParse/cscanner.o CParse/parser.o CParse/templ.o CParse/util.o DOH/base.o DOH/file.o DOH/fio.o DOH/hash.o DOH/list.o DOH/memory.o DOH/string.o DOH/void.o Doxygen/csharpdoc.o Doxygen/doxyentity.o Doxygen/doxyparser.o Doxygen/doxytranslator.o Doxygen/javadoc.o Doxygen/pydoc.o Modules/allocate.o Modules/contract.o Modules/c.o Modules/csharp.o Modules/d.o Modules/directors.o Modules/emit.o Modules/go.o Modules/guile.o Modules/interface.o Modules/java.o Modules/javascript.o Modules/lang.o Modules/lua.o Modules/main.o Modules/nested.o Modules/ocaml.o Modules/octave.o Modules/overload.o Modules/perl5.o Modules/php.o Modules/python.o Modules/r.o Modules/ruby.o Modules/scilab.o Modules/swigmain.o Modules/tcl8.o Modules/typepass.o Modules/utils.o Modules/xml.o Preprocessor/cpp.o Preprocessor/expr.o Swig/cwrap.o Swig/deprecate.o Swig/error.o Swig/extend.o Swig/fragment.o Swig/getopt.o Swig/include.o Swig/misc.o Swig/naming.o Swig/parms.o Swig/scanner.o Swig/stype.o Swig/symbol.o Swig/tree.o Swig/typemap.o Swig/typeobj.o Swig/typesys.o Swig/wrapfunc.o  -L/nix/store/x2zjc47pkhcwxr4iyv5xj3hdqfzfnyd9-pcre2-10.46/lib -lpcre2-8
/nix/store/x2zjc47pkhcwxr4iyv5xj3hdqfzfnyd9-pcre2-10.46/lib/libpcre2-8.so: file not recognized: file format not recognized
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:879: eswig] Error 1
make[2]: Leaving directory '/build/source/Source'
make[1]: *** [Makefile:635: all] Error 2
make[1]: Leaving directory '/build/source/Source'
make: *** [Makefile:36: source] Error 2
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
