### PR TITLE
igprof: 5.9.18 -> 6.0.0

### DIFF
--- a/pkgs/by-name/ig/igprof/package.nix
+++ b/pkgs/by-name/ig/igprof/package.nix
@@ -4,32 +4,25 @@
   fetchFromGitHub,
   libunwind,
   cmake,
-  pcre,
+  pcre2,
   gdb,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "5.9.18";
+  version = "6.0.0";
   pname = "igprof";
 
   src = fetchFromGitHub {
     owner = "igprof";
     repo = "igprof";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-UTrAaH8C79km78Z/7NxvQ6dnl4u4Ki80nORf4bsoSNw=";
+    hash = "sha256-RIDnilCoYlq0D9CBJKMX1zg1DBQ4RPcOlfGcZ2xosUo=";
   };
-
-  postPatch = ''
-    substituteInPlace src/igprof \
-      --replace-fail libigprof.so $out/lib/libigprof.so
-    substituteInPlace CMakeLists.txt \
-      --replace-fail "CMAKE_MINIMUM_REQUIRED(VERSION 2.6)" "CMAKE_MINIMUM_REQUIRED(VERSION 3.10)"
-  '';
 
   buildInputs = [
     libunwind
     gdb
-    pcre
+    pcre2
   ];
   nativeBuildInputs = [ cmake ];
 
@@ -41,7 +34,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
-    broken = (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64);
     description = "Ignominous Profiler";
 
     longDescription = ''


### PR DESCRIPTION
## Things done

@ktf release a new version which upgrades pcre to pcre2 (#356387) and many long standing bugs finally fixed and their fix validated in production.  See: https://github.com/igprof/igprof/releases/tag/v6.0.0

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
