### PR TITLE
discord: use buildFHSEnv to fix krisp

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/darwin.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/darwin.nix
@@ -1,48 +1,44 @@
 {
+  # Package metadata
   pname,
   source,
   meta,
-  stdenv,
   binaryName,
   desktopName,
-  self,
+  passthru,
+  moduleSrcs,
+  # Package utilities
+  disableBreakingUpdates,
+  stageModules,
+  # Feature flags (cross-platform)
+  withOpenASAR ? false,
+  withVencord ? false,
+  withEquicord ? false,
+  withMoonlight ? false,
+  # Disabling this would normally break Discord.
+  # The intended use-case for this is when SKIP_HOST_UPDATE is enabled via other means,
+  # for example if a settings.json is linked declaratively (e.g., with home-manager).
+  disableUpdates ? true,
+  # Package arguments
+  commandLineArgs ? "",
+  # Miscellaneous
   lib,
-  fetchurl,
+  stdenv,
   makeWrapper,
-  writeScript,
-  writeShellScript,
   brotli,
   python3,
-  runCommand,
-  branch,
-  withOpenASAR ? false,
+  writeScript,
+  fetchurl,
   openasar,
-  withVencord ? false,
   vencord,
-  withEquicord ? false,
   equicord,
-  withMoonlight ? false,
   moonlight,
-  commandLineArgs ? "",
 }:
 
 let
-  discordMods = [
-    withVencord
-    withEquicord
-    withMoonlight
-  ];
-  enabledDiscordModsCount = builtins.length (lib.filter (x: x) discordMods);
-
   inherit (source) version;
 
   src = fetchurl { inherit (source.distro) url hash; };
-
-  moduleSrcs = lib.mapAttrs (_: mod: fetchurl { inherit (mod) url hash; }) source.modules;
-
-  moduleVersions = lib.mapAttrs (_: mod: mod.version) source.modules;
-
-  configDirName = lib.replaceStrings [ " " ] [ "" ] (lib.toLower binaryName);
 
   fixDistroSymlinks = writeScript "discord-fix-distro-symlinks.py" ''
     #!${python3.interpreter}
@@ -61,44 +57,16 @@ let
             path.unlink(missing_ok=True)
             path.symlink_to(member.linkname)
   '';
-
-  stageModules = writeShellScript "discord-stage-modules" ''
-    store_modules="$1"
-    user_data_dir="''${DISCORD_USER_DATA_DIR-$HOME/Library/Application Support}"
-    modules_dir="$user_data_dir''${user_data_dir:+/}${configDirName}/${version}/modules"
-    mkdir -p "$modules_dir"
-    for m in ${lib.concatStringsSep " " (lib.attrNames moduleSrcs)}; do
-      rm -rf "$modules_dir/$m"
-      ln -s "$store_modules/$m" "$modules_dir/$m"
-    done
-    echo '${builtins.toJSON (lib.mapAttrs (_: mod: { installedVersion = mod; }) moduleVersions)}' \
-      > "$modules_dir/installed.json"
-  '';
-
-  disableBreakingUpdates =
-    runCommand "disable-breaking-updates.py"
-      {
-        pythonInterpreter = "${python3.interpreter}";
-        configDirName = lib.toLower binaryName;
-        skipModuleUpdate = lib.boolToString withOpenASAR;
-        meta.mainProgram = "disable-breaking-updates.py";
-      }
-      ''
-        mkdir -p $out/bin
-        cp ${./disable-breaking-updates.py} $out/bin/disable-breaking-updates.py
-        substituteAllInPlace $out/bin/disable-breaking-updates.py
-        chmod +x $out/bin/disable-breaking-updates.py
-      '';
 in
-assert lib.assertMsg (
-  enabledDiscordModsCount <= 1
-) "discord: Only one of Vencord, Equicord or Moonlight can be enabled at the same time";
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   inherit
     pname
     version
     src
     meta
