### PR TITLE
gwm: init at 1.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14354,6 +14354,12 @@
     githubId = 26346867;
     name = "K.B.Dharun Krishna";
   };
+  kbrdn1 = {
+    email = "kylianb1@icloud.com";
+    github = "kbrdn1";
+    githubId = 94058709;
+    name = "Kylian Bardini";
+  };
   kbudde = {
     email = "kris@budd.ee";
     github = "kbudde";

--- a/pkgs/by-name/gw/gwm/package.nix
+++ b/pkgs/by-name/gw/gwm/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  cmake,
+  perl,
+  installShellFiles,
+  makeWrapper,
+  gitMinimal,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "gwm";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "kbrdn1";
+    repo = "gwm-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-QQebYXTMfPZ2jwyVGf6orvHKPNYkyEJA3fhHOI6Pu94=";
+  };
+
+  cargoHash = "sha256-qSdcLGUkyBqjbNs71fLe35wVJtU3amaorMCDGfe8Sbs=";
+
+  __structuredAttrs = true;
+
+  # `git2` is built with the `vendored-libgit2` feature and `libz-sys` with
+  # `static`, so libgit2 and zlib are compiled from source: cmake and perl are
+  # all the C side needs, and there is no system libgit2/openssl to plumb.
+  nativeBuildInputs = [
+    cmake
+    perl
+    installShellFiles
+    makeWrapper
+  ];
+
+  # The CLI suite drives the real binary against real repos: it needs `git` on
+  # PATH (`gwm clean` gates on `git check-ignore`, and a missing git fails
+  # safe, silently skipping the reclaim the test asserts), and a writable HOME
+  # (the default `worktree.base` is `{home}/cc-worktree/{repo}`, which lands on
+  # the read-only /homeless-shelter without the hook).
+  nativeCheckInputs = [
+    gitMinimal
+    writableTmpDirAsHomeHook
+  ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  # gwm drives libgit2 for worktree operations but still shells out to `git`
+  # for sync, rename, clean and the TUI previews, so it is a runtime dep that
+  # no library-level dependency scan can infer.
+  postInstall = ''
+    wrapProgram $out/bin/gwm \
+      --prefix PATH : ${lib.makeBinPath [ gitMinimal ]}
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd gwm \
+      --bash <($out/bin/gwm completions bash) \
+      --fish <($out/bin/gwm completions fish) \
+      --zsh <($out/bin/gwm completions zsh)
+  '';
+
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Git worktree manager with a TUI and per-repo bootstrap";
+    longDescription = ''
+      gwm creates, lists and removes git worktrees from a per-repo `.gwm.toml`
+      manifest, bootstrapping each new worktree by copying untracked files
+      (such as `.env`), refusing to inherit dependency symlinks, and running
+      post-create hooks. It ships both a CLI and a ratatui-based TUI.
+    '';
+    homepage = "https://github.com/kbrdn1/gwm-cli";
+    # Per-version file, not the root CHANGELOG.md: upstream moves the entries
+    # into `changelogs/<version>.md` when cutting the release, leaving the root
+    # index empty at the tag.
+    changelog = "https://github.com/kbrdn1/gwm-cli/blob/v${finalAttrs.version}/changelogs/${finalAttrs.version}.md";
+    license = lib.licenses.mit;
+    mainProgram = "gwm";
+    maintainers = with lib.maintainers; [ kbrdn1 ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Supersedes #542900, which I accidentally killed: while bumping the init to the latest upstream release I force-pushed an amend made in a depth-1 clone, which rewrote the branch as a parentless root commit touching the whole tree. The branch was restored within minutes, but a PR whose head was force-pushed while closed cannot be reopened. No review feedback existed on it yet. The branch now carries the same two clean commits as before (`maintainers: add kbrdn1` + `gwm: init at 1.3.0`, one new file each).

Adds [gwm](https://github.com/kbrdn1/gwm-cli), a git worktree manager (Rust CLI + ratatui TUI) that creates worktrees from a per-repo `.gwm.toml` manifest and bootstraps each one by copying untracked files, refusing to inherit dependency symlinks, and running post-create hooks.

I am the upstream author and am adding myself as maintainer.

### Notes on the derivation

- **No system libgit2 / openssl.** `git2` is built with the `vendored-libgit2` feature and `libz-sys` with `static`, so libgit2 and zlib compile from source. `cmake` + `perl` cover the C side.
- **`git` is wrapped onto PATH.** gwm drives libgit2 for worktree operations but shells out to the `git` binary for sync, rename, clean and the TUI previews (14 call sites). It is a real runtime dependency that no library-level scan can infer, so it is wrapped rather than left to the user's environment.
- **Check phase needs `gitMinimal` + `writableTmpDirAsHomeHook`.** The suite drives the built binary against real repos. Without git on PATH, `gwm clean` (which gates on `git check-ignore`) fails safe and silently skips the reclaim a test asserts. Without a writable HOME, the default `worktree.base` of `{home}/cc-worktree/{repo}` resolves under the read-only `/homeless-shelter`. Both were found by running the build, not guessed.
- **`changelog` points at the per-version file**, not the root `CHANGELOG.md`: upstream moves entries into `changelogs/<version>.md` when cutting a release, so the root index is empty at the tag.
- `passthru.updateScript = nix-update-script { }` for version bumps.

### Things done

- Built on platform(s)
  - [x] aarch64-darwin
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - Full upstream test suite runs in the check phase (86 test binaries, 2100+ tests, all green).
  - `versionCheckHook` confirms `gwm --version` reports `1.3.0`.
  - Verified the wrapper puts `git-minimal` on PATH and that bash/zsh/fish completions install.
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` — n/a, new leaf package with no dependents.
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
