### PR TITLE
vivaldi-ffmpeg-codecs: fixes

### DIFF
--- a/pkgs/by-name/vi/vivaldi-ffmpeg-codecs/package.nix
+++ b/pkgs/by-name/vi/vivaldi-ffmpeg-codecs/package.nix
@@ -9,21 +9,23 @@
 # downloads at https://vivaldi.com/download/
 
 let
+  # IMPORTANT: Use the maintainer's update script to update these. The build number suffixes are unique to
+  # each platform and must be updated together. The actual version number requires unpacking the snap.
   sources = {
     x86_64-linux = fetchurl {
-      url = "https://api.snapcraft.io/api/v1/snaps/download/XXzVIXswXKHqlUATPqGCj2w2l7BxosS8_117.snap";
-      hash = "sha256-YEE7oF8NLGDCQ3gpY5z6B+7xDxcOumjOzwUztJUM+/s=";
+      url = "https://api.snapcraft.io/api/v1/snaps/download/XXzVIXswXKHqlUATPqGCj2w2l7BxosS8_118.snap";
+      hash = "sha256-NYSbCLPCr2oxrVUokEC8g1BiZfIcQLaNKeMBkMNCsaI=";
     };
     aarch64-linux = fetchurl {
-      url = "https://api.snapcraft.io/api/v1/snaps/download/XXzVIXswXKHqlUATPqGCj2w2l7BxosS8_116.snap";
-      hash = "sha256-4RmVOQ9emlRyzAGxeiSLwvkGv+7R/mKLVYm5IWXqLpo=";
+      url = "https://api.snapcraft.io/api/v1/snaps/download/XXzVIXswXKHqlUATPqGCj2w2l7BxosS8_119.snap";
+      hash = "sha256-ehepMMrt0GO9zoi40fFbO4sEQSgRJjbQax6efQnmF60=";
     };
   };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "chromium-codecs-ffmpeg-extra";
 
-  version = "2026-05-18";
+  version = "123075"; # Do not update by hand, use the update script
 
   src = sources."${stdenv.hostPlatform.system}";
 
@@ -34,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   installPhase = ''
-    install -vD chromium-ffmpeg-git-${finalAttrs.version}/chromium-ffmpeg/libffmpeg.so $out/lib/libffmpeg.so
+    install -vD chromium-ffmpeg-${finalAttrs.version}/chromium-ffmpeg/libffmpeg.so $out/lib/libffmpeg.so
   '';
 
   passthru = {

--- a/pkgs/by-name/vi/vivaldi-ffmpeg-codecs/update.sh
+++ b/pkgs/by-name/vi/vivaldi-ffmpeg-codecs/update.sh
@@ -1,44 +1,60 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p common-updater-scripts coreutils gnugrep jq squashfsTools
+#!nix-shell -i bash -p gawk common-updater-scripts coreutils jq squashfsTools
 
 set -eu -o pipefail
 
 RELEASES=$(curl -H 'Snap-Device-Series: 16' http://api.snapcraft.io/v2/snaps/info/chromium-ffmpeg)
-STABLE_RELEASES=$(echo $RELEASES | jq '."channel-map" | .[] | select(.channel.risk=="stable")')
+# We only need the download url and architecture
+STABLE_RELEASES=$(echo $RELEASES | jq '.["channel-map"] | .[] |  select(.channel.risk=="stable") | { arch: .channel.architecture, url: .download.url }')
+
+function get_url() {
+  local architecture=$1
+  echo $(echo $STABLE_RELEASES | jq -r '. | select(.arch=="'${architecture}'") | .url')
+}
+
+# TODO If nix ever supports sha3-384, we can get that from the JSON and use it for the download hash
+function get_source() {
+  local url=$1
+  # returns the source path
+  echo $(nix-prefetch-url --print-path "$url" | tail -n 1)
+}
 
 function max_version() {
-  local versions=$(echo $1 | jq -r '.version')
-  echo "$(echo $versions |  grep -E -o '^[0-9]+')"
+  local source=$1
+  local versions="$(unsquashfs -l $source | awk -F- '$0 ~ "^squashfs-root/chromium-ffmpeg-[[:digit:]]+$" { print $NF }')"
+  echo "$versions" | sort -V | tail -n 1
 }
 
 function update_source() {
   local platform=$1
-  local selectedRelease=$2
-  local version=$3
-  local url=$(echo $selectedRelease | jq -r '.download.url')
-  source="$(nix-prefetch-url "$url")"
-  hash=$(nix-hash --to-sri --type sha256 "$source")
-  update-source-version vivaldi-ffmpeg-codecs "$version" "$hash" "$url" --ignore-same-version --system=$platform --source-key="sources.$platform" --file "package.nix"
+  local url=$2
+  local source=$3
+  local version=$4
+  local source_hash=$(nix-hash --type sha256 --flat --base32 "$source")
+  local hash=$(nix-hash --to-sri --type sha256 "$source_hash")
+  update-source-version vivaldi-ffmpeg-codecs $version $hash "$url" --ignore-same-version --system=$platform --source-key="sources.$platform"
 }
 
-x86Release="$(echo $STABLE_RELEASES | jq 'select(.channel.architecture=="amd64")')"
-x86CodecVersion=$(max_version "$x86Release")
-arm64Release="$(echo $STABLE_RELEASES | jq -r 'select(.channel.architecture=="arm64")')"
-arm64CodecVersion=$(max_version "$arm64Release")
+x86_url="$(get_url amd64)"
+x86_source="$(get_source ${x86_url})"
+x86_version="$(max_version ${x86_source})"
 
-currentVersion=$(grep 'version =' ./package.nix | cut -d '"' -f 2)
+arm64_url="$(get_url "arm64")"
+arm64_source="$(get_source ${arm64_url})"
+arm64_version="$(max_version ${arm64_source})"
 
-if [[ "$currentVersion" == "$x86CodecVersion" ]]; then
+currentVersion=$(nix eval --raw -f . vivaldi-ffmpeg-codecs.version)
+
+if [[ "$currentVersion" == "$x86_version" ]]; then
   exit 0
 fi
 
-# If this fails too often, consider finding the max common version between the two architectures
-if [[ "$x86CodecVersion" != "$arm64CodecVersion" ]]; then
-    >&2 echo "Multiple chromium versions found: $x86CodecVersion (intel) and $arm64CodecVersion (arm); no update"
+# If this fails too often, we can try using the lesser of the two versions for both
+# as the snap contains the last 4-5 versions.
+if [[ "$x86_version" != "$arm64_version" ]]; then
+    >&2 echo "Multiple chromium versions found: $x86_version (intel) and $arm64_version (arm); no update"
     exit 1
 fi
 
-
-
-update_source "x86_64-linux" "$x86Release" "$x86CodecVersion"
-update_source "aarch64-linux" "$arm64Release" "$arm64CodecVersion"
+update_source "x86_64-linux" "$x86_url" "$x86_source" "$x86_version"
+update_source "aarch64-linux" "$arm64_url" "$arm64_source" "$arm64_version"


### PR DESCRIPTION
The `vivaldi-ffmpeg-codecs` update script has been broken for some time due to a change in the snap store API, see #544294

Previous update attempts have managed to get the intel and arm64 codecs out of sync due to the complexity of getting the correct version from the snap. Also, since the update script was broken, some devs tried the vivaldi's browser's update script but that only updates one platform.

1. Corrected `update.sh` to do the right thing.
2. Added notes to the derivation explaining this should be updated via the standard updater.
3. Bumped the intel and arm builds to the latest version (and the same for both).

Closes #544294

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
