### PR TITLE
c2ffi: llvmPackages_18 -> llvmPackages_21

### DIFF
--- a/pkgs/by-name/c2/c2ffi/package.nix
+++ b/pkgs/by-name/c2/c2ffi/package.nix
@@ -2,13 +2,13 @@
   lib,
   fetchFromGitHub,
   cmake,
-  llvmPackages_18,
+  llvmPackages_21,
   unstableGitUpdater,
 }:
 
 let
-  c2ffiBranch = "llvm-18.1.0";
-  llvmPackages = llvmPackages_18;
+  c2ffiBranch = "llvm-21.1.0";
+  llvmPackages = llvmPackages_21;
 in
 
 llvmPackages.stdenv.mkDerivation {
@@ -18,8 +18,8 @@ llvmPackages.stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "rpav";
     repo = "c2ffi";
-    rev = "d6eba0d91dfd58831e5c3133e868c62892595680";
-    hash = "sha256-9bRHsVdj0VOeJyEE9sdN4xKIRSrB05viAOoxjeqWW2Q=";
+    rev = "f52a6c90651cd5f2f5239b67b41fb9a7e4de1f2e";
+    hash = "sha256-9PUTuRmTuycHN1L4p9jiJnrymnD1EBctzHXeAJwzulY=";
   };
 
   passthru.updateScript = unstableGitUpdater {


### PR DESCRIPTION
switch to the upstream llvm 21 branch. tested with the example code in the README, which produces the correct output.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
