### PR TITLE
zig.fetchDeps: fix zig 0.16.0 builds

### DIFF
--- a/pkgs/development/compilers/zig/fetcher.nix
+++ b/pkgs/development/compilers/zig/fetcher.nix
@@ -21,13 +21,21 @@ runCommand "${name}-zig-deps"
     outputHashMode = "recursive";
     outputHash = hash;
   }
-  ''
-    export ZIG_GLOBAL_CACHE_DIR=$(mktemp -d)
+  (
+    ''
+      export ZIG_GLOBAL_CACHE_DIR=$(mktemp -d)
+    ''
+    # work around: https://codeberg.org/ziglang/zig/issues/31964 and https://codeberg.org/ziglang/zig/issues/35264
+    # fixes builds for zig 0.16.0
+    + lib.optionalString (
+      lib.versions.majorMinor zig.version == "0.16"
+    ) "mkdir -p $ZIG_GLOBAL_CACHE_DIR/tmp\n"
+    + ''
+      runHook unpackPhase
 
-    runHook unpackPhase
+      cd $sourceRoot
+      zig build --fetch''${fetchAll:+=all}
 
-    cd $sourceRoot
-    zig build --fetch''${fetchAll:+=all}
-
-    mv $ZIG_GLOBAL_CACHE_DIR/p $out
-  ''
+      mv $ZIG_GLOBAL_CACHE_DIR/p $out
+    ''
+  )


### PR DESCRIPTION
create some tmp dir in the zig cache to work around https://codeberg.org/ziglang/zig/issues/31964 and
https://codeberg.org/ziglang/zig/issues/35264 affecting zig 0.16.0

## Things done
- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