+    passthru
+    disableBreakingUpdates
+    stageModules
     ;
 
   nativeBuildInputs = [
@@ -142,8 +110,8 @@ stdenv.mkDerivation {
     # wrap executable to $out/bin
     mkdir -p $out/bin
     makeWrapper "$out/Applications/${desktopName}.app/Contents/MacOS/${binaryName}" "$out/bin/${binaryName}" \
-      --run ${lib.getExe disableBreakingUpdates} \
-      --run "${stageModules} \"$out/Applications/${desktopName}.app/Contents/Resources/modules\"" \
+      ${lib.strings.optionalString disableUpdates "--run ${lib.getExe finalAttrs.disableBreakingUpdates}"} \
+      --run "${finalAttrs.stageModules} \"$out/Applications/${desktopName}.app/Contents/Resources/modules\"" \
       --add-flags ${lib.escapeShellArg commandLineArgs}
 
     runHook postInstall
@@ -171,26 +139,4 @@ stdenv.mkDerivation {
       echo '{"name":"discord","main":"injector.js","private": true}' > "$out/Applications/${desktopName}.app/Contents/Resources/app.asar/package.json"
       echo 'require("${moonlight}/injector.js").inject(require("path").join(__dirname, "../_app.asar"));' > "$out/Applications/${desktopName}.app/Contents/Resources/app.asar/injector.js"
     '';
-
-  passthru = {
-    # make it possible to run disableBreakingUpdates standalone
-    inherit disableBreakingUpdates;
-    inherit source;
-    updateScript = ./update.py;
-
-    tests = {
-      withVencord = self.override {
-        withVencord = true;
-      };
-      withEquicord = self.override {
-        withEquicord = true;
-      };
-      withMoonlight = self.override {
-        withMoonlight = true;
-      };
-      withOpenASAR = self.override {
-        withOpenASAR = true;
-      };
-    };
-  };
-}
+})

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -77,6 +77,7 @@ let
       infinidoge
       jopejoe1
       Scrumplex
