### PR TITLE
draft: init at 0.17.15

### DIFF
--- a/pkgs/by-name/dr/draft/package.nix
+++ b/pkgs/by-name/dr/draft/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "draft";
+  version = "0.17.15";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Azure";
+    repo = "draft";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-n5VZjQBSmVC06drEW9x+OhRSgxWacEwlXH8jg48iEoE=";
+  };
+
+  vendorHash = "sha256-rtLwvo0vTQZ1ukZYiv/kXOa/m87y49sSPc8c1C6cdTI=";
+
+  ldflags = [ "-s" ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  checkFlags =
+    let
+      skippedTests = [
+        # Tries to HTTP GET https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/pod-v1.json
+        "TestCreateK8sFileMatchesValidFile"
+        "TestCreateK8sFileMatchesInvalidFile"
+        "TestCreateK8sFileMatchesNestedValidFile"
+        "TestCreateK8sFileMatchesNestedInvalidFile"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd draft \
+      --bash <($out/bin/draft completion bash) \
+      --fish <($out/bin/draft completion fish) \
+      --zsh <($out/bin/draft completion zsh)
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A day 0 tool for getting your app on k8s fast";
+    homepage = "https://github.com/Azure/draft";
+    changelog = "https://github.com/Azure/draft/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kpbaks ];
+    mainProgram = "draft";
+  };
+})


### PR DESCRIPTION
https://github.com/Azure/draft

Assisted-by: nix-init

I have not added `versionCheckHook` because the project current hardcodes the version value in [source code](https://github.com/Azure/draft/blob/b180ebcd9a99b07313993b3d0b6a948c442959eb/cmd/version.go#L10), to an older version

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
