### PR TITLE
linux_lqx: reintroduce at 7.1.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4940,6 +4940,11 @@
     matrix = "@chayleaf:matrix.pavluk.org";
     name = "Anna Pavlyuk";
   };
+  cheerfulScumbag = {
+    github = "cheerfulScumbag";
+    githubId = 164391367;
+    name = "kenn";
+  };
   cheeseecake = {
     email = "chanelnjw@gmail.com";
     github = "cheeseecake";

--- a/pkgs/os-specific/linux/kernel/liquorix-kernel.nix
+++ b/pkgs/os-specific/linux/kernel/liquorix-kernel.nix
@@ -1,0 +1,114 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildLinux,
+  ...
+}@args:
+
+let
+  # Common kernel options use priority 100. Liquorix policy must win over those
+  # defaults while still allowing users to override it with lib.mkForce.
+  mkKernelOverride = lib.mkOverride 90;
+  suffix = "lqx1";
+in
+
+buildLinux (
+  args
+  // rec {
+    pname = "linux-lqx";
+    version = "7.1.4";
+    modDirVersion = lib.versions.pad 3 "${version}-${suffix}";
+    isZen = true;
+
+    src = fetchFromGitHub {
+      owner = "zen-kernel";
+      repo = "zen-kernel";
+      rev = "v${version}-${suffix}";
+      sha256 = "1g14af9957vynr66cd3cgvi2b0i7gakdvy6nn5rw6q0gc0b5xhps";
+    };
+
+    # Keep this to Liquorix-specific policy. Hardware enablement continues to
+    # come from the Nixpkgs kernel configuration.
+    structuredExtraConfig = with lib.kernel; {
+      ZEN_INTERACTIVE = yes;
+
+      # Low-latency scheduling and timer policy.
+      PREEMPT = mkKernelOverride yes;
+      PREEMPT_LAZY = mkKernelOverride no;
+      PREEMPT_DYNAMIC = mkKernelOverride no;
+      NO_HZ_FULL = mkKernelOverride yes;
+      NO_HZ_IDLE = mkKernelOverride no;
+      HZ = freeform "1000";
+      HZ_1000 = yes;
+
+      # Project C scheduler used by Liquorix.
+      SCHED_ALT = yes;
+      SCHED_PDS = yes;
+      CFS_BANDWIDTH = yes;
+      PSI = yes;
+      RT_GROUP_SCHED = mkKernelOverride yes;
+
+      # These Nixpkgs defaults are unavailable with the alternative scheduler.
+      SCHED_AUTOGROUP = mkKernelOverride (option no);
+      SCHED_CLASS_EXT = mkKernelOverride (option no);
+      SCHED_CORE = mkKernelOverride (option no);
+      THERMAL_GOV_POWER_ALLOCATOR = mkKernelOverride (option no);
+
+      # Preemptible tree-based hierarchical RCU.
+      TREE_RCU = yes;
+      PREEMPT_RCU = yes;
+      RCU_EXPERT = yes;
+      TREE_SRCU = yes;
+      TASKS_RCU_GENERIC = yes;
+      TASKS_RCU = yes;
+      TASKS_RUDE_RCU = yes;
+      TASKS_TRACE_RCU = yes;
+      RCU_STALL_COMMON = yes;
+      RCU_NEED_SEGCBLIST = yes;
+      RCU_FANOUT = freeform "64";
+      RCU_FANOUT_LEAF = freeform "16";
+      RCU_BOOST = mkKernelOverride no;
+      RCU_NOCB_CPU = yes;
+      RCU_NOCB_CPU_DEFAULT_ALL = yes;
+      RCU_LAZY = mkKernelOverride no;
+      RCU_DOUBLE_CHECK_CB_TIME = yes;
+
+      # Desktop, gaming, storage, and network latency policy.
+      IOSCHED_BFQ = mkKernelOverride yes;
+      FUTEX = yes;
+      FUTEX_PI = yes;
+      NTSYNC = yes;
+      NET_SCH_DEFAULT = yes;
+      DEFAULT_FQ_CODEL = yes;
+      TCP_CONG_BBR3 = yes;
+      DEFAULT_BBR3 = yes;
+      ZSWAP_COMPRESSOR_DEFAULT_LZ4 = yes;
+      ZSWAP_COMPRESSOR_DEFAULT_ZSTD = mkKernelOverride no;
+      SLAB_BUCKETS = yes;
+      WQ_POWER_EFFICIENT_DEFAULT = yes;
+      ENERGY_MODEL = mkKernelOverride (option no);
+
+      # This is a fallback command line. CMDLINE_OVERRIDE remains disabled, so
+      # the command line supplied by the NixOS boot loader takes precedence.
+      CMDLINE_BOOL = yes;
+      CMDLINE = freeform "audit=0 intel_pstate=disable amd_pstate=disable split_lock_detect=off ";
+      CMDLINE_OVERRIDE = mkKernelOverride no;
+    };
+
+    extraPassthru.updateScript = {
+      command = [ ./update-liquorix.py ];
+      attrPath = "linux_lqx";
+      supportedFeatures = [ "commit" ];
+    };
+
+    extraMeta = {
+      branch = lib.versions.majorMinor version + "/master";
+      description = "Liquorix kernel for desktop, multimedia, and gaming workloads";
+      homepage = "https://liquorix.net/";
+      maintainers = with lib.maintainers; [ cheerfulScumbag ];
+      platforms = [ "x86_64-linux" ];
+      teams = [ ];
+    };
+  }
+  // (args.argsOverride or { })
+)

