### PR TITLE
openvfs: init at 0.1.0

### DIFF
--- a/pkgs/by-name/op/openvfs/package.nix
+++ b/pkgs/by-name/op/openvfs/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  fetchFromGitHub,
+  fuse3,
+  kdePackages,
+  nix-update-script,
+  nlohmann_json,
+  qt6,
+}:
+#
+stdenv.mkDerivation (finalAttrs: {
+  pname = "openvfs";
+  version = "0.1.0-unstable-2026-07-22";
+
+  src = fetchFromGitHub {
+    owner = "opencloud-eu";
+    repo = "openvfs";
+    rev = "525d8c6c9158c12604b0aaaedb6bae532804328d";
+    hash = "sha256-O/or88niQACm7oA9MGqHZe+cw9XTAzUKhfkBg3fGUz8=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    kdePackages.extra-cmake-modules
+    qt6.qtbase
+    fuse3
+  ];
+
+  buildInputs = [
+    fuse3
+    nlohmann_json
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+  dontWrapQtApps = true;
+
+  cmakeFlags = [
+    (lib.cmakeFeature "ECM_DIR" "${kdePackages.extra-cmake-modules}/share/ECM/cmake")
+    (lib.cmakeBool "KDE_INSTALL_USE_QT_SYS_PATHS" false)
+    (lib.cmakeFeature "CMAKE_PREFIX_PATH" "${qt6.qtbase}")
+  ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    description = "Virtual Filesystem Layer for cloud storages for the free desktop (FUSE based files-on-demand)";
+    homepage = "https://github.com/opencloud-eu/openvfs";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "openvfs";
+    maintainers = [ ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added [OpenVFS](https://github.com/opencloud-eu/openvfs), a library used by recent (unreleased) OpenCloud Desktop versions.

I've tested this package by building the lastest OpenCloud Desktop commit and confirming VFS works.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
