### PR TITLE
rounded-mgenplus: use mirror URL, modernize, add shadowrz to maintainers

### DIFF
--- a/pkgs/by-name/ro/rounded-mgenplus/package.nix
+++ b/pkgs/by-name/ro/rounded-mgenplus/package.nix
@@ -2,29 +2,28 @@
   lib,
   stdenvNoCC,
   fetchurl,
+  installFonts,
   p7zip,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "rounded-mgenplus";
   version = "20150602";
 
   src = fetchurl {
-    url = "https://osdn.jp/downloads/users/8/8598/${pname}-${version}.7z";
+    url = "mirror://osdn/users/8/8598/${finalAttrs.pname}-${finalAttrs.version}.7z";
     hash = "sha256-7OpnZJc9k5NiOPHAbtJGMQvsMg9j81DCvbfo0f7uJcw=";
   };
 
   sourceRoot = ".";
 
-  nativeBuildInputs = [ p7zip ];
+  __srtucturedAttrs = true;
+  strictDeps = true;
 
-  installPhase = ''
-    runHook preInstall
-
-    install -m 444 -D -t $out/share/fonts/${pname} ${pname}-*.ttf
-
-    runHook postInstall
-  '';
+  nativeBuildInputs = [
+    installFonts
+    p7zip
+  ];
 
   meta = {
     description = "Japanese font based on Rounded M+ and Noto Sans Japanese";
@@ -33,4 +32,4 @@ stdenvNoCC.mkDerivation rec {
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ mnacamura ];
   };
-}
+})

--- a/pkgs/by-name/ro/rounded-mgenplus/package.nix
+++ b/pkgs/by-name/ro/rounded-mgenplus/package.nix
@@ -30,6 +30,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "http://jikasei.me/font/rounded-mgenplus/";
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ mnacamura ];
+    maintainers = with lib.maintainers; [
+      mnacamura
+      shadowrz
+    ];
   };
 })


### PR DESCRIPTION
Closes #473116

Part of #471645 + #495640

Since the original maintainer https://github.com/mnacamura have no activities in 2025 and 2026, I decided to maintain it.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
