### PR TITLE
meta.problems: move unsupported platform support to meta.problems

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -653,7 +653,7 @@ let
       unsupported = hasUnsupportedPlatform' attrs;
       insecure = isMarkedInsecure attrs;
 
-      problems = completeMetaProblems config attrs;
+      problems = completeMetaProblems config hostPlatform attrs;
 
       available =
         validity.valid != "no"
@@ -701,11 +701,12 @@ let
     hostPlatform:
     let
       checkValidity' = checkValidity hostPlatform;
+      checkProblems' = checkProblems hostPlatform;
     in
     { meta, attrs }:
     let
       invalid = checkValidity' attrs;
-      problems = checkProblems attrs;
+      problems = checkProblems' attrs;
     in
     if invalid == null then
       if problems == null then

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -32,12 +32,7 @@ let
     ;
 
   inherit (lib.meta)
-    platformMatch
     cpeFullVersionWithVendor
-    ;
-
-  inherit (lib.generators)
-    toPretty
     ;
 
   inherit (builtins)
@@ -50,12 +45,11 @@ let
     completeMetaProblems
     ;
 
-
-    inherit (import ./remediation.nix { inherit lib; })
-      remediateOutputsToInstall
-      remediate_allowlist
-      remediate_predicate
-      remediate_insecure
+  inherit (import ./remediation.nix { inherit lib; })
+    remediateOutputsToInstall
+    remediate_allowlist
+    remediate_predicate
+    remediate_insecure
     ;
 
   checkProblems = genCheckProblems config;
@@ -105,9 +99,6 @@ let
 
   hasBlocklistedLicense = hasListedLicense blocklist;
 
-  allowUnsupportedSystem =
-    config.allowUnsupportedSystem || getEnv "NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM" == "1";
-
   isUnfree =
     licenses:
     if isAttrs licenses && licenses ? "licenseType" then
@@ -126,20 +117,6 @@ let
   hasUnfreeLicense = attrs: attrs ? meta.license && isUnfree attrs.meta.license;
 
   isMarkedBroken = attrs: attrs.meta.broken or false;
-
-  # Logical inversion of meta.availableOn for hostPlatform
-  hasUnsupportedPlatform =
-    hostPlatform:
-    let
-      inherit (hostPlatform) system;
-      # in almost all cases, meta.platforms is a simple list of strings, and we
-      # can just check if it contains the current system. we only run the more
-      # intensive platformMatch if necessary
-      anyHostPlatform = list: elem system list || any (platformMatch hostPlatform) list;
-    in
-    pkg:
-    pkg ? meta.platforms && !(anyHostPlatform pkg.meta.platforms)
-    || pkg ? meta.badPlatforms && anyHostPlatform pkg.meta.badPlatforms;
 
   isMarkedInsecure = attrs: (attrs.meta.knownVulnerabilities or [ ]) != [ ];
 
@@ -203,7 +180,6 @@ let
   showSourceType = showLicenseOrSourceType;
 
   pos_str = meta: meta.position or "«unknown-file»";
-
 
   metaType =
     let
@@ -305,11 +281,7 @@ let
   # !!! reason strings are hardcoded into OfBorg, make sure to keep them in sync
   # Along with a boolean flag for each reason
   checkValidity =
-    hostPlatform:
-    let
-      hasUnsupportedPlatform' = hasUnsupportedPlatform hostPlatform;
-    in
-    attrs:
+    hostPlatform: attrs:
     if !attrs ? meta then
       null
     else
@@ -350,23 +322,6 @@ let
         reason = "non-source";
         msg = "contains elements not built from source (‘${showSourceType attrs.meta.sourceProvenance}’)";
         remediation = remediate_allowlist "NonSource" (remediate_predicate "allowNonSourcePredicate" attrs);
