### PR TITLE
vivliostyle: init at 11.1.0 

### DIFF
--- a/pkgs/by-name/vi/vivliostyle/0001-allow-specifying-browser-path-via-env-var.patch
+++ b/pkgs/by-name/vi/vivliostyle/0001-allow-specifying-browser-path-via-env-var.patch
@@ -1,0 +1,20 @@
+---
+ src/browser.ts | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/browser.ts b/src/browser.ts
+index 8e653e2..ae57d2f 100644
+--- a/src/browser.ts
++++ b/src/browser.ts
+@@ -355,6 +355,8 @@ export async function getExecutableBrowserPath({
+   type,
+   tag,
+ }: ResolvedTaskConfig['browser']): Promise<string> {
++  const envPath = process.env.VIVLIOSTYLE_BROWSER_PATH;
++  if (envPath && fs.existsSync(envPath)) return envPath;
+   const browsers = await importNodeModule('@puppeteer/browsers');
+   const buildId = await resolveBuildId({ type, tag, browsers });
+   return browsers.computeExecutablePath({
+-- 
+2.54.0
+

--- a/pkgs/by-name/vi/vivliostyle/package.nix
+++ b/pkgs/by-name/vi/vivliostyle/package.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  nix-update-script,
+
+  # build-time
+  makeBinaryWrapper,
+  nodejs,
+  pnpmBuildHook,
+  pnpmConfigHook,
+  pnpm_10,
+
+  chromium,
+  defaultBrowser ? chromium,
+}:
+
+let
+  pnpm = pnpm_10;
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vivliostyle";
+  version = "11.1.0";
+
+  src = fetchFromGitHub {
+    owner = "vivliostyle";
+    repo = "vivliostyle-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rbb/av3amlLit7OjTc+S/pf1SrxEnsENQOArgnc7k3s=";
+  };
+
+  patches = [
+    ./0001-allow-specifying-browser-path-via-env-var.patch
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = "sha256-WPTCLAEWmD1TY84281TJCzp+mcjMFM5Xwf02s7U+M4U=";
+  };
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    nodejs
+    pnpm
+    pnpmBuildHook
+    pnpmConfigHook
+  ];
+
+  pnpmBuildFlags = [
+    "--mode"
+    "production"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,lib}
+    mv {node_modules,dist,examples,packages,package.json} $out/lib
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    chmod +x $out/lib/dist/cli.js
+    patchShebangs $out/usr/lib/dist/cli.js
+
+    makeWrapper $out/lib/dist/cli.js $out/bin/vivliostyle \
+      --prefix PATH : ${lib.makeBinPath [ nodejs ]} \
+      --set VIVLIOSTYLE_BROWSER_PATH ${lib.getExe defaultBrowser}
+
+    ln -s $out/bin/vivliostyle $out/bin/vs
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "CLI tool for typesetting HTML and Markdown documents";
+    longDescription = ''
+      Vivliostyle is a CSS typesetting ecosystem for creating beautifully
+      formatted documents using web technologies.
+    '';
+    homepage = "https://github.com/vivliostyle/vivliostyle-cli";
+    changelog = "https://github.com/vivliostyle/vivliostyle-cli/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    mainProgram = "vivliostyle";
+    license = lib.licenses.agpl3Only;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})


### PR DESCRIPTION
[Vivliostyle](https://github.com/vivliostyle/vivliostyle.js) is a CSS typesetting ecosystem for creating beautifully formatted documents using web technologies.

This PR adds the [CLI tool of Vivliostyle](https://github.com/vivliostyle/vivliostyle-cli).

> [!NOTE]
> Work done as part of the [Nix@NGI](https://nixos.org/community/teams/ngi/) packaging effort 

Assisted-by: [nix-init](https://github.com/nix-community/nix-init)
Assisted-by: `DeepSeek V4 Flash Free` in adding the browser env var

Closes: https://github.com/ngi-nix/projects/issues/1301

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test