### PR TITLE
python3Packages.pyglet: replace gtk2 usage with pillow

### DIFF
--- a/pkgs/development/python-modules/pyglet/default.nix
+++ b/pkgs/development/python-modules/pyglet/default.nix
@@ -13,10 +13,9 @@
   libxinerama,
   libxext,
   libx11,
+  pillow,
   pytestCheckHook,
   glibc,
-  gtk2-x11,
-  gdk-pixbuf,
   fontconfig,
   freetype,
   ffmpeg-full,
@@ -62,10 +61,6 @@ buildPythonPackage rec {
                   path = '${glibc}/lib/libc${ext}.6'
               elif name == 'X11':
                   path = '${libx11}/lib/libX11${ext}'
-              elif name == 'gdk-x11-2.0':
-                  path = '${gtk2-x11}/lib/libgdk-x11-2.0${ext}'
-              elif name == 'gdk_pixbuf-2.0':
-                  path = '${gdk-pixbuf}/lib/libgdk_pixbuf-2.0${ext}'
               elif name == 'Xext':
                   path = '${libxext}/lib/libXext${ext}'
               elif name == 'fontconfig':
@@ -125,6 +120,8 @@ buildPythonPackage rec {
     '';
 
   build-system = [ flit-core ];
+
+  dependencies = [ pillow ];
 
   # needs GL set up which isn't really possible in a build environment even in headless mode.
   # tests do run and pass in nix-shell, however.


### PR DESCRIPTION
Pyglet uses GDK 2.x for loading images in a gdkpixbuf. It also supports the same with Pillow, which is far more covenient and not dead.

Part of #410814

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
