### PR TITLE
home-assistant-custom-components.hochwasserportal: 1.0.8 -> 1.0.9

### DIFF
--- a/pkgs/development/python-modules/lhpapi/default.nix
+++ b/pkgs/development/python-modules/lhpapi/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "lhpapi";
-  version = "1.0.10";
+  version = "1.0.11";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "stephan192";
     repo = "lhpapi";
     tag = "v${version}";
-    hash = "sha256-Q9X1STaWWbWWy8wmCQ3Cx+z19+X3EcGl0u/Mmc49rAM=";
+    hash = "sha256-tz1/+NTg8wI0mWcPfM1zk7EheUwShv8eCoYA7wAb/lM=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/hochwasserportal/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/hochwasserportal/package.nix
@@ -11,13 +11,13 @@
 buildHomeAssistantComponent rec {
   owner = "stephan192";
   domain = "hochwasserportal";
-  version = "1.0.8";
+  version = "1.0.9";
 
   src = fetchFromGitHub {
     owner = "stephan192";
     repo = "hochwasserportal";
     tag = "v${version}";
-    hash = "sha256-q2usHeWcx/1UrM7MQ156SFy8cFIiCcsmIr6721hzSLI=";
+    hash = "sha256-/mnAQc+s6L9NVzk6gDA5p1+DfY3AZ5Sy6AWhnpkT++Q=";
   };
 
   dependencies = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

release notes:
https://github.com/stephan192/lhpapi/releases/tag/v1.0.11
https://github.com/stephan192/hochwasserportal/releases/tag/v1.0.9

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
