### PR TITLE
openctm: remove the gtk2 viewer on linux

### DIFF
--- a/pkgs/by-name/op/openctm/package.nix
+++ b/pkgs/by-name/op/openctm/package.nix
@@ -4,8 +4,8 @@
   fetchurl,
   pkg-config,
   libglut,
-  gtk2,
   libGLU,
+  libx11,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -30,14 +30,18 @@ stdenv.mkDerivation (finalAttrs: {
     libglut
     libGLU
   ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [ gtk2 ];
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ libx11 ];
 
   postPatch =
     lib.optionalString stdenv.hostPlatform.isLinux ''
       substituteInPlace "tools/tinyxml/Makefile.linux" \
         --replace-warn "-Wno-format" "-Wno-format -Wno-format-security"
       substituteInPlace "tools/Makefile.linux" \
-        --replace-warn "-lglut" "-lglut -lGL -lGLU"
+        --replace-warn "-lglut" "-lglut -lGL -lGLU" \
+        --replace-fail "all: ctmconv ctmviewer ctmbench" "all: ctmconv ctmbench"
+      substituteInPlace "Makefile.linux" \
+        --replace-fail "$""(CP) tools/ctmviewer $""(BINDIR)" "" \
+        --replace-fail "$""(CP) doc/ctmviewer.1 $""(MAN1DIR)" ""
     ''
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
       substituteInPlace "lib/Makefile.macosx" \


### PR DESCRIPTION
ref. #410814

That viewer was not available on macos and this package and meshcat are fine there without it anyways


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
