### PR TITLE
caribou: drop gtk2 module

### DIFF
--- a/pkgs/by-name/ca/caribou/package.nix
+++ b/pkgs/by-name/ca/caribou/package.nix
@@ -13,7 +13,6 @@
   libxml2,
   libxklavier,
   libxtst,
-  gtk2,
   intltool,
   libxslt,
   at-spi2-core,
@@ -82,13 +81,14 @@ stdenv.mkDerivation (finalAttrs: {
     pythonEnv
     python3.pkgs.pygobject3
     libxtst
-    gtk2
   ];
 
   propagatedBuildInputs = [
     libgee
     libxklavier
   ];
+
+  configureFlags = [ "--enable-gtk2-module=no" ];
 
   postPatch = ''
     patchShebangs .


### PR DESCRIPTION
Closes #545113
Part of #410814

Looks like `caribou` supports not compiling GTK2 module, and we don't have GTK2 programs depending on it, should be safe to drop GTK2 module without making `cinnamon-screensaver` lose virtual keyboard

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
