### PR TITLE
matrix-commander-rs: 1.0.1 -> 0.11.0, enable __structuredAttrs, add ilkecan to maintainers

### DIFF
--- a/pkgs/by-name/ma/matrix-commander-rs/package.nix
+++ b/pkgs/by-name/ma/matrix-commander-rs/package.nix
@@ -21,6 +21,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-OWuKwaJfwOAtwtN0so/afWeHq2oslAT2YahnJC0QB6w=";
 
+  __structuredAttrs = true;
+
   nativeBuildInputs = [
     pkg-config
     perl

--- a/pkgs/by-name/ma/matrix-commander-rs/package.nix
+++ b/pkgs/by-name/ma/matrix-commander-rs/package.nix
@@ -5,20 +5,21 @@
   pkg-config,
   rustPlatform,
   perl,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "matrix-commander-rs";
-  version = "1.0.1";
+  version = "0.11.0";
 
   src = fetchFromGitHub {
     owner = "8go";
     repo = "matrix-commander-rs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-SyAKKSPGO8yjP3Pgsr2sPW5cpNyNLiYTy7CDDAXdztw=";
+    hash = "sha256-eWD1nj+xRWNkyC3lM/hIZACI2i1Awl9NTgslR8rJZSc=";
   };
 
-  cargoHash = "sha256-X1xBhJ0B4FcC66qKtYZbcX2+92hy2R4fM/GYBI8AFTY=";
+  cargoHash = "sha256-OWuKwaJfwOAtwtN0so/afWeHq2oslAT2YahnJC0QB6w=";
 
   nativeBuildInputs = [
     pkg-config
@@ -27,10 +28,17 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   buildInputs = [ openssl ];
 
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^v(0.*)$" # https://github.com/8go/matrix-commander-rs/issues/194#issuecomment-4864773450
+    ];
+  };
+
   meta = {
     description = "CLI-based Matrix client app for sending and receiving";
     homepage = "https://github.com/8go/matrix-commander-rs";
-    changelog = "https://github.com/8go/matrix-commander-rs/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/8go/matrix-commander-rs/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "matrix-commander-rs";

--- a/pkgs/by-name/ma/matrix-commander-rs/package.nix
+++ b/pkgs/by-name/ma/matrix-commander-rs/package.nix
@@ -42,7 +42,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/8go/matrix-commander-rs";
     changelog = "https://github.com/8go/matrix-commander-rs/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ fab ];
+    maintainers = with lib.maintainers; [
+      fab
+      ilkecan
+    ];
     mainProgram = "matrix-commander-rs";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

It seems the upstream project [decided to go back](https://github.com/8go/matrix-commander-rs/issues/194#issuecomment-4864773450) to `v0.x` versioning from `v1.x` because the project is not "feature complete" yet. In any case `v0.11.0` is a newer release than `v1.0.1`[^1], so I have added `--version-regex "v(0.*)"` to only consider `v0.*` releases until `v1` is re-released.

I am not sure if there is a different procedure to handle something like this (i.e. a version downgrade in terms of the version number).

[^1]: https://github.com/8go/matrix-commander-rs/releases

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
