### PR TITLE
esphome: 2026.6.2 -> 2026.6.5

### DIFF
--- a/pkgs/by-name/es/esphome/package.nix
+++ b/pkgs/by-name/es/esphome/package.nix
@@ -24,14 +24,14 @@ let
 in
 python.pkgs.buildPythonApplication (finalAttrs: {
   pname = "esphome";
-  version = "2026.6.2";
+  version = "2026.6.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "esphome";
     repo = "esphome";
     tag = finalAttrs.version;
-    hash = "sha256-h7aMPSXmIUutCGMoZlE3Z1wX2xNxdmZsHfBllcFHBHc=";
+    hash = "sha256-4sbc/X86OWN/Bx2sPk3H2lgzGxdQNS6bIspNLAVqHz8=";
   };
 
   patches = [

--- a/pkgs/by-name/es/esphome/package.nix
+++ b/pkgs/by-name/es/esphome/package.nix
@@ -9,6 +9,7 @@
   esptool,
   git,
   versionCheckHook,
+  addBinToPathHook,
   nixosTests,
 }:
 
@@ -137,6 +138,7 @@ python.pkgs.buildPythonApplication (finalAttrs: {
     ++ [
       git
       versionCheckHook
+      addBinToPathHook
     ];
 
   disabledTestPaths = [
@@ -148,10 +150,6 @@ python.pkgs.buildPythonApplication (finalAttrs: {
     "tests/unit_tests/test_espidf_component.py"
   ];
 
-  preCheck = ''
-    export PATH=$PATH:$out/bin
-  '';
-
   postInstall =
     let
       argcomplete = lib.getExe' python.pkgs.argcomplete "register-python-argcomplete";
@@ -162,8 +160,6 @@ python.pkgs.buildPythonApplication (finalAttrs: {
         --zsh <(${argcomplete} --shell zsh esphome) \
         --fish <(${argcomplete} --shell fish esphome)
     '';
-
-  doInstallCheck = true;
 
   disabledTests = [
     # tries to import platformio, which is wrapped in an fhsenv

--- a/pkgs/by-name/es/esphome/package.nix
+++ b/pkgs/by-name/es/esphome/package.nix
@@ -85,7 +85,6 @@ python.pkgs.buildPythonApplication (finalAttrs: {
     jinja2
     paho-mqtt
     pillow
-    platformio
     puremagic
     py7zr
     pyparsing

--- a/pkgs/by-name/es/esphome/package.nix
+++ b/pkgs/by-name/es/esphome/package.nix
@@ -207,6 +207,7 @@ python.pkgs.buildPythonApplication (finalAttrs: {
       picnoir
       thanegill
       karlbeecken
+      tmarkus
     ];
     mainProgram = "esphome";
   };


### PR DESCRIPTION
Note: ESPHome 2026.7.0 requires additional changes due to the change to the device builder, so let's update to ESPHome 2026.6.5 first
* https://github.com/esphome/esphome/releases/tag/2026.6.5
* https://github.com/esphome/esphome/releases/tag/2026.6.4
* https://github.com/esphome/esphome/releases/tag/2026.6.3
* add myself as maintainer
* remove `platformio` from `dependencies` as discussed in #535285
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
