### PR TITLE
vimPlugins.blink-pairs 0.5.0 -> 0.6.0

### DIFF
--- a/pkgs/applications/editors/vim/plugins/non-generated/blink-pairs/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/blink-pairs/default.nix
@@ -3,25 +3,26 @@
   rustPlatform,
   fetchFromGitHub,
   pkg-config,
+  vimPlugins,
   vimUtils,
   stdenv,
   nix-update-script,
 }:
 let
-  version = "0.5.0";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "Saghen";
     repo = "blink.pairs";
     tag = "v${version}";
-    hash = "sha256-PTbj6jlXNRUOmwFSplvRDDiyyGqkBzUKtuBrvZm9kzM=";
+    hash = "sha256-XWrsZAH0tIPyRjr3PnAS2QAGE3+1z00jdnsxkKG0qPE=";
   };
 
   blink-pairs-lib = rustPlatform.buildRustPackage {
     pname = "blink-pairs";
     inherit version src;
 
-    cargoHash = "sha256-Cn9zRsQkBwaKbBD/JEpFMBOF6CBZTDx7fQa6Aoic4YU=";
+    cargoHash = "sha256-XLlluprxhVueHhkIufJa7fJXvFxpJJzh89+yL9PZ4GI=";
 
     env = {
       RUSTC_BOOTSTRAP = 1;
@@ -42,13 +43,15 @@ vimUtils.buildVimPlugin {
   pname = "blink.pairs";
   inherit version src;
 
+  dependencies = [ vimPlugins.blink-lib ];
+
   preInstall =
     let
       ext = stdenv.hostPlatform.extensions.sharedLibrary;
     in
     ''
-      mkdir -p target/release
-      ln -s ${blink-pairs-lib}/lib/libblink_pairs${ext} target/release/
+      mkdir -p lib
+      ln -s ${blink-pairs-lib}/lib/libblink_pairs_parser${ext} lib/
     '';
 
   nvimSkipModules = [

--- a/pkgs/applications/editors/vim/plugins/non-generated/blink-pairs/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/blink-pairs/default.nix
@@ -71,6 +71,9 @@ vimUtils.buildVimPlugin {
     homepage = "https://github.com/Saghen/blink.pairs";
     changelog = "https://github.com/Saghen/blink.pairs/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ isabelroses ];
+    maintainers = with lib.maintainers; [
+      isabelroses
+      saadndm
+    ];
   };
 }


### PR DESCRIPTION
Diff: https://github.com/saghen/blink.pairs/compare/v0.5.0...v0.6.0
Changelog: [Saghen/blink.pairs@v0.6.0/CHANGELOG.md](https://github.com/saghen/blink.pairs/blob/main/CHANGELOG.md#060---2026-06-11)

- Added myself as maintainer
- Added `blink-cmp` as a dependency
- Reflect upstream rust crate rername from `blink_pairs` to `blink_pairs_parser`
- Moved native lib from `target/release` to `lib` since `blink.cmp` expects them there

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
