### PR TITLE
nixos/programs/ioquake3: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -56,6 +56,8 @@
 
 - [Unpackerr](https://unpackerr.zip), extracts downloads for Radarr, Sonarr, Lidarr, Readarr, and/or a Watch folder. Available as [services.unpackerr](#opt-services.unpackerr.enable).
 
+- [ioquake3](https://ioquake3.org), a open-source port of the 3D action shooter Quake 3 Arena. Available as [programs.ioquake3](#opt-programs.ioquake3.enable).
+
 - [Matrix Authentication Service](https://github.com/element-hq/matrix-authentication-service) is an OAuth2.0 and OpenID Connect provider for Matrix homeservers (such as Synapse). It replaces standard password authentication with modern OpenID Connect flows, and can delegate authentication to upstream OIDC providers. Available as [services.matrix-authentication-service](#opt-services.matrix-authentication-service.enable).
 
 - [stash-clipboard](https://github.com/NotAShelf/stash), a Wayland clipboard "manager" with fast persistent history and multi-media support. Available as [services.stash-clipboard](#opt-services.stash-clipboard.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -247,6 +247,7 @@
   ./programs/iftop.nix
   ./programs/iio-hyprland.nix
   ./programs/immersed.nix
+  ./programs/ioquake3.nix
   ./programs/iotop.nix
   ./programs/jai-jail.nix
   ./programs/java.nix

--- a/nixos/modules/programs/ioquake3.nix
+++ b/nixos/modules/programs/ioquake3.nix
@@ -1,0 +1,79 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.ioquake3;
+
+  toIoquake3Value = value: if lib.isBool value then (if value then "1" else "0") else toString value;
+
+  # Quake 3 is unable to read or execute long config files from the Nix store,
+  # therefore we link it to /etc
+  fsBasepath = "/etc/xdg/ioquake3";
+
+  toIoquake3Config =
+    settings:
+    lib.concatStrings (
+      lib.mapAttrsToList (name: value: ''seta ${name} "${toIoquake3Value value}"'' + "\n") settings
+    );
+
+  configFile = pkgs.writeText "ioquake3-settings.cfg" (toIoquake3Config cfg.settings);
+
+  ioquake3Wrapped = pkgs.symlinkJoin {
+    name = "ioquake3-wrapped";
+    paths = [ cfg.package ];
+    nativeBuildInputs = [ pkgs.makeWrapper ];
+    postBuild = ''
+      wrapProgram "$out/bin/ioquake3" --add-flags  "+set fs_basepath ${fsBasepath} +exec settings.cfg"
+    '';
+  };
+in
+{
+  options.programs.ioquake3 = {
+    enable = lib.mkEnableOption "ioquake3, an enhanced, cross-platform, open source engine for id Software's Quake 3";
+
+    package = lib.mkPackageOption pkgs "ioquake3" { };
+
+    settings = lib.mkOption {
+      type = lib.types.attrsOf (
+        lib.types.oneOf [
+          lib.types.str
+          lib.types.int
+          lib.types.float
+          lib.types.bool
+        ]
+      );
+      default = { };
+      example = lib.literalExpression ''
+        {
+          name = "Player";
+          sensitivity = 5;
+          r_fullscreen = true;
+          cl_maxfps = 125;
+        }
+      '';
+      description = ''
+        ioquake3 configuration, written out as a cfg file that is loaded on
+        startup via `+exec`. Keys are cvar names, values are the cvar
+        values.
+
+        See <https://ioquake3.org/help/players-guide/> for some available
+        configuration options.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment = {
+      systemPackages = [ ioquake3Wrapped ];
+      etc."xdg/ioquake3/baseq3/settings.cfg".source = configFile;
+    };
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [ onny ];
+  };
+}


### PR DESCRIPTION
Configure the game [ioquake3](https://ioquake3.org/) or Quake3, example config:

```
programs.ioquake3 = {
  enable = true;
  settings = {
    name = "onny";
    com_maxfps = 125;
    cg_frawFPS = true;
    cg_fov = 115;
    r_mode = "-1";
    r_customheight = 1080;
    r_customwidth = 1920;
    model = "sarge/default";
  };
};
```

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
