### PR TITLE
wezterm: add darwin signing warning for notifications

### DIFF
--- a/pkgs/by-name/we/wezterm/package.nix
+++ b/pkgs/by-name/we/wezterm/package.nix
@@ -26,142 +26,147 @@
   zlib,
 }:
 
-rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "wezterm";
-  version = "0-unstable-2026-07-16";
+lib.warnIf (stdenv.hostPlatform.isDarwin)
+  "wezterm: this build is not code-signed, so macOS notifications (UNUserNotificationCenter) will not work. See https://github.com/wez/wezterm/issues/6731."
 
-  src = fetchFromGitHub {
-    owner = "wezterm";
-    repo = "wezterm";
-    rev = "76b606ec597a3c0263fa60321548637451c0a547";
-    fetchSubmodules = true;
-    hash = "sha256-FLU1R78C1xLPsJ1udBk9bW0BbVry4lGiC0kvPfMI66c=";
-  };
+  (
+    rustPlatform.buildRustPackage (finalAttrs: {
+      pname = "wezterm";
+      version = "0-unstable-2026-07-16";
 
-  postPatch = ''
-    echo ${finalAttrs.version} > .tag
+      src = fetchFromGitHub {
+        owner = "wezterm";
+        repo = "wezterm";
+        rev = "76b606ec597a3c0263fa60321548637451c0a547";
+        fetchSubmodules = true;
+        hash = "sha256-FLU1R78C1xLPsJ1udBk9bW0BbVry4lGiC0kvPfMI66c=";
+      };
 
-    # hash does not work well with NixOS
-    substituteInPlace assets/shell-integration/wezterm.sh \
-      --replace-fail 'hash wezterm 2>/dev/null' 'command type -P wezterm &>/dev/null' \
-      --replace-fail 'hash base64 2>/dev/null' 'command type -P base64 &>/dev/null' \
-      --replace-fail 'hash hostname 2>/dev/null' 'command type -P hostname &>/dev/null' \
-      --replace-fail 'hash hostnamectl 2>/dev/null' 'command type -P hostnamectl &>/dev/null'
-  ''
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    # many tests fail with: No such file or directory
-    rm -r wezterm-ssh/tests
-  '';
+      postPatch = ''
+        echo ${finalAttrs.version} > .tag
 
-  # dep: syntax causes build failures in rare cases
-  # https://github.com/rust-secure-code/cargo-auditable/issues/124
-  # https://github.com/wezterm/wezterm/blob/main/nix/flake.nix#L134
-  auditable = false;
+        # hash does not work well with NixOS
+        substituteInPlace assets/shell-integration/wezterm.sh \
+          --replace-fail 'hash wezterm 2>/dev/null' 'command type -P wezterm &>/dev/null' \
+          --replace-fail 'hash base64 2>/dev/null' 'command type -P base64 &>/dev/null' \
+          --replace-fail 'hash hostname 2>/dev/null' 'command type -P hostname &>/dev/null' \
+          --replace-fail 'hash hostnamectl 2>/dev/null' 'command type -P hostnamectl &>/dev/null'
+      ''
+      + lib.optionalString stdenv.hostPlatform.isDarwin ''
+        # many tests fail with: No such file or directory
+        rm -r wezterm-ssh/tests
+      '';
 
-  cargoHash = "sha256-jY7lTOfbT74tAZ7he1xudCN7BUxZBzY+8+e1d2g2v4I=";
+      # dep: syntax causes build failures in rare cases
+      # https://github.com/rust-secure-code/cargo-auditable/issues/124
+      # https://github.com/wezterm/wezterm/blob/main/nix/flake.nix#L134
+      auditable = false;
 
-  nativeBuildInputs = [
-    installShellFiles
-    ncurses # tic for terminfo
-    pkg-config
-    python3
-  ]
-  ++ lib.optional stdenv.hostPlatform.isDarwin perl;
+      cargoHash = "sha256-jY7lTOfbT74tAZ7he1xudCN7BUxZBzY+8+e1d2g2v4I=";
 
-  buildInputs = [
-    fontconfig
-    openssl
-    zlib
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
-    libx11
-    libxcb
-    libxkbcommon
-    wayland
-    libxcb-util
-    libxcb-image
-    libxcb-keysyms
-    libxcb-wm # contains xcb-ewmh among others
-  ];
-
-  buildFeatures = [ "distro-defaults" ];
-
-  postInstall = ''
-    mkdir -p $out/nix-support
-    echo "${finalAttrs.passthru.terminfo}" >> $out/nix-support/propagated-user-env-packages
-
-    install -Dm644 assets/icon/terminal.png $out/share/icons/hicolor/128x128/apps/org.wezfurlong.wezterm.png
-    install -Dm644 assets/wezterm.desktop $out/share/applications/org.wezfurlong.wezterm.desktop
-    install -Dm644 assets/wezterm.appdata.xml $out/share/metainfo/org.wezfurlong.wezterm.appdata.xml
-
-    install -Dm644 assets/shell-integration/wezterm.sh -t $out/etc/profile.d
-    installShellCompletion --cmd wezterm \
-      --bash assets/shell-completion/bash \
-      --fish assets/shell-completion/fish \
-      --zsh assets/shell-completion/zsh
-
-    install -Dm644 assets/wezterm-nautilus.py -t $out/share/nautilus-python/extensions
-  '';
-
-  preFixup =
-    lib.optionalString stdenv.hostPlatform.isLinux ''
-      patchelf \
-        --add-needed "${libGL}/lib/libEGL.so.1" \
-        --add-needed "${vulkan-loader}/lib/libvulkan.so.1" \
-        $out/bin/wezterm-gui
-    ''
-    + lib.optionalString stdenv.hostPlatform.isDarwin ''
-      mkdir -p "$out/Applications"
-      OUT_APP="$out/Applications/WezTerm.app"
-      cp -r assets/macos/WezTerm.app "$OUT_APP"
-      rm $OUT_APP/*.dylib
-      cp -r assets/shell-integration/* "$OUT_APP"
-      # https://github.com/wezterm/wezterm/pull/6886
-      # macOS will only recognize our application bundle
-      # if the binaries are inside of it. Move them there
-      # and create symbolic links for them in bin/.
-      mv $out/bin/{wezterm,wezterm-mux-server,wezterm-gui,strip-ansi-escapes} "$OUT_APP"
-      ln -s "$OUT_APP"/{wezterm,wezterm-mux-server,wezterm-gui,strip-ansi-escapes} "$out/bin"
-    '';
-
-  passthru = {
-    # the headless variant is useful when deploying wezterm's mux server on remote severs
-    headless = import ./headless.nix {
-      inherit
-        openssl
+      nativeBuildInputs = [
+        installShellFiles
+        ncurses # tic for terminfo
         pkg-config
-        rustPlatform
-        wezterm
-        ;
-    };
+        python3
+      ]
+      ++ lib.optional stdenv.hostPlatform.isDarwin perl;
 
-    terminfo =
-      runCommand "wezterm-terminfo"
-        {
-          nativeBuildInputs = [ ncurses ];
-        }
+      buildInputs = [
+        fontconfig
+        openssl
+        zlib
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isLinux [
+        libx11
+        libxcb
+        libxkbcommon
+        wayland
+        libxcb-util
+        libxcb-image
+        libxcb-keysyms
+        libxcb-wm # contains xcb-ewmh among others
+      ];
+
+      buildFeatures = [ "distro-defaults" ];
+
+      postInstall = ''
+        mkdir -p $out/nix-support
+        echo "${finalAttrs.passthru.terminfo}" >> $out/nix-support/propagated-user-env-packages
+
+        install -Dm644 assets/icon/terminal.png $out/share/icons/hicolor/128x128/apps/org.wezfurlong.wezterm.png
+        install -Dm644 assets/wezterm.desktop $out/share/applications/org.wezfurlong.wezterm.desktop
+        install -Dm644 assets/wezterm.appdata.xml $out/share/metainfo/org.wezfurlong.wezterm.appdata.xml
+
+        install -Dm644 assets/shell-integration/wezterm.sh -t $out/etc/profile.d
+        installShellCompletion --cmd wezterm \
+          --bash assets/shell-completion/bash \
+          --fish assets/shell-completion/fish \
+          --zsh assets/shell-completion/zsh
+
+        install -Dm644 assets/wezterm-nautilus.py -t $out/share/nautilus-python/extensions
+      '';
+
+      preFixup =
+        lib.optionalString stdenv.hostPlatform.isLinux ''
+          patchelf \
+            --add-needed "${libGL}/lib/libEGL.so.1" \
+            --add-needed "${vulkan-loader}/lib/libvulkan.so.1" \
+            $out/bin/wezterm-gui
         ''
-          mkdir -p $out/share/terminfo $out/nix-support
-          tic -x -o $out/share/terminfo ${finalAttrs.src}/termwiz/data/wezterm.terminfo
+        + lib.optionalString stdenv.hostPlatform.isDarwin ''
+          mkdir -p "$out/Applications"
+          OUT_APP="$out/Applications/WezTerm.app"
+          cp -r assets/macos/WezTerm.app "$OUT_APP"
+          rm $OUT_APP/*.dylib
+          cp -r assets/shell-integration/* "$OUT_APP"
+          # https://github.com/wezterm/wezterm/pull/6886
+          # macOS will only recognize our application bundle
+          # if the binaries are inside of it. Move them there
+          # and create symbolic links for them in bin/.
+          mv $out/bin/{wezterm,wezterm-mux-server,wezterm-gui,strip-ansi-escapes} "$OUT_APP"
+          ln -s "$OUT_APP"/{wezterm,wezterm-mux-server,wezterm-gui,strip-ansi-escapes} "$out/bin"
         '';
 
-    tests = {
-      all-terminfo = nixosTests.allTerminfo;
-      # the test is commented out in nixos/tests/terminal-emulators.nix
-      #terminal-emulators = nixosTests.terminal-emulators.wezterm;
-    };
+      passthru = {
+        # the headless variant is useful when deploying wezterm's mux server on remote severs
+        headless = import ./headless.nix {
+          inherit
+            openssl
+            pkg-config
+            rustPlatform
+            wezterm
+            ;
+        };
 
-    updateScript = ./update.sh;
-  };
+        terminfo =
+          runCommand "wezterm-terminfo"
+            {
+              nativeBuildInputs = [ ncurses ];
+            }
+            ''
+              mkdir -p $out/share/terminfo $out/nix-support
+              tic -x -o $out/share/terminfo ${finalAttrs.src}/termwiz/data/wezterm.terminfo
+            '';
 
-  meta = {
-    description = "GPU-accelerated cross-platform terminal emulator and multiplexer written by @wez and implemented in Rust";
-    homepage = "https://wezterm.org";
-    license = lib.licenses.mit;
-    mainProgram = "wezterm";
-    maintainers = with lib.maintainers; [
-      SuperSandro2000
-      yvnth
-    ];
-  };
-})
+        tests = {
+          all-terminfo = nixosTests.allTerminfo;
+          # the test is commented out in nixos/tests/terminal-emulators.nix
+          #terminal-emulators = nixosTests.terminal-emulators.wezterm;
+        };
+
+        updateScript = ./update.sh;
+      };
+
+      meta = {
+        description = "GPU-accelerated cross-platform terminal emulator and multiplexer written by @wez and implemented in Rust";
+        homepage = "https://wezterm.org";
+        license = lib.licenses.mit;
+        mainProgram = "wezterm";
+        maintainers = with lib.maintainers; [
+          SuperSandro2000
+          yvnth
+        ];
+      };
+    })
+  )


### PR DESCRIPTION
Resolves #545211

Adds an eval-time warning on Darwin noting that the nixpkgs wezterm build is not code-signed, so macOS notifications (`UNUserNotificationCenter`) will not work. See wez/wezterm#6731 for upstream context confirming this is a signing requirement, not something fixable via nixpkgs packaging.

No build logic or dependencies changed,  just wraps the existing derivation in `lib.warnIf`.

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test