### PR TITLE
freebsd: Bump `main` (16.0 series) and start fixing 

### DIFF
--- a/pkgs/os-specific/bsd/freebsd/patches/16.0/bsd-lib-mk-force-static.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/16.0/bsd-lib-mk-force-static.patch
@@ -1,0 +1,66 @@
+diff --git a/share/mk/bsd.lib.mk b/share/mk/bsd.lib.mk
+index 5f328d5378ca..89d16dc6fa41 100644
+--- a/share/mk/bsd.lib.mk
++++ b/share/mk/bsd.lib.mk
+@@ -242,7 +242,7 @@ PO_FLAG=-pg
+ _LIBDIR:=${LIBDIR}
+ _SHLIBDIR:=${SHLIBDIR}
+ 
+-.if defined(SHLIB_NAME)
++.if defined(SHLIB_NAME) && !empty(SHLIB_NAME)
+ .if ${MK_DEBUG_FILES} != "no"
+ SHLIB_NAME_FULL=${SHLIB_NAME}.full
+ # Use ${DEBUGDIR} for base system debug files, else .debug subdirectory
+@@ -277,7 +277,7 @@ LDFLAGS+=	-Wl,--undefined-version
+ .endif
+ .endif
+ 
+-.if defined(LIB) && !empty(LIB) || defined(SHLIB_NAME)
++.if defined(LIB) && !empty(LIB) || (defined(SHLIB_NAME) && !empty(SHLIB_NAME))
+ OBJS+=		${SRCS:N*.h:${OBJS_SRCS_FILTER:ts:}:S/$/.o/}
+ BCOBJS+=	${SRCS:N*.[hsS]:N*.asm:${OBJS_SRCS_FILTER:ts:}:S/$/.bco/g}
+ LLOBJS+=	${SRCS:N*.[hsS]:N*.asm:${OBJS_SRCS_FILTER:ts:}:S/$/.llo/g}
+@@ -320,14 +320,14 @@ lib${LIB_PRIVATE}${LIB}.ll: ${LLOBJS}
+ CLEANFILES+=	lib${LIB_PRIVATE}${LIB}.bc lib${LIB_PRIVATE}${LIB}.ll
+ .endif
+ 
+-.if defined(SHLIB_NAME) || \
++.if (defined(SHLIB_NAME) && !empty(SHLIB_NAME)) || \
+     defined(INSTALL_PIC_ARCHIVE) && defined(LIB) && !empty(LIB)
+ SOBJS+=		${OBJS:.o=.pico}
+ DEPENDOBJS+=	${SOBJS}
+ CLEANFILES+=	${SOBJS}
+ .endif
+ 
+-.if defined(SHLIB_NAME)
++.if defined(SHLIB_NAME) && !empty(SHLIB_NAME)
+ _LIBS+=		${SHLIB_NAME}
+ 
+ SOLINKOPTS+=	-shared -Wl,-x
+@@ -435,7 +435,7 @@ all: all-man
+ CLEANFILES+=	${_LIBS}
+ 
+ _EXTRADEPEND:
+-.if !defined(NO_EXTRADEPEND) && defined(SHLIB_NAME)
++.if !defined(NO_EXTRADEPEND) && defined(SHLIB_NAME) && !empty(SHLIB_NAME)
+ .if defined(DPADD) && !empty(DPADD)
+ 	echo ${SHLIB_NAME_FULL}: ${DPADD} >> ${DEPENDFILE}
+ .endif
+@@ -501,7 +501,7 @@ _libinstall:
+	    ${_INSTALLFLAGS} lib${LIB_PRIVATE}${LIB}${_STATICLIB_SUFFIX}.a ${DESTDIR}${_LIBDIR}/
+ .endif
+ .endif
+-.if defined(SHLIB_NAME)
++.if defined(SHLIB_NAME) && !empty(SHLIB_NAME)
+	${INSTALL} ${LIB_TAG_ARGS} ${STRIP} -o ${LIBOWN} -g ${LIBGRP} -m ${LIBMODE} \
+	    ${_INSTALLFLAGS} ${_SHLINSTALLFLAGS} \
+	    ${SHLIB_NAME} ${DESTDIR}${_SHLIBDIR}/
+@@ -588,7 +588,7 @@ OBJS_DEPEND_GUESS+= ${SRCS:M*.h}
+ OBJS_DEPEND_GUESS.${_S:${OBJS_SRCS_FILTER:ts:}}.po+=	${_S}
+ .endfor
+ .endif
+-.if defined(SHLIB_NAME) || \
++.if (defined(SHLIB_NAME) && !empty(SHLIB_NAME)) || \
+     defined(INSTALL_PIC_ARCHIVE) && defined(LIB) && !empty(LIB)
+ .for _S in ${SRCS:N*.[hly]}
+ OBJS_DEPEND_GUESS.${_S:${OBJS_SRCS_FILTER:ts:}}.pico+=	${_S}

--- a/pkgs/os-specific/bsd/freebsd/patches/16.0/compat-install-dirs.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/16.0/compat-install-dirs.patch
@@ -1,0 +1,44 @@
+diff --git a/tools/build/Makefile b/tools/build/Makefile
+index d71cc710be87..7765cba73fac 100644
+--- a/tools/build/Makefile
++++ b/tools/build/Makefile
+@@ -508,16 +508,16 @@ host-symlinks:
+ # and cross-tools stages. We do this here using mkdir since mtree may not exist
+ # yet (this happens if we are crossbuilding from Linux/Mac).
+ INSTALLDIR_LIST= \
+-	bin \
+-	lib/geom \
+-	usr/include/casper \
+-	usr/include/openssl \
+-	usr/include/private/ucl \
+-	usr/include/private/yaml \
+-	usr/include/private/zstd \
+-	usr/lib \
+-	usr/libdata/pkgconfig \
+-	usr/libexec
++	${BINDIR} \
++	${LIBDIR}/geom \
++	${INCLUDEDIR}/casper \
++	${INCLUDEDIR}/openssl \
++	${INCLUDEDIR}/private/ucl \
++	${INCLUDEDIR}/private/yaml \
++	${INCLUDEDIR}/private/zstd \
++	${LIBDIR} \
++	${LIBDIR}/libdata/pkgconfig \
++	${LIBEXECDIR}
+ 
+ installdirs:
+ 	mkdir -p ${INSTALLDIR_LIST:S,^,${DESTDIR}/,}
+@@ -535,9 +535,9 @@ installdirs:
+ 	    rm -rf "${DESTDIR}/${_dir}"; \
+ 	fi
+ .endfor
+-	ln -sfn bin ${DESTDIR}/sbin
+-	ln -sfn ../bin ${DESTDIR}/usr/bin
+-	ln -sfn ../bin ${DESTDIR}/usr/sbin
++	ln -sfn bin ${DESTDIR}/${SBINDIR}
++	ln -sfn ../bin ${DESTDIR}/${BINDIR}
++	ln -sfn ../bin ${DESTDIR}/${SBINDIR}
+ .for _group in ${INCSGROUPS:NINCS}
+ 	mkdir -p "${DESTDIR}/${${_group}DIR}"
+ .endfor

