### PR TITLE
gtk-gnutella: disable gui to avoid gtk2

### DIFF
--- a/pkgs/by-name/gt/gtk-gnutella/package.nix
+++ b/pkgs/by-name/gt/gtk-gnutella/package.nix
@@ -7,12 +7,10 @@
   gettext,
   pkg-config,
   glib,
-  gtk2,
   libxml2,
   libbfd,
   zlib,
   gnutls,
-  enableGui ? true,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -40,16 +38,11 @@ stdenv.mkDerivation (finalAttrs: {
     libbfd
     libxml2
     zlib
-  ]
-  ++ lib.optionals enableGui [
-    gtk2
   ];
 
   configureScript = "./build.sh";
   configureFlags = [
     "--configure-only"
-  ]
-  ++ lib.optionals (!enableGui) [
     "--topless"
   ];
 


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/410814

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test