### PR TITLE
python3Packages.lxst: 0.4.4 -> 0.5.0

### DIFF
--- a/pkgs/development/python-modules/lxst/default.nix
+++ b/pkgs/development/python-modules/lxst/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
+  fetchPypi,
   setuptools,
   libpulseaudio,
   audioop-lts,
@@ -14,19 +14,24 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "lxst";
-  version = "0.4.4";
-  pyproject = true;
+  version = "0.5.0";
+  format = "wheel";
   __structuredAttrs = true;
 
-  src = fetchFromGitHub {
-    owner = "markqvist";
-    repo = "lxst";
-    tag = finalAttrs.version;
-    hash = "sha256-MAJ1n6EUZ6FmIfKKuM2ppbTVrWkxpjC5KIICo5stc+k=";
+  src = fetchPypi {
+    pname = "lxst";
+    version = finalAttrs.version;
+    format = "wheel";
+    dist = "py3";
+    python = "py3";
+    hash = "sha256-k1HiWv/5iIuSjaeIIDyELX+1FHI3k15IJwxUwUutpM0=";
   };
 
-  postPatch = ''
-    substituteInPlace LXST/Platforms/linux/soundcard.py \
+  # We can't use a postPatch here to do the substitution because the wheel is
+  # already built and the file is not present in the source tree, only the
+  # wheel archive.
+  postInstall = ''
+    substituteInPlace "$out/lib/python"*/site-packages/LXST/Platforms/linux/soundcard.py \
       --replace-fail "libpulse.so" "${lib.getLib libpulseaudio}/lib/libpulse.so"
   '';
 
@@ -47,7 +52,7 @@ buildPythonPackage (finalAttrs: {
     changelog = "https://github.com/markqvist/LXST/releases/tag/${finalAttrs.version}";
     description = "Simple and flexible real-time streaming format and delivery protocol for Reticulum";
     homepage = "https://github.com/markqvist/LXST";
-    license = lib.licenses.cc-by-nc-nd-40;
+    license = lib.licenses.reticulum;
     maintainers = with lib.maintainers; [
       drupol
     ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
