### PR TITLE
[Backport release-26.05] flameshot: toctou symlink attack fix (CVE-2026-62294)

### DIFF
--- a/pkgs/by-name/fl/flameshot/package.nix
+++ b/pkgs/by-name/fl/flameshot/package.nix
@@ -12,6 +12,7 @@
   nix-update-script,
   enableWlrSupport ? !stdenv.hostPlatform.isDarwin,
   enableMonochromeIcon ? false,
+  fetchpatch,
   wrapGAppsHook3,
 }:
 
@@ -48,6 +49,11 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     ./load-missing-deps.patch
     ./macos-build.patch
+    (fetchpatch {
+      name = "CVE-2026-62294.patch";
+      url = "https://github.com/flameshot-org/flameshot/commit/936716b8d8b7052be461c3d5e2f88492b6eb3b96.patch";
+      hash = "sha256-bhJ6fQJXkRoUME8juj6/8bQAO5V50tJfV0wcJfIoPg0=";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
In versions of Flameshot prior to 14.0, [CVE-2026-62294](https://nvd.nist.gov/vuln/detail/CVE-2026-62294) is present (TOCTOU symlink attack via "Open With...").
On the 26.05 release branch, Flameshot is on version 13.3.0, thus exposed to the vulnerability. 
This PR pulls patches in commit with the security fix while preserving current package version.

Resolves #544166
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
