### PR TITLE
python3Packages.paho-mqtt: rerun flaky tests

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -1508,12 +1508,12 @@
     "vendorHash": "sha256-8p6dJwGyTK+qtgplSLtIRKxnNAQAgHfs4z/EsBcg/iY="
   },
   "yandex-cloud_yandex": {
-    "hash": "sha256-YiUARVEsGfD4IUuTFSrkAIAD6kOyFUoLebSaZtW9FcE=",
+    "hash": "sha256-0155GXJMfoCnyqaJiF5SJIA1Qz1q2AYe/BB0AYODG/0=",
     "homepage": "https://registry.terraform.io/providers/yandex-cloud/yandex",
     "owner": "yandex-cloud",
     "repo": "terraform-provider-yandex",
-    "rev": "v0.215.0",
+    "rev": "v0.218.0",
     "spdx": "MPL-2.0",
-    "vendorHash": "sha256-YNCd1i2HDa0aToZ0vEr6tRugXnBXE+zymhLM+rmRNPI="
+    "vendorHash": "sha256-FfZvuC/XXhKS03E+l4/9KCLSwx+uTP1LzywckZqX6pA="
   }
 }

--- a/pkgs/by-name/ca/caesura/package.nix
+++ b/pkgs/by-name/ca/caesura/package.nix
@@ -1,7 +1,10 @@
 {
   lib,
   fetchFromGitHub,
+  fetchpatch2,
   rustPlatform,
+  cacert,
+  writableTmpDirAsHomeHook,
   flac,
   lame,
   makeBinaryWrapper,
@@ -16,24 +19,37 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "caesura";
-  version = "0.27.2";
+  version = "0.31.0";
 
   src = fetchFromGitHub {
     owner = "RogueOneEcho";
     repo = "caesura";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ifaZ+rmMmWhn8HM25sRPXJKuXvWE5VG+5hFMi9hqxA0=";
+    hash = "sha256-+REt+MKImO7fnYWJ32P6mKzulGJTnxc+9ednVF5aCJU=";
   };
 
-  cargoHash = "sha256-g8Duhl5nZ6umIrAafW7s4vtDS+f06CWnFLoLSw0wa4o=";
+  patches = [
+    (fetchpatch2 {
+      name = "normalize-sox-dependent-full-spectrogram-widths.patch";
+      url = "https://github.com/RogueOneEcho/caesura/commit/3af818ae35a3e18f444c889d9d3b88294f4f110f.patch?full_index=1";
+      hash = "sha256-znAbk6hFVj198BUUwwDo76SWei0cKINeXzlYEFvTwHA=";
+    })
+  ];
+
+  cargoHash = "sha256-0+vZma8AC44XqVHzmJT/roV7sy8w6DYhujRK9N91J5c=";
 
   nativeBuildInputs = [
     makeBinaryWrapper
   ];
-  nativeCheckInputs = runtimeDeps;
+  nativeCheckInputs = [
+    cacert
+    writableTmpDirAsHomeHook
+  ]
+  ++ runtimeDeps;
 
   env = {
     CAESURA_NIX = "1";
+    SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
   };
 
   postPatch = ''

--- a/pkgs/by-name/ge/gecode/package.nix
+++ b/pkgs/by-name/ge/gecode/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   bison,
+  cmake,
   flex,
   perl,
   gmp,
@@ -13,19 +14,20 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gecode";
-  version = "6.3.0";
+  version = "6.4.0";
 
   src = fetchFromGitHub {
     owner = "Gecode";
     repo = "gecode";
     tag = "release-${finalAttrs.version}";
-    hash = "sha256-i1geBYMO+edZJekKe/zO+kkgd/S4jSiSZnDLfSRlXwc=";
+    hash = "sha256-WhMN7QC+VQfvHUV1LLaW7I7fG++/fznh1ZDUY/Q8zD8=";
   };
 
   enableParallelBuilding = true;
   dontWrapQtApps = true;
   nativeBuildInputs = [
     bison
+    cmake
     flex
   ];
   buildInputs = [

--- a/pkgs/by-name/ge/gecode/package.nix
+++ b/pkgs/by-name/ge/gecode/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   bison,
   flex,
   perl,
@@ -12,25 +11,16 @@
   enableGist ? true,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gecode";
-  version = "6.2.0";
+  version = "6.3.0";
 
   src = fetchFromGitHub {
     owner = "Gecode";
     repo = "gecode";
-    rev = "release-${version}";
-    sha256 = "0b1cq0c810j1xr2x9y9996p894571sdxng5h74py17c6nr8c6dmk";
+    tag = "release-${finalAttrs.version}";
+    hash = "sha256-i1geBYMO+edZJekKe/zO+kkgd/S4jSiSZnDLfSRlXwc=";
   };
-
-  patches = [
-    # https://github.com/Gecode/gecode/pull/74
-    (fetchpatch {
-      name = "fix-const-weights-clang.patch";
-      url = "https://github.com/Gecode/gecode/commit/c810c96b1ce5d3692e93439f76c4fa7d3daf9fbb.patch";
-      sha256 = "0270msm22q5g5sqbdh8kmrihlxnnxqrxszk9a49hdxd72736p4fc";
-    })
-  ];
 
   enableParallelBuilding = true;
   dontWrapQtApps = true;
@@ -52,4 +42,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.all;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/by-name/mi/minizinc/package.nix
+++ b/pkgs/by-name/mi/minizinc/package.nix
@@ -13,22 +13,6 @@
   zlib,
 }:
 
-let
-  gecode_6_3_0 = gecode.overrideAttrs (_: {
-    version = "6.3.0";
-    src = fetchFromGitHub {
-      owner = "gecode";
-      repo = "gecode";
-      rev = "f7f0d7c273d6844698f01cec8229ebe0b66a016a";
-      hash = "sha256-skf2JEtNkRqEwfHb44WjDGedSygxVuqUixskTozi/5k=";
-    };
-    patches = [ ];
-  });
-in
-let
-  gecode = gecode_6_3_0;
-in
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "minizinc";
   version = "2.9.7";

--- a/pkgs/by-name/sc/schemat/package.nix
+++ b/pkgs/by-name/sc/schemat/package.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "schemat";
-  version = "0.5.2";
+  version = "0.5.3";
 
   src = fetchFromGitHub {
     owner = "raviqqe";
     repo = "schemat";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Ij7JigbXhE2o0Z61uZ3W/pK7zcQyrX+SMpF0iKsVx30=";
+    hash = "sha256-vA5J76wU2FlKz1fxTgv8jVuV4RIOML+tI5Y/dXyc9f0=";
   };
 
-  cargoHash = "sha256-oaET2IGU78TUC98HKsiQnbg7R262ugrn8oiLeKC767s=";
+  cargoHash = "sha256-LGZE3r9n+KtnCiCxc/3K981wq4fN6ZR/KD8b638DmeM=";
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];

