### PR TITLE
python3Packages.puremagic: 1.30 -> 2.2.0

### DIFF
--- a/pkgs/development/python-modules/puremagic/default.nix
+++ b/pkgs/development/python-modules/puremagic/default.nix
@@ -4,21 +4,25 @@
   fetchFromGitHub,
   pytestCheckHook,
   setuptools,
+  setuptools-scm,
 }:
 
 buildPythonPackage rec {
   pname = "puremagic";
-  version = "1.30";
+  version = "2.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "cdgriffith";
     repo = "puremagic";
     tag = version;
-    hash = "sha256-k2xrcML8XxI9cMTQTv0pDLkOrmEr5mbDnVsyWuD1rEc=";
+    hash = "sha256-Mvhn/1xcgYgVkWok2qZXAe40pocfu6nJo5xuPruw2dc=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 


### PR DESCRIPTION
Updates `puremagic` to 2.2.0.
Changelog: https://github.com/cdgriffith/puremagic/blob/2.2.0/CHANGELOG.md

The 2.x releases are additive (new and improved file-type scanners: Ogg, ASF, EBML, CFBF/OLE2, better OOXML detection) plus bug fixes; there are no API removals. Note the WAV MIME type changed from `audio/wave` to `audio/wav` in 2.1.0, which is potentially visible to dependents. The build now requires `setuptools-scm`.

Upstream test suite (95 tests) passes.

Targeted at staging: puremagic is a test dependency of `mocket`, which is a test dependency of `opentelemetry-instrumentation-requests`, so this bump rebuilds 700+ packages on x86_64-linux.

Disclosure per the [automation/AI policy]: this PR was prepared with the assistance of an LLM-based tool (Claude Code). All changes were reviewed and built before submission.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