--- a/pkgs/os-specific/bsd/freebsd/patches/16.0/compat-systypes.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/16.0/compat-systypes.patch
@@ -1,0 +1,12 @@
+diff --git a/tools/build/cross-build/include/common/sys/types.h b/tools/build/cross-build/include/common/sys/types.h
+index 18b607ed82d2..ee7692b31273 100644
+--- a/tools/build/cross-build/include/common/sys/types.h
++++ b/tools/build/cross-build/include/common/sys/types.h
+@@ -34,6 +34,7 @@
+  * SUCH DAMAGE.
+  */
+ #pragma once
++#include <sys/cdefs.h>
+ #include_next <sys/types.h>
+ #include <sys/_types.h>
+ /*

--- a/pkgs/os-specific/bsd/freebsd/patches/16.0/fsck-path.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/16.0/fsck-path.patch
@@ -1,0 +1,18 @@
+diff --git a/sbin/fsck/fsck.c b/sbin/fsck/fsck.c
+index 3757ed062ba5..584ada116386 100644
+--- a/sbin/fsck/fsck.c
++++ b/sbin/fsck/fsck.c
+@@ -375,11 +375,8 @@ checkfs(const char *pvfstype, const char *spec, const char *mntpt,
+ 			_exit(0);
+ 
+ 		/* Go find an executable. */
+-		execvP(execbase, _PATH_SYSPATH, __DECONST(char * const *, argv));
+-		if (spec)
+-			warn("exec %s for %s in %s", execbase, spec, _PATH_SYSPATH);
+-		else
+-			warn("exec %s in %s", execbase, _PATH_SYSPATH);
++		execvp(execbase, __DECONST(char * const *, argv));
++		warn("exec %s not found", execbase);
+ 		_exit(1);
+ 		/* NOTREACHED */
+ 

--- a/pkgs/os-specific/bsd/freebsd/patches/16.0/install-bootstrap-Makefile.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/16.0/install-bootstrap-Makefile.patch
@@ -1,0 +1,11 @@
+--- a/usr.bin/xinstall/Makefile	2023-09-23 19:18:49.165192183 -0700
++++ b/usr.bin/xinstall/Makefile	2023-12-06 17:06:57.836888028 -0700
+@@ -14,7 +14,7 @@
+ CFLAGS+=	-I${SRCTOP}/lib/libnetbsd
+ 
+ LIBADD=		md
+-CFLAGS+=	-DWITH_MD5 -DWITH_RIPEMD160
++CFLAGS+=		-I${BSDSRCDIR}/contrib/libc-vis -I${BSDSRCDIR}/lib/libnetbsd
+ 
+ .ifdef BOOTSTRAPPING
+ # For the bootstrap we disable copy_file_range()

--- a/pkgs/os-specific/bsd/freebsd/patches/16.0/libc-msun-arch-subdir.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/16.0/libc-msun-arch-subdir.patch
@@ -1,0 +1,11 @@
+--- a/lib/libc/Makefile
++++ b/lib/libc/Makefile
+@@ -194,7 +194,7 @@ SUBDIR.${MK_TESTS}+= tests
+ # recording a build dependency
+ CFLAGS+= -I${SRCTOP}/lib/libutil
+ # Same issue with libm
+-MSUN_ARCH_SUBDIR != ${MAKE} -B -C ${SRCTOP}/lib/msun -V ARCH_SUBDIR
++MSUN_ARCH_SUBDIR = ${MACHINE_CPUARCH:S/i386/i387/}
+ # unfortunately msun/src contains both private and public headers
+ CFLAGS+= -I${SRCTOP}/lib/msun/${MSUN_ARCH_SUBDIR}
+ .if ${MACHINE_CPUARCH} == "i386" || ${MACHINE_CPUARCH} == "amd64"

--- a/pkgs/os-specific/bsd/freebsd/patches/16.0/libcxxrt-headers.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/16.0/libcxxrt-headers.patch
@@ -1,0 +1,11 @@
+--- freebsd/lib/libcxxrt/Makefile	2024-05-30 14:27:42.328086005 -0700
++++ freebsd/lib/libcxxrt/Makefile.mod	2024-05-30 14:27:48.048014581 -0700
+@@ -19,6 +19,8 @@
+ SRCS+=		terminate.cc
+ SRCS+=		typeinfo.cc
+ 
++INCS+=cxxabi.h
++
+ WARNS?=		0
+ CFLAGS+=	-isystem ${SRCDIR} -nostdinc++
+ CXXSTD?=	c++14

--- a/pkgs/os-specific/bsd/freebsd/patches/16.0/libifconfig-no-internal.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/16.0/libifconfig-no-internal.patch
@@ -1,0 +1,34 @@
+diff --git a/lib/libifconfig/Makefile b/lib/libifconfig/Makefile
+index 6bdb202bec1d..ebc626901cfc 100644
+--- a/lib/libifconfig/Makefile
++++ b/lib/libifconfig/Makefile
+@@ -1,5 +1,4 @@
+ LIB=		ifconfig
+-INTERNALLIB=	true
+ 
+ LIBADD=		m
+ 
+@@ -36,8 +35,8 @@ SRCS+=	${GEN}
+ CLEANFILES+= ${GEN}
+ 
+ # If libifconfig become public uncomment those two lines
+-#INCSDIR=	${INCLUDEDIR}
+-#INCS=		libifconfig.h libifconfig_sfp.h libifconfig_sfp_tables.h
++INCSDIR=	${INCLUDEDIR}
++INCS=		libifconfig.h libifconfig_sfp.h libifconfig_sfp_tables.h
+ 
+ #MAN=		libifconfig.3
+ 
+diff --git a/lib/libifconfig/Symbol.map b/lib/libifconfig/Symbol.map
+index 2d80fb31652a..8b08947112e5 100644
+--- a/lib/libifconfig/Symbol.map
++++ b/lib/libifconfig/Symbol.map
+@@ -2,6 +2,8 @@
+ 	ifconfig_bridge_get_bridge_status;
+ 	ifconfig_bridge_free_bridge_status;
+ 	ifconfig_carp_get_info;
++	ifconfig_carp_get_vhid;
++	ifconfig_carp_set_info;
+ 	ifconfig_close;
+ 	ifconfig_create_interface;
+ 	ifconfig_create_interface_vlan;

--- a/pkgs/os-specific/bsd/freebsd/patches/16.0/libncurses-tinfo-makefile-gnused.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/16.0/libncurses-tinfo-makefile-gnused.patch
@@ -1,0 +1,22 @@
+diff --git a/lib/ncurses/tinfo/Makefile b/lib/ncurses/tinfo/Makefile
+index 08c2311cd7a9..9efadea9bee0 100644
+--- a/lib/ncurses/tinfo/Makefile
++++ b/lib/ncurses/tinfo/Makefile
+@@ -269,7 +269,7 @@ curses.h: curses.head MKkey_defs.sh Caps Caps-ncurses
+ 	cat curses.head > $@.new
+ 	AWK=${AWK} _POSIX2_VERSION=199209 sh ${NCURSES_DIR}/include/MKkey_defs.sh \
+ 	    ${NCURSES_DIR}/include/Caps ${NCURSES_DIR}/include/Caps-ncurses >> $@.new
+-	sed -i '' 's|${SRCTOP}|${NCURSES_SRCTOP}|g' $@.new
++	sed -i 's|${SRCTOP}|${NCURSES_SRCTOP}|g' $@.new
+ 	cat ${NCURSES_DIR}/include/curses.wide >> $@.new
+ 	cat ${NCURSES_DIR}/include/curses.tail >> $@.new
+ 	mv -f $@.new $@
+@@ -394,7 +394,7 @@ unctrl.h: unctrl.h.in
+ terminfo.5: MKterminfo.sh terminfo.head Caps
+ 	sh ${NCURSES_DIR}/man/MKterminfo.sh ${NCURSES_DIR}/man/terminfo.head \
+ 	    ${NCURSES_DIR}/include/Caps ${NCURSES_DIR}/man/terminfo.tail >$@
+-	sed -i '' 's|${SRCTOP}|${NCURSES_SRCTOP}|g' $@
++	sed -i 's|${SRCTOP}|${NCURSES_SRCTOP}|g' $@
+ 
+ CLEANFILES+=	terminfo.5
+ 

