### PR TITLE
libsidplayfp: Drop RamKromberg from meta.maintainers

### DIFF
--- a/pkgs/by-name/li/libsidplayfp/package.nix
+++ b/pkgs/by-name/li/libsidplayfp/package.nix
@@ -106,7 +106,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/libsidplayfp/libsidplayfp/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
-      ramkromberg
       OPNA2608
     ];
     platforms = lib.platforms.all;


### PR DESCRIPTION
This seems more accurate.

https://github.com/NixOS/nixpkgs/pull/517074#issuecomment-4984010971

> @RamKromberg, you are listed as a maintainer for `libsidplayfp`. `libresidfp` has been split out of `libsidplayfp` into its own package. […]
> 
> I don't remember… *ever?* seeing you respond to PRs about this package, and you don't seem to be in the nixpkgs packge maintainers group either.
> 
> [Would] you instead be fine with me removing you from `libsidplayfp`'s `meta.maintainers` maybe? Prolly no point in pinging you all the time if you're no longer interested in maintaining this.

Question received no reply. Question hereby goes out one last time.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