-      }
-    else if hasUnsupportedPlatform' attrs && !allowUnsupportedSystem then
-      let
-        toPretty' = toPretty {
-          allowPrettyValues = true;
-          indent = "  ";
-        };
-      in
-      {
-        reason = "unsupported";
-        msg = ''
-          is not available on the requested hostPlatform:
-            hostPlatform.system = "${hostPlatform.system}"
-            package.meta.platforms = ${toPretty' (attrs.meta.platforms or [ ])}
-            package.meta.badPlatforms = ${toPretty' (attrs.meta.badPlatforms or [ ])}
-        '';
-        remediation = remediate_allowlist "UnsupportedSystem" "";
       }
     else if hasDisallowedInsecure attrs then
       {
@@ -415,9 +370,6 @@ let
   #   validity = checkMeta.assertValidity hostPlatform { inherit meta attrs; };
   commonMeta =
     hostPlatform:
-    let
-      hasUnsupportedPlatform' = hasUnsupportedPlatform hostPlatform;
-    in
     {
       validity,
       attrs,
@@ -556,7 +508,6 @@ let
       # Expose the result of the checks for everyone to see.
       unfree = hasUnfreeLicense attrs;
       broken = isMarkedBroken attrs;
-      unsupported = hasUnsupportedPlatform' attrs;
       insecure = isMarkedInsecure attrs;
 
       problems = completeMetaProblems config hostPlatform attrs;

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -11,8 +11,6 @@ let
     all
     attrValues
     concatMapStrings
-    concatStrings
-    filter
     findFirst
     getName
     length
@@ -51,6 +49,15 @@ let
     genCheckProblems
     completeMetaProblems
     ;
+
+
+    inherit (import ./remediation.nix { inherit lib; })
+      remediateOutputsToInstall
+      remediate_allowlist
+      remediate_predicate
+      remediate_insecure
+    ;
+
   checkProblems = genCheckProblems config;
 
   # If we're in hydra, we can dispense with the more verbose error
@@ -197,107 +204,6 @@ let
 
   pos_str = meta: meta.position or "«unknown-file»";
 
-  remediation_env_var =
-    allow_attr:
-    {
-      Unfree = "NIXPKGS_ALLOW_UNFREE";
-      UnsupportedSystem = "NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM";
-      NonSource = "NIXPKGS_ALLOW_NONSOURCE";
-    }
-    .${allow_attr};
-  remediation_phrase =
-    allow_attr:
-    {
-      Unfree = "unfree packages";
-      UnsupportedSystem = "packages that are unsupported for this system";
-      NonSource = "packages not built from source";
-    }
-    .${allow_attr};
-  remediate_predicate = predicateConfigAttr: attrs: ''
-
-    Alternatively you can configure a predicate to allow specific packages:
-      { nixpkgs.config.${predicateConfigAttr} = pkg: builtins.elem (lib.getName pkg) [
-          "${getName attrs}"
-        ];
-      }
-  '';
-
-  # flakeNote will be printed in the remediation messages below.
-  flakeNote = "
-   Note: When using `nix shell`, `nix build`, `nix develop`, etc with a flake,
-         then pass `--impure` in order to allow use of environment variables.
-    ";
-
-  remediate_allowlist = allow_attr: rebuild_amendment: ''
-    a) To temporarily allow ${remediation_phrase allow_attr}, you can use an environment variable
-       for a single invocation of the nix tools.
-
-         $ export ${remediation_env_var allow_attr}=1
-         ${flakeNote}
-    b) For `nixos-rebuild` you can set
-      { nixpkgs.config.allow${allow_attr} = true; }
-    in configuration.nix to override this.
-    ${rebuild_amendment}
-    c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
-      { allow${allow_attr} = true; }
-    to ~/.config/nixpkgs/config.nix.
-  '';
-
-  remediate_insecure =
-    attrs:
-    ''
-
-      Known issues:
-    ''
-    + (concatStrings (map (issue: " - ${issue}\n") attrs.meta.knownVulnerabilities))
-    + ''
-
-      You can install it anyway by allowing this package, using the
-      following methods:
-
-      a) To temporarily allow all insecure packages, you can use an environment
-         variable for a single invocation of the nix tools:
-
-           $ export NIXPKGS_ALLOW_INSECURE=1
-           ${flakeNote}
-      b) for `nixos-rebuild` you can add ‘${getNameWithVersion attrs}’ to
-         `nixpkgs.config.permittedInsecurePackages` in the configuration.nix,
-         like so:
-
-           {
-             nixpkgs.config.permittedInsecurePackages = [
-               "${getNameWithVersion attrs}"
-             ];
-           }
-
-      c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
-         ‘${getNameWithVersion attrs}’ to `permittedInsecurePackages` in
-         ~/.config/nixpkgs/config.nix, like so:
-
-           {
-             permittedInsecurePackages = [
-               "${getNameWithVersion attrs}"
-             ];
-           }
-
-    '';
-
-  remediateOutputsToInstall =
-    attrs:
-    let
-      expectedOutputs = attrs.meta.outputsToInstall or [ ];
-      actualOutputs = attrs.outputs or [ "out" ];
-      missingOutputs = filter (output: !elem output actualOutputs) expectedOutputs;
-    in
-    ''
-      The package ${getNameWithVersion attrs} has set meta.outputsToInstall to: ${builtins.concatStringsSep ", " expectedOutputs}
-
-      however ${getNameWithVersion attrs} only has the outputs: ${builtins.concatStringsSep ", " actualOutputs}
-
-      and is missing the following outputs:
-
-      ${concatStrings (map (output: "  - ${output}\n") missingOutputs)}
-    '';
 
   metaType =
     let

