### PR TITLE
easylpac: create .app bundle on darwin

### DIFF
--- a/pkgs/by-name/ea/easylpac/package.nix
+++ b/pkgs/by-name/ea/easylpac/package.nix
@@ -1,11 +1,13 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   pkg-config,
   wrapGAppsHook3,
   makeDesktopItem,
   copyDesktopItems,
+  desktopToDarwinBundle,
   gtk3,
   libglvnd,
   libxxf86vm,
@@ -35,6 +37,11 @@ buildGoModule rec {
     copyDesktopItems
     pkg-config
     wrapGAppsHook3
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # Generate Applications/EasyLPAC.app from the desktop item, so the
+    # app shows up in Spotlight/Launchpad instead of being CLI-only.
+    desktopToDarwinBundle
   ];
 
   buildInputs = [


### PR DESCRIPTION
### Description

On darwin the package installs only `bin/` + `share/`, so the app never shows up in Spotlight/Launchpad and can only be launched from a terminal. This adds `desktopToDarwinBundle` (darwin-only), which converts the already-present desktop item and hicolor icons into a proper `Applications/EasyLPAC.app`.

The generated bundle is fully functional:

- `Contents/MacOS/EasyLPAC` is the `wrapGAppsHook3`-wrapped launcher, so `lpac` on `PATH` and the GTK environment survive a Finder launch;
- `Contents/Resources/EasyLPAC.icns` is generated from the package's own hicolor PNGs;
- `Info.plist` passes `plutil -lint`.

```
Applications/EasyLPAC.app/Contents/Info.plist
Applications/EasyLPAC.app/Contents/MacOS/EasyLPAC
Applications/EasyLPAC.app/Contents/Resources/EasyLPAC.icns
```

Note for reviewers: on my machine (macOS 27 beta) the package currently fails to **link** with master's cctools 1010.6 (`ld: Trace/BPT trap: 5`) — a pre-existing beta-host toolchain issue unrelated to this change. I therefore verified the change by building the same expression against the nixos-26.05 toolchain on aarch64-darwin, which succeeds and produces the bundle above. CI's darwin builders (release macOS) should build it normally.

**Automation/AI disclosure:** this change was prepared with the assistance of Claude Code (model: Claude Fable 5); the submitter reviewed the diff and the build evidence above. The commit carries the corresponding `Assisted-by:` trailer.

### Relevant Links

- `desktopToDarwinBundle`: pkgs/build-support/make-darwin-bundle (same pattern as e.g. viking, smuview, spatialite-gui)

### Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test