### PR TITLE
wlr-protocols: modernize

### DIFF
--- a/pkgs/development/libraries/wlroots/protocols.nix
+++ b/pkgs/development/libraries/wlroots/protocols.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation {
   pname = "wlr-protocols";
-  version = "unstable-2022-09-05";
+  version = "0-unstable-2022-09-05";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
@@ -22,8 +22,8 @@ stdenv.mkDerivation {
 
   patchPhase = ''
     substituteInPlace wlr-protocols.pc.in \
-      --replace '=''${pc_sysrootdir}' "=" \
-      --replace '=@prefix@' "=$out"
+      --replace-fail '=''${pc_sysrootdir}' "=" \
+      --replace-fail '=@prefix@' "=$out"
   '';
 
   doCheck = true;


### PR DESCRIPTION
As part of https://github.com/NixOS/nixpkgs/issues/356002, https://github.com/NixOS/nixpkgs/issues/541820
Should I have made them as two separate commits instead?

<!--
^ Please summarise the changes you have done and explain why they are necessary here
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
