### PR TITLE
kenku-fm: init at 1.5.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6246,6 +6246,12 @@
     githubId = 160084;
     name = "Daniel Sidhion";
   };
+  DanielTallon = {
+    email = "fredrick.martin.shultz@gmail.com";
+    github = "DanielTallon";
+    githubId = 269919984;
+    name = "Fredrick Martin-Shultz";
+  };
   danihek = {
     email = "danihek07@gmail.com";
     github = "danihek";


### PR DESCRIPTION
## Motivation for this change
This adds `kenku-fm`, a tool for playing music over a discord channel.
This resolves stale issue #259472 by using the binary `.deb` distribution to avoid non-reproducible hash errors with the proprietary Castlabs Electron dependency.

## Things done
<!-- Please check what applies. Note that these are not hard requirements but mandatory. -->
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- [x] Built on platform(s): x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)
- [x] Added myself to `maintainers/maintainer-list.nix`
- [x] Package is marked `unfree` (requires `allowUnfree = true`)

## Notes
- This package includes proprietary DRM components.
- The `--no-sandbox` flag is added by default to ensure functionality.   