### PR TITLE
plume: init at 0-unstable-2026-07-23

### DIFF
--- a/pkgs/by-name/pl/plume/package.nix
+++ b/pkgs/by-name/pl/plume/package.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  pkg-config,
+  scdoc,
+  ftxui,
+  curl,
+  sqlite,
+  nlohmann_json,
+  tomlplusplus,
+  luajit,
+  sol2,
+  tree-sitter,
+  chafa,
+  spdlog,
+  doctest,
+  stb,
+  libsecret,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "plume";
+  version = "0-unstable-2026-07-23";
+
+  src = fetchFromGitHub {
+    owner = "vmfunc";
+    repo = "plume";
+    rev = "bdf4c095fab7aa7c8972ebe5f6f8248e9e5e5f61";
+    hash = "sha256-gRDxeZMS8uam7D3RPt/CagStZ4E93JYCSTd5bLpgBjg=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    scdoc
+  ];
+
+  buildInputs = [
+    ftxui
+    curl
+    sqlite
+    nlohmann_json
+    tomlplusplus
+    luajit
+    sol2
+    tree-sitter
+    chafa
+    spdlog
+    doctest
+    stb
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ libsecret ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "PLUME_VERSION" finalAttrs.version)
+    # -Werror is fragile across compiler versions; upstream keeps it on for dev.
+    (lib.cmakeBool "PLUME_WERROR" false)
+  ];
+
+  doCheck = true;
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version=branch"
+      "--version-regex=(0-unstable-.*)"
+    ];
+  };
+
+  meta = {
+    description = "Terminal client for language models with a weaveable conversation tree";
+    homepage = "https://github.com/vmfunc/plume";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ vmfunc ];
+    mainProgram = "plume";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
add [plume](https://github.com/vmfunc/plume), a terminal client for language models: streaming chat where every conversation is a weaveable tree (branch a reply, walk the siblings, graft, prune), inline images, one sqlite file for history, lua plugins, and mcp. no electron, no telemetry.

keeping it on unstable releases for now until it settles into a proper release cadence; ci builds and runs the test suite on every push. builds against the default gcc stdenv (needs a c++23 compiler for `std::expected`).

built and ran it locally with `nix-build -A plume`: the binary, `--version`, and the doctest suite (via `doCheck`) all pass. nixpkgs-review's git-merge step errored in my checkout, but the package builds cleanly in the sandbox.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
