### PR TITLE
various: remove gtk2 support where it is off by default

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -83,6 +83,8 @@
 
 - `pdns` has been updated from `5.0.x` to `5.1.x`. Please be sure to review the [Upgrade Notes](https://doc.powerdns.com/authoritative/upgrading.html#to-5-1-0) before upgrading. Namely LUA record updates are no longer allowed by default, and the embedded webserver no longer includes a `access-control-allow-origin: *` header by default.
 
+- `davmail` no longer supports building with GTK 2, and the `preferGtk3` override flag has been removed as GTK 3 is always used.
+
 - Support for the legacy U‐Boot image format has been removed from the Linux kernel builders, as it is deprecated upstream and no longer used by any platform in Nixpkgs.
 
 - `etcd_3_4` package was dropped, as it's gone EOL. Please upgrade to either 3.5 or 3.6. See [migration notes](https://etcd.io/docs/v3.6/upgrades/upgrade_3_6/) for incompatibilities and upgrade procedure.

--- a/pkgs/by-name/da/davmail/package.nix
+++ b/pkgs/by-name/da/davmail/package.nix
@@ -5,7 +5,6 @@
   nix-update-script,
   makeWrapper,
   glib,
-  gtk2,
   gtk3,
   ant,
   jdk,
@@ -13,13 +12,11 @@
   coreutils,
   gnugrep,
   zulu,
-  preferGtk3 ? true,
   preferZulu ? false,
 }:
 
 let
   jre' = (if preferZulu then zulu else jdk).override { enableJavaFX = true; };
-  gtk' = if preferGtk3 then gtk3 else gtk2;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "davmail";
@@ -57,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     cp -R ./dist/{lib,davmail{,.jar}} $out/share/davmail
     chmod +x $out/share/davmail/davmail
     makeWrapper $out/share/davmail/davmail $out/bin/davmail \
