### PR TITLE
intune-portal: 1.2605.16-noble -> 1.2605.16-resolute

### DIFF
--- a/pkgs/by-name/in/intune-portal/package.nix
+++ b/pkgs/by-name/in/intune-portal/package.nix
@@ -29,11 +29,12 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "intune-portal";
-  version = "1.2605.16-noble";
+  version = "1.2605.16-resolute";
+  ubuntuVersion = "26.04";
 
   src = fetchurl {
-    url = "https://packages.microsoft.com/ubuntu/24.04/prod/pool/main/i/intune-portal/intune-portal_${version}_amd64.deb";
-    hash = "sha256-lPwOwxtsI40jeiLNKvWEz858QMOwGfxvhi7nFiidgLE=";
+    url = "https://packages.microsoft.com/ubuntu/${ubuntuVersion}/prod/pool/main/i/intune-portal/intune-portal_${version}_amd64.deb";
+    hash = "sha256-EWJutvcKnzDj4Y+3oHHryRRyMLkNkaRPuCLqO2gq/Xo=";
   };
 
   nativeBuildInputs = [ dpkg ];
@@ -80,6 +81,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     cp -a opt/microsoft/intune/bin/* $out/bin/
     cp -a usr/share $out
+    cp -a opt/microsoft/intune/share/* $out/share/
     cp -a lib $out
     mkdir -p $out/lib/security
     cp -a ./usr/lib/x86_64-linux-gnu/security/pam_intune.so $out/lib/security/
@@ -115,6 +117,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.unfree;
     platforms = [ "x86_64-linux" ];
     maintainers = with lib.maintainers; [ rhysmdnz ];
+    mainProgram = "intune-portal";
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
   };
 }

--- a/pkgs/by-name/in/intune-portal/update.sh
+++ b/pkgs/by-name/in/intune-portal/update.sh
@@ -1,26 +1,66 @@
-#! /usr/bin/env nix-shell
-#! nix-shell -i bash -p curl gzip dpkg common-updater-scripts
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl dpkg gnugrep gnused coreutils jq nix
+# shellcheck shell=bash
 
-index_file=$(curl -sL https://packages.microsoft.com/ubuntu/24.04/prod/dists/noble/main/binary-amd64/Packages.gz | gzip -dc)
+set -euo pipefail
 
-latest_version="0"
+nixpkgs="$(git rev-parse --show-toplevel)"
+path="$nixpkgs/pkgs/by-name/in/intune-portal/package.nix"
+repository_root="https://packages.microsoft.com/ubuntu"
+package_path="prod/pool/main/i/intune-portal"
 
-echo "$index_file" | while read -r line; do
-    if [[ "$line" =~ ^Package:[[:space:]]*(.*) ]]; then
-        Package="${BASH_REMATCH[1]}"
+old_ubuntu_version=$(sed -nE 's/^[[:space:]]*ubuntuVersion = "([^"]+)";.*/\1/p' "$path")
+old_version=$(sed -nE 's/^[[:space:]]*version = "([^"]+)";.*/\1/p' "$path")
+
+# update-source-version cannot discover or update the Ubuntu repository version,
+# so inspect every published Ubuntu repository and update both fields together.
+mapfile -t ubuntu_versions < <(
+    curl -fsSL "$repository_root/" \
+        | sed -nE 's@.*href="([0-9]+\.[0-9]+)/".*@\1@p' \
+        | sort -Vr
+)
+
+new_ubuntu_version=""
+new_version=""
+new_upstream_version=""
+
+for ubuntu_version in "${ubuntu_versions[@]}"; do
+    if ! package_index=$(curl -fsSL "$repository_root/$ubuntu_version/$package_path/" 2>/dev/null); then
+        continue
     fi
-    if [[ "$line" =~ ^Version:[[:space:]]*(.*) ]]; then
-        Version="${BASH_REMATCH[1]}"
-    fi
 
-    if ! [[ "$line" ]] && [[ "${Package}" == "intune-portal" ]]; then
-        if ( dpkg --compare-versions ${Version} gt ${latest_version} ); then
-            latest_version="${Version}"
-
-            echo $latest_version
+    while IFS= read -r candidate; do
+        candidate_upstream_version="${candidate%%-*}"
+        if [[ -z "$new_version" ]] || dpkg --compare-versions "$candidate_upstream_version" gt "$new_upstream_version"; then
+            new_ubuntu_version="$ubuntu_version"
+            new_version="$candidate"
+            new_upstream_version="$candidate_upstream_version"
         fi
+    done < <(
+        printf '%s\n' "$package_index" \
+            | sed -nE 's@.*href="intune-portal_([^"]+)_amd64\.deb".*@\1@p'
+    )
+done
 
-        Package=""
-        Version=""
-    fi
-done | tail -n 1 | (read version; update-source-version intune-portal $version)
+if [[ -z "$new_ubuntu_version" || -z "$new_version" ]]; then
+    echo "Error: Could not resolve an Intune Portal release" >&2
+    exit 1
+fi
+
+if [[ "$old_ubuntu_version" == "$new_ubuntu_version" && "$old_version" == "$new_version" ]]; then
+    echo "Current Ubuntu $old_ubuntu_version package $old_version is up-to-date"
+    exit 0
+fi
+
+url="$repository_root/$new_ubuntu_version/$package_path/intune-portal_${new_version}_amd64.deb"
+new_hash=$(nix store prefetch-file --json "$url" | jq -er .hash)
+
+echo "Updating intune-portal: Ubuntu $old_ubuntu_version/$old_version -> Ubuntu $new_ubuntu_version/$new_version"
+
+sed -i \
+    -e "s|ubuntuVersion = \"$old_ubuntu_version\";|ubuntuVersion = \"$new_ubuntu_version\";|" \
+    -e "s|version = \"$old_version\";|version = \"$new_version\";|" \
+    -e "s|hash = \"sha256-[^\"]*\";|hash = \"$new_hash\";|" \
+    "$path"
+
+echo "Updated intune-portal to Ubuntu $new_ubuntu_version package $new_version"


### PR DESCRIPTION
Updates Intune Portal to the Ubuntu 26.04 (Resolute) build.

- Uses the Resolute package source and installs its shared application assets.
- Makes the update script Ubuntu-distribution-aware: it scans the published Ubuntu repositories and updates `ubuntuVersion`, `version`, and the source hash together.

Upstream does not publish a separate changelog for this distribution rebuild. Package source: https://packages.microsoft.com/ubuntu/26.04/prod/pool/main/i/intune-portal/

Automation disclosure: This PR was prepared with Oh My Pi using `gpt-5.6-sol`. Verification used `nix-build`, the package update script, `nixfmt`, and ShellCheck.

Related PR: #544767

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test