### PR TITLE
rocqide & rocqide-server packages

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11729,6 +11729,13 @@
     githubId = 15371828;
     name = "Hugo Lageneste";
   };
+  hugomartel = {
+    email = "hugo.martel@ik.me";
+    github = "HugoMartel";
+    githubId = 56939649;
+    name = "Hugo Martel";
+    keys = [ { fingerprint = "460D E18E 12B5 5B5F 49AC  213A 12CB 9757 F51C 86A5"; } ];
+  };
   hugoreeves = {
     email = "hugo@hugoreeves.com";
     github = "HugoReeves";

--- a/pkgs/development/rocq-modules/rocqide-server/default.nix
+++ b/pkgs/development/rocq-modules/rocqide-server/default.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  mkRocqDerivation,
+  rocq-core,
+  version ? null,
+}:
+
+let
+  # If the version is not set, use the rocq-core version
+  version' = if isNull version then rocq-core.version else version;
+  rocq-core' = rocq-core.override { version = version'; };
+
+  versionAtLeast' = v: vmin: v == "master" || lib.versionAtLeast v vmin;
+in
+mkRocqDerivation rec {
+  pname = "rocqide-server";
+  owner = "rocq-prover";
+  repo = "rocq";
+
+  # rocq-core version is used as a default version
+  version = version';
+  inherit (rocq-core) rocq-version;
+
+  # Same repository (and release hashes) as rocq-core
+  # release = { version = "rocq-core src hash for that version"; };
+  release = {
+    "${version'}".sha256 = rocq-core'.src.hash;
+  };
+  releaseRev = v: "V${v}";
+  # NOTE: directly reusing `rocq-core.src` falls into the `case = isString` of
+  # the mkRocqDerivation fetcher, causing to set the package version as "dev"
+
+  postPatch = ''
+    patchShebangs dev/tools/
+  '';
+
+  prefixKey = "-prefix ";
+
+  useDune = true;
+
+  # NOTE: the server opam package name still uses coq for Rocq < 9.4
+  opam-name = if versionAtLeast' version' "9.4" then "rocqide-server" else "coqide-server";
+
+  buildInputs = [
+    rocq-core
+  ];
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+    dune runtest -p ${opam-name} -j $NIX_BUILD_CORES
+    runHook postCheck
+  '';
+
+  createFindlibDestdir = true;
+  # Override the whole installPhase since useDune=true still uses broken `coq`
+  # related commands that fail currently
+  # https://github.com/NixOS/nixpkgs/blob/69cfa0e28f8d311dfe4e543e6b43eda2af9c374f/pkgs/build-support/rocq/default.nix#L256
+  installPhase = ''
+    runHook preInstall
+    dune install --prefix $out ${opam-name}
+    ln -s $out/lib/${opam-name} $OCAMLFIND_DESTDIR/${opam-name}
+    runHook postInstall
+  '';
+  postInstall = ''
+    # Provide Rocq friendly names for future updates
+    ln -s $out/bin/coqidetop $out/bin/rocqidetop
+    ln -s $out/lib/${opam-name} $out/lib/${pname}
+    # Don't forget the OCaml findlib link
+    ln -s $out/lib/${pname} $OCAMLFIND_DESTDIR/${pname}
+  '';
+
+  meta = {
+    homepage = "https://rocq-prover.org";
+    description = "The Rocq Prover, XML protocol server";
+    mainProgram = "coqidetop"; # Kept with `coq` for compatibility reasons
+    license = lib.licenses.lgpl21Plus;
+    maintainers = with lib.maintainers; [ hugomartel ];
+  };
+}

