### PR TITLE
splicePackages: wrap <pkg>.overrideAttrs

### DIFF
--- a/pkgs/test/overriding.nix
+++ b/pkgs/test/overriding.nix
@@ -12,7 +12,8 @@ let
     // tests-fetchhg
     // tests-fetchurl
     // tests-go
-    // tests-python;
+    // tests-python
+    // test-splice;
 
   tests-stdenv =
     let
@@ -552,6 +553,131 @@ let
         ];
         expected = lib.genAttrs [ "a" "b" "c" "d" ] lib.id;
       };
+    };
+
+  test-splice =
+    let
+      buildSystemName = stdenvNoCC.buildPlatform.system;
+      pkgsCrossSpliced =
+        (if buildSystemName == "x86_64-linux" then pkgs.pkgsCross.gnu32 else pkgs.pkgsCross.gnu64)
+        .__splicedPackages;
+      hostSystemName = pkgsCrossSpliced.stdenvNoCC.hostPlatform.system;
+      sample-package = pkgsCrossSpliced.hello;
+      bar-overridden-package = sample-package.overrideAttrs { bar = 2; };
+      baz-overridden-package = bar-overridden-package.overrideAttrs { baz = 3; };
+      genTestsForPackage =
+        {
+          package,
+          prefix,
+          isBarOverridden ? false,
+          isBazOverridden ? false,
+        }:
+        let
+          addPrefix = lib.mapAttrs' (
+            n: v: {
+              name = "splice-${prefix}-" + n;
+              value = v;
+            }
+          );
+          nonEmptySplicedAttrs = lib.filterAttrs (_: v: v != { }) package.__spliced;
+          barExpected = if isBarOverridden then 2 else null;
+          bazExpected = if isBazOverridden then 3 else null;
+        in
+        addPrefix {
+          is-cross = {
+            expr = buildSystemName != hostSystemName;
+            expected = true;
+          };
+          has-overrideAttrs = {
+            expr = package ? overrideAttrs;
+            expected = true;
+          };
+          overrideAttrs-overridden-empty = {
+            expr = (package.overrideAttrs (f: p: { })).drvPath;
+            expected = package.drvPath;
+          };
+          overrideAttrs-overridden-foo = {
+            expr = (sample-package.overrideAttrs { foo = 1; }).foo or null;
+            expected = 1;
+          };
+          build-system-name = {
+            expr = sample-package.stdenv.buildPlatform.system;
+            expected = buildSystemName;
+          };
+          host-system-name = {
+            expr = sample-package.stdenv.hostPlatform.system;
+            expected = hostSystemName;
+          };
+          has-spliced-attribute = {
+            expr = sample-package ? __spliced;
+            expected = true;
+          };
+          has-non-empty-spliced-attributes = {
+            expr = nonEmptySplicedAttrs != { };
+            expected = true;
+          };
+          has-significant-spliced-attributes = {
+            expr = removeAttrs nonEmptySplicedAttrs [ "hostTarget" ] != { };
+            expected = true;
+          };
+          each-non-empty-spliced-attribute-is-derivation = {
+            expr = lib.mapAttrs (n: v: lib.isDerivation v) nonEmptySplicedAttrs;
+            expected = lib.mapAttrs (n: v: true) nonEmptySplicedAttrs;
+          };
+          each-non-empty-spliced-attribute-build-system-name = {
+            expr = lib.mapAttrs (n: v: v.stdenv.buildPlatform.system) nonEmptySplicedAttrs;
+            expected = lib.mapAttrs (n: v: buildSystemName) nonEmptySplicedAttrs;
+          };
+          each-non-empty-spliced-attribute-host-system-name = {
+            expr = lib.mapAttrs (n: v: v.stdenv.hostPlatform.system) nonEmptySplicedAttrs;
+            expected = lib.mapAttrs (
+              n: v: if lib.hasPrefix "build" n then buildSystemName else hostSystemName
+            ) nonEmptySplicedAttrs;
+          };
+          each-non-empty-spliced-attribute-has-overrideAttrs = {
+            expr = lib.mapAttrs (n: v: v ? overrideAttrs) nonEmptySplicedAttrs;
+            expected = lib.mapAttrs (n: v: true) nonEmptySplicedAttrs;
+          };
+          each-non-empty-spliced-attribute-overrideAttrs-overridden-empty = {
+            expr = lib.mapAttrs (n: v: (v.overrideAttrs (f: p: { })).drvPath) nonEmptySplicedAttrs;
+            expected = lib.mapAttrs (n: v: v.drvPath) nonEmptySplicedAttrs;
+          };
+          each-non-empty-spliced-attribute-overrideAttrs-overridden-foo = {
+            expr = lib.mapAttrs (n: v: (v.overrideAttrs { foo = 1; }).foo or null) nonEmptySplicedAttrs;
+            expected = lib.mapAttrs (n: v: 1) nonEmptySplicedAttrs;
+          };
+          is-bar-overridden = {
+            expr = package.bar or null;
+            expected = barExpected;
+          };
+          each-non-empty-spliced-attribute-is-bar-overridden = {
+            expr = lib.mapAttrs (n: v: v.bar or null) nonEmptySplicedAttrs;
+            expected = lib.mapAttrs (n: v: barExpected) nonEmptySplicedAttrs;
+          };
+          is-baz-overridden = {
+            expr = package.baz or null;
+            expected = bazExpected;
+          };
+          each-non-empty-spliced-attribute-is-baz-overridden = {
+            expr = lib.mapAttrs (n: v: v.baz or null) nonEmptySplicedAttrs;
+            expected = lib.mapAttrs (n: v: bazExpected) nonEmptySplicedAttrs;
+          };
+        };
+    in
+    genTestsForPackage {
+      package = sample-package;
+      prefix = "sample";
+    }
+    // genTestsForPackage {
+      package = bar-overridden-package;
+      prefix = "bar-overridden";
+      isBarOverridden = true;
+    }
+    // genTestsForPackage {
+      package = baz-overridden-package;
+      prefix = "baz-overridden";
+      isBarOverridden = true;
+      isBazOverridden = true;
     };
 
 in

