### PR TITLE
gnuradioPackages.osmosdr: add airspyhf package

### DIFF
--- a/pkgs/by-name/ai/airspyhf/package.nix
+++ b/pkgs/by-name/ai/airspyhf/package.nix
@@ -9,12 +9,14 @@
 
 stdenv.mkDerivation {
   pname = "airspyhf";
-  version = "1.6.8-unstable-2025-07-12";
+  version = "1.8.1";
 
   src = fetchFromGitHub {
     owner = "airspy";
     repo = "airspyhf";
-    rev = "87cf12a30f3a0f10f313aab8e54999ca69b753af";
+    # Not clear why upstream won't tag releases. See:
+    # https://github.com/airspy/airspyhf/commit/c0bb66dd8976651c53884ccec3d70a108f1e50e1#r193607536
+    rev = "c0bb66dd8976651c53884ccec3d70a108f1e50e1";
     hash = "sha256-7bXBv4YTOaWRFI6Svb9/lSBEAssUgJMqxKM5zHk1swM=";
   };
 

--- a/pkgs/development/gnuradio-modules/osmosdr/default.nix
+++ b/pkgs/development/gnuradio-modules/osmosdr/default.nix
@@ -22,6 +22,7 @@
   uhd,
   icu,
   airspy,
+  airspyhf,
   hackrf,
   libbladeRF,
   rtl-sdr,
@@ -95,6 +96,7 @@ mkDerivation (finalAttrs: {
       # Other features don't have dependencies but can still be disabled in the
       # `features` argument.
       airspy = [ airspy ];
+      airspyhf = [ airspyhf ];
       bladerf = [ libbladeRF ];
       hackrf = [ hackrf ];
       rtl = [ rtl-sdr ];


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test