### PR TITLE
nixos/zfs: skip key loading for canmount=off/noauto datasets

### DIFF
--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -138,7 +138,7 @@ let
     if lib.isBool cfgZfs.requestEncryptionCredentials then
       {
         hasKeys = cfgZfs.requestEncryptionCredentials;
-        command = "${cfgZfs.package}/sbin/zfs list -rHo name,keylocation,keystatus -t volume,filesystem ${pool}";
+        command = "${cfgZfs.package}/sbin/zfs list -rHo name,keylocation,keystatus,canmount -t volume,filesystem ${pool}";
       }
     else
       let
@@ -146,7 +146,7 @@ let
       in
       {
         hasKeys = keys != [ ];
-        command = "${cfgZfs.package}/sbin/zfs list -Ho name,keylocation,keystatus -t volume,filesystem ${toString keys}";
+        command = "${cfgZfs.package}/sbin/zfs list -Ho name,keylocation,keystatus,canmount -t volume,filesystem ${toString keys}";
       };
 
   createImportService =
@@ -212,9 +212,17 @@ let
 
 
             ${lib.optionalString keyLocations.hasKeys ''
-              ${keyLocations.command} | while IFS=$'\t' read -r ds kl ks; do
+              ${keyLocations.command} | while IFS=$'\t' read -r ds kl ks cm; do
                 {
                 if [[ "$ks" != unavailable ]]; then
+                  continue
+                fi
+                # Don't load keys for datasets that are not going to be mounted
+                # automatically anyway (canmount=noauto or canmount=off). This
+                # avoids blocking boot on a passphrase prompt for volumes that
+                # are not needed for boot, such as encrypted backups where the
+                # target host will never see the key.
+                if [[ "$cm" == noauto || "$cm" == off ]]; then
                   continue
                 fi
                 case "$kl" in

--- a/nixos/tests/zfs.nix
+++ b/nixos/tests/zfs.nix
@@ -95,6 +95,17 @@ let
             };
           };
 
+          specialisation.noautoencryption.configuration = {
+            # Import an extra (non-root) pool via ZFS-native logic. Its key
+            # loading is handled by the zfs-import-<pool> service, which must
+            # skip datasets marked canmount=off/noauto.
+            boot.zfs.extraPools = [ "noautotank" ];
+            boot.zfs.requestEncryptionCredentials = true;
+            # If a passphrase is ever requested during boot (i.e. the fix
+            # regressed), fail fast instead of hanging forever.
+            boot.zfs.passwordTimeout = 10;
+          };
+
           specialisation.forcepool.configuration = {
             systemd.services.zfs-import-forcepool.wantedBy = lib.mkVMOverride [ "forcepool.mount" ];
             systemd.targets.zfs.wantedBy = lib.mkVMOverride [ ];
@@ -126,6 +137,8 @@ let
         let
           samba = nodes.machine.specialisation.samba.configuration.system.build.toplevel;
           encryption = nodes.machine.specialisation.encryption.configuration.system.build.toplevel;
+          noautoencryption =
+            nodes.machine.specialisation.noautoencryption.configuration.system.build.toplevel;
           forcepool = nodes.machine.specialisation.forcepool.configuration.system.build.toplevel;
         in
         # python
@@ -185,6 +198,62 @@ let
                   "umount /automatic /manual/encrypted /manual/httpkey /manual",
                   "zpool destroy automatic",
                   "zpool destroy manual",
+              )
+
+          with subtest("encrypted canmount=noauto/off datasets are left alone at boot"):
+              # An extra (non-root) pool with a plain auto-mounted dataset and
+              # two encrypted datasets that should not be mounted at boot: one
+              # canmount=noauto, one canmount=off. Their passphrases are only
+              # available via an interactive prompt (keylocation=prompt).
+              #
+              # Without the fix, the zfs-import-<pool> service would run
+              # `systemd-ask-password` for these datasets during boot, blocking
+              # on a passphrase that never comes; after passwordTimeout (set to
+              # 10s here) it retries and ultimately the service *fails*. With the
+              # fix it skips both datasets, so the import service succeeds and no
+              # prompt is ever shown.
+              machine.succeed(
+                  "zpool create -O mountpoint=none noautotank /dev/vdc1",
+                  "zfs create -o mountpoint=/plain noautotank/plain",
+                  "echo pass-for-noauto | zfs create -o encryption=aes-256-gcm "
+                  + "-o keyformat=passphrase -o canmount=noauto "
+                  + "-o mountpoint=/secret noautotank/secret-noauto",
+                  "echo pass-for-off | zfs create -o encryption=aes-256-gcm "
+                  + "-o keyformat=passphrase -o canmount=off noautotank/secret-off",
+                  "${noautoencryption}/bin/switch-to-configuration boot",
+                  "sync",
+                  "zpool export noautotank",
+              )
+              machine.crash()
+              # The import service must succeed (i.e. not have gotten stuck on /
+              # failed a passphrase prompt for the noauto/off datasets). This
+              # is the assertion that regresses without the fix.
+              machine.wait_for_unit("zfs-import-noautotank.service")
+              machine.wait_for_unit("multi-user.target")
+              # It must never have asked for either dataset's key.
+              machine.fail(
+                  "journalctl -u zfs-import-noautotank.service | grep -F 'Enter key for noautotank/secret-noauto'",
+                  "journalctl -u zfs-import-noautotank.service | grep -F 'Enter key for noautotank/secret-off'",
+              )
+              # Pool imported, plain dataset auto-mounted.
+              machine.succeed(
+                  "zpool status noautotank",
+                  "mount | grep -F ' on /plain '",
+              )
+              # The encrypted noauto/off datasets must be untouched: key not
+              # loaded, not mounted.
+              machine.succeed(
+                  "zfs get -Ho value keystatus noautotank/secret-noauto | grep -Fx unavailable",
+                  "zfs get -Ho value mounted noautotank/secret-noauto | grep -Fx no",
+                  "zfs get -Ho value keystatus noautotank/secret-off | grep -Fx unavailable",
+              )
+              # The noauto dataset is still usable on demand.
+              machine.succeed(
+                  "echo pass-for-noauto | zfs load-key noautotank/secret-noauto",
+                  "zfs mount noautotank/secret-noauto",
+                  "mount | grep -F ' on /secret '",
+                  "umount /plain /secret",
+                  "zpool destroy noautotank",
               )
 
           with subtest("boot.zfs.forceImportAll works"):


### PR DESCRIPTION
The boot-time ZFS pool import service prompts for encryption passphrases for every encrypted dataset with an unavailable key. This blocks boot on headless machines that have encrypted volumes not needed for boot.

Skip key loading for datasets marked canmount=off or canmount=noauto, since they will not be mounted automatically anyway.

Add a subtest to nixos/tests/zfs.nix covering an extra pool with an encrypted canmount=noauto dataset: boot must not request its key and must leave it unmounted with keystatus=unavailable.

---

Much of this was done by Claude, but I have reviewed the change, and I have confirmed the test does fail without the fix.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
