### PR TITLE
dms-greeter: init at 1.6.0

### DIFF
--- a/nixos/modules/services/display-managers/dms-greeter.nix
+++ b/nixos/modules/services/display-managers/dms-greeter.nix
@@ -44,19 +44,17 @@ let
       makeBinPath [
         cfg.quickshell.package
         compositorPkg
+        pkgs.glib # provides gdbus, used by the fprintd hardware probe and portal reads
       ]
     }
     ${
       escapeShellArgs (
         [
-          "sh"
-          "${cfg.package}/share/quickshell/dms/Modules/Greetd/assets/dms-greeter"
+          "${cfg.package}/bin/dms-greeter"
           "--cache-dir"
           cacheDir
           "--command"
           cfg.compositor.name
-          "-p"
-          "${cfg.package}/share/quickshell/dms"
         ]
         ++ lib.optionals (cfg.compositor.customConfig != "") [
           "-C"
@@ -114,21 +112,7 @@ in
   options.services.displayManager.dms-greeter = {
     enable = mkEnableOption "DankMaterialShell greeter";
 
-    package = mkOption {
-      type = types.package;
-      default = if cfgDms.enable then cfgDms.package else pkgs.dms-shell;
-      defaultText = literalExpression ''
-        if config.programs.dms-shell.enable
-        then config.programs.dms-shell.package
-        else pkgs.dms-shell;
-      '';
-      description = ''
-        The DankMaterialShell package to use for the greeter.
-
-        Defaults to the package from `programs.dms-shell` if it is enabled,
-        otherwise defaults to `pkgs.dms-shell`.
-      '';
-    };
+    package = lib.mkPackageOption pkgs "dms-greeter" { };
 
     compositor = {
       name = mkOption {

--- a/pkgs/by-name/dm/dms-greeter/package.nix
+++ b/pkgs/by-name/dm/dms-greeter/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenvNoCC,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "dms-greeter";
+  version = "1.6.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "AvengeMedia";
+    repo = "dank-greeter";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-XAd81SHwl7zChwpl+PXjePzV9bejy9e2WataOZJ+ioA=";
+    fetchSubmodules = true;
+  };
+
+  vendorHash = "sha256-Ort6y6BTKfuMRjDpTjY5tnCE5VAS4CItwo1U5dAvHpw=";
+
+  modRoot = "core";
+  subPackages = [ "cmd/dms-greeter" ];
+
+  tags = [ "withshell" ];
+
+  # Bakes the quickshell UI into the binary
+  preBuild = ''
+    make sync-shell
+  '';
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.Version=${finalAttrs.version}"
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  postInstall = lib.optionalString (stdenvNoCC.buildPlatform.canExecute stdenvNoCC.hostPlatform) ''
+    installShellCompletion --cmd dms-greeter \
+      --bash <($out/bin/dms-greeter completion bash) \
+      --fish <($out/bin/dms-greeter completion fish) \
+      --zsh <($out/bin/dms-greeter completion zsh)
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Greetd-based greeter for the Dank Material Linux suite";
+    homepage = "https://github.com/AvengeMedia/dank-greeter";
+    platforms = lib.platforms.linux;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ johnrtitor ];
+    teams = [ lib.teams.danklinux ];
+    mainProgram = "dms-greeter";
+  };
+})


### PR DESCRIPTION
Add dms-greeter standalone package. Derivation adapted from https://github.com/AvengeMedia/dank-greeter/blob/master/flake.nix

This is useful for those who only want the standalone greeter binary and not the whole shell. Since dms-greeter repo doesn't have tags yet, I used unstable versioning schema with DMS-shell version as base version.

I added the dank shell team as maintainer.

No longer applicable: ~AI Disclosure: Update script created with the assistance of Gemini 3.1 Pro~

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
