### PR TITLE
proftpd: 1.3.9a -> 1.3.9c

### DIFF
--- a/pkgs/by-name/pr/proftpd/package.nix
+++ b/pkgs/by-name/pr/proftpd/package.nix
@@ -1,7 +1,6 @@
 {
   stdenv,
   lib,
-  fetchpatch,
   fetchFromGitHub,
   libcap,
   libsodium,
@@ -20,23 +19,16 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "proftpd";
-  version = "1.3.9a";
+  version = "1.3.9c";
 
   src = fetchFromGitHub {
     owner = "proftpd";
     repo = "proftpd";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-SNLzIwMF6XU2SAc5B9LIW2Jeh1Fa4CVumQYd2O0XxRY=";
+    hash = "sha256-3Wy5Xm9vynYWmNhoFYtYXCVfAaAMU4kB/ZaRNyRwiQQ=";
   };
 
-  patches = [
-    ./no-install-user.patch
-    (fetchpatch {
-      name = "CVE-2026-44331.patch";
-      url = "https://github.com/proftpd/proftpd/commit/5e06acc4687046c7bf794b55bd8c44a86a05ae61.patch";
-      hash = "sha256-1YM9yeiZJwU2CasPhf4g9O8Jf/B01ullFeUkERFe9WY=";
-    })
-  ];
+  patches = [ ./no-install-user.patch ];
 
   strictDeps = true;
   enableParallelBuilding = true;


### PR DESCRIPTION
Updates ProFTPD to [1.3.9c](https://github.com/proftpd/proftpd/releases/tag/v1.3.9c), fixing CVE-2026-53994, CVE-2026-63090, and CVE-2026-63091.

The existing patch for CVE-2026-44331 is included upstream in this release and is removed.

Addresses #544126. A `release-26.05` backport is still required.

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