--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -41,6 +41,7 @@ let
           augmentedValue = defaultValue // {
             __spliced = lib.filterAttrs (k: v: inputs.${k} ? ${name}) value';
           };
+
           # Get the set of outputs of a derivation. If one derivation fails to
           # evaluate we don't want to diverge the entire splice, so we fall back
           # on {}
@@ -56,11 +57,27 @@ let
           outputSplice = spliceReal (
             mapCrossIndex tryGetOutputs value' // { hostTarget = getOutputs value'.hostTarget; }
           );
+
+          # Wrap the <pkg>.overrideAttrs for a spliced package
+          # to preserve <pkg>.__spliced after overriding.
+          wrapOverrideAttrs =
+            augmentedValue:
+            augmentedValue
+            // {
+              overrideAttrs =
+                newArgs:
+                wrapOverrideAttrs (
+                  augmentedValue.overrideAttrs newArgs
+                  // {
+                    __spliced = mapAttrs (_: drv: drv.overrideAttrs newArgs) augmentedValue.__spliced;
+                  }
+                );
+            };
         in
         # The derivation along with its outputs, which we recur
         # on to splice them together.
         if lib.isDerivation defaultValue then
-          augmentedValue // lib.genAttrs outputNames (out: outputSplice.${out})
+          wrapOverrideAttrs augmentedValue // lib.genAttrs outputNames (out: outputSplice.${out})
         else if lib.isAttrs defaultValue then
           spliceReal value'
         else


### PR DESCRIPTION
Wrap the <pkg>.overrideAttrs of a spliced package to have overridden <pkg>.__spliced after overriding.

If applied, package authors can override package dependencies while keeping it spliced.

The change itself causes no rebuilds. The rebuild comes from the test case addition.

Prior arts:
- PR #201734
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
