### PR TITLE
tests.problems: only match on the error message

### DIFF
--- a/pkgs/test/problems/cases/allow-broken-predicate-mismatch/expected-stderr
+++ b/pkgs/test/problems/cases/allow-broken-predicate-mismatch/expected-stderr
@@ -1,5 +1,3 @@
-(stack trace truncated; use '--show-trace' to show the full, detailed trace)
-
 error: Refusing to evaluate package 'a-0' in /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-default.nix:16 because it has problems:
 - broken: This package is broken.
 

--- a/pkgs/test/problems/cases/broken-manual/expected-stderr
+++ b/pkgs/test/problems/cases/broken-manual/expected-stderr
@@ -1,5 +1,3 @@
-(stack trace truncated; use '--show-trace' to show the full, detailed trace)
-
 error: Refusing to evaluate package 'a-0' in /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-default.nix:12 because it has problems:
 - broken: This package is broken because horse.
 

--- a/pkgs/test/problems/cases/broken/expected-stderr
+++ b/pkgs/test/problems/cases/broken/expected-stderr
@@ -1,5 +1,3 @@
-(stack trace truncated; use '--show-trace' to show the full, detailed trace)
-
 error: Refusing to evaluate package 'a-0' in /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-default.nix:12 because it has problems:
 - broken: This package is broken.
 

--- a/pkgs/test/problems/cases/deprecated-and-removal-and-maintainerless-error/expected-stderr
+++ b/pkgs/test/problems/cases/deprecated-and-removal-and-maintainerless-error/expected-stderr
@@ -1,5 +1,3 @@
-(stack trace truncated; use '--show-trace' to show the full, detailed trace)
-
 error: Refusing to evaluate package 'a-0' in /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-default.nix:18 because it has problems:
 - deprecated: Package is deprecated and replaced by b.
 - maintainerless: This package has no declared maintainer, i.e. an empty `meta.maintainers` and `meta.teams` attribute.

--- a/pkgs/test/problems/cases/deprecated-and-removal-error/expected-stderr
+++ b/pkgs/test/problems/cases/deprecated-and-removal-error/expected-stderr
@@ -1,5 +1,3 @@
-(stack trace truncated; use '--show-trace' to show the full, detailed trace)
-
 error: Refusing to evaluate package 'a-0' in /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-default.nix:16 because it has problems:
 - deprecated: Package is deprecated and replaced by b
 - removal: Package will be removed

--- a/pkgs/test/problems/cases/deprecated-error/expected-stderr
+++ b/pkgs/test/problems/cases/deprecated-error/expected-stderr
@@ -1,5 +1,3 @@
-(stack trace truncated; use '--show-trace' to show the full, detailed trace)
-
 error: Refusing to evaluate package 'a-0' in /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-default.nix:15 because it has problems:
 - deprecated: Package is deprecated and replaced by b
 

--- a/pkgs/test/problems/cases/invalid-kind-error/expected-stderr
+++ b/pkgs/test/problems/cases/invalid-kind-error/expected-stderr
@@ -1,4 +1,2 @@
-(stack trace truncated; use '--show-trace' to show the full, detailed trace)
-
 error: Refusing to evaluate package 'a-0' in /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-default.nix:11 because it has an invalid meta attrset:
   - a.meta.problems.invalid: Problem kind invalid, inferred from the problem name, is invalid; expected enum<broken,deprecated,maintainerless,removal>. You can specify an explicit problem kind with `a.meta.problems.invalid.kind`

--- a/pkgs/test/problems/cases/maintainerless-error/expected-stderr
+++ b/pkgs/test/problems/cases/maintainerless-error/expected-stderr
@@ -1,5 +1,3 @@
-(stack trace truncated; use '--show-trace' to show the full, detailed trace)
-
 error: Refusing to evaluate package 'a-0' in /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-default.nix:16 because it has problems:
 - maintainerless: This package has no declared maintainer, i.e. an empty `meta.maintainers` and `meta.teams` attribute.
 