--- a/pkgs/os-specific/linux/kernel/update-liquorix.py
+++ b/pkgs/os-specific/linux/kernel/update-liquorix.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i python3 -p python3 nix
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from urllib.request import Request, urlopen
+
+
+GITHUB_RELEASES = (
+    "https://api.github.com/repos/zen-kernel/zen-kernel/releases?per_page=100"
+)
+SOURCE_URL = "https://github.com/zen-kernel/zen-kernel/archive/refs/tags/{tag}.tar.gz"
+PACKAGE_FILE = Path(__file__).with_name("liquorix-kernel.nix")
+REPO_PACKAGE_FILE = "pkgs/os-specific/linux/kernel/liquorix-kernel.nix"
+TAG_PATTERN = re.compile(
+    r"^v(?P<version>[0-9]+\.[0-9]+(?:\.[0-9]+)?)-(?P<suffix>lqx(?P<revision>[0-9]+))$"
+)
+
+# This is deliberately an allowlist of Liquorix policy, not its full Debian
+# hardware configuration. A changed value is a human-review event.
+CONFIG_POLICY = {
+    "CONFIG_CFS_BANDWIDTH": "y",
+    "CONFIG_CMDLINE": '"audit=0 intel_pstate=disable amd_pstate=disable split_lock_detect=off "',
+    "CONFIG_CMDLINE_BOOL": "y",
+    "CONFIG_DEFAULT_BBR3": "y",
+    "CONFIG_DEFAULT_FQ_CODEL": "y",
+    "CONFIG_ENERGY_MODEL": "n",
+    "CONFIG_FUTEX": "y",
+    "CONFIG_FUTEX_PI": "y",
+    "CONFIG_HZ": "1000",
+    "CONFIG_HZ_1000": "y",
+    "CONFIG_IOSCHED_BFQ": "y",
+    "CONFIG_NET_SCH_DEFAULT": "y",
+    "CONFIG_NO_HZ_FULL": "y",
+    "CONFIG_NO_HZ_IDLE": "n",
+    "CONFIG_NTSYNC": "y",
+    "CONFIG_PREEMPT": "y",
+    "CONFIG_PREEMPT_DYNAMIC": "n",
+    "CONFIG_PREEMPT_LAZY": "n",
+    "CONFIG_PSI": "y",
+    "CONFIG_RCU_BOOST": "n",
+    "CONFIG_RCU_LAZY": "n",
+    "CONFIG_RCU_NOCB_CPU": "y",
+    "CONFIG_RCU_NOCB_CPU_DEFAULT_ALL": "y",
+    "CONFIG_RT_GROUP_SCHED": "y",
+    "CONFIG_SCHED_ALT": "y",
+    "CONFIG_SCHED_PDS": "y",
+    "CONFIG_SLAB_BUCKETS": "y",
+    "CONFIG_TCP_CONG_BBR3": "y",
+    "CONFIG_WQ_POWER_EFFICIENT_DEFAULT": "y",
+    "CONFIG_ZSWAP_COMPRESSOR_DEFAULT_LZ4": "y",
+    "CONFIG_ZSWAP_COMPRESSOR_DEFAULT_ZSTD": "n",
+    "CONFIG_ZEN_INTERACTIVE": "y",
+}
+
+
+def fetch_json(url):
+    request = Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "nixpkgs-liquorix-updater",
+        },
+    )
+    with urlopen(request) as response:
+        return json.load(response)
+
+
+def parse_tag(tag):
+    match = TAG_PATTERN.fullmatch(tag)
+    if match is None:
+        return None
+    version = match.group("version")
+    suffix = match.group("suffix")
+    version_key = tuple(int(component) for component in version.split("."))
+    return {
+        "tag": tag,
+        "version": version,
+        "suffix": suffix,
+        "key": (version_key, int(match.group("revision"))),
+    }
+
+
+def select_latest_release(releases):
+    candidates = []
+    for release in releases:
+        if release.get("draft") or release.get("prerelease"):
+            continue
+        parsed = parse_tag(release.get("tag_name", ""))
+        if parsed is not None:
+            candidates.append(parsed)
+    if not candidates:
+        raise RuntimeError("GitHub returned no stable Liquorix releases")
+    return max(candidates, key=lambda release: release["key"])
+
+
+def read_package(path=PACKAGE_FILE):
+    contents = path.read_text()
+    version_match = re.search(r'^\s+version = "([^"]+)";$', contents, re.MULTILINE)
+    suffix_match = re.search(r'^\s+suffix = "([^"]+)";$', contents, re.MULTILINE)
+    if version_match is None or suffix_match is None:
+        raise RuntimeError(f"could not read version and suffix from {path}")
+    return contents, version_match.group(1), suffix_match.group(1)
+
+
+def render_package(contents, version, suffix, sha256):
+    replacements = (
+        (r'^(\s+version = )"[^"]+";$', rf'\1"{version}";'),
+        (r'^(\s+suffix = )"[^"]+";$', rf'\1"{suffix}";'),
+        (r'^(\s+sha256 = )"[^"]+";$', rf'\1"{sha256}";'),
+    )
+    result = contents
+    for pattern, replacement in replacements:
+        result, count = re.subn(
+            pattern, replacement, result, count=1, flags=re.MULTILINE
+        )
+        if count != 1:
+            raise RuntimeError(f"expected one match for {pattern}, found {count}")
+    return result
+
+
+def prefetch(tag):
+    print(f"prefetching {tag}", file=sys.stderr)
+    return subprocess.check_output(
+        ["nix-prefetch-url", "--unpack", SOURCE_URL.format(tag=tag)],
+        text=True,
+    ).strip()
+
+
+def fetch_text(url):
+    request = Request(url, headers={"User-Agent": "nixpkgs-liquorix-updater"})
+    with urlopen(request) as response:
+        return response.read().decode()
+
+
+def parse_kernel_config(contents):
+    result = {}
+    for line in contents.splitlines():
+        enabled = re.fullmatch(r"(CONFIG_[A-Z0-9_]+)=(.*)", line)
+        disabled = re.fullmatch(r"# (CONFIG_[A-Z0-9_]+) is not set", line)
+        if enabled:
+            result[enabled.group(1)] = enabled.group(2)
+        elif disabled:
+            result[disabled.group(1)] = "n"
+    return result
+
+
+def config_report(version, config_text=None):
+    branch = ".".join(version.split(".")[:2]) + "/master"
+    url = (
+        "https://raw.githubusercontent.com/damentz/liquorix-package/"
+        f"{branch}/linux-liquorix/debian/config/kernelarch-x86/config-arch-64"
+    )
+    upstream = parse_kernel_config(
+        config_text if config_text is not None else fetch_text(url)
+    )
+    actual = {key: upstream.get(key, "missing") for key in CONFIG_POLICY}
+    drift = {
+        key: {"expected": expected, "actual": actual[key]}
+        for key, expected in CONFIG_POLICY.items()
+        if actual[key] != expected
+    }
+    return {"branch": branch, "url": url, "values": actual, "drift": drift}
+
+
+def load_releases(path):
+    if path is not None:
+        return json.loads(path.read_text())
+    return fetch_json(GITHUB_RELEASES)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Update the Nixpkgs Liquorix kernel")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--check", action="store_true", help="report without changing files"
+    )
+    mode.add_argument(
+        "--config-report",
+        action="store_true",
+        help="compare the tracked Liquorix policy with its upstream configuration",
+    )
+    parser.add_argument(
+        "--release-json",
+        type=Path,
+        help="read GitHub release data from a fixture instead of the network",
+    )
+    args = parser.parse_args()
+
+    release = select_latest_release(load_releases(args.release_json))
+    contents, old_version, old_suffix = read_package()
+    current = old_version == release["version"] and old_suffix == release["suffix"]
+
+    if args.config_report:
+        report = config_report(release["version"])
+        json.dump(report, sys.stdout, indent=2, sort_keys=True)
+        print()
+        return 1 if report["drift"] else 0
+
+    if args.check:
+        json.dump(
+            {
+                "current": current,
+                "oldVersion": old_version,
+                "oldSuffix": old_suffix,
+                "newVersion": release["version"],
+                "newSuffix": release["suffix"],
+                "tag": release["tag"],
+            },
+            sys.stdout,
+            sort_keys=True,
+        )
+        print()
+        return 0
+
+    if current:
+        print("[]")
+        return 0
+
+    sha256 = prefetch(release["tag"])
+    PACKAGE_FILE.write_text(
+        render_package(contents, release["version"], release["suffix"], sha256)
+    )
+    change = {
+        "attrPath": os.environ.get("UPDATE_NIX_ATTR_PATH", "linux_lqx"),
+        "oldVersion": old_version,
+        "newVersion": release["version"],
+        "files": [REPO_PACKAGE_FILE],
+        "commitBody": (
+            f"- Release: https://github.com/zen-kernel/zen-kernel/releases/tag/{release['tag']}\n"
+            f"- Compare: https://github.com/zen-kernel/zen-kernel/compare/"
+            f"v{old_version}-{old_suffix}...{release['tag']}"
+        ),
+    }
+    print(json.dumps([change]))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pkgs/os-specific/linux/kernel/update-liquorix_test.py
+++ b/pkgs/os-specific/linux/kernel/update-liquorix_test.py
@@ -1,0 +1,61 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("update-liquorix.py")
+SPEC = importlib.util.spec_from_file_location("update_liquorix", SCRIPT)
+UPDATE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(UPDATE)
+
+
+class LiquorixUpdaterTests(unittest.TestCase):
+    def test_selects_latest_stable_liquorix_release(self):
+        releases = [
+            {"tag_name": "v7.1.4-zen1"},
+            {"tag_name": "v7.1.3-lqx3", "draft": False, "prerelease": False},
+            {"tag_name": "v7.1.4-lqx1", "draft": False, "prerelease": False},
+            {"tag_name": "v7.2-lqx1", "draft": False, "prerelease": True},
+        ]
+        release = UPDATE.select_latest_release(releases)
+        self.assertEqual(release["version"], "7.1.4")
+        self.assertEqual(release["suffix"], "lqx1")
+
+    def test_revision_orders_numerically(self):
+        releases = [
+            {"tag_name": "v7.1.4-lqx2"},
+            {"tag_name": "v7.1.4-lqx10"},
+        ]
+        self.assertEqual(
+            UPDATE.select_latest_release(releases)["suffix"],
+            "lqx10",
+        )
+
+    def test_render_updates_only_source_fields(self):
+        original = """
+  suffix = "lqx1";
+    version = "7.1.3";
+      sha256 = "old";
+"""
+        rendered = UPDATE.render_package(original, "7.1.4", "lqx2", "new")
+        self.assertIn('suffix = "lqx2";', rendered)
+        self.assertIn('version = "7.1.4";', rendered)
+        self.assertIn('sha256 = "new";', rendered)
+
+    def test_config_report_detects_policy_drift(self):
+        config = "\n".join(
+            f"{key}={value}" if value != "n" else f"# {key} is not set"
+            for key, value in UPDATE.CONFIG_POLICY.items()
+        )
+        report = UPDATE.config_report("7.1.4", config)
+        self.assertEqual(report["drift"], {})
+
+        report = UPDATE.config_report(
+            "7.1.4",
+            config.replace("CONFIG_HZ=1000", "CONFIG_HZ=250"),
+        )
+        self.assertEqual(report["drift"]["CONFIG_HZ"]["actual"], "250")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1356,7 +1356,6 @@ mapAliases {
   linux_ham = throw "linux_ham has been removed in favour of the standard kernel packages"; # Added 2025-06-24
   linux_hardened = throw "linux_hardened has been removed due to lack of maintenance"; # Added 2026-03-18
   linux_latest-libre = throw "linux_latest_libre has been removed due to lack of maintenance"; # Added 2025-10-01
-  linux_lqx = throw "linux_lqx has been removed due to lack of maintenance"; # Added 2026-03-13
   linux_rpi0 = linuxKernel.kernels.linux_rpi1;
   linux_rpi1 = linuxKernel.kernels.linux_rpi1;
   linux_rpi2 = linuxKernel.kernels.linux_rpi2;
@@ -1393,7 +1392,6 @@ mapAliases {
   linuxPackages_hardened = throw "linuxPackages_hardened has been removed due to lack of maintenance"; # Added 2026-03-18
   linuxPackages_latest-libre = throw "linux_latest_libre has been removed due to lack of maintenance"; # Added 2025-10-01
   linuxPackages_latest_xen_dom0 = throw "'linuxPackages_latest_xen_dom0' has been renamed to/replaced by 'linuxPackages_latest'"; # Converted to throw 2025-10-27
-  linuxPackages_lqx = throw "linuxPackages_lqx has been removed due to lack of maintenance"; # Added 2026-03-13
   linuxPackages_rpi0 = linuxKernel.packages.linux_rpi1;
   linuxPackages_rpi1 = linuxKernel.packages.linux_rpi1;
   linuxPackages_rpi2 = linuxKernel.packages.linux_rpi2;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7842,6 +7842,10 @@ with pkgs;
   linuxPackages_zen = linuxKernel.packages.linux_zen;
   linux_zen = linuxPackages_zen.kernel;
 
+  # Liquorix kernel
+  linuxPackages_lqx = linuxKernel.packages.linux_lqx;
+  linux_lqx = linuxPackages_lqx.kernel;
+
   # XanMod kernel
   linuxPackages_xanmod = linuxKernel.packages.linux_xanmod;
   linux_xanmod = linuxKernel.kernels.linux_xanmod;

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -126,6 +126,13 @@ in
           ];
         };
 
