### PR TITLE
[Backport 26.05] listmonk: 6.1.0 -> 6.2.0

### DIFF
--- a/pkgs/by-name/li/listmonk/email-builder.nix
+++ b/pkgs/by-name/li/listmonk/email-builder.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
 
   offlineCache = fetchYarnDeps {
     yarnLock = "${src}/frontend/email-builder/yarn.lock";
-    hash = "sha256-sFRmnMPStNp45hxcF+Iq1WhH6LtVFtgq2regq6MPzcc=";
+    hash = "sha256-ANPLOL9j0gljtNtbfb+ZifVRN9vLexPddAevpeFwX4o=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/listmonk/frontend.nix
+++ b/pkgs/by-name/li/listmonk/frontend.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   offlineCache = fetchYarnDeps {
     yarnLock = "${src}/frontend/yarn.lock";
-    hash = "sha256-VCaEMftA7AzW/6jyceVO596iby0wC3LW9YDG66kLJmw=";
+    hash = "sha256-R2xHcHksTtFfFh41FLeBhpuz84ceixGt6oz6SQWWyMQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/listmonk/package.nix
+++ b/pkgs/by-name/li/listmonk/package.nix
@@ -11,16 +11,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "listmonk";
-  version = "6.1.0";
+  version = "6.2.0";
 
   src = fetchFromGitHub {
     owner = "knadh";
     repo = "listmonk";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-SG9PhQOu3QB0LA9dNLnNzwwtfaib7MCfvOcBMkWMRPw=";
+    hash = "sha256-eora/+zJf60trmANEqAhYAQXfEMifyw5gLPKcqBW46w=";
   };
 
-  vendorHash = "sha256-0KrjaExgT9tN4M99CfyQpqpGYnXOpzsPRk/Ih4qXsuE=";
+  vendorHash = "sha256-t4l8872bniTmNIW4ias1gImURJgrR6htXkncqfrJ+AU=";
 
   nativeBuildInputs = [
     stuffbin

--- a/pkgs/by-name/li/listmonk/package.nix
+++ b/pkgs/by-name/li/listmonk/package.nix
@@ -17,7 +17,7 @@ buildGoModule (finalAttrs: {
     owner = "knadh";
     repo = "listmonk";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-eora/+zJf60trmANEqAhYAQXfEMifyw5gLPKcqBW46w=";
+    hash = "sha256-yLOs1vhTV/0zzq/2Rk5rJ3/1z+kE5xaYODM5NO06F6U=";
   };
 
   vendorHash = "sha256-t4l8872bniTmNIW4ias1gImURJgrR6htXkncqfrJ+AU=";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[CVE-2026-62361](https://nvd.nist.gov/vuln/detail/CVE-2026-62361) https://github.com/NixOS/nixpkgs/issues/544171

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
