### PR TITLE
scroll: init at 1.12.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21437,6 +21437,12 @@
     githubId = 55047947;
     name = "Oli";
   };
+  olimoli = {
+    email = "olimoli@disroot.org";
+    github = "Diax170";
+    githubId = 138491143;
+    name = "Oli";
+  };
   oliver-koss = {
     email = "oliver.koss06@gmail.com";
     github = "oliver-koss";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21728,6 +21728,12 @@
     githubId = 55047947;
     name = "Oli";
   };
+  olimoli = {
+    email = "olimoli@disroot.org";
+    github = "Diax170";
+    githubId = 138491143;
+    name = "Oli";
+  };
   oliver-koss = {
     email = "oliver.koss06@gmail.com";
     github = "oliver-koss";

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -32,6 +32,8 @@
 
 - [compsize](https://github.com/kilobyte/compsize), setcap wrapper for `compsize` package, a cli utility to to inspect compression type/ratio on BTRFS filesystems. Available as [programs.compsize](#opt-programs.compsize.enable)
 
+- [scroll](https://github.com/dawsers/scroll), a [Sway](https://swaywm.org) fork with a scrolling tiling layout. Available as [programs.scroll](#opt-programs.scroll.enable)
+
 - [tranquil](https://tangled.org/tranquil.farm/tranquil-pds) is an ATProto PDS (personal data server) implementation in Rust. A featureful, spec conscious and community driven alternative to the Bluesky reference implementation PDS. Available as [services.tranquil-pds](#opt-services.tranquil-pds.enable).
 
 - [Cardwire](https://github.com/OpenGamingCollective/cardwire), a GPU manager for Linux that uses eBPF+LSM hooks to control GPUs. Available as [services.cardwired](#opt-services.cardwired.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -372,6 +372,7 @@
   ./programs/wayland/noctalia.nix
   ./programs/wayland/pinnacle.nix
   ./programs/wayland/river.nix
+  ./programs/wayland/scroll.nix
   ./programs/wayland/sway.nix
   ./programs/wayland/umbriel.nix
   ./programs/wayland/uwsm.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -370,6 +370,7 @@
   ./programs/wayland/noctalia.nix
   ./programs/wayland/pinnacle.nix
   ./programs/wayland/river.nix
+  ./programs/wayland/scroll.nix
   ./programs/wayland/sway.nix
   ./programs/wayland/uwsm.nix
   ./programs/wayland/waybar.nix

--- a/nixos/modules/programs/wayland/scroll.nix
+++ b/nixos/modules/programs/wayland/scroll.nix
@@ -1,0 +1,223 @@
+{
+  config,
+  lib,
+  pkgs,
+  modulesPath,
+  ...
+}:
+let
+  cfg = config.programs.scroll;
+
+  wayland-lib = import (modulesPath + "/programs/wayland/lib.nix") { inherit lib; };
+in
+{
+  options.programs.scroll = {
+    enable = lib.mkEnableOption ''
+      scroll, a fork of Sway (an i3-compatible Wayland compositor) with a scrolling
+      tiling layout.
+    '';
+
+    package =
+      lib.mkPackageOption pkgs "scroll" {
+        nullable = true;
+        extraDescription = ''
+          If the package is not overridable with `extraSessionCommands`, `extraOptions`,
+          `withBaseWrapper`, `withGtkWrapper`, `enableXWayland` and `isNixOS`,
+          then the module options {option}`wrapperFeatures`, {option}`extraSessionCommands`,
+          {option}`extraOptions` and {option}`xwayland` will have no effect.
+
+          Set to `null` to not add any scroll package to your path.
+          This should be done if you want to use the Home Manager module to install scroll.
+        '';
+      }
+      // {
+        apply =
+          p:
+          if p == null then
+            null
+          else
+            wayland-lib.genFinalPackage p {
+              extraSessionCommands = cfg.extraSessionCommands;
+              extraOptions = cfg.extraOptions;
+              withBaseWrapper = cfg.wrapperFeatures.base;
+              withGtkWrapper = cfg.wrapperFeatures.gtk;
+              enableXWayland = cfg.xwayland.enable;
+              isNixOS = true;
+            };
+      };
+
+    wrapperFeatures = {
+      base =
+        lib.mkEnableOption ''
+          the base wrapper to execute extra session commands and prepend a
+          dbus-run-session to the scroll command''
+        // {
+          default = true;
+        };
+      gtk = lib.mkEnableOption ''
+        the wrapGAppsHook wrapper to execute scroll with required environment
+        variables for GTK applications'';
+    };
+
+    extraSessionCommands = lib.mkOption {
+      type = lib.types.lines;
+      default = "";
+      example = ''
+        # Sway/Scroll needs its environment variables here
+        # Set GTK theme
+        export GTK_THEME=Adwaita-dark
+        # Tell QT, GDK and others to use the Wayland backend by default, X11 if not available
+        export QT_QPA_PLATFORM="wayland;xcb"
+        export GDK_BACKEND="wayland,x11"
+        export SDL_VIDEODRIVER=wayland
+        export CLUTTER_BACKEND=wayland
+
+        # XDG desktop variables to set scroll as the desktop
+        export XDG_CURRENT_DESKTOP=scroll
+        export XDG_SESSION_TYPE=wayland
+        export XDG_SESSION_DESKTOP=scroll
+
+        # Configure Electron to use Wayland instead of X11
+        export ELECTRON_OZONE_PLATFORM_HINT=wayland
+
+        export QT_WAYLAND_DISABLE_WINDOWDECORATION=1 # Disables window decorations on Qt applications
+        export QT_QPA_PLATFORMTHEME=qt6ct
+        # This is to (temporarily) fix font rendering on QWebEngineView 6
+        # (qutebrowser, goldendict etc.)
+        # https://bugreports.qt.io/browse/QTBUG-113574
+        export QT_SCALE_FACTOR_ROUNDING_POLICY=RoundPreferFloor
+
+        # If you use a Nvidia card
+        # NVIDIA environment variables
+        export LIBVA_DRIVER_NAME=nvidia
+        export GBM_BACKEND=nvidia-drm
+        export __GLX_VENDOR_LIBRARY_NAME=nvidia
+
+        export XCURSOR_THEME=Adwaita
+        export XCURSOR_SIZE=24
+      '';
+      description = ''
+        Shell commands executed just before scroll is started. See
+        <https://github.com/swaywm/sway/wiki/Running-programs-natively-under-wayland>,
+        <https://github.com/swaywm/wlroots/blob/master/docs/env_vars.md>
+        and <https://github.com/dawsers/scroll#environment-variables>
+        for some useful environment variables.
+      '';
+    };
+
+    extraOptions = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [
+        "--verbose"
+        "--debug"
+        # --unsupported-gpu isn't required on Scroll
+      ];
+      description = ''
+        Command line arguments passed to launch scroll.
+      '';
+    };
+
+    xwayland.enable = lib.mkEnableOption "XWayland" // {
+      default = true;
+    };
+
+    extraPackages = lib.mkOption {
+      type = with lib.types; listOf package;
+      # Packages used in default config + portals recommended by the readme
+      default = with pkgs; [
+        brightnessctl
+        kitty
+        grim
+        pulseaudio
+        swayidle
+        swaylock
+        wmenu
+      ];
+      defaultText = lib.literalExpression ''
+        with pkgs; [ brightnessctl kitty grim pulseaudio swayidle swaylock wmenu xdg-desktop-portal xdg-desktop-portal-gtk xdg-desktop-portal-wlr slurp ];
+      '';
+      example = lib.literalExpression ''
+        with pkgs; [ i3status i3status-rust termite rofi light ]
+      '';
+      description = ''
+        Extra packages to be installed system wide. See
+        <https://github.com/swaywm/sway/wiki/Useful-add-ons-for-sway> and
+        <https://github.com/swaywm/sway/wiki/i3-Migration-Guide#common-x11-apps-used-on-i3-with-wayland-alternatives>
+        for a list of useful software.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        assertions = [
+          {
+            assertion = cfg.extraSessionCommands != "" -> cfg.wrapperFeatures.base;
+            message = ''
+              The extraSessionCommands for scroll will not be run if wrapperFeatures.base is disabled.
+            '';
+          }
+        ];
+
+        warnings =
+          lib.mkIf
+            (
+              (lib.elem "nvidia" config.services.xserver.videoDrivers)
+              && (lib.versionOlder (lib.versions.major (lib.getVersion config.hardware.nvidia.package)) "551")
+            )
+            [
+              "Using scroll with Nvidia driver version <= 550 may result in a poor experience. Configure hardware.nvidia.package to use a newer version, or alternatively switch to using Nouveau."
+            ];
+
+        environment = {
+          systemPackages = lib.optional (cfg.package != null) cfg.package ++ cfg.extraPackages;
+
+          # include the default sway wallpapers because they're apparently still here
+          pathsToLink = lib.optional (cfg.package != null) "/share/backgrounds/scroll";
+
+          etc = {
+            "scroll/config.d/nixos.conf".source = pkgs.writeText "nixos.conf" ''
+              # Import the most important environment variables into the D-Bus and systemd
+              # user environments (e.g. required for screen sharing and Pinentry prompts):
+              exec dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY I3SOCK SWAYSOCK SCROLLSOCK XDG_CURRENT_DESKTOP XDG_SESSION_TYPE PATH NIXOS_OZONE_WL XCURSOR_THEME XCURSOR_SIZE
+              # enable systemd-integration
+              exec "systemctl --user import-environment {,WAYLAND_}DISPLAY I3SOCK SWAYSOCK SCROLLSOCK; systemctl --user start scroll-session.target"
+              exec scrollmsg -t subscribe '["shutdown"]' && systemctl --user stop scroll-session.target
+            '';
+          }
+          // lib.optionalAttrs (cfg.package != null) {
+            "scroll/config".source = lib.mkOptionDefault "${cfg.package}/etc/scroll/config";
+          };
+        };
+
+        systemd.user.targets.scroll-session = {
+          description = "scroll compositor session";
+          documentation = [ "man:systemd.special(7)" ];
+          bindsTo = [ "graphical-session.target" ];
+          wants = [ "graphical-session-pre.target" ];
+          after = [ "graphical-session-pre.target" ];
+        };
+
+        # To make a scroll session available if a display manager like SDDM is enabled:
+        services.displayManager.sessionPackages = lib.optional (cfg.package != null) cfg.package;
+
+        # Set up XDG portal config how it's suggested in the readme
+        xdg.portal.config.scroll = {
+          default = [ "gtk" ];
+          "org.freedesktop.impl.portal.ScreenCast" = "wlr";
+          "org.freedesktop.impl.portal.Screenshot" = "wlr";
+          "org.freedesktop.impl.portal.Inhibit" = "none";
+        };
+      }
+
+      (import ./wayland-session.nix {
+        inherit lib pkgs;
+        enableXWayland = cfg.xwayland.enable;
+      })
+    ]
+  );
+
+  meta.maintainers = with lib.maintainers; [ olimoli ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1554,6 +1554,7 @@ in
   scanservjs = runTest ./scanservjs.nix;
   schleuder = runTest ./schleuder.nix;
   scion-freestanding-deployment = runTest ./scion/freestanding-deployment;
+  scroll = runTest ./scroll.nix;
   scrutiny = runTest ./scrutiny.nix;
   scx = runTest ./scx/default.nix;
   scx-loader = runTest ./scx/loader.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1647,6 +1647,7 @@ in
   scanservjs = runTest ./scanservjs.nix;
   schleuder = runTest ./schleuder.nix;
   scion-freestanding-deployment = runTest ./scion/freestanding-deployment;
+  scroll = runTest ./scroll.nix;
   scrutiny = runTest ./scrutiny.nix;
   scx = runTest ./scx/default.nix;
   scx-loader = runTest ./scx/loader.nix;

--- a/nixos/tests/scroll.nix
+++ b/nixos/tests/scroll.nix
@@ -1,0 +1,222 @@
+{ pkgs, lib, ... }:
+{
+  name = "scroll";
+  meta = {
+    maintainers = with lib.maintainers; [ olimoli ];
+  };
+
+  # testScriptWithTypes:49: error: Cannot call function of unknown type
+  #           (machine.succeed if succeed else machine.execute)(
+  #           ^
+  # Found 1 error in 1 file (checked 1 source file)
+  skipTypeCheck = true;
+
+  nodes.machine =
+    { config, ... }:
+    {
+      # Automatically login on tty1 as a normal user:
+      imports = [ ./common/user-account.nix ];
+      services.getty.autologinUser = "alice";
+
+      environment = {
+        # For glinfo and wayland-info:
+        systemPackages = with pkgs; [
+          mesa-demos
+          wayland-utils
+          alacritty
+          foot
+          swaylock
+        ];
+        # Use a fixed SWAYSOCK path (for swaymsg):
+        variables = {
+          "SWAYSOCK" = "/tmp/scroll-ipc.sock";
+          "SCROLLSOCK" = "/tmp/scroll-ipc.sock";
+          # TODO: Investigate if we can get hardware acceleration to work (via
+          # virtio-gpu and Virgil). We currently have to use the Pixman software
+          # renderer since the GLES2 renderer doesn't work inside the VM (even
+          # with WLR_RENDERER_ALLOW_SOFTWARE):
+          # "WLR_RENDERER_ALLOW_SOFTWARE" = "1";
+          "WLR_RENDERER" = "pixman";
+        };
+        # For convenience:
+        shellAliases = {
+          test-x11 = "glinfo | tee /tmp/test-x11.out && touch /tmp/test-x11-exit-ok";
+          test-wayland = "wayland-info | tee /tmp/test-wayland.out && touch /tmp/test-wayland-exit-ok";
+        };
+
+        # To help with OCR:
+        etc."xdg/foot/foot.ini".text = lib.generators.toINI { } {
+          main = {
+            font = "inconsolata:size=14";
+          };
+          colors = rec {
+            foreground = "000000";
+            background = "ffffff";
+            regular2 = foreground;
+          };
+        };
+
+        etc."gpg-agent.conf".text = ''
+          pinentry-timeout 86400
+        '';
+      };
+
+      fonts.packages = [ pkgs.inconsolata ];
+
+      # Automatically configure and start scroll when logging in on tty1:
+      programs.bash.loginShellInit = ''
+        if [ "$(tty)" = "/dev/tty1" ]; then
+          set -e
+
+          # Create custom minimal config to prevent conflicts
+          # Heredocs wouldn't work for some reason
+          mkdir -p ~/.config/scroll
+          echo 'bindsym Mod1+3 workspace 3' > ~/.config/scroll/config
+          echo 'bindsym Mod1+Return exec foot' >> ~/.config/scroll/config
+          echo 'bindsym Mod1+Backspace kill' >> ~/.config/scroll/config
+          echo 'bar position top' >> ~/.config/scroll/config
+          echo 'include /etc/scroll/config.d/*.conf' >> ~/.config/scroll/config
+
+          scroll --validate
+          scroll && touch /tmp/scroll-exit-ok
+        fi
+      '';
+
+      programs.scroll = {
+        enable = true;
+        extraPackages = [ ];
+      };
+
+      # To test pinentry via gpg-agent:
+      programs.gnupg.agent.enable = true;
+
+      # Need to switch to a different GPU driver than the default one (-vga std) so that scroll can launch:
+      virtualisation.qemu.options = [ "-vga none -device virtio-gpu-pci" ];
+    };
+
+  testScript =
+    { nodes, ... }:
+    ''
+      import shlex
+      import json
+
+      q = shlex.quote
+      NODE_GROUPS = ["nodes", "floating_nodes"]
+
+
+      def scrollmsg(command: str = "", succeed=True, type="command"):
+          assert command != "" or type != "command", "Must specify command or type"
+          shell = q(f"scrollmsg -t {q(type)} -- {q(command)}")
+          with machine.nested(
+              f"sending scrollmsg {shell!r}" + " (allowed to fail)" * (not succeed)
+          ):
+              ret = (machine.succeed if succeed else machine.execute)(
+                  f"su - alice -c {shell}"
+              )
+
+          # execute also returns a status code, but disregard.
+          if not succeed:
+              _, ret = ret
+
+          if not succeed and not ret:
+              return None
+
+          parsed = json.loads(ret)
+          return parsed
+
+
+      def walk(tree):
+          yield tree
+          for group in NODE_GROUPS:
+              for node in tree.get(group, []):
+                  yield from walk(node)
+
+
+      def wait_for_window(pattern):
+          def func(last_chance):
+              nodes = (
+                  node["name"]
+                  for node in walk(scrollmsg(type="get_tree"))
+                  if node.get("name") is not None
+              )
+
+              if last_chance:
+                  nodes = list(nodes)
+                  machine.log(f"Last call! Current list of windows: {nodes}")
+
+              return any(pattern in name for name in nodes)
+
+          retry(func)
+
+      start_all()
+      machine.wait_for_unit("multi-user.target")
+
+      # To check the version:
+      print(machine.succeed("scroll --version"))
+
+      # Wait for scroll to complete startup:
+      machine.wait_for_file("/run/user/1000/wayland-1")
+      machine.wait_for_file("/tmp/scroll-ipc.sock")
+
+      # Test XWayland (foot does not support X):
+      scrollmsg("exec WINIT_UNIX_BACKEND=x11 WAYLAND_DISPLAY= alacritty")
+      wait_for_window("alice@machine")
+      machine.send_chars("test-x11\n")
+      machine.wait_for_file("/tmp/test-x11-exit-ok")
+      print(machine.succeed("cat /tmp/test-x11.out"))
+      machine.copy_from_machine("/tmp/test-x11.out")
+      machine.screenshot("alacritty_glinfo")
+      machine.succeed("pkill alacritty")
+
+      # Start a terminal (foot) on workspace 3:
+      machine.send_key("alt-3")
+      machine.sleep(3)
+      machine.send_key("alt-ret")
+      wait_for_window("alice@machine")
+      machine.send_chars("test-wayland\n")
+      machine.wait_for_file("/tmp/test-wayland-exit-ok")
+      print(machine.succeed("cat /tmp/test-wayland.out"))
+      machine.copy_from_machine("/tmp/test-wayland.out")
+      machine.screenshot("foot_wayland_info")
+      machine.send_key("alt-backspace")
+      machine.wait_until_fails("pgrep foot")
+
+      # Test gpg-agent starting pinentry-gnome3 via D-Bus (tests if
+      # $WAYLAND_DISPLAY is correctly imported into the D-Bus user env):
+      scrollmsg("exec mkdir -p ~/.gnupg")
+      scrollmsg("exec cp /etc/gpg-agent.conf ~/.gnupg")
+
+      scrollmsg("exec DISPLAY=INVALID gpg --no-tty --yes --quick-generate-key test", succeed=False)
+      machine.wait_until_succeeds("pgrep --exact gpg")
+      wait_for_window("gpg")
+      machine.succeed("pgrep --exact gpg")
+      machine.screenshot("gpg_pinentry")
+      machine.send_key("alt-backspace")
+      machine.wait_until_fails("pgrep --exact gpg")
+
+
+      ${lib.optionalString pkgs.stdenv.hostPlatform.isx86_64 ''
+        # Test scrollnag:
+        # Broken on aarch64-linux, see https://github.com/NixOS/nixpkgs/issues/416217
+        def get_height():
+            return [node['rect']['height'] for node in walk(scrollmsg(type="get_tree")) if node['focused']][0]
+
+        before = get_height()
+        scrollmsg("exec scrollnag -m testing")
+        retry(lambda _: get_height() < before)
+        machine.screenshot("scroll_exit")
+      ''}
+
+      scrollmsg("exec swaylock")
+      machine.wait_until_succeeds("pgrep -xf swaylock")
+      machine.sleep(3)
+      machine.send_chars("${nodes.machine.users.users.alice.password}")
+      machine.send_key("ret")
+      machine.wait_until_fails("pgrep -xf swaylock")
+
+      # Exit scroll and verify process exit status 0:
+      scrollmsg("exit", succeed=False)
+      machine.wait_until_fails("pgrep -xf scroll")
+      machine.wait_for_file("/tmp/scroll-exit-ok")
+    '';
+}

--- a/pkgs/by-name/sc/scroll-unwrapped/package.nix
+++ b/pkgs/by-name/sc/scroll-unwrapped/package.nix
@@ -1,0 +1,160 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  wayland-scanner,
+  scdoc,
+  libGL,
+  wayland,
+  libxkbcommon,
+  pcre2,
+  json_c,
+  libevdev,
+  pango,
+  cairo,
+  libinput,
+  gdk-pixbuf,
+  librsvg,
+  wayland-protocols,
+  libdrm,
+  evdev-proto,
+  # Scroll-specific:
+  glslang,
+  hwdata,
+  lua54Packages,
+  vulkan-loader,
+  xwayland,
+  seatd,
+  lcms,
+  libdisplay-info,
+  libxcb-render-util,
+  libxcb-errors,
+  libliftoff,
+  libgbm,
+  readline,
+  # Used by the NixOS module:
+  isNixOS ? false,
+  enableXWayland ? true,
+  libxcb-wm,
+  systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd,
+  systemd,
+  trayEnabled ? systemdSupport,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "scroll-unwrapped";
+  version = "1.12.19";
+
+  inherit
+    enableXWayland
+    isNixOS
+    systemdSupport
+    trayEnabled
+    ;
+  src = fetchFromGitHub {
+    owner = "dawsers";
+    repo = "scroll";
+    rev = finalAttrs.version;
+    hash = "sha256-SIGDld/pnVULiEH1iOZKz9o1FuqsvF7kEdvSxFxrCAM=";
+  };
+
+  patches = [ ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  depsBuildBuild = [
+    pkg-config
+  ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    wayland-scanner
+    scdoc
+
+    # Scroll-specific
+    glslang
+    lcms
+    hwdata
+    libliftoff
+  ];
+
+  buildInputs = [
+    libGL
+    wayland
+    libxkbcommon
+    pcre2
+    json_c
+    libevdev
+    pango
+    cairo
+    libinput
+    gdk-pixbuf
+    librsvg
+    wayland-protocols
+    libdrm
+    # Scroll uses its own version of wlroots
+
+    # Scroll-specific
+    lua54Packages.lua
+    vulkan-loader
+    seatd
+    lcms
+    libdisplay-info
+    libliftoff
+    libgbm
+    readline
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isFreeBSD [
+    evdev-proto
+  ]
+  ++ lib.optionals finalAttrs.enableXWayland [
+    libxcb-wm
+    # Scroll-specific
+    xwayland
+    libxcb-render-util
+    libxcb-errors
+  ];
+
+  mesonFlags =
+    let
+      inherit (lib.strings) mesonEnable mesonOption;
+
+      # The "sd-bus-provider" meson option does not include a "none" option,
+      # but it is silently ignored iff "-Dtray=disabled".  We use "basu"
+      # (which is not in nixpkgs) instead of "none" to alert us if this
+      # changes: https://github.com/swaywm/sway/issues/6843#issuecomment-1047288761
+      # assert trayEnabled -> systemdSupport && dbusSupport;
+
+      sd-bus-provider = if systemdSupport then "libsystemd" else "basu";
+    in
+    [
+      (mesonOption "sd-bus-provider" sd-bus-provider)
+      (mesonEnable "tray" finalAttrs.trayEnabled)
+      # Scroll-specific
+      (lib.strings.mesonOption "c_args" "-Wno-error=maybe-uninitialized")
+    ];
+
+  meta = {
+    description = "Sway fork with a scrolling tiling layout";
+    longDescription = ''
+      Scroll is a Wayland compositor forked from Sway. The main difference is
+      scroll only supports a scrolling layout similar to PaperWM.
+      scroll works very similarly to hyprscroller and is mostly compatible with
+      Sway configurations aside from the window layout. It adds some features
+      such as animations, overview and jump modes, Lua scripting, trails and
+      trailmarks or pinning windows.
+    '';
+    homepage = "https://github.com/dawsers/scroll";
+    changelog = "https://github.com/dawsers/scroll/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux ++ lib.platforms.freebsd;
+    maintainers = with lib.maintainers; [ olimoli ];
+    mainProgram = "scroll";
+  };
+})

--- a/pkgs/by-name/sc/scroll-unwrapped/package.nix
+++ b/pkgs/by-name/sc/scroll-unwrapped/package.nix
@@ -21,6 +21,7 @@
   wayland-protocols,
   libdrm,
   evdev-proto,
+  nixosTests,
   # Scroll-specific:
   glslang,
   hwdata,
@@ -139,6 +140,8 @@ stdenv.mkDerivation (finalAttrs: {
       # Scroll-specific
       (lib.strings.mesonOption "c_args" "-Wno-error=maybe-uninitialized")
     ];
+
+  passthru.tests.basic = nixosTests.scroll;
 
   meta = {
     description = "Sway fork with a scrolling tiling layout";

--- a/pkgs/by-name/sc/scroll/package.nix
+++ b/pkgs/by-name/sc/scroll/package.nix
@@ -1,0 +1,89 @@
+{
+  lib,
+  scroll-unwrapped,
+  makeWrapper,
+  symlinkJoin,
+  writeShellScriptBin,
+  withBaseWrapper ? true,
+  extraSessionCommands ? "",
+  dbus,
+  withGtkWrapper ? false,
+  wrapGAppsHook3,
+  gdk-pixbuf,
+  glib,
+  gtk3,
+  extraOptions ? [ ], # E.g.: [ "--verbose" ]
+  # Used by the NixOS module:
+  isNixOS ? false,
+
+  enableXWayland ? true,
+  dbusSupport ? true,
+}:
+
+assert extraSessionCommands != "" -> withBaseWrapper;
+
+let
+  inherit (builtins) replaceStrings;
+  inherit (lib.lists) optional optionals;
+  inherit (lib.meta) getExe;
+  inherit (lib.strings) concatMapStrings optionalString;
+
+  scroll = scroll-unwrapped.overrideAttrs (old: {
+    inherit isNixOS enableXWayland;
+  });
+  baseWrapper = writeShellScriptBin scroll.meta.mainProgram ''
+    set -o errexit
+    if [ ! "$_SWAY_WRAPPER_ALREADY_EXECUTED" ]; then
+      export XDG_CURRENT_DESKTOP=${scroll.meta.mainProgram}
+      ${extraSessionCommands}
+      export _SWAY_WRAPPER_ALREADY_EXECUTED=1
+    fi
+    if [ "$DBUS_SESSION_BUS_ADDRESS" ]; then
+      export DBUS_SESSION_BUS_ADDRESS
+      exec ${getExe scroll} "$@"
+    elif [ -n "$XDG_RUNTIME_DIR" ] && [ -S "$XDG_RUNTIME_DIR/bus" ]; then
+      # Prefer the systemd --user bus (dbus-daemon or dbus-broker) over
+      # spawning a redundant session bus via dbus-run-session.
+      export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
+      exec ${getExe scroll} "$@"
+    else
+      exec ${optionalString dbusSupport "${dbus}/bin/dbus-run-session"} ${getExe scroll} "$@"
+    fi
+  '';
+in
+symlinkJoin {
+  pname = replaceStrings [ "-unwrapped" ] [ "" ] scroll.pname;
+  inherit (scroll) version;
+
+  paths = (optional withBaseWrapper baseWrapper) ++ [ scroll ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+  nativeBuildInputs = [ makeWrapper ] ++ (optional withGtkWrapper wrapGAppsHook3);
+
+  buildInputs = optionals withGtkWrapper [
+    gdk-pixbuf
+    glib
+    gtk3
+  ];
+
+  # We want to run wrapProgram manually
+  dontWrapGApps = true;
+
+  postBuild = ''
+    ${optionalString withGtkWrapper "gappsWrapperArgsHook"}
+
+    wrapProgram $out/bin/${scroll.meta.mainProgram} \
+      ${optionalString withGtkWrapper ''"''${gappsWrapperArgs[@]}"''} \
+      ${optionalString (extraOptions != [ ])
+        "${concatMapStrings (x: " --add-flags " + x) extraOptions}"
+      }
+  '';
+
+  passthru = {
+    inherit (scroll.passthru) tests;
+    providedSessions = [ scroll.meta.mainProgram ];
+  };
+
+  inherit (scroll) meta;
+}


### PR DESCRIPTION
I'm the current maintainer of [scroll-flake](https://github.com/Diax170/scroll-flake) (originally created by AsahiRocks). I've recently created some Nix modules and commits to Nixpkgs and figured out that I can as well port [scroll](https://github.com/dawsers/scroll), a well-maintained Sway fork with a scrolling layout (similar to PaperWM) I use. I also plan creating ~a NixOS test (possibly will add to this PR) and~ a Home Manager module for Scroll a bit later.

To scroll-flake users: scroll-flake will continue to function mainly because of the git release. The release I'm PRing here is the stable one.

Also see https://github.com/dawsers/scroll/discussions/236

Edit: I've added a basic test mostly copy/pasted from Sway test

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
