### PR TITLE
Revert "lib/services: add some generalization options (#535695)"

### DIFF
--- a/lib/services/service.nix
+++ b/lib/services/service.nix
@@ -6,7 +6,6 @@
 # The module
 {
   lib,
-  config,
   ...
 }:
 let
@@ -50,53 +49,6 @@ in
           a shell script or `importas` from `pkgs.execline`.
         '';
       };
-
-      reloadSignal = mkOption {
-        type = types.nullOr types.str;
-        default = null;
-        example = "HUP";
-        description = ''
-          Configures the reload signal to send to the service manager.
-        '';
-      };
-
-      reloadCommand = mkOption {
-        type = types.nullOr types.str;
-        default = null;
-        example = lib.literalExpression ''"''${pkgs.coreutils}/bin/kill -HUP $MAINPID"'';
-
-        description = ''
-          Command used for reloading in the underlying service manager to reload.
-        '';
-      };
     };
-
-    notificationProtocol = mkOption {
-      type = types.listOf (
-        types.enum [
-          "systemd"
-          "s6"
-        ]
-      );
-
-      default = [ ];
-      apply = v: lib.unique v;
-      description = ''
-        Notification protocol that this service supports with the underlying service manager.
-      '';
-    };
-  };
-
-  config = {
-    assertions = [
-      {
-        assertion = config.process.reloadSignal != null && config.process.reloadCommand != null;
-        message = "reloadSignal conflicts with reloadCommand. Please either use reloadSignal or reloadCommand.";
-      }
-    ];
-
-    process.reloadCommand = (lib.mkIf config.process.reloadSignal != null) (
-      lib.mkForce "${pkgs.coreutils}/bin/kill -${config.process.reloadSignal} $MAINPID"
-    );
   };
 }

--- a/nixos/modules/system/service/systemd/service.nix
+++ b/nixos/modules/system/service/systemd/service.nix
@@ -113,48 +113,6 @@ in
       defaultText = lib.literalExpression "config.systemd.lib.escapeSystemdExecArgs config.process.argv";
     };
 
-    systemd.mainExecReload = mkOption {
-      description = ''
-        Main command line for systemd's ExecReload with systemd's specifier and
-        environment variable substitution enabled.
-
-        This option sets the primary ExecRestart entry. Additional ExecReload entries
-        can be added via `systemd.service.serviceConfig.ExecReload` with `lib.mkBefore`
-        or `lib.mkAfter`.
-
-        This option allows you to use systemd specifiers like `%n` (unit name),
-        `%i` (instance), `%t` (runtime directory), and environment variables using
-        `''${VAR}` syntax in your command line.
-
-        By default, it is either set to null or this is set to the escaped version of {option}`process.reloadCommand`
-        when specified to prevent systemd substitution. Set this option explicitly to enable
-        systemd's substitution features.
-
-        To extend {option}`process.reloadCommand` with systemd specifiers, you can append
-        to the escaped arguments:
-
-        ```nix
-        systemd.mainExecReload =
-          config.systemd.lib.escapeSystemdExecArgs config.process.reload + " --systemd-unit %n";
-        ```
-
-        This pattern allows you to pass the unit name (or other systemd specifiers)
-        as additional arguments while keeping the base command from {option}`process.argv`
-        properly escaped.
-
-        See {manpage}`systemd.service(5)` (section "COMMAND LINES") for details on
-        variable substitution and {manpage}`systemd.unit(5)` (section "SPECIFIERS")
-        for available specifiers like `%n`, `%i`, `%t`.
-      '';
-      type = types.nullOr types.str;
-      default =
-        if config.process.reloadCommand then
-          config.systemd.lib.escapeSystemdExecArgs config.process.reloadCommand
-        else
-          "";
-      defaultText = lib.literalExpression "config.systemd.lib.escapeSystemdExecArgs config.process.reloadCommand";
-    };
-
     systemd.services = mkOption {
       description = ''
         This module configures systemd services, with the notable difference that their unit names will be prefixed with the abstract service name.
@@ -212,10 +170,7 @@ in
       # TODO description;
       wantedBy = lib.mkDefault [ "multi-user.target" ];
       serviceConfig = {
-        ExecReload = config.systemd.mainExecReload;
-        Type = lib.mkDefault (
-          if (config.serviceManager.notificationProtocol == "systemd") then "notify" else "simple"
-        );
+        Type = lib.mkDefault "simple";
         Restart = lib.mkDefault "always";
         RestartSec = lib.mkDefault "5";
         ExecStart = [


### PR DESCRIPTION
This reverts commit fa6488337a9f548b99e9cf430b465e9f0fa8699a due to nix expr issues and untested code, next time don't rush the pr and have a proper thing to test this and eval before merging, but lucky it's experimental. 

Ref: https://github.com/NixOS/nixpkgs/pull/540857#issuecomment-5051546049

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