--- a/pkgs/development/rocq-modules/rocqide/default.nix
+++ b/pkgs/development/rocq-modules/rocqide/default.nix
@@ -1,0 +1,100 @@
+{
+  lib,
+  makeDesktopItem,
+  copyDesktopItems,
+  wrapGAppsHook3,
+  glib,
+  adwaita-icon-theme,
+  mkRocqDerivation,
+  rocq-core,
+  rocqide-server,
+  version ? null,
+}:
+
+let
+  pname = "rocqide";
+  # If the version is not set, use the rocq-core version as a default
+  version' = if isNull version then rocq-core.version else version;
+  rocq-core' = rocq-core.override { version = version'; };
+in
+mkRocqDerivation {
+  inherit pname;
+  owner = "rocq-prover";
+  repo = "rocq";
+
+  version = version';
+  inherit (rocq-core) rocq-version;
+
+  # Same repository (and release hashes) as rocq-core
+  # release = { version = "rocq-core src hash for that version"; };
+  release = {
+    "${version'}".sha256 = (rocq-core'.src.hash);
+  };
+  releaseRev = v: "V${v}";
+  # NOTE: directly reusing `rocq-core.src` falls into the `case = isString` of
+  # the mkRocqDerivation fetcher, causing to set the package version as "dev"
+
+  postPatch = ''
+    patchShebangs dev/tools/
+    # RocqIDE relies on the `coqidetop` binary being available at runtime
+    # Patch RocqIDE looking for coqidetop in its install directory
+    # <https://github.com/rocq-prover/rocq/blob/6df5ae331262750d9fc2d115dd2198a6373e4dd0/ide/rocqide/ideutils.ml#L409>
+    substituteInPlace ide/rocqide/ideutils.ml \
+      --replace-fail 'System.get_toplevel_path "coqidetop"' '"${lib.getExe rocqide-server}"'
+  '';
+
+  prefixKey = "-prefix ";
+
+  useDune = true;
+  opam-name = pname;
+
+  buildInputs = [
+    copyDesktopItems
+    wrapGAppsHook3
+    rocq-core.ocamlPackages.lablgtk3-sourceview3
+    glib
+    adwaita-icon-theme
+    rocqide-server
+  ];
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+    dune runtest -p ${pname} -j $NIX_BUILD_CORES
+    runHook postCheck
+  '';
+
+  # Override the whole installPhase since useDune=true still uses broken `coq`
+  # related commands that fail currently
+  # https://github.com/NixOS/nixpkgs/blob/69cfa0e28f8d311dfe4e543e6b43eda2af9c374f/pkgs/build-support/rocq/default.nix#L256
+  installPhase = ''
+    runHook preInstall
+    dune install --prefix $out ${pname}
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = "rocqide";
+      icon = "coq";
+      desktopName = "RocqIDE";
+      comment = "Graphical interface for the Rocq Prover";
+      categories = [
+        "Development"
+        "Science"
+        "Math"
+        "IDE"
+        "GTK"
+      ];
+    })
+  ];
+
+  meta = {
+    homepage = "https://rocq-prover.org";
+    description = "RocqIDE user interface for the Rocq Prover";
+    mainProgram = "rocqide";
+    license = lib.licenses.lgpl21Plus;
+    maintainers = with lib.maintainers; [ hugomartel ];
+  };
+}

--- a/pkgs/top-level/rocq-packages.nix
+++ b/pkgs/top-level/rocq-packages.nix
@@ -219,6 +219,7 @@ let
       rewriter = callPackage ../development/rocq-modules/rewriter { };
       rocq-elpi = callPackage ../development/rocq-modules/rocq-elpi { };
       coq-elpi = self.rocq-elpi;
+      rocqide-server = callPackage ../development/rocq-modules/rocqide-server { };
       rocqnavi = callPackage ../development/rocq-modules/rocqnavi { };
       RustExtraction = callPackage ../development/rocq-modules/RustExtraction { };
       semantics = callPackage ../development/rocq-modules/semantics { };

--- a/pkgs/top-level/rocq-packages.nix
+++ b/pkgs/top-level/rocq-packages.nix
@@ -220,6 +220,7 @@ let
       rocq-elpi = callPackage ../development/rocq-modules/rocq-elpi { };
       coq-elpi = self.rocq-elpi;
       rocqide-server = callPackage ../development/rocq-modules/rocqide-server { };
+      rocqide = callPackage ../development/rocq-modules/rocqide { };
       rocqnavi = callPackage ../development/rocq-modules/rocqnavi { };
       RustExtraction = callPackage ../development/rocq-modules/RustExtraction { };
       semantics = callPackage ../development/rocq-modules/semantics { };


### PR DESCRIPTION
RocqIDE and RocqIDE-Server are both built from the Rocq repository. These packages are added to the rocqPackages package set.

The derivations are inspired by the opam scripts from the [Rocq repo](https://github.com/rocq-prover/rocq/blob/master/coqide-server.opam) and the `rocq-core` derivation.

I started working on the `rocqide` derivation before seeing #537939, feel free to discard my attempt if @Skyb0rg007 already has something better or already done.

For `rocqide-server` everything is still written using `coq`, so the "rocq" is simply a symbolic link, and RocqIDE still uses `coqide-server` by default. I am unsure if this is the best way to achieve what I wanted.

*I didn't add maintainers because I didn't know if people already wanted or were maintaining it previously through the `coq` compat derivation with the `buildIde` flag*

I didn't add the `release` attribute set in each rocqDerivation since I didn't really get how it worked, and built with fakeHashes without any trouble.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
