### PR TITLE
freeipa: 4.12.5 -> 4.13.1

### DIFF
--- a/pkgs/by-name/fr/freeipa/package.nix
+++ b/pkgs/by-name/fr/freeipa/package.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchurl,
-  fetchpatch,
   pkg-config,
   autoconf,
   automake,
@@ -75,25 +74,12 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "freeipa";
-  version = "4.12.5";
+  version = "4.13.1";
 
   src = fetchurl {
     url = "https://releases.pagure.org/freeipa/freeipa-${finalAttrs.version}.tar.gz";
-    hash = "sha256-jvXS9Hx9VGFccFL19HogfH15JVIW7pc3/TY1pOvJglM=";
+    hash = "sha256-U1MSfXxWynK8LUWDdtRX+LDMRRzb0x3Hk5qIBY6RUnw=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "support-pyca-44.0";
-      url = "https://github.com/freeipa/freeipa/pull/7619/commits/2dc4133920fe58ce414c545102c74173d40d1997.patch";
-      hash = "sha256-PROnPc/1qS3hcO8s5sel55tsyZ1VPjEKLcua8Pd4DP0=";
-    })
-    (fetchpatch {
-      name = "fix-tripledes-cipher-warnings";
-      url = "https://github.com/freeipa/freeipa/pull/7619/commits/e2bf6e4091c7b5320ec6387dab2d5cabe4a9a42d.patch";
-      hash = "sha256-AyMK0hjXMrFK4/qIcjPMFH9DKvnvYOK2QS83Otcc+l4=";
-    })
-  ];
 
   nativeBuildInputs = [
     python3Packages.wrapPython


### PR DESCRIPTION
https://www.freeipa.org/release-notes/4-13-0.html
https://www.freeipa.org/release-notes/4-13-1.html

4.13.2 is already tagged in the development repo, but not available at the usual download location.

The patches are no longer needed, since they are included in this release.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
