### PR TITLE
bat: fix escaping of shell settings values

### DIFF
--- a/nixos/modules/programs/bat.nix
+++ b/nixos/modules/programs/bat.nix
@@ -8,6 +8,7 @@ let
   inherit (builtins) isList;
   inherit (lib)
     concatMapStrings
+    escapeShellArg
     literalExpression
     maintainers
     mapAttrs'
@@ -34,7 +35,7 @@ let
     else if isBool value then
       boolToString value
     else
-      toString value;
+      escapeShellArg (toString value);
 in
 {
   options.programs.bat = {


### PR DESCRIPTION
`programs.bat.settings` values are converted with `toString` when generating the config, and the result is later parsed by the shell. This breaks whenever a value contains spaces, such as theme names.

For example, setting:
```nix
programs.bat.settings.theme = "Catppuccin Frappe";
```
produces the config line `--theme=Catppuccin Frappe`, which the shell then splits into two separate arguments. This causes `bat` to fail with:
```
[bat error]: 'Frappe': No such file or directory (os error 2)
[bat warning]: Unknown theme 'Catppuccin', using default.
```

As a workaround, users can wrap the value in extra quotes (e.g. `"'Catppuccin Frappe'"`), but the proper fix is to escape these values correctly for the shell.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

