### PR TITLE
crossover: init at 26.3.0

### DIFF
--- a/pkgs/by-name/cr/crossover/package.nix
+++ b/pkgs/by-name/cr/crossover/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  unzip,
+  writeShellScript,
+  curl,
+  gnugrep,
+  gnused,
+  coreutils,
+  common-updater-scripts,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "crossover";
+  version = "26.3.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchurl {
+    url = "https://media.codeweavers.com/pub/crossover/cxmac/demo/crossover-${finalAttrs.version}.zip";
+    hash = "sha256-hojghIxOX3nxzDUctS0yRH2gDGwAz9O0uy0WTURYmiY=";
+  };
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [ unzip ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    cp -R CrossOver.app $out/Applications/
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = writeShellScript "crossover-update-script" ''
+    set -euo pipefail
+    export PATH="${
+      lib.makeBinPath [
+        curl
+        gnugrep
+        gnused
+        coreutils
+        common-updater-scripts
+      ]
+    }"
+
+    new_version=$(curl -s "https://www.codeweavers.com/xml/versions/cxmac.xml" \
+      | grep -oE 'crossover-[0-9]+\.[0-9]+\.[0-9]+\.zip' \
+      | sed -E 's/crossover-(.*)\.zip/\1/' \
+      | sort -V \
+      | tail -n1)
+
+    if [[ "${finalAttrs.version}" = "$new_version" ]]; then
+      echo "crossover is already at the latest version $new_version."
+      exit 0
+    fi
+
+    update-source-version "crossover" "$new_version" \
+      --ignore-same-version
+  '';
+
+  meta = {
+    description = "Run Windows applications on macOS without a Windows license";
+    homepage = "https://www.codeweavers.com/crossover";
+    license = lib.licenses.unfree;
+    maintainers = [ lib.maintainers.delafthi ];
+    platforms = lib.platforms.darwin;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
