### PR TITLE
datadog-pup: init at 1.7.0

### DIFF
--- a/pkgs/by-name/da/datadog-pup/package.nix
+++ b/pkgs/by-name/da/datadog-pup/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "datadog-pup";
+  version = "1.7.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "DataDog";
+    repo = "pup";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-zXb6SM6ylFVoIg+M7loNvPT45mda1okTSXslfLzOHpQ=";
+  };
+
+  cargoHash = "sha256-b3aDH3UOa7VSiLEGZkr8EIvsZ9WnADnHOL8EOnAKHkM=";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  doCheck = false;
+  doInstallCheck = true;
+
+  meta = {
+    description = "CLI for Datadog's observability platform";
+    homepage = "https://github.com/DataDog/pup";
+    changelog = "https://github.com/DataDog/pup/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ bobvanderlinden ];
+    mainProgram = "pup";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
This adds `datadog-pup`. The CLI is called `pup`, but since we already have a package called `pup` I have opted to call this one `datadog-pup`.

I wasn't sure whether a package test or a versionCheckHook was preferred, so I went with versionCheckHook.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
