### PR TITLE
nixos/limine: avoid rewriting boot order on update

### DIFF
--- a/nixos/modules/system/boot/loader/limine/limine-install.py
+++ b/nixos/modules/system/boot/loader/limine/limine-install.py
@@ -730,6 +730,14 @@ def install_bootloader() -> None:
                     boot_order = re.findall(
                         r"BootOrder: ((?:[0-9a-fA-F]{4},?)*)", efibootmgr_output
                     )[0]
+                    normalized_boot_order = boot_order.upper().split(",")
+                    create_options = ["-C"]
+                    if limine_boot_entry.upper() in normalized_boot_order:
+                        create_options = [
+                            "-c",
+                            "--index",
+                            str(normalized_boot_order.index(limine_boot_entry.upper())),
+                        ]
 
                     efibootmgr_output = subprocess.check_output(
                         [
@@ -745,7 +753,7 @@ def install_bootloader() -> None:
                     efibootmgr_output = subprocess.check_output(
                         [
                             efibootmgr,
-                            "-c",
+                            *create_options,
                             "-b",
                             limine_boot_entry,
                             "-d",
@@ -756,8 +764,6 @@ def install_bootloader() -> None:
                             f"\\efi\\limine\\{boot_file}",
                             "-L",
                             "Limine",
-                            "-o",
-                            boot_order,
                         ],
                         stderr=subprocess.STDOUT,
                         universal_newlines=True,


### PR DESCRIPTION
Some firmwares add `BootOrder` entries without corresponding `BootXXXX`
variables. When replacing an existing Limine entry, the installer passes the
complete reported order to `efibootmgr -o`, which rejects those nonexistent
entries and aborts with status 8. See the replacement failure reported by
@compguy284 in [#493017](https://github.com/NixOS/nixpkgs/issues/493017#issuecomment-3971238883).

Instead of rewriting `BootOrder`, recreate Limine at its previous position
using `--index`. If Limine was already excluded from `BootOrder`, use `-C` to
keep it excluded. This preserves firmware-reported entries and the
established behavior that bootloader updates do not change Limine's
ordering.

PR description prepared with assistance from gpt-5.6-sol.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/` (bootloader installer on a physical UEFI system)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
