### PR TITLE
quickjs: 2025-09-13-2 -> 2026-06-04, unmark as insecure

### DIFF
--- a/pkgs/by-name/qu/quickjs/package.nix
+++ b/pkgs/by-name/qu/quickjs/package.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "quickjs";
-  version = "2025-09-13-2";
+  version = "2026-06-04";
 
   src = fetchurl {
     url = "https://bellard.org/quickjs/quickjs-${finalAttrs.version}.tar.xz";
-    hash = "sha256-mWxrUBj8lVrU0GQm0OnLcTaFoAyCWqXAQYvVP334sLQ=";
+    hash = "sha256-s3boObMil4MT2Sn9IGY7EbpYt131pGwSbdGeovpwrSo=";
   };
 
   outputs = [
@@ -121,11 +121,5 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = [ ];
     mainProgram = "qjs";
     platforms = lib.platforms.all;
-    # Pending upstream fix: https://github.com/bellard/quickjs/pull/483
-    knownVulnerabilities = [
-      "CVE-2026-1144"
-      "CVE-2026-1145"
-      "CVE-2026-3979"
-    ];
   };
 })

--- a/pkgs/development/python-modules/quickjs/0002-Update-for-QuickJS-2026-06-04-release.patch
+++ b/pkgs/development/python-modules/quickjs/0002-Update-for-QuickJS-2026-06-04-release.patch
@@ -1,0 +1,20 @@
+--- a/test_quickjs.py
++++ b/test_quickjs.py
+@@ -119,7 +119,7 @@
+         """
+         self.context.eval(code)
+         self.context.set_memory_limit(1000)
+-        with self.assertRaisesRegex(quickjs.JSException, "null"):
++        with self.assertRaisesRegex(quickjs.JSException, "out of memory"):
+             self.context.eval(code)
+         self.context.set_memory_limit(1000000)
+         self.context.eval(code)
+@@ -508,7 +508,7 @@
+         """)
+
+         self.assertEqual(f(100), 100)
+-        limit = 1500
++        limit = 3000
+         with self.assertRaises(quickjs.StackOverflow):
+             f(limit)
+         f.set_max_stack_size(2000 * limit)

--- a/pkgs/development/python-modules/quickjs/default.nix
+++ b/pkgs/development/python-modules/quickjs/default.nix
@@ -24,7 +24,11 @@ buildPythonPackage rec {
     hash = "sha256-nLloXJWOuaK/enZfwXJI94IcsAMYrkBtG4i3gmxuhfw=";
   };
 
-  patches = [ ./0001-Update-for-QuickJS-2025-04-26-release.patch ];
+  patches = [
+    ./0001-Update-for-QuickJS-2025-04-26-release.patch
+    # Refreshes two stale resource-limit test expectations for the newer quickjs nixpkgs de-vendors
+    ./0002-Update-for-QuickJS-2026-06-04-release.patch
+  ];
 
   # Upstream uses Git submodules; let's de-vendor and use Nix, so that we gain security fixes like
   # https://github.com/NixOS/nixpkgs/pull/407469


### PR DESCRIPTION
## Things done

See commits messages.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
