### PR TITLE
obsbot-camera-control: init at 1.3.0

### DIFF
--- a/pkgs/by-name/ob/obsbot-camera-control/package.nix
+++ b/pkgs/by-name/ob/obsbot-camera-control/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  qt6,
+  pipewire,
+  makeWrapper,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "obsbot-camera-control";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "aaronsb";
+    repo = "obsbot-camera-control";
+    rev = "v${version}";
+    hash = "sha256-Q9Y+TpD0W0CdFYrDNfi5CvF9crViCiSzc+nJUBh6MGI=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cmake
+    qt6.wrapQtAppsHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtmultimedia
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DCMAKE_SKIP_BUILD_RPATH=ON"
+    "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON"
+    "-DCMAKE_INSTALL_RPATH=${placeholder "out"}/lib"
+  ];
+
+  qtWrapperArgs = [
+    "--prefix"
+    "LD_LIBRARY_PATH"
+    ":"
+    (lib.makeLibraryPath [ pipewire ])
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    # Install binaries
+    install -Dm755 ../bin/obsbot-gui $out/bin/obsbot-gui
+    install -Dm755 ../bin/obsbot-cli $out/bin/obsbot-cli
+
+    # Install SDK library
+    install -Dm755 ../sdk/lib/libdev.so.1.0.2 $out/lib/libdev.so.1.0.2
+    ln -s libdev.so.1.0.2 $out/lib/libdev.so.1
+    ln -s libdev.so.1.0.2 $out/lib/libdev.so
+
+    # Install desktop file
+    install -Dm644 ../obsbot-control.desktop $out/share/applications/obsbot-control.desktop
+
+    # Install icon
+    install -Dm644 ../resources/icons/camera.svg $out/share/icons/hicolor/scalable/apps/obsbot-control.svg
+
+    # Install license
+    install -Dm644 ../LICENSE $out/share/licenses/${pname}/LICENSE
+
+    # Install systemd and modprobe configs
+    install -Dm644 ../resources/modprobe.d/obsbot-virtual-camera.conf $out/lib/modprobe.d/obsbot-virtual-camera.conf
+    install -Dm644 ../resources/systemd/obsbot-virtual-camera.service $out/lib/systemd/system/obsbot-virtual-camera.service
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Native Linux control app for OBSBOT cameras with PTZ, auto-framing, presets, and live preview";
+    homepage = "https://github.com/aaronsb/obsbot-camera-control";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with lib.maintainers; [ justanotherariel ];
+    mainProgram = "obsbot-gui";
+  };
+}


### PR DESCRIPTION
Add [Obsbot Camera Control](https://github.com/aaronsb/obsbot-camera-control) to nixpkgs, an application which allows full control over Obsbot Meet 2 webcams. Previously #483492, but that PR didn't pick up commits pushed onto my branch anymore for some reason.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
