### PR TITLE
heidisql: init at 12.20

### DIFF
--- a/pkgs/by-name/he/heidisql/package.nix
+++ b/pkgs/by-name/he/heidisql/package.nix
@@ -1,0 +1,157 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  fpc,
+  lazarus-qt6,
+  qt6Packages,
+  autoPatchelfHook,
+  writableTmpDirAsHomeHook,
+  mariadb-connector-c,
+  libpq,
+  sqlite,
+  freetds,
+  firebird,
+  writers,
+  copyDesktopItems,
+  makeDesktopItem,
+  gitUpdater,
+}:
+
+stdenv.mkDerivation (
+  finalAttrs:
+  let
+    makeDbConnector =
+      {
+        package,
+        library,
+        path ? "lib",
+      }:
+      {
+        inherit package library;
+        path = "${lib.getLib package}/${path}";
+      };
+
+    dbConnectors = [
+      (makeDbConnector {
+        package = mariadb-connector-c;
+        library = "libmariadb.so";
+        path = "lib/mariadb";
+      })
+      (makeDbConnector {
+        package = libpq;
+        library = "libpq.so";
+      })
+      (makeDbConnector {
+        package = sqlite;
+        library = "libsqlite3.so";
+      })
+      (makeDbConnector {
+        package = freetds;
+        library = "libsybdb.so";
+      })
+      (makeDbConnector {
+        package = firebird;
+        library = "libfbclient.so";
+      })
+    ];
+
+    customScript = writers.writeBashBin "heidisql-ldconfig" (
+      lib.concatStringsSep "\n" (
+        map (
+          x: "printf '\t%s (libc6,x86-64) => %s/%s\n' \"${x.library}\" \"${x.path}\" \"${x.library}\""
+        ) dbConnectors
+      )
+    );
+  in
+  {
+    pname = "heidisql";
+    version = "12.20";
+
+    strictDeps = true;
+    __structuredAttrs = true;
+
+    src = fetchFromGitHub {
+      owner = "HeidiSQL";
+      repo = "HeidiSQL";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-Ol5JPf1+R47+tennlFsCk/XExH3lQbtQ3dVsxaU6kpU=";
+    };
+
+    nativeBuildInputs = [
+      fpc
+      lazarus-qt6
+      qt6Packages.wrapQtAppsHook
+      autoPatchelfHook
+      writableTmpDirAsHomeHook
+      copyDesktopItems
+    ];
+
+    buildInputs = [
+      qt6Packages.qtbase
+      qt6Packages.libqtpas
+    ]
+    ++ (map (x: x.package) dbConnectors);
+
+    postPatch = ''
+      substituteInPlace source/dbconnection.pas \
+        --replace-fail "/sbin/ldconfig" "$out/bin/heidisql-ldconfig"
+    '';
+
+    buildPhase = ''
+      lazbuild \
+        --lazarusdir=${lazarus-qt6}/share/lazarus \
+        --widgetset=qt6 \
+        --build-mode=Release \
+        heidisql.lpi
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      install -D out/heidisql $out/bin/heidisql
+      install -D ${customScript}/bin/heidisql-ldconfig $out/bin/heidisql-ldconfig
+      install -D res/mainicon.png $out/share/icons/hicolor/48x48/apps/heidisql.png
+
+      install -D LICENSE $out/share/licenses/heidisql/LICENSE
+      install -D LICENSE-openssl $out/share/licenses/heidisql/LICENSE-openssl
+      install -D license.txt $out/share/licenses/heidisql/license.txt
+
+      mkdir -p $out/share/heidisql/{ini,locale}
+      install -D extra/ini/* $out/share/heidisql/ini/.
+      install -D extra/locale/* $out/share/heidisql/locale/.
+
+      runHook postInstall
+    '';
+
+    desktopItems = [
+      (makeDesktopItem {
+        name = "heidisql";
+        desktopName = "HeidiSQL";
+        comment = "A lightweight client for managing MariaDB, MySQL, SQL Server, PostgreSQL, SQLite, Interbase and Firebird, written in Delphi and Lazarus/FreePascal";
+        icon = "heidisql";
+        exec = "heidisql";
+        terminal = false;
+        categories = [
+          "Qt"
+          "Development"
+        ];
+      })
+    ];
+
+    passthru.updateScript = gitUpdater {
+      ignoredVersions = "[v0-9.]*-Windows$";
+      allowedVersions = "v[0-9]*.[0-9]*";
+      rev-prefix = "v";
+    };
+
+    meta = {
+      mainProgram = "heidisql";
+      description = "A lightweight client for managing MariaDB, MySQL, SQL Server, PostgreSQL, SQLite, Interbase and Firebird, written in Delphi and Lazarus/FreePascal";
+      homepage = "https://www.heidisql.com/";
+      platforms = [ "x86_64-linux" ];
+      license = lib.licenses.gpl2;
+      maintainers = with lib.maintainers; [ leoflo ];
+    };
+  }
+)


### PR DESCRIPTION
HeidiSQL is a client for relational databases.

- [Official website](https://www.heidisql.com/)
- [Github (FreePascal/Lazarus branch)](https://github.com/HeidiSQL/HeidiSQL/tree/lazarus)

Currently there are official Pacman, APT and RPM packages.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
