### PR TITLE
[haskell-updates] haskell.packages.ghc9125: 9.12.4.20260614 -> 9.12.4.20260713

### DIFF
--- a/pkgs/development/compilers/ghc/9.12.5.nix
+++ b/pkgs/development/compilers/ghc/9.12.5.nix
@@ -1,5 +1,5 @@
 import ./common-hadrian.nix {
-  version = "9.12.4.20260614";
-  url = "https://downloads.haskell.org/~ghc/9.12.5-rc2/ghc-9.12.4.20260614-src.tar.gz";
-  sha256 = "3ab5987e18dafff3bc8d62ea6934e2edc0dd2151454af044790cd1074070fd4b";
+  version = "9.12.4.20260713";
+  url = "https://downloads.haskell.org/~ghc/9.12.5-rc3/ghc-9.12.4.20260713-src.tar.gz";
+  sha256 = "cc77cff2014dd99c16c9f311f7558d9a11aa3c3a2dee47425b109c3dac35338c";
 }


### PR DESCRIPTION
rc2 -> rc3


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
