### PR TITLE
rocqPackages.rocq-elpi: 3.4.0 -> 3.5.0

### DIFF
--- a/pkgs/development/coq-modules/multinomials/default.nix
+++ b/pkgs/development/coq-modules/multinomials/default.nix
@@ -33,7 +33,7 @@ mkCoqDerivation {
     lib.switch
       [ coq.coq-version mathcomp.version ]
       [
-        (case (range "9.0" "9.2") (range "2.6.0" "2.6.0") "2.5.0") # also works on MC 2.4 and 2.5 but breaks validsdp
+        (case (range "9.0" "9.3") (range "2.6.0" "2.6.0") "2.5.0") # also works on MC 2.4 and 2.5 but breaks validsdp
         (case (range "8.18" "9.1") (range "2.1.0" "2.5.0") "2.4.0")
         (case (range "8.17" "9.0") (range "2.1.0" "2.3.0") "2.3.0")
         (case (range "8.17" "8.20") (isGe "2.1.0") "2.2.0")

--- a/pkgs/development/coq-modules/odd-order/default.nix
+++ b/pkgs/development/coq-modules/odd-order/default.nix
@@ -34,7 +34,7 @@ mkCoqDerivation {
     lib.switch
       [ coq.coq-version mathcomp-character.version ]
       [
-        (case (range "9.1" "9.2") (range "2.5" "2.6") "2.4.0")
+        (case (range "9.1" "9.3") (range "2.5" "2.6") "2.4.0")
         (case (range "9.0" "9.1") (range "2.5" "2.5") "2.3.0")
         (case (range "8.16" "9.1") (range "2.2.0" "2.4.0") "2.2.0")
         (case (range "8.16" "9.0") (range "2.1.0" "2.3.0") "2.1.0")

--- a/pkgs/development/rocq-modules/hierarchy-builder/default.nix
+++ b/pkgs/development/rocq-modules/hierarchy-builder/default.nix
@@ -17,7 +17,7 @@ let
       in
       with lib.versions;
       lib.switch rocq-core.rocq-version [
-        (case (range "9.0" "9.2") "1.10.3")
+        (case (range "9.0" "9.3") "1.10.3")
         (case (range "9.0" "9.1") "1.10.2")
         (case (range "9.0" "9.1") "1.10.0")
         (case (range "9.0" "9.1") "1.9.1")

--- a/pkgs/development/rocq-modules/mathcomp-bigenough/default.nix
+++ b/pkgs/development/rocq-modules/mathcomp-bigenough/default.nix
@@ -25,7 +25,7 @@ mkRocqDerivation {
     in
     with lib.versions;
     lib.switch rocq-core.rocq-version [
-      (case (range "9.0" "9.2") "1.0.4")
+      (case (range "9.0" "9.3") "1.0.4")
     ] null;
 
   propagatedBuildInputs = [ mathcomp-boot ];

--- a/pkgs/development/rocq-modules/mathcomp-finmap/default.nix
+++ b/pkgs/development/rocq-modules/mathcomp-finmap/default.nix
@@ -29,7 +29,7 @@ mkRocqDerivation {
     lib.switch
       [ rocq-core.rocq-version mathcomp-boot.version ]
       [
-        (case (range "9.2" "9.2") (range "2.5" "2.6") "2.2.4") # also compiles on Rocq 9.0 and 9.1 (but requires graph-theory update)
+        (case (range "9.2" "9.3") (range "2.5" "2.6") "2.2.4") # also compiles on Rocq 9.0 and 9.1 (but requires graph-theory update)
         (case (range "9.0" "9.1") (range "2.3" "2.5") "2.2.2")
       ]
       null;

--- a/pkgs/development/rocq-modules/mathcomp-real-closed/default.nix
+++ b/pkgs/development/rocq-modules/mathcomp-real-closed/default.nix
@@ -35,7 +35,7 @@ mkRocqDerivation {
     lib.switch
       [ rocq-core.version mathcomp.version ]
       [
-        (case (range "9.0" "9.2") (isGe "2.6.0") "2.0.6")
+        (case (range "9.0" "9.3") (isGe "2.6.0") "2.0.6")
         (case (range "9.0" "9.2") (isEq "2.5.0") "2.0.5")
       ]
       null;

--- a/pkgs/development/rocq-modules/mathcomp/default.nix
+++ b/pkgs/development/rocq-modules/mathcomp/default.nix
@@ -35,7 +35,7 @@ let
       inherit (lib.versions) range;
     in
     lib.switch rocq-core.rocq-version [
-      (case (range "9.2" "9.2") "2.6.0") # also compiles on Rocq 9.0 and 9.1
+      (case (range "9.2" "9.3") "2.6.0") # also compiles on Rocq 9.0 and 9.1
       (case (range "9.0" "9.1") "2.5.0")
     ] null;
   release = {

--- a/pkgs/development/rocq-modules/micromega-plugin/default.nix
+++ b/pkgs/development/rocq-modules/micromega-plugin/default.nix
@@ -15,10 +15,12 @@ mkRocqDerivation {
     in
     with lib.versions;
     lib.switch rocq-core.rocq-version [
+      (case (range "9.0" "9.3") "1.1.1")
       (case (range "9.0" "9.2") "1.1.0")
     ] null;
 
   release = {
+    "1.1.1".hash = "sha256-TIUbrMRoPkLx3QcBGTAEdnzqt4HcKOHaQwJWUtBXUQA=";
     "1.1.0".hash = "sha256-CWMbGErC5bu20Yu9eskgslLkzmSof6klNlOYEkQjUjc=";
   };
   releaseRev = v: "v${v}";

--- a/pkgs/development/rocq-modules/rocq-elpi/default.nix
+++ b/pkgs/development/rocq-modules/rocq-elpi/default.nix
@@ -17,7 +17,7 @@ let
       in
       with lib.versions;
       lib.switch rocq-core.rocq-version [
-        (case (range "9.0" "9.2") "3.7.1")
+        (case (range "9.0" "9.3") "3.7.1")
         (case (range "9.0" "9.1") "3.4.5")
         (case (range "9.0" "9.1") "2.0.7")
       ] rocq-core.ocamlPackages.elpi.version;
@@ -37,11 +37,13 @@ let
       in
       with lib.versions;
       lib.switch rocq-core.rocq-version [
+        (case (range "9.0" "9.3") "3.5.0")
         (case (range "9.0" "9.2") "3.4.0")
         (case (range "9.0" "9.1") "3.2.0")
         (case (range "9.0" "9.1") "2.6.0")
         (case "9.0" "2.5.2")
       ] null;
+    release."3.5.0".sha256 = "sha256-k6kbkFRngQmKUP0owiFOxJzdJVRte5IlZWG4Tpqd3YU=";
     release."3.4.0".sha256 = "sha256-8x2Sa/+pUpXEqB+NdyfOyw6Yyzp6Q1k5LnhrjG/qJNM=";
     release."3.3.0".sha256 = "sha256-wcsUpw7S+H9CaXuz+W3g22IFWO2cLllJ4xm2qLTG0nM=";
     release."3.2.0".sha256 = "sha256-FyYG/8lEyt1L/paMez8jYAnnUE+sxIp4Da5MztmwJ/c=";

--- a/pkgs/development/rocq-modules/rocqnavi/default.nix
+++ b/pkgs/development/rocq-modules/rocqnavi/default.nix
@@ -17,7 +17,7 @@ mkRocqDerivation {
     in
     with versions;
     switch rocq-core.rocq-version [
-      (case (range "9.0" "9.2") "0.5.0")
+      (case (range "9.0" "9.3") "0.5.0")
     ] null;
   release = {
     "0.5.0".hash = "sha256-pmK4gD5ccerjr2UVgwGIVbjH/RiXdYQq79/XFetiHZg=";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
