### PR TITLE
cargo-readme: add sshine as maintainer

### DIFF
--- a/pkgs/by-name/ca/cargo-readme/package.nix
+++ b/pkgs/by-name/ca/cargo-readme/package.nix
@@ -34,6 +34,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     maintainers = with lib.maintainers; [
       baloo
       matthiasbeyer
+      sshine
     ];
   };
 })


### PR DESCRIPTION
sshine is also the upstream co-maintainer for cargo-readme