### PR TITLE
vscode-extensions.ms-dotnettools.csharp: write install.Lock into $out

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/ms-dotnettools.csharp/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-dotnettools.csharp/default.nix
@@ -38,9 +38,11 @@ let
   #       everyone to reuse.
   roslyn-copilot = fetchzip {
     url = "https://roslyn.blob.core.windows.net/releases/Microsoft.VisualStudio.Copilot.Roslyn.LanguageServer-18.3.72-alpha.zip";
-    hash = "sha256-Eh1XaF9eCN5saTrIf4NeZZKDeiEvrTo0m+vOiM5QZoI=";
+    hash = "sha256-vzowJOPp/VVeWkPihvWX2jvTrbFMZMtgX03eLezdanE=";
+    # Must be written to $out: fetchzip runs postFetch with cwd = $TMPDIR/unpack,
+    # which stripRoot has already emptied by moving the payload to $out.
     postFetch = ''
-      touch install.Lock
+      touch "$out/install.Lock"
     '';
   };
 in


### PR DESCRIPTION
`roslyn-copilot`'s `postFetch` writes `install.Lock` with a **relative path**, so the marker never reaches the output.

`fetchzip` runs a package's `postFetch` with cwd = `$TMPDIR/unpack`, and with the default `stripRoot = true` it has already moved the payload to `$out` by that point — leaving that directory empty. `touch install.Lock` therefore creates a file in the build tree which is discarded, and the fetch output keeps matching its pinned hash. The extension ships `.roslynCopilot/` containing only the DLL.

That matters because the extension's runtime-dependency installer treats a component as installed only when `<installPath>/install.Lock` exists. Without it, `.roslynCopilot` is considered not-installed, so on activation the installer tries to `touch .roslynCopilot/install.Begin`. On a read-only store (VS Code with `mutableExtensionsDir = false`) that fails with `EROFS` and the extension reports ".NET debugging will not be enabled".

Writing the marker into `$out` changes the fetch output, hence the new hash.

Before:

```console
$ ls result/share/vscode/extensions/ms-dotnettools.csharp/.roslynCopilot/
Microsoft.VisualStudio.Copilot.Roslyn.LanguageServer.dll
```

After:

```console
$ ls result/share/vscode/extensions/ms-dotnettools.csharp/.roslynCopilot/
install.Lock  Microsoft.VisualStudio.Copilot.Roslyn.LanguageServer.dll
```

The scope is deliberately narrow. Making `fetchzip` `cd "$out"` before running `postFetch` would fix this class of mistake generally, but it would silently change behaviour for every package whose `postFetch` relies on the current cwd — and a grep of `postFetch` blocks across Nixpkgs found this to be the only relative-path *content* write; the other hits are deliberate scratch use (`$GNUPGHOME`, `$TMPDIR/…`, `unpackDir`). So this fixes the caller rather than the contract.

Found while carrying a downstream overlay that worked around the missing marker; the overlay can be dropped once this lands.

<sup>Disclosure: this pull request summary was written with assistance from Claude Code (Claude Opus 4.8). The change itself carries an `Assisted-by:` trailer per the automation/AI policy.</sup>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
