### PR TITLE
fstar: fix build of z3-4.8.5 after setuptool update

### DIFF
--- a/pkgs/by-name/fs/fstar/z3/default.nix
+++ b/pkgs/by-name/fs/fstar/z3/default.nix
@@ -64,6 +64,18 @@ let
           ]
           ++ [
             ./4-8-5-typos.diff
+            (fetchpatch {
+              url = "https://github.com/Z3Prover/z3/commit/40183d7b73fcc4020b4d4b2e658b24a8c4b648ee.patch";
+              hash = "sha256-+VpPYUBVAVB9BQIp+phmL6IAEc0RC+YoUVCIsIe5TSQ=";
+            })
+            (fetchpatch {
+              url = "https://github.com/Z3Prover/z3/commit/03ae6d86cb4db88c71d6b245e29400e9a44cb59f.patch";
+              hash = "sha256-nNjkQpaSCyAqnPEZcRtG+cMTPeA+CQfvmNUe5fAK93Q=";
+            })
+            (fetchpatch {
+              url = "https://github.com/Z3Prover/z3/commit/f6c9ead10c0cf904925d7495f5c08dae66643b7a.patch";
+              hash = "sha256-eUeFayyfdg9Q8s97H6khBXst9nLYWM7NSEoQ2btMHEE=";
+            })
           ];
 
         postPatch =


### PR DESCRIPTION
`fstar.z3` has been broken since #521373. This applies upstream patches and fixes it.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
