### PR TITLE
Add python3Packages.spacetrack

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7979,6 +7979,13 @@
     githubId = 25820532;
     name = "Luca Schwan";
   };
+  eidoom = {
+    email = "ryanmoodie@gmail.com";
+    github = "eidoom";
+    githubId = 10097705;
+    matrix = "@eidoom:matrix.org";
+    name = "Ryan Moodie";
+  };
   eikek = {
     email = "eike.kettner@posteo.de";
     github = "eikek";

--- a/pkgs/development/python-modules/represent/default.nix
+++ b/pkgs/development/python-modules/represent/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  setuptools,
+  wheel,
+}:
+
+buildPythonPackage (finalAttrs: {
+
+  pname = "Represent";
+
+  version = "2.1";
+
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-Cy0BXBTnums7Xmp7oTGpUgE/6UQzmsU4dkznKKddvKw=";
+  };
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  meta = {
+    changelog = "https://github.com/RazerM/represent/blob/master/CHANGELOG.md";
+    description = "Python libary to generate __repr__";
+    homepage = "https://represent.readthedocs.io/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ eidoom ];
+  };
+
+})

--- a/pkgs/development/python-modules/rush/default.nix
+++ b/pkgs/development/python-modules/rush/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  setuptools,
+  wheel,
+
+  # dependencies
+  attrs,
+}:
+
+buildPythonPackage (finalAttrs: {
+
+  pname = "rush";
+
+  version = "2021.4.0";
+
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-gYYkB18DE/ZKTDi6YrxKZSbuMbRjmQyK6/A6mPWq8mQ=";
+  };
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  dependencies = [
+    attrs
+  ];
+
+  meta = {
+    changelog = "https://rush.readthedocs.io/en/latest/releases/${finalAttrs.version}.html";
+    description = "Python libary for rate limiting";
+    homepage = "https://rush.readthedocs.io/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ eidoom ];
+  };
+
+})

--- a/pkgs/development/python-modules/spacetrack/default.nix
+++ b/pkgs/development/python-modules/spacetrack/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  setuptools,
+  wheel,
+
+  # dependencies
+  filelock,
+  httpx,
+  logbook,
+  outcome,
+  platformdirs,
+  represent,
+  rush,
+  sniffio,
+}:
+
+buildPythonPackage (finalAttrs: {
+
+  pname = "spacetrack";
+
+  version = "1.4.0";
+
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-/ktUw97eBJag7MQDkhFIGiWuT70O/15UGQRB8NRDTHQ=";
+  };
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  dependencies = [
+    filelock
+    httpx
+    logbook
+    outcome
+    platformdirs
+    represent
+    rush
+    sniffio
+  ];
+
+  meta = {
+    changelog = "https://spacetrack.readthedocs.io/en/stable/changelog.html";
+    description = "Python libary for querying the space-track.org API";
+    homepage = "https://spacetrack.readthedocs.io/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ eidoom ];
+  };
+
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17597,6 +17597,8 @@ self: super: with self; {
 
   repoze-who = callPackage ../development/python-modules/repoze-who { };
 
+  represent = callPackage ../development/python-modules/represent { };
+
   reprint = callPackage ../development/python-modules/reprint { };
 
   reproject = callPackage ../development/python-modules/reproject { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19011,6 +19011,8 @@ self: super: with self; {
 
   soxr = callPackage ../development/python-modules/soxr { libsoxr = pkgs.soxr; };
 
+  spacetrack = callPackage ../development/python-modules/spacetrack { };
+
   spacy = callPackage ../development/python-modules/spacy { };
 
   spacy-alignments = callPackage ../development/python-modules/spacy-alignments { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18030,6 +18030,8 @@ self: super: with self; {
 
   runtype = callPackage ../development/python-modules/runtype { };
 
+  rush = callPackage ../development/python-modules/rush { };
+
   russound = callPackage ../development/python-modules/russound { };
 
   rustworkx = callPackage ../development/python-modules/rustworkx { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added [`spacetrack`](https://spacetrack.readthedocs.io/), a Python client for [Space-Track](https://www.space-track.org/), which provides space situational awareness data such as satellite TLEs. 

Also includes a couple of Python library dependencies, [`rush`](https://rush.readthedocs.io/) and [`represent`](https://represent.readthedocs.io/). Note PR #541884 fixes a bug in the dependency `logbook`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
