### PR TITLE
liteparse: 1.5.3 -> 2.8.0

### DIFF
--- a/pkgs/by-name/li/liteparse/package.nix
+++ b/pkgs/by-name/li/liteparse/package.nix
@@ -1,39 +1,144 @@
 {
   lib,
+  stdenv,
+  rustPlatform,
   fetchFromGitHub,
-  buildNpmPackage,
-  makeBinaryWrapper,
+  fetchurl,
+  cmake,
+  makeWrapper,
   nix-update-script,
+  openssl,
+  pkg-config,
   versionCheckHook,
+  writableTmpDirAsHomeHook,
+  leptonica,
   tesseract,
 }:
 
-buildNpmPackage (finalAttrs: {
+let
+  # Keep in sync with PDFIUM_RELEASE_TAG in upstream:
+  # https://github.com/run-llama/liteparse/blob/main/crates/pdfium-sys/build.rs#L6
+  pdfium =
+    let
+      asset =
+        {
+          "x86_64-linux" = "pdfium-linux-x64";
+          "aarch64-linux" = "pdfium-linux-arm64";
+        }
+        .${stdenv.hostPlatform.system};
+
+      hash =
+        {
+          "pdfium-linux-x64" = "sha256-r5byH9jp1TlVAT2tHRewA9ASACXnh7fOYRpoXVcodZQ=";
+          "pdfium-linux-arm64" = "sha256-6B7ER90ACX6y/CbP+IvlPqMhSVcRpDr56ntQvr3qkiY=";
+        }
+        .${asset};
+    in
+    stdenv.mkDerivation {
+      pname = "pdfium";
+      version = "chromium-7897";
+
+      __structuredAttrs = true;
+      strictDeps = true;
+
+      src = fetchurl {
+        url = "https://github.com/run-llama/pdfium-binaries/releases/download/chromium%2F7897/${asset}.tgz";
+        inherit hash;
+      };
+
+      unpackPhase = ''
+        mkdir source
+        tar -xzf $src -C source
+      '';
+      sourceRoot = "source";
+
+      installPhase = ''
+        cp -r . $out
+      '';
+    };
+
+  # Reuse the same upstream sources as the nixpkgs leptonica/tesseract packages
+  # so versions stay in sync without separate pins in this expression.
+  leptonicaSrc = leptonica.src;
+  tesseractSrc = tesseract.tesseractBase.src;
+in
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "liteparse";
-  version = "1.5.3";
+  version = "2.8.0";
 
   src = fetchFromGitHub {
     owner = "run-llama";
     repo = "liteparse";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-hbCD9kXuI3Zh4S69FCXtNQxVFWpP172YwJ95BY/INBw=";
+    tag = "crates-v${finalAttrs.version}";
+    hash = "sha256-s6NWlr1zHfnZer31fxUZcitHpjZeQpWmQMgB1Myq+qs=";
   };
 
-  npmDepsHash = "sha256-KhtwPl1J9ZZMT9xT5bQJjPa3fYTvi9oRnxijCm0o+2c=";
-  npmBuildScript = "build";
+  postPatch = ''
+    mkdir -p .tesseract-rs/third_party
+    ln -s ${leptonicaSrc} .tesseract-rs/third_party/leptonica
+    ln -s ${tesseractSrc} .tesseract-rs/third_party/tesseract
 
-  nativeBuildInputs = [ makeBinaryWrapper ];
+    # tesseract-rs builds leptonica/tesseract via cmake and expects libraries under
+    # lib/, while newer upstream sources may install to lib64 on some platforms.
+    tesseractRsBuildRs=$(echo "$cargoDepsCopy"/source-registry-*/tesseract-rs-*/build.rs)
+    substituteInPlace "$tesseractRsBuildRs" \
+      --replace-fail \
+        '.define("CMAKE_INSTALL_PREFIX", &leptonica_install_dir)' \
+        '.define("CMAKE_INSTALL_PREFIX", &leptonica_install_dir)
+                    .define("CMAKE_INSTALL_LIBDIR", "lib")' \
+      --replace-fail \
+        '.define("CMAKE_INSTALL_PREFIX", &tesseract_install_dir)' \
+        '.define("CMAKE_INSTALL_PREFIX", &tesseract_install_dir)
+                    .define("CMAKE_INSTALL_LIBDIR", "lib")'
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+    pkg-config
+    writableTmpDirAsHomeHook
+  ];
+
+  buildInputs = [
+    openssl
+    tesseract
+  ];
+
+  cargoHash = "sha256-0rqhhTsL0Jft13KxhFUzCPIHV5qVt3FKZxne8/Ek3Zk=";
+  cargoBuildFlags = [
+    "--package"
+    "liteparse"
+  ];
+  cargoInstallFlags = [
+    "--path"
+    "crates/liteparse"
+  ];
+  doCheck = false;
+
+  preBuild = ''
+    mkdir -p "$HOME/.tesseract-rs"
+    cp -rL .tesseract-rs/third_party "$HOME/.tesseract-rs/"
+    chmod -R u+w "$HOME/.tesseract-rs"
+    mkdir -p "$HOME/.tesseract-rs/tessdata"
+    cp ${tesseract.languages.eng} "$HOME/.tesseract-rs/tessdata/eng.traineddata"
+    cp ${tesseract.languages.tur} "$HOME/.tesseract-rs/tessdata/tur.traineddata"
+  '';
+
+  env = {
+    OPENSSL_NO_VENDOR = true;
+    PDFIUM_INCLUDE_PATH = "${pdfium}/include";
+    PDFIUM_LIB_PATH = "${pdfium}/lib";
+  };
 
   postInstall = ''
     wrapProgram $out/bin/lit \
+      --set PDFIUM_LIB_PATH "${pdfium}/lib" \
       --set TESSDATA_PREFIX "${tesseract}/share/tessdata"
   '';
 
-  # https://github.com/run-llama/liteparse/blob/270d558441fefdc4a53da258c5ee0cf9d5881286/package-lock.json#L3
-  # lock file needs to be updated
-  #  nativeInstallCheckInputs = [
-  #    versionCheckHook
-  #  ];
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
   doInstallCheck = true;
 
   passthru.updateScript = nix-update-script { };
@@ -41,10 +146,13 @@ buildNpmPackage (finalAttrs: {
   meta = {
     description = "Fast and lightweight document parser by LlamaIndex";
     homepage = "https://github.com/run-llama/liteparse";
-    changelog = "https://github.com/run-llama/liteparse/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/run-llama/liteparse/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ daspk04 ];
-    platforms = lib.platforms.all;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
     mainProgram = "lit";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Update the version to latest, 
- Updated the build for rust packaging as from v2.x.x the it package has moved to a rust package rather than a node package.    

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
