### PR TITLE
calf: don't build gtk2 gui

### DIFF
--- a/pkgs/by-name/ca/calf/package.nix
+++ b/pkgs/by-name/ca/calf/package.nix
@@ -1,15 +1,11 @@
 {
   lib,
   stdenv,
-  cairo,
   expat,
   fftwSinglePrec,
   fluidsynth,
-  glib,
-  gtk2,
   libjack2,
   ladspa-header,
-  gnome2,
   lv2,
   pkg-config,
   fetchFromGitHub,
@@ -33,21 +29,19 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
+  cmakeFlags = [ (lib.cmakeBool "WANT_GUI" false) ];
+
   nativeBuildInputs = [
     cmake
     pkg-config
   ];
 
   buildInputs = [
-    cairo
     expat
     fftwSinglePrec
     fluidsynth
-    glib
-    gtk2
     libjack2
     ladspa-header
-    gnome2.libglade
     lv2
   ];
 


### PR DESCRIPTION
calf is used to provide audio effects when part of other programs, but also has its own gtk2-based gui. as we reduce the usage of the long-deprecated gtk2 (#410814), we drop the gui part of calf as well.

the main in-tree dependent is `easyeffects`, which still builds. from what we gather,  easyeffects shouldn't be affected by removing the gui at all, but would appreciate if the maintainers could confirm that this is unlikely to cause problems: @getchoo @Aleksanaa @Gliczy

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
