### PR TITLE
python3Packages.protobuf4: fix for setuptools >= 81

### DIFF
--- a/pkgs/development/python-modules/protobuf/4.nix
+++ b/pkgs/development/python-modules/protobuf/4.nix
@@ -6,6 +6,7 @@
   lib,
   stdenv,
   numpy,
+  packaging,
   protobuf,
   pytestCheckHook,
   pythonAtLeast,
@@ -68,9 +69,18 @@ buildPythonPackage {
     + ''
       substituteInPlace google/protobuf/internal/json_format_test.py \
         --replace-warn assertRaisesRegexp assertRaisesRegex
+    ''
+    # setuptools 81 dropped pkg_resources, parse versions via packaging module
+    + ''
+      substituteInPlace setup.py \
+        --replace-fail "import pkg_resources" "import packaging.version" \
+        --replace-fail "pkg_resources.parse_version" "packaging.version.parse"
     '';
 
-  nativeBuildInputs = lib.optional isPyPy tzdata;
+  nativeBuildInputs = [
+    packaging
+  ]
+  ++ lib.optional isPyPy tzdata;
 
   buildInputs = [ protobuf ];
 


### PR DESCRIPTION
`pkg_resources` was finally removed, use `packaging` for parsing version strings instead

this is the recommended approach from setuptools' docs: https://setuptools.pypa.io/en/latest/deprecated/pkg_resources.html


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
