### PR TITLE
mongodb-mcp-server: init at 1.14.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5307,6 +5307,11 @@
     githubId = 22559310;
     name = "Clara Rostock";
   };
+  clay53 = {
+    github = "clay53";
+    githubId = 16981283;
+    name = "Clayton Hickey";
+  };
   claymorwan = {
     name = "claymorwan";
     github = "claymorwan";

--- a/pkgs/by-name/mo/mongodb-mcp-server/package.nix
+++ b/pkgs/by-name/mo/mongodb-mcp-server/package.nix
@@ -1,0 +1,90 @@
+{
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  lib,
+  makeWrapper,
+  nix-update-script,
+  nodejs_24,
+  pnpm_11,
+  pnpmConfigHook,
+  stdenv,
+  versionCheckHook,
+}:
+let
+  nodejs = nodejs_24;
+  pnpm = pnpm_11;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mongodb-mcp-server";
+  version = "1.14.0";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "mongodb-js";
+    repo = "mongodb-mcp-server";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-n/KY3Od+IgqIY1/RgZNf7T2vWTZxnQZbT1N80Qu3BiQ=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    pnpm
+    pnpmConfigHook
+    makeWrapper
+  ];
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = "sha256-svT6N2+fe3yDFPzV9ih1Iz6vdgXQSIb06dLZj2FKOH4=";
+  };
+
+  dontStrip = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm run build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    # The prepare script (husky && pnpm run build) doesn't do anything useful in this context
+    # since husky just installs git hooks, the package is already built, and it causes an error
+    pnpm pkg delete scripts.prepare
+
+    # --config.inject-workspace-packages=true: enables workspace option required by deploy since pnpm 10
+    pnpm --filter ${finalAttrs.pname} \
+         --offline \
+         --prod \
+         --config.inject-workspace-packages=true \
+         deploy $out/lib/mongodb-mcp-server
+
+    mkdir -p $out/bin
+    makeWrapper ${lib.getExe nodejs} $out/bin/mongodb-mcp-server \
+      --add-flags "$out/lib/mongodb-mcp-server/dist/esm/index.js"
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Model Context Protocol server to connect to MongoDB databases and MongoDB Atlas clusters";
+    homepage = "https://github.com/mongodb-js/mongodb-mcp-server";
+    changelog = "https://github.com/mongodb-js/mongodb-mcp-server/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ clay53 ];
+    mainProgram = "mongodb-mcp-server";
+    platforms = nodejs.meta.platforms;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I added myself to the maintainer list and added a new package: [mongodb-mcp-server](https://github.com/mongodb-js/mongodb-mcp-server). The MCP server gives an AI agent tools for interacting with a MongoDB server. At the company I'm working at, we plan on using it for debugging problems. Packaging it with nix makes it easier for us to automatically install it on our developer's machines.

Currently, I have not configured the build to install optional dependencies that depend on external binaries. You can see which are not excluded in follow installPhase log:
```
../../../../../store/vy9mxqkipb8dq6calcwyhbnh9h7gzn2x-mongodb-mcp-server-1.14.0/lib/mongodb-mcp-server/node_modules/.pnpm/macos-export-certificate-and-key@2.0.1/node_modules/macos-export-certificate-and-key: Running install script...
../../../../../store/vy9mxqkipb8dq6calcwyhbnh9h7gzn2x-mongodb-mcp-server-1.14.0/lib/mongodb-mcp-server/node_modules/.pnpm/os-dns-native@2.0.1/node_modules/os-dns-native: Running install script...
../../../../../store/vy9mxqkipb8dq6calcwyhbnh9h7gzn2x-mongodb-mcp-server-1.14.0/lib/mongodb-mcp-server/node_modules/.pnpm/cpu-features@0.0.10/node_modules/cpu-features: Running install script...
../../../../../store/vy9mxqkipb8dq6calcwyhbnh9h7gzn2x-mongodb-mcp-server-1.14.0/lib/mongodb-mcp-server/node_modules/.pnpm/kerberos@7.0.0/node_modules/kerberos: Running install script...
../../../../../store/vy9mxqkipb8dq6calcwyhbnh9h7gzn2x-mongodb-mcp-server-1.14.0/lib/mongodb-mcp-server/node_modules/.pnpm/mongodb-client-encryption@7.0.0/node_modules/mongodb-client-encryption: Running install script...
../../../../../store/vy9mxqkipb8dq6calcwyhbnh9h7gzn2x-mongodb-mcp-server-1.14.0/lib/mongodb-mcp-server/node_modules/.pnpm/macos-export-certificate-and-key@2.0.1/node_modules/macos-export-certificate-and-key: Running install script, failed in 2s (skipped as optional)
../../../../../store/vy9mxqkipb8dq6calcwyhbnh9h7gzn2x-mongodb-mcp-server-1.14.0/lib/mongodb-mcp-server/node_modules/.pnpm/os-dns-native@2.0.1/node_modules/os-dns-native: Running install script, failed in 2s (skipped as optional)
../../../../../store/vy9mxqkipb8dq6calcwyhbnh9h7gzn2x-mongodb-mcp-server-1.14.0/lib/mongodb-mcp-server/node_modules/.pnpm/mongodb-client-encryption@7.0.0/node_modules/mongodb-client-encryption: Running install script, failed in 2.3s (skipped as optional)
../../../../../store/vy9mxqkipb8dq6calcwyhbnh9h7gzn2x-mongodb-mcp-server-1.14.0/lib/mongodb-mcp-server/node_modules/.pnpm/kerberos@7.0.0/node_modules/kerberos: Running install script, failed in 2.3s (skipped as optional)
../../../../../store/vy9mxqkipb8dq6calcwyhbnh9h7gzn2x-mongodb-mcp-server-1.14.0/lib/mongodb-mcp-server/node_modules/.pnpm/cpu-features@0.0.10/node_modules/cpu-features: Running install script, failed in 4.5s (skipped as optional)
```

The tools exposed by the MCP server seem to work: [cursor_mongodb_mcp_tools_testing.md](https://github.com/user-attachments/files/30358129/cursor_mongodb_mcp_tools_testing.md)

Regarding use of an LLM in this contribution, I have manually reviewed all of its output and made many manual changes. To the best of my knowledge and research, the submitted code is correct and not unnecessarily complicated.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
