### PR TITLE
makeAutostartItem: use extendMkDerivation

### DIFF
--- a/pkgs/build-support/make-startupitem/default.nix
+++ b/pkgs/build-support/make-startupitem/default.nix
@@ -1,47 +1,65 @@
+{ stdenv, lib }:
+
 # given a package with a $name.desktop file, makes a copy
 # as autostart item.
-
-{ stdenv, lib }:
-{
-  name, # name of the desktop file (without .desktop)
-  package, # package where the desktop file resides in
-  srcPrefix ? "", # additional prefix that the desktop file may have in the 'package'
-  after ? null,
-  condition ? null,
-  phase ? "2",
-  prependExtraArgs ? [ ],
-  appendExtraArgs ? [ ],
-}:
-
+#
 # the builder requires that
 #   $package/share/applications/$name.desktop
 # exists as file.
+lib.extendMkDerivation {
+  constructDrv = stdenv.mkDerivation;
 
-stdenv.mkDerivation {
-  name = "autostart-${name}";
-  priority = 5;
+  excludeDrvArgNames = [
+    "package"
+    "srcPrefix"
+    "after"
+    "condition"
+    "phase"
+    "prependExtraArgs"
+    "appendExtraArgs"
+  ];
 
-  buildCommand =
-    let
-      escapeArgs = args: lib.escapeRegex (lib.escapeShellArgs args);
-      prependArgs = lib.optionalString (prependExtraArgs != [ ]) "${escapeArgs prependExtraArgs} ";
-      appendArgs = lib.optionalString (appendExtraArgs != [ ]) " ${escapeArgs appendExtraArgs}";
-    in
-    ''
-      mkdir -p $out/etc/xdg/autostart
-      target=${name}.desktop
-      cp ${package}/share/applications/${srcPrefix}${name}.desktop $target
-      ${lib.optionalString (prependExtraArgs != [ ] || appendExtraArgs != [ ]) ''
-        sed -i -r "s/^(Exec=)([^ \n]*) *(.*)/\1\2 ${prependArgs}\3${appendArgs}/" $target
-      ''}
-      chmod +rw $target
-      echo "X-KDE-autostart-phase=${phase}" >> $target
-      ${lib.optionalString (after != null) ''echo "${after}" >> $target''}
-      ${lib.optionalString (condition != null) ''echo "${condition}" >> $target''}
-      cp $target $out/etc/xdg/autostart
-    '';
+  inheritFunctionArgs = false;
 
-  # this will automatically put 'package' in the environment when you
-  # put its startup item in there.
-  propagatedBuildInputs = [ package ];
+  extendDrvArgs =
+    finalAttrs:
+    {
+      name, # name of the desktop file (without .desktop)
+      package, # package where the desktop file resides in
+      srcPrefix ? "", # additional prefix that the desktop file may have in the 'package'
+      after ? null,
+      condition ? null,
+      phase ? "2",
+      prependExtraArgs ? [ ],
+      appendExtraArgs ? [ ],
+      propagatedBuildInputs ? [ ],
+    }:
+    {
+      name = "autostart-${name}";
+      priority = 5;
+
+      buildCommand =
+        let
+          escapeArgs = args: lib.escapeRegex (lib.escapeShellArgs args);
+          prependArgs = lib.optionalString (prependExtraArgs != [ ]) "${escapeArgs prependExtraArgs} ";
+          appendArgs = lib.optionalString (appendExtraArgs != [ ]) " ${escapeArgs appendExtraArgs}";
+        in
+        ''
+          mkdir -p $out/etc/xdg/autostart
+          target=${name}.desktop
+          cp ${package}/share/applications/${srcPrefix}${name}.desktop $target
+          ${lib.optionalString (prependExtraArgs != [ ] || appendExtraArgs != [ ]) ''
+            sed -i -r "s/^(Exec=)([^ \n]*) *(.*)/\1\2 ${prependArgs}\3${appendArgs}/" $target
+          ''}
+          chmod +rw $target
+          echo "X-KDE-autostart-phase=${phase}" >> $target
+          ${lib.optionalString (after != null) ''echo "${after}" >> $target''}
+          ${lib.optionalString (condition != null) ''echo "${condition}" >> $target''}
+          cp $target $out/etc/xdg/autostart
+        '';
+
+      # this will automatically put 'package' in the environment when you
+      # put its startup item in there.
+      propagatedBuildInputs = [ package ] ++ propagatedBuildInputs;
+    };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/NixOS/nixpkgs/issues/489490

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] (0 rebuilds) aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] (n/a) Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
