### PR TITLE
dia: unstable-2025-10-26 -> 0.97.2-unstable-2026-07-24, fix build

### DIFF
--- a/pkgs/by-name/di/dia/fix-build-with-poppler-26-06.patch
+++ b/pkgs/by-name/di/dia/fix-build-with-poppler-26-06.patch
@@ -1,0 +1,33 @@
+From 2373861a858fb6ee7d50870ae66a59f05c6cd4bd Mon Sep 17 00:00:00 2001
+From: Nadzeya Hutsko <nadzeya@ubuntu.com>
+Date: Wed, 22 Jul 2026 20:46:52 +0200
+Subject: [PATCH] Fix build with Poppler >= 26.06
+
+poppler 26.06 changed the Page box accessors to return a const reference
+instead of a pointer. Take the address of the result, guarded by a
+version check so older poppler still builds
+---
+ plug-ins/pdf/pdf-import.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/plug-ins/pdf/pdf-import.cpp b/plug-ins/pdf/pdf-import.cpp
+index 3af268646..35fc6d9e3 100644
+--- a/plug-ins/pdf/pdf-import.cpp
++++ b/plug-ins/pdf/pdf-import.cpp
+@@ -93,8 +93,13 @@ public :
+                       (Annot *annot, void *user_data) G_GNUC_UNUSED,
+                   void   *annotDisplayDecideCbkData   G_GNUC_UNUSED)
+   {
++#if POPPLER_VERSION_MAJOR > 26 || (POPPLER_VERSION_MAJOR == 26 && POPPLER_VERSION_MINOR >= 6)
++    const PDFRectangle *mediaBox = &page->getMediaBox();
++    const PDFRectangle *clipBox = &page->getCropBox ();
++#else
+     const PDFRectangle *mediaBox = page->getMediaBox();
+     const PDFRectangle *clipBox = page->getCropBox ();
++#endif
+ 
+     if (page->isOk()) {
+       real w1 = (clipBox->x2 - clipBox->x1);
+-- 
+GitLab
+

--- a/pkgs/by-name/di/dia/package.nix
+++ b/pkgs/by-name/di/dia/package.nix
@@ -50,15 +50,20 @@ let
 in
 stdenv.mkDerivation {
   pname = "dia";
-  version = "unstable-2025-10-26";
+  version = "0.97.2-unstable-2026-07-24";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "GNOME";
     repo = "dia";
-    rev = "efdf829e8afdbbeb371820932769e35415ebe886";
-    hash = "sha256-VFFU5iJnVJdZ2tkNszZ2ooBD+GiCL6MqanzpEWIJerk=";
+    rev = "ad68cc378b7a187706bc2648c48b44d16fb80819";
+    hash = "sha256-ejjSc9GGXD5GsbeRps1T20xifJuzWA1yq/G7jk797Cw=";
   };
+
+  patches = [
+    # https://gitlab.gnome.org/GNOME/dia/-/merge_requests/146
+    ./fix-build-with-poppler-26-06.patch
+  ];
 
   postPatch = ''
     # Fix build with poppler 25.10.0


### PR DESCRIPTION
Closes #545149

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
