### PR TITLE
prettier-plugin-tailwindcss: init at 0.8.1

### DIFF
--- a/pkgs/by-name/pr/prettier-plugin-tailwindcss/package.nix
+++ b/pkgs/by-name/pr/prettier-plugin-tailwindcss/package.nix
@@ -1,0 +1,76 @@
+{
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  lib,
+  nix-update-script,
+  nodejs,
+  pnpmConfigHook,
+  pnpm_11,
+  stdenv,
+}:
+
+let
+  pnpm = pnpm_11;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "prettier-plugin-tailwindcss";
+  version = "0.8.1";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "tailwindlabs";
+    repo = "prettier-plugin-tailwindcss";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-mqK3R1+VJ8PqKhkltZnQpTAn8mbQC4VfptoaqmxqobM=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    pnpm
+    pnpmConfigHook
+  ];
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = "sha256-ZhtyQsEnIoA9SpyD+oaXFzGSDAfufWnwiL7C8ImLZ7E=";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    NODE_ENV=production pnpm run build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/node_modules/prettier-plugin-tailwindcss
+
+    # Required for `pnpm deploy` to work without the `--legacy` flag
+    pnpm config set --location=project inject-workspace-packages true
+
+    pnpm --filter=prettier-plugin-tailwindcss --prod \
+      deploy $out/lib/node_modules/prettier-plugin-tailwindcss/
+
+    # Workaround for "Cannot find package 'prettier' imported from ..."
+    cp -rL node_modules/prettier $out/lib/node_modules/prettier-plugin-tailwindcss/node_modules/
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Formatter plugin for Tailwind CSS";
+    homepage = "https://github.com/tailwindlabs/prettier-plugin-tailwindcss";
+    changelog = "https://github.com/tailwindlabs/prettier-plugin-tailwindcss/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ starryreverie ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).

I have tested this plugin by integrating `pkgs.prettier` with it:

```bash
starryreverie@superposition (init-prettier-plugin-tailwindcss) ~/u/d/nixpkgs (21:43)
> nix-build --expr "let pkgs = (import ./. { }); in pkgs.prettier.override { plugins = [ pkgs.prettier-plugin-tailwindcss ]; }"
/nix/store/icnkkidkcprds9akxlk02kiwphzqwh0j-prettier-3.8.3
starryreverie@superposition (init-prettier-plugin-tailwindcss) ~/u/d/nixpkgs (21:43)
> cat /tmp/prettier-plugin-tailwindcss/MyButton.jsx
function MyButton({ children }) {
  return (
    <button class="bg-blue-500 py-2 px-4 text-base text-white rounded">
      {children}
    </button>
  );
}
starryreverie@superposition (init-prettier-plugin-tailwindcss) ~/u/d/nixpkgs (21:43)
> ./result/bin/prettier /tmp/prettier-plugin-tailwindcss/MyButton.jsx
function MyButton({ children }) {
  return (
    <button class="rounded bg-blue-500 px-4 py-2 text-base text-white">
      {children}
    </button>
  );
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
