### PR TITLE
gotosocial: fix cross-compilation on RISCV

### DIFF
--- a/pkgs/by-name/go/gotosocial/package.nix
+++ b/pkgs/by-name/go/gotosocial/package.nix
@@ -1,13 +1,25 @@
 {
   lib,
+  stdenv,
   buildGo125Module,
   fetchFromCodeberg,
   fetchYarnDeps,
   nodejs,
   yarn,
   yarnConfigHook,
+  makeBinaryWrapper,
+  ffmpeg,
   nixosTests,
   nix-update-script,
+  # Wazero (the WASM runtime GoToSocial uses to bundle ffmpeg/ffprobe/sqlite3)
+  # only has a fast "compiler" backend for amd64 and arm64. On every other
+  # architecture (riscv64, 32-bit ARM, ppc64le, ...) it falls back to a WASM
+  # interpreter that is far too slow for real-world media processing.
+  # Upstream exposes the explicitly unsupported/experimental "nowasm" build
+  # tag for this situation: it drops the embedded WASM ffmpeg/ffprobe/sqlite3
+  # and instead shells out to ffmpeg/ffprobe binaries found on $PATH.
+  # See: https://docs.gotosocial.org/en/latest/advanced/builds/nowasm/
+  withWasm ? stdenv.hostPlatform.isx86_64 || stdenv.hostPlatform.isAarch64,
 }:
 buildGo125Module (finalAttrs: {
   pname = "gotosocial";
@@ -30,13 +42,15 @@ buildGo125Module (finalAttrs: {
 
   tags = [
     "kvformat"
-  ];
+  ]
+  ++ lib.optionals (!withWasm) [ "nowasm" ];
 
   nativeBuildInputs = [
     nodejs
     yarn
     yarnConfigHook
-  ];
+  ]
+  ++ lib.optionals (!withWasm) [ makeBinaryWrapper ];
 
   yarnOfflineCache = fetchYarnDeps {
     yarnLock = "${finalAttrs.src}/web/source/yarn.lock";
@@ -68,6 +82,12 @@ buildGo125Module (finalAttrs: {
 
     mkdir -p $out/share/gotosocial/web
     mv web/{assets,template} $out/share/gotosocial/web
+  ''
+  + lib.optionalString (!withWasm) ''
+    # nowasm builds need ffmpeg/ffprobe available on $PATH at runtime,
+    # since the embedded WASM copies have been compiled out.
+    wrapProgram $out/bin/gotosocial \
+      --prefix PATH : ${lib.makeBinPath [ ffmpeg ]}
   '';
 
   # tests are working only on x86_64-linux


### PR DESCRIPTION
Patch to enable cross-compilation and running on RISCV.

```
  # Wazero (the WASM runtime GoToSocial uses to bundle ffmpeg/ffprobe/sqlite3)
  # only has a fast "compiler" backend for amd64 and arm64. On every other
  # architecture (riscv64, 32-bit ARM, ppc64le, ...) it falls back to a WASM
  # interpreter that is far too slow for real-world media processing.
  # Upstream exposes the explicitly unsupported/experimental "nowasm" build
  # tag for this situation: it drops the embedded WASM ffmpeg/ffprobe/sqlite3
  # and instead shells out to ffmpeg/ffprobe binaries found on $PATH.
  # See: https://docs.gotosocial.org/en/latest/advanced/builds/nowasm/
```  

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
