### PR TITLE
csvtk: 0.33.0 -> 0.37.0

### DIFF
--- a/pkgs/by-name/cs/csvtk/package.nix
+++ b/pkgs/by-name/cs/csvtk/package.nix
@@ -7,7 +7,7 @@
   buildPackages,
 }:
 let
-  version = "0.33.0";
+  version = "0.37.0";
 in
 buildGoModule {
   pname = "csvtk";
@@ -17,10 +17,13 @@ buildGoModule {
     owner = "shenwei356";
     repo = "csvtk";
     tag = "v${version}";
-    hash = "sha256-Zacs1hw4pryVNxnrkLIoBNWo0jcKjtYdx6kW2LTFEIs=";
+    hash = "sha256-dpWxLOckdA0tNhSM8wGqBag/cXmMFhonybN+W1+KBXA=";
   };
 
-  vendorHash = "sha256-T9flXxly3i8SKQlhp4AF2FNCqgcnGAHxv5b7nqzM3DI=";
+  vendorHash = "sha256-wi7WPwCg0MoNxgCLZO1UxG4M0g/Vo/GCiCGu8c5avyU=";
+
+  # stale upstream test: asserts byte length, but expr-lang now returns rune count
+  checkFlags = [ "-skip=TestMutate3" ];
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
Bumps csvtk 0.33.0 -> 0.37.0.

Added a `checkFlags` to skip `TestMutate3`. In 0.37.0 the `mutate3` expression engine (expr-lang 1.17.7) changed `len()` to count characters instead of bytes, so on non-ASCII input the result is different, e.g. `len("沈伟")` is now `2` instead of `6`. The upstream test still expects the old value, so it fails in checkPhase. Skipping just that test; the binary builds and runs fine.

Reported upstream: https://github.com/shenwei356/csvtk/issues/368

Changelog: https://github.com/shenwei356/csvtk/releases/tag/v0.37.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
