### PR TITLE
python3Packages.frictionless: switch to pytest 9.0

### DIFF
--- a/pkgs/development/python-modules/frictionless/default.nix
+++ b/pkgs/development/python-modules/frictionless/default.nix
@@ -1,4 +1,4 @@
-{
+args@{
   lib,
   buildPythonPackage,
   fetchFromGitHub,
@@ -56,12 +56,21 @@
   pytest-mock,
   pytest-timeout,
   pytest-vcr,
-  pytestCheckHook,
+  pytest_9_0,
+  pytest9_0CheckHook,
   requests-mock,
   xlrd,
   yattag,
 }:
 
+let
+  # With pytest 9.1 fails: AssertionError: assert not self._finalizers
+  pytestCheckHook = pytest9_0CheckHook;
+  pytest-lazy-fixtures = args.pytest-lazy-fixtures.override {
+    pytest = pytest_9_0;
+    pytestCheckHook = pytest9_0CheckHook;
+  };
+in
 buildPythonPackage (finalAttrs: {
   pname = "frictionless";
   version = "5.19.0";


### PR DESCRIPTION
Without it, tests fail in setup phase when configuring fixtures.
Probably some incompatibility issue with pytest + pytest-lazy-fixtures
combination.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
