### PR TITLE
space-station-14-launcher: rename derivation; remove rec; add version; reorganize

### DIFF
--- a/pkgs/by-name/sp/space-station-14-launcher/package.nix
+++ b/pkgs/by-name/sp/space-station-14-launcher/package.nix
@@ -39,15 +39,13 @@
   soundfont-path ? "${soundfont-fluid}/share/soundfonts/FluidR3_GM2-2.sf2",
 }:
 let
-  pname = "space-station-14-launcher";
   version = "0.39.1";
+  buildType = "Release";
 in
-buildDotnetModule rec {
-  inherit pname;
+buildDotnetModule {
+  inherit version buildType;
 
-  # Workaround to prevent buildDotnetModule from overriding assembly versions.
-  # If you inherit version it will break loading Robust.LoaderApi when connecting to a server!
-  name = "${pname}-${version}";
+  pname = "SS14.Launcher";
 
   src = fetchFromGitHub {
     owner = "space-wizards";
@@ -57,22 +55,21 @@ buildDotnetModule rec {
     fetchSubmodules = true;
   };
 
-  buildType = "Release";
-  selfContainedBuild = false;
+  _structuredAttrs = true;
+  strictDeps = true;
+
+  nugetDeps = ./deps.json;
+
+  passthru.updateScript = nix-update-script { };
 
   projectFile = [
     "SS14.Loader/SS14.Loader.csproj"
     "SS14.Launcher/SS14.Launcher.csproj"
   ];
 
-  nugetDeps = ./deps.json;
-
-  passthru = {
-    inherit version;
-  };
-
   dotnet-sdk = dotnetCorePackages.sdk_10_0;
-  dotnet-runtime = dotnetCorePackages.runtime_10_0;
+
+  executables = [ "SS14.Launcher" ];
 
   dotnetFlags = [
     "-p:FullRelease=true"
@@ -80,10 +77,13 @@ buildDotnetModule rec {
     "-nologo"
   ];
 
-  nativeBuildInputs = [
-    iconConvTools
-    copyDesktopItems
-  ];
+  # Workaround to prevent buildDotnetModule from overriding assembly versions.
+  # If this is not done it will break Robust.LoaderApi when connecting to a server!
+  # I do not believe there is any way in nix (apart from overrideAttrs) to do this
+  preBuild = ''
+    version=""
+    versionForDotnet=""
+  '';
 
   runtimeDeps = [
     libGL
@@ -113,32 +113,33 @@ buildDotnetModule rec {
   # via https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html under ${parameter@operator}
   makeWrapperArgs = [ "--set ROBUST_SOUNDFONT_OVERRIDE ${soundfont-path}" ];
 
-  executables = [ "SS14.Launcher" ];
+  nativeBuildInputs = [
+    iconConvTools
+    copyDesktopItems
+  ];
 
   desktopItems = [
     (makeDesktopItem {
-      name = pname;
-      exec = meta.mainProgram;
-      icon = pname;
+      name = "SS14.Launcher";
+      exec = "SS14.Launcher";
+      icon = "SS14";
       desktopName = "Space Station 14 Launcher";
-      comment = meta.description;
+      comment = "A multiplayer disaster simulator";
       categories = [ "Game" ];
-      startupWMClass = meta.mainProgram;
+      startupWMClass = "SS14.Launcher";
     })
   ];
 
   postInstall = ''
-    mkdir -p $out/lib/space-station-14-launcher/loader
-    cp -r SS14.Loader/bin/${buildType}/*/*/* $out/lib/space-station-14-launcher/loader/
+    mkdir -p $out/lib/SS14.Launcher/loader
+    cp -r SS14.Loader/bin/${buildType}/*/*/* $out/lib/SS14.Launcher/loader/
 
-    icoFileToHiColorTheme SS14.Launcher/Assets/icon.ico ${pname} $out
+    icoFileToHiColorTheme SS14.Launcher/Assets/icon.ico SS14 $out
   '';
-
-  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Launcher for Space Station 14, a multiplayer game about paranoia and disaster";
-    homepage = "https://spacestation14.io";
+    homepage = "https://spacestation14.com";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.coca ];
     platforms = [ "x86_64-linux" ];


### PR DESCRIPTION
General grab-bag of changes to try to make the package less cursed. `space-station-14-launcher` is now only the name in nixpkgs and isn't used anywhere in the derivation, being replaced entirely with the actual name (`SS14.Launcher`).

Moved around atttributes to at least somewhat be ordered by the phases of packaging it.

Add version onto the derivation finally by using a hack in `preBuild` to make it work. I'm not really happy with this but I think `overrideAttrs` would be even worse to use (`InformationalVersion` also still needs to not be added as far as I've tested) and I cannot think of another way of fixing this without changing `buildDotnetModule`.

Changed the site to the one that actually exists right now and removed the recursive attribute.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
