### PR TITLE
terragrunt: 1.0.4 -> 1.1.2

### DIFF
--- a/pkgs/by-name/te/terragrunt/package.nix
+++ b/pkgs/by-name/te/terragrunt/package.nix
@@ -7,13 +7,13 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "terragrunt";
-  version = "1.0.4";
+  version = "1.0.5";
 
   src = fetchFromGitHub {
     owner = "gruntwork-io";
     repo = "terragrunt";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-uOX+PTNL6VPu+QN9RiWNonV+WRWYNEadRLvljy49M5Q=";
+    hash = "sha256-HKxWRAawT/r081ww/AoVtVDD43XxEPSRx8GCrIB/cYc=";
   };
 
   nativeBuildInputs = [
@@ -26,7 +26,7 @@ buildGoModule (finalAttrs: {
     make generate-mocks
   '';
 
-  vendorHash = "sha256-LqkHHkX1kMuF4XtpxFPc6Xwas4B+jSMfMxSyv1nzerc=";
+  vendorHash = "sha256-h1DrVYR8Ob1VVV8g3jbxZWAvyOhS4oNlkktZMdhRXmI=";
 
   excludedPackages = [ "test/flake" ];
 

--- a/pkgs/by-name/te/terragrunt/package.nix
+++ b/pkgs/by-name/te/terragrunt/package.nix
@@ -7,13 +7,13 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "terragrunt";
-  version = "1.0.8";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "gruntwork-io";
     repo = "terragrunt";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-LK6WMYcOfQR5Qp7ivkx5A3hpsU+r5VrxIg+1Gum+Kxw=";
+    hash = "sha256-4XQrAhMTl+hBtDEx3INQAUCpIkjgw8VgEHsDFF3Y24w=";
   };
 
   nativeBuildInputs = [
@@ -26,7 +26,7 @@ buildGoModule (finalAttrs: {
     make generate-mocks
   '';
 
-  vendorHash = "sha256-ilgZ8rzYtaol7q5qNSiA81oBMnpdckNtlYfvmT7ZOcM=";
+  vendorHash = "sha256-Iw5ij7+HdY0Er2KsU/sWorD9q4Tzs2imYlnCOwSAhX0=";
 
   excludedPackages = [ "test/flake" ];
 

--- a/pkgs/by-name/te/terragrunt/package.nix
+++ b/pkgs/by-name/te/terragrunt/package.nix
@@ -7,13 +7,13 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "terragrunt";
-  version = "1.1.0";
+  version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "gruntwork-io";
     repo = "terragrunt";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-4XQrAhMTl+hBtDEx3INQAUCpIkjgw8VgEHsDFF3Y24w=";
+    hash = "sha256-MCtMcyY2Rbv173rbcoCKEpnW3LvK2n7uTPXfAH4X0vc=";
   };
 
   nativeBuildInputs = [
@@ -26,7 +26,7 @@ buildGoModule (finalAttrs: {
     make generate-mocks
   '';
 
-  vendorHash = "sha256-Iw5ij7+HdY0Er2KsU/sWorD9q4Tzs2imYlnCOwSAhX0=";
+  vendorHash = "sha256-Jur6XJV35UpQKKynIe8bZ9M63uW+TY5VtPSLpO6aPuc=";
 
   excludedPackages = [ "test/flake" ];
 

--- a/pkgs/by-name/te/terragrunt/package.nix
+++ b/pkgs/by-name/te/terragrunt/package.nix
@@ -7,13 +7,13 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "terragrunt";
-  version = "1.0.5";
+  version = "1.0.6";
 
   src = fetchFromGitHub {
     owner = "gruntwork-io";
     repo = "terragrunt";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-HKxWRAawT/r081ww/AoVtVDD43XxEPSRx8GCrIB/cYc=";
+    hash = "sha256-Rhul6qRX7aZtsc01DF/92kGgxqRXi6hRm4co8I9/OFA=";
   };
 
   nativeBuildInputs = [
@@ -26,7 +26,7 @@ buildGoModule (finalAttrs: {
     make generate-mocks
   '';
 
-  vendorHash = "sha256-h1DrVYR8Ob1VVV8g3jbxZWAvyOhS4oNlkktZMdhRXmI=";
+  vendorHash = "sha256-8hI+6Dv6mgHvLyyJW5+uCUEioWm1c1r1a3d8RVZeBag=";
 
   excludedPackages = [ "test/flake" ];
 
@@ -34,7 +34,7 @@ buildGoModule (finalAttrs: {
 
   ldflags = [
     "-s"
-    "-X github.com/gruntwork-io/go-commons/version.Version=v${finalAttrs.version}"
+    "-X github.com/gruntwork-io/terragrunt/internal/version.Version=v${finalAttrs.version}"
     "-extldflags '-static'"
   ];
 

--- a/pkgs/by-name/te/terragrunt/package.nix
+++ b/pkgs/by-name/te/terragrunt/package.nix
@@ -7,13 +7,13 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "terragrunt";
-  version = "1.0.7";
+  version = "1.0.8";
 
   src = fetchFromGitHub {
     owner = "gruntwork-io";
     repo = "terragrunt";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-C0YKidNZ8qGCv9gf44SPHh6FikvqQh6dhwbCgIkYhuc=";
+    hash = "sha256-LK6WMYcOfQR5Qp7ivkx5A3hpsU+r5VrxIg+1Gum+Kxw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/te/terragrunt/package.nix
+++ b/pkgs/by-name/te/terragrunt/package.nix
@@ -7,13 +7,13 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "terragrunt";
-  version = "1.0.6";
+  version = "1.0.7";
 
   src = fetchFromGitHub {
     owner = "gruntwork-io";
     repo = "terragrunt";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Rhul6qRX7aZtsc01DF/92kGgxqRXi6hRm4co8I9/OFA=";
+    hash = "sha256-C0YKidNZ8qGCv9gf44SPHh6FikvqQh6dhwbCgIkYhuc=";
   };
 
   nativeBuildInputs = [
@@ -26,7 +26,7 @@ buildGoModule (finalAttrs: {
     make generate-mocks
   '';
 
-  vendorHash = "sha256-8hI+6Dv6mgHvLyyJW5+uCUEioWm1c1r1a3d8RVZeBag=";
+  vendorHash = "sha256-ilgZ8rzYtaol7q5qNSiA81oBMnpdckNtlYfvmT7ZOcM=";
 
   excludedPackages = [ "test/flake" ];
 

--- a/pkgs/by-name/te/terragrunt/package.nix
+++ b/pkgs/by-name/te/terragrunt/package.nix
@@ -7,13 +7,13 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "terragrunt";
-  version = "1.1.1";
+  version = "1.1.2";
 
   src = fetchFromGitHub {
     owner = "gruntwork-io";
     repo = "terragrunt";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-MCtMcyY2Rbv173rbcoCKEpnW3LvK2n7uTPXfAH4X0vc=";
+    hash = "sha256-FzexCmOwZGqo1i2fhmEX+BlEB3S8/8vVKMUIsfymRrs=";
   };
 
   nativeBuildInputs = [
@@ -26,7 +26,7 @@ buildGoModule (finalAttrs: {
     make generate-mocks
   '';
 
-  vendorHash = "sha256-Jur6XJV35UpQKKynIe8bZ9M63uW+TY5VtPSLpO6aPuc=";
+  vendorHash = "sha256-H6NF/V0wzPSusq606+BvORYxJFdMSFGoD8bl++WdoFM=";
 
   excludedPackages = [ "test/flake" ];
 


### PR DESCRIPTION
**Diff:** https://github.com/gruntwork-io/terragrunt/compare/v1.0.4...v1.1.2
**Changelog:**

- https://github.com/gruntwork-io/terragrunt/releases/tag/v1.0.5
- https://github.com/gruntwork-io/terragrunt/releases/tag/v1.0.6
- https://github.com/gruntwork-io/terragrunt/releases/tag/v1.0.7
- https://github.com/gruntwork-io/terragrunt/releases/tag/v1.0.8
- https://github.com/gruntwork-io/terragrunt/releases/tag/v1.1.0
- https://github.com/gruntwork-io/terragrunt/releases/tag/v1.1.1
- https://github.com/gruntwork-io/terragrunt/releases/tag/v1.1.2

**Maintainers:** @06kellyjac @qjoly @kashw2

Chose to bump one version per commit (given how specific version pins are often required for infrastructure-related tools), to allow pinning per nixpkgs SHA (instead of `overrides`).
(As far as I know, these intermediate package versions won't be built/cached; they merely serve as "a convenience".)

All commits are normal `version` + `hash` updates with the exception of `1.0.5 -> 1.0.6`, which fixes the `ldflags` `-X` path: gruntwork-io/terragrunt#6180 moved the version variable to `internal/version`, so `terragrunt --version` would report `latest` (and `versionCheckHook` would fail the check).

Closes #521683 by @r-ryantm - which I guess got "stuck" in `1.0.4 -> 1.0.5` due to `versionCheckHook` in subsequent version bumps.


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