+        linux_lqx = callPackage ../os-specific/linux/kernel/liquorix-kernel.nix {
+          kernelPatches = [
+            kernelPatches.bridge_stp_helper
+            kernelPatches.request_key_helper
+          ];
+        };
+
         # This contains the variants of the XanMod kernel
         xanmodKernels = callPackage ../os-specific/linux/kernel/xanmod-kernels.nix;
 
@@ -152,7 +159,6 @@ in
         };
       }
       // lib.optionalAttrs config.allowAliases {
-        linux_lqx = throw "linux_lqx has been removed due to lack of maintenance";
         linux_libre = throw "linux_libre has been removed due to lack of maintenance";
         linux_latest_libre = throw "linux_latest_libre has been removed due to lack of maintenance";
 
@@ -699,12 +705,12 @@ in
       linux_testing = packagesFor kernels.linux_testing;
 
       linux_zen = recurseIntoAttrs (packagesFor kernels.linux_zen);
+      linux_lqx = recurseIntoAttrs (packagesFor kernels.linux_lqx);
       linux_xanmod = recurseIntoAttrs (packagesFor kernels.linux_xanmod);
       linux_xanmod_stable = recurseIntoAttrs (packagesFor kernels.linux_xanmod_stable);
       linux_xanmod_latest = recurseIntoAttrs (packagesFor kernels.linux_xanmod_latest);
     }
     // lib.optionalAttrs config.allowAliases {
