### PR TITLE
rust_1_97: build against LLVM 22

### DIFF
--- a/pkgs/development/compilers/rust/1_97.nix
+++ b/pkgs/development/compilers/rust/1_97.nix
@@ -25,17 +25,26 @@
   pkgsTargetTarget,
   makeRustPlatform,
   wrapRustcWith,
-  llvmPackages,
-  llvm,
+  llvmPackages_22,
+  llvm_22,
   cargo-auditable,
   wrapCCWith,
   overrideCC,
   fetchpatch,
 }@args:
 let
+  # Rust 1.97 upstream is built and tested against LLVM 22 (its
+  # src/llvm-project submodule pins the rustc/22.1 branch; see the policy
+  # note at the top of this file about matching upstream's LLVM). The
+  # default llvmPackages (21) is too old: rustc codegen since 1.96 emits
+  # llvm.experimental.vector.partial.reduce.add, which the X86 backend
+  # lowers to AVX512-VNNI intrinsics (e.g. llvm.x86.avx512.vpdpwssd.512)
+  # that LLVM 21 fails to instruction-select on baseline x86-64
+  # ("Cannot select"); LLVM 22 lowers them correctly.
+  # Drop this pin once the default llvmPackages reaches 22.
   llvmSharedFor =
     pkgSet:
-    pkgSet.llvmPackages.libllvm.override (
+    pkgSet.llvmPackages_22.libllvm.override (
       {
         enableSharedLibraries = true;
       }
@@ -43,7 +52,7 @@ let
         # Force LLVM to compile using clang + LLVM libs when targeting pkgsLLVM
         stdenv = pkgSet.stdenv.override {
           allowedRequisites = null;
-          cc = pkgSet.pkgsBuildHost.llvmPackages.clangUseLLVM;
+          cc = pkgSet.pkgsBuildHost.llvmPackages_22.clangUseLLVM;
         };
       }
     );
@@ -57,7 +66,8 @@ import ./default.nix
     llvmSharedForHost = llvmSharedFor pkgsBuildHost;
     llvmSharedForTarget = llvmSharedFor pkgsBuildTarget;
 
-    inherit llvmPackages cargo-auditable;
+    inherit cargo-auditable;
+    llvmPackages = llvmPackages_22;
 
     # For use at runtime
     llvmShared = llvmSharedFor pkgsHostTarget;
