### PR TITLE
ankiAddons.jisho-kanji-stroke-order: init at 1.1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14466,6 +14466,12 @@
     githubId = 28487599;
     keys = [ { fingerprint = "D9AF 0A42 09B7 C2DE 11A8  84BF ACBC 5536 60D9 993D"; } ];
   };
+  kentario = {
+    github = "kentario";
+    githubId = 48628650;
+    email = "ken+nixpkgs@wuertele.com";
+    name = "Kentaro";
+  };
   kentjames = {
     email = "jameschristopherkent@gmail.com";
     github = "KentJames";

--- a/pkgs/by-name/an/anki/addons/default.nix
+++ b/pkgs/by-name/an/anki/addons/default.nix
@@ -16,6 +16,8 @@
 
   image-occlusion-enhanced = callPackage ./image-occlusion-enhanced { };
 
+  jisho-kanji-stroke-order = callPackage ./jisho-kanji-stroke-order { };
+
   local-audio-yomichan = callPackage ./local-audio-yomichan { };
 
   passfail2 = callPackage ./passfail2 { };

--- a/pkgs/by-name/an/anki/addons/jisho-kanji-stroke-order/default.nix
+++ b/pkgs/by-name/an/anki/addons/jisho-kanji-stroke-order/default.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  anki-utils,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  nodejs,
+  pnpm_11,
+  pnpmConfigHook,
+  nix-update-script,
+}:
+let
+  pnpm = pnpm_11;
+in
+anki-utils.buildAnkiAddon (finalAttrs: {
+  pname = "jisho-kanji-stroke-order";
+  version = "0-unstable-2026-07-29";
+  src = fetchFromGitHub {
+    owner = "soleuniverse101";
+    repo = "anki-jisho-strokes";
+    rev = "23b09d2e9b79e533f33915c8a7c37b492be9bbb8";
+    hash = "sha256-LTQpVKzWEfZi4npD4Nj9by/SV5aiARBnXgONamTPriE=";
+  };
+
+  kanjivg = fetchFromGitHub {
+    owner = "KanjiVG";
+    repo = "kanjivg";
+    rev = "bd13ffbcc9d85cb86ae98bbbf001d9069220b901";
+    hash = "sha256-z1VvU/ZoDR3jEJiM1l8ZUujSs7uz6CqMCmTRyc+LGDM=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    pnpmConfigHook
+    pnpm
+  ];
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = "sha256-+T1jed5g8vWYLeAh+D8UHP1n6VN58BFeyJwySQvWpK8=";
+  };
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    ln -s ${finalAttrs.kanjivg}/kanji resources/kanji
+
+    pnpm process-svg
+
+    runHook postBuild
+  '';
+
+  preInstall = ''
+    cd addon
+  '';
+
+  meta = {
+    description = "Display kanji's stroke order when hovering over it in the style of jisho.org";
+    longDescription = ''
+      This addon must be configured to apply to certain note types. The options to configure this add-on can be found [here](https://github.com/soleuniverse101/anki-jisho-strokes/blob/main/addon/config.md).
+      Example:
+
+      ```nix
+      (pkgs.ankiAddons.jisho-kanji-stroke-order.withConfig {
+        config = {
+          note_types = [ "japanese anki deck" "*kanji*" ]
+        };
+      })
+      ```
+    '';
+    homepage = "https://github.com/soleuniverse101/anki-jisho-strokes";
+    license = lib.licenses.cc-by-sa-30;
+    maintainers = with lib.maintainers; [ kentario ];
+  };
+})


### PR DESCRIPTION
Add the anki addon that makes hovering over kanji show their stroke order in the style of jisho.org
https://github.com/soleuniverse101/anki-jisho-strokes
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
