### PR TITLE
coqPackages.mathcomp-word: 3.4 → 3.5

### DIFF
--- a/pkgs/development/coq-modules/mathcomp-word/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-word/default.nix
@@ -46,6 +46,7 @@ mkCoqDerivation {
 
   releaseRev = v: "v${v}";
 
+  release."3.5".hash = "sha256-ur6XGhTUQ1XdcyC6RERYaTwyzL58mWwdihY/yemjfQg=";
   release."3.4".hash = "sha256-AnyiM5B7JJZI5LR0vSi6baVIx9SibYRiho7UBg1uV5w=";
   release."3.3".hash = "sha256-Zn9245fr0OhgaXjWlIO1QwSxrQYetj7qPHwZAXTdqNc=";
   release."3.2".hash = "sha256-4HOFFQzKbHIq+ktjJaS5b2Qr8WL1eQ26YxF4vt1FdWM=";
@@ -72,7 +73,7 @@ mkCoqDerivation {
     lib.switch
       [ coq.coq-version mathcomp.version ]
       [
-        (case (range "8.16" "9.1") (isGe "2.0") "3.4")
+        (case (range "8.16" "9.1") (isGe "2.0") "3.5")
         (case (range "8.12" "8.20") (range "1.12" "1.19") "2.4")
       ]
       null;

--- a/pkgs/development/coq-modules/ssprove/default.nix
+++ b/pkgs/development/coq-modules/ssprove/default.nix
@@ -32,7 +32,6 @@
       [ coq.coq-version mathcomp-boot.version ]
       [
         (case (range "8.20" "9.1") (range "2.3.0" "2.5.0") "0.3.1")
-        (case (range "8.18" "9.1") (range "2.3.0" "2.4.0") "0.2.4")
         (case (range "8.18" "8.20") (range "2.3.0" "2.3.0") "0.2.3")
         (case (range "8.18" "8.20") (range "2.1.0" "2.2.0") "0.2.2")
         # This is the original dependency:


### PR DESCRIPTION
Tested: https://github.com/rocq-community/coq-nix-toolbox/pull/491

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
