### PR TITLE
md2conf: init at 0.6.1

### DIFF
--- a/pkgs/by-name/md/md2conf/package.nix
+++ b/pkgs/by-name/md/md2conf/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  versionCheckHook,
+  nix-update-script,
+  runCommand,
+  testers,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "md2conf";
+  version = "0.6.1";
+  __structuredAttrs = true;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "hunyadi";
+    repo = "md2conf";
+    tag = finalAttrs.version;
+    hash = "sha256-DFGFDJYpadcRZ6gJ4yjYHS7d+oJtu4L/fwKIyJDNneA=";
+  };
+
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [
+    cattrs
+    lxml
+    markdown
+    orjson
+    pymdown-extensions
+    pyyaml
+    requests
+    truststore
+    # "formulas" optional extra (matplotlib): available but omitted, to keep the closure lean
+    # typing-extensions is conditional on Python < 3.11; default interpreter is 3.12
+  ];
+
+  # The "dev" extra (mypy, ruff, types-*) is omitted: development tooling, not runtime.
+
+  pythonImportsCheck = [ "md2conf" ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = {
+      version = testers.testVersion {
+        package = finalAttrs.finalPackage;
+      };
+      help =
+        runCommand "md2conf-help-test"
+          {
+            nativeBuildInputs = [ finalAttrs.finalPackage ];
+          }
+          ''
+            md2conf --help > /dev/null
+            touch $out
+          '';
+    };
+  };
+
+  meta = {
+    description = "Publish Markdown files to Confluence wiki";
+    homepage = "https://github.com/hunyadi/md2conf";
+    changelog = "https://github.com/hunyadi/md2conf/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.gdifolco ];
+    mainProgram = "md2conf";
+  };
+})


### PR DESCRIPTION
md2conf converts Markdown files to Confluence Storage Format (XHTML) and publishes them to Confluence via the REST API. It supports sections, links, code blocks, images, tables, draw.io/Mermaid/PlantUML diagrams, LaTeX formulas and Confluence labels. Homepage: https://github.com/hunyadi/md2conf

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

