### PR TITLE
python3Packages.{httpcore2,httpx2}: 2.5.0 -> 2.9.1

### DIFF
--- a/pkgs/development/python-modules/httpcore2/default.nix
+++ b/pkgs/development/python-modules/httpcore2/default.nix
@@ -29,14 +29,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "httpcore2";
-  version = "2.5.0";
+  version = "2.9.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pydantic";
     repo = "httpx2";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-vIWAUjHPyafbeeUc2OvGpkiOoTj1fTniRnQiKSdkm6s=";
+    hash = "sha256-3kghDQMYksF9a4sFGajzNfGPOjdX1OiMwv7rH/fbmM0=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/httpx2/default.nix
+++ b/pkgs/development/python-modules/httpx2/default.nix
@@ -24,14 +24,17 @@
   pygments,
   rich,
   socksio,
+  wsproto,
   zstandard,
 
   # tests
   chardet,
   pytestCheckHook,
   pytest-trio,
+  starlette,
   trustme,
   uvicorn,
+  websockets,
 
   # reverse deps
   httpx2,
@@ -39,14 +42,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "httpx2";
-  version = "2.5.0";
+  version = "2.9.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pydantic";
     repo = "httpx2";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-vIWAUjHPyafbeeUc2OvGpkiOoTj1fTniRnQiKSdkm6s=";
+    hash = "sha256-3kghDQMYksF9a4sFGajzNfGPOjdX1OiMwv7rH/fbmM0=";
   };
 
   postPatch = ''
@@ -75,6 +78,7 @@ buildPythonPackage (finalAttrs: {
     ];
     http2 = [ h2 ];
     socks = [ socksio ];
+    ws = [ wsproto ];
     zstd = lib.optionals (pythonOlder "3.14") [ zstandard ];
   };
 
@@ -89,10 +93,11 @@ buildPythonPackage (finalAttrs: {
   nativeCheckInputs = [
     chardet
     pytestCheckHook
-    # pytest-httpbin
     pytest-trio
+    (starlette.overridePythonAttrs { doCheck = false; })
     trustme
     uvicorn
+    websockets
   ]
   ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
 


### PR DESCRIPTION
https://github.com/pydantic/httpx2/blob/v2.9.1/src/httpcore2/CHANGELOG.md
https://github.com/pydantic/httpx2/blob/v2.9.1/src/httpx2/CHANGELOG.md

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
