### PR TITLE
afew: use versionCheckHook

### DIFF
--- a/pkgs/by-name/af/afew/package.nix
+++ b/pkgs/by-name/af/afew/package.nix
@@ -3,8 +3,7 @@
   python3Packages,
   fetchPypi,
   pkgs,
-  testers,
-  afew,
+  versionCheckHook,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
@@ -39,6 +38,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   nativeCheckInputs = [
     pkgs.notmuch
+    versionCheckHook
   ]
   ++ (with python3Packages; [
     freezegun
@@ -54,12 +54,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "doc"
     "man"
   ];
-
-  passthru.tests = {
-    version = testers.testVersion {
-      package = afew;
-    };
-  };
 
   meta = {
     homepage = "https://github.com/afewmail/afew";


### PR DESCRIPTION
Suugested in https://github.com/NixOS/nixpkgs/pull/544256#issuecomment-5036216052.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
