### PR TITLE
nixos-test-driver: Drop temporary directory in copy_from_machine

### DIFF
--- a/nixos/lib/test-driver/src/test_driver/machine/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/machine/__init__.py
@@ -660,25 +660,22 @@ class BaseMachine(ABC):
     def copy_from_machine(self, source: str, target_dir: str = "") -> None:
         """Copy a file from the machine (specified by an in-machine source path) to a path
         relative to `$out`. The file is copied via the `shared_dir` shared among
-        all the machines (using a temporary directory).
+        all the machines.
         """
         # Compute the source, target, and intermediate shared file names
         vm_src = Path(source)
-        with tempfile.TemporaryDirectory(dir=self.shared_dir) as shared_td:
-            shared_temp = Path(shared_td)
-            vm_shared_temp = Path("/tmp/shared") / shared_temp.name
-            vm_intermediate = vm_shared_temp / vm_src.name
-            intermediate = shared_temp / vm_src.name
-            # Copy the file to the shared directory inside machines
-            self.succeed(make_command(["mkdir", "-p", vm_shared_temp]))
-            self.succeed(make_command(["cp", "-r", vm_src, vm_intermediate]))
-            abs_target = self.out_dir / target_dir / vm_src.name
-            abs_target.parent.mkdir(exist_ok=True, parents=True)
-            # Copy the file from the shared directory outside machines
-            if intermediate.is_dir():
-                shutil.copytree(intermediate, abs_target)
-            else:
-                shutil.copy(intermediate, abs_target)
+        vm_intermediate = Path("/tmp/shared") / target_dir / vm_src.name
+        intermediate = self.shared_dir / target_dir / vm_src.name
+        # Copy the file to the shared directory inside machines
+        self.succeed(make_command(["mkdir", "-p", vm_intermediate.parent]))
+        self.succeed(make_command(["cp", "-r", vm_src, vm_intermediate]))
+        abs_target = self.out_dir / target_dir / vm_src.name
+        abs_target.parent.mkdir(exist_ok=True, parents=True)
+        # Copy the file from the shared directory outside machines
+        if intermediate.is_dir():
+            shutil.copytree(intermediate, abs_target)
+        else:
+            shutil.copy(intermediate, abs_target)
 
     @warnings.deprecated("Use copy_from_machine() instead")
     def copy_from_vm(self, source: str, target_dir: str = "") -> None:


### PR DESCRIPTION
Remove temporary directory in `copy_from_machine`. This allows persisting artifacts to a deterministic path on failure using `--keep-failed`--useful for debugging flaky tests from CI. This runs the risk of creating filename collisions, but since we are already copying files to `abs_target = self.out_dir / target_dir / vm_src.name`, I think this is already an invariant / known behavior. Users can still achieve fully unique paths by using a unique `target_dir` instead.

See discourse issue: https://discourse.nixos.org/t/output-from-a-nixos-integration-test/17459/5

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Testing: ran `systemd-analyze` with `--keep-failed` and verified that adding an assertion yields the expected output under `/nix/var/nix/builds/nix-xyz/shared-xchg/systemd-analyze`.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
