### PR TITLE
hyperscan: mark static build broken, replace pcre with pcre2; rspamd: pcre -> pcre2; 4.1.0 -> 4.1.2

### DIFF
--- a/nixos/modules/services/mail/rspamd.nix
+++ b/nixos/modules/services/mail/rspamd.nix
@@ -506,6 +506,7 @@ in
         CapabilityBoundingSet = "";
         DevicePolicy = "closed";
         LockPersonality = true;
+        MemoryDenyWriteExecute = false; # pcre2 jit
         NoNewPrivileges = true;
         PrivateDevices = true;
         PrivateMounts = true;

--- a/pkgs/by-name/hy/hyperscan/package.nix
+++ b/pkgs/by-name/hy/hyperscan/package.nix
@@ -8,7 +8,7 @@
   util-linux,
   pkg-config,
   boost,
-  pcre,
+  pcre2,
   withStatic ? false, # build only shared libs by default, build static+shared if true
 }:
 
@@ -78,7 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
   preConfigure = lib.optionalString withStatic (
     ''
       mkdir -p pcre
-      tar xvf ${pcre.src} --strip-components 1 -C pcre
+      tar xvf ${pcre2.src} --strip-components 1 -C pcre
     ''
     # - CMake 4 dropped support of versions lower than 3.5, versions lower than 3.10 are deprecated.
     #   https://github.com/NixOS/nixpkgs/issues/445447
@@ -111,6 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
+    broken = stdenv.hostPlatform.isStatic; # A minimum of SSSE3 compiler support is required
     description = "High-performance multiple regex matching library";
     longDescription = ''
       Hyperscan is a high-performance multiple regex matching library.

--- a/pkgs/by-name/rs/rspamd/package.nix
+++ b/pkgs/by-name/rs/rspamd/package.nix
@@ -46,13 +46,13 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rspamd";
-  version = "4.1.0";
+  version = "4.1.2";
 
   src = fetchFromGitHub {
     owner = "rspamd";
     repo = "rspamd";
     tag = finalAttrs.version;
-    hash = "sha256-QAeh8SwUwGTGmbbFlJyrprXY0quk4grP/zA/KMQQBdo=";
+    hash = "sha256-LqFLzOcLyZeDT5kRlENmyTzUhyVC0HBhoSKInMFpqZA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/rs/rspamd/package.nix
+++ b/pkgs/by-name/rs/rspamd/package.nix
@@ -21,7 +21,7 @@
   lua,
   luajit,
   openssl,
-  pcre,
+  pcre2,
   ragel,
   sqlite,
   vectorscan,
@@ -71,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
     libsodium
     (if withLuaJIT then luajit else lua)
     openssl
-    pcre
+    pcre2
     ragel
     sqlite
     vectorscan
@@ -92,8 +92,7 @@ stdenv.mkDerivation (finalAttrs: {
     (cmakeBool' "ENABLE_HYPERSCAN" true)
     (cmakeBool' "ENABLE_JEMALLOC" true)
     (cmakeBool' "ENABLE_LUAJIT" withLuaJIT)
-    # pcre2 jit seems to cause crashes: https://github.com/NixOS/nixpkgs/pull/181908
-    (cmakeBool' "ENABLE_PCRE2" false)
+    (cmakeBool' "ENABLE_PCRE2" true)
     # doctest 2.5.0 compat problems https://github.com/rspamd/rspamd/issues/5994
     (cmakeBool' "SYSTEM_DOCTEST" false)
     (cmakeBool' "SYSTEM_XXHASH" true)


### PR DESCRIPTION
Part of: #356387
Closes: #533396

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
