### PR TITLE
emacs.pkgs.ghostel: teach updateScript to update vendored zig deps

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/ghostel/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/ghostel/package.nix
@@ -69,9 +69,10 @@ melpaBuild {
   '';
 
   passthru = {
-    updateScript = nix-update-script { };
+    updateScript = nix-update-script { extraArgs = [ "--custom-dep=deps" ]; };
 
     inherit module;
+    inherit (module) deps;
   };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/ghostel/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/ghostel/package.nix
@@ -26,7 +26,7 @@ let
   module = stdenv.mkDerivation (finalAttrs: {
     inherit pname version src;
 
-    deps = zig.fetchDeps {
+    zigDeps = zig.fetchDeps {
       inherit (finalAttrs) src pname version;
       fetchAll = true;
       hash = "sha256-yrVgiofdmVjTGJ+PGPGRCc8gb/JcEca1uAzIoPgHHqU=";
@@ -49,7 +49,7 @@ let
     zigBuildFlags = finalAttrs.zigCheckFlags;
 
     postConfigure = ''
-      cp -rLT ${finalAttrs.deps} "$ZIG_GLOBAL_CACHE_DIR/p"
+      cp -rLT ${finalAttrs.zigDeps} "$ZIG_GLOBAL_CACHE_DIR/p"
       chmod -R u+w "$ZIG_GLOBAL_CACHE_DIR/p"
     '';
   });
@@ -69,10 +69,10 @@ melpaBuild {
   '';
 
   passthru = {
-    updateScript = nix-update-script { extraArgs = [ "--custom-dep=deps" ]; };
+    updateScript = nix-update-script { };
 
     inherit module;
-    inherit (module) deps;
+    inherit (module) zigDeps;
   };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/ghostel/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/ghostel/package.nix
@@ -12,6 +12,46 @@
 let
   zig = zig_0_15;
 
+  mkModule =
+    {
+      pname,
+      version,
+      src,
+      zigDeps,
+    }:
+    stdenv.mkDerivation (finalAttrs: {
+      inherit
+        pname
+        version
+        src
+        zigDeps
+        ;
+
+      nativeBuildInputs = [ zig ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ xcbuild ];
+
+      env.EMACS_INCLUDE_DIR = "${emacs}/include";
+
+      dontSetZigDefaultFlags = true;
+
+      doCheck = true;
+
+      zigCheckFlags = [
+        "-Dcpu=baseline"
+        # See https://github.com/ghostty-org/ghostty/blob/main/PACKAGING.md#build-options
+        "-Doptimize=ReleaseFast"
+      ];
+
+      zigBuildFlags = finalAttrs.zigCheckFlags;
+
+      postConfigure = ''
+        cp -rLT ${finalAttrs.zigDeps} "$ZIG_GLOBAL_CACHE_DIR/p"
+        chmod -R u+w "$ZIG_GLOBAL_CACHE_DIR/p"
+      '';
+    });
+
+  libExt = stdenv.hostPlatform.extensions.sharedLibrary;
+in
+melpaBuild (finalAttrs: {
   pname = "ghostel";
 
   version = "0.44.0";
@@ -19,60 +59,37 @@ let
   src = fetchFromGitHub {
     owner = "dakra";
     repo = "ghostel";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-vRGZoQtjsL42ga07fOfEjccKRidAhqgwHBoKs++62Ls=";
   };
 
-  module = stdenv.mkDerivation (finalAttrs: {
-    inherit pname version src;
-
-    zigDeps = zig.fetchDeps {
-      inherit (finalAttrs) src pname version;
-      fetchAll = true;
-      hash = "sha256-yrVgiofdmVjTGJ+PGPGRCc8gb/JcEca1uAzIoPgHHqU=";
-    };
-
-    nativeBuildInputs = [ zig ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ xcbuild ];
-
-    env.EMACS_INCLUDE_DIR = "${emacs}/include";
-
-    dontSetZigDefaultFlags = true;
-
-    doCheck = true;
-
-    zigCheckFlags = [
-      "-Dcpu=baseline"
-      # See https://github.com/ghostty-org/ghostty/blob/main/PACKAGING.md#build-options
-      "-Doptimize=ReleaseFast"
-    ];
-
-    zigBuildFlags = finalAttrs.zigCheckFlags;
-
-    postConfigure = ''
-      cp -rLT ${finalAttrs.zigDeps} "$ZIG_GLOBAL_CACHE_DIR/p"
-      chmod -R u+w "$ZIG_GLOBAL_CACHE_DIR/p"
-    '';
-  });
-
-  libExt = stdenv.hostPlatform.extensions.sharedLibrary;
-in
-melpaBuild {
-  inherit pname version src;
+  # this can be put into mkModule, but we put it here to ease user overrideAttrs
+  zigDeps = zig.fetchDeps {
+    inherit (finalAttrs) src pname version;
+    fetchAll = true;
+    hash = "sha256-yrVgiofdmVjTGJ+PGPGRCc8gb/JcEca1uAzIoPgHHqU=";
+  };
 
   files = ''
     (:defaults "etc" "ghostel-module${libExt}" "ghostel-module.version")
   '';
 
   preBuild = ''
-    install ${module}/ghostel-module${libExt} ghostel-module${libExt}
-    install --mode=444 ${module}/ghostel-module.version ghostel-module.version
+    install ${finalAttrs.finalPackage.module}/ghostel-module${libExt} ghostel-module${libExt}
+    install --mode=444 ${finalAttrs.finalPackage.module}/ghostel-module.version ghostel-module.version
   '';
 
   passthru = {
     updateScript = nix-update-script { };
 
-    inherit module;
-    inherit (module) zigDeps;
+    module = mkModule {
+      pname = "${finalAttrs.pname}-module";
+      inherit (finalAttrs)
+        version
+        src
+        zigDeps
+        ;
+    };
   };
 
   meta = {
@@ -84,4 +101,4 @@ melpaBuild {
     ];
     license = lib.licenses.gpl3Plus;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

It is easier to review this PR commit by commit.

See commit messages for details.

The first two commits are about updateScript.  I have tested that they can produce correct results.

The 3rd commit is about better overrideAttrs experience.  It is easier to review it using a github feature called "Hide whitespace".  I have tested it by check the built result files but I did not actually run the built result.  Reviewers, please do an overrideAttrs and test the result.
(This commit is a bit offtopic for this PR but I am too lazy to create a separate PR for it 😅.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
