### PR TITLE
ddccontrol: 1.0.3 -> 3.2.0

### DIFF
--- a/pkgs/by-name/dd/ddccontrol/package.nix
+++ b/pkgs/by-name/dd/ddccontrol/package.nix
@@ -56,6 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Program used to control monitor parameters by software";
     homepage = "https://github.com/ddccontrol/ddccontrol";
+    mainProgram = "ddccontrol";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/dd/ddccontrol/package.nix
+++ b/pkgs/by-name/dd/ddccontrol/package.nix
@@ -2,11 +2,15 @@
   lib,
   stdenv,
   fetchFromGitHub,
+
+  # nativeBuildInputs
   autoreconfHook,
   intltool,
+  pkg-config,
+
+  # buildInputs
   libxml2,
   pciutils,
-  pkg-config,
   gtk2,
   ddccontrol-db,
 }:

--- a/pkgs/by-name/dd/ddccontrol/package.nix
+++ b/pkgs/by-name/dd/ddccontrol/package.nix
@@ -40,9 +40,9 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   prePatch = ''
-    substituteInPlace configure.ac              \
-      --replace-fail                            \
-      "\$""{datadir}/ddccontrol-db"             \
+    substituteInPlace configure.ac \
+      --replace-fail \
+      "\$""{datadir}/ddccontrol-db" \
       "${ddccontrol-db}/share/ddccontrol-db"
 
     substituteInPlace src/ddcpci/Makefile.am    \

--- a/pkgs/by-name/dd/ddccontrol/package.nix
+++ b/pkgs/by-name/dd/ddccontrol/package.nix
@@ -7,35 +7,46 @@
   autoreconfHook,
   intltool,
   pkg-config,
+  rustPlatform,
+  cargo,
+  rustc,
 
   # buildInputs
   libxml2,
   pciutils,
-  gtk2,
+  gtk3,
   ddccontrol-db,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ddccontrol";
-  version = "1.0.3";
+  version = "3.2.0";
 
   src = fetchFromGitHub {
     owner = "ddccontrol";
     repo = "ddccontrol";
     tag = finalAttrs.version;
-    sha256 = "sha256-qyD6i44yH3EufIW+LA/LBMW20Tejb49zvsDfv6YFD6c=";
+    sha256 = "sha256-8VqnmWLXt6rXapAqvzvtDQ9XjQ7H6s7pLqPhQ6Zflc4=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-UN308Tt9LCRLBSswem06UupjdIFntt6SqpTxteY5O78=";
   };
 
   nativeBuildInputs = [
     autoreconfHook
     intltool
     pkg-config
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
   ];
 
   buildInputs = [
     libxml2
     pciutils
-    gtk2
+    gtk3
     ddccontrol-db
   ];
 
@@ -48,9 +59,10 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail \
       "\$""{datadir}/ddccontrol-db" \
       "${ddccontrol-db}/share/ddccontrol-db"
-
-    substituteInPlace src/ddcpci/Makefile.am    \
-       --replace "chmod 4711" "chmod 0711"
+    substituteInPlace src/lib/Makefile.am \
+      --replace-fail \
+      'DDCONTROL_DATADIR="$(datadir)/ddccontrol-db"' \
+      'DDCONTROL_DATADIR="${ddccontrol-db}/share/ddccontrol-db"'
   '';
 
   preConfigure = ''

--- a/pkgs/by-name/dd/ddccontrol/package.nix
+++ b/pkgs/by-name/dd/ddccontrol/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   prePatch = ''
     substituteInPlace configure.ac              \
-      --replace                                 \
+      --replace-fail                            \
       "\$""{datadir}/ddccontrol-db"             \
       "${ddccontrol-db}/share/ddccontrol-db"
 


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/410814

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test