### PR TITLE
unstableGitUpdater: gitUpdater: support updating hashes for vendored deps

### DIFF
--- a/pkgs/common-updater/unstable-updater.nix
+++ b/pkgs/common-updater/unstable-updater.nix
@@ -21,6 +21,7 @@
   tagPrefix ? null, # strip this prefix from a tag name
   tagConverter ? null, # A command to convert more complex tag formats. It receives the git tag via stdin and should convert it into x.y.z format to stdout
   shallowClone ? true,
+  vendoredDeps ? [ ], # things like pnpmDeps
 }:
 
 assert lib.asserts.assertMsg (
@@ -40,6 +41,7 @@ let
       set -ex
 
       url=""
+      vendored_deps=""
       branch=""
       hardcode_zero_version=""
       tag_format=""
@@ -54,6 +56,9 @@ let
           case "$flag" in
             --url=*)
               url="''${flag#*=}"
+              ;;
+            --vendored-deps=*)
+              vendored_deps="''${flag#*=}"
               ;;
             --branch=*)
               branch="''${flag#*=}"
@@ -159,6 +164,13 @@ let
           "$new_version" \
           --rev="$commit_sha" \
           --print-changes
+      # update hashes of vendored deps, do not use --print-changes
+      for vendored_dep in $vendored_deps; do
+          update-source-version \
+              "$UPDATE_NIX_ATTR_PATH" \
+              --ignore-same-version \
+              --source-key="$vendored_dep"
+      done
     '';
   };
 
@@ -182,4 +194,7 @@ in
 ]
 ++ lib.optionals shallowClone [
   "--shallow-clone"
+]
+++ lib.optionals (vendoredDeps != [ ]) [
+  "--vendored-deps=${toString vendoredDeps}"
 ]


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

One pain point of in-tree updaters is that they cannot update hashes for vendored deps.  So they cannot be used in packages with vendored deps, such as rust, go and pnpm packages.

It turns out it is quite easy to implement this feature!

For now, I just implemented it for `unstableGitUpdater`.  Do you think this is a good idea?  If so, I will implement it for `gitUpdater`.

We can also use [known attribute names][1], such as `pnpmDeps` and `cargoDeps.vendorStaging`, as default values for `vendoredDeps`, like what `nix-update` does.  Do you think it is a good idea?

[1]: https://github.com/Mic92/nix-update/blob/cf68051e7b7e08de6c707484cdcd1a53feb48e05/nix_update/dependency_hashes.py#L217-L233

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