--- a/pkgs/stdenv/generic/problems.nix
+++ b/pkgs/stdenv/generic/problems.nix
@@ -52,6 +52,10 @@ rec {
     unique
     ;
 
+  inherit (lib.generators)
+    toPretty
+    ;
+
   inherit (lib.meta)
     platformMatch
     ;
@@ -133,6 +137,65 @@ rec {
           message = "This package is broken.";
         };
       };
+    };
+    unsupported = {
+      manualAllowed = true;
+      isUnique = true;
+      nixpkgsInternalUseAllowed = true;
+      automatic =
+        let
+          envAllowUnsupportedSystem = getEnv "NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM" == "1";
+          # Logical inversion of meta.availableOn for hostPlatform
+          hasUnsupportedPlatform =
+            hostPlatform:
+            let
+              inherit (hostPlatform) system;
+              # in almost all cases, meta.platforms is a simple list of strings, and we
+              # can just check if it contains the current system. we only run the more
+              # intensive platformMatch if necessary
+              anyHostPlatform = list: elem system list || any (platformMatch hostPlatform) list;
+            in
+            pkg:
+            pkg ? meta.platforms && !(anyHostPlatform pkg.meta.platforms)
+            || pkg ? meta.badPlatforms && anyHostPlatform pkg.meta.badPlatforms;
+        in
+        {
+          condition =
+            config:
+            let
+              allowUnsupportedSystem = config.allowUnsupportedSystem || envAllowUnsupportedSystem;
+            in
+            hostPlatform:
+            let
+              hasUnsupportedPlatform' = hasUnsupportedPlatform hostPlatform;
+            in
+            attrs: hasUnsupportedPlatform' attrs && !allowUnsupportedSystem;
+          value =
+            let
+              # lazily importing the library only when we need it for
+              # the actual message value. The import will be cached
+              # anyway and the thunk will only exist once unless there
+              # are multiple lines importing it.
+              inherit (import ./remediations.nix { inherit lib; }) remediate_allowlist;
+            in
+            _config: hostPlatform: attrs: {
+              message =
+                let
+                  toPretty' = toPretty {
+                    allowPrettyValues = true;
+                    indent = "  ";
+                  };
+                in
+                ''
+                  is not available on the requested hostPlatform:
+                    hostPlatform.system = "${hostPlatform.system}"
+                    package.meta.platforms = ${toPretty' (attrs.meta.platforms or [ ])}
+                    package.meta.badPlatforms = ${toPretty' (attrs.meta.badPlatforms or [ ])}
+                '';
+              # FIXME: add remediation support to meta.problems
+              remediation = remediate_allowlist "UnsupportedSystem" "";
+            };
+        };
     };
     removal = {
       manualAllowed = true;
@@ -580,6 +643,7 @@ rec {
               ${concatMapStringsSep "\n" (x: "- ${fullMessage x}") errorProblems}
             '';
             ## TODO: Add mention of problem.matchers, or maybe better link to docs of that
+            ## TODO: add remediation
             remediation = ''
               See also https://nixos.org/manual/nixpkgs/unstable#sec-problems
               To allow evaluation regardless, use:

--- a/pkgs/stdenv/generic/problems.nix
+++ b/pkgs/stdenv/generic/problems.nix
@@ -93,7 +93,9 @@ rec {
           && (attrs.meta.teams or [ ] == [ ])
           && (!attrs ? outputHash)
           && (attrs ? meta.description);
-        value.message = "This package has no declared maintainer, i.e. an empty `meta.maintainers` and `meta.teams` attribute.";
+        value = _config: _attrs: {
+          message = "This package has no declared maintainer, i.e. an empty `meta.maintainers` and `meta.teams` attribute.";
+        };
       };
     };
     broken = {
@@ -118,7 +120,9 @@ rec {
             attrs: attrs ? meta.broken && attrs.meta.broken && !allowBrokenPredicate attrs
           else
             attrs: attrs ? meta.broken && attrs.meta.broken;
-        value.message = "This package is broken.";
+        value = _config: _attrs: {
+          message = "This package is broken.";
+        };
       };
     };
     removal = {
@@ -151,7 +155,7 @@ rec {
   genAutomaticProblems =
     config: attrs:
     listToAttrs (
-      map (problem: lib.nameValuePair problem.kindName problem.value) (
+      map (problem: lib.nameValuePair problem.kindName (problem.value config attrs)) (
         filter (problem: problem.condition config attrs) automaticProblems
       )
     );

--- a/pkgs/stdenv/generic/problems.nix
+++ b/pkgs/stdenv/generic/problems.nix
@@ -52,6 +52,14 @@ rec {
     unique
     ;
 
+  inherit (lib.meta)
+    platformMatch
+    ;
+
+  inherit (builtins)
+    getEnv
+    ;
+
   handlers = rec {
     # Ordered from less to more
     levels = [
@@ -87,13 +95,13 @@ rec {
           # If `description` is not defined, the derivation is probably not a package.
           # Simply checking whether `meta` is defined is insufficient,
           # as some fetchers and trivial builders do define meta.
-          config: attrs:
+          config: _hostPlatform: attrs:
           # Order of checks optimised for short-circuiting the common case of having maintainers
           (attrs.meta.maintainers or [ ] == [ ])
           && (attrs.meta.teams or [ ] == [ ])
           && (!attrs ? outputHash)
           && (attrs ? meta.description);
-        value = _config: _attrs: {
+        value = _config: _hostPlatform: _attrs: {
           message = "This package has no declared maintainer, i.e. an empty `meta.maintainers` and `meta.teams` attribute.";
         };
       };
@@ -114,13 +122,14 @@ rec {
                 "config.allowBrokenPredicate is deprecated, use config.problems.handlers.myPackage.broken = \"warn\" for individual packages instead."
                 config.allowBrokenPredicate;
           in
+          _hostPlatform:
           if allowBroken then
             attrs: false
           else if config ? allowBrokenPredicate then
             attrs: attrs ? meta.broken && attrs.meta.broken && !allowBrokenPredicate attrs
           else
             attrs: attrs ? meta.broken && attrs.meta.broken;
-        value = _config: _attrs: {
+        value = _config: _hostPlatform: _attrs: {
           message = "This package is broken.";
         };
       };
@@ -153,10 +162,10 @@ rec {
   );
 
   genAutomaticProblems =
-    config: attrs:
+    config: hostPlatform: attrs:
     listToAttrs (
-      map (problem: lib.nameValuePair problem.kindName (problem.value config attrs)) (
-        filter (problem: problem.condition config attrs) automaticProblems
+      map (problem: lib.nameValuePair problem.kindName (problem.value config hostPlatform attrs)) (
+        filter (problem: problem.condition config hostPlatform attrs) automaticProblems
       )
     );
 
@@ -473,7 +482,7 @@ rec {
     };
 
   genCheckProblems =
-    config:
+    config: hostPlatform:
     let
       # This is here so that it gets cached for a (checkProblems config) thunk
       inherit (genHandlerSwitch config)
@@ -490,7 +499,7 @@ rec {
       automaticProblemsConfigCache = concatMap (
         problem:
         optional (elem problem.kindName configuredProblems) {
-          condition = problem.condition config;
+          condition = problem.condition config hostPlatform;
           handler = handlerForProblem problem.kindName problem.kindName;
         }
       ) automaticProblems;
@@ -515,7 +524,7 @@ rec {
       # Slow path, only here we actually figure out which problems we need to handle
       let
         pname = getName attrs;
-        problems = attrs.meta.problems or { } // genAutomaticProblems config attrs;
+        problems = attrs.meta.problems or { } // genAutomaticProblems config hostPlatform attrs;
         problemsToHandle = filter (v: v.handler != "ignore") (
           mapAttrsToList (name: problem: rec {
             inherit name;
@@ -529,9 +538,9 @@ rec {
       processProblems pname problemsToHandle;
 
   completeMetaProblems =
-    config: attrs:
+    config: hostPlatform: attrs:
     mapAttrs (name: problem: { kind = name; } // problem) (
-      (attrs.meta.problems or { }) // genAutomaticProblems config attrs
+      (attrs.meta.problems or { }) // genAutomaticProblems config hostPlatform attrs
     );
 
   processProblems =

--- a/pkgs/stdenv/generic/remediations.nix
+++ b/pkgs/stdenv/generic/remediations.nix
@@ -1,0 +1,115 @@
+{ lib }:
+let
+  inherit (lib)
+    getName
+    concatStrings
+    filter
+    elem
+    ;
+
+  # FIXME: duplicated across check-meta.nix and this file
+  getNameWithVersion =
+    attrs: attrs.name or "${attrs.pname or "«name-missing»"}-${attrs.version or "«version-missing»"}";
+
+  # flakeNote will be printed in the remediation messages below.
+  flakeNote = "
+   Note: When using `nix shell`, `nix build`, `nix develop`, etc with a flake,
+         then pass `--impure` in order to allow use of environment variables.
+    ";
+  remediation_env_var =
+    allow_attr:
+    {
+      Unfree = "NIXPKGS_ALLOW_UNFREE";
+      UnsupportedSystem = "NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM";
+      NonSource = "NIXPKGS_ALLOW_NONSOURCE";
+    }
+    .${allow_attr};
+  remediation_phrase =
+    allow_attr:
+    {
+      Unfree = "unfree packages";
+      UnsupportedSystem = "packages that are unsupported for this system";
+      NonSource = "packages not built from source";
+    }
+    .${allow_attr};
+in
+{
+  remediate_predicate = predicateConfigAttr: attrs: ''
+
+    Alternatively you can configure a predicate to allow specific packages:
+      { nixpkgs.config.${predicateConfigAttr} = pkg: builtins.elem (lib.getName pkg) [
+          "${getName attrs}"
+        ];
+      }
+  '';
+  remediate_allowlist = allow_attr: rebuild_amendment: ''
+    a) To temporarily allow ${remediation_phrase allow_attr}, you can use an environment variable
+       for a single invocation of the nix tools.
+
+         $ export ${remediation_env_var allow_attr}=1
+         ${flakeNote}
+    b) For `nixos-rebuild` you can set
+      { nixpkgs.config.allow${allow_attr} = true; }
+    in configuration.nix to override this.
+    ${rebuild_amendment}
+    c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
+      { allow${allow_attr} = true; }
+    to ~/.config/nixpkgs/config.nix.
+  '';
+
+  remediate_insecure =
+    attrs:
+    ''
+
+      Known issues:
+    ''
+    + (concatStrings (map (issue: " - ${issue}\n") attrs.meta.knownVulnerabilities))
+    + ''
+
+      You can install it anyway by allowing this package, using the
+      following methods:
+
+      a) To temporarily allow all insecure packages, you can use an environment
+         variable for a single invocation of the nix tools:
+
+           $ export NIXPKGS_ALLOW_INSECURE=1
+           ${flakeNote}
+      b) for `nixos-rebuild` you can add ‘${getNameWithVersion attrs}’ to
+         `nixpkgs.config.permittedInsecurePackages` in the configuration.nix,
+         like so:
+
+           {
+             nixpkgs.config.permittedInsecurePackages = [
+               "${getNameWithVersion attrs}"
+             ];
+           }
+
+      c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
+         ‘${getNameWithVersion attrs}’ to `permittedInsecurePackages` in
+         ~/.config/nixpkgs/config.nix, like so:
+
+           {
+             permittedInsecurePackages = [
+               "${getNameWithVersion attrs}"
+             ];
+           }
+
+    '';
+
+  remediateOutputsToInstall =
+    attrs:
+    let
+      expectedOutputs = attrs.meta.outputsToInstall or [ ];
+      actualOutputs = attrs.outputs or [ "out" ];
+      missingOutputs = filter (output: !elem output actualOutputs) expectedOutputs;
+    in
+    ''
+      The package ${getNameWithVersion attrs} has set meta.outputsToInstall to: ${builtins.concatStringsSep ", " expectedOutputs}
+
+      however ${getNameWithVersion attrs} only has the outputs: ${builtins.concatStringsSep ", " actualOutputs}
+
+      and is missing the following outputs:
+
+      ${concatStrings (map (output: "  - ${output}\n") missingOutputs)}
+    '';
+}

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -549,6 +549,11 @@ in
         kind = "removal";
         handler = "warn";
       }
+      # unsupported platforms should abort eval
+      {
+        kind = "unsupported";
+        handler = "error";
+      }
       (lib.mkIf (lib.elem "maintainerless" config.showDerivationWarnings) {
         kind = "maintainerless";
         handler = "warn";


### PR DESCRIPTION

## Things done

This is the initial draft of migrating the `meta.platforms` checks aka `unsupported` (platforms) into the new [RFC127](https://github.com/NixOS/rfcs/blob/master/rfcs/0127-issues-warnings.md) style `meta.problems`.

This is still missing support for
 * proper remediation messages like we used to have them. The way they are currently implemented in `problems.nix` isn't flexible enough yet. I'll work on that next.
 * it isn't enabled by default (see commit messages) 
 * there are no new tests for it yet but I've some locally and will add them once the kinks are ironed out
 * release notes making note of using the `matchers` facilities to deal with unsupported platform attributes. The current configuration via `nixpkgs.config` and the environment variables are still supported. We likely need at least one release cycles before we can deprecate them (if we want that).

This PR currently depends on #545182 as the test otherwise show false negatives when ran.

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
  - [x] `nix-build -A tests.problems`
- NixOS Release Notes
  - [ ] Make note in the matchers sections
  - [ ] Make a deprecation note on the old behaviour, probably first a `builtins.throw` warning when they are bing used (as authoritative override), then a failure and then rip them out for good in N+2 releases?
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy]. No AI was used for this work :)

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
