### PR TITLE
faugus-launcher: 1.22.8 -> 2.0.2

### DIFF
--- a/pkgs/by-name/fa/faugus-launcher/package.nix
+++ b/pkgs/by-name/fa/faugus-launcher/package.nix
@@ -2,48 +2,49 @@
   fetchFromGitHub,
   gobject-introspection,
   icoextract,
-  imagemagick,
   lib,
-  libayatana-appindicator,
-  libcanberra-gtk3,
   lsfg-vk,
   meson,
   ninja,
   nix-update-script,
   python3Packages,
   umu-launcher,
-  vulkan-tools,
-  wrapGAppsHook3,
+  wrapGAppsHook4,
   xdg-utils,
+  gtk4,
+  libadwaita,
+  libmanette,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "faugus-launcher";
-  version = "1.22.8";
+  version = "2.0.2";
   pyproject = false;
 
   src = fetchFromGitHub {
     owner = "Faugus";
     repo = "faugus-launcher";
     tag = finalAttrs.version;
-    hash = "sha256-2FsuD40u5O7VwbziTqhsfVyceyfmSRvdmsizfBy/Xys=";
+    hash = "sha256-0knobTbMLOkRIGze+gHaee2Duq4ClMapTCzICX35A8s=";
   };
 
   nativeBuildInputs = [
     gobject-introspection
     meson
     ninja
-    wrapGAppsHook3
+    wrapGAppsHook4
   ];
 
   buildInputs = [
-    libayatana-appindicator
+    gtk4
+    libadwaita
+    libmanette
   ];
 
   dependencies = with python3Packages; [
+    dbus-python
     pillow
     psutil
-    pygame
     pygobject3
     requests
     vdf
@@ -68,10 +69,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
       --suffix PATH : "${
         lib.makeBinPath [
           icoextract
-          imagemagick
-          libcanberra-gtk3
           umu-launcher
-          vulkan-tools
           xdg-utils
         ]
       }"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updates `faugus-launcher` from 1.22.8 to 2.0.2.

Upstream release notes:

* https://github.com/Faugus/faugus-launcher/releases/tag/2.0.2

Version 2.0 includes the migration to GTK 4. The package dependencies and wrapping were updated to reflect that.

I tested the package on `x86_64-linux` under Wayland (NixOS, GNOME 50). The application launches successfully, and I used it to run Artisan TD.

AI disclosure: ChatGPT 5.6 was used for guidance only. The package changes were made and tested manually by myself (a human).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
