### PR TITLE
octopus: 16.3 -> 16.4, add cuda and hip support

### DIFF
--- a/pkgs/by-name/oc/octopus/cuda-nvtx3.patch
+++ b/pkgs/by-name/oc/octopus/cuda-nvtx3.patch
@@ -1,0 +1,36 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -177,7 +177,13 @@
+ if (OCTOPUS_CUDA)
+ 	find_package(CUDAToolkit)
+ 	set(HAVE_CUDA 1)
+-	set(HAVE_NVTX 1)
++	# NVTX profiling relies on the legacy nvToolsExt library, which NVIDIA dropped
++	# from the redistributable cuda_nvtx package in CUDA 12.9. Enable profiling
++	# only when the legacy target is available (CUDA < 12.9); on 12.9+ nvtx_low.cc
++	# falls back to no-op markers (and links the header-only nvtx3 target).
++	if (TARGET CUDA::nvToolsExt)
++		set(HAVE_NVTX 1)
++	endif ()
+ 	set_package_properties(CUDAToolkit PROPERTIES TYPE REQUIRED)
+ 	if (OCTOPUS_MPI)
+ 		include(cmake/GPUawareMPI.cmake)
+--- a/src/basic/CMakeLists.txt
++++ b/src/basic/CMakeLists.txt
+@@ -90,8 +90,14 @@
+ 		CUDA::cuda_driver
+ 		CUDA::cublas
+ 		CUDA::cufft
+-		CUDA::nvrtc
+-		CUDA::nvToolsExt)
++		CUDA::nvrtc)
++	# Legacy nvToolsExt (shared lib) was dropped from cuda_nvtx in CUDA 12.9.
++	# Link it when present; otherwise fall back to the header-only nvtx3.
++	if (TARGET CUDA::nvToolsExt)
++		target_link_libraries(Octopus_lib PRIVATE CUDA::nvToolsExt)
++	elseif (TARGET CUDA::nvtx3)
++		target_link_libraries(Octopus_lib PRIVATE CUDA::nvtx3)
++	endif ()
+ endif ()
+ 
+ if (OCTOPUS_HIP)

--- a/pkgs/by-name/oc/octopus/gfortran-15-c-loc.patch
+++ b/pkgs/by-name/oc/octopus/gfortran-15-c-loc.patch
@@ -1,0 +1,41 @@
+--- a/src/basic/accel_inc.F90
++++ b/src/basic/accel_inc.F90
+@@ -61,7 +61,11 @@
+     if (ierr /= CL_SUCCESS) call opencl_print_error(ierr, "EnqueueWriteBuffer")
+ #endif
+ #ifdef HAVE_CUDA
+-    call cuda_memcpy_htod(this%mem, c_loc(data), fsize, offset_)
++    block
++      type(c_ptr) :: cptr
++      cptr = c_loc(data)
++      call cuda_memcpy_htod(this%mem, cptr, fsize, offset_)
++    end block
+ #endif
+ 
+     call profiling_count_transfers(size, data)
+@@ -240,7 +244,11 @@
+     if (ierr /= CL_SUCCESS) call opencl_print_error(ierr, "EnqueueReadBuffer")
+ #endif
+ #ifdef HAVE_CUDA
+-    call cuda_memcpy_dtoh(this%mem, c_loc(data), fsize, offset_)
++    block
++      type(c_ptr) :: cptr
++      cptr = c_loc(data)
++      call cuda_memcpy_dtoh(this%mem, cptr, fsize, offset_)
++    end block
+ #endif
+ 
+     call profiling_count_transfers(size, data)
+@@ -401,7 +409,11 @@
+ 
+   ! no push_sub, called too frequently
+ #ifdef HAVE_CUDA
+-  call cuda_kernel_set_arg_value(kernel%arguments, c_loc(data), narg, types_get_size(R_TYPE_VAL))
++  block
++      type(c_ptr) :: cptr
++      cptr = c_loc(data)
++      call cuda_kernel_set_arg_value(kernel%arguments, cptr, narg, types_get_size(R_TYPE_VAL))
++    end block
+ #endif
+ 
+ #ifdef HAVE_OPENCL

--- a/pkgs/by-name/oc/octopus/hipblas-hipDoubleComplex.patch
+++ b/pkgs/by-name/oc/octopus/hipblas-hipDoubleComplex.patch
@@ -1,0 +1,11 @@
+--- a/src/basic/cublas.cc
++++ b/src/basic/cublas.cc
+@@ -66,7 +66,7 @@
+ #define cublasZgemv hipblasZgemv /*_v2*/
+ #define cublasZherk hipblasZherk /*_v2*/
+ #define cublasZtrsm hipblasZtrsm /*_v2*/
+-#define cuDoubleComplex hipblasDoubleComplex
++#define cuDoubleComplex hipDoubleComplex
+ #else
+ #include <cublas_v2.h>
+ #include <cuda.h>

--- a/pkgs/by-name/oc/octopus/package.nix
+++ b/pkgs/by-name/oc/octopus/package.nix
@@ -23,11 +23,19 @@
   scalapack,
   mpi,
   enableMpi ? true,
