### PR TITLE
bitwarden-desktop: 2026.6.1 -> 2026.7.0

### DIFF
--- a/pkgs/by-name/bi/bitwarden-desktop/dont-auto-setup-biometrics.patch
+++ b/pkgs/by-name/bi/bitwarden-desktop/dont-auto-setup-biometrics.patch
@@ -1,8 +1,8 @@
-diff --git a/apps/desktop/src/key-management/biometrics/os-biometrics-linux.service.ts b/apps/desktop/src/key-management/biometrics/os-biometrics-linux.service.ts
-index 791b4d6f88..dfee0bbf8d 100644
---- a/apps/desktop/src/key-management/biometrics/os-biometrics-linux.service.ts
-+++ b/apps/desktop/src/key-management/biometrics/os-biometrics-linux.service.ts
-@@ -115,7 +115,7 @@ export default class OsBiometricsServiceLinux implements OsBiometricService {
+diff --git a/apps/desktop/src/key-management/biometrics/native-v2/os-biometrics-linux.service.ts b/apps/desktop/src/key-management/biometrics/native-v2/os-biometrics-linux.service.ts
+index 110db23ec79..dfaf600bcdf 100644
+--- a/apps/desktop/src/key-management/biometrics/native-v2/os-biometrics-linux.service.ts
++++ b/apps/desktop/src/key-management/biometrics/native-v2/os-biometrics-linux.service.ts
+@@ -83,7 +83,7 @@ export default class OsBiometricsServiceLinux implements OsBiometricService {
      // The user needs to manually set up the polkit policy outside of the sandbox
      // since we allow access to polkit via dbus for the sandboxed clients, the authentication works from
      // the sandbox, once the policy is set up outside of the sandbox.
@@ -10,4 +10,4 @@ index 791b4d6f88..dfee0bbf8d 100644
 +    return false;
    }
  
-   async osBiometricsSetup(): Promise<void> {
+   async runSetup(): Promise<void> {

--- a/pkgs/by-name/bi/bitwarden-desktop/package.nix
+++ b/pkgs/by-name/bi/bitwarden-desktop/package.nix
@@ -5,14 +5,14 @@
   copyDesktopItems,
   dart-sass,
   darwin,
-  electron_39,
+  electron_41,
   fetchFromGitHub,
   gnome-keyring,
   jq,
   makeDesktopItem,
   makeWrapper,
   nix-update-script,
-  nodejs_22,
+  nodejs_24,
   pkg-config,
   rustc,
   rustPlatform,
@@ -22,17 +22,17 @@
 
 let
   icon = "bitwarden";
-  electron = electron_39;
+  electron = electron_41;
 in
 buildNpmPackage (finalAttrs: {
   pname = "bitwarden-desktop";
-  version = "2026.6.1";
+  version = "2026.7.0";
 
   src = fetchFromGitHub {
     owner = "bitwarden";
     repo = "clients";
     tag = "desktop-v${finalAttrs.version}";
-    hash = "sha256-ee+C58Y5pZWEmqbRO/w7rdY+e6gy4EL7Sn0S1AxGMXI=";
+    hash = "sha256-E4glf4G70BuT0GYu1kEb5Z9B76ElIlDPe1rdGSdmCzo=";
   };
 
   patches = [
@@ -64,7 +64,7 @@ buildNpmPackage (finalAttrs: {
     rm -r apps/cli
   '';
 
-  nodejs = nodejs_22;
+  nodejs = nodejs_24;
 
   makeCacheWritable = true;
   npmFlags = [
@@ -74,7 +74,7 @@ buildNpmPackage (finalAttrs: {
 
   npmWorkspace = "apps/desktop";
   npmDepsFetcherVersion = 3;
-  npmDepsHash = "sha256-C5GLei/WWetd4qLv7obBJWbQR9LBy+Sqdbjko3/W7VY=";
+  npmDepsHash = "sha256-8wjt5wnJG4S4EeGWGxbo6Bwt76GIqrSiwqwwwQ17Y5Y=";
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs)
@@ -84,7 +84,7 @@ buildNpmPackage (finalAttrs: {
       cargoRoot
       patches
       ;
-    hash = "sha256-xyK3+z2yfCG9K5XAB6LNEeyqMRknONi6ZfY/3oko7Z8=";
+    hash = "sha256-PLfR+yS+MtscRRuyLaK/qIWJVDoefhOobev1fpNeHNo=";
   };
   cargoRoot = "apps/desktop/desktop_native";
 
@@ -197,7 +197,7 @@ buildNpmPackage (finalAttrs: {
     # Extract the polkit policy file from the multiline string in the source code.
     # This may break in the future but its better than copy-pasting it manually.
     mkdir -p $out/share/polkit-1/actions/
-    pushd apps/desktop/src/key-management/biometrics
+    pushd apps/desktop/src/key-management/biometrics/native-v2
     awk '/const polkitPolicy = `/{gsub(/^.*`/, ""); print; str=1; next} str{if (/`;/) str=0; gsub(/`;/, ""); print}' os-biometrics-linux.service.ts > $out/share/polkit-1/actions/com.bitwarden.Bitwarden.policy
     popd
 


### PR DESCRIPTION
Diff: https://github.com/bitwarden/clients/compare/desktop-v2026.6.1...desktop-v2026.7.0

Changelog: https://github.com/bitwarden/clients/releases/tag/desktop-v2026.7.0

Fixes https://github.com/NixOS/nixpkgs/issues/526914


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
