### PR TITLE
wsjtz: 2.0.16 -> 2.0.18, fix desktopitem to avoid against wsjtx

### DIFF
--- a/pkgs/by-name/ws/wsjtz/package.nix
+++ b/pkgs/by-name/ws/wsjtz/package.nix
@@ -7,18 +7,22 @@
 wsjtx.overrideAttrs (
   finalAttrs: old: {
     pname = "wsjtz";
-    version = "2.0.16";
+    version = "2.0.18";
 
     src = fetchFromGitHub {
       owner = "sq9fve";
       repo = "wsjt-z";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-O7HHAr3am4bH4b/RldoaB9LWWhciUbDc+u+lPO60UUY=";
+      hash = "sha256-YxO4pSdKKeO0Ye7Ay/0gdjPvceLbC5eMQk1ZBh1ZHCw=";
     };
 
     postInstall = ''
       mv $out/bin/wsjtx $out/bin/wsjtz
       mv $out/bin/wsjtx_app_version $out/bin/wsjtz_app_version
+
+      substituteInPlace $out/share/applications/wsjtx.desktop \
+        --replace-fail "Exec=wsjtx" "Exec=wsjtz" \
+        --replace-fail "Name=wsjtx" "Name=wsjtz"
     '';
 
     meta = {
@@ -27,6 +31,7 @@ wsjtx.overrideAttrs (
       license = lib.licenses.gpl3Only;
       platforms = lib.platforms.linux;
       maintainers = with lib.maintainers; [
+        Cryolitia
         scd31
       ];
       mainProgram = "wsjtz";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
