### PR TITLE
gameconf: init at version 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12862,6 +12862,12 @@
     githubId = 1608697;
     name = "Jens Binkert";
   };
+  jeppe = {
+    email = "JeppeToftlund@proton.me";
+    github = "JeppeToftlund";
+    githubId = 308726180;
+    name = "Jeppe Johansen";
+  };
   jeremiahs = {
     email = "jeremiah@secrist.xyz";
     github = "JeremiahSecrist";

--- a/pkgs/by-name/ga/gameconf/package.nix
+++ b/pkgs/by-name/ga/gameconf/package.nix
@@ -1,0 +1,50 @@
+{
+  stdenv,
+  lib,
+  fetchFromCodeberg,
+  zig_0_16,
+  linkFarm,
+  fetchgit,
+}:
+let
+  zig = zig_0_16;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gameconf";
+  version = "1.0.0";
+
+  src = fetchFromCodeberg {
+    owner = "JeppeUseNixos";
+    repo = "gameconf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6K4s1dy9+kcw1SfduCsxYByK7buXa6cVDX/Xu9Dhifs=";
+  };
+
+  nativeBuildInputs = [ zig.hook ];
+
+  zigDeps = zig.fetchDeps {
+    inherit (finalAttrs) src pname version;
+    fetchAll = true;
+    hash = "sha256-Rem8TXZz/UFgqqN8D+3SeTgBc5XFdhTIwpoVy+mJHOQ=";
+  };
+  #zigBuildFlags = [
+  #  "--system"
+  #  "${finalAttrs.zigDeps}"
+  #];
+
+  strictDeps = true;
+  postConfigure = ''
+    ln -s ${finalAttrs.zigDeps} "$ZIG_GLOBAL_CACHE_DIR/p"
+  '';
+
+  __structuredAttrs = true;
+
+  meta = {
+    homepage = "https://codeberg.org/JeppeUseNixos/gameconf";
+    description = "Tool for configuring steam games";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ jeppe ];
+    platforms = lib.platforms.linux;
+  };
+
+})


### PR DESCRIPTION
Adds gameconf at version 1.0.0

Gameconf is a tool for exporting proton version and launchoptions of your steam games. To make it easy to transfer to a different
machine. And make it easier for new linux users to get started in the future

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
