### PR TITLE
nixos-option: add system.nix and nixos-system support

### DIFF
--- a/pkgs/by-name/ni/nixos-option/nixos-option.8
+++ b/pkgs/by-name/ni/nixos-option/nixos-option.8
@@ -29,6 +29,10 @@ in
 (which by default is
 .Pa /etc/nixos/configuration.nix Ns
 ),
+.Pa nixos-system
+in
+.Ev NIX_PATH ,
+.Pa /etc/nixos/system.nix ,
 .Pa /etc/nixos/flake.nix
 or the file and attribute specified by the
 .Fl I

--- a/pkgs/by-name/ni/nixos-option/nixos-option.sh
+++ b/pkgs/by-name/ni/nixos-option/nixos-option.sh
@@ -5,7 +5,7 @@ set -eou pipefail
 recursive=false
 no_flake=false
 positional_args=()
-nix_args=(--arg nixos "import <nixpkgs/nixos> { }")
+nix_args=()
 flake=""
 
 
@@ -83,18 +83,31 @@ done
 
 # Detection order, from high to low:
 # `--flake`
+# <nixos-system> in NIX_PATH
+# /etc/nixos/system.nix
 # $NIXOS_CONFIG
 # nixos-config=<path> in NIX_PATH (normally /etc/nixos/configuration.nix)
 # `-I` (implies `--no-flake`)
 # `--no-flake`
 # /etc/nixos/flake.nix (if exists)
 
-if [[ -n "${NIXOS_CONFIG:-}" ]] || nix-instantiate --find-file nixos-config >/dev/null 2>&1; then
-  no_flake=true
+hostname=$(< /proc/sys/kernel/hostname)
+if [[ -z "${hostname:-}" ]]; then
+  hostname=default
 fi
 
-if [[ -z "$flake" ]] && [[ -e /etc/nixos/flake.nix ]] && [[ "$no_flake" == "false" ]]; then
+if [[ -n "$flake" ]]; then
+  : # flake set by --flake flag, handled below
+elif nix-instantiate --find-file nixos-system >/dev/null 2>&1; then
+  nix_args+=(--arg nixos "(import <nixos-system>).\"$hostname\"")
+elif [[ -e /etc/nixos/system.nix ]]; then
+  nix_args+=(--arg nixos "(import /etc/nixos/system.nix).\"$hostname\"")
+elif [[ -n "${NIXOS_CONFIG:-}" ]] || nix-instantiate --find-file nixos-config >/dev/null 2>&1; then
+  nix_args+=(--arg nixos "import <nixpkgs/nixos> { }")
+elif [[ -e /etc/nixos/flake.nix ]] && [[ "$no_flake" == "false" ]]; then
   flake="$(dirname "$(realpath /etc/nixos/flake.nix)")"
+else
+  nix_args+=(--arg nixos "import <nixpkgs/nixos> { }")
 fi
 
 if [[ -n "$flake" ]]; then
@@ -111,10 +124,6 @@ if [[ -n "$flake" ]]; then
     fi
   fi
   if [[ -z "${flakeAttr:-}" ]]; then
-    hostname=$(< /proc/sys/kernel/hostname)
-    if [[ -z "${hostname:-}" ]]; then
-      hostname=default
-    fi
     flakeAttr="nixosConfigurations.\"$hostname\""
   else
     flakeAttr="nixosConfigurations.\"$flakeAttr\""


### PR DESCRIPTION
Detect <nixos-system> in NIX_PATH and /etc/nixos/system.nix before falling back to nixos-config or flake auto-detect. For system.nix and nixos-system paths, select the hostname attribute similar to flake.

This allows nixos-option to work with self-contained system configurations, matching what nixos-rebuild-ng already supports.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
