### PR TITLE
abseil-cpp: allow overriding cxxStandard

### DIFF
--- a/pkgs/by-name/ab/abseil-cpp/package.nix
+++ b/pkgs/by-name/ab/abseil-cpp/package.nix
@@ -5,4 +5,8 @@
 # library.”  Therefore, we keep packages `abseil-cpp_YYYYMM` for each
 # required LTS branch, leaving `abseil-cpp` as an alias.
 
-{ abseil-cpp_202601 }: abseil-cpp_202601
+{
+  abseil-cpp_202601,
+  cxxStandard ? null,
+}:
+abseil-cpp_202601.override { inherit cxxStandard; }


### PR DESCRIPTION
individual abseil-cpp_* versions allow overriding the C++ standard version that abseil is built with. this is very useful when the default compiler C++ standard is different than the project's C++ standard. accordingly, we extend this capability to the top-level abseil-cpp wrapper alias as there's no reason to pin to an abseil LTS just for this. i've hit this a couple times while working on the GCC 16 upgrade (https://github.com/NixOS/nixpkgs/pull/537781, since that switches the default to C++20), e.g. in #538007 and #545413. in general duplicating the pin of C++ standards outside of the individual projects' build systems feels quite bad (easy to go out of sync), but we're not sure if there's a better approach here. would be happy to take advice.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
