### PR TITLE
tdarr: Fix pnpm packaging regression

### DIFF
--- a/pkgs/tools/misc/tdarr/common.nix
+++ b/pkgs/tools/misc/tdarr/common.nix
@@ -26,6 +26,8 @@
   apprise,
   openssl,
   nixosTests,
+  pnpm_10,
+  nodejs,
 }:
 {
   pname,
@@ -54,6 +56,8 @@ let
     [
       jellyfin-ffmpeg
       mkvtoolnix
+      pnpm_10
+      nodejs
     ]
     ++ includeInPath
     # ! Handbrake is currently marked as broken on darwin
@@ -85,8 +89,6 @@ let
       "--set-default"
       "mkvpropeditPath"
       "${mkvtoolnix}/bin/mkvpropedit"
-    ]
-    ++ lib.optionals (component == "server") [
       "--set-default"
       "ccextractorPath"
       "${ccextractor}/bin/ccextractor"
@@ -143,6 +145,11 @@ stdenv.mkDerivation (finalAttrs: {
     # * exiftool-vendored checks for /usr/bin/perl existence; when missing (NixOS), it sets ignoreShebang=true which breaks spawn by using shell:true with an env lacking PATH. Since we patched the shebang, force ignoreShebang to false.
     substituteInPlace node_modules/exiftool-vendored/dist/ExifTool.js \
       --replace-fail '!_fs.existsSync("/usr/bin/perl")' 'false'
+
+    # * Substitute in nixpkgs version of pnpm as autopatchelf breaks the bundled copy see: https://github.com/NixOS/nixpkgs/issues/544841
+    rm ./runtime/pnpm
+    makeWrapper ${pnpm_10}/bin/pnpm ./runtime/pnpm \
+      --prefix PATH : ${lib.makeBinPath [ nodejs ]}
   '';
 
   preInstall = ''


### PR DESCRIPTION
Replaced bundled pnpm binary with the nixpkgs version as autopatchelf caused a regression that prevented plugins from updating. Refer to https://github.com/NixOS/nixpkgs/issues/544841

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
