### PR TITLE
netatalk-client: init at 0.9.5

### DIFF
--- a/pkgs/by-name/ne/netatalk-client/package.nix
+++ b/pkgs/by-name/ne/netatalk-client/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  libgcrypt,
+  readline,
+  libbsd,
+  fuse3,
+  # Build the FUSE filesystem client (afp_client / mount_afpfs).
+  withFuse ? stdenv.hostPlatform.isLinux,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "netatalk-client";
+  version = "0.9.5";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Netatalk";
+    repo = "netatalk-client";
+    tag = finalAttrs.version;
+    hash = "sha256-D4Urd+Hy0oiI5ETowWii7D+MHi7s6ltwZz26gCRWL1s=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    libgcrypt
+    readline
+  ]
+  ++ lib.optional stdenv.hostPlatform.isLinux libbsd
+  ++ lib.optional withFuse fuse3;
+
+  mesonFlags = [
+    (lib.mesonBool "enable-fuse" withFuse)
+  ];
+
+  meta = {
+    description = "AFP (Apple Filing Protocol) client: afpcmd shell and FUSE filesystem";
+    homepage = "https://github.com/Netatalk/netatalk-client";
+    changelog = "https://github.com/Netatalk/netatalk-client/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.gpl2Only;
+    mainProgram = "afpcmd";
+    maintainers = with lib.maintainers; [ nulleric ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
AFP (Apple Filing Protocol) client forked from afpfs-ng, providing the afpcmd command-line shell and a FUSE filesystem for mounting AFP shares from Netatalk servers, classic/OS X Macs, Time Capsule and other NAS devices.

https://github.com/Netatalk/netatalk-client

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
