### PR TITLE
rtk: fix build with Rust 1.97

### DIFF
--- a/pkgs/by-name/rt/rtk/package.nix
+++ b/pkgs/by-name/rt/rtk/package.nix
@@ -24,6 +24,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-XKUKdhxfnwUCOx9slqx4oUFa09HcosPLVh5Xkh87oSk=";
 
+  # Rust 1.97's dead_code_pub_in_binary analysis exposes dead code in test builds.
+  # Fixed upstream on develop after 0.43.0:
+  # https://github.com/rtk-ai/rtk/commit/73b8cb3069297374a3de58552b9fe4aa2cda3a41
+  # TODO: Remove RUSTFLAGS when updating rtk to the next release.
+  env.RUSTFLAGS = "--cap-lints warn";
+
   nativeBuildInputs = [
     makeWrapper
     pkg-config


### PR DESCRIPTION
Rust 1.97 changed dead-code analysis for binary test targets. As a result, building `rtk` 0.43.0 fails because its `warnings = "deny"` policy promotes two dead-code warnings to errors.

This change caps those lints at warning level while preserving the full test suite. The underlying issue is already fixed on the upstream `develop` branch by [rtk-ai/rtk@73b8cb3](https://github.com/rtk-ai/rtk/commit/73b8cb3069297374a3de58552b9fe4aa2cda3a41). A `TODO` records that the temporary `RUSTFLAGS` workaround must be removed during the next `rtk` version update.

> @GaetanLepage
> Resolve issue https://github.com/NixOS/nixpkgs/issues/545229

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] Package test suite through `checkPhase`: 2,287 tests passed, 0 failed, 8 ignored.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - `versionCheckHook` successfully ran `rtk --version` and found `rtk 0.43.0`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test