### PR TITLE
audible-cli: 0.3.3 -> 0.4.0

### DIFF
--- a/pkgs/by-name/au/audible-cli/package.nix
+++ b/pkgs/by-name/au/audible-cli/package.nix
@@ -9,47 +9,44 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "audible-cli";
-  version = "0.3.3";
+  version = "0.4.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mkb79";
     repo = "audible-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ckI6nZUggIMvjJtN1zWXvTlVdiog0uJy6YR110A+JxM=";
+    hash = "sha256-GsPnnu7xwdcEM/Cj2jmRiDtUN3SSNmNFQrYbjXOfs0g=";
   };
 
-  nativeBuildInputs =
+  build-system = with python3Packages; [ hatchling ];
+
+  nativeBuildInputs = [
+    addBinToPathHook
+    installShellFiles
+  ];
+
+  dependencies =
     with python3Packages;
     [
-      hatchling
+      aiofiles
+      audible
+      click
+      httpx
+      packaging
+      pillow
+      questionary
+      tabulate
+      toml
+      tqdm
     ]
-    ++ [
-      addBinToPathHook
-      installShellFiles
-    ];
-
-  propagatedBuildInputs = with python3Packages; [
-    aiofiles
-    audible
-    click
-    httpx
-    packaging
-    pillow
-    questionary
-    tabulate
-    toml
-    tqdm
-  ];
-
-  pythonRelaxDeps = [
-    "httpx"
-  ];
+    ++ audible.optional-dependencies.cryptography;
 
   postInstall = ''
     installShellCompletion --cmd audible \
       --bash <(source utils/code_completion/audible-complete-bash.sh) \
-      --zsh <(source utils/code_completion/audible-complete-zsh-fish.sh)
+      --zsh <(source utils/code_completion/audible-complete-zsh.sh) \
+      --fish <(source utils/code_completion/audible-complete-fish.sh)
   '';
 
   # upstream has no tests

--- a/pkgs/development/python-modules/audible/default.nix
+++ b/pkgs/development/python-modules/audible/default.nix
@@ -4,7 +4,7 @@
   buildPythonPackage,
 
   # build-system
-  poetry-core,
+  hatchling,
 
   # dependencies
   beautifulsoup4,
@@ -13,26 +13,33 @@
   pillow,
   pyaes,
   rsa,
+  cryptography,
+  pycryptodome,
+  orjson,
+  ujson,
+  python-rapidjson,
 
   # test dependencies
   pytestCheckHook,
+  git,
+  git-cliff,
 }:
 
 buildPythonPackage rec {
   pname = "audible";
-  version = "0.10.0";
+  version = "0.12.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mkb79";
     repo = "Audible";
     tag = "v${version}";
-    hash = "sha256-ILGhjuPIxpRxu/dVDmz531FUgMWosk4P+onPJltuPIs=";
+    hash = "sha256-N13R6HQyfd3Q2cBvxjnVzCXtoW9JE54IMqBX5qgeteI=";
   };
 
-  nativeBuildInputs = [ poetry-core ];
+  build-system = [ hatchling ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     pillow
     beautifulsoup4
     httpx
@@ -41,7 +48,24 @@ buildPythonPackage rec {
     rsa
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  optional-dependencies = {
+    cryptography = [ cryptography ];
+    pycryptodome = [ pycryptodome ];
+    orjson = [ orjson ];
+    ujson = [ ujson ];
+    rapidjson = [ python-rapidjson ];
+    json-fast = [ orjson ];
+    json-full = [
+      orjson
+      ujson
+    ];
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    git
+    git-cliff
+  ];
 
   pythonImportsCheck = [ "audible" ];
 

--- a/pkgs/development/python-modules/click/default.nix
+++ b/pkgs/development/python-modules/click/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  importlib-metadata,
   pytestCheckHook,
 
   # large-rebuild downstream dependencies and applications
@@ -16,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "click";
-  version = "8.3.3";
+  version = "8.4.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pallets";
     repo = "click";
     tag = version;
-    hash = "sha256-LcnAI4hyiuaJ4qnFnbAR5Cft/yvW5tAIjY6qc6K/Nrw=";
+    hash = "sha256-66JFGGwPXeCU7Fbqsrsq3giv6qsea1ZKGmZYPu9rcog=";
   };
 
   build-system = [ flit-core ];

--- a/pkgs/development/python-modules/rsa/default.nix
+++ b/pkgs/development/python-modules/rsa/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
+  fetchPypi,
   poetry-core,
   pyasn1,
   pytestCheckHook,
@@ -9,27 +9,19 @@
 
 buildPythonPackage rec {
   pname = "rsa";
-  version = "4.9";
+  version = "4.9.1";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "sybrenstuvel";
-    repo = "python-rsa";
-    rev = "version-${version}";
-    hash = "sha256-PwaRe+ICy0UoguXSMSh3PFl5R+YAhJwNdNN9isadlJY=";
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-572/21SX2kwH39NVMOGpAmWdtv8kHjnZlTytBuvQrnU=";
   };
 
-  nativeBuildInputs = [ poetry-core ];
+  build-system = [ poetry-core ];
+  dependencies = [ pyasn1 ];
 
-  propagatedBuildInputs = [ pyasn1 ];
-
-  preCheck = ''
-    sed -i '/addopts/d' tox.ini
-  '';
-
-  nativeCheckInputs = [ pytestCheckHook ];
-
-  disabledTestPaths = [ "tests/test_mypy.py" ];
+  # PyPi package does not include tests.
+  doCheck = false;
 
   meta = {
     homepage = "https://stuvel.eu/rsa";

--- a/pkgs/development/python-modules/tqdm/default.nix
+++ b/pkgs/development/python-modules/tqdm/default.nix
@@ -16,12 +16,12 @@
 
 buildPythonPackage rec {
   pname = "tqdm";
-  version = "4.68.4";
+  version = "4.69.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-GYKclnNjjyoLhhfaTNy5J+gxzYi8/LbnjUKk0a8TFSA=";
+    hash = "sha256-cAxehdzV8AndYiJYiikYChk6dIJHpdhVtNZ9uT15pTs=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
https://github.com/mkb79/audible-cli/releases/tag/v0.4.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
