### PR TITLE
curd: init at 2.0.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6090,6 +6090,12 @@
     github = "dadada";
     githubId = 7216772;
   };
+  dageus = {
+    email = "jomouzio@gmail.com";
+    github = "Dageus";
+    githubId = 101069446;
+    name = "João Miguel Nogueira";
+  };
   dalance = {
     email = "dalance@gmail.com";
     github = "dalance";

--- a/pkgs/by-name/cu/curd/package.nix
+++ b/pkgs/by-name/cu/curd/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  makeWrapper,
+  mpv,
+  rofi,
+  ueberzugpp,
+  testers,
+  curd,
+}:
+
+buildGoModule (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "curd";
+  version = "2.0.2";
+
+  src = fetchFromGitHub {
+    owner = "Wraient";
+    repo = "curd";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-yuHWluuJMWBr4wVRa8yEphpkef0YZrSilpCybMRS6o4=";
+  };
+
+  vendorHash = null;
+
+  subPackages = [ "cmd/curd" ];
+
+  ldflags = [
+    "-X main.version=${finalAttrs.version}"
+    "-s"
+    "-w"
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/curd \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          mpv
+          rofi
+          ueberzugpp
+        ]
+      }
+  '';
+
+  passthru.tests = {
+    version = testers.testVersion {
+      package = curd;
+      command = ''
+        export HOME=$(mktemp -d)
+        curd -v
+      '';
+    };
+  };
+
+  meta = {
+    description = "Watch anime in CLI with AniList Tracking, MAL Integration and Discord RPC";
+    homepage = "https://github.com/Wraient/curd";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ dageus ];
+    mainProgram = "curd";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
This PR introduces `curd`, a terminal-based anime media player and tracker written in Go. It integrates with AniList, MAL, and Discord RPC, and uses `mpv`, `rofi`, and `ueberzugpp` under the hood. 

Homepage: [https://github.com/Wraient/curd](https://github.com/Wraient/curd)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
