### PR TITLE
czkawka: fix nix-darwin build

### DIFF
--- a/pkgs/by-name/cz/czkawka/package.nix
+++ b/pkgs/by-name/cz/czkawka/package.nix
@@ -15,6 +15,7 @@
   libxi,
   libxkbcommon,
   libxrandr,
+  lld,
   pango,
   pkg-config,
   rustPlatform,
@@ -44,6 +45,9 @@ let
       gobject-introspection
       pkg-config
       wrapGAppsHook4
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      lld # ld crashes
     ];
 
     buildInputs = [


### PR DESCRIPTION
Hi, I ran into a linker crash with this package after updating to latest unstable package version (12.0) and rebuilding. 

Trimmed error log:
```
error: Cannot build '/nix/store/…-czkawka-12.0.0.drv'.
       Reason: builder failed with exit code 101.
       > Compiling czkawka_gui v12.0.0
       > error: linking with `…/clang-wrapper-21.1.8/bin/cc` failed: exit status: 1
       >   = note: "…/cc" "-Wl,-exported_symbols_list" [17 object files + ~400 rlibs omitted] \
       >           "-framework" "AppKit" … "-arch" "arm64" "-mmacosx-version-min=14.0.0" \
       >           -o …/release/deps/libcedinia.dylib
       >   = note: …/cctools-binutils-darwin-wrapper-1010.6/bin/ld: line 292: \
       >           Trace/BPT trap: 5   …/cctools-binutils-darwin-1010.6/bin/ld "@$responseFile"
       >           clang: error: linker command failed with exit code 133 (use -v to see invocation)
       > error: could not compile `cedinia` (lib)
       > … (identical crash then repeats for the `krokiet` binary) …
       > error: could not compile `krokiet` (bin "krokiet")
```

Fix ended up being applying lld specifically for nix-darwin. I followed existing example of [deno](https://github.com/NixOS/nixpkgs/blob/15831b3a51be57d728fd45faa20f3c00cf28b9af/pkgs/by-name/de/deno/package.nix#L83). Which made the package build + run correctly :)

Screenshot of running krokiet (czkawka_gui) 12.0 attached:
<img width="1212" height="912" alt="scrn" src="https://github.com/user-attachments/assets/91dbc6c6-a839-4950-b9ff-5ee8b9c175bc" />

Hope this helps! Wishing a great day from down under 🦘 🌞 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
