### PR TITLE
cinnamon-screensaver: remove caribou

### DIFF
--- a/pkgs/by-name/ci/cinnamon-screensaver/package.nix
+++ b/pkgs/by-name/ci/cinnamon-screensaver/package.nix
@@ -14,7 +14,6 @@
   libxslt,
   gtk3,
   libgnomekbd,
-  caribou,
   libtool,
   wrapGAppsHook3,
   gobject-introspection,
@@ -83,7 +82,6 @@ stdenv.mkDerivation (finalAttrs: {
     cinnamon-desktop
     cinnamon
     libgnomekbd
-    caribou
   ];
 
   postPatch = ''
@@ -92,13 +90,6 @@ stdenv.mkDerivation (finalAttrs: {
       -e s,/usr/share/locale,/run/current-system/sw/share/locale,g \
       -e s,/usr/share/iso-flag-png,${iso-flags-png-320x240}/share/iso-flags-png,g \
       {} +
-  '';
-
-  preFixup = ''
-    # https://github.com/NixOS/nixpkgs/issues/101881
-    gappsWrapperArgs+=(
-      --prefix XDG_DATA_DIRS : "${caribou}/share"
-    )
   '';
 
   postFixup = ''


### PR DESCRIPTION
Remove `caribou` from `cinnamon-screensaver`, as `caribou` is archived (#551373). This will disable virtual keyboard support.

See https://github.com/linuxmint/cinnamon-screensaver/issues/488 and https://github.com/linuxmint/cinnamon-screensaver/pull/489

Reopened as part of #551373

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
