### PR TITLE
droast: init at 1.4.10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11864,6 +11864,12 @@
     githubId = 510202;
     name = "Ismaël Bouya";
   };
+  immanuwell = {
+    email = "focused.ethan@gmail.com";
+    github = "immanuwell";
+    githubId = 122638311;
+    name = "Immanuel Tikhonov";
+  };
   impl = {
     email = "noah@noahfontes.com";
     matrix = "@impl:matrix.org";

--- a/pkgs/by-name/dr/droast/package.nix
+++ b/pkgs/by-name/dr/droast/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "droast";
+  version = "1.4.10";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "immanuwell";
+    repo = "dockerfile-roast";
+    tag = finalAttrs.version;
+    hash = "sha256-/UeM75dXpYYZ1Y5MVUSHvfw2nmSoKWJwW22c6NXuj6o=";
+  };
+
+  cargoHash = "sha256-EZykAREpe5HnDXwGgx6wUzg9PXm8QIgmNZbncfqVb5k=";
+
+  # Some CLI tests require the source tree to be a Git checkout, which is not
+  # available from the release archive used by fetchFromGitHub.
+  doCheck = false;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Opinionated Dockerfile linter";
+    homepage = "https://github.com/immanuwell/dockerfile-roast";
+    changelog = "https://github.com/immanuwell/dockerfile-roast/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.immanuwell ];
+    mainProgram = "droast";
+  };
+})


### PR DESCRIPTION
Adds droast, an opinionated Dockerfile linter, built reproducibly from the upstream 1.4.10 source tag

Validation:
- `nix build .#droast --no-link`
- `droast --version`
- `droast --help`

The packaged source is a github archive rather than a git checkout
The upstream CLI test cases that require a `.git` directory are therefore disabled in the Nix build; the installed executable is validated with `versionCheckHook`

Future release updates are supported by `nix-update-script`