### PR TITLE
moonshine: init at 0.13.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19919,6 +19919,12 @@
     name = "neo";
     email = "chojs990222@gmail.com";
   };
+  neobrain = {
+    github = "neobrain";
+    githubId = 4840017;
+    matrix = "@neobrain:matrix.org";
+    name = "Tony Wasserka";
+  };
   neonvoid = {
     email = "me@neonvoid.dev";
     github = "neonvoidx";

--- a/pkgs/by-name/mo/moonshine/package.nix
+++ b/pkgs/by-name/mo/moonshine/package.nix
@@ -1,0 +1,125 @@
+{
+  cmake,
+  fetchFromGitHub,
+  pkg-config,
+  lib,
+  libevdev,
+  libgbm,
+  libGL,
+  libopus,
+  libx11,
+  libxkbcommon,
+  libxres,
+  nix-update-script,
+  rustPlatform,
+  versionCheckHook,
+  vulkan-loader,
+  wayland,
+}:
+
+let
+  # Fetch the C++ sources of inputtino explicitly since the inputtino-sys crate requires them to be present.
+  # Revision matches Cargo.lock
+  inputtino-src = fetchFromGitHub {
+    owner = "games-on-whales";
+    repo = "inputtino";
+    rev = "f4ce2b0df536ef309e9ff318f75b460f7097d7c1";
+    hash = "sha256-mAAXbIK7aNSLyN7OZX9YeesMvT6OZmT9uAx0md6pyRM=";
+  };
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "moonshine";
+  version = "0.13.5";
+
+  src = fetchFromGitHub {
+    owner = "hgaiser";
+    repo = "moonshine";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DwRUVMAm4fSqZu6jECeasiRpnwBt7thWkXzztNRIjcs=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  cargoHash = "sha256-M/VNPnccqK3koa0TeMd+tml79O7BKLxHmrGcGPemGhI=";
+
+  # Build Moonshine binary and Vulkan layer
+  cargoBuildFlags = [
+    "-p"
+    "moonshine"
+    "-p"
+    "moonshine-wsi"
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    libevdev
+    libgbm
+    libopus
+    libxkbcommon
+    wayland
+  ];
+
+  # Patch build.rs from inputtino-sys with the C++ inputtino sources.
+  # Also drop the unneeded libc++ dependency.
+  postPatch = ''
+    grep -q 'inputtino#${inputtino-src.rev}' Cargo.lock || {
+      echo "ERROR: inputtino revision needs update (must match Cargo.lock)"
+      exit 1
+    }
+
+    substituteInPlace $cargoDepsCopy/*/inputtino-sys-*/build.rs \
+      --replace-fail 'PathBuf::from("../../../")' 'PathBuf::from("${inputtino-src}")' \
+      --replace-fail 'println!("cargo:rustc-link-lib=c++");' ""
+  '';
+
+  postInstall = ''
+    # Setup implicit Vulkan layer manifest as required by Moonshine
+    install -d "$out/share/vulkan/implicit_layer.d"
+    substitute dist/VkLayer_moonshine_wsi.json \
+      "$out/share/vulkan/implicit_layer.d/VkLayer_moonshine_wsi.json" \
+      --replace-fail /usr/lib/moonshine/vulkan-layers/libmoonshine_wsi.so \
+        "$out/lib/libmoonshine_wsi.so"
+
+    # udev rules for input
+    install -Dm644 dist/60-moonshine.rules "$out/lib/udev/rules.d/60-moonshine.rules"
+  '';
+
+  postFixup = ''
+    patchelf --add-rpath ${
+      lib.makeLibraryPath [
+        libGL
+        vulkan-loader
+        # Required by Steam focus protocol (x11_focus.rs)
+        libx11
+        libxres
+      ]
+    } "$out/bin/moonshine"
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  # NOTE: If upstream bumps inputtino, this must be manually updated above
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Headless streaming server for Moonlight clients";
+    longDescription = ''
+      Moonshine lets you stream games from your PC to any device running Moonlight.
+      Your keyboard, mouse, and controller inputs are sent back to the host so you
+      can play games remotely as if you were sitting in front of it.
+    '';
+    homepage = "https://github.com/hgaiser/moonshine";
+    changelog = "https://github.com/hgaiser/moonshine/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ neobrain ];
+    mainProgram = "moonshine";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds [Moonshine](https://github.com/hgaiser/moonshine), a game streaming server for Moonlight clients. In contrast to Sunshine it uses headless operation, so it can be used without a physical display connected.

I started with a Claude-generated derivation on July 5 and revised it quite heavily, since a lot of its output was non-idiomatic or straight up unnecessary. **Every line submitted for review has a well-understood purpose and is required for proper Moonshine operation**, and generated comments have been replaced in favor of human-written ones. The package output has been regularly tested in the last 2 weeks against Moonlight running on an Android phone (verifying that both the `moonshine` binary and its Vulkan helper layer function correctly).

Sadly *after* cleaning up I noticed that #544393 was submitted in parallel, which seems to have taken the first output of an LLM and stuck with it. As mentioned this output has shortcomings, so I'm submitting mine as a partial alternative (my NixOS module is not part of the PR as I have only partially cleaned it up).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - ~~[ ] [NixOS tests] in [nixos/tests].~~
  - ~~[ ] [Package tests] at `passthru.tests`.~~
  - ~~[ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.~~
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
