### PR TITLE
SDL_mixer: 1.2.12 -> 1.2.12-unstable-2026-05-11

### DIFF
--- a/pkgs/by-name/sd/SDL_mixer/package.nix
+++ b/pkgs/by-name/sd/SDL_mixer/package.nix
@@ -1,81 +1,45 @@
 {
   lib,
   SDL,
-  fetchpatch,
-  fetchurl,
+  fetchFromGitHub,
   fluidsynth,
   libopenmpt-modplug,
   libogg,
   libvorbis,
   pkg-config,
-  smpeg,
+  libmpg123,
+  flac,
+  autoreconfHook,
   stdenv,
+  unstableGitUpdater,
   # passthru.tests
   onscripter,
+  testers,
   # Boolean flags
-  enableNativeMidi ? false,
   enableSdltest ? (!stdenv.hostPlatform.isDarwin),
-  enableSmpegtest ? (!stdenv.hostPlatform.isDarwin),
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "SDL_mixer";
-  version = "1.2.12";
+  version = "1.2.12-unstable-2026-05-11";
 
   # word of caution: while there is a somewhat maintained SDL-1.2 branch on
   # https://github.com/libsdl-org/SDL_mixer, it switches from smpeg to mpg123 which
-  # breaks autoconf in a bunch of packages, it's better to cherry-pick patches as needed
-  src = fetchurl {
-    url = "http://www.libsdl.org/projects/SDL_mixer/release/SDL_mixer-${finalAttrs.version}.tar.gz";
-    hash = "sha256-FkQwgnmpdXmQSeSCavLPx4fK0quxGqFFYuQCUh+GmSo=";
+  # breaks autoconf in a bunch of packages.
+  # smpeg is increasingly showing its age, which is why we no longer wish to depend on it.
+  src = fetchFromGitHub {
+    owner = "libsdl-org";
+    repo = "SDL_mixer";
+    rev = "50517740a3916e5ffd719c053c6e7b65f933e23a";
+    hash = "sha256-VQywKO2aaZKTAzseWsb0nywLfpS9NHxCCanNTmUsUcs=";
   };
-
-  patches = [
-    # Fixes implicit declaration of `Mix_QuitFluidSynth`, which causes build failures with clang.
-    # https://github.com/libsdl-org/SDL_mixer/issues/287
-    (fetchpatch {
-      name = "fluidsynth-fix-implicit-declaration.patch";
-      url = "https://github.com/libsdl-org/SDL_mixer/commit/05b12a3c22c0746c29dc5478f5b7fbd8a51a1303.patch";
-      hash = "sha256-MDuViLD1w1tAVLoX2yFeJ865v21S2roi0x7Yi7GYRVU=";
-    })
-    # Backport of 2.0 fixes for incompatible function pointer conversions, fixing builds with clang.
-    (fetchpatch {
-      name = "fluidsynth-fix-function-pointer-conversions.patch";
-      url = "https://github.com/libsdl-org/SDL_mixer/commit/0c504159d212b710a47cb25c669b21730fc78edd.patch";
-      hash = "sha256-FSj7JLE2MbGVYCspoq3trXP5Ho+lAtnro2IUOHkto/U";
-    })
-    # Backport of MikMod fixes, which includes incompatible function pointer conversions.
-    (fetchpatch {
-      name = "mikmod-fixes.patch";
-      url = "https://github.com/libsdl-org/SDL_mixer/commit/a3e5ff8142cf3530cddcb27b58f871f387796ab6.patch";
-      hash = "sha256-dqD8hxx6U2HaelUx0WsGPiWuso++LjwasaAeTTGqdbk=";
-    })
-    # More incompatible function pointer conversion fixes (this time in Vorbis-decoding code).
-    (fetchpatch {
-      name = "vorbis-fix-function-pointer-conversion.patch";
-      url = "https://github.com/libsdl-org/SDL_mixer/commit/9e6d7b67a00656a68ea0c2eace75c587871549b9.patch";
-      hash = "sha256-rZI3bFb/KxnduTkA/9CISccKHUgrX22KXg69sl/uXvU=";
-    })
-    (fetchpatch {
-      name = "vorbis-fix-function-pointer-conversion-header-part.patch";
-      url = "https://github.com/libsdl-org/SDL_mixer/commit/03bd4ca6aa38c1a382c892cef86296cd621ecc1d.patch";
-      hash = "sha256-7HrSHYFYVgpamP7Q9znrFZMZ72jvz5wYpJEPqWev/I4=";
-    })
-    (fetchpatch {
-      name = "vorbis-fix-function-pointer-signature.patch";
-      url = "https://github.com/libsdl-org/SDL_mixer/commit/d28cbc34d63dd20b256103c3fe506ecf3d34d379.patch";
-      hash = "sha256-sGbtF+Tcjf+6a28nJgawefeeKXnhcwu7G55e94oS9AU=";
-    })
-  ];
-
-  # Fix location of modplug header
-  postPatch = ''
-    substituteInPlace music_modplug.h \
-      --replace-fail '#include "modplug.h"' '#include <libmodplug/modplug.h>'
-  '';
 
   nativeBuildInputs = [
     pkg-config
+    # upstream configure is pre-built expecting FHS compliance:
+    # ./configure: line 5346: /usr/bin/file: No such file or directory
+    autoreconfHook
+    SDL # for sdl.m4
   ];
 
   buildInputs = [
@@ -84,20 +48,15 @@ stdenv.mkDerivation (finalAttrs: {
     libopenmpt-modplug
     libogg
     libvorbis
-    smpeg
+    libmpg123
+    flac
   ];
-
-  # pass in correct *-config for cross builds
-  env.SDL_CONFIG = lib.getExe' (lib.getDev SDL) "sdl-config";
-  env.SMPEG_CONFIG = lib.getExe' smpeg.dev "smpeg-config";
 
   configureFlags = [
     (lib.enableFeature false "music-ogg-shared")
     (lib.enableFeature false "music-mod-shared")
     (lib.enableFeature true "music-mod-modplug")
-    (lib.enableFeature enableNativeMidi "music-native-midi-gpl")
     (lib.enableFeature enableSdltest "sdltest")
-    (lib.enableFeature enableSmpegtest "smpegtest")
   ];
 
   outputs = [
@@ -106,14 +65,23 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   strictDeps = true;
+  __structuredAttrs = true;
 
   passthru.tests = {
     inherit onscripter;
+    pkg-config = testers.hasPkgConfigModules { package = finalAttrs.finalPackage; };
+  };
+
+  passthru.updateScript = unstableGitUpdater {
+    tagFormat = "release-1.*";
+    tagPrefix = "release-";
+    branch = "SDL-1.2";
   };
 
   meta = {
     description = "SDL multi-channel audio mixer library";
     homepage = "http://www.libsdl.org/projects/SDL_mixer/";
+    pkgConfigModules = [ "SDL_mixer" ];
     teams = [ lib.teams.sdl ];
     license = lib.licenses.zlib;
     inherit (SDL.meta) platforms;


### PR DESCRIPTION
Following https://github.com/NixOS/nixpkgs/pull/544591 as part of https://github.com/NixOS/nixpkgs/issues/410814, our `smpeg` is mostly stripped. It *barely* does the job of doing mpeg parsing, i see little reason to still depend on it more than needed.

The SDL_mixer 1.2 branch is somewhat maintained, and updates to `libmpg123`. Supposedly this can cause issues on consuming packages, but all dependents build perfectly fine still. The header and package config files are compatible, and library loading should just work correctly without additional fixes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
