### PR TITLE
nxv: 0.1.4 -> 0.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12454,6 +12454,12 @@
     github = "james-atkins";
     githubId = 9221409;
   };
+  jamesbrink = {
+    email = "dev.urandom.io@gmail.com";
+    name = "James Brink";
+    github = "jamesbrink";
+    githubId = 646361;
+  };
   jamespeapen = {
     name = "James Eapen";
     email = "james.eapen@vai.org";

--- a/pkgs/by-name/nx/nxv/package.nix
+++ b/pkgs/by-name/nx/nxv/package.nix
@@ -8,17 +8,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nxv";
-  version = "0.1.4";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "utensils";
     repo = "nxv";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-714babrR7inR+zkFSk8eqho4GIvUn6ITj7S54i5UcBI=";
-    fetchSubmodules = true;
+    hash = "sha256-Ym30QiImry+3Io933SFQw5q6Lyl5p8nuidQhrXHSv54=";
   };
 
-  cargoHash = "sha256-oc/R/Z0dXqt6JTNCVzejTO2LEuTmiYHdn5WNsxQ8IHQ=";
+  cargoHash = "sha256-syAlYsXPxMUIyPNankujiVD3lXaAgGmr5v585ysxIWI=";
 
   # Tests use mockito which needs to bind to localhost
   __darwinAllowLocalNetworking = true;
@@ -32,7 +31,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Find any version of any Nix package instantly";
     longDescription = ''
-      nxv indexes the entire nixpkgs git history to help you discover
+      nxv indexes nixpkgs channel releases (2016+) to help you discover
       when packages were added, which versions existed, and the exact
       commit to use with `nix shell nixpkgs/<commit>#package`.
     '';

--- a/pkgs/by-name/nx/nxv/package.nix
+++ b/pkgs/by-name/nx/nxv/package.nix
@@ -38,7 +38,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://nxv.urandom.io";
     changelog = "https://github.com/utensils/nxv/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ yiyu ];
+    maintainers = with lib.maintainers; [
+      yiyu
+      jamesbrink
+    ];
     mainProgram = "nxv";
   };
 })


### PR DESCRIPTION
nxv is a CLI + HTTP API for finding any version of any Nix package across nixpkgs history. This updates 0.1.4 → 0.6.0 ([changelog](https://github.com/utensils/nxv/blob/v0.6.0/CHANGELOG.md), [full diff](https://github.com/utensils/nxv/compare/v0.1.4...v0.6.0)).

Notable since 0.1.4: the indexer was rewritten to ingest channel-release snapshots instead of walking git history (schema v4). **Breaking CLI change in 0.6.0**: `nxv update` now only self-updates the application and the new `nxv sync` refreshes the package index. JSON output emits real arrays for license/maintainers/platforms.

`fetchSubmodules` is dropped — the vestigial nixpkgs submodule was unused by the build and has been removed upstream. `longDescription` updated to match the snapshot-based design.

Adds myself (upstream author of nxv) to `meta.maintainers` alongside @yiyu, with a `maintainers: add jamesbrink` commit first per convention. cc @yiyu — happy to co-maintain; review welcome.

Disclosure per the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy): prepared with Claude Code (Claude Fable 5); reviewed, built, and tested by me. Commits carry `Assisted-by:` trailers. This PR summary was likewise drafted with the same tooling and reviewed by me.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test