### PR TITLE
nextcloud-talk-desktop: 2.1.1 -> 2.2.1

### DIFF
--- a/pkgs/by-name/ne/nextcloud-talk-desktop/package.nix
+++ b/pkgs/by-name/ne/nextcloud-talk-desktop/package.nix
@@ -32,11 +32,11 @@
 }:
 let
   pname = "nextcloud-talk-desktop";
-  version = "2.1.1"; # Ensure both hashes (Linux and Darwin) are updated!
+  version = "2.2.1"; # Ensure both hashes (Linux and Darwin) are updated!
 
   hashes = {
-    linux = "sha256-s6+p21KLoDvcQz0EgV7WYIwYc9JolZpqkxZ8iIol8Yg=";
-    darwin = "sha256-rp6+bYb3Y8yEXYUY+cuDo7Lw6cq/EUnPjLIqscKeULc=";
+    linux = "sha256-AhNHPejdnGmL55/mHGKkDaGWl2fm7uufX4JaB5VSBos=";
+    darwin = "sha256-TkLAydkedLbi6vqd3kvQNkVnXGSHfF6xTBF3PCOgJ6I=";
   };
 
   # Only x86_64-linux is supported with Darwin support being universal
@@ -62,7 +62,7 @@ let
   meta = {
     description = "Nextcloud Talk Desktop Client";
     homepage = "https://github.com/nextcloud/talk-desktop";
-    changelog = "https://github.com/nextcloud/talk-desktop/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/nextcloud/talk-desktop/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [ kashw2 ];
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];


### PR DESCRIPTION
Update Nextcloud Talk Desktop to 2.2.1.

Upstream changelog: https://github.com/nextcloud/talk-desktop/blob/v2.2.1/CHANGELOG.md

This also corrects the package's changelog URL to include upstream's `v` tag prefix. The existing Linux patching and runtime dependency set remains sufficient; `autoPatchelfHook` reported no unsatisfied dependencies.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

PR summary drafted with Oh My Pi using `gpt-5.6-sol`.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/tree/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/tree/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/tree/master/pkgs/test