--- a/pkgs/os-specific/bsd/freebsd/patches/16.0/libnetbsd-do-install.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/16.0/libnetbsd-do-install.patch
@@ -1,0 +1,32 @@
+diff --git a/Makefile b/Makefile
+index 22710f3d933..22effc848cf 100644
+--- a/lib/libnetbsd/Makefile
++++ b/lib/libnetbsd/Makefile
+@@ -9,6 +9,26 @@ CFLAGS+=	-I${.CURDIR}
+ 
+ SRCS+=	efun.c sockaddr_snprintf.c strsuftoll.c util.c util.h
+ 
+-INTERNALLIB=
++INCSGROUPS= INCS SYSINCS NETINETINCS
++
++INCS+= \
++	glob.h \
++	pthread.h \
++	rmd160.h \
++	sha1.h \
++	sha2.h \
++	stdlib.h \
++	util.h
++
++SYSINCSDIR= ${INCLUDEDIR}/sys
++SYSINCS+= \
++	sys/cdefs.h \
++	sys/event.h \
++	sys/types.h \
++	sys/wait.h
++
++NETINETINCSDIR= ${INCLUDEDIR}/netinet
++NETINETINCS+= \
++	netinet/in.h
+ 
+ .include <bsd.lib.mk>

--- a/pkgs/os-specific/bsd/freebsd/patches/16.0/librpcsvc-include-subdir.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/16.0/librpcsvc-include-subdir.patch
@@ -1,0 +1,11 @@
+--- a/lib/librpcsvc/Makefile
++++ b/lib/librpcsvc/Makefile
+@@ -20,7 +20,7 @@ OTHERSRCS+= yp_passwd.c yp_update.c
+ 
+ RPCCOM=	RPCGEN_CPP=${CPP:Q} rpcgen -C
+ 
+-INCDIRS= -I${SYSROOT:U${DESTDIR}}/usr/include/rpcsvc
++INCDIRS= -I${INCLUDEDIR}/rpcsvc
+ 
+ CFLAGS+= -DYP ${INCDIRS}
+ 

--- a/pkgs/os-specific/bsd/freebsd/patches/16.0/localedef.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/16.0/localedef.patch
@@ -1,0 +1,158 @@
+diff --git a/include/_ctype.h b/include/_ctype.h
+index 91e6b1d14f6b..a6896b598da3 100644
+--- a/include/_ctype.h
++++ b/include/_ctype.h
+@@ -44,7 +44,7 @@
+ #define	__CTYPE_H_
+ 
+ #include <sys/cdefs.h>
+-#include <sys/_types.h>
++#include <sys/types.h>
+ 
+ #define	_CTYPE_A	0x00000100L		/* Alpha */
+ #define	_CTYPE_C	0x00000200L		/* Control */
+diff --git a/lib/libc/locale/collate.h b/lib/libc/locale/collate.h
+index 2d3723b49f5b..6bbff732b9d7 100644
+--- a/lib/libc/locale/collate.h
++++ b/lib/libc/locale/collate.h
+@@ -36,6 +36,7 @@
+ #ifndef _COLLATE_H_
+ #define        _COLLATE_H_
+ 
++#include <stdint.h>
+ #include <sys/types.h>
+ #include <limits.h>
+ #include "xlocale_private.h"
+diff --git a/usr.bin/localedef/charmap.c b/usr.bin/localedef/charmap.c
+index 44b7e3292eae..79c30b7cf372 100644
+--- a/usr.bin/localedef/charmap.c
++++ b/usr.bin/localedef/charmap.c
+@@ -31,6 +31,7 @@
+  * CHARMAP file handling for localedef.
+  */
+ 
++#include <stdint.h>
+ #include <sys/types.h>
+ #include <sys/tree.h>
+ 
+diff --git a/usr.bin/localedef/collate.c b/usr.bin/localedef/collate.c
+index 2a080773a95e..3f0030c638f5 100644
+--- a/usr.bin/localedef/collate.c
++++ b/usr.bin/localedef/collate.c
+@@ -31,6 +31,7 @@
+  * LC_COLLATE database generation routines for localedef.
+  */
+ 
++#include <stdint.h>
+ #include <sys/types.h>
+ #include <sys/tree.h>
+ 
+diff --git a/usr.bin/localedef/ctype.c b/usr.bin/localedef/ctype.c
+index ab7b76e57b2d..846c6d6480a8 100644
+--- a/usr.bin/localedef/ctype.c
++++ b/usr.bin/localedef/ctype.c
+@@ -32,6 +32,7 @@
+ /*
+  * LC_CTYPE database generation routines for localedef.
+  */
++#include <stdint.h>
+ #include <sys/cdefs.h>
+ #include <sys/tree.h>
+ 
+diff --git a/usr.bin/localedef/localedef.c b/usr.bin/localedef/localedef.c
+index 5ff146d6f655..ed69aa1f0c0e 100644
+--- a/usr.bin/localedef/localedef.c
++++ b/usr.bin/localedef/localedef.c
+@@ -32,7 +32,7 @@
+  * POSIX localedef.
+  */
+ #include <sys/cdefs.h>
+-#include <sys/endian.h>
++#include <endian.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
+ 
+diff --git a/usr.bin/localedef/messages.c b/usr.bin/localedef/messages.c
+index 6b8eb9d684dd..0155821d0e56 100644
+--- a/usr.bin/localedef/messages.c
++++ b/usr.bin/localedef/messages.c
+@@ -31,6 +31,7 @@
+ /*
+  * LC_MESSAGES database generation routines for localedef.
+  */
++#include <stdint.h>
+ #include <sys/cdefs.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+diff --git a/usr.bin/localedef/monetary.c b/usr.bin/localedef/monetary.c
+index 7a77ac7e256c..7636c4deca1f 100644
+--- a/usr.bin/localedef/monetary.c
++++ b/usr.bin/localedef/monetary.c
+@@ -31,6 +31,7 @@
+ /*
+  * LC_MONETARY database generation routines for localedef.
+  */
++#include <stdint.h>
+ #include <sys/cdefs.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+diff --git a/usr.bin/localedef/numeric.c b/usr.bin/localedef/numeric.c
+index 5533b7c10e1a..9c47494f815c 100644
+--- a/usr.bin/localedef/numeric.c
++++ b/usr.bin/localedef/numeric.c
+@@ -31,6 +31,7 @@
+ /*
+  * LC_NUMERIC database generation routines for localedef.
+  */
++#include <stdint.h>
+ #include <sys/cdefs.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+diff --git a/usr.bin/localedef/parser.y b/usr.bin/localedef/parser.y
+index 23b3b54f8a6e..e01330f0152d 100644
+--- a/usr.bin/localedef/parser.y
++++ b/usr.bin/localedef/parser.y
+@@ -33,6 +33,7 @@
+  * POSIX localedef grammar.
+  */
+ 
++#include <stdint.h>
+ #include <wchar.h>
+ #include <stdio.h>
+ #include <limits.h>
+diff --git a/usr.bin/localedef/scanner.c b/usr.bin/localedef/scanner.c
+index c6d45a993f28..b17670ef4b4a 100644
+--- a/usr.bin/localedef/scanner.c
++++ b/usr.bin/localedef/scanner.c
+@@ -32,6 +32,7 @@
+  * This file contains the "scanner", which tokenizes the input files
+  * for localedef for processing by the higher level grammar processor.
+  */
++#include <stdint.h>
+ #include <sys/cdefs.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+diff --git a/usr.bin/localedef/time.c b/usr.bin/localedef/time.c
+index 7a56e244c921..0e409a742d0a 100644
+--- a/usr.bin/localedef/time.c
++++ b/usr.bin/localedef/time.c
+@@ -31,6 +31,7 @@
+ /*
+  * LC_TIME database generation routines for localedef.
+  */
++#include <stdint.h>
+ #include <sys/cdefs.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+diff --git a/usr.bin/localedef/wide.c b/usr.bin/localedef/wide.c
+index 062e120e6912..a199cddb198d 100644
+--- a/usr.bin/localedef/wide.c
++++ b/usr.bin/localedef/wide.c
+@@ -34,6 +34,7 @@
+  * to the wide character forms used internally by libc.  Unfortunately,
+  * this approach means that we need a method for each and every encoding.
+  */
++#include <stdint.h>
+ #include <sys/cdefs.h>
+ #include <ctype.h>
+ #include <stdlib.h>

