### PR TITLE
litestream: 0.5.11 -> 0.5.15, add konradmalik as maintainer

### DIFF
--- a/pkgs/by-name/li/litestream/package.nix
+++ b/pkgs/by-name/li/litestream/package.nix
@@ -6,13 +6,13 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "litestream";
-  version = "0.5.11";
+  version = "0.5.15";
 
   src = fetchFromGitHub {
     owner = "benbjohnson";
     repo = "litestream";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-LGlcc/FoBiZ7YiZUyqdYmAoV9BgUm4h2/n/KQ3NzFa4=";
+    hash = "sha256-SsHyi7E/1dHEzFQgKr8eSi1fEf61iqTQ6Avr4c/h9j4=";
   };
 
   ldflags = [
@@ -21,7 +21,7 @@ buildGoModule (finalAttrs: {
     "-X main.Version=${finalAttrs.version}"
   ];
 
-  vendorHash = "sha256-Zf7BdL0mljGFrRTx4JJxAUXUm6Uh/sVJP/zOJ4ef/CU=";
+  vendorHash = "sha256-Ms33rbFjsWzGbLy9v6kFGl6b62QQI4XAZ4wr73g5udw=";
 
   passthru.tests = { inherit (nixosTests) litestream; };
 

--- a/pkgs/by-name/li/litestream/package.nix
+++ b/pkgs/by-name/li/litestream/package.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   lib,
   nixosTests,
+  testers,
 }:
 buildGoModule (finalAttrs: {
   pname = "litestream";
@@ -23,13 +24,25 @@ buildGoModule (finalAttrs: {
 
   vendorHash = "sha256-Ms33rbFjsWzGbLy9v6kFGl6b62QQI4XAZ4wr73g5udw=";
 
-  passthru.tests = { inherit (nixosTests) litestream; };
+  # httptest servers in tests
+  __darwinAllowLocalNetworking = true;
+
+  passthru.tests = {
+    inherit (nixosTests) litestream;
+    version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      command = "litestream version";
+    };
+  };
 
   meta = {
     description = "Streaming replication for SQLite";
     mainProgram = "litestream";
     license = lib.licenses.asl20;
     homepage = "https://litestream.io/";
-    maintainers = with lib.maintainers; [ fbrs ];
+    maintainers = with lib.maintainers; [
+      fbrs
+      konradmalik
+    ];
   };
 })


### PR DESCRIPTION
https://github.com/benbjohnson/litestream/releases

- Added me as maintainer
- added simple version test for faster feedback on updates.
- https://github.com/NixOS/nixpkgs/pull/529653 - automatic update was not merged for quite some time, 0.5.11 has numerous bugs fixes in later versions.
- fixed test on darwin

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