--- a/pkgs/development/python-modules/paho-mqtt/default.nix
+++ b/pkgs/development/python-modules/paho-mqtt/default.nix
@@ -6,6 +6,7 @@
   hatchling,
   openssl,
   pytestCheckHook,
+  pytest-rerunfailures,
   writableTmpDirAsHomeHook,
 }:
 
@@ -44,6 +45,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     openssl
     pytestCheckHook
+    pytest-rerunfailures
     writableTmpDirAsHomeHook
   ];
 
@@ -57,6 +59,11 @@ buildPythonPackage rec {
     # paho.mqtt not in top-level dir to get caught by this
     export PYTHONPATH=".:$PYTHONPATH"
   '';
+
+  pytestFlags = [
+    "--reruns=3"
+    "--reruns-delay=1"
+  ];
 
   disabledTests = [
     # Fails during teardown


### PR DESCRIPTION
During testing, MQTT clients are spawned as subprocesses and then
stopped via SIGINT. Whether or not the SIGINT signal arrives before or
after the client has completed the initial setup and reached its `loop_forever()` or `wait_for_keyboard_input()` call is timing-dependent. This limitaiton seems to be known by the upstream developers as witnessed by [this comment](https://github.com/eclipse-paho/paho.mqtt.python/blob/1d04072c479ded28559e5207cd96f19d4075ca44/tests/paho_test.py#L431) in the custom implementation of `wait_for_keyboard_interrupt`. As a consequence of it, people are getting failures during teardown for different tests depending on the machine as
the timing is slightly different, see https://github.com/NixOS/nixpkgs/issues/542586.

Fixing via a static set of disabled tests seems to not be the right
approach. This PR instead uses pytest-rerunfailures to allow multiple
retries which (hopefully) makes failures much more unlikely. This may
increase the runtime of checkPhase, but for me it reliably prevents the
test from failing.

Assisted by: Claude Sonnet 5, which helped me understand the issue and suggested simply rerunning the flaky tests.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
