### PR TITLE
noctalia: init at 5.0.0-beta.4

### DIFF
--- a/pkgs/by-name/no/noctalia/package.nix
+++ b/pkgs/by-name/no/noctalia/package.nix
@@ -1,0 +1,146 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+
+  # build
+  meson,
+  ninja,
+  pkg-config,
+  wayland-scanner,
+  makeBinaryWrapper,
+
+  # libraries
+  cairo,
+  curl,
+  fontconfig,
+  freetype,
+  glib,
+  harfbuzz,
+  jemalloc,
+  libGL,
+  libqalculate,
+  librsvg,
+  libsecret,
+  libsodium,
+  libwebp,
+  libxkbcommon,
+  libxml2,
+  md4c,
+  nlohmann_json,
+  pam,
+  pango,
+  pipewire,
+  polkit,
+  sdbus-cpp_2,
+  stb,
+  systemdLibs,
+  tomlplusplus,
+  wayland,
+  wayland-protocols,
+  wireplumber,
+
+  # runtime
+  gitMinimal,
+}:
+
+let
+  # nixpkgs stb doesn't have stb_image_resize2.h which noctalia needs
+  stb' = stb.overrideAttrs {
+    version = "0-unstable-2025-10-26";
+    src = fetchFromGitHub {
+      owner = "nothings";
+      repo = "stb";
+      rev = "f1c79c02822848a9bed4315b12c8c8f3761e1296";
+      hash = "sha256-BlyXJtAI7WqXCTT3ylww8zoG0hBxaojJnQDvdQOXJPE=";
+    };
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "noctalia";
+  version = "5.0.0-beta.4";
+
+  src = fetchFromGitHub {
+    owner = "noctalia-dev";
+    repo = "noctalia";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jXz2vFHgidbyU46ScROLSuBIhsqqtyqNu2M0tmGX/FA=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    wayland-scanner
+    makeBinaryWrapper
+  ];
+
+  buildInputs = [
+    cairo
+    curl
+    fontconfig
+    freetype
+    glib
+    harfbuzz
+    jemalloc
+    libGL
+    libqalculate
+    librsvg
+    libsecret
+    libsodium
+    libwebp
+    libxkbcommon
+    libxml2
+    md4c
+    nlohmann_json
+    pam
+    pango
+    pipewire
+    polkit
+    sdbus-cpp_2
+    stb'
+    systemdLibs
+    tomlplusplus
+    wayland
+    wayland-protocols
+    wireplumber
+  ];
+
+  mesonBuildType = "release";
+
+  # plugins are installed by cloning their repos
+  postFixup = ''
+    wrapProgram $out/bin/noctalia \
+      --prefix PATH : ${lib.makeBinPath [ gitMinimal ]}
+  '';
+
+  # remove --version=unstable once 5.0.0 stable is released
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version=unstable"
+      "--version-regex"
+      "v(5\\..*)"
+    ];
+  };
+
+  meta = {
+    description = "A sleek, customizable desktop shell crafted for Wayland.";
+    homepage = "https://github.com/noctalia-dev/noctalia";
+    changelog = "https://github.com/noctalia-dev/noctalia/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [
+      mit
+      asl20 # material_color_utilities is Apache 2.0
+    ];
+    mainProgram = "noctalia";
+    maintainers = with lib.maintainers; [
+      samiser
+      pyrox0
+    ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Adds noctalia v5, which is a rewrite of noctalia-shell. It doesn't share any code or dependencies with v4/noctalia-shell, and they have intentionally said it's separate from v4, so this is a new package rather than an update.

Some notes:
- Compared to noctalia-shell, this package doesn't have any of the same flags for optionally including dependencies that it would shell out to since pretty much all functionality has been moved into the binary itself.
- It still wraps ddcutil and wlr-randr but it handles their absence gracefully, so I decided against copying the noctalia-shell module and adding options to include them as dependencies since I think that should be handled at the nixOS module level, but if that's wrong then I can change it
- The beta releases are tagged as 5.0.0-beta.N, so the upgrade script passes the unstable flag and there's a regex for v5 so any v4 tags won't be matched (they're in the same repo).
- postPatch removes `-march=native -mtune=native` to avoid builds targeting specific CPUs and ensure reproducibility

I tested by building on x86_64-linux and running the binary in my Wayland session, and since I'm already using noctalia v5 via flake input there was already configured settings and plugins for it to interact with, which all worked fine. Also testing installing a plugin which works.

cc @spacedentist (maintainer of noctalia-shell)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
