### PR TITLE
protonplus: 0.5.21 -> 0.6.5

### DIFF
--- a/pkgs/by-name/pr/protonplus/package.nix
+++ b/pkgs/by-name/pr/protonplus/package.nix
@@ -17,16 +17,19 @@
   libarchive,
   libgee,
   libsoup_3,
+  sdl3,
+  libnotify,
+  appstream,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "protonplus";
-  version = "0.5.21";
+  version = "0.6.5";
 
   src = fetchFromGitHub {
     owner = "Vysp3r";
     repo = "protonplus";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-elc2hDAiMT15bAZW4z55K9EsTRmHeU3YBccTx2GMTIE=";
+    hash = "sha256-9KHtPG/gTtNjYCuStpb4tO3BiB09cSsTk7PpnX8o7qI=";
   };
 
   nativeBuildInputs = [
@@ -47,6 +50,9 @@ stdenv.mkDerivation (finalAttrs: {
     libarchive
     libgee
     libsoup_3
+    sdl3
+    libnotify
+    appstream
   ];
 
   passthru = {


### PR DESCRIPTION
Release notes:
- https://github.com/Vysp3r/ProtonPlus/releases/tag/v0.5.22
-  https://github.com/Vysp3r/ProtonPlus/releases/tag/v0.6.0
-  https://github.com/Vysp3r/ProtonPlus/releases/tag/v0.6.1
-  https://github.com/Vysp3r/ProtonPlus/releases/tag/v0.6.1-1
-  https://github.com/Vysp3r/ProtonPlus/releases/tag/v0.6.2
- https://github.com/Vysp3r/ProtonPlus/releases/tag/v0.6.3
- https://github.com/Vysp3r/ProtonPlus/releases/tag/v0.6.4
- https://github.com/Vysp3r/ProtonPlus/releases/tag/v0.6.5

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
