### PR TITLE
home-assistant-custom-components.mypyllant: 0.9.18 -> 0.9.19

### DIFF
--- a/pkgs/development/python-modules/mypyllant/default.nix
+++ b/pkgs/development/python-modules/mypyllant/default.nix
@@ -24,16 +24,16 @@
   requests,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "mypyllant";
-  version = "0.9.17";
+  version = "0.9.18";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "signalkraft";
     repo = "myPyllant";
-    tag = "v${version}";
-    hash = "sha256-C6/rCpY4Pn8j8dNo1mlz2GRzMBeMo9CZMitlmtuBRE0=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-wLdyajxakYvO27DOmWNk9QnGdprdKnQNZHKPFQg0yM8=";
   };
 
   build-system = [
@@ -66,8 +66,8 @@ buildPythonPackage rec {
   meta = {
     description = "Python library to interact with the API behind the myVAILLANT app";
     homepage = "https://github.com/signalkraft/myPyllant";
-    changelog = "https://github.com/signalkraft/myPyllant/releases/tag/${src.tag}";
+    changelog = "https://github.com/signalkraft/myPyllant/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ urbas ];
   };
-}
+})

--- a/pkgs/servers/home-assistant/custom-components/mypyllant/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/mypyllant/package.nix
@@ -16,16 +16,16 @@
   pytestCheckHook,
 }:
 
-buildHomeAssistantComponent rec {
+buildHomeAssistantComponent (finalAttrs: {
   owner = "signalkraft";
   domain = "mypyllant";
-  version = "0.9.18";
+  version = "0.9.19";
 
   src = fetchFromGitHub {
     owner = "signalkraft";
     repo = "mypyllant-component";
-    tag = "v${version}";
-    hash = "sha256-7huCAslbm5CLzArYMzSGkKPHlQoX6Qc0WLuv7e6OYLQ=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-7+KHmsgfGPIIWu+TTumswcaEoyQF9KvBVAKNGtNhZuQ=";
   };
 
   dependencies = [
@@ -44,9 +44,9 @@ buildHomeAssistantComponent rec {
 
   meta = {
     description = "Unofficial Home Assistant integration for interacting with myVAILLANT";
-    changelog = "https://github.com/signalkraft/mypyllant-component/releases/tag/${src.tag}";
+    changelog = "https://github.com/signalkraft/mypyllant-component/releases/tag/${finalAttrs.src.tag}";
     homepage = "https://github.com/signalkraft/mypyllant-component";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ urbas ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is a response to [this comment](https://github.com/NixOS/nixpkgs/pull/545030#issuecomment-5063525940) in the automated update PR #545030.

This PR updates the mypyllant-component (a Home Assistant custom component) from 0.9.18 to 0.9.19 and its upstream dependency mypyllant (a Python library package) from 0.9.17 to 0.9.18. Unfortunately, these two packages have to be updated in lock-step but they are not aligned on the same version (that's why the component is on 0.9.19 and the python library on 0.9.18).

I built and deployed this change on my personal Home Assistant deployment. I verified that it works there.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

I haven't used any AI for any part of this PR.