### PR TITLE
renode: add aarch64-linux support

### DIFF
--- a/pkgs/by-name/re/renode/package.nix
+++ b/pkgs/by-name/re/renode/package.nix
@@ -10,10 +10,19 @@
   gtk3-x11,
   gtk3,
   lib,
-  python3Packages,
+  python313Packages,
+  stdenv,
 }:
 
 let
+  hostArch =
+    if stdenv.hostPlatform.isx86 then
+      "i386"
+    else if stdenv.hostPlatform.isAarch64 then
+      "aarch64"
+    else
+      throw "renode: unsupported host architecture ${stdenv.hostPlatform.system}";
+
   resources = fetchFromGitHub {
     owner = "renode";
     repo = "renode-resources";
@@ -22,7 +31,7 @@ let
   };
 
   pythonLibs =
-    with python3Packages;
+    with python313Packages;
     makePythonPath [
       construct
       psutil
@@ -36,7 +45,8 @@ let
       # from tools/execution_tracer/requirements.txt
       pyelftools
 
-      (robotframework.overrideDerivation (oldAttrs: {
+      (robotframework.overridePythonAttrs (oldAttrs: {
+        version = "6.1";
         src = fetchFromGitHub {
           owner = "robotframework";
           repo = "robotframework";
@@ -151,7 +161,7 @@ buildDotnetModule rec {
           CMAKE_CONF_FLAGS+=" -DTARGET_WORDS_BIGENDIAN=1"
       fi
 
-      cmake $CMAKE_CONF_FLAGS -DHOST_ARCH=i386 $SOURCE
+      cmake $CMAKE_CONF_FLAGS -DHOST_ARCH=${hostArch} $SOURCE
       cmake --build . -j$NIX_BUILD_CORES
       popd
     done
@@ -194,6 +204,9 @@ buildDotnetModule rec {
       otavio
       znaniye
     ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
