### PR TITLE
Bump xontribs

### DIFF
--- a/pkgs/by-name/xo/xonsh/unwrapped.nix
+++ b/pkgs/by-name/xo/xonsh/unwrapped.nix
@@ -160,6 +160,9 @@ buildPythonPackage rec {
     changelog = "https://github.com/xonsh/xonsh/blob/${version}/CHANGELOG.md";
     license = lib.licenses.bsd3;
     mainProgram = "xonsh";
-    maintainers = with lib.maintainers; [ samlukeyes123 ];
+    maintainers = with lib.maintainers; [
+      samlukeyes123
+      infinidoge
+    ];
   };
 }

--- a/pkgs/by-name/xo/xonsh/xontribs/xonsh-direnv/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xonsh-direnv/default.nix
@@ -35,6 +35,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/74th/xonsh-direnv/";
     changelog = "https://github.com/74th/xonsh-direnv/releases/tag/${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ greg ];
+    maintainers = with lib.maintainers; [
+      greg
+      infinidoge
+    ];
   };
 }

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-abbrevs/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-abbrevs/default.nix
@@ -15,20 +15,15 @@
 
 buildPythonPackage rec {
   pname = "xontrib-abbrevs";
-  version = "0.1.0";
+  version = "0.1.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "xonsh";
     repo = "xontrib-abbrevs";
     tag = "v${version}";
-    hash = "sha256-JxH5b2ey99tvHXSUreU5r6fS8nko4RrS/1c8psNbJNc=";
+    hash = "sha256-xJUSbYo/+RFFCHenDEybVNxpOrEqSkU3eAaI+TNTmQI=";
   };
-
-  prePatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail '"xonsh>=0.17", ' ""
-  '';
 
   build-system = [
     setuptools

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-abbrevs/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-abbrevs/default.nix
@@ -48,6 +48,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/xonsh/xontrib-abbrevs";
     changelog = "https://github.com/xonsh/xontrib-apprevs/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ greg ];
+    maintainers = with lib.maintainers; [
+      greg
+      infinidoge
+    ];
   };
 }

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-bashisms/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-bashisms/default.nix
@@ -43,6 +43,9 @@ buildPythonPackage rec {
     description = "Bash-like interactive mode extensions for the xonsh shell";
     homepage = "https://github.com/xonsh/xontrib-bashisms";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ greg ];
+    maintainers = with lib.maintainers; [
+      greg
+      infinidoge
+    ];
   };
 }

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-debug-tools/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-debug-tools/default.nix
@@ -43,6 +43,9 @@ buildPythonPackage rec {
     description = "Debug tools for xonsh shell";
     homepage = "https://github.com/xonsh/xontrib-debug-tools";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ greg ];
+    maintainers = with lib.maintainers; [
+      greg
+      infinidoge
+    ];
   };
 }

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-distributed/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-distributed/default.nix
@@ -51,6 +51,9 @@ buildPythonPackage rec {
     description = "Dask Distributed integration for Xonsh";
     homepage = "https://github.com/xonsh/xontrib-distributed";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ greg ];
+    maintainers = with lib.maintainers; [
+      greg
+      infinidoge
+    ];
   };
 }

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-fish-completer/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-fish-completer/default.nix
@@ -40,6 +40,9 @@ buildPythonPackage rec {
     description = "Populate rich completions using fish and remove the default bash based completer";
     homepage = "https://github.com/xonsh/xontrib-fish-completer";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ greg ];
+    maintainers = with lib.maintainers; [
+      greg
+      infinidoge
+    ];
   };
 }

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-fish-completer/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-fish-completer/default.nix
@@ -13,20 +13,15 @@
 
 buildPythonPackage rec {
   pname = "xontrib-fish-completer";
-  version = "0.0.1";
+  version = "0.0.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "xonsh";
     repo = "xontrib-fish-completer";
     tag = version;
-    hash = "sha256-PhhdZ3iLPDEIG9uDeR5ctJ9zz2+YORHBhbsiLrJckyA=";
+    hash = "sha256-9S0Gj1CQxuX1mGL1+4Xyyld/NHUYUi7DJ424lUlExVc=";
   };
