### PR TITLE
nixos/{corefreq, auditd}: fix mkEnableOption description

### DIFF
--- a/nixos/modules/programs/corefreq.nix
+++ b/nixos/modules/programs/corefreq.nix
@@ -12,7 +12,7 @@ in
 {
   options = {
     programs.corefreq = {
-      enable = lib.mkEnableOption "Whether to enable the corefreq daemon and kernel module";
+      enable = lib.mkEnableOption "the corefreq daemon and kernel module";
 
       package = lib.mkOption {
         type = lib.types.package;

--- a/nixos/modules/security/auditd.nix
+++ b/nixos/modules/security/auditd.nix
@@ -18,7 +18,7 @@ let
 
   pluginOptions = lib.types.submodule {
     options = {
-      active = lib.mkEnableOption "Whether to enable this plugin";
+      active = lib.mkEnableOption "this plugin";
       direction = lib.mkOption {
         type = lib.types.enum [
           "in"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Fixed the description of `programs.corefreq.enable` and `security.auditd.plugins.<name>.active`. These both included `Whether to enable` in the description argument of `mkEnableOption`, resulting in the actual description looking like this:

```
Whether to enable Whether to enable <enabled-thing>
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
