### PR TITLE
ci: label pull requests by size

### DIFF
--- a/ci/github-script/bot.js
+++ b/ci/github-script/bot.js
@@ -6,6 +6,7 @@ module.exports = async ({ github, context, core, dry }) => {
   const { classify } = require('../supportedBranches.js')
   const { handleMerge } = require('./merge.js')
   const { handleReviewers } = require('./reviewers.js')
+  const { PR_SIZE_LABELS, classifyPullRequestSize } = require('./pr-size.js')
 
   const artifactClient = new DefaultArtifactClient()
 
@@ -283,6 +284,13 @@ module.exports = async ({ github, context, core, dry }) => {
     const merge_commit_sha_valid =
       Date.now() - new Date(pull_request.created_at) > 3 * 60 * 1000
 
+    const sizeLabel = classifyPullRequestSize({
+      additions: pull_request.additions,
+      deletions: pull_request.deletions,
+      changedFiles: pull_request.changed_files,
+    })
+    log('size', sizeLabel)
+
     const prLabels = {
       // We intentionally don't use the mergeable or mergeable_state attributes.
       // Those have an intermediate state while the test merge commit is created.
@@ -298,6 +306,9 @@ module.exports = async ({ github, context, core, dry }) => {
       '2.status: merge conflict':
         merge_commit_sha_valid && !pull_request.merge_commit_sha,
       '2.status: merge-bot eligible': merge_bot_eligible,
+      ...Object.fromEntries(
+        PR_SIZE_LABELS.map((label) => [label, label === sizeLabel]),
+      ),
       '12.approvals: 1': approvals.size === 1,
       '12.approvals: 2': approvals.size === 2,
       '12.approvals: 3+': approvals.size >= 3,

--- a/ci/github-script/pr-size.js
+++ b/ci/github-script/pr-size.js
@@ -1,0 +1,45 @@
+const PR_SIZE_THRESHOLDS = [
+  {
+    label: '7.size: XS',
+    maxChangedLines: 10,
+    maxChangedFiles: 1,
+  },
+  {
+    label: '7.size: S',
+    maxChangedLines: 50,
+    maxChangedFiles: 3,
+  },
+  {
+    label: '7.size: M',
+    maxChangedLines: 200,
+    maxChangedFiles: 10,
+  },
+  {
+    label: '7.size: L',
+    maxChangedLines: 1000,
+    maxChangedFiles: 50,
+  },
+  {
+    label: '7.size: XL',
+    maxChangedLines: Infinity,
+    maxChangedFiles: Infinity,
+  },
+]
+
+const PR_SIZE_LABELS = PR_SIZE_THRESHOLDS.map(({ label }) => label)
+
+function classifyPullRequestSize({ additions, deletions, changedFiles }) {
+  // GitHub reports a modified line as both an addition and a deletion.
+  const changedLines = additions + deletions
+
+  // A PR belongs to the first tier whose line and file limits both contain it.
+  return PR_SIZE_THRESHOLDS.find(
+    ({ maxChangedLines, maxChangedFiles }) =>
+      changedLines <= maxChangedLines && changedFiles <= maxChangedFiles,
+  ).label
+}
+
+module.exports = {
+  PR_SIZE_LABELS,
+  classifyPullRequestSize,
+}


### PR DESCRIPTION
Pull request size does not _always_ determine review effort, but it
often does. Add labels to help reviewers estimate time and effort
required to assess a contribution.

Labels are: `7.size: {XS,S,M,L,XL}`. Classifier considers both lines
changed (deleted + added) and the number of files touched.

---

Example run:

```
$ gh pr view https://github.com/NixOS/nixpkgs/pull/544749 --json additions,deletions,changedFiles |\
node -e '
  const fs = require("node:fs")
  const pr = JSON.parse(fs.readFileSync(0, "utf8"))
  const { classifyPullRequestSize } = require("./pr-size.js")
  console.log({ ...pr, label: classifyPullRequestSize(pr) })
'
{ additions: 7, changedFiles: 1, deletions: 2, label: '7.size: XS' }
```

```
$ gh pr view https://github.com/NixOS/nixpkgs/pull/545064 --json additions,deletions,changedFiles |\
node -e '
  const fs = require("node:fs")
  const pr = JSON.parse(fs.readFileSync(0, "utf8"))
  const { classifyPullRequestSize } = require("./pr-size.js")
  console.log({ ...pr, label: classifyPullRequestSize(pr) })
'
{ additions: 18, changedFiles: 2, deletions: 2, label: '7.size: S' }
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