-
-  prePatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail '"xonsh>=0.12.5"' ""
-  '';
 
   build-system = [
     setuptools

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-jedi/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-jedi/default.nix
@@ -54,6 +54,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/xonsh/xontrib-jedi";
     changelog = "https://github.com/xonsh/xontrib-jedi/releases/tag/${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ greg ];
+    maintainers = with lib.maintainers; [
+      greg
+      infinidoge
+    ];
   };
 }

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-jedi/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-jedi/default.nix
@@ -13,20 +13,15 @@
 
 buildPythonPackage rec {
   pname = "xontrib-jedi";
-  version = "0.1.1";
+  version = "0.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "xonsh";
     repo = "xontrib-jedi";
     tag = "v${version}";
-    hash = "sha256-T4Yxr91emM2mjclQOjQsnnPO/JijAGNcqmZjxrz72Bs=";
+    hash = "sha256-n2zJKlI52TMuYA6q822ZIHgxT6sGW+GE8paI5WB7Cyg=";
   };
-
-  prePatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail 'xonsh = ">=0.17"' ""
-  '';
 
   build-system = [
     poetry-core
@@ -45,6 +40,11 @@ buildPythonPackage rec {
     writableTmpDirAsHomeHook
     pytestCheckHook
     xonsh
+  ];
+
+  disabledTests = [
+    # stdout not properly captured?
+    "test_jedi_error_logged_when_debug_set"
   ];
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-jupyter/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-jupyter/default.nix
@@ -48,6 +48,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/xonsh/xontrib-jupyter";
     changelog = "https://github.com/xonsh/xontrib-jupyter/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ greg ];
+    maintainers = with lib.maintainers; [
+      greg
+      infinidoge
+    ];
   };
 }

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-jupyter/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-jupyter/default.nix
@@ -3,7 +3,9 @@
   buildPythonPackage,
   fetchFromGitHub,
 
-  poetry-core,
+  hatchling,
+  hatch-vcs,
+  ipykernel,
   jupyter-client,
   writableTmpDirAsHomeHook,
   pytestCheckHook,
@@ -13,29 +15,23 @@
 
 buildPythonPackage rec {
   pname = "xontrib-jupyter";
-  version = "0.3.2";
+  version = "0.4.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "xonsh";
     repo = "xontrib-jupyter";
     tag = "v${version}";
-    hash = "sha256-gf+jyA2il7MD+Moez/zBYpf4EaPiNcgr5ZrJFK4uD2k=";
+    hash = "sha256-3Nmp7fmIgRvSpxog3Hu9jyqYzC/m/jnmEgmvPZvFCT8=";
   };
 
-  prePatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail 'xonsh = ">=0.12"' ""
-
-    substituteInPlace xonsh_jupyter/shell.py \
-      --replace-fail 'xonsh.base_shell' 'xonsh.shells.base_shell'
-  '';
-
   build-system = [
-    poetry-core
+    hatchling
+    hatch-vcs
   ];
 
   dependencies = [
+    ipykernel
     jupyter-client
   ];
 

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-vox/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-vox/default.nix
@@ -55,6 +55,9 @@ buildPythonPackage rec {
     description = "Python virtual environment manager for the xonsh shell";
     homepage = "https://github.com/xonsh/xontrib-vox";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ greg ];
+    maintainers = with lib.maintainers; [
+      greg
+      infinidoge
+    ];
   };
 }

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-whole-word-jumping/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-whole-word-jumping/default.nix
@@ -38,6 +38,9 @@ buildPythonPackage rec {
     description = "Additional keyboard navigation for interactive xonsh shells";
     homepage = "https://github.com/xonsh/xontrib-whole-word-jumping";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ greg ];
+    maintainers = with lib.maintainers; [
+      greg
+      infinidoge
+    ];
   };
 }

--- a/pkgs/by-name/xo/xonsh/xontribs/xontrib-whole-word-jumping/default.nix
+++ b/pkgs/by-name/xo/xonsh/xontribs/xontrib-whole-word-jumping/default.nix
@@ -12,20 +12,15 @@
 
 buildPythonPackage rec {
   pname = "xontrib-whole-word-jumping";
-  version = "0.0.1";
+  version = "0.0.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "xonsh";
     repo = "xontrib-whole-word-jumping";
     tag = version;
-    hash = "sha256-zLAOGW9prjYDQBDITFNMggn4X1JTyAnVdjkBOH9gXPs=";
+    hash = "sha256-quwtTIPEVcVAyVIE//nNkW0O8gwUT2Adaxr3esoTjh8=";
   };
-
-  prePatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail '"xonsh>=0.12.5", ' ""
-  '';
 
   build-system = [
     setuptools


### PR DESCRIPTION
Several of the Xontribs in nixpkgs have been updated for recent Xonsh versions. This bumps the ones with updates.

Also removed unnecessary and out-of-date replacements.
All of these build with the proper version of Xonsh, so removing the dependency in the pyproject.toml isn't needed anymore.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