@@ -93,8 +103,8 @@ import ./default.nix
 
   (
     removeAttrs args [
-      "llvmPackages"
-      "llvm"
+      "llvmPackages_22"
+      "llvm_22"
       "wrapCCWith"
       "overrideCC"
       "pkgsHostTarget"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4061,7 +4061,9 @@ with pkgs;
   wrapRustcWith = { rustc-unwrapped, ... }@args: callPackage ../build-support/rust/rustc-wrapper args;
   wrapRustc = rustc-unwrapped: wrapRustcWith { inherit rustc-unwrapped; };
 
-  rust_1_97 = callPackage ../development/compilers/rust/1_97.nix { };
+  rust_1_97 = callPackage ../development/compilers/rust/1_97.nix {
+    llvm_22 = llvmPackages_22.libllvm;
+  };
   rust = rust_1_97;
 
   mrustc = callPackage ../development/compilers/mrustc { };


### PR DESCRIPTION
## Problem

rustc crashes compiling certain crates at `opt-level = 3` on x86_64-linux:

```
rustc-LLVM ERROR: Cannot select: intrinsic %llvm.x86.avx512.vpdpwssd.512
```

Reproducer (surrealdb's `diskann-vector`, versions 0.52.0 and 0.54.0 both trigger it):

```
cargo new repro && cd repro
cargo add diskann-vector@0.54.0
cargo build -r
```

Same rustc source, different LLVM, opposite outcomes:

| Toolchain | rustc source | LLVM linked | Result |
|---|---|---|---|
| Official rust 1.96.1 (static.rust-lang.org) | 31fca3adb | bundled 22.1.2 | compiles clean |
| nixpkgs rustc 1.96.1 | 31fca3adb (same commit) | system 21.1.8 | `Cannot select: intrinsic %llvm.x86.avx512.vpdpwssd.512` |

The official rust 1.97.0 tarball likewise reports `LLVM version: 22.1.6`.

## Root cause

Since Rust 1.96, rustc codegen emits `llvm.experimental.vector.partial.reduce.add`, which the X86 backend lowers via AVX512-VNNI intrinsics (`llvm.x86.avx512.vpdpwssd.512` / `vpdpbusd.512`). LLVM 22 can instruction-select these on baseline x86-64; LLVM 21 cannot.

The header of `pkgs/development/compilers/rust/1_97.nix` says the build LLVM "should match with rust upstream" (check the `src/llvm-project` submodule). Rust 1.97.0 pins that submodule to a `rustc/22.1` branch (the official 1.97.0 tarball reports `LLVM version: 22.1.6`). But since deb4234fc197 ("rust: track latest LLVM to simplify version bumps"), rust's real LLVM comes from `pkgSet.llvmPackages`, the tree default, which is still 21, so the mismatch happened silently when the default lagged upstream.

This is already being felt in tree: see #537113 and the diagnosis in its comments (rustc expects the rust-lang/llvm-project fix 94e2c19f86a699d7a19ff0f4130b696699189c8d, present in LLVM 22, missing from nixpkgs' LLVM 21). Two packages carry per-package workarounds gated on `lib.versionOlder rustc.llvm.version "22"`, which auto-deactivate with this change and can be removed in a follow-up:

- `pkgs/servers/sql/postgresql/ext/vectorchord/package.nix` (disables avx512vnni)
- `pkgs/by-name/mi/mistral-rs/package.nix`

## Fix

Pin rust 1.97 to `llvmPackages_22` inside `1_97.nix` itself: the `llvmSharedFor` lookups become `pkgSet.llvmPackages_22.libllvm.override ...` (and `pkgSet.pkgsBuildHost.llvmPackages_22.clangUseLLVM`), and `llvmPackages = llvmPackages_22` is passed through to `./default.nix`. This is the reverse of deb4234fc197's generalization and matches the established idiom from before that commit (1_89.nix on `llvmPackages_20`).

Note for reviewers: a callPackage-level `llvmPackages` override in all-packages.nix does not work here. `llvmShared*` are computed from the whole package sets, so such an override only changes the passthru and auxiliary flags while rustc keeps linking LLVM 21, and it would misreport the LLVM version to LTO consumers. The in-file versioned pin is the only override point that keeps the linked LLVM, the passthru, and all four cross pkgSet lookups consistent.

The pin should be dropped when the default `llvmPackages` moves to 22, or folded into the next rust release init.

## Verification status

Stating this plainly rather than implying more than was done:

- `nix eval .#rustc.llvm.version` (the actually-linked LLVM) resolves to 22.1.8 on this branch, as does `.#rustc.llvmPackages.llvm.version`; `pkgsCross.aarch64-multiplatform.rustc.llvm.version` evals to 22.1.8 as well.
- The miscompile/crash pair was confirmed against the official upstream toolchain (same rustc commit, bundled LLVM 22 compiles clean; nixpkgs LLVM 21 crashes), not by rebuilding this derivation end to end.
- This was NOT full-bootstrap-built locally (mass-rebuild scale is out of reach on my hardware). Requesting OfBorg builds of `rustc.passthru.tests` (fd, ripgrep, wezterm, firefox, thunderbird) and ideally chromium; Hydra/staging CI is the real end-to-end test for a change of this size.

## Question for maintainers: browser toolchain coupling

`rustc.llvmPackages` is consumed by `build-mozilla-mach` and chromium/electron as their entire C++ toolchain ("Target the LLVM version that rustc is built with for LTO"). The clang/rustc LTO version match is preserved by construction here, since clang and rustc move to 22 together. But the side effect is that firefox, thunderbird, librewolf, floorp, chromium and electron all silently switch to clang 22 (chromium already carries `chromium-*-llvm-22.patch` files, so 22 was anticipated there). Two explicit questions:

1. Is firefox-esr-140 under clang 22 known-good, or should its build be gated/checked first? That is the single most plausible breakage and is currently unverified.
2. Would you rather take this per-rust pin now, or coordinate it with a tree-wide default `llvmPackages` 21 to 22 bump? The pin matches the file's own "match rust upstream" policy either way.

A possible hardening for discussion: an assertion comparing `lib.versions.major llvmPackages_22.llvm.version` against the expected major from the release checklist, so a silent default-LLVM drift cannot recur unnoticed.

## Scope / process

- Mass rebuild: `rust = rust_1_97` is the only rust in tree, so this rebuilds the bootstrap chain, cargo, every rustPlatform/buildRustPackage package (~2800+), plus the browsers. Targeted at `staging` per the 1_97.nix header and CONTRIBUTING.md.
- This is a recurrence of a documented checklist gap: the 1_97.nix header instructs verifying the LLVM match against the `src/llvm-project` submodule at each release, and that step was evidently skipped; the rust team may want to tighten the bump template.
- Review requested from @NixOS/rust (via the review-request UI); mozilla and chromium maintainers pinged for the toolchain switch.
