### PR TITLE
python3Packages.oxipng-pybind: init at 10.1.1.post3

### DIFF
--- a/pkgs/development/python-modules/oxipng-pybind/default.nix
+++ b/pkgs/development/python-modules/oxipng-pybind/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  pillow,
+  tomlkit,
+  pyyaml,
+  rustPlatform,
+}:
+
+buildPythonPackage rec {
+  pname = "oxipng-pybind";
+  version = "10.1.1.post3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pdomain";
+    repo = "oxipng-pybind";
+    rev = "v${version}";
+    hash = "sha256-6ET4bfe5hk+SS4LtvK1WfCj9Zccp/zse5la5osituAo=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit pname version src;
+    hash = "sha256-DiM0Iwx2BJJSvOayw9FZ1ZmFX2H0TFBeaD+dxTqIqPE=";
+  };
+
+  nativeBuildInputs = with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+  ];
+
+  nativeCheckInputs = [
+    rustPlatform.cargoCheckHook
+    pytestCheckHook
+    pillow
+    tomlkit
+    pyyaml
+  ];
+
+  pythonImportsCheck = [
+    "oxipng"
+  ];
+
+  meta = {
+    description = "Focused Python bindings for oxipng";
+    homepage = "https://github.com/pdomain/oxipng-pybind";
+    changelog = "https://github.com/pdomain/oxipng-pybind/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.unlicense;
+    maintainers = with lib.maintainers; [ xavwe ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12674,6 +12674,8 @@ self: super: with self; {
 
   owslib = callPackage ../development/python-modules/owslib { };
 
+  oxipng-pybind = callPackage ../development/python-modules/oxipng-pybind { };
+
   oyaml = callPackage ../development/python-modules/oyaml { };
 
   p1monitor = callPackage ../development/python-modules/p1monitor { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
