### PR TITLE
kicad-bin: init at 10.0.6

### DIFF
--- a/pkgs/by-name/ki/kicad-bin/package.nix
+++ b/pkgs/by-name/ki/kicad-bin/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  _7zz,
+  makeBinaryWrapper,
+  writeShellScript,
+  curl,
+  gnugrep,
+  gnused,
+  coreutils,
+  common-updater-scripts,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "kicad-bin";
+  version = "10.0.6";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchurl {
+    url = "https://s3.cern.ch/kicad-downloads/osx/stable/kicad-unified-universal-${finalAttrs.version}.dmg";
+    hash = "sha256-703NQnjEbT780oyNsnPVlX1o79oCj2v3m0gR/FMC3Gg=";
+  };
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [
+    _7zz
+    makeBinaryWrapper
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    7zz -snld x $src
+
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    mv KiCad/KiCad/KiCad.app $out/Applications/
+    makeBinaryWrapper "$out/Applications/KiCad.app/Contents/MacOS/kicad" "$out/bin/kicad"
+    makeBinaryWrapper "$out/Applications/KiCad.app/Contents/MacOS/kicad-cli" "$out/bin/kicad-cli"
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    updateScript = writeShellScript "kicad-bin-update-script" ''
+      set -euo pipefail
+      export PATH="${
+        lib.makeBinPath [
+          curl
+          gnugrep
+          gnused
+          coreutils
+          common-updater-scripts
+        ]
+      }"
+
+      new_version=$(curl -s "https://s3.cern.ch/kicad-downloads/?list-type=2&prefix=osx/stable/kicad-unified-universal-" \
+        | grep -oE 'kicad-unified-universal-[0-9]+\.[0-9]+\.[0-9]+\.dmg' \
+        | sed -E 's/kicad-unified-universal-(.*)\.dmg/\1/' \
+        | sort -V \
+        | tail -n1)
+
+      if [[ "${finalAttrs.version}" = "$new_version" ]]; then
+        echo "kicad-bin is already at the latest version $new_version."
+        exit 0
+      fi
+
+      update-source-version "kicad-bin" "$new_version" \
+        --ignore-same-version
+    '';
+  };
+
+  meta = {
+    description = "EDA suite for schematic and PCB design";
+    homepage = "https://www.kicad.org/";
+    changelog = "https://www.kicad.org/blog/categories/Release-Notes/";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.delafthi ];
+    platforms = lib.platforms.darwin;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    mainProgram = "kicad";
+  };
+})


### PR DESCRIPTION
Analogous to `ghostty` and `ghostty-bin`, provide a packaged binary alternative for darwin users.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