--- a/pkgs/os-specific/bsd/freebsd/patches/16.0/more-gnu-date.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/16.0/more-gnu-date.patch
@@ -1,0 +1,13 @@
+diff --git a/stand/common/newvers.sh b/stand/common/newvers.sh
+index 8541d61ed76c..368f233de1e1 100755
+--- a/stand/common/newvers.sh
++++ b/stand/common/newvers.sh
+@@ -45,7 +45,7 @@ shift $((OPTIND - 1))
+ LC_ALL=C; export LC_ALL
+ u=${USER-root} h=${HOSTNAME-`hostname`}
+ if [ -n "$SOURCE_DATE_EPOCH" ]; then
+-	if ! t=$(date -ur $SOURCE_DATE_EPOCH 2>/dev/null); then
++	if ! t=$(date -d @$SOURCE_DATE_EPOCH 2>/dev/null); then
+ 		echo "Invalid SOURCE_DATE_EPOCH" >&2
+ 		exit 1
+ 	fi

--- a/pkgs/os-specific/bsd/freebsd/patches/16.0/mount-use-path.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/16.0/mount-use-path.patch
@@ -1,0 +1,18 @@
+diff --git a/sbin/mount/mount.c b/sbin/mount/mount.c
+index 2fcc94e40818..7de6da1bb20e 100644
+--- a/sbin/mount/mount.c
++++ b/sbin/mount/mount.c
+@@ -155,12 +155,9 @@ exec_mountprog(const char *name, const char *execname, char *const argv[])
+ 		EXIT(1);
+ 	case 0:					/* Child. */
+ 		/* Go find an executable. */
+-		execvP(execname, _PATH_SYSPATH, argv);
++		execvp(execname, argv);
+ 		if (errno == ENOENT) {
+ 			xo_warn("exec %s not found", execname);
+-			if (execname[0] != '/') {
+-				xo_warnx("in path: %s", _PATH_SYSPATH);
+-			}
+ 		}
+ 		EXIT(1);
+ 	default:				/* Parent. */

--- a/pkgs/os-specific/bsd/freebsd/patches/16.0/mtree-Makefile.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/16.0/mtree-Makefile.patch
@@ -1,0 +1,13 @@
+--- a/contrib/mtree/Makefile	2023-12-04 23:02:13.919144141 -0700
++++ b/contrib/mtree/Makefile		2023-12-04 23:02:58.371810109 -0700
+@@ -10,8 +10,8 @@
+ SRCS=  compare.c crc.c create.c excludes.c misc.c mtree.c spec.c specspec.c \
+        verify.c getid.c pack_dev.c only.c
+ .if (${HOSTPROG:U} == "")
+-DPADD+= ${LIBUTIL}
+-LDADD+= -lutil
++LIBADD+= ${LIBUTIL}
++#LIBADD+= -lutil
+ .endif
+
+ CPPFLAGS+=	-I${NETBSDSRCDIR}/sbin/mknod

--- a/pkgs/os-specific/bsd/freebsd/patches/16.0/no-perms-BSD.include.dist.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/16.0/no-perms-BSD.include.dist.patch
@@ -1,0 +1,11 @@
+--- a/etc/mtree/BSD.include.dist
++++ b/etc/mtree/BSD.include.dist
+@@ -3,7 +3,7 @@
+ # Please see the file src/etc/mtree/README before making changes to this file.
+ #
+ 
+-/set type=dir uname=root gname=wheel mode=0755 tags=package=clibs-dev
++/set type=dir
+ .
+     arpa
+     ..

--- a/pkgs/os-specific/bsd/freebsd/patches/16.0/rc-bash.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/16.0/rc-bash.patch
@@ -1,0 +1,13 @@
+diff --git a/libexec/rc/rc.subr b/libexec/rc/rc.subr
+index 101c69e93cde..b95fc1b93285 100644
+--- a/libexec/rc/rc.subr
++++ b/libexec/rc/rc.subr
+@@ -2493,7 +2493,7 @@ ltr()
+ 		fi
+ 	done
+ 	if [ -n "${_var}" ]; then
+-		setvar "${_var}" "${_out}"
++		printf -v "${_var}" "%s" "${_out}"
+ 	else
+ 		echo "${_out}"
+ 	fi

--- a/pkgs/os-specific/bsd/freebsd/patches/16.0/rc-no-verify.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/16.0/rc-no-verify.patch
@@ -1,0 +1,17 @@
+--- a/libexec/rc/rc	2024-08-25 17:13:49.568517103 -0700
++++ b/libexec/rc/rc	2024-08-25 17:14:00.909389872 -0700
+@@ -62,14 +62,7 @@
+ 	sh /etc/rc.initdiskless
+ fi
+ 
+-# Run these after determining whether we are booting diskless in order
+-# to minimize the number of files that are needed on a diskless system,
+-# and to make the configuration file variables available to rc itself.
+-#
+-# -o verify has no effect if mac_veriexec is not active
+-set -o verify
+ . /etc/rc.subr
+-set +o verify
+ load_rc_config $rc_config_xtra
+ 
+ if have DebugOn; then

--- a/pkgs/os-specific/bsd/freebsd/patches/16.0/rc-user.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/16.0/rc-user.patch
@@ -1,0 +1,17 @@
+diff --git a/libexec/rc/rc b/libexec/rc/rc
+index 0ea61a4b2c0a..d9bfb228224c 100644
+--- a/libexec/rc/rc
++++ b/libexec/rc/rc
+@@ -87,6 +87,12 @@ if ! [ -e ${firstboot_sentinel} ]; then
+ 	skip_firstboot="-s firstboot"
+ fi
+ 
++if [ -z "$USER_LOGIN" ]; then
++        skip="$skip -s user"
++else
++        skip="$skip -k user"
++fi
++
+ # Do a first pass to get everything up to $early_late_divider so that
+ # we can do a second pass that includes $local_startup directories
+ #

