### PR TITLE
judy: replace struct hack with flexible array + enable tests

### DIFF
--- a/pkgs/by-name/ju/judy/no-struct-hack.patch
+++ b/pkgs/by-name/ju/judy/no-struct-hack.patch
@@ -1,0 +1,19 @@
+diff --git a/src/JudySL/JudySL.c b/src/JudySL/JudySL.c
+index d7314a7..6252bab 100644
+--- a/src/JudySL/JudySL.c
++++ b/src/JudySL/JudySL.c
+@@ -184,12 +184,12 @@
+ typedef struct SHORCUTLEAF
+ {
+     Pvoid_t   scl_Pvalue;               // callers value area.
+-    uint8_t   scl_Index[WORDSIZE];      // base Index string.
++    uint8_t   scl_Index[];              // base Index string.
+ } scl_t  , *Pscl_t;
+ 
+ // overhead of the scl_Pvalue only, the scl_Index is calculate elsewhere
+ 
+-#define STRUCTOVD       (sizeof(scl_t) - WORDSIZE)
++#define STRUCTOVD       (sizeof(scl_t))
+ 
+ // How big to malloc a shortcut leaf; stringlen should already include the
+ // trailing null char:

--- a/pkgs/by-name/ju/judy/package.nix
+++ b/pkgs/by-name/ju/judy/package.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   depsBuildBuild = [ pkgsBuildBuild.stdenv.cc ];
   patches = [
     ./cross.patch
+    ./no-struct-hack.patch
     # Fix reproducible timestamps.
     ./fix-source-date.patch
   ];
@@ -28,6 +29,14 @@ stdenv.mkDerivation (finalAttrs: {
   #    make[2]: *** No rule to make target 'man/man3/JSLD', needed by 'all-am'.  Stop.
   # Let's wait for the upstream fix similar to https://sourceforge.net/p/judy/patches/4/
   enableParallelBuilding = false;
+
+  doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+    make -C test check-TESTS
+    runHook postCheck
+  '';
 
   outputs = [
     "out"


### PR DESCRIPTION
With _FORTIFY_SOURCE, codebases using JudySL see any access to struct hack element scl_Index with an offset >= WORDSIZE as an out-of-bounds access, causing the program to crash and exit. This was encountered with GTKWave.

The out-of-bound access check properly handles structs with C99 flexible arrays, however.

I have also turned on the included tests.

See https://github.com/NixOS/nixpkgs/issues/544994 for more background.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
