### PR TITLE
python3Packages.tern: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/tern/default.nix
+++ b/pkgs/development/python-modules/tern/default.nix
@@ -18,13 +18,16 @@
   stevedore,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "tern";
   version = "2.12.1";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
-    inherit pname version;
+    pname = "tern";
+    inherit (finalAttrs) version;
     hash = "sha256-yMIvFiliEHrbZMqvX3ZAROWcqii5VmB54QEYHGRJocA=";
   };
 
@@ -61,8 +64,8 @@ buildPythonPackage rec {
     description = "Software composition analysis tool and Python library that generates a Software Bill of Materials for container images and Dockerfiles";
     mainProgram = "tern";
     homepage = "https://github.com/tern-tools/tern";
-    changelog = "https://github.com/tern-tools/tern/releases/tag/v${version}";
+    changelog = "https://github.com/tern-tools/tern/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.bsd2;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/tern/default.nix
+++ b/pkgs/development/python-modules/tern/default.nix
@@ -5,6 +5,7 @@
   docker,
   dockerfile-parse,
   fetchPypi,
+  setuptools,
   gitpython,
   idna,
   license-expression,
@@ -20,20 +21,23 @@
 buildPythonPackage rec {
   pname = "tern";
   version = "2.12.1";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-yMIvFiliEHrbZMqvX3ZAROWcqii5VmB54QEYHGRJocA=";
   };
 
+  build-system = [
+    setuptools
+    pbr
+  ];
+
   preBuild = ''
     cp requirements.{in,txt}
   '';
 
-  nativeBuildInputs = [ pbr ];
-
-  propagatedBuildInputs = [
+  dependencies = [
     pyyaml
     docker
     dockerfile-parse


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
