### PR TITLE
invidious: apply hotfix for Innertube 400 errors

### DIFF
--- a/pkgs/by-name/in/invidious/package.nix
+++ b/pkgs/by-name/in/invidious/package.nix
@@ -49,6 +49,19 @@ crystal.buildCrystalPackage rec {
       url = "https://github.com/iv-org/invidious/commit/77ad41678b45c4f6815940123f1796fc51259f45.patch?full_index=1";
       hash = "sha256-0pf6eu0ckQ2gYHLr2tEDy+1dvAhVjepG26kuxuHbZl8=";
     })
+    # fix Innertube 400 errors (block by YouTube) by changing the reported client version
+    # https://github.com/iv-org/invidious/issues/5817
+    # remove with the first release containing these two commits
+    (fetchpatch2 {
+      name = "innertube-400-hotfix-1.patch";
+      url = "https://github.com/iv-org/invidious/commit/30c0656a93ff196aa50a7f820afaf68f9994c809.patch?full_index=1";
+      hash = "sha256-7tbGlv3UzqqHrpmieV8t+RDQ2ItMqr3NBRo4hmkiuTg=";
+    })
+    (fetchpatch2 {
+      name = "innertube-400-hotfix-2.patch";
+      url = "https://github.com/iv-org/invidious/commit/adfec7646b80ab3e68d7e854730986b46726bff9.patch?full_index=1";
+      hash = "sha256-hLKBgXhFUnizEt7nucgVP8bSlSa/e6+Ehql84S/VtIY=";
+    })
   ];
 
   postPatch =


### PR DESCRIPTION
Requests done by Invidious have started failing with a status of 400. According to an upstream discussion, this was probably caused by YouTube blocking requests with an old client version.

This PR adds two commits from upstream that change the hard-coded client strings to a combination that currently doesn't get blocked.

Fixes #544966
Upstream issue: https://github.com/iv-org/invidious/issues/5817

Commits included as patches:
https://github.com/iv-org/invidious/commit/30c0656a93ff196aa50a7f820afaf68f9994c809
https://github.com/iv-org/invidious/commit/adfec7646b80ab3e68d7e854730986b46726bff9

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
