### PR TITLE
throttled: 0.11 -> 0.12.2

### DIFF
--- a/pkgs/by-name/th/throttled/package.nix
+++ b/pkgs/by-name/th/throttled/package.nix
@@ -2,63 +2,59 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  gobject-introspection,
   python3Packages,
   pciutils,
-  wrapGAppsNoGuiHook,
+  versionCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "throttled";
-  version = "0.11";
+  version = "0.12.2";
 
   src = fetchFromGitHub {
     owner = "erpalma";
     repo = "throttled";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-+3ktDkr5hvOfHcch4+mjgJqcuw24UgWTkJqTyDQumyk=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hwnJO9KEDOizpGcb9NYHYHoEEHKa3PkLt76cKpwgEUs=";
   };
 
-  nativeBuildInputs = [
-    gobject-introspection
-    python3Packages.wrapPython
-    wrapGAppsNoGuiHook
-  ];
+  nativeBuildInputs = [ python3Packages.wrapPython ];
 
-  pythonPath = with python3Packages; [
-    configparser
-    dbus-python
-    pygobject3
-  ];
+  pythonPath = [ python3Packages.dbus-fast ];
 
-  # The upstream unit both assumes the install location, and tries to run in a virtualenv
+  # The upstream unit assumes the /opt/throttled venv install location
   postPatch = ''
     sed -e 's|ExecStart=.*|ExecStart=${placeholder "out"}/bin/throttled.py|' -i systemd/throttled.service
 
-    substituteInPlace throttled.py --replace "'setpci'" "'${pciutils}/bin/setpci'"
+    substituteInPlace throttled.py --replace-fail "'setpci'" "'${lib.getExe' pciutils "setpci"}'"
   '';
 
   installPhase = ''
     runHook preInstall
+
     install -D -m755 -t $out/bin throttled.py
-    install -D -t $out/bin throttled.py mmio.py
+    install -D -m644 -t $out/bin mmio.py throttled_version.py
     install -D -m644 -t $out/etc etc/*
     install -D -m644 -t $out/lib/systemd/system systemd/*
+
     runHook postInstall
-  '';
-
-  dontWrapGApps = true;
-
-  preFixup = ''
-    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
   '';
 
   postFixup = "wrapPythonPrograms";
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  # the check run imports mmio/throttled_version next to the script; keep it
+  # from littering $out/bin with __pycache__ (the hook strips the environment)
+  env.PYTHONDONTWRITEBYTECODE = "1";
+  versionCheckKeepEnvironment = "PYTHONDONTWRITEBYTECODE";
+
   meta = {
     description = "Fix for Intel CPU throttling issues";
     homepage = "https://github.com/erpalma/throttled";
+    changelog = "https://github.com/erpalma/throttled/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
+    mainProgram = "throttled.py";
     platforms = [ "x86_64-linux" ];
     maintainers = [ ];
   };

--- a/pkgs/by-name/th/throttled/package.nix
+++ b/pkgs/by-name/th/throttled/package.nix
@@ -24,7 +24,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   # The upstream unit assumes the /opt/throttled venv install location
   postPatch = ''
-    sed -e 's|ExecStart=.*|ExecStart=${placeholder "out"}/bin/throttled.py|' -i systemd/throttled.service
+    substituteInPlace systemd/throttled.service \
+      --replace-fail '/opt/throttled/venv/bin/throttled' \
+      '${placeholder "out"}/bin/throttled.py'
 
     substituteInPlace throttled.py --replace-fail "'setpci'" "'${lib.getExe' pciutils "setpci"}'"
   '';


### PR DESCRIPTION
Upgrade throttled 0.11 -> 0.12.2 (release notes: [v0.12](https://github.com/erpalma/throttled/releases/tag/v0.12), [v0.12.1](https://github.com/erpalma/throttled/releases/tag/v0.12.1), [v0.12.2](https://github.com/erpalma/throttled/releases/tag/v0.12.2)).

Since 0.12.1 the daemon runs on [dbus-fast](https://github.com/Bluetooth-Devices/dbus-fast) instead of dbus-python + pygobject3, so the GLib/GObject wrapper machinery (gobject-introspection, wrapGAppsNoGuiHook) is dropped. 0.12.2 splits the version constant into `throttled_version.py`, imported by the daemon at startup, which must therefore be installed next to the script: a plain version+hash bump still builds and then crashes with ImportError when the service starts — which is why this supersedes #540564. versionCheckHook is added and catches exactly that class of breakage at build time.

Runtime-verified on a ThinkPad P53 (i7-9850H, Coffee Lake) through the `services.throttled` NixOS module: the daemon starts, detects the CPU, unlocks MSR writes and applies the configured undervolt/power limits.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`): `throttled.py --version`, plus the daemon runtime-tested on real hardware via the NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)