-      --set-default JAVA_OPTS "-Xmx512M -Dsun.net.inetaddr.ttl=60 -Djdk.gtk.version=${lib.versions.major gtk'.version}" \
+      --set-default JAVA_OPTS "-Xmx512M -Dsun.net.inetaddr.ttl=60 -Djdk.gtk.version=${lib.versions.major gtk3.version}" \
       --prefix PATH : ${
         lib.makeBinPath [
           jre'
@@ -68,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
       --prefix LD_LIBRARY_PATH : ${
         lib.makeLibraryPath [
           glib
-          gtk'
+          gtk3
           libxtst
         ]
       }

--- a/pkgs/by-name/lx/lxappearance/package.nix
+++ b/pkgs/by-name/lx/lxappearance/package.nix
@@ -6,12 +6,10 @@
   intltool,
   pkg-config,
   libx11,
-  gtk2,
   gtk3,
   libxslt,
   docbook_xsl,
   wrapGAppsHook3,
-  withGtk3 ? true,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -38,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     libx11
-    (if withGtk3 then gtk3 else gtk2)
+    gtk3
   ];
 
   patches = [
@@ -47,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   env.XSLTPROC = lib.getExe' libxslt "xsltproc";
 
-  configureFlags = lib.optional withGtk3 "--enable-gtk3";
+  configureFlags = [ "--enable-gtk3" ];
 
   meta = {
     description = "Lightweight program for configuring the theme and fonts of gtk applications";

--- a/pkgs/by-name/lx/lxpanel/package.nix
+++ b/pkgs/by-name/lx/lxpanel/package.nix
@@ -8,14 +8,11 @@
   m4,
   intltool,
   libxmlxx,
-  keybinder,
   keybinder3,
-  gtk2-x11,
   gtk3,
   libx11,
   libfm,
   libwnck,
-  libwnck2,
   libxmu,
   libxpm,
   cairo,
@@ -27,7 +24,6 @@
   curl,
   supportAlsa ? false,
   alsa-lib,
-  withGtk3 ? true,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -53,11 +49,11 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    (if withGtk3 then keybinder3 else keybinder)
-    (if withGtk3 then gtk3 else gtk2-x11)
+    (libfm.override { withGtk3 = true; })
+    keybinder3
+    gtk3
     libx11
-    (libfm.override { inherit withGtk3; })
-    (if withGtk3 then libwnck else libwnck2)
+    libwnck
     libxmu
     libxpm
     cairo
@@ -71,7 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optional supportAlsa alsa-lib;
 
-  configureFlags = lib.optional withGtk3 "--enable-gtk3";
+  configureFlags = [ "--enable-gtk3" ];
 
   meta = {
     description = "Lightweight X11 desktop panel for LXDE";

--- a/pkgs/by-name/pc/pcmanfm/package.nix
+++ b/pkgs/by-name/pc/pcmanfm/package.nix
@@ -11,17 +11,13 @@
   pkg-config,
   wrapGAppsHook3,
   adwaita-icon-theme,
-  withGtk3 ? true,
-  gtk2,
   gtk3,
   gettext,
   nix-update-script,
 }:
 
 let
-  libfm' = libfm.override { inherit withGtk3; };
-  gtk = if withGtk3 then gtk3 else gtk2;
-  inherit (lib) optional;
+  libfm' = libfm.override { withGtk3 = true; };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "pcmanfm";
@@ -43,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     glib
-    gtk
+    gtk3
     libfm'
     libx11
     pango
@@ -52,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   env.ACLOCAL = "aclocal -I ${gettext}/share/gettext/m4";
 
-  configureFlags = optional withGtk3 "--with-gtk=3";
+  configureFlags = [ "--with-gtk=3" ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/pe/perf/package.nix
+++ b/pkgs/by-name/pe/perf/package.nix
@@ -28,8 +28,6 @@
   numactl,
   zlib,
   babeltrace,
-  withGtk ? false,
-  gtk2,
   withZstd ? true,
   zstd,
   withLibcap ? true,
@@ -86,8 +84,8 @@ stdenv.mkDerivation {
     "ASCIIDOC8=1"
     "ARCH=${stdenv.hostPlatform.linuxArch}"
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+    "NO_GTK2=1"
   ]
-  ++ lib.optional (!withGtk) "NO_GTK2=1"
   ++ lib.optional (!withZstd) "NO_LIBZSTD=1"
   ++ lib.optional (!withLibcap) "NO_LIBCAP=1"
   ++ lib.optional (!withPython) "NO_LIBPYTHON=1";
@@ -124,7 +122,6 @@ stdenv.mkDerivation {
     libpfm
   ]
   ++ lib.optional (lib.meta.availableOn stdenv.hostPlatform systemtap-unwrapped) systemtap-unwrapped
-  ++ lib.optional withGtk gtk2
   ++ lib.optional withZstd zstd
   ++ lib.optional withLibcap libcap
   ++ lib.optionals withPython [

--- a/pkgs/by-name/pk/pktgen/package.nix
+++ b/pkgs/by-name/pk/pktgen/package.nix
@@ -11,9 +11,7 @@
   lua5_3,
   numactl,
   util-linux,
-  gtk2,
   which,
-  withGtk ? false,
   nix-update-script,
 }:
 
@@ -44,15 +42,10 @@ stdenv.mkDerivation (finalAttrs: {
     lua5_3
     numactl
     which
-  ]
-  ++ lib.optionals withGtk [
-    gtk2
   ];
 
   env = {
     RTE_SDK = dpdk;
-    GUI = lib.optionalString withGtk "true";
-
     NIX_CFLAGS_COMPILE = toString [
       "-Wno-error=sign-compare"
     ];

--- a/pkgs/by-name/su/suil/package.nix
+++ b/pkgs/by-name/su/suil/package.nix
@@ -16,8 +16,6 @@
   lv2,
 
   # options
-  withGtk2 ? false,
-  gtk2,
   withGtk3 ? true,
   gtk3,
   withQt5 ? true,
@@ -51,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   mesonFlags = [
-    (mesonEnable "gtk2" withGtk2)
+    (mesonEnable "gtk2" false)
     (mesonEnable "gtk3" withGtk3)
     (mesonEnable "qt5" withQt5)
     (mesonEnable "x11" withX11)
@@ -60,7 +58,6 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     lv2
   ]
-  ++ lib.optionals withGtk2 [ gtk2 ]
   ++ lib.optionals withGtk3 [ gtk3 ]
   ++ lib.optionals withQt5 (
     with qt5;

--- a/pkgs/by-name/th/thc-hydra/package.nix
+++ b/pkgs/by-name/th/thc-hydra/package.nix
@@ -11,10 +11,6 @@
   libmysqlclient,
   libpq,
   samba,
-  withGUI ? false,
-  makeWrapper,
-  pkg-config,
-  gtk2,
 }:
 
 stdenv.mkDerivation rec {
@@ -43,11 +39,6 @@ stdenv.mkDerivation rec {
         --replace-fail "-lcurses" "-lncurses"
     '';
 
-  nativeBuildInputs = lib.optionals withGUI [
-    pkg-config
-    makeWrapper
-  ];
-
   buildInputs = [
     zlib
     openssl
@@ -58,17 +49,11 @@ stdenv.mkDerivation rec {
     libmysqlclient
     libpq
     samba
-  ]
-  ++ lib.optional withGUI gtk2;
+  ];
 
   enableParallelBuilding = true;
 
   env.DATADIR = "/share/${pname}";
-
-  postInstall = lib.optionalString withGUI ''
-    wrapProgram $out/bin/xhydra \
-      --add-flags --hydra-path --add-flags "$out/bin/hydra"
-  '';
 
   meta = {
     description = "Very fast network logon cracker which support many different services";

--- a/pkgs/by-name/ye/yersinia/package.nix
+++ b/pkgs/by-name/ye/yersinia/package.nix
@@ -8,9 +8,6 @@
   ncurses,
   libpcap,
   libnet,
-  # alpha version of GTK interface
-  withGtk ? false,
-  gtk2,
   # enable remote admin interface
   enableAdmin ? false,
 }:
@@ -44,17 +41,16 @@ stdenv.mkDerivation {
     libpcap
     libnet
     ncurses
-  ]
-  ++ lib.optional withGtk gtk2;
+  ];
 
   autoreconfPhase = "./autogen.sh";
 
   configureFlags = [
     "--with-pcap-includes=${lib.getDev libpcap}/include"
     "--with-libnet-includes=${lib.getDev libnet}/include"
+    "--disable-gtk"
   ]
-  ++ lib.optional (!enableAdmin) "--disable-admin"
-  ++ lib.optional (!withGtk) "--disable-gtk";
+  ++ lib.optional (!enableAdmin) "--disable-admin";
 
   makeFlags = [ "LDFLAGS=-lncurses" ];
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1451,6 +1451,7 @@ mapAliases {
   luminanceHDR = throw "'luminanceHDR' has been removed as it depended on EOL qt5 webengine and was unmaintained"; # Added 2026-04-17
   lunarvim = throw "'lunarvim' has been removed since it was abandoned upstream and relied on an older version of 'neovim' to work properly"; # Added 2026-02-05
   lunatic = throw "'lunatic' has been removed, as it is unmaintained"; # Added 2026-05-04
+  lxappearance-gtk2 = throw "'lxappearance-gtk2' was removed because it depended on the deprecated GTK2 engine. Consider using the GTK3-based 'lxappearance' instead."; # Added 2026-07-22
   lxd = throw "
     LXD has been removed from NixOS due to lack of Nixpkgs maintenance.
     Consider migrating or switching to Incus, or remove from your configuration.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10195,11 +10195,6 @@ with pkgs;
 
   ### DESKTOPS/LXDE
 
-  lxappearance-gtk2 = callPackage ../by-name/lx/lxappearance/package.nix {
-    gtk2 = gtk2-x11;
-    withGtk3 = false;
-  };
-
   lxqt = recurseIntoAttrs (
     import ../desktops/lxqt {
       inherit pkgs;


### PR DESCRIPTION
gtk 2 has been end of life upstream for a long time, and is in the slow process of being removed from Nixpkgs (#410814). these packages already do not default to gtk 2, so this changes ≈nothing and just drops support for gtk 2 where it's not needed.

if one of the users thinks its really worth keeping around for a while, we can drop any of these commits. there just doesn't seem to be obvious utility to do so since it was already disabled by default.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
