### PR TITLE
ocamlPackages.camlimages: drop camlimages.lablgtk2

### DIFF
--- a/pkgs/development/ocaml-modules/camlimages/default.nix
+++ b/pkgs/development/ocaml-modules/camlimages/default.nix
@@ -6,15 +6,12 @@
   dune-configurator,
   cppo,
   graphics,
-  lablgtk,
   stdio,
 }:
 
 buildDunePackage (finalAttrs: {
   pname = "camlimages";
   version = "5.0.5";
-
-  minimalOCamlVersion = "4.07";
 
   src = fetchFromGitLab {
     owner = "camlspotter";
@@ -31,17 +28,15 @@ buildDunePackage (finalAttrs: {
     dune-configurator
     findlib
     graphics
-    lablgtk
     stdio
   ];
 
   meta = {
     branch = "5.0";
-    inherit (finalAttrs.src.meta) homepage;
+    homepage = "https://gitlab.com/camlspotter/camlimages";
     description = "OCaml image processing library";
     license = lib.licenses.lgpl2;
     maintainers = [
-      lib.maintainers.vbgl
       lib.maintainers.mt-caret
     ];
   };


### PR DESCRIPTION
cc #410814

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
