### PR TITLE
monero-cli: 0.18.5.0 -> 0.18.5.1; monero-gui: 0.18.5.0 -> 0.18.5.1

### DIFF
--- a/pkgs/by-name/mo/monero-cli/package.nix
+++ b/pkgs/by-name/mo/monero-cli/package.nix
@@ -38,13 +38,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "monero-cli";
-  version = "0.18.5.0";
+  version = "0.18.5.1";
 
   src = fetchFromGitHub {
     owner = "monero-project";
     repo = "monero";
     rev = "v${version}";
-    hash = "sha256-clw+7mZenWp58iA7fuEp4BPFH3KUwL53cC4IChIVh7w=";
+    hash = "sha256-RxuhR+GH4Y5kSzNxsqJklRWMbq1K82K3A2V+6JqYR98=";
   };
 
   patches = [

--- a/pkgs/by-name/mo/monero-gui/package.nix
+++ b/pkgs/by-name/mo/monero-gui/package.nix
@@ -27,13 +27,13 @@
 
 stdenv.mkDerivation rec {
   pname = "monero-gui";
-  version = "0.18.5.0";
+  version = "0.18.5.2";
 
   src = fetchFromGitHub {
     owner = "monero-project";
     repo = "monero-gui";
     rev = "v${version}";
-    hash = "sha256-uBZMBQ6Co1+H8DsyeL1vbjtVlKyIkJopKxHxr24BZv0=";
+    hash = "sha256-2FlenQtrsoHmRTfU+KhWtg3eVPzz9ktQ3dnOlWhOPC8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ra/randomx/package.nix
+++ b/pkgs/by-name/ra/randomx/package.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "randomX";
-  version = "1.2.1";
+  version = "1.2.2";
 
   nativeBuildInputs = [ cmake ];
 
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "tevador";
     repo = "randomX";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-dfImzwbEfJQcaPZCoWypHiI6dishVRdqS/r+n3tfjvM=";
+    sha256 = "sha256-15hRPPEo48SL09gYpGtdpXqsVlOTQuMRn4AoXQJWEMI=";
   };
 
   meta = {


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Tested connecting to a remote node and syncing a wallet
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
