### PR TITLE
python3Packages.textdistance: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/textdistance/default.nix
+++ b/pkgs/development/python-modules/textdistance/default.nix
@@ -3,6 +3,9 @@
   buildPythonPackage,
   fetchPypi,
   setuptools,
+  pytestCheckHook,
+  hypothesis,
+  numpy,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -20,8 +23,13 @@ buildPythonPackage (finalAttrs: {
 
   build-system = [ setuptools ];
 
-  # There aren't tests
-  doCheck = false;
+  nativeCheckInputs = [
+    pytestCheckHook
+    hypothesis
+    numpy
+  ];
+
+  disabledTestPaths = [ "tests/test_external.py" ];
 
   pythonImportsCheck = [ "textdistance" ];
 

--- a/pkgs/development/python-modules/textdistance/default.nix
+++ b/pkgs/development/python-modules/textdistance/default.nix
@@ -5,13 +5,16 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "textdistance";
   version = "4.6.3";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
-    inherit pname version;
+    pname = "textdistance";
+    inherit (finalAttrs) version;
     hash = "sha256-1tq8ULTqgyzc8OHmAhvQx/zZreFViI15u2o8Mfzi3G8=";
   };
 
@@ -25,8 +28,8 @@ buildPythonPackage rec {
   meta = {
     description = "Python library for comparing distance between two or more sequences";
     homepage = "https://github.com/life4/textdistance";
-    changelog = "https://github.com/life4/textdistance/releases/tag/${version}";
+    changelog = "https://github.com/life4/textdistance/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/textdistance/default.nix
+++ b/pkgs/development/python-modules/textdistance/default.nix
@@ -2,17 +2,20 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "textdistance";
   version = "4.6.3";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-1tq8ULTqgyzc8OHmAhvQx/zZreFViI15u2o8Mfzi3G8=";
   };
+
+  build-system = [ setuptools ];
 
   # There aren't tests
   doCheck = false;


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
