### PR TITLE
gaypanel: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12104,6 +12104,11 @@
     githubId = 17727163;
     keys = [ { fingerprint = "FBAA B86A 101B 4C5F D4F1  25D2 E93D DAC1 7E5D 6CA1"; } ];
   };
+  itsyunaya = {
+    name = "Ashley Marino";
+    github = "itsyunaya";
+    githubId = 40719746;
+  };
   ius = {
     email = "j.de.gram@gmail.com";
     name = "Joerie de Gram";

--- a/pkgs/by-name/ga/gaypanel/package.nix
+++ b/pkgs/by-name/ga/gaypanel/package.nix
@@ -1,0 +1,56 @@
+{
+  alsa-lib,
+  blueprint-compiler,
+  dbus,
+  fetchFromCodeberg,
+  gdk-pixbuf,
+  glib,
+  gtk4,
+  gtk4-layer-shell,
+  lib,
+  libadwaita,
+  libxkbcommon,
+  pango,
+  pkg-config,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "gaypanel";
+  version = "1.0.0";
+
+  src = fetchFromCodeberg {
+    owner = "pastthepixels";
+    repo = "gaypanel";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Hli57fE4lAfhUQf4kjRqvu+QwMy2U81hMzKjSUB3aoI=";
+  };
+
+  cargoHash = "sha256-1kNqtuley4L7VAq2UgJk/BWVqKNtvrQ3sNx+J1ZTIdI=";
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    blueprint-compiler
+    pkg-config
+  ];
+
+  buildInputs = [
+    alsa-lib
+    dbus
+    gdk-pixbuf
+    glib
+    gtk4
+    gtk4-layer-shell
+    libadwaita
+    libxkbcommon
+    pango
+  ];
+
+  meta = {
+    description = "Panel for Wayland compositors";
+    homepage = "https://codeberg.org/pastthepixels/gaypanel";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ itsyunaya ];
+    mainProgram = "gaypanel";
+  };
+})


### PR DESCRIPTION
Adds [gaypanel](https://codeberg.org/pastthepixels/gaypanel), a panel for Wayland compositors
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