+      sophiebsw
     ];
     platforms = [
       "x86_64-linux"
@@ -84,7 +85,6 @@ let
     ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
-  package = if stdenv.hostPlatform.isLinux then ./linux.nix else ./darwin.nix;
 
   sources = lib.importJSON ./sources.json;
 in
@@ -95,7 +95,7 @@ lib.genAttrs [ "discord" "discord-ptb" "discord-canary" "discord-development" ] 
     platformName = if stdenv.hostPlatform.isDarwin then "osx" else "linux";
     source = sources."${platformName}-${args.branch}";
   in
-  callPackage package (
+  callPackage ./wrapper.nix (
     args
     // {
       inherit pname source;

--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -1,195 +1,170 @@
 {
+  # Package metadata
   pname,
   source,
   meta,
   binaryName,
   desktopName,
-  self,
-  autoPatchelfHook,
+  passthru,
+  moduleSrcs,
+  # Package utilities
+  disableBreakingUpdates,
+  stageModules,
+  # Feature flags (cross-platform)
+  withOpenASAR ? false,
+  withVencord ? false,
+  withEquicord ? false,
+  withMoonlight ? false,
+  # Disabling this would normally break Discord.
+  # The intended use-case for this is when SKIP_HOST_UPDATE is enabled via other means,
+  # for example if a settings.json is linked declaratively (e.g., with home-manager).
+  disableUpdates ? true,
+  # Feature flags (Linux exclusive)
+  withTTS ? true,
+  enableAutoscroll ? false,
+  # Package arguments
+  commandLineArgs ? "",
+  useFHSEnv ? true,
+  # Miscellaneous
+  lib,
+  stdenv,
+  makeShellWrapper,
+  gtk3,
+  brotli,
   addDriverRunpath,
   fetchurl,
   makeDesktopItem,
-  lib,
-  stdenv,
+  autoPatchelfHook,
+  cups,
+  libdrm,
+  libuuid,
+  libxdamage,
+  libx11,
+  libxscrnsaver,
+  libxtst,
+  libxcb,
+  libxshmfence,
   wrapGAppsHook3,
-  makeShellWrapper,
   alsa-lib,
+  libgbm,
+  nspr,
+  nss,
+  libpulseaudio,
+  libcxx,
+  systemdLibs,
+  atk,
   at-spi2-atk,
   at-spi2-core,
-  atk,
   cairo,
-  cups,
   dbus,
   expat,
   fontconfig,
   freetype,
   gdk-pixbuf,
   glib,
-  gtk3,
-  libcxx,
-  libdrm,
   libglvnd,
   libnotify,
-  libpulseaudio,
-  libuuid,
-  libva,
-  libx11,
-  libxscrnsaver,
   libxcomposite,
+  libunity,
+  libva,
   libxcursor,
-  libxdamage,
   libxext,
   libxfixes,
   libxi,
   libxrandr,
   libxrender,
-  libxtst,
-  libxcb,
   libxkbcommon,
-  libxshmfence,
-  libgbm,
-  nspr,
-  nss,
   pango,
-  systemdLibs,
+  pipewire,
   libappindicator-gtk3,
   libdbusmenu,
-  brotli,
-  writeShellScript,
-  pipewire,
-  python3,
-  runCommand,
-  libunity,
-  speechd-minimal,
   wayland,
-  branch,
-  withOpenASAR ? false,
+  speechd-minimal,
   openasar,
-  withVencord ? false,
   vencord,
-  withEquicord ? false,
   equicord,
-  withMoonlight ? false,
   moonlight,
-  withTTS ? true,
-  enableAutoscroll ? false,
-  # Disabling this would normally break Discord.
-  # The intended use-case for this is when SKIP_HOST_UPDATE is enabled via other means,
-  # for example if a settings.json is linked declaratively (e.g., with home-manager).
-  disableUpdates ? true,
-  commandLineArgs ? "",
-}:
+}@args:
 
 let
-  discordMods = [
-    withVencord
-    withEquicord
-    withMoonlight
-  ];
-  enabledDiscordModsCount = builtins.length (lib.filter (x: x) discordMods);
-
   inherit (source) version;
 
   src = fetchurl { inherit (source.distro) url hash; };
 
-  moduleSrcs = lib.mapAttrs (_: mod: fetchurl { inherit (mod) url hash; }) source.modules;
+  targetPkgs =
+    pkgs:
+    (lib.attrValues {
+      inherit (pkgs)
+        libcxx
+        systemdLibs
+        libpulseaudio
+        libdrm
+        libgbm
+        alsa-lib
+        atk
+        at-spi2-atk
+        at-spi2-core
+        cairo
+        cups
+        dbus
+        expat
+        fontconfig
+        freetype
+        gdk-pixbuf
+        glib
+        gtk3
+        libglvnd
+        libnotify
+        libx11
+        libxcomposite
+        libunity
+        libuuid
+        libva
+        libxcursor
+        libxdamage
+        libxext
+        libxfixes
+        libxi
+        libxrandr
+        libxrender
+        libxtst
+        nspr
+        libxcb
+        libxkbcommon
+        pango
+        pipewire
+        libxscrnsaver
+        libappindicator-gtk3
+        libdbusmenu
+        wayland
+        ;
 
-  moduleVersions = lib.mapAttrs (_: mod: mod.version) source.modules;
-
-  libPath = lib.makeLibraryPath (
-    [
-      libcxx
-      systemdLibs
-      libpulseaudio
-      libdrm
-      libgbm
-      stdenv.cc.cc
-      alsa-lib
-      atk
-      at-spi2-atk
-      at-spi2-core
-      cairo
-      cups
-      dbus
-      expat
-      fontconfig
-      freetype
-      gdk-pixbuf
-      glib
-      gtk3
-      libglvnd
-      libnotify
-      libx11
-      libxcomposite
-      libunity
-      libuuid
-      libva
-      libxcursor
-      libxdamage
-      libxext
-      libxfixes
-      libxi
-      libxrandr
-      libxrender
-      libxtst
-      nspr
-      # nss is intentionally NOT in libPath: it would leak via LD_LIBRARY_PATH
-      # to xdg-open and break Firefox children when versions diverge (#514859,
-      # PR #186603)
-      libxcb
-      libxkbcommon
-      pango
-      pipewire
-      libxscrnsaver
-      libappindicator-gtk3
-      libdbusmenu
-      wayland
-    ]
-    ++ lib.optionals withTTS [ speechd-minimal ]
-  );
-
-  # Symlink native modules from the nix store into the user config dir
-  # where Discord's JS moduleUpdater expects them.
-  stageModules = writeShellScript "discord-stage-modules" ''
-    store_modules="$1"
-    user_data_dir="''${DISCORD_USER_DATA_DIR-''${XDG_CONFIG_HOME:-$HOME/.config}}"
-    modules_dir="$user_data_dir''${user_data_dir:+/}${lib.toLower binaryName}/${version}/modules"
-    rm -rf "$modules_dir"
-    mkdir -p "$modules_dir"
-    for m in ${lib.concatStringsSep " " (lib.attrNames moduleSrcs)}; do
-      ln -sn "$store_modules/$m" "$modules_dir/$m"
-    done
-    echo '${builtins.toJSON (lib.mapAttrs (_: mod: { installedVersion = mod; }) moduleVersions)}' \
-      > "$modules_dir/installed.json"
-  '';
-
-  disableBreakingUpdates =
-    runCommand "disable-breaking-updates.py"
-      {
-        pythonInterpreter = "${python3.interpreter}";
-        configDirName = lib.toLower binaryName;
-        skipModuleUpdate = lib.boolToString withOpenASAR;
-        meta.mainProgram = "disable-breaking-updates.py";
-      }
-      ''
-        mkdir -p $out/bin
-        cp ${./disable-breaking-updates.py} $out/bin/disable-breaking-updates.py
-        substituteAllInPlace $out/bin/disable-breaking-updates.py
-        chmod +x $out/bin/disable-breaking-updates.py
-      '';
+      inherit (pkgs.stdenv.cc) cc;
+    })
+    ++ lib.optionals withTTS [ pkgs.speechd-minimal ]
+    # nss is intentionally NOT in libPath: it would leak via LD_LIBRARY_PATH
+    # to xdg-open and break Firefox children when versions diverge (#514859,
+    # PR #186603)
+    ++ lib.optionals useFHSEnv [ pkgs.nss ];
 in
-assert lib.assertMsg (
-  enabledDiscordModsCount <= 1
-) "discord: Only one of Vencord, Equicord or Moonlight can be enabled at the same time";
 stdenv.mkDerivation (finalAttrs: {
   inherit
-    pname
     version
     src
     meta
+    disableBreakingUpdates
+    stageModules
     ;
 
+  pname = if useFHSEnv then "${pname}-unwrapped" else pname;
+
+  libPath = if useFHSEnv then null else lib.makeLibraryPath (targetPkgs args);
+
   nativeBuildInputs = [
+    makeShellWrapper
+    brotli
+  ]
+  ++ lib.optionals (!useFHSEnv) [
     autoPatchelfHook
     cups
     libdrm
@@ -201,13 +176,9 @@ stdenv.mkDerivation (finalAttrs: {
     libxcb
     libxshmfence
     wrapGAppsHook3
-    makeShellWrapper
-    brotli
   ];
 
-  dontWrapGApps = true;
-
-  buildInputs = [
+  buildInputs = lib.optionals (!useFHSEnv) [
     alsa-lib
     libgbm
     nspr
@@ -223,9 +194,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   dontUnpack = true;
 
-  inherit libPath stageModules;
+  dontPatchELF = useFHSEnv;
+  dontStrip = useFHSEnv;
 
-  autoPatchelfIgnoreMissingDeps = [
+  autoPatchelfIgnoreMissingDeps = lib.optionals (!useFHSEnv) [
     "libssl.so.1.1"
     "libcrypto.so.1.1"
   ];
@@ -251,6 +223,8 @@ stdenv.mkDerivation (finalAttrs: {
       '') moduleSrcs
     )}
 
+    mkdir -p $out/opt/${binaryName}/modules/discord_krisp/KMS/logs
+
     wrapProgramShell $out/opt/${binaryName}/${binaryName} \
         "''${gappsWrapperArgs[@]}" \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
@@ -260,10 +234,14 @@ stdenv.mkDerivation (finalAttrs: {
         ''} \
         ${lib.strings.optionalString enableAutoscroll "--add-flags \"--enable-blink-features=MiddleClickAutoscroll\""} \
         --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
-        --prefix LD_LIBRARY_PATH : ${finalAttrs.libPath}:$out/opt/${binaryName}:${addDriverRunpath.driverLink}/lib \
+        ${
+          lib.strings.optionalString (!useFHSEnv)
+            "--prefix LD_LIBRARY_PATH : ${finalAttrs.libPath}:$out/opt/${binaryName}:${addDriverRunpath.driverLink}/lib"
+        } \
         --suffix VK_ADD_DRIVER_FILES : "${addDriverRunpath.driverLink}/share/vulkan/icd.d" \
-        ${lib.strings.optionalString disableUpdates "--run ${lib.getExe disableBreakingUpdates}"} \
+        ${lib.strings.optionalString disableUpdates "--run ${lib.getExe finalAttrs.disableBreakingUpdates}"} \
         --run "${finalAttrs.stageModules} $out/opt/${binaryName}/modules" \
+        --run '[ -t 1 ] || exec > /dev/null 2>&1' \
         --add-flags ${lib.escapeShellArg commandLineArgs}
 
     ln -s $out/opt/${binaryName}/${binaryName} $out/bin/
@@ -314,26 +292,7 @@ stdenv.mkDerivation (finalAttrs: {
     startupWMClass = "discord";
   };
 
-  passthru = {
-    # make it possible to run disableBreakingUpdates standalone
-    inherit disableBreakingUpdates;
-    # Exposed so reviewers can inspect which distro modules are pinned
-    inherit source moduleVersions;
-    updateScript = ./update.py;
-
-    tests = {
-      withVencord = self.override {
-        withVencord = true;
-      };
-      withEquicord = self.override {
-        withEquicord = true;
-      };
-      withMoonlight = self.override {
-        withMoonlight = true;
-      };
-      withOpenASAR = self.override {
-        withOpenASAR = true;
-      };
-    };
+  passthru = passthru // {
+    inherit targetPkgs;
   };
 })

--- a/pkgs/applications/networking/instant-messengers/discord/wrapper.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/wrapper.nix
@@ -1,0 +1,201 @@
+{
+  # Package metadata
+  pname,
+  source,
+  meta,
+  binaryName,
+  desktopName,
+  self,
+  branch,
+  # Feature flags (cross-platform)
+  withOpenASAR ? false,
+  withVencord ? false,
+  withEquicord ? false,
+  withMoonlight ? false,
+  # Disabling this would normally break Discord.
+  # The intended use-case for this is when SKIP_HOST_UPDATE is enabled via other means,
+  # for example if a settings.json is linked declaratively (e.g., with home-manager).
+  disableUpdates ? true,
+  # Feature flags (Linux exclusive)
+  withTTS ? true,
+  enableAutoscroll ? false,
+  # If true, the resulting derivation will be made using buildFHSEnv to wrap the inner
+  # Discord package. If false, the unwrappedDiscord package will be returned directly.
+  # Setting this value to false is not recommended, as Krisp will refuse to load due
+  # to the Discord binary being patched.
+  useFHSEnv ? stdenv.hostPlatform.isLinux,
+  # Package arguments
+  commandLineArgs ? "",
+  unwrappedDiscord ? null,
+  # Miscellaneous
+  lib,
+  stdenv,
+  buildFHSEnv,
+  writeShellScript,
+  runCommand,
+  callPackage,
+  fetchurl,
+  python3,
+  # Discord mods
+  openasar,
+  vencord,
+  equicord,
+  moonlight,
+}@args:
+
+let
+  inherit (stdenv.hostPlatform) isLinux;
+
+  pkgArgs = removeAttrs args [
+    "branch"
+    "self"
+    "unwrappedDiscord"
+    "buildFHSEnv"
+    "writeShellScript"
+    "runCommand"
+    "callPackage"
+    "python3"
+  ];
+
+  discordMods = [
+    withVencord
+    withEquicord
+    withMoonlight
+  ];
+  enabledDiscordModsCount = builtins.length (lib.filter (x: x) discordMods);
+
+  inherit (source) version;
+
+  moduleSrcs = lib.mapAttrs (_: mod: fetchurl { inherit (mod) url hash; }) source.modules;
+
+  moduleVersions = lib.mapAttrs (_: mod: mod.version) source.modules;
+
+  configDir =
+    if isLinux then
+      "\${DISCORD_USER_DATA_DIR-\${XDG_CONFIG_HOME:-$HOME/.config}}/${lib.toLower binaryName}"
+    else
+      let
+        configDirName = lib.replaceStrings [ " " ] [ "" ] (lib.toLower binaryName);
+      in
+      "\${DISCORD_USER_DATA_DIR-$HOME/Library/Application Support}/${configDirName}";
+
+  # Symlink native modules from the nix store into the user config dir
+  # where Discord's JS moduleUpdater expects them.
+  stageModules = writeShellScript "discord-stage-modules" ''
+    store_modules="$1"
+    modules_dir="${configDir}/${version}/modules"
+    rm -rf "$modules_dir"
+    mkdir -p "$modules_dir"
+    for m in ${lib.concatStringsSep " " (lib.attrNames moduleSrcs)}; do
+      ln -sn "$store_modules/$m" "$modules_dir/$m"
+    done
+    echo '${builtins.toJSON (lib.mapAttrs (_: mod: { installedVersion = mod; }) moduleVersions)}' \
+      > "$modules_dir/installed.json"
+  '';
+
+  disableBreakingUpdates =
+    runCommand "disable-breaking-updates.py"
+      {
+        pythonInterpreter = python3.interpreter;
+        configDirName = lib.toLower binaryName;
+        skipModuleUpdate = lib.boolToString withOpenASAR;
+        meta.mainProgram = "disable-breaking-updates.py";
+      }
+      ''
+        mkdir -p $out/bin
+        cp ${./disable-breaking-updates.py} $out/bin/disable-breaking-updates.py
+        substituteAllInPlace $out/bin/disable-breaking-updates.py
+        chmod +x $out/bin/disable-breaking-updates.py
+      '';
+
+  # Remove arguments not supported by the Darwin package.
+  platformPkgArgs =
+    if isLinux then
+      pkgArgs
+    else
+      removeAttrs pkgArgs [
+        "withTTS"
+        "enableAutoscroll"
+        "useFHSEnv"
+      ];
+  finalUnwrapped =
+    if unwrappedDiscord != null then
+      unwrappedDiscord
+    else
+      callPackage (if isLinux then ./linux.nix else ./darwin.nix) (
+        platformPkgArgs
+        // {
+          inherit
+            pname
+            passthru
+            disableBreakingUpdates
+            stageModules
+            moduleSrcs
+            ;
+        }
+      );
+
+  passthru = {
+    # make it possible to run disableBreakingUpdates and stageModules standalone
+    inherit disableBreakingUpdates stageModules;
+    # Exposed so reviewers can inspect which distro modules are pinned
+    inherit source moduleVersions;
+    updateScript = ./update.py;
+
+    unwrappedDiscord = finalUnwrapped;
+
+    tests = {
+      withVencord = self.override {
+        withVencord = true;
+      };
+      withEquicord = self.override {
+        withEquicord = true;
+      };
+      withMoonlight = self.override {
+        withMoonlight = true;
+      };
+      withOpenASAR = self.override {
+        withOpenASAR = true;
+      };
+      noFHSEnv = self.override {
+        useFHSEnv = false;
+      };
+    };
+  };
+
+in
+assert lib.assertMsg (
+  enabledDiscordModsCount <= 1
+) "discord: Only one of Vencord, Equicord, or Moonlight can be enabled at the same time";
+if useFHSEnv then
+  assert lib.assertMsg isLinux "discord: buildFHSEnv is only available on Linux";
+  buildFHSEnv {
+    inherit
+      source
+      pname
+      meta
+      version
+      passthru
+      stageModules
+      disableBreakingUpdates
+      ;
+
+    inherit (finalUnwrapped.passthru) targetPkgs;
+
+    src = fetchurl { inherit (source.distro) url hash; };
+
+    extraInstallCommands = ''
+      ln -s ${finalUnwrapped}/share $out/share
+
+      # Without || true the install would fail on case-insensitive filesystems
+      ln -s $out/bin/${binaryName} $out/bin/${lib.strings.toLower binaryName} || true
+    '';
+
+    executableName = binaryName;
+
+    runScript = "${finalUnwrapped}/bin/${binaryName}";
+  }
+else
+  finalUnwrapped.overrideAttrs (oldAttrs: {
+    passthru = (oldAttrs.passthru or { }) // passthru;
+  })


### PR DESCRIPTION
this PR modifies the discord package to use buildFHSEnv (and sets dontPatchELF and dontStrip = true) as a fix to #195512

i am new to contributing, please be nice

fixes https://github.com/NixOS/nixpkgs/issues/195512
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
