### PR TITLE
python3Packages.pycyphal2: init at 2.0.0.dev9

### DIFF
--- a/pkgs/development/python-modules/pycyphal2/default.nix
+++ b/pkgs/development/python-modules/pycyphal2/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build system
+  setuptools,
+
+  # optional dependencies
+  ifaddr,
+  python-can,
+
+  # tests
+  pytest-asyncio,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pycyphal2";
+  version = "2.0.0.dev9";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "OpenCyphal";
+    repo = "pycyphal";
+    tag = version;
+    hash = "sha256-s4VTQ4VxZwPZHPAHYtLk7rcJ8bZHk4Wy9jP+8Q7seXc=";
+    fetchSubmodules = true;
+  };
+
+  build-system = [ setuptools ];
+
+  optional-dependencies = {
+    pythoncan = [ python-can ] ++ python-can.optional-dependencies.serial;
+    udp = [ ifaddr ];
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+  ]
+  ++ lib.concatAttrValues optional-dependencies;
+
+  pythonImportsCheck = [ "pycyphal2" ];
+
+  meta = {
+    description = "Pure-Python implementation of the Cyphal protocol stack";
+    longDescription = ''
+      Cyphal in Python — decentralized real-time pub/sub with tunable reliability, service discovery, and zero configuration. Works anywhere, including baremetal MCUs.
+    '';
+    homepage = "https://opencyphal.org/";
+    changelog = "https://github.com/OpenCyphal/pycyphal/blob/${version}/CHANGELOG.rst";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bjsowa ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14306,6 +14306,8 @@ self: super: with self; {
 
   pycyphal = callPackage ../development/python-modules/pycyphal { };
 
+  pycyphal2 = callPackage ../development/python-modules/pycyphal2 { };
+
   pydaikin = callPackage ../development/python-modules/pydaikin { };
 
   pydal = callPackage ../development/python-modules/pydal { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Python implementation of the [Cyphal](https://opencyphal.org/) stack that runs on GNU/Linux, Windows, and macOS.

This is v2 version of the library, pushed under a different name to allow coexistence with v1 pycyphal.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