-      linux_lqx = throw "linux_lqx has been removed due to lack of maintenance";
       linux_libre = throw "linux_libre has been removed due to lack of maintenance";
       linux_latest_libre = throw "linux_latest_libre has been removed due to lack of maintenance";
 


### PR DESCRIPTION
## Motivation

`linux_lqx` was removed because it did not have an active maintainer. This
reintroduces it with me (`@cheerfulScumbag`) as the maintainer and limits the
supported platform to `x86_64-linux`.

Liquorix remains useful for desktop, multimedia, audio, and gaming workloads
that benefit from its low-latency policy and Project C/PDS scheduler.

## What this adds

- `linux_lqx` and `linuxPackages_lqx`, currently at `7.1.4-lqx1`
- a focused structured configuration based on Liquorix policy rather than a
  copied hardware configuration
- a Nixpkgs update script that selects stable `vX.Y.Z-lqxN` releases and
  refreshes the unpacked source hash
- a configuration-drift report for the Liquorix policy options that require
  human review
- maintainer metadata for `@cheerfulScumbag`

## Ongoing maintenance

I will maintain this package and respond to release updates, hash changes,
kernel configuration drift, point-release build failures, and Nixpkgs review
feedback.

The companion automation is public at
https://github.com/cheerfulScumbag/liquorix-nixpkgs-maintainer. It checks for
releases daily, batches routine updates weekly, runs tiered validation, and
only opens draft PRs after successful checks. Optional AI triage is advisory:
logs are sanitized, suggested patches are not applied automatically, and all
changes still require human review and approval.

## Validation

- full `linux_lqx` build
- generated kernel configuration
- Nixpkgs maintainer-list test
- built-in NixOS kernel VM boot and external-module smoke test
- `versionDoesNotDependOnPatchesEtc`
- live release check and Liquorix configuration-drift check
- external modules:
  - `v4l2loopback`
  - VirtualBox host modules
  - `acpi_call`
  - `evdi`
  - `r8125`
  - `xpadneo`
- updater unit tests, Ruff, nixfmt, and strict evaluation

An unbounded `nixpkgs-review` exposes every external module as a newly added
attribute. Several already lag the Linux 7.1 API; those failures are not
specific to the Liquorix kernel. The automated new-line gate therefore uses a
documented, bounded compatibility matrix. ZFS is also not claimed as supported
while its current Nixpkgs module is marked broken for this kernel line.
