### PR TITLE
Migrate various things off pnpm_9 (artalk, etherpad-lite, firezone-server, n8n-nodes-evaluation-api, parca, overlayed)

### DIFF
--- a/pkgs/by-name/ar/artalk/package.nix
+++ b/pkgs/by-name/ar/artalk/package.nix
@@ -3,7 +3,7 @@
   buildGoModule,
   fetchFromGitHub,
   nodejs,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   installShellFiles,
@@ -31,14 +31,14 @@ let
     nativeBuildInputs = [
       nodejs
       pnpmConfigHook
-      pnpm_9
+      pnpm_10
     ];
 
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname version src;
-      pnpm = pnpm_9;
-      fetcherVersion = 3;
-      hash = "sha256-HypDGYb0MRCIDBHY8pVgwFoZQWC8us44cunORZRk3RM=";
+      pnpm = pnpm_10;
+      fetcherVersion = 4;
+      hash = "sha256-RSz/bx8/BAqLZH3/yQ6/H/nnwGvcCg8EzIEJ4/xkQgQ=";
     };
 
     buildPhase = ''

--- a/pkgs/by-name/et/etherpad-lite/package.nix
+++ b/pkgs/by-name/et/etherpad-lite/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   nix-update-script,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   makeWrapper,
@@ -30,14 +30,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-2nKpmGxC+KVg0oF0BsswS9L84QxzpRF7NvKyqyQ7WJM=";
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-scJhcZDyqUVdKv/EQvB5+EJN/SvMw220+QOcTUxTFJQ=";
   };
 
   nativeBuildInputs = [
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
     makeWrapper
   ];
 
@@ -70,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper ${lib.getExe nodejs} $out/bin/etherpad-lite \
       --inherit-argv0 \
       --add-flags "--require tsx/cjs $out/lib/etherpad-lite/node_modules/ep_etherpad-lite/node/server.ts" \
-      --suffix PATH : "${lib.makeBinPath [ pnpm_9 ]}" \
+      --suffix PATH : "${lib.makeBinPath [ pnpm_10 ]}" \
       --set NODE_PATH "$out/lib/node_modules:$out/lib/etherpad-lite/node_modules/ep_etherpad-lite/node_modules" \
       --set-default NODE_ENV production
     find $out/lib -xtype l -delete

--- a/pkgs/by-name/fi/firezone-server/package.nix
+++ b/pkgs/by-name/fi/firezone-server/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   beam27Packages,
   gitMinimal,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   nodejs,
@@ -34,10 +34,10 @@ beam27Packages.mixRelease rec {
 
   pnpmDeps = fetchPnpmDeps {
     inherit pname version;
-    pnpm = pnpm_9;
+    pnpm = pnpm_10;
     src = "${src}/apps/web/assets";
-    fetcherVersion = 3;
-    hash = "sha256-tB0y3T/dZBe8BHz7AV913zQ4oQu7VLyqHCnzBycNg18=";
+    fetcherVersion = 4;
+    hash = "sha256-Uq6dAYYWT8G6upYcNEzVc8Gb2HUj8SaWRD0/w0quaRE=";
   };
   pnpmRoot = "apps/web/assets";
 
@@ -63,7 +63,7 @@ beam27Packages.mixRelease rec {
 
   nativeBuildInputs = [
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
     nodejs
   ];
 

--- a/pkgs/by-name/n8/n8n-nodes-evolution-api/package.nix
+++ b/pkgs/by-name/n8/n8n-nodes-evolution-api/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   fetchPnpmDeps,
   nodejs,
-  pnpm_9,
+  pnpm_10,
   pnpmConfigHook,
   nix-update-script,
   n8n,
@@ -24,14 +24,14 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
   ];
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-hMjWFjDhc61HGkQOG/q2EU8pPShUhtHSTe+6wUAa5M4=";
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-jAHeQHUPUzC4NiKl/h7i8UwStyzw2tCKs42ZkeGZVSw=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/ov/overlayed/package.nix
+++ b/pkgs/by-name/ov/overlayed/package.nix
@@ -8,7 +8,7 @@
   moreutils,
   nodejs,
   pkg-config,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
 
@@ -35,9 +35,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-KJZuucXB7BEMnqPmgytveG/IBEzq4mgMo9ZJHPe/gVs=";
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-DkVV5Dz5UV/xMuteSXWgSko3e8t8u1Saq1X1UxaaZFA=";
   };
 
   nativeBuildInputs = [
@@ -47,7 +47,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     nodejs
     pkg-config
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
   ];
 
   buildInputs = [

--- a/pkgs/by-name/pa/parca/package.nix
+++ b/pkgs/by-name/pa/parca/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   lib,
   nodejs,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   stdenv,
@@ -26,16 +26,16 @@ let
 
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname src version;
-      pnpm = pnpm_9;
-      fetcherVersion = 3;
-      hash = "sha256-zHdMwJyeafzbIlp+Fhh1khcUVrLsoUg6ViSGm/ByGAA=";
+      pnpm = pnpm_10;
+      fetcherVersion = 4;
+      hash = "sha256-cd9sA01DTXsrKm4enFeS3zmn3w4A5N7QXhtZ0wcpNss=";
     };
 
     nativeBuildInputs = [
       faketty
       nodejs
       pnpmConfigHook
-      pnpm_9
+      pnpm_10
     ];
 
     # faketty is required to work around a bug in nx.

--- a/pkgs/by-name/pa/parca/update.sh
+++ b/pkgs/by-name/pa/parca/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -I nixpkgs=./. -i bash -p curl jq git pnpm_9
+#!nix-shell -I nixpkgs=./. -i bash -p curl jq git pnpm_10
 # shellcheck shell=bash
 set -euo pipefail
 nixpkgs="$(pwd)"


### PR DESCRIPTION
Sprinting https://github.com/NixOS/nixpkgs/issues/529285

That was supposed to be your job!
- @Moraxyc 
- @erdnaxe 
- @f2k1de 
- @oddlama 
- @PatrickDaG 
- @vitorpavani 
- @Bot-wxt1221 
- @brancz 
- @metalmatze 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