+  config,
+  cudaPackages,
+  enableCuda ? config.cudaSupport,
+  rocmPackages,
+  enableHip ? config.rocmSupport,
+  makeWrapper,
+  addDriverRunpath,
   python3,
 }:
 
 assert (!blas.isILP64) && (!lapack.isILP64);
 assert (blas.isILP64 == arpack.isILP64);
+assert !(enableCuda && enableHip);
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "octopus";
@@ -46,6 +54,12 @@ stdenv.mkDerivation (finalAttrs: {
     "testsuite"
   ];
 
+  patches = [
+    ./hipblas-hipDoubleComplex.patch
+    ./cuda-nvtx3.patch
+    ./gfortran-15-c-loc.patch
+  ];
+
   nativeBuildInputs = [
     which
     perl
@@ -54,6 +68,11 @@ stdenv.mkDerivation (finalAttrs: {
     gfortran
     pkg-config
     ninja
+    makeWrapper
+  ]
+  ++ lib.optionals enableCuda [
+    cudaPackages.cuda_nvcc
+    addDriverRunpath
   ];
 
   buildInputs = [
@@ -70,7 +89,20 @@ stdenv.mkDerivation (finalAttrs: {
     metis
     (python3.withPackages (ps: [ ps.pyyaml ]))
   ]
-  ++ lib.optional enableMpi scalapack;
+  ++ lib.optional enableMpi scalapack
+  ++ lib.optionals enableCuda [
+    cudaPackages.cuda_cudart
+    cudaPackages.libcublas
+    cudaPackages.libcufft
+    cudaPackages.cuda_nvrtc
+    cudaPackages.cuda_nvtx
+  ]
+  ++ lib.optionals enableHip [
+    rocmPackages.clr
+    rocmPackages.hipblas
+    rocmPackages.hipfft
+    rocmPackages.roctracer
+  ];
 
   propagatedBuildInputs = lib.optional enableMpi mpi;
   propagatedUserEnvPkgs = lib.optional enableMpi mpi;
@@ -80,7 +112,19 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "OCTOPUS_ScaLAPACK" enableMpi)
     (lib.cmakeBool "OCTOPUS_OpenMP" true)
     (lib.cmakeBool "OCTOPUS_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
-  ];
+  ]
+  ++ lib.optional enableCuda (lib.cmakeBool "OCTOPUS_CUDA" true)
+  ++ lib.optionals enableHip [
+    (lib.cmakeBool "OCTOPUS_HIP" true)
+    "-DHIP_ROOT_DIR=${rocmPackages.clr}"
+    "-DCMAKE_MODULE_PATH=${rocmPackages.clr}/lib/cmake/hip"
+  ]
+  # gfortran >= 15 tightened ISO_C_BINDING argument checking; octopus passes
+  # `c_loc()` results to by-reference `type(c_ptr)` dummies in several GPU
+  # interop wrappers, which now errors. Relax it for GPU builds only.
+  ++ lib.optional (enableCuda || enableHip) (
+    lib.cmakeFeature "CMAKE_Fortran_FLAGS" "-fallow-argument-mismatch"
+  );
 
   nativeCheckInputs = lib.optional enableMpi mpi;
   doCheck = false; # requires installed data
@@ -96,6 +140,23 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall = ''
     mkdir -p $testsuite
     moveToOutput share/octopus/testsuite $testsuite
+  '';
+
+  # Octopus JIT-compiles its GPU kernels at runtime via hiprtc, which
+  # delegates to libamd_comgr for the actual compilation. comgr reads
+  # only two environment variables: HIP_PATH (to find the device compiler
+  # at $HIP_PATH/llvm/bin/clang) and HIP_DEVICE_LIB_PATH (to find the
+  # device bitcode libraries). The clr setup-hook only exports these
+  # during the build, so bake them into a wrapper for every installed
+  # binary so GPU runs work out of the box.
+  postFixup = lib.optionalString enableHip ''
+    for bin in $out/bin/*; do
+      if [ -f "$bin" ] && [ ! -L "$bin" ] && head -c 4 "$bin" | grep -qa 'ELF'; then
+        wrapProgram "$bin" \
+          --set HIP_PATH "${rocmPackages.clr}" \
+          --set HIP_DEVICE_LIB_PATH "${rocmPackages.rocm-device-libs}/amdgcn/bitcode"
+      fi
+    done
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/oc/octopus/package.nix
+++ b/pkgs/by-name/oc/octopus/package.nix
@@ -31,13 +31,13 @@ assert (blas.isILP64 == arpack.isILP64);
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "octopus";
-  version = "16.3";
+  version = "16.4";
 
   src = fetchFromGitLab {
     owner = "octopus-code";
     repo = "octopus";
     tag = finalAttrs.version;
-    hash = "sha256-3DYfgoKznIWY8/HZByzz0MX03QzbivU9B3gDyNMnTQ4=";
+    hash = "sha256-XN9Smpmzu8KQpQ92TSCfK/tKMFpn5yj/B8wTzyF3GK0=";
   };
 
   outputs = [


### PR DESCRIPTION
Updates Octopus to latest release and adds support for CUDA and HIP. Somehow there are now release notes available, although 16.4 is already 3 months old https://octopus-code.org/documentation/16/releases/changes/#octopus-16

HIP support has been tested on Hardware, CUDA not (I have no NVidia GPU right now).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
