### PR TITLE
purefetch: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21707,6 +21707,12 @@
     githubId = 34910574;
     keys = [ { fingerprint = "D055 8A23 3947 B7A0 F966  B07F 0B41 0348 9833 7273"; } ];
   };
+  ooonea = {
+    name = "ooonea";
+    email = "ooonea@gmail.com";
+    github = "ooonea";
+    githubId = 35407790;
+  };
   Oops418 = {
     email = "oooopsxxx@gmail.com";
     github = "Oops418";

--- a/pkgs/by-name/pu/purefetch/package.nix
+++ b/pkgs/by-name/pu/purefetch/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "purefetch";
+  version = "0.2.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "ooonea";
+    repo = "purefetch";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Pp3WfRb9Nt95pbZfU5enqlERRafHOtk9fpvZwt77TYs=";
+  };
+
+  cargoHash = "sha256-kvXQzP9JD6hkcTjrMJnM8v+MzLEzJD47kDrJkYKlsYU=";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Fast, fastfetch-style system information tool written entirely in Rust with zero dependencies";
+    homepage = "https://github.com/ooonea/purefetch";
+    changelog = "https://github.com/ooonea/purefetch/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license =
+      with lib.licenses;
+      OR [
+        mit
+        asl20
+      ];
+    mainProgram = "purefetch";
+    maintainers = with lib.maintainers; [ ooonea ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
## Description

purefetch is a fast, fastfetch-style system information tool written entirely in Rust with **zero dependencies** — no crates.io crates at all: raw syscalls + /proc + /sys on Linux, direct libSystem FFI on macOS. Supports x86_64/aarch64/riscv64/loongarch64 Linux and aarch64/x86_64 darwin (real-hardware CI runs on both macOS architectures upstream).

Upstream: https://github.com/ooonea/purefetch — MIT OR Apache-2.0, on crates.io as `purefetch`.

First commit adds me to the maintainer list (I'm the upstream author).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files: `./result/bin/purefetch` (banner correct), `--version` verified in-build by `versionCheckHook`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md)
- [x] Follows the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy) (`Assisted-by:` trailers on both commits)
- [x] `nixfmt`-clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)