--- a/pkgs/test/problems/cases/no-message/expected-stderr
+++ b/pkgs/test/problems/cases/no-message/expected-stderr
@@ -1,4 +1,2 @@
-(stack trace truncated; use '--show-trace' to show the full, detailed trace)
-
 error: Refusing to evaluate package 'a-0' in /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-default.nix:20 because it has an invalid meta attrset:
   - a.meta.problems.removal: `.message` not specified

--- a/pkgs/test/problems/cases/non-attrs-problem/expected-stderr
+++ b/pkgs/test/problems/cases/non-attrs-problem/expected-stderr
@@ -1,5 +1,3 @@
-(stack trace truncated; use '--show-trace' to show the full, detailed trace)
-
 error: Refusing to evaluate package 'a-0' in /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-default.nix:19 because it has an invalid meta attrset:
   - a.meta.problems.florp: Invalid value; expected attrs, got
     true

--- a/pkgs/test/problems/cases/package-name-matcher/expected-stderr
+++ b/pkgs/test/problems/cases/package-name-matcher/expected-stderr
@@ -1,5 +1,3 @@
-(stack trace truncated; use '--show-trace' to show the full, detailed trace)
-
 error: Failed assertions:
 - There is a problems.matchers with `package = "a"` and `name = "b". Use the following instead:
   problems.handlers.a.b = "error";

--- a/pkgs/test/problems/cases/problem-urls/expected-stderr
+++ b/pkgs/test/problems/cases/problem-urls/expected-stderr
@@ -1,5 +1,3 @@
-(stack trace truncated; use '--show-trace' to show the full, detailed trace)
-
 error: Refusing to evaluate package 'a-0' in /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-default.nix:20 because it has problems:
 - removal: Removed because of XYZ. (https://example.com, https://anotherexample.com)
 

--- a/pkgs/test/problems/cases/removal-error/expected-stderr
+++ b/pkgs/test/problems/cases/removal-error/expected-stderr
@@ -1,5 +1,3 @@
-(stack trace truncated; use '--show-trace' to show the full, detailed trace)
-
 error: Refusing to evaluate package 'a-0' in /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-default.nix:13 because it has problems:
 - removal: This package has been abandoned upstream and will be removed.
 

--- a/pkgs/test/problems/cases/removal-twice-error/expected-stderr
+++ b/pkgs/test/problems/cases/removal-twice-error/expected-stderr
@@ -1,4 +1,2 @@
-(stack trace truncated; use '--show-trace' to show the full, detailed trace)
-
 error: Refusing to evaluate package 'a-0' in /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-default.nix:12 because it has an invalid meta attrset:
   - a.meta.problems: Problem kind removal should be unique, but is used for these problems: removal, removal2

--- a/pkgs/test/problems/default.nix
+++ b/pkgs/test/problems/default.nix
@@ -50,10 +50,15 @@ lib.mapAttrs (
       echo "$?" > $out/code
       echo "Command exited with code $(<$out/code)"
       remove-references-to -t ${nixFile} $out/stderr
-      if grep '(stack trace truncated.*)' $out/stderr; then
-        sed -i -n '/(stack trace truncated.*)/,$ p' $out/stderr
-      fi
+
       sed -i 's/^       //' $out/stderr
+
+      # extract only from the error message to the end, sometimes the stack
+      # traces are too short for nix to truncate them and then we've false
+      # negative CI results due to unrelated changes in nixpkgs.
+      if grep -q '^error: .' $out/stderr; then
+        sed -i -n '/^error: ./,$ p' $out/stderr
+      fi
     '';
     checker = runCommand "test-problems-check-${name}" { } ''
       if ! PAGER=cat ${lib.getExe gitMinimal} diff --no-index ${


### PR DESCRIPTION
This drops matching on the truncated stack trace marker as that only
appears if the stack trace is actually long enough. In some cases the
stack trace is simply too short so Nix prints it out entirely. Then
the tests fail and I'm unhappy.

This was caused by a90d993 which to the best of my understanding
forces the error message very early in the eval and thus doesn't have
a very long stack trace.

Unfortunately we do have to touch each of the expected output files but given that this should be more stable seems sensible.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
  - [x] `tests.problems`
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
