### PR TITLE
zsign: 1.0.8 -> 1.1.1

### DIFF
--- a/pkgs/by-name/zs/zsign/package.nix
+++ b/pkgs/by-name/zs/zsign/package.nix
@@ -1,33 +1,42 @@
 {
-  lib,
   fetchFromGitHub,
-  stdenv,
+  lib,
+  minizip,
+  nix-update-script,
   openssl,
   pkg-config,
-  nix-update-script,
+  stdenv,
   versionCheckHook,
+  zlib,
 }:
 let
   platformName = if stdenv.hostPlatform.isLinux then "linux" else "macos";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "zsign";
-  version = "1.0.8";
+  version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "zhlynn";
     repo = "zsign";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-zyywaE87HcGZ5QV6tFsCn9j+mAD1/ENVxZ22E/ItlSA=";
+    hash = "sha256-PU/LhtTkRZobb4Chdms8/FBjPyHve4EZ7W5iHaWKwm8=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/build/${platformName}";
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ openssl ];
+  nativeBuildInputs = [
+    pkg-config
+  ];
+  buildInputs = [
+    minizip
+    openssl
+    zlib
+  ];
 
   makeFlags = [
     "BINDIR=bin/"
+    "SYSTEM_MINIZIP=1"
     "CXX=${stdenv.cc.targetPrefix}c++"
     "VERSION=${finalAttrs.version}"
   ];


### PR DESCRIPTION
This supersedes #544451 to use the system minizip/zlib. Everything else is the same (modulo argument sorting).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
