### PR TITLE
python3Packages: various fixes

### DIFF
--- a/pkgs/development/python-modules/anndata/default.nix
+++ b/pkgs/development/python-modules/anndata/default.nix
@@ -1,45 +1,54 @@
 {
-  anndata,
-  array-api-compat,
-  awkward,
-  boltons,
+  lib,
   buildPythonPackage,
-  dask,
-  distributed,
   fetchFromGitHub,
-  filelock,
-  h5py,
+
+  # build-system
   hatch-vcs,
   hatchling,
-  joblib,
-  lib,
+
+  # dependencies
+  array-api-compat,
+  h5py,
   legacy-api-wrap,
   natsort,
-  numba,
   numpy,
-  openpyxl,
   pandas,
+  scipy,
+  scverse-misc,
+  zarr,
+  pythonOlder,
+  typing-extensions,
+
+  # tests
+  awkward,
+  boltons,
+  dask,
+  distributed,
+  filelock,
+  joblib,
+  jsonschema,
+  numba,
+  openpyxl,
   pyarrow,
   pytest-mock,
   pytest-xdist,
   pytestCheckHook,
   scanpy,
   scikit-learn,
-  scipy,
-  stdenv,
-  zarr,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "anndata";
-  version = "0.12.7";
+  version = "0.13.2";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "scverse";
     repo = "anndata";
-    tag = version;
-    hash = "sha256-LVpkLWlt7GtsHoh5rcHPM0JWlTDQqTl/c/38Mz7oBJA=";
+    tag = finalAttrs.version;
+    hash = "sha256-Iw8LJklySaJGcyvtv6nl81xC63+bALtmH83H+LidHkQ=";
   };
 
   build-system = [
@@ -55,8 +64,15 @@ buildPythonPackage rec {
     numpy
     pandas
     scipy
+    scverse-misc
     zarr
+  ]
+  ++ scverse-misc.optional-dependencies.settings
+  ++ lib.optionals (pythonOlder "3.14") [
+    typing-extensions
   ];
+
+  pythonImportsCheck = [ "anndata" ];
 
   nativeCheckInputs = [
     awkward
@@ -65,14 +81,15 @@ buildPythonPackage rec {
     distributed
     filelock
     joblib
+    jsonschema
     numba
     openpyxl
     pyarrow
     pytest-mock
     pytest-xdist
     pytestCheckHook
-    scikit-learn
     scanpy
+    scikit-learn
   ];
 
   # Optionally disable pytest-xdist to make it easier to debug the test suite.
@@ -84,9 +101,10 @@ buildPythonPackage rec {
     export NUMBA_CACHE_DIR=$(mktemp -d);
   '';
 
-  doCheck = false; # use passthru.tests instead to prevent circularity with `scanpy`
-
-  passthru.tests = anndata.overridePythonAttrs { doCheck = true; };
+  disabledTestPaths = [
+    # UnicodeDecodeError: 'ascii' codec can't decode byte 0xc5 in position 263183: ordinal not in range(128)
+    "accessors.rst"
+  ];
 
   disabledTests = [
     # requires data from a previous test execution:
@@ -125,20 +143,21 @@ buildPythonPackage rec {
 
     # Tests that are seemingly broken. See https://github.com/scverse/anndata/issues/2017.
     "test_concat_dask_sparse_matches_memory"
-  ]
-  ++ lib.optionals (stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isDarwin) [
-    # RuntimeError: Cluster failed to start: [Errno 1] Operation not permitted
-    "test_dask_distributed_write"
-    "test_read_lazy_h5_cluster"
   ];
 
-  pythonImportsCheck = [ "anndata" ];
+  __darwinAllowLocalNetworking = true;
+
+  doCheck = false; # use passthru.tests instead to prevent circularity with `scanpy`
+
+  passthru.tests = finalAttrs.finalPackage.overrideAttrs {
+    doInstallCheck = true;
+  };
 
   meta = {
-    changelog = "https://github.com/scverse/anndata/blob/main/docs/release-notes/${src.tag}.md";
+    changelog = "https://github.com/scverse/anndata/blob/main/docs/release-notes/${finalAttrs.src.tag}.md";
     description = "Python package for handling annotated data matrices in memory and on disk";
     homepage = "https://anndata.readthedocs.io/";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ samuela ];
   };
-}
+})

