### PR TITLE
systemd-boot: use correct flag for EFI variables

### DIFF
--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -496,7 +496,7 @@ def install_bootloader(args: argparse.Namespace) -> None:
         bootctl_flags.append(f"--boot-path={BOOT_MOUNT_POINT}")
 
     if not CAN_TOUCH_EFI_VARIABLES:
-        bootctl_flags.append("--no-variables")
+        bootctl_flags.append("--variables=no")
 
     if GRACEFUL:
         bootctl_flags.append("--graceful")


### PR DESCRIPTION
systemd 258 changed this flag to a form that takes a boolean. This can be used to force EFI variable enrollment inside chroot and container environments.

https://github.com/systemd/systemd/commit/bbeeea43625d22d2ab92b26ed93378acbad8ca66
