### PR TITLE
maintainers: add ooonea

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21296,6 +21296,11 @@
     githubId = 34910574;
     keys = [ { fingerprint = "D055 8A23 3947 B7A0 F966  B07F 0B41 0348 9833 7273"; } ];
   };
+  ooonea = {
+    name = "ooonea";
+    github = "ooonea";
+    githubId = 35407790;
+  };
   Oops418 = {
     email = "oooopsxxx@gmail.com";
     github = "Oops418";


### PR DESCRIPTION
Adding myself to the maintainer list, as agreed in #537215: @minegameYTB added me to `meta.maintainers` of the incoming `claude-desktop` package, and that reference needs this entry to evaluate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)