### PR TITLE
rocqPackages.stdlib: 9.1.0 -> 9.2.0

### DIFF
--- a/pkgs/development/coq-modules/Cheerios/default.nix
+++ b/pkgs/development/coq-modules/Cheerios/default.nix
@@ -16,7 +16,7 @@ mkCoqDerivation {
     in
     with lib.versions;
     lib.switch coq.version [
-      (case (range "8.14" "9.2") "20230107")
+      (case (range "8.14" "9.3") "20230107")
       (case (range "8.6" "8.16") "20200201")
     ] null;
   release."20230107".rev = "bad8ad2476e14df6b5a819b7aaddc27a7c53fb69";

--- a/pkgs/development/coq-modules/InfSeqExt/default.nix
+++ b/pkgs/development/coq-modules/InfSeqExt/default.nix
@@ -16,7 +16,7 @@ mkCoqDerivation {
     in
     with lib.versions;
     lib.switch coq.version [
-      (case (range "8.9" "9.2") "20230107")
+      (case (range "8.9" "9.3") "20230107")
       (case (range "8.5" "8.16") "20200131")
     ] null;
   release."20230107".rev = "601e89ec019501c48c27fcfc14b9a3c70456e408";

--- a/pkgs/development/coq-modules/Ordinal/default.nix
+++ b/pkgs/development/coq-modules/Ordinal/default.nix
@@ -10,12 +10,12 @@ mkCoqDerivation {
   owner = "snu-sf";
   inherit version;
   defaultVersion =
+    let
+      case = case: out: { inherit case out; };
+    in
     with lib.versions;
-    lib.switch coq.version [
-      {
-        case = range "8.12" "9.2";
-        out = "0.5.6";
-      }
+    lib.switch coq.coq-version [
+      (case (range "8.12" "9.3") "0.5.6")
     ] null;
   release = {
     "0.5.6".hash = "sha256-ox9GaUsh/tWJGEPawPnNqXULI0kYglKmNmiTL8dF3uU=";

--- a/pkgs/development/coq-modules/StructTact/default.nix
+++ b/pkgs/development/coq-modules/StructTact/default.nix
@@ -16,7 +16,7 @@ mkCoqDerivation {
     in
     with lib.versions;
     lib.switch coq.coq-version [
-      (case (range "8.9" "9.2") "20230107")
+      (case (range "8.9" "9.3") "20230107")
       (case (range "8.6" "8.16") "20210328")
       (case (range "8.5" "8.13") "20181102")
     ] null;

--- a/pkgs/development/coq-modules/ceres/default.nix
+++ b/pkgs/development/coq-modules/ceres/default.nix
@@ -19,7 +19,7 @@ mkCoqDerivation {
     in
     with lib.versions;
     lib.switch coq.version [
-      (case (range "8.14" "9.2") "0.4.1")
+      (case (range "8.14" "9.3") "0.4.1")
       (case (range "8.8" "8.16") "0.4.0")
     ] null;
   release."0.4.1".hash = "sha256-9vyk8/8IVsqNyhw3WPzl8w3L9Wu7gfaMVa3n2nWjFiA=";

--- a/pkgs/development/coq-modules/coq-record-update/default.nix
+++ b/pkgs/development/coq-modules/coq-record-update/default.nix
@@ -15,7 +15,7 @@ mkCoqDerivation {
     in
     with lib.versions;
     lib.switch coq.coq-version [
-      (case (range "8.14" "9.2") "0.3.6")
+      (case (range "8.14" "9.3") "0.3.6")
       (case (range "8.10" "9.1") "0.3.4")
     ] null;
   release."0.3.6".hash = "sha256-Sd9cmRPb/0MDlR9mzbFrrF9ifP/2vd0KG6u5fGOydds=";

--- a/pkgs/development/coq-modules/coqeal/default.nix
+++ b/pkgs/development/coq-modules/coqeal/default.nix
@@ -30,7 +30,7 @@ let
       lib.switch
         [ coq.coq-version mathcomp.version ]
         [
-          (case (range "9.0" "9.2") (isGe "2.5.0") "2.1.2")
+          (case (range "9.0" "9.3") (isGe "2.5.0") "2.1.2")
           (case (range "8.20" "9.1") (range "2.3.0" "2.5.0") "2.1.1")
           (case (range "8.20" "9.1") (range "2.3.0" "2.5.0") "2.1.0")
           (case (range "8.16" "8.20") (isGe "2.1.0") "2.0.3")

--- a/pkgs/development/coq-modules/coqutil/default.nix
+++ b/pkgs/development/coq-modules/coqutil/default.nix
@@ -18,7 +18,7 @@
       inherit (lib.versions) range;
     in
     lib.switch coq.version [
-      (case (range "9.0" "9.2") "0.0.7")
+      (case (range "9.0" "9.3") "0.0.7")
       (case (range "8.18" "8.20") "0.0.6")
       (case (range "8.17" "8.20") "0.0.5")
     ] null;

--- a/pkgs/development/coq-modules/flocq/default.nix
+++ b/pkgs/development/coq-modules/flocq/default.nix
@@ -20,7 +20,7 @@ let
       in
       with lib.versions;
       lib.switch coq.coq-version [
-        (case (range "8.15" "9.2") "4.2.2")
+        (case (range "8.15" "9.3") "4.2.2")
         (case (range "8.15" "9.1") "4.2.1")
         (case (range "8.14" "8.20") "4.2.0")
         (case (range "8.14" "8.18") "4.1.3")

--- a/pkgs/development/coq-modules/gaia/default.nix
+++ b/pkgs/development/coq-modules/gaia/default.nix
@@ -36,7 +36,7 @@ mkCoqDerivation {
     lib.switch
       [ coq.coq-version mathcomp.version ]
       [
-        (case (range "8.16" "9.2") (range "2.0" "2.6") "2.4")
+        (case (range "8.16" "9.3") (range "2.0" "2.6") "2.4")
         (case (range "8.16" "9.1") (range "2.0" "2.5") "2.3")
         (case (range "8.16" "9.0") (range "2.0" "2.3") "2.2")
         (case (range "8.10" "8.18") (range "1.12.0" "1.18.0") "1.17")

--- a/pkgs/development/coq-modules/mathcomp-tarjan/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-tarjan/default.nix
@@ -31,7 +31,7 @@ mkCoqDerivation {
     lib.switch
       [ coq.coq-version mathcomp-ssreflect.version ]
       [
-        (case (range "8.16" "9.2") (range "2.0.0" "2.6.0") "1.0.5")
+        (case (range "8.16" "9.3") (range "2.0.0" "2.6.0") "1.0.5")
         (case (range "8.16" "9.1") (range "2.0.0" "2.5.0") "1.0.4")
         (case (range "8.16" "9.1") (range "2.0.0" "2.4.0") "1.0.3")
         (case (range "8.16" "9.0") (range "2.0.0" "2.3.0") "1.0.2")

--- a/pkgs/development/coq-modules/paco/default.nix
+++ b/pkgs/development/coq-modules/paco/default.nix
@@ -16,7 +16,7 @@ mkCoqDerivation {
     in
     with lib.versions;
     lib.switch coq.coq-version [
-      (case (range "8.14" "9.2") "4.2.3")
+      (case (range "8.14" "9.3") "4.2.3")
       (case (isEq "8.13") "4.2.2")
       (case (range "8.12" "8.17") "4.1.2")
       (case (range "8.9" "8.13") "4.1.1")

--- a/pkgs/development/coq-modules/rewriter/default.nix
+++ b/pkgs/development/coq-modules/rewriter/default.nix
@@ -12,13 +12,11 @@ mkCoqDerivation {
   inherit version;
   defaultVersion =
     let
-      inherit (lib.versions) range;
+      case = case: out: { inherit case out; };
     in
+    with lib.versions;
     lib.switch coq.coq-version [
-      {
-        case = range "8.17" "9.2";
-        out = "0.0.15";
-      }
+      (case (range "8.17" "9.2") "0.0.15")
     ] null;
   release = {
     "0.0.15".hash = "sha256-zxNIMppFXUKShOXLbdZphy0Je5ii6cjcWUUcQMTcaHk=";

--- a/pkgs/development/rocq-modules/bignums/default.nix
+++ b/pkgs/development/rocq-modules/bignums/default.nix
@@ -16,7 +16,8 @@ mkRocqDerivation {
     in
     with lib.versions;
     lib.switch rocq-core.rocq-version [
-      (case (range "9.0" "9.2") "9.0.0+rocq${rocq-core.rocq-version}")
+      (case (range "9.2" "9.3") "9.0.0+rocq9.2")
+      (case (range "9.0" "9.1") "9.0.0+rocq${rocq-core.rocq-version}")
     ] null;
 
   release."9.0.0+rocq9.0".sha256 = "sha256-ctnwpyNVhryEUA5YEsAImrcJsNMhtBgDSOz+z5Z4R78=";

--- a/pkgs/development/rocq-modules/iris/default.nix
+++ b/pkgs/development/rocq-modules/iris/default.nix
@@ -18,7 +18,7 @@ mkRocqDerivation {
     in
     with lib.versions;
     lib.switch rocq-core.rocq-version [
-      (case (range "9.0" "9.2") "4.5.0")
+      (case (range "9.0" "9.3") "4.5.0")
     ] null;
   release."4.5.0".sha256 = "sha256-oGqo+W1prLtAwRwo2U15VGhmrkDIPPE6uMbNrTa8iAQ=";
   releaseRev = v: "iris-${v}";

--- a/pkgs/development/rocq-modules/mathcomp-analysis/default.nix
+++ b/pkgs/development/rocq-modules/mathcomp-analysis/default.nix
@@ -31,7 +31,7 @@ let
     lib.switch
       [ rocq-core.rocq-version mathcomp.version ]
       [
-        (case (range "9.0" "9.2") (range "2.4.0" "2.6.0") "1.16.0")
+        (case (range "9.0" "9.3") (range "2.4.0" "2.6.0") "1.16.0")
       ]
       null;
 

--- a/pkgs/development/rocq-modules/parseque/default.nix
+++ b/pkgs/development/rocq-modules/parseque/default.nix
@@ -13,15 +13,13 @@ mkRocqDerivation {
 
   inherit version;
   defaultVersion =
-    lib.switch
-      [ rocq-core.rocq-version ]
-      [
-        {
-          cases = [ (lib.versions.range "9.0" "9.2") ];
-          out = "0.3.1";
-        }
-      ]
-      null;
+    let
+      case = case: out: { inherit case out; };
+    in
+    with lib.versions;
+    lib.switch rocq-core.rocq-version [
+      (case (range "9.0" "9.3") "0.3.1")
+    ] null;
 
   release."0.3.0".sha256 = "sha256-W2eenv5Q421eVn2ubbninFmmdT875f3w/Zs7yGHUKP4=";
   release."0.3.1".sha256 = "sha256-t7nHpHl6E3iXkhMO0A53URmKVpWENjf/VODVXjD9Y1A=";

--- a/pkgs/development/rocq-modules/stdlib/default.nix
+++ b/pkgs/development/rocq-modules/stdlib/default.nix
@@ -18,6 +18,7 @@ mkRocqDerivation {
     in
     with lib.versions;
     lib.switch rocq-core.version [
+      (case (range "9.3" "9.3") "9.2.0")
       (case (range "9.2" "9.2") "9.1.0")
       (case (range "9.0" "9.1") "9.0.0")
     ] null;
@@ -25,6 +26,7 @@ mkRocqDerivation {
 
   release."9.0.0".sha256 = "sha256-2l7ak5Q/NbiNvUzIVXOniEneDXouBMNSSVFbD1Pf8cQ=";
   release."9.1.0".sha256 = "sha256-D/kCMsJDg5OnP37GhvXIr2Fi/xCbgCCzoikKx5rL6p4=";
+  release."9.2.0".sha256 = "sha256-ySNY8XUQOH6B1B2p+39jdJ7UjIMrRDl499JJwpLEHuM=";
 
   mlPlugin = true;
 

--- a/pkgs/development/rocq-modules/stdpp/default.nix
+++ b/pkgs/development/rocq-modules/stdpp/default.nix
@@ -17,7 +17,7 @@ mkRocqDerivation {
     in
     with lib.versions;
     lib.switch rocq-core.rocq-version [
-      (case (range "9.0" "9.2") "1.13.0")
+      (case (range "9.0" "9.3") "1.13.0")
     ] null;
   release."1.13.0".sha256 = "sha256-kj8oBzarsLB4DDQ43yz4ViQbyzuISqext28wC2Fh3Sw=";
   releaseRev = v: "stdpp-${v}";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
