### PR TITLE
gui-for-singbox: 1.25.4 -> 1.26.1

### DIFF
--- a/pkgs/by-name/gu/gui-for-singbox/frontend-runtime-path.patch
+++ b/pkgs/by-name/gu/gui-for-singbox/frontend-runtime-path.patch
@@ -57,14 +57,14 @@ diff -ruN a/src/stores/kernelApi.ts b/src/stores/kernelApi.ts
 diff -ruN a/src/types/app.d.ts b/src/types/app.d.ts
 --- a/src/types/app.d.ts
 +++ b/src/types/app.d.ts
-@@ -19,6 +19,7 @@
-   appName: string
-   appVersion: string
-   basePath: string
-+  configPath: string
-   appPath: string
-   os: OS
-   arch: string
+@@ -17,6 +17,7 @@
+     appName: string
+     appVersion: string
+     basePath: string
++    configPath: string
+     appPath: string
+     os: OS
+     arch: string
 diff -ruN a/src/views/PluginsView/index.vue b/src/views/PluginsView/index.vue
 --- a/src/views/PluginsView/index.vue
 +++ b/src/views/PluginsView/index.vue

--- a/pkgs/by-name/gu/gui-for-singbox/package.nix
+++ b/pkgs/by-name/gu/gui-for-singbox/package.nix
@@ -20,13 +20,13 @@
 
 let
   pname = "gui-for-singbox";
-  version = "1.25.4";
+  version = "1.26.1";
 
   src = fetchFromGitHub {
     owner = "GUI-for-Cores";
     repo = "GUI.for.SingBox";
     tag = "v${version}";
-    hash = "sha256-+2MdFF1iufbPJvf5XGrM9t9vaY7BNdIu/vSWgAKcbvQ=";
+    hash = "sha256-MXcn9s+FAuOnPpiDBO8fnqzE74wg6noZRxQtpIXr1Sw=";
   };
 
   metaCommon = {
@@ -58,7 +58,7 @@ let
         ;
       pnpm = pnpm_10;
       fetcherVersion = 3;
-      hash = "sha256-BrDO9xdMuMnhXPAd9QvtU4R1W1WacnsVcGde+WFjvGA=";
+      hash = "sha256-NB5Tn9cTCUctRiEMnjphs30P04v6V0eo52k2MUsvd1U=";
     };
 
     buildPhase = ''
@@ -89,7 +89,7 @@ buildGo126Module {
 
   patches = [ ./xdg-path-and-restart-patch.patch ];
 
-  vendorHash = "sha256-Xi/EgMLex25p2tmRHEldCv6hgUKIpLJTmrMpHPGLY5M=";
+  vendorHash = "sha256-cApwC//nM+5yJwrTDbjb/0+hcs9Bd10MM7L/lPxq8Og=";
 
   nativeBuildInputs = [
     autoPatchelfHook


### PR DESCRIPTION
Upstream changelog: https://github.com/GUI-for-Cores/GUI.for.SingBox/releases/tag/v1.26.1

Changes:

    Update gui-for-singbox 1.25.4 -> 1.26.1
    Update `frontend-runtime-path.patch` for the new upstream version

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
