### PR TITLE
nixos/qBittorrent: add configFile option

### DIFF
--- a/nixos/modules/services/torrent/qbittorrent.nix
+++ b/nixos/modules/services/torrent/qbittorrent.nix
@@ -53,7 +53,7 @@ let
       else
         mkKeyValueDefault { } sep k v;
   };
-  configFile = pkgs.writeText "qBittorrent.conf" (gendeepINI cfg.serverConfig);
+  generatedConfigFile = pkgs.writeText "qBittorrent.conf" (gendeepINI cfg.serverConfig);
 in
 {
   options.services.qbittorrent = {
@@ -136,6 +136,15 @@ in
       '';
     };
 
+    configFile = mkOption {
+      type = nullOr path;
+      default = null;
+      description = ''
+        Path to a {file}`qBittorrent.conf` file to use instead of the one generated from the {option}`services.qbittorrent.serverConfig` option.
+        Note that this configuration file cannot be strictly enforced, since it needs to be writable by qBittorrent.
+      '';
+    };
+
     extraArgs = mkOption {
       type = listOf str;
       default = [ ];
@@ -148,6 +157,13 @@ in
     };
   };
   config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !(cfg.configFile != null && cfg.serverConfig != { });
+        message = "Can not set both services.qbittorrent.serverConfig and services.qbittorrent.configFile";
+      }
+    ];
+
     systemd = {
       tmpfiles.settings = {
         qbittorrent = {
@@ -170,7 +186,9 @@ in
           "nss-lookup.target"
         ];
         wantedBy = [ "multi-user.target" ];
-        restartTriggers = optionals (cfg.serverConfig != { }) [ configFile ];
+        restartTriggers =
+          optionals (cfg.serverConfig != { }) [ generatedConfigFile ]
+          ++ optionals (cfg.configFile != null) [ cfg.configFile ];
 
         serviceConfig = {
           Type = "simple";
@@ -178,8 +196,10 @@ in
           Group = cfg.group;
 
           # the config file has to be writable, so we have to do this weird dance
-          ExecStartPre = lib.mkIf (cfg.serverConfig != { }) ''
-            ${pkgs.coreutils}/bin/install -Dm600 ${configFile} "${cfg.profileDir}/qBittorrent/config/qBittorrent.conf"
+          ExecStartPre = lib.mkIf (cfg.serverConfig != { } || cfg.configFile != null) ''
+            ${pkgs.coreutils}/bin/install -Dm600 ${
+              if cfg.serverConfig != { } then generatedConfigFile else cfg.configFile
+            } "${cfg.profileDir}/qBittorrent/config/qBittorrent.conf"
           '';
 
           ExecStart = utils.escapeSystemdExecArgs (

--- a/nixos/tests/qbittorrent.nix
+++ b/nixos/tests/qbittorrent.nix
@@ -1,4 +1,13 @@
-{ pkgs, lib, ... }:
+{
+  pkgs,
+  hostPkgs,
+  lib,
+  ...
+}:
+let
+  runtimeConfigPath = "/run/qbittorrent-secrets/qBittorrent.conf";
+  apiKey = "qbt_8nLHxYQAKLKJj2x5NJN8g8PwSwHu";
+in
 {
   name = "qbittorrent";
 
@@ -65,6 +74,13 @@
           serverConfig.Preferences.WebUI.Port = "7171";
         };
       };
+
+      specialisation.runtimeConfigFile.configuration = {
+        services.qbittorrent = {
+          serverConfig = lib.mkForce { };
+          configFile = runtimeConfigPath;
+        };
+      };
     };
   };
 
@@ -77,8 +93,16 @@
       openPorts = "${simpleSpecPath}/openPorts";
       serverConfig = "${simpleSpecPath}/serverConfig";
       serverConfigChange = "${declarativeSpecPath}/serverConfigChange";
+      runtimeConfigFile = "${declarativeSpecPath}/runtimeConfigFile";
+      runtimeConfig = hostPkgs.writeText "qBittorrent.conf" ''
+        [Preferences]
+        WebUI\Port=8282
+        WebUI\APIKey=${apiKey}
+      '';
     in
     ''
+      import json
+
       simple.start(allow_reboot=True)
       declarative.start(allow_reboot=True)
 
@@ -104,6 +128,21 @@
               f'curl --header "Referer: {qb_url}" \
               --data "{post_data}" {api_url}/app/setPreferences \
               -b {cookie_path}'
+          )
+
+
+      def getPreferences_api(machine, port, post_creds):
+          qb_url = f"http://localhost:{port}"
+          api_url = f"{qb_url}/api/v2"
+          cookie_path = "/tmp/qbittorrent.cookie"
+
+          machine.succeed(
+              f'curl --header "Referer: {qb_url}" \
+              --data "{post_creds}" {api_url}/auth/login \
+              -c {cookie_path}'
+          )
+          return json.loads(
+              machine.succeed(f"curl --fail {api_url}/app/preferences -b {cookie_path}")
           )
 
 
@@ -189,5 +228,29 @@
       with subtest("changes in serverConfig are applied correctly"):
           declarative.succeed("${serverConfigChange}/bin/switch-to-configuration test")
           test_webui(declarative, 7171)
+
+      with subtest("configFile outside of the nix store is read by qbittorrent"):
+          declarative.copy_from_host(
+              "${runtimeConfig}", "${runtimeConfigPath}"
+          )
+
+          declarative.succeed("${runtimeConfigFile}/bin/switch-to-configuration test")
+
+          test_webui(declarative, 8282)
+
+          declarative.succeed(
+              "systemctl cat qbittorrent.service |"
+              " grep -q ${runtimeConfigPath}"
+          )
+
+          temp_pass = get_temp_pass(declarative)
+
+          prefs = getPreferences_api(
+              machine=declarative,
+              port=8282,
+              post_creds=f"username=admin&password={temp_pass}",
+          )
+          assert prefs["web_ui_port"] == 8282, prefs["web_ui_port"]
+          assert prefs["web_ui_api_key"] == "${apiKey}", prefs["web_ui_api_key"]
     '';
 }


### PR DESCRIPTION
I use this to configure an API key using [sops-nix](https://github.com/mic92/sops-nix) like this:

```nix
sops.secrets."qbittorrent/api-key" = { };

sops.templates."qBittorrent.conf" = {
  mode = "0444";
  content = ''
    [Preferences]
    WebUI\APIKey=${config.sops.placeholder."qbittorrent/api-key"}
  '';
};

services.qbittorrent = {
  enable = true;
  configFile = config.sops.templates."qBittorrent.conf".path;
};
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
