### PR TITLE
keyd: add updateScript and do some housekeeping

### DIFF
--- a/pkgs/by-name/ke/keyd/package.nix
+++ b/pkgs/by-name/ke/keyd/package.nix
@@ -4,48 +4,23 @@
   fetchFromGitHub,
   runtimeShell,
   python3Packages,
-  nixosTests,
   versionCheckHook,
+  nixosTests,
+  nix-update-script,
 }:
-let
+stdenv.mkDerivation (finalAttrs: {
+  pname = "keyd";
   version = "2.6.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "rvaiya";
     repo = "keyd";
-    rev = "v" + version;
+    tag = "v${finalAttrs.version}";
     hash = "sha256-l7yjGpicX1ly4UwF7gcOTaaHPRnxVUMwZkH70NDLL5M=";
   };
-
-  appMap = python3Packages.buildPythonApplication (finalAttrs: {
-    pname = "keyd-application-mapper";
-    inherit version src;
-    pyproject = false;
-
-    postPatch = ''
-      substituteInPlace scripts/${finalAttrs.pname} \
-        --replace-fail /bin/sh ${runtimeShell}
-    '';
-
-    propagatedBuildInputs = with python3Packages; [
-      python-xlib
-      pygobject3.out
-      dbus-python.out
-    ];
-
-    dontBuild = true;
-
-    installPhase = ''
-      install -Dm555 -t $out/bin scripts/${finalAttrs.pname}
-    '';
-
-    meta.mainProgram = "keyd-application-mapper";
-  });
-
-in
-stdenv.mkDerivation {
-  pname = "keyd";
-  inherit version src;
 
   postPatch = ''
     substituteInPlace Makefile \
@@ -57,24 +32,52 @@ stdenv.mkDerivation {
 
   installFlags = [ "DESTDIR=${placeholder "out"}" ];
 
-  nativeInstallCheckInputs = [ versionCheckHook ];
-  doInstallCheck = true;
-
   enableParallelBuilding = true;
 
   postInstall = ''
-    ln -sf ${lib.getExe appMap} $out/bin/${appMap.pname}
+    ln -sf ${lib.getExe finalAttrs.passthru.appMap} $out/bin/${finalAttrs.passthru.appMap.pname}
     rm -rf $out/etc
   '';
 
-  passthru.tests.keyd = nixosTests.keyd;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru = {
+    tests.keyd = nixosTests.keyd;
+    updateScript = nix-update-script { };
+    appMap = python3Packages.buildPythonApplication (finalAttrsApp: {
+      pname = "keyd-application-mapper";
+      inherit (finalAttrs) version src;
+      pyproject = false;
+
+      postPatch = ''
+        substituteInPlace scripts/${finalAttrsApp.pname} \
+          --replace-fail /bin/sh ${runtimeShell}
+      '';
+
+      propagatedBuildInputs = with python3Packages; [
+        python-xlib
+        pygobject3.out
+        dbus-python.out
+      ];
+
+      dontBuild = true;
+
+      installPhase = ''
+        install -Dm555 -t $out/bin scripts/${finalAttrsApp.pname}
+      '';
+
+      meta.mainProgram = "keyd-application-mapper";
+    });
+  };
 
   meta = {
     description = "Key remapping daemon for Linux";
     homepage = "https://github.com/rvaiya/keyd";
+    changelog = "https://github.com/rvaiya/keyd/blob/master/docs/CHANGELOG.md";
     license = lib.licenses.mit;
     mainProgram = "keyd";
     maintainers = with lib.maintainers; [ alfarel ];
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
- I added an updateScript to automate the update of the package for the maintainer.
- I also updated the package to use the `finalAttrs` logic for the package itself and not only the appMap.
- Added the `__structuredAttrs` and `strictDeps` attributes.
- Replaced `rev` with `tag` in the `src` attribute.
- Put install check config bellow the install phase. 
- Added a changelog link to the release page on github of the project.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