--- a/pkgs/development/python-modules/array-api-compat/default.nix
+++ b/pkgs/development/python-modules/array-api-compat/default.nix
@@ -5,8 +5,7 @@
   fetchFromGitHub,
 
   # build-system
-  setuptools,
-  setuptools-scm,
+  meson-python,
 
   # tests
   array-api-strict,
@@ -22,21 +21,21 @@
   cudaSupport ? config.cudaSupport,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "array-api-compat";
-  version = "1.14";
+  version = "1.15";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "data-apis";
     repo = "array-api-compat";
-    tag = version;
-    hash = "sha256-Dhiq6GWxVm9BEeO81VSa3L644gp00LxFPJAliz8LbAE=";
+    tag = finalAttrs.version;
+    hash = "sha256-z6B+lOYciT71Uz3Py9M/8x7R+8IZ46nd8i8AYot5Rlo=";
   };
 
   build-system = [
-    setuptools
-    setuptools-scm
+    meson-python
   ];
 
   nativeCheckInputs = [
@@ -53,16 +52,20 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "array_api_compat" ];
 
-  # CUDA (used via cupy) is not available in the testing sandbox
   disabledTests = [
+    # CUDA (used via cupy) is not available in the testing sandbox
     "cupy"
+
+    # ValueError: api_version='2024.12' is not available; available versions are: ['2025.12']
+    "test_array_namespace[jax.numpy-2024.12-False]"
+    "test_array_namespace[jax.numpy-2024.12-None]"
   ];
 
   meta = {
-    homepage = "https://data-apis.org/array-api-compat";
-    changelog = "https://github.com/data-apis/array-api-compat/releases/tag/${src.tag}";
     description = "Compatibility layer for NumPy to support the Python array API";
+    homepage = "https://data-apis.org/array-api-compat";
+    changelog = "https://github.com/data-apis/array-api-compat/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ berquist ];
   };
-}
+})

--- a/pkgs/development/python-modules/lerobot/default.nix
+++ b/pkgs/development/python-modules/lerobot/default.nix
@@ -52,13 +52,16 @@ buildPythonPackage (finalAttrs: {
   dontUseCmakeConfigure = true;
 
   pythonRelaxDeps = [
+    "cmake"
     "draccus"
     "numpy"
     "packaging"
+    "setuptools"
     "torch"
     "torchvision"
   ];
   dependencies = [
+    cmake
     draccus
     einops
     gymnasium
@@ -69,6 +72,7 @@ buildPythonPackage (finalAttrs: {
     pillow
     requests
     safetensors
+    setuptools
     termcolor
     torch
     torchcodec

--- a/pkgs/development/python-modules/scanpy/default.nix
+++ b/pkgs/development/python-modules/scanpy/default.nix
@@ -64,7 +64,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "scanpy";
-  version = "1.12.2";
+  version = "1.12.3";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -72,7 +72,7 @@ buildPythonPackage (finalAttrs: {
     owner = "scverse";
     repo = "scanpy";
     tag = finalAttrs.version;
-    hash = "sha256-0CtFaj0+mCNDLG5h728vJkvYGcsa48SbDd3/Y8TXtQo=";
+    hash = "sha256-/QkkKNwc8RS4dYSkptqJDwRmmP9WDBpBoPtufqKvwqw=";
   };
 
   # Otherwise, several tests fail to be collected:
@@ -239,6 +239,10 @@ buildPythonPackage (finalAttrs: {
     # 'write/test.h5ad', errno = 2, error message = 'No such file or directory', flags = 13, o_flags
     # = 242)
     "test_write"
+
+    # numba thread-count assertions that depend on the host's thread settings
+    "test_numba_thread_limit_restores_previous_value"
+    "test_set_numba_threads_from_settings"
 
     # Snapshot tests failing because of warnings in output
     "scanpy.datasets._datasets.krumsiek11"


### PR DESCRIPTION
## Things done

- `python3Packages.scanpy: 1.12.2 -> 1.12.3` ([Diff](https://github.com/scverse/scanpy/compare/1.12.2...1.12.3), [Changelog](https://github.com/scverse/scanpy/releases/tag/1.12.3))
- `python3Packages.anndata: 0.12.7 -> 0.13.2` ([Diff](https://github.com/scverse/anndata/compare/0.12.7...0.13.2), [Changelog](https://github.com/scverse/anndata/blob/main/docs/release-notes/0.13.2.md))
- `python3Packages.lerobot: fix`

cc @bcdarwin

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test