### PR TITLE
di-tui: 1.14.0 -> 1.15.0

### DIFF
--- a/pkgs/by-name/di/di-tui/package.nix
+++ b/pkgs/by-name/di/di-tui/package.nix
@@ -2,17 +2,18 @@
   lib,
   nix-update-script,
   buildGoModule,
-  fetchFromGitHub,
+  fetchFromGitea,
 }:
 buildGoModule (finalAttrs: {
   pname = "di-tui";
-  version = "1.14.0";
+  version = "1.15.0";
 
-  src = fetchFromGitHub {
-    owner = "acaloiaro";
+  src = fetchFromGitea {
+    domain = "code.adriano.fyi";
+    owner = "me";
     repo = "di-tui";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-P784Tf3XA/28PgKTr89yizKAX1MhAb4877gV7vVHBYE=";
+    hash = "sha256-3dYcecrDSfd5sP5PjkagbFt2RmhaQSVw6kMt9J7wyeM=";
   };
 
   vendorHash = "sha256-b7dG0nSjPQpjWUbOlIxWudPZWKqtq96sQaJxKvsQT9I=";
@@ -21,7 +22,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Simple terminal UI player for di.fm";
-    homepage = "https://github.com/acaloiaro/di-tui";
+    homepage = "https://code.adriano.fyi/me/di-tui";
     license = lib.licenses.bsd2;
     maintainers = [ lib.maintainers.acaloiaro ];
     mainProgram = "di-tui";


### PR DESCRIPTION
Moves source from GitHub to self-hosted Gitea instance at code.adriano.fyi.

Release notes: https://code.adriano.fyi/me/di-tui/releases/tag/v1.15.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test