### PR TITLE
jiratui: 1.3.0 -> 1.10.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4669,6 +4669,12 @@
     githubId = 53847249;
     name = "Casey Avila";
   };
+  caspersonn = {
+    email = "lucakasper8@gmail.com";
+    github = "Caspersonn";
+    githubId = 96787412;
+    name = "Luca Kasper";
+  };
   cassandracomar = {
     name = "Cassandra Comar";
     github = "cassandracomar";

--- a/pkgs/by-name/ji/jiratui/package.nix
+++ b/pkgs/by-name/ji/jiratui/package.nix
@@ -7,14 +7,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "jiratui";
-  version = "1.3.0";
+  version = "1.10.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "whyisdifficult";
     repo = "jiratui";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-b5bSMPnqHqpeFDl501gSun7G38OlhV/IMNMYXQT+j/4=";
+    hash = "sha256-yXVc3evYK3lbiLwn09M++lZfbb5F9bXSR5ge6Pfgs6w=";
   };
 
   postPatch = ''
@@ -32,19 +32,28 @@ python3Packages.buildPythonApplication (finalAttrs: {
       click
       gitpython
       httpx
-      pyaml
+      marklas
+      puremagic
       pydantic-settings
       python-dateutil
       python-json-logger
-      python-magic
+      pyyaml
       textual
+      textual-autocomplete
       textual-image
+      urllib3
       xdg-base-dirs
     ]
     ++ textual.optional-dependencies.syntax;
 
   pythonRelaxDeps = [
     "click"
+    "marklas"
+    # upstream wants puremagic >= 2.2.0 but only uses puremagic.magic_string,
+    # which is compatible with 1.x; drop once puremagic >= 2.2.0 lands
+    "puremagic"
+    "pydantic-settings"
+    "python-json-logger"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/marklas/default.nix
+++ b/pkgs/development/python-modules/marklas/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  uv-build,
+
+  # dependencies
+  mistune,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "marklas";
+  version = "0.8.6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "byExist";
+    repo = "marklas";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-vzjU1a/uWho9SpPO7RC3fgs3iXnh8BD3uCLTnZge2Po=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.9.21,<0.10.0" "uv_build>=0.9.21"
+  '';
+
+  build-system = [ uv-build ];
+
+  dependencies = [ mistune ];
+
+  pythonImportsCheck = [ "marklas" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = {
+    description = "Bidirectional converter between GitHub Flavored Markdown and Atlassian Document Format";
+    homepage = "https://github.com/byExist/marklas";
+    changelog = "https://github.com/byExist/marklas/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ caspersonn ];
+  };
+})

--- a/pkgs/development/python-modules/textual-image/default.nix
+++ b/pkgs/development/python-modules/textual-image/default.nix
@@ -5,7 +5,7 @@
   fetchFromGitHub,
 
   # build-system
-  setuptools,
+  hatchling,
 
   # dependencies
   rich,
@@ -18,7 +18,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "textual-image";
-  version = "0.12.0";
+  version = "0.13.2";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -26,10 +26,10 @@ buildPythonPackage (finalAttrs: {
     owner = "lnqs";
     repo = "textual-image";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-W0f9ZnSZ58XqiPnr9SZEv22EE4yCsvXcgNA8eJebJQo=";
+    hash = "sha256-7TPng2rBYVY1r7Y1pkSZYo4r+MdyD8HzqJAMpzyNqZE=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [ hatchling ];
 
   dependencies = [
     pillow

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10119,6 +10119,8 @@ self: super: with self; {
 
   markitdown = callPackage ../development/python-modules/markitdown { };
 
+  marklas = callPackage ../development/python-modules/marklas { };
+
   marko = callPackage ../development/python-modules/marko { };
 
   markuppy = callPackage ../development/python-modules/markuppy { };


### PR DESCRIPTION
Updates `jiratui` to 1.10.1.
Changelog: https://github.com/whyisdifficult/jiratui/blob/v1.10.1/CHANGELOG.md

The update required some dependency work, split into separate commits:

- `maintainers: add caspersonn` — maintainer entry for the new marklas package below.
- `python3Packages.marklas: init at 0.8.6` — new dependency of jiratui (bidirectional Markdown ⇄ Atlassian Document Format converter, https://github.com/byExist/marklas, MIT). jiratui pins `marklas==0.8.2`; 0.8.3–0.8.6 are bugfix-only releases, so the latest version is packaged and the pin is relaxed. The upstream test suite (633 tests) is enabled and passes.
- `python3Packages.textual-image: 0.12.0 -> 0.13.2` — jiratui needs `>=0.13.2,<0.14.0`. Upstream switched the build system from setuptools to hatchling. Only other dependent is oterm, which builds fine. Changelog: https://github.com/lnqs/textual-image/blob/v0.13.2/CHANGELOG.md
- `jiratui: 1.3.0 -> 1.10.1`

jiratui dependency changes: `python-magic` and `pyaml` dropped; `marklas`, `puremagic`, `textual-autocomplete`, `urllib3` and `pyyaml` (for the `pydantic-settings[yaml]` extra) added.

`pythonRelaxDeps`: `click` (nixpkgs 8.3.3 < required 8.4.2), `pydantic-settings` (2.12.0 < 2.14.2), `python-json-logger` (4.0.0 < 4.1.0), `marklas` (0.8.6 vs `==0.8.2` pin), and `puremagic`. Upstream wants `puremagic>=2.2.0` but nixpkgs is at 1.30; jiratui only uses `puremagic.magic_string()`, which is API-compatible with 1.x — verified working, including live Jira API calls. Bumping puremagic itself causes 700+ rebuilds (it is a test dependency of `mocket` → `opentelemetry-instrumentation-requests`), so that update is submitted separately against staging: https://github.com/NixOS/nixpkgs/pull/544854. The relax can be dropped once it lands.

Functional testing beyond the build (on x86_64-linux, real Jira Cloud instance): `jiratui version`, `jiratui config` (config parsing via pydantic-settings), `jiratui themes`, a live read-only API query (`jiratui users search`), and a TUI launch in a PTY — all working.

This update is also relevant for the current stable release; requesting `backport release-26.05` (jiratui is at 1.3.0 there as well, and this change set is small and leaf-only).

Disclosure per the [automation/AI policy]: this PR was prepared with the assistance of an LLM-based tool (Claude Code). All changes were reviewed, built, and functionally tested before submission.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review rev HEAD`
Commit: `2e63139ba4bd95d942ea56ce188050579152f441`

### `x86_64-linux`
<details>
  <summary>:white_check_mark: 6 packages built:</summary>
  <ul>
    <li>jiratui</li>
    <li>oterm</li>
    <li>python313Packages.marklas</li>
    <li>python313Packages.textual-image</li>
    <li>python314Packages.marklas</li>
    <li>python314Packages.textual-image</li>
  </ul>
</details>
