### PR TITLE
python3Packages.repro-zipfile: init at 0.4.1

### DIFF
--- a/pkgs/development/python-modules/repro-zipfile/default.nix
+++ b/pkgs/development/python-modules/repro-zipfile/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  pytestCheckHook,
+  pytest-cases,
+  pytest-cov,
+  zip,
+}:
+
+buildPythonPackage rec {
+  pname = "repro-zipfile";
+  version = "0.4.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "drivendataorg";
+    repo = "repro-zipfile";
+    rev = "v${version}";
+    hash = "sha256-UpxgxD6KhtMlo7iKjcciQouiJumC4ogqUflibJFvRsQ=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  pythonImportsCheck = [
+    "repro_zipfile"
+  ];
+
+  disabledTestPaths = [
+    "tests/test_cli.py" # those tests depend on the cli "rpzip" which depends on repro-zipfile (circular dependencies)
+  ];
+
+  # without that the "test_writestr" test with python 3.14 fails
+  preCheck = ''
+    unset SOURCE_DATE_EPOCH
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cases
+    pytest-cov
+  ];
+
+  meta = {
+    description = "A tiny, zero-dependency replacement for Python's zipfile.ZipFile for creating reproducible/deterministic ZIP archives";
+    homepage = "https://github.com/drivendataorg/repro-zipfile";
+    changelog = "https://github.com/drivendataorg/repro-zipfile/blob/${src.rev}/CHANGELOG.md";
+    license = with lib.licenses; [
+      mit
+      psfl
+    ];
+    maintainers = with lib.maintainers; [ xavwe ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17589,6 +17589,8 @@ self: super: with self; {
 
   reprint = callPackage ../development/python-modules/reprint { };
 
+  repro-zipfile = callPackage ../development/python-modules/repro-zipfile { };
+
   reproject = callPackage ../development/python-modules/reproject { };
 
   reprshed = callPackage ../development/python-modules/reprshed { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
