### PR TITLE
tableplus: 0.1.296 -> 0.1.308

### DIFF
--- a/pkgs/by-name/ta/tableplus/linux.nix
+++ b/pkgs/by-name/ta/tableplus/linux.nix
@@ -19,14 +19,13 @@
   libx11,
   libxcb,
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "tableplus";
-  version = "0.1.296";
+  version = "0.1.308";
 
   src = fetchurl {
     url = "https://web.archive.org/web/20251230232124/https://deb.tableplus.com/debian/22/pool/main/t/tableplus/tableplus_${finalAttrs.version}_amd64.deb";
-    hash = "sha256-BJ+S2cBRZtehDU5DOzNEVGzhMoF4jvsNSwntoa5bnlc=";
+    hash = "sha256-sqiA+iCZrqHPIkh24JejtfBvILtZt3HN2bKf/1Sc714=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].