### PR TITLE
[26.05] dcmtk: patch CVE-2026-5663

### DIFF
--- a/pkgs/by-name/dc/dcmtk/package.nix
+++ b/pkgs/by-name/dc/dcmtk/package.nix
@@ -26,6 +26,12 @@ stdenv.mkDerivation (finalAttrs: {
   # The following patches are taken from the Debian package
   # See https://salsa.debian.org/med-team/dcmtk
   patches = [
+    # Backport of upstream commit edbb085e for 3.6.9; remove when updating past 3.7.0.
+    (fetchurl {
+      name = "CVE-2026-5663.patch";
+      url = "https://salsa.debian.org/med-team/dcmtk/-/raw/debian/3.6.9-5%2Bdeb13u1/debian/patches/0016-CVE-2026-5663.patch";
+      hash = "sha256-o8k+ns+O2qECL2i4upSRIpDD8rXDhmjkwjp4kC/rv8Y=";
+    })
     (fetchurl {
       url = "https://salsa.debian.org/med-team/dcmtk/-/raw/debian/3.6.9-4/debian/patches/01_dcmtk_3.6.0-1.patch";
       hash = "sha256-kDEZvPqcF8+PYID24srMoPSBPltmnGiJ67LHsLVcPYM=";


### PR DESCRIPTION
Backports #543467 to `release-26.05`. The master patch contains a 3.7.0-specific hunk that does not apply to dcmtk 3.6.9, so this intentionally uses [Debian's published 3.6.9-compatible backport](https://salsa.debian.org/med-team/dcmtk/-/blob/debian/3.6.9-5%2Bdeb13u1/debian/patches/0016-CVE-2026-5663.patch) of the same security fix for CVE-2026-5663.

Closes #543762

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
