### PR TITLE
arcanist: restore, on new upstream, in by-name form

### DIFF
--- a/pkgs/by-name/ar/arcanist/dont-require-python3-in-path.patch
+++ b/pkgs/by-name/ar/arcanist/dont-require-python3-in-path.patch
@@ -1,0 +1,26 @@
+Don't require python3 in PATH
+
+Once packaged, the arcanoid.py script has an absolute path shebang to
+python3, so there is no need to also require python3 in PATH.
+
+This prevents leaking in a python3 in PATH in the environment which arc
+runs linters etc.
+
+Author: bjorn.forsman@gmail.com
+diff -uNr arcanist.orig/src/workflow/ArcanistAnoidWorkflow.php arcanist.new/src/workflow/ArcanistAnoidWorkflow.php
+--- arcanist.orig/src/workflow/ArcanistAnoidWorkflow.php	2022-03-31 13:23:30.865095192 +0200
++++ arcanist.new/src/workflow/ArcanistAnoidWorkflow.php	2022-04-01 12:19:15.644159639 +0200
+@@ -24,13 +24,6 @@
+   }
+ 
+   protected function runWorkflow() {
+-    if (!Filesystem::binaryExists('python3')) {
+-      throw new PhutilArgumentUsageException(
+-        pht(
+-          'The "arc anoid" workflow requires "python3" to be available '.
+-          'in your $PATH.'));
+-    }
+-
+     $support_dir = phutil_get_library_root('arcanist');
+     $support_dir = dirname($support_dir);
+     $support_dir = $support_dir.'/support/';

--- a/pkgs/by-name/ar/arcanist/package.nix
+++ b/pkgs/by-name/ar/arcanist/package.nix
@@ -1,0 +1,102 @@
+{
+  bison,
+  cacert,
+  fetchFromGitHub,
+  flex,
+  php,
+  lib,
+  stdenv,
+  installShellFiles,
+  which,
+  python3,
+}:
+
+# Make a custom wrapper. If `wrapProgram` is used, arcanist thinks .arc-wrapped is being
+# invoked and complains about it being an unknown toolset. We could use `makeWrapper`, but
+# then we’d need to still craft a script that does the `php libexec/arcanist/bin/...` dance
+# anyway... So just do everything at once.
+let
+  makeArcWrapper = toolset: ''
+    cat << WRAPPER > $out/bin/${toolset}
+    #!$shell -e
+    export PATH='${php}/bin:${which}/bin'\''${PATH:+':'}\$PATH
+    exec ${php}/bin/php $out/libexec/arcanist/bin/${toolset} "\$@"
+    WRAPPER
+    chmod +x $out/bin/${toolset}
+  '';
+
+in
+stdenv.mkDerivation {
+  pname = "arcanist";
+  version = "0-unstable-2026-07-19";
+
+  # The phorgeit fork is the maintained continuation of the upstream
+  # (archived) phacility/arcanist.
+  src = fetchFromGitHub {
+    owner = "phorgeit";
+    repo = "arcanist";
+    rev = "b084cd508f587aaa2ed6fef5e2cee163b4bdd259";
+    hash = "sha256-8QxRCYF4gnuuOBO2lZm9bbfj0ApeqUobPy/MXfhH8zE=";
+  };
+
+  patches = [
+    ./dont-require-python3-in-path.patch
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  # python3 stays in buildInputs so patchShebangs resolves the
+  # arcanoid.py shebang; php also runs at build time (xhpast codegen).
+  buildInputs = [ python3 ];
+
+  nativeBuildInputs = [
+    bison
+    flex
+    installShellFiles
+    php
+  ];
+
+  postPatch = lib.optionalString stdenv.isAarch64 ''
+    substituteInPlace support/xhpast/Makefile \
+      --replace "-minline-all-stringops" ""
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    make cleanall -C support/xhpast $makeFlags "''${makeFlagsArray[@]}" -j $NIX_BUILD_CORES
+    make xhpast   -C support/xhpast $makeFlags "''${makeFlagsArray[@]}" -j $NIX_BUILD_CORES
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin $out/libexec
+    make install  -C support/xhpast $makeFlags "''${makeFlagsArray[@]}" -j $NIX_BUILD_CORES
+    make cleanall -C support/xhpast $makeFlags "''${makeFlagsArray[@]}" -j $NIX_BUILD_CORES
+    cp -R . $out/libexec/arcanist
+    ln -sf ${cacert}/etc/ssl/certs/ca-bundle.crt $out/libexec/arcanist/resources/ssl/default.pem
+
+    ${makeArcWrapper "arc"}
+    ${makeArcWrapper "phage"}
+
+    $out/bin/arc shell-complete --generate --
+    installShellCompletion --cmd arc --bash $out/libexec/arcanist/support/shell/rules/bash-rules.sh
+    installShellCompletion --cmd phage --bash $out/libexec/arcanist/support/shell/rules/bash-rules.sh
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/arc help diff -- > /dev/null
+    $out/bin/phage help alias -- > /dev/null
+  '';
+
+  meta = {
+    description = "Command line interface to Phorge and Phabricator";
+    homepage = "https://we.phorge.it/";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.unix;
+    mainProgram = "arc";
+  };
+}


### PR DESCRIPTION
Restores the package removed in 5ed483f0d794, but with a maintained fork rather than abdanoned repo:

- Upstream phacility/arcanist is archived; use its maintained continuation, the phorgeit fork, at current master (0-unstable-2026-07-19).

- Regenerate the python3-in-PATH patch (`runWorkflow` visibility changed) and drop `shellcomplete-strlen-null.patch` (now merged upstream, it seems).

- Put in `pkgs/by-name` (unlike before), refresh `meta` for Phorge, set `mainProgram`.

Assisted-by: Claude Code (Claude Fable 5)

-------

I am packaging this because I personally need it to submit FreeBSD kernel patches.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