--- a/pkgs/os-specific/bsd/freebsd/patches/16.0/rtld-makefile-nolibsys.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/16.0/rtld-makefile-nolibsys.patch
@@ -1,0 +1,10 @@
+diff --git a/libexec/rtld-elf/Makefile b/libexec/rtld-elf/Makefile
+index b6ff7681e658..9a65abcab442 100644
+--- a/libexec/rtld-elf/Makefile
++++ b/libexec/rtld-elf/Makefile
+@@ -131,4 +131,4 @@ CFLAGS+=	-Wno-redundant-decls
+ 
+ # Add dependencies on libc and libsys archives after bsd.prog.mk
+ # includes bsd.libnames.mk so they are defined.
+-rtld_libc.a: ${LIBC_NOSSP_PIC} ${LIBSYS_PIC}
++rtld_libc.a: ${LIBC_NOSSP_PIC}

--- a/pkgs/os-specific/bsd/freebsd/patches/16.0/stand-label.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/16.0/stand-label.patch
@@ -1,0 +1,390 @@
+diff --git a/stand/common/disk.c b/stand/common/disk.c
+index c1650f0fa..1baf91efa 100644
+--- a/stand/common/disk.c
++++ b/stand/common/disk.c
+@@ -468,7 +468,7 @@ disk_parsedev(struct devdesc **idev, const char *devspec, const char **path)
+ 
+ 	if (*cp != '\0' && *cp != ':')
+ 		return (EINVAL);
+-	dev = malloc(sizeof(*dev));
++	dev = calloc(sizeof(*dev), 1);
+ 	if (dev == NULL)
+ 		return (ENOMEM);
+ 	dev->dd.d_unit = unit;
+diff --git a/stand/efi/include/efi.h b/stand/efi/include/efi.h
+index b603c3a78..d430a7012 100644
+--- a/stand/efi/include/efi.h
++++ b/stand/efi/include/efi.h
+@@ -74,14 +74,16 @@ typedef uint32_t   UINTN;
+ #include "efidef.h"
+ #include "efidevp.h"
+ #include "efipciio.h"
+-#include "efiprot.h"
+ #include "eficon.h"
++#include "efiapi.h"
++#include "efipart.h"
++#include "efigpt.h"
++#include "efiprot.h"
+ #include "eficonsctl.h"
+ #include "efiser.h"
+ #include "efi_nii.h"
+ #include "efipxebc.h"
+ #include "efinet.h"
+-#include "efiapi.h"
+ #include "efifs.h"
+ #include "efierr.h"
+ #include "efigop.h"
+@@ -91,6 +93,7 @@ typedef uint32_t   UINTN;
+ #include "efipoint.h"
+ #include "efiuga.h"
+ #include <sys/types.h>
++#include "efichar.h"
+ 
+ /*
+  * Global variables
+diff --git a/stand/efi/include/efilib.h b/stand/efi/include/efilib.h
+index e1920430a..3bbd83a50 100644
+--- a/stand/efi/include/efilib.h
++++ b/stand/efi/include/efilib.h
+@@ -40,6 +40,7 @@ extern EFI_RUNTIME_SERVICES	*RS;
+ extern struct devsw efipart_fddev;
+ extern struct devsw efipart_cddev;
+ extern struct devsw efipart_hddev;
++extern struct devsw efipart_label;
+ extern struct devsw efihttp_dev;
+ extern struct devsw efinet_dev;
+ extern struct netif_driver efinetif;
+@@ -58,6 +59,7 @@ typedef struct pdinfo
+ 	uint32_t		pd_unit;	/* unit number */
+ 	uint32_t		pd_open;	/* reference counter */
+ 	void			*pd_bcache;	/* buffer cache data */
++	char			pd_volname[36*2];
+ 	struct pdinfo		*pd_parent;	/* Linked items (eg partitions) */
+ 	struct devsw		*pd_devsw;	/* Back pointer to devsw */
+ } pdinfo_t;
+diff --git a/stand/efi/include/efiprot.h b/stand/efi/include/efiprot.h
+index be11ea83b..1463c756c 100644
+--- a/stand/efi/include/efiprot.h
++++ b/stand/efi/include/efiprot.h
+@@ -632,4 +632,41 @@ typedef struct _EFI_COMPONENT_NAME2 {
+     CHAR8 **SupportedLanguages;
+ } EFI_COMPONENT_NAME2;
+ 
++//
++// Partition Info Protocol
++//
++
++#define PARTITION_INFO_PROTOCOL \
++  { 0x8cf2f62c, 0xbc9b, 0x4821, {0x80, 0x8d, 0xec, 0x9e, 0xc4, 0x21, 0xa1, 0xa0} }
++
++INTERFACE_DECL(_EFI_PARTITION_INFO);
++
++#define EFI_PARTITION_INFO_INTERFACE_REVISION 0x0001000
++#define PARTITION_TYPE_OTHER 0x00
++#define PARTITION_TYPE_MBR 0x01
++#define PARTITION_TYPE_GPT 0x02
++
++#pragma pack(1)
++
++typedef struct _EFI_PARTITION_INFO {
++
++  UINT32         Revision;
++  UINT32         Type;
++  UINT8          System;
++  UINT8          Reserved[7];
++  union {
++   ///
++   /// MBR data
++   ///
++   MBR_PARTITION_RECORD Mbr;
++
++   ///
++   /// GPT data
++   ///
++   EFI_PARTITION_ENTRY Gpt;
++  } Info;
++} EFI_PARTITION_INFO;
++
++#pragma pack()
++
+ #endif
+diff --git a/stand/efi/libefi/efipart.c b/stand/efi/libefi/efipart.c
+index 3df603457..a7b6050ff 100644
+--- a/stand/efi/libefi/efipart.c
++++ b/stand/efi/libefi/efipart.c
+@@ -35,11 +35,10 @@
+ 
+ #include <efi.h>
+ #include <efilib.h>
+-#include <efiprot.h>
+-#include <efichar.h>
+ #include <disk.h>
+ 
+ static EFI_GUID blkio_guid = BLOCK_IO_PROTOCOL;
++static EFI_GUID partinfo_guid = PARTITION_INFO_PROTOCOL;
+ 
+ typedef bool (*pd_test_cb_t)(pdinfo_t *, pdinfo_t *);
+ static int efipart_initfd(void);
+@@ -58,6 +57,12 @@ static int efipart_printfd(int);
+ static int efipart_printcd(int);
+ static int efipart_printhd(int);
+ 
++static int efipart_get_volname(EFI_HANDLE h, char *dest, int size);
++static int label_parsedev(struct devdesc **idev, const char *devspec, const char **path);
++
++static char *nullfmt(struct devdesc *vdev);
++static int nullinit(void);
++
+ /* EISA PNP ID's for floppy controllers */
+ #define	PNP0604	0x604
+ #define	PNP0700	0x700
+@@ -104,6 +109,20 @@ struct devsw efipart_hddev = {
+ 	.dv_parsedev = disk_parsedev,
+ };
+ 
++struct devsw efipart_label = {
++	.dv_name = "label",
++	.dv_type = DEVT_LABEL,
++	.dv_init = nullinit,
++	.dv_strategy = efipart_strategy,
++	.dv_open = efipart_open,
++	.dv_close = efipart_close,
++	.dv_ioctl = efipart_ioctl,
++	.dv_print = efipart_printhd,
++	.dv_cleanup = nullsys,
++	.dv_fmtdev = nullfmt,
++	.dv_parsedev = label_parsedev,
++};
++
+ static pdinfo_list_t fdinfo = STAILQ_HEAD_INITIALIZER(fdinfo);
+ static pdinfo_list_t cdinfo = STAILQ_HEAD_INITIALIZER(cdinfo);
+ static pdinfo_list_t hdinfo = STAILQ_HEAD_INITIALIZER(hdinfo);
+@@ -406,6 +425,8 @@ efipart_inithandles(void)
+ 		pd->pd_handle = hin[i];
+ 		pd->pd_devpath = devpath;
+ 		pd->pd_blkio = blkio;
++		/* Do not fail here */
++		efipart_get_volname(hin[i], pd->pd_volname, sizeof(pd->pd_volname));
+ 		STAILQ_INSERT_TAIL(&pdinfo, pd, pd_link);
+ 	}
+ 
+@@ -419,6 +440,20 @@ efipart_inithandles(void)
+ 	return (0);
+ }
+ 
++static int
++efipart_get_volname(EFI_HANDLE h, char *dest, int size)
++{
++	EFI_PARTITION_INFO *partinfo;
++	int status;
++
++	status = OpenProtocolByHandle(h, &partinfo_guid, (void **)&partinfo);
++	if (EFI_ERROR(status)) {
++		return (efi_status_to_errno(status));
++	}
++	cpy16to8(partinfo->Info.Gpt.PartitionName, dest, size);
++	return (0);
++}
++
+ /*
+  * Get node identified by pd_test() from plist.
+  */
+@@ -1249,3 +1284,99 @@ efipart_realstrategy(void *devdata, int rw, daddr_t blk, size_t size,
+ 		free(blkbuf);
+ 	return (rc);
+ }
++
++static pdinfo_t *
++label_lookup_part(const char *label, struct devsw **dev)
++{
++	pdinfo_t *dp, *pp;
++
++	/*
++	 * Check hard disks, then cd, then floppy
++	 */
++	STAILQ_FOREACH(dp, &hdinfo, pd_link) {
++		if (!strcmp(label, dp->pd_volname)) {
++			*dev = &efipart_hddev;
++			return (dp);
++		}
++		STAILQ_FOREACH(pp, &dp->pd_part, pd_link) {
++			if (!strcmp(label, pp->pd_volname)) {
++				*dev = &efipart_hddev;
++				return (pp);
++			}
++		}
++	}
++	STAILQ_FOREACH(dp, &cdinfo, pd_link) {
++		if (!strcmp(label, dp->pd_volname)) {
++			*dev = &efipart_cddev;
++			return (dp);
++		}
++		STAILQ_FOREACH(pp, &dp->pd_part, pd_link) {
++			if (!strcmp(label, pp->pd_volname)) {
++				*dev = &efipart_cddev;
++				return (pp);
++			}
++		}
++	}
++	STAILQ_FOREACH(dp, &fdinfo, pd_link) {
++		if (!strcmp(label, dp->pd_volname)) {
++			*dev = &efipart_fddev;
++			return (dp);
++		}
++	}
++	return (NULL);
++}
++
++static int
++label_parsedev(struct devdesc **idev, const char *devspec, const char **path)
++{
++	pdinfo_t *part;
++	const char *devspeci, *devspecp;
++	char *label;
++	struct disk_devdesc *dev;
++
++	if (strncmp(devspec, "label:", strlen("label:"))) {
++		return (EINVAL);
++	}
++	devspeci = devspec + strlen("label:");
++	devspecp = strchr(devspeci, ':');
++	if (devspecp == NULL) {
++		return (EINVAL);
++	}
++	label = malloc(devspecp - devspeci + 1);
++	if (label == NULL) {
++		return (ENOMEM);
++	}
++	memcpy(label, devspeci, devspecp - devspeci);
++	label[devspecp - devspeci] = 0;
++
++	dev = calloc(sizeof(*dev), 1);
++	if (dev == NULL)
++		return (ENOMEM);
++
++	part = label_lookup_part(label, &dev->dd.d_dev);
++	if (part == NULL) {
++		return (ENOENT);
++	}
++
++	dev->dd.d_unit = part->pd_parent->pd_unit;
++	dev->d_slice = part->pd_unit;
++	dev->d_partition = D_PARTISGPT;
++	*idev = &dev->dd;
++	if (path != NULL) {
++		*path = devspecp + 1;
++	}
++
++	return (0);
++}
++
++static char *
++nullfmt(struct devdesc *vdev)
++{
++	return ("");
++}
++
++static int
++nullinit(void)
++{
++	return (0);
++}
+diff --git a/stand/efi/loader/conf.c b/stand/efi/loader/conf.c
+index 3bc74ea63..042aa15b3 100644
+--- a/stand/efi/loader/conf.c
++++ b/stand/efi/loader/conf.c
+@@ -40,6 +40,7 @@ struct devsw *devsw[] = {
+ 	&efipart_fddev,
+ 	&efipart_cddev,
+ 	&efipart_hddev,
++	&efipart_label,
+ 	&efihttp_dev, /* ordering with efinet_dev matters */
+ #if defined(LOADER_NET_SUPPORT)
+ 	&efinet_dev,
+diff --git a/stand/kboot/kboot/hostdisk.c b/stand/kboot/kboot/hostdisk.c
+index a9117d4c1..fc98bf534 100644
+--- a/stand/kboot/kboot/hostdisk.c
++++ b/stand/kboot/kboot/hostdisk.c
+@@ -465,7 +465,7 @@ hostdisk_parsedev(struct devdesc **idev, const char *devspec, const char **path)
+ 		return (EINVAL);
+ 	}
+ 	free(fn);
+-	dev = malloc(sizeof(*dev));
++	dev = calloc(sizeof(*dev), 1);
+ 	if (dev == NULL)
+ 		return (ENOMEM);
+ 	dev->d_unit = 0;
+diff --git a/stand/libofw/devicename.c b/stand/libofw/devicename.c
+index 5e3a789c1..dd7eb2cf8 100644
+--- a/stand/libofw/devicename.c
++++ b/stand/libofw/devicename.c
+@@ -98,7 +98,7 @@ ofw_common_parsedev(struct devdesc **dev, const char *devspec, const char **path
+ 
+ 	if (ofw_path_to_handle(devspec, ofwtype, &rem_path) == -1)
+ 		return (ENOENT);
+-	idev = malloc(sizeof(struct ofw_devdesc));
++	idev = calloc(sizeof(struct ofw_devdesc), 1);
+ 	if (idev == NULL) {
+ 		printf("ofw_parsedev: malloc failed\n");
+ 		return ENOMEM;
+diff --git a/stand/libsa/dev.c b/stand/libsa/dev.c
+index 1edc843d5..841615588 100644
+--- a/stand/libsa/dev.c
++++ b/stand/libsa/dev.c
+@@ -72,7 +72,7 @@ default_parsedev(struct devdesc **dev, const char *devspec,
+ 	int unit, err;
+ 	char *cp;
+ 
+-	idev = malloc(sizeof(struct devdesc));
++	idev = calloc(sizeof(struct devdesc), 1);
+ 	if (idev == NULL)
+ 		return (ENOMEM);
+ 
+@@ -139,7 +139,8 @@ devparse(struct devdesc **dev, const char *devspec, const char **path)
+ 	if (err != 0)
+ 		return (err);
+ 
+-	idev->d_dev = dv;
++	if (idev->d_dev == NULL)
++		idev->d_dev = dv;
+ 	if (dev != NULL)
+ 		*dev = idev;
+ 	else
+diff --git a/stand/libsa/stand.h b/stand/libsa/stand.h
+index 260defa3a..8fb5c818d 100644
+--- a/stand/libsa/stand.h
++++ b/stand/libsa/stand.h
+@@ -148,6 +148,7 @@ struct devsw {
+ #define DEVT_CD		3
+ #define DEVT_ZFS	4
+ #define DEVT_FD		5
++#define DEVT_LABEL	6
+     int		(*dv_init)(void);	/* early probe call */
+     int		(*dv_strategy)(void *devdata, int rw, daddr_t blk,
+ 			size_t size, char *buf, size_t *rsize);
+diff --git a/stand/libsa/zfs/zfs.c b/stand/libsa/zfs/zfs.c
+index 70a102f64..2f7c1caaa 100644
+--- a/stand/libsa/zfs/zfs.c
++++ b/stand/libsa/zfs/zfs.c
+@@ -1643,7 +1643,7 @@ zfs_parsedev(struct devdesc **idev, const char *devspec, const char **path)
+ 	spa = spa_find_by_name(poolname);
+ 	if (!spa)
+ 		return (ENXIO);
+-	dev = malloc(sizeof(*dev));
++	dev = calloc(sizeof(*dev), 1);
+ 	if (dev == NULL)
+ 		return (ENOMEM);
+ 	dev->pool_guid = spa->spa_guid;
+diff --git a/stand/uboot/devicename.c b/stand/uboot/devicename.c
+index 4ee9c7fd7..23670d759 100644
+--- a/stand/uboot/devicename.c
++++ b/stand/uboot/devicename.c
+@@ -102,7 +102,7 @@ uboot_parsedev(struct uboot_devdesc **dev, const char *devspec,
+ 	}
+ 	if (dv == NULL)
+ 		return(ENOENT);
+-	idev = malloc(sizeof(struct uboot_devdesc));
++	idev = calloc(sizeof(struct uboot_devdesc), 1);
+ 	err = 0;
+ 	np = (devspec + strlen(dv->dv_name));
+ 

--- a/pkgs/os-specific/bsd/freebsd/patches/16.0/sys-gnu-date.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/16.0/sys-gnu-date.patch
@@ -1,0 +1,13 @@
+diff --git a/sys/conf/newvers.sh b/sys/conf/newvers.sh
+index de696a192853..60a603c4546f 100644
+--- a/sys/conf/newvers.sh
++++ b/sys/conf/newvers.sh
+@@ -194,7 +194,7 @@ u=${USER:-root}
+ d=$builddir
+ h=${HOSTNAME:-$(hostname)}
+ if [ -n "$SOURCE_DATE_EPOCH" ]; then
+-	if ! t=$(date -ur $SOURCE_DATE_EPOCH 2>/dev/null); then
++	if ! t=$(date -ud @$SOURCE_DATE_EPOCH 2>/dev/null); then
+ 		echo "Invalid SOURCE_DATE_EPOCH" >&2
+ 		exit 1
+ 	fi

--- a/pkgs/os-specific/bsd/freebsd/patches/16.0/sys-no-explicit-intrinsics-dep.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/16.0/sys-no-explicit-intrinsics-dep.patch
@@ -1,0 +1,43 @@
+diff --git a/sys/modules/aesni/Makefile b/sys/modules/aesni/Makefile
+index 4219182f03fe..d3cc10654523 100644
+--- a/sys/modules/aesni/Makefile
++++ b/sys/modules/aesni/Makefile
+@@ -1,5 +1,4 @@
+ .PATH: ${SRCTOP}/sys/crypto/aesni
+-.PATH: ${SRCTOP}/contrib/llvm-project/clang/lib/Headers
+ 
+ KMOD=	aesni
+ SRCS=	aesni.c
+@@ -38,8 +37,8 @@ intel_sha256.o: intel_sha256.c
+ aesni_ghash.o: aesni.h
+ aesni_wrap.o: aesni.h
+ aesni_ccm.o: aesni.h
+-intel_sha1.o: sha_sse.h immintrin.h shaintrin.h tmmintrin.h xmmintrin.h
+-intel_sha256.o: sha_sse.h immintrin.h shaintrin.h tmmintrin.h xmmintrin.h
++intel_sha1.o: sha_sse.h
++intel_sha256.o: sha_sse.h
+ 
+ .include <bsd.kmod.mk>
+ 
+diff --git a/sys/modules/blake2/Makefile b/sys/modules/blake2/Makefile
+index 85d4bff8dede..9296ef5b3cf6 100644
+--- a/sys/modules/blake2/Makefile
++++ b/sys/modules/blake2/Makefile
+@@ -1,7 +1,6 @@
+ .PATH:	${SRCTOP}/sys/contrib/libb2
+ .PATH:	${SRCTOP}/sys/crypto/blake2
+ .PATH:	${SRCTOP}/sys/opencrypto
+-.PATH:	${SRCTOP}/contrib/llvm-project/clang/lib/Headers
+ 
+ KMOD	= blake2
+ 
+@@ -62,8 +61,7 @@ ${src:S/.c/.o/}: ${src}
+ 	    -D_MM_MALLOC_H_INCLUDED -Wno-unused-function ${.IMPSRC}
+ 	${CTFCONVERT_CMD}
+ 
+-${src:S/.c/.o/}: intrin.h emmintrin.h tmmintrin.h smmintrin.h immintrin.h \
+-    x86intrin.h ${SRCS:M*.h}
++${src:S/.c/.o/}: ${SRCS:M*.h}
+ .endfor
+ 
+ # FreeBSD-specific sources:

--- a/pkgs/os-specific/bsd/freebsd/patches/16.0/tinfo-host-cc.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/16.0/tinfo-host-cc.patch
@@ -1,0 +1,15 @@
+--- a/lib/ncurses/tinfo/Makefile	2023-12-26 23:02:07.827892619 -0800
++++ b/lib/ncurses/tinfo/Makefile	2023-12-26 23:01:24.175546100 -0800
+@@ -282,10 +282,10 @@
+ build-tools: make_hash make_keys
+ 
+ make_keys: make_keys.c names.c ncurses_def.h ${HEADERS} ${BUILD_TOOLS_META}
+-	${CC:N${CCACHE_BIN}} -o $@ ${CFLAGS} ${NCURSES_DIR}/ncurses/tinfo/make_keys.c
++	${CC_HOST:N${CCACHE_BIN}} -o $@ ${CFLAGS} ${NCURSES_DIR}/ncurses/tinfo/make_keys.c
+ 
+ make_hash: make_hash.c hashsize.h ncurses_def.h ${HEADERS} ${BUILD_TOOLS_META}
+-	${CC:N${CCACHE_BIN}} -o $@ ${CFLAGS} -DMAIN_PROGRAM \
++	${CC_HOST:N${CCACHE_BIN}} -o $@ ${CFLAGS} -DMAIN_PROGRAM \
+ 		${NCURSES_DIR}/ncurses/tinfo/make_hash.c
+ .endif
+ .if ${MK_DIRDEPS_BUILD} == "yes" && ${MACHINE} != "host"

--- a/pkgs/os-specific/bsd/freebsd/patches/16.0/zfsd-headers.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/16.0/zfsd-headers.patch
@@ -1,0 +1,12 @@
+diff --git a/cddl/usr.sbin/zfsd/case_file.cc b/cddl/usr.sbin/zfsd/case_file.cc
+index 852767aeb227..69086b4a7255 100644
+--- a/cddl/usr.sbin/zfsd/case_file.cc
++++ b/cddl/usr.sbin/zfsd/case_file.cc
+@@ -49,6 +49,7 @@
+ #include <iomanip>
+ #include <fstream>
+ #include <functional>
++#include <algorithm>
+ #include <sstream>
+ #include <syslog.h>
+ #include <unistd.h>

--- a/pkgs/os-specific/bsd/freebsd/pkgs/compat/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/compat/package.nix
@@ -116,6 +116,9 @@ mkDerivation {
 
     "contrib/libedit/readline/readline.h"
   ]
+  ++ lib.optionals (versionData.major >= 16) [
+    "include/stdckdint.h"
+  ]
   ++ [
 
     # Listed in Makefile as SYSINCS

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libgcc.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libgcc.nix
@@ -38,12 +38,14 @@ mkDerivation {
     export NIX_LDFLAGS="$NIX_LDFLAGS --undefined-version"
   '';
 
+  # libcompiler_rt before libgcc_s: since 16.0, libgcc_s has
+  # LIBADD+=compiler_rt and links against the freshly built library.
   postBuild = ''
-    mkdir $BSDSRCDIR/lib/libgcc_s/i386 $BSDSRCDIR/lib/libgcc_s/cpu_model
-    make -C $BSDSRCDIR/lib/libgcc_s $makeFlags
-
     mkdir $BSDSRCDIR/lib/libcompiler_rt/i386 $BSDSRCDIR/lib/libcompiler_rt/cpu_model
     make -C $BSDSRCDIR/lib/libcompiler_rt $makeFlags
+
+    mkdir $BSDSRCDIR/lib/libgcc_s/i386 $BSDSRCDIR/lib/libgcc_s/cpu_model
+    make -C $BSDSRCDIR/lib/libgcc_s $makeFlags
   '';
 
   postInstall = ''

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libthr.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libthr.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchpatch,
+  versionData,
   mkDerivation,
   libsys,
   libcMinimal,
@@ -36,8 +37,8 @@ mkDerivation {
     libsys
   ];
 
-  patches = [
-    # https://github.com/freebsd/freebsd-src/pull/1882
+  # https://github.com/freebsd/freebsd-src/pull/1882, landed in 16.0
+  patches = lib.optionals (versionData.major <= 15) [
     (fetchpatch {
       name = "freebsd-libthr-use-nonstring-attribute.patch";
       url = "https://github.com/freebsd/freebsd-src/pull/1882/commits/650800993deb513dc31e99ef5cdecd50ee70bb04.diff";

--- a/pkgs/os-specific/bsd/freebsd/pkgs/rtld-elf.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/rtld-elf.nix
@@ -3,6 +3,7 @@
   stdenv,
   mkDerivation,
   fetchpatch,
+  versionData,
   include,
   rpcgen,
   libsys,
@@ -40,8 +41,8 @@ mkDerivation {
   ]
   ++ extraSrc;
 
-  patches = [
-    # https://github.com/freebsd/freebsd-src/pull/1882
+  # https://github.com/freebsd/freebsd-src/pull/1882, landed in 16.0
+  patches = lib.optionals (versionData.major <= 15) [
     (fetchpatch {
       name = "freebsd-rtld-use-nonstring-attribute.patch";
       url = "https://github.com/freebsd/freebsd-src/pull/1882/commits/650800993deb513dc31e99ef5cdecd50ee70bb04.diff";

--- a/pkgs/os-specific/bsd/freebsd/update.py
+++ b/pkgs/os-specific/bsd/freebsd/update.py
@@ -25,6 +25,11 @@ TAG_PATTERN = re.compile(
     f"^release/({packaging.version.VERSION_PATTERN})$", re.IGNORECASE | re.VERBOSE
 )
 REMOTE = "origin"
+# The canonical repo (git.FreeBSD.org, usually `origin`) can be ahead of
+# the GitHub mirror that fetchFromGitHub actually downloads from.  For
+# branches we therefore record the merge-base of the two heads — the
+# newest commit both sides have.
+GITHUB_URL = "https://github.com/freebsd/freebsd-src.git"
 BRANCH_PATTERN = re.compile(
     f"^{REMOTE}/((stable|releng)/({packaging.version.VERSION_PATTERN}))$",
     re.IGNORECASE | re.VERBOSE,
@@ -115,6 +120,13 @@ def handle_commit(
     }
 
 
+def github_remote(repo: git.Repo) -> git.Remote:
+    for remote in repo.remotes:
+        if any("github.com" in url and "freebsd-src" in url for url in remote.urls):
+            return remote
+    return repo.create_remote("github", GITHUB_URL)
+
+
 def main() -> None:
     # Normally uses /run/user/*, which is on a tmpfs and too small
     temp_dir = tempfile.TemporaryDirectory(dir="/tmp")
@@ -166,6 +178,10 @@ def main() -> None:
 
         versions[tag.name] = result
 
+    github = github_remote(repo)
+    print(f"Fetching updates on GitHub mirror remote {github.name}")
+    github.fetch()
+
     for branch in repo.remote("origin").refs:
         m = BRANCH_PATTERN.match(branch.name)
         if m is not None:
@@ -181,8 +197,29 @@ def main() -> None:
         else:
             continue
 
+        commit = branch.commit
+        try:
+            github_commit = repo.commit(f"{github.name}/{fullname}")
+            base = repo.merge_base(commit, github_commit)[0]
+            if base not in (commit, github_commit):
+                # One repo should always be a fast-forward of the other;
+                # a third-commit merge-base means diverged histories.
+                raise RuntimeError(
+                    f"{fullname}: {REMOTE} ({commit.hexsha}) and GitHub "
+                    f"mirror ({github_commit.hexsha}) have diverged; "
+                    f"merge-base {base.hexsha} is neither head"
+                )
+            if base != commit:
+                print(
+                    f"{fullname}: {REMOTE} and GitHub mirror heads differ, "
+                    f"using older head {base.hexsha}"
+                )
+            commit = base
+        except (git.BadName, IndexError):
+            print(f"{fullname}: not on GitHub mirror, using {REMOTE} head")
+
         result = handle_commit(
-            repo, branch.commit, fullname, "branch", supported_refs, old_versions
+            repo, commit, fullname, "branch", supported_refs, old_versions
         )
         versions[fullname] = result
 

--- a/pkgs/os-specific/bsd/freebsd/versions.json
+++ b/pkgs/os-specific/bsd/freebsd/versions.json
@@ -1,15 +1,15 @@
 {
   "main": {
-    "hash": "sha256-2bJSM8zOFzAFXhrWZX06ULA0p6MvdJZ3VEHI9Q+bU1g=",
+    "hash": "sha256-wNbrPhnoAXkfi/ClLCZ1RCc+JlPHpmeDxzpGJD1LQIU=",
     "ref": "main",
     "refType": "branch",
-    "rev": "9ec8196f68bac015965164f7f1a65c619bab4e85",
+    "rev": "2b1df6149e8a2d50a09d13c64d1574dad91e10b1",
     "supported": false,
     "version": {
       "branch": "CURRENT",
       "major": 16,
       "minor": 0,
-      "reldate": "1600004",
+      "reldate": "1600019",
       "release": "16.0-CURRENT",
       "revision": "16.0",
       "type": "FreeBSD",


### PR DESCRIPTION
CC @artemist @rhelmot 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
