### PR TITLE
bellepoule: gtk2 -> gtk3

### DIFF
--- a/pkgs/by-name/be/bellepoule/package.nix
+++ b/pkgs/by-name/be/bellepoule/package.nix
@@ -2,9 +2,9 @@
   lib,
   stdenv,
   fetchgit,
-  goocanvas_1,
+  goocanvas_2,
   pkg-config,
-  gtk2,
+  gtk3,
   libxml2,
   curl,
   libmicrohttpd,
@@ -39,11 +39,11 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [
-    gtk2
+    gtk3
     libxml2
     curl
     libmicrohttpd
-    goocanvas_1
+    goocanvas_2
     qrencode
     openssl
     json-glib
@@ -59,17 +59,27 @@ stdenv.mkDerivation (finalAttrs: {
     "DESTDIR=$(out)"
   ];
 
-  # Use system php
-  # Disable git soft depend
-  # Disable dch changelog generation
-  # FixUp `install` phase output
   postPatch = ''
+    # Use system php
     substituteInPlace ./sources/common/network/web_server.cpp --replace-fail "php7.4" "${php}/bin/php"
+
+    # FixUp desktop templates to point to our own output
     substituteInPlace ./build/BellePoule/debian/bellepoule.desktop.template --replace-fail "/usr" "$out"
+
+    # FixUp erroneous properties in glade files tripping-up GTK2 -> GTK3 upgrade (identation is intentional here)
+    # Such as https://git.launchpad.net/bellepoule/tree/resources/glade/contest.glade?h=5.0/master#n197
+    substituteInPlace ./resources/glade/*.glade --replace "            <property name=\"homogeneous\">True</property>" ""
+
+    # Disable git soft depend
+    # Disable dch changelog generation
+    # FixUp output path
+    # Upgrade GTK2 -> GTK3, goocanvas1 -> goocanvas2
     substituteInPlace ./build/BellePoule/Makefile \
       --replace-fail "git" "#git" \
       --replace-fail "dch" "echo Ignoring: dch" \
-      --replace-fail "/usr" ""
+      --replace-fail "/usr" "" \
+      --replace-fail "gtk+-2.0" "gtk+-3.0" \
+      --replace-fail "GOO = goocanvas" "GOO = goocanvas-2.0"
   '';
 
   # Prepare release directory for buildPhase


### PR DESCRIPTION
As per https://github.com/NixOS/nixpkgs/issues/410814

This project usually runs on GTK2, but compiling with GTK3 (along with goocanvas2) can be achieved without much effort (the MakeFile even has comments of previous GTK3 trials!).
I tested all basic functionalities without any hiccups, so I guess that's fine?

There is one new patch to make this work, fixing an upstream issue preventing the app to start with GTK3.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
