### PR TITLE
various: remove unused pcre dependency

### DIFF
--- a/pkgs/by-name/io/io/package.nix
+++ b/pkgs/by-name/io/io/package.nix
@@ -21,7 +21,6 @@
   libxml2,
   libglut,
   libsamplerate,
-  pcre,
   libevent,
   libedit,
   yajl,
@@ -81,7 +80,6 @@ stdenv.mkDerivation {
     libxml2
     libglut
     libsamplerate
-    pcre
     libevent
     libedit
     yajl

--- a/pkgs/by-name/ke/kermit-terminal/package.nix
+++ b/pkgs/by-name/ke/kermit-terminal/package.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   cmake,
   gtk3,
-  pcre,
   pkg-config,
   vte,
   nixosTests,
@@ -33,7 +32,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     gtk3
-    pcre
     vte
   ];
 

--- a/pkgs/by-name/li/libgaminggear/package.nix
+++ b/pkgs/by-name/li/libgaminggear/package.nix
@@ -9,7 +9,6 @@
   gtk2,
   libcanberra,
   libnotify,
-  pcre,
   sqlite,
   libxdmcp,
   libpthread-stubs,
@@ -48,7 +47,6 @@ stdenv.mkDerivation (finalAttrs: {
     gtk2
     libcanberra
     libnotify
-    pcre
     sqlite
     libxdmcp
     libpthread-stubs

--- a/pkgs/by-name/rc/rcon/package.nix
+++ b/pkgs/by-name/rc/rcon/package.nix
@@ -7,7 +7,6 @@
   glib,
   libbsd,
   check,
-  pcre,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -30,7 +29,6 @@ stdenv.mkDerivation (finalAttrs: {
     glib
     libbsd
     check
-    pcre
   ];
 
   postPatch = ''

--- a/pkgs/by-name/sa/sayonara/package.nix
+++ b/pkgs/by-name/sa/sayonara/package.nix
@@ -7,7 +7,6 @@
   lib,
   libpulseaudio,
   ninja,
-  pcre,
   pkg-config,
   taglib,
   zlib,
@@ -43,7 +42,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     libpulseaudio
-    pcre
     libsForQt5.qtbase
     taglib
     zlib

--- a/pkgs/by-name/ti/tiscamera/package.nix
+++ b/pkgs/by-name/ti/tiscamera/package.nix
@@ -14,7 +14,6 @@
   libuuid,
   libzip,
   orc,
-  pcre,
   zstd,
   glib,
   gobject-introspection,
@@ -78,7 +77,6 @@ stdenv.mkDerivation (finalAttrs: {
     libuuid
     libzip
     orc
-    pcre
     zstd
     glib
     gst_all_1.gstreamer

--- a/pkgs/desktops/lxqt/obconf-qt/default.nix
+++ b/pkgs/desktops/lxqt/obconf-qt/default.nix
@@ -8,7 +8,6 @@
   libpthread-stubs,
   lxqt-build-tools,
   openbox,
-  pcre,
   pkg-config,
   qtbase,
   qttools,
@@ -41,7 +40,6 @@ stdenv.mkDerivation rec {
     libxdmcp
     libpthread-stubs
     openbox
-    pcre
     qtbase
     qtwayland
   ];


### PR DESCRIPTION
## Methodology:

Built with and without `pcre`, compared build output using `diffoscope`. Also checked upstream sources.

part of #356387
closes #533273
closes #532653
closes #532565
closes #532594

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
