### PR TITLE
stalwart_0_16: install webui to webui.zip instead of webui.tar.gz

### DIFF
--- a/pkgs/by-name/st/stalwart_0_16/webui.nix
+++ b/pkgs/by-name/st/stalwart_0_16/webui.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildNpmPackage,
-  gnutar,
+  zip,
   stalwart_0_16,
   fetchFromGitHub,
   nix-update-script,
@@ -27,7 +27,7 @@ buildNpmPackage (finalAttrs: {
     VITE_OAUTH_CLIENT_ID = "stalwart-webui";
   };
 
-  nativeBuildInputs = [ gnutar ];
+  nativeBuildInputs = [ zip ];
   preBuild = ''
     rm .env.development
   '';
@@ -42,7 +42,9 @@ buildNpmPackage (finalAttrs: {
   installPhase = ''
     runHook preInstall
     mkdir -p $out
-    tar -czvf $out/webui.tar.gz dist
+    cd dist
+    zip -r $out/webui.zip *
+    cd ..
     runHook postInstall
   '';
 


### PR DESCRIPTION
Stalwart only knows about zip...
Was an original commit slop?

Resource error (resource.error) {
  causedBy = "crates/common/src/manager/application.rs:253",
  reason = "invalid Zip archive: Could not find EOCD",
  url = "file:///nix/store/h5c2hza661m829v1jin9qszyy74mqq02-webui-1.0.4/webui.tar.gz",
  details = "Failed to decompress application bundle"
}

test with something like:
```nix
(destroy "Application" {})
(create "Application" {
  "app-a" = {
    enabled = true;
    description = "Stalwart Web Application";
    resourceUrl = "file://${webui}/webui.zip";
    urlPrefix = {
      "/admin" = true;
      "/account" = true;
    };
  };
})
```

NOTE: I made this patch through github webui and haven't actually build it, but similar overlay works for me, so this should work too.

Also that one webadmin that is for stalwart 0.15 is shipped in zip format too, idk why this one was packaged in .tar.gz


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
