### PR TITLE
rspamd: replace deprecated pcre with pcre2

### DIFF
--- a/pkgs/by-name/rs/rspamd/package.nix
+++ b/pkgs/by-name/rs/rspamd/package.nix
@@ -20,8 +20,8 @@
   libsodium,
   lua,
   luajit,
+  pcre2,
   openssl,
-  pcre,
   ragel,
   sqlite,
   vectorscan,
@@ -70,8 +70,8 @@ stdenv.mkDerivation (finalAttrs: {
     libarchive
     libsodium
     (if withLuaJIT then luajit else lua)
+    pcre2
     openssl
-    pcre
     ragel
     sqlite
     vectorscan
@@ -93,7 +93,7 @@ stdenv.mkDerivation (finalAttrs: {
     (cmakeBool' "ENABLE_JEMALLOC" true)
     (cmakeBool' "ENABLE_LUAJIT" withLuaJIT)
     # pcre2 jit seems to cause crashes: https://github.com/NixOS/nixpkgs/pull/181908
-    (cmakeBool' "ENABLE_PCRE2" false)
+    (cmakeBool' "ENABLE_PCRE2" true)
     # doctest 2.5.0 compat problems https://github.com/rspamd/rspamd/issues/5994
     (cmakeBool' "SYSTEM_DOCTEST" false)
     (cmakeBool' "SYSTEM_XXHASH" true)


### PR DESCRIPTION
Replace deprecated pcre with pcre2
(part of #356387 )

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
