### PR TITLE
_389-ds-base: enable __structuredAttrs, strictDeps

### DIFF
--- a/pkgs/by-name/_3/_389-ds-base/package.nix
+++ b/pkgs/by-name/_3/_389-ds-base/package.nix
@@ -26,6 +26,7 @@
   withNetSnmp ? true,
   krb5,
   pcre2,
+  perl,
   python3,
   rustPlatform,
   rustc,
@@ -42,6 +43,9 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "389-ds-base";
   version = "3.1.3";
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "389ds";
@@ -101,6 +105,8 @@ stdenv.mkDerivation (finalAttrs: {
     pcre2
     openssl
     zlib
+    perl
+    python3
   ]
   ++ lib.optional withSystemd systemd
   ++ lib.optional withOpenldap openldap
@@ -125,12 +131,16 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals withOpenldap [
     "--with-openldap"
+    "--with-openldap-inc=${lib.getDev openldap}/include"
+    "--with-openldap-lib=${lib.getLib openldap}/lib"
+    "--with-openldap-bin=${lib.getBin openldap}/bin"
   ]
   ++ lib.optionals withBdb [
     "--with-db-inc=${lib.getDev db}/include"
     "--with-db-lib=${lib.getLib db}/lib"
   ]
   ++ lib.optionals withNetSnmp [
+    "--with-netsnmp=${lib.getDev net-snmp}"
     "--with-netsnmp-inc=${lib.getDev net-snmp}/include"
     "--with-netsnmp-lib=${lib.getLib net-snmp}/lib"
   ]


### PR DESCRIPTION
#178468 

I also added Perl and Python to `buildInputs` since they are required for some scripts

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
