### PR TITLE
python3Packages.pandas-stubs: pin pytest to 9.0

### DIFF
--- a/pkgs/development/python-modules/pandas-stubs/default.nix
+++ b/pkgs/development/python-modules/pandas-stubs/default.nix
@@ -12,7 +12,8 @@
   types-pytz,
 
   # tests
-  pytestCheckHook,
+  # pytestCheckHook,
+  pytest9_0CheckHook,
   beautifulsoup4,
   html5lib,
   jinja2,
@@ -32,7 +33,14 @@
   xarray,
   xlsxwriter,
 }:
-
+let
+  # pytest 9.1 turns non-list/tuple argvalues in @parametrize into
+  # PytestRemovedIn10Warning, which pandas-stubs' warning filter treats
+  # as a fatal error during test collection.
+  # Pin to 9.0 until upstream converts the affected
+  # generators to lists/tuples
+  pytestCheckHook = pytest9_0CheckHook;
+in
 buildPythonPackage rec {
   pname = "pandas-stubs";
   version = "3.0.3.260530";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I have pinned the pytest to 9.0.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
