### PR TITLE
microsoft-identity-diagnostics: init at 3.0.2-resolute

### DIFF
--- a/pkgs/by-name/mi/microsoft-identity-diagnostics/package.nix
+++ b/pkgs/by-name/mi/microsoft-identity-diagnostics/package.nix
@@ -1,0 +1,74 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  dpkg,
+  makeWrapper,
+  jre_headless,
+  coreutils,
+  findutils,
+  gnused,
+  jq,
+  systemd,
+  sudo,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "microsoft-identity-diagnostics";
+  version = "3.0.2-resolute";
+  ubuntuVersion = "26.04";
+
+  src = fetchurl {
+    url = "https://packages.microsoft.com/ubuntu/${finalAttrs.ubuntuVersion}/prod/pool/main/m/microsoft-identity-diagnostics/microsoft-identity-diagnostics_${finalAttrs.version}_amd64.deb";
+    hash = "sha256-t7IAiQ9aNAxoDzUPjzn+28ol4XPocf172qJ9+ytJjX4=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share
+    cp -a opt/microsoft/microsoft-identity-diagnostics $out/share/
+
+    makeWrapper \
+      $out/share/microsoft-identity-diagnostics/bin/microsoft-identity-diagnostics \
+      $out/bin/microsoft-identity-diagnostics-uploader \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          findutils
+          gnused
+          jre_headless
+        ]
+      }
+
+    makeWrapper \
+      $out/share/microsoft-identity-diagnostics/scripts/collect_logs \
+      $out/bin/collect-microsoft-identity-diagnostics \
+      --prefix PATH : "$out/bin:${
+        lib.makeBinPath [
+          coreutils
+          jq
+          sudo
+          systemd
+        ]
+      }"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Microsoft Identity diagnostic log collection and upload tool";
+    homepage = "https://www.microsoft.com/";
+    license = lib.licenses.unfree;
+    mainProgram = "collect-microsoft-identity-diagnostics";
+    maintainers = with lib.maintainers; [ codgician ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+  };
+})

--- a/pkgs/by-name/mi/microsoft-identity-diagnostics/update.sh
+++ b/pkgs/by-name/mi/microsoft-identity-diagnostics/update.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl dpkg gnugrep gnused coreutils jq nix
+# shellcheck shell=bash
+
+set -euo pipefail
+
+nixpkgs="$(git rev-parse --show-toplevel)"
+path="$nixpkgs/pkgs/by-name/mi/microsoft-identity-diagnostics/package.nix"
+repository_root="https://packages.microsoft.com/ubuntu"
+package_path="prod/pool/main/m/microsoft-identity-diagnostics"
+
+old_ubuntu_version=$(sed -nE 's/^[[:space:]]*ubuntuVersion = "([^"]+)";.*/\1/p' "$path")
+old_version=$(sed -nE 's/^[[:space:]]*version = "([^"]+)";.*/\1/p' "$path")
+
+# update-source-version cannot discover or update the Ubuntu repository version,
+# so inspect every published Ubuntu repository and update both fields together.
+mapfile -t ubuntu_versions < <(
+    curl -fsSL "$repository_root/" \
+        | sed -nE 's@.*href="([0-9]+\.[0-9]+)/".*@\1@p' \
+        | sort -Vr
+)
+
+new_ubuntu_version=""
+new_version=""
+new_upstream_version=""
+
+for ubuntu_version in "${ubuntu_versions[@]}"; do
+    if ! package_index=$(curl -fsSL "$repository_root/$ubuntu_version/$package_path/" 2>/dev/null); then
+        continue
+    fi
+
+    while IFS= read -r candidate; do
+        candidate_upstream_version="${candidate%%-*}"
+        if [[ -z "$new_version" ]] || dpkg --compare-versions "$candidate_upstream_version" gt "$new_upstream_version"; then
+            new_ubuntu_version="$ubuntu_version"
+            new_version="$candidate"
+            new_upstream_version="$candidate_upstream_version"
+        fi
+    done < <(
+        printf '%s\n' "$package_index" \
+            | sed -nE 's@.*href="microsoft-identity-diagnostics_([^"]+)_amd64\.deb".*@\1@p'
+    )
+done
+
+if [[ -z "$new_ubuntu_version" || -z "$new_version" ]]; then
+    echo "Error: Could not resolve a Microsoft Identity Diagnostics release" >&2
+    exit 1
+fi
+
+if [[ "$old_ubuntu_version" == "$new_ubuntu_version" && "$old_version" == "$new_version" ]]; then
+    echo "Current Ubuntu $old_ubuntu_version package $old_version is up-to-date"
+    exit 0
+fi
+
+url="$repository_root/$new_ubuntu_version/$package_path/microsoft-identity-diagnostics_${new_version}_amd64.deb"
+new_hash=$(nix store prefetch-file --json "$url" | jq -er .hash)
+
+echo "Updating microsoft-identity-diagnostics: Ubuntu $old_ubuntu_version/$old_version -> Ubuntu $new_ubuntu_version/$new_version"
+
+sed -i \
+    -e "s|ubuntuVersion = \"$old_ubuntu_version\";|ubuntuVersion = \"$new_ubuntu_version\";|" \
+    -e "s|version = \"$old_version\";|version = \"$new_version\";|" \
+    -e "s|hash = \"sha256-[^\"]*\";|hash = \"$new_hash\";|" \
+    "$path"
+
+echo "Updated microsoft-identity-diagnostics to Ubuntu $new_ubuntu_version package $new_version"


### PR DESCRIPTION
Packages Microsoft Identity Diagnostics 3.0.2 for Ubuntu 26.04 (Resolute). It provides the diagnostic log collector and the PowerLift upload CLI, with Java and runtime utilities wrapped into their execution paths.

The update script is Ubuntu-distribution-aware: it scans the published Ubuntu repositories and updates `ubuntuVersion`, `version`, and the source hash together.

Package source: https://packages.microsoft.com/ubuntu/26.04/prod/pool/main/m/microsoft-identity-diagnostics/

Automation disclosure: This PR was prepared with Oh My Pi using `gpt-5.6-sol`. Verification used `nix-build`, the package update script, `nixfmt`, ShellCheck, and a CLI help smoke test.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test