### PR TITLE
gtk4: backport Wayland session cleanup null check

### DIFF
--- a/pkgs/by-name/gt/gtk4/package.nix
+++ b/pkgs/by-name/gt/gtk4/package.nix
@@ -101,6 +101,11 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://gitlab.gnome.org/GNOME/gtk/-/commit/10d43de8f4f942cb591ada3103474bd7213425f1.patch";
       hash = "sha256-DJIL6M3XcsjBoMO77OxNi84d1DxAphAfot3N7Nq1QqQ=";
     })
+    (fetchpatch {
+      name = "gtkapplication-wayland-null-check.patch";
+      url = "https://gitlab.gnome.org/GNOME/gtk/-/commit/221cd8e1904f2ca35d89dff3c1068616c6ce588c.patch";
+      hash = "sha256-SLMmWDZ2mLXW3/GJfFdoszthNg4Hd15yvZO2XOld4Uw=";
+    })
   ];
 
   depsBuildBuild = [


### PR DESCRIPTION
See:
- https://gitlab.gnome.org/GNOME/gtk/-/work_items/8098
- https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/9643

This patch is shipped in Debian and Fedora, and its absence causes my [yawsf](https://github.com/bitbloxhub/yawsf)-based desktop shell to segfault randomly.
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
      Not all of them or actually on staging, but the demos worked after putting this patch on master.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
