### PR TITLE
pkgsStatic.coreutils: fix build

### DIFF
--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -23,6 +23,7 @@
   openssl,
   withPrefix ? false,
   singleBinary ? "symlinks", # you can also pass "shebangs" or false
+  pkgsStatic,
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus cannot use
@@ -42,6 +43,11 @@ let
     optionalString
     ;
   isCross = (stdenv.hostPlatform != stdenv.buildPlatform);
+  # stdbuf relies on an LD_PRELOAD shared library, so it is not built in
+  # static builds; drop it from the binlore override there.
+  #
+  # https://github.com/coreutils/coreutils/blob/6e812858bb8b5cc1a4c91b16502a3092ead1d72f/src/stdbuf.c#L389
+  stdbuf = optionalString (!stdenv.hostPlatform.isStatic) "stdbuf,";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "coreutils" + (optionalString (!minimal) "-full");
@@ -230,32 +236,35 @@ stdenv.mkDerivation (finalAttrs: {
       rm -r "$out/share"
     '';
 
-  passthru =
-    { }
-    // optionalAttrs (singleBinary != false) {
-      # everything in the single binary gets the same verdict, so we
-      # override _that case_ with verdicts from separate binaries.
-      #
-      # binlore only spots exec in runcon on some platforms (i.e., not
-      # darwin; see comment on inverse case below)
-      binlore.out = binlore.synthesize finalAttrs.finalPackage ''
-        execer can bin/${
-          if withPrefix then "g" else ""
-        }{chroot,env,install,nice,nohup,runcon,sort,split,stdbuf,timeout}
-        execer cannot bin/${
-          if withPrefix then "g" else ""
-        }{[,b2sum,base32,base64,basename,basenc,cat,chcon,chgrp,chmod,chown,cksum,comm,cp,csplit,cut,date,dd,df,dir,dircolors,dirname,du,echo,expand,expr,factor,false,fmt,fold,groups,head,hostid,id,join,kill,link,ln,logname,ls,md5sum,mkdir,mkfifo,mknod,mktemp,mv,nl,nproc,numfmt,od,paste,pathchk,pinky,pr,printenv,printf,ptx,pwd,readlink,realpath,rm,rmdir,seq,sha1sum,sha224sum,sha256sum,sha384sum,sha512sum,shred,shuf,sleep,stat,stty,sum,sync,tac,tail,tee,test,touch,tr,true,truncate,tsort,tty,uname,unexpand,uniq,unlink,uptime,users,vdir,wc,who,whoami,yes}
-      '';
-    }
-    // optionalAttrs (singleBinary == false) {
-      # binlore only spots exec in runcon on some platforms (i.e., not
-      # darwin; I have a note that the behavior may need selinux?).
-      # hard-set it so people working on macOS don't miss cases of
-      # runcon until ofBorg fails.
-      binlore.out = binlore.synthesize finalAttrs.finalPackage ''
-        execer can bin/${if withPrefix then "g" else ""}runcon
-      '';
+  passthru = {
+    tests = {
+      static = pkgsStatic.coreutils;
     };
+  }
+  // optionalAttrs (singleBinary != false) {
+    # everything in the single binary gets the same verdict, so we
+    # override _that case_ with verdicts from separate binaries.
+    #
+    # binlore only spots exec in runcon on some platforms (i.e., not
+    # darwin; see comment on inverse case below)
+    binlore.out = binlore.synthesize finalAttrs.finalPackage ''
+      execer can bin/${
+        if withPrefix then "g" else ""
+      }{chroot,env,install,nice,nohup,runcon,sort,split,${stdbuf}timeout}
+      execer cannot bin/${
+        if withPrefix then "g" else ""
+      }{[,b2sum,base32,base64,basename,basenc,cat,chcon,chgrp,chmod,chown,cksum,comm,cp,csplit,cut,date,dd,df,dir,dircolors,dirname,du,echo,expand,expr,factor,false,fmt,fold,groups,head,hostid,id,join,kill,link,ln,logname,ls,md5sum,mkdir,mkfifo,mknod,mktemp,mv,nl,nproc,numfmt,od,paste,pathchk,pinky,pr,printenv,printf,ptx,pwd,readlink,realpath,rm,rmdir,seq,sha1sum,sha224sum,sha256sum,sha384sum,sha512sum,shred,shuf,sleep,stat,stty,sum,sync,tac,tail,tee,test,touch,tr,true,truncate,tsort,tty,uname,unexpand,uniq,unlink,uptime,users,vdir,wc,who,whoami,yes}
+    '';
+  }
+  // optionalAttrs (singleBinary == false) {
+    # binlore only spots exec in runcon on some platforms (i.e., not
+    # darwin; I have a note that the behavior may need selinux?).
+    # hard-set it so people working on macOS don't miss cases of
+    # runcon until ofBorg fails.
+    binlore.out = binlore.synthesize finalAttrs.finalPackage ''
+      execer can bin/${if withPrefix then "g" else ""}runcon
+    '';
+  };
 
   meta = {
     homepage = "https://www.gnu.org/software/coreutils/";


### PR DESCRIPTION
Diff is bigger than it deserves, but this is how `nix fmt` wants it.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
