### PR TITLE
xf86-video-*: disable bindnow hardening

### DIFF
--- a/pkgs/by-name/xf/xf86-video-apm/package.nix
+++ b/pkgs/by-name/xf/xf86-video-apm/package.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Q10YmtxgWiFvMqvS0RKBhWPVqyFoWNjTe1RLvt7Kxlg=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-ark/package.nix
+++ b/pkgs/by-name/xf/xf86-video-ark/package.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-IE35hEZVsfxjwrNxV/xtw8bdox9pwlO/Ra8vkcK19pM=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-ast/package.nix
+++ b/pkgs/by-name/xf/xf86-video-ast/package.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Xz9ZvngAsEb/9+YOGOkJQIbFzofKw+2V6sST8Ry2tvo=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-ati/package.nix
+++ b/pkgs/by-name/xf/xf86-video-ati/package.nix
@@ -27,6 +27,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-q8+lMYS9tfO64xT7t6PYIqsARX8Dv/8uMTMeP1JCt08=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-chips/package.nix
+++ b/pkgs/by-name/xf/xf86-video-chips/package.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-MQ6aT+fWKFtpdzV40LzMrr046h0ZRmHi2sgWjuYUMq8=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-cirrus/package.nix
+++ b/pkgs/by-name/xf/xf86-video-cirrus/package.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-7V3czOujUIKFe9UqNX4FwpDWq9XsZeaLRu9ALnZyRMw=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-fbdev/package.nix
+++ b/pkgs/by-name/xf/xf86-video-fbdev/package.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-JlSTosvQCiNeWbveYdj4+Ulgd/guc37xYUMaAhyS7K8=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-geode/package.nix
+++ b/pkgs/by-name/xf/xf86-video-geode/package.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-G0w6Ft172ar5dwR3NAu+8vuvJqWKaknmpbdThpPR+kY=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-i128/package.nix
+++ b/pkgs/by-name/xf/xf86-video-i128/package.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-2yjzaJV5DIATEmByIZJXZyZ781lTUNzfafCmIlBSBRg=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-i740/package.nix
+++ b/pkgs/by-name/xf/xf86-video-i740/package.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-wEpTkmzMjEebkPf6/69gjmDdJ0OQ3MrnosIXFIQor8A=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-intel/package.nix
+++ b/pkgs/by-name/xf/xf86-video-intel/package.nix
@@ -56,6 +56,10 @@ stdenv.mkDerivation (finalAttrs: {
     ./use_crocus_and_iris.patch
   ];
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-mga/package.nix
+++ b/pkgs/by-name/xf/xf86-video-mga/package.nix
@@ -24,6 +24,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-9DpqSyGTu4jOttZlF95/rpi2oEu+JPU3sniuHTatoRo=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-neomagic/package.nix
+++ b/pkgs/by-name/xf/xf86-video-neomagic/package.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-j1zhKGYmKADZ/6WuCQTca7l+rTgqlLhGoQvYhWxWAAE=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-nested/package.nix
+++ b/pkgs/by-name/xf/xf86-video-nested/package.nix
@@ -24,6 +24,10 @@ stdenv.mkDerivation {
     hash = "sha256-EPQOcE23m6RSG05txjBjREBz9JlwZrmK4Rn6Fg2IyT4=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-nouveau/package.nix
+++ b/pkgs/by-name/xf/xf86-video-nouveau/package.nix
@@ -25,6 +25,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-gsrq32h0EKesivMoNbe1Thlc7FfubmS6zdwQmMxHsOk=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-nv/package.nix
+++ b/pkgs/by-name/xf/xf86-video-nv/package.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-8I7PnxOPXrUv0Ezj1H2qgUQdRDE99znSqUaieP6Pu8s=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-omap/package.nix
+++ b/pkgs/by-name/xf/xf86-video-omap/package.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-5IffoBuSqSs0bQVCJHva/465KK0njrJyvG51dZX/rnM=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-openchrome/package.nix
+++ b/pkgs/by-name/xf/xf86-video-openchrome/package.nix
@@ -26,6 +26,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Aa0Mhb6miSakAEZKCZ5/+n9oyCp4y4srq9ljRNqP7F4=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-qxl/package.nix
+++ b/pkgs/by-name/xf/xf86-video-qxl/package.nix
@@ -26,6 +26,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-g7NvAjmvPjyqUTXnZREDDs18O2e9Zl5hZeAza2a/1Jw=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-r128/package.nix
+++ b/pkgs/by-name/xf/xf86-video-r128/package.nix
@@ -24,6 +24,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-f75PQ3pmWtyqeEfrMQpO31U0QOydlmQ49gJuvneRoso=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-s3virge/package.nix
+++ b/pkgs/by-name/xf/xf86-video-s3virge/package.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-UxAzsevKIMA3p6Q5cKjRPOku4cfbXiLmcJQWNEjpu7s=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-savage/package.nix
+++ b/pkgs/by-name/xf/xf86-video-savage/package.nix
@@ -24,6 +24,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-MimTtOPSVQ0uEREYNJDqwDOF2RaNxv/pWmhxcqVfSqA=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-siliconmotion/package.nix
+++ b/pkgs/by-name/xf/xf86-video-siliconmotion/package.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-CRuzdxlES6TFMDGIKk5sBAXF2Pa781jmTzlVT+A2Muk=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-sis/package.nix
+++ b/pkgs/by-name/xf/xf86-video-sis/package.nix
@@ -24,6 +24,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-C9OG/vWFIVXgRRAzn3AqE2ApABZOKT94CuIxgnOapjs=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-sisusb/package.nix
+++ b/pkgs/by-name/xf/xf86-video-sisusb/package.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Z4q1ChH+u5u+NOsrwTnBVF2iJbvkd/stffdCRK73DS8=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-suncg6/package.nix
+++ b/pkgs/by-name/xf/xf86-video-suncg6/package.nix
@@ -22,6 +22,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-M9O0BNrKAFdiEgpZstH8KHRVIMEy5dI3y8rP+MSzLCY=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-sunffb/package.nix
+++ b/pkgs/by-name/xf/xf86-video-sunffb/package.nix
@@ -22,6 +22,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-wuzODH7iRBxWHzVE8v/npy1/BwS3r08GduMEDdtJd9E=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-sunleo/package.nix
+++ b/pkgs/by-name/xf/xf86-video-sunleo/package.nix
@@ -22,6 +22,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-YAm1KpPpY+jJ+uBTxzi9bju1XNVnKy28IofP57MzQmk=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-tdfx/package.nix
+++ b/pkgs/by-name/xf/xf86-video-tdfx/package.nix
@@ -24,6 +24,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-95LFAPBT4nTuTLx83wsdOCwLOLed39WtP5FXPqiO/LI=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-trident/package.nix
+++ b/pkgs/by-name/xf/xf86-video-trident/package.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-xTBktn813s8Dy3gPScEHVlWMzSRx7oIymbFUpkvYAhE=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-vbox/package.nix
+++ b/pkgs/by-name/xf/xf86-video-vbox/package.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-C+5spc9EABu3p5Ck7R4bWedLDm8h0DrbYic2AwIUAqU=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-vesa/package.nix
+++ b/pkgs/by-name/xf/xf86-video-vesa/package.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-M8/mSgD398wBswOp0oEXvlcgVsYdWcTIw3ah5e1uHV8=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-vmware/package.nix
+++ b/pkgs/by-name/xf/xf86-video-vmware/package.nix
@@ -27,6 +27,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-aC/LsAvrVtG+2SrMaB7ROJTUIleZTcLydmt5cQf0dHc=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xf86-video-voodoo/package.nix
+++ b/pkgs/by-name/xf/xf86-video-voodoo/package.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-OuKGgrdGIIUF6CHD1BwO7ZQgvcbhGHQETExv+Ra0X2E=";
   };
 
+  # Xorg loads helper modules after loading this driver, so their symbols must
+  # be resolved lazily.
+  hardeningDisable = [ "bindnow" ];
+
   strictDeps = true;
 
   nativeBuildInputs = [


### PR DESCRIPTION
This PR extends #484928 to every Xorg video driver module in Nixpkgs that exhibits the same eager-binding loader failure.

Xorg loads driver DSOs with `RTLD_LAZY | RTLD_GLOBAL`, then the drivers load helper modules such as `vgahw`, `fbdevhw`, `exa`, `shadow`, `vbe`, and `int10` during probing or initialization. Nixpkgs currently links most of these drivers with `-z now`, which forces their helper symbols to be resolved before the helpers are available and makes `dlopen` fail.

An audit of all 37 `xf86-video-*` packages available on `x86_64-linux` found 34 affected driver modules. Every failure is an unresolved helper symbol from a module that would be loaded later, and every failure disappears when only `bindnow` is disabled.

| Deferred helper | Example unresolved symbols | Affected driver modules |
| --- | --- | --- |
| `vgahw` | `vgaHWFreeHWRec`, `vgaHWGetIndex` | `apm`, `ark`, `ast`, `chips`, `cirrus`, `i128`, `i740`, `neomagic`, `openchrome`, `qxl`, `s3virge`, `tdfx`, `trident`, `vboxvideo`, `vmware` |
| `fbdevhw` | `fbdevHWSave` | `fbdev`, `mga`, `nv`, `r128` |
| `exa` | `exaDriverAlloc`, `exaWaitSync` | `nouveau`, `omap`, `radeon`, `savage`, `siliconmotion` |
| `shadow` | `ShadowFBInit`, `shadowRemove`, `shadowUpdateRotate8_90` | `geode`, `nested`, `sisusb`, `voodoo` |
| `vbe` / `int10` | `vbeFree`, `VBESetModeParameters`, `xf86InitInt10` | `intel`, `sis`, `vesa` |
| SBus helpers | `xf86SbusHideOsHwCursor` | `suncg6`, `sunffb`, `sunleo` |

The package-level exception is intentionally not added to `xf86-video-dummy` or `xf86-video-v4l`, whose modules load successfully with `BIND_NOW`. `xf86-video-amdgpu` already has the exception from #484928. All other hardening flags remain enabled.

## Verification

Tested on NixOS 26.05, `x86_64-linux`. All 37 available `xf86-video-*` packages build successfully. For both comparisons, their `/lib/xorg/modules` outputs were combined into a `buildEnv` and loaded by the same Xorg 21.1.24 build. The baseline keeps the existing `xf86-video-amdgpu` exception but removes the exceptions introduced by this PR.

`Xorg -showopts` exercises module loading and driver registration without requiring root access, a VT, or graphics hardware.

Build Xorg and the combined baseline/fixed module trees with:

```console
$ nix-build -A xorg-server -o result-xorg

$ nix-build -E '
let
  pkgs = import ./. { config.allowUnfree = true; };
  names = builtins.filter (name: builtins.match "xf86-video-.*" name != null) (builtins.attrNames pkgs);
  packages = map (name: pkgs.${name}) names;
  available = builtins.filter (package: pkgs.lib.meta.availableOn pkgs.stdenv.hostPlatform package) packages;
  mkModuleTree = name: paths: pkgs.buildEnv {
    inherit name paths;
    pathsToLink = [ "/lib/xorg/modules" ];
    ignoreCollisions = true;
  };
  baseline = mkModuleTree "xorg-video-drivers-baseline" (map (package:
    if package.pname == "xf86-video-amdgpu" then package
    else package.overrideAttrs (_: { hardeningDisable = [ ]; })
  ) available);
  fixed = mkModuleTree "xorg-video-drivers-fixed" available;
in
pkgs.linkFarm "xorg-video-driver-showopts-inputs" [
  { name = "baseline"; path = baseline; }
  { name = "fixed"; path = fixed; }
]
' -o result-xorg-video-drivers
```

Before this change:

```console
$ result-xorg/bin/Xorg :93 -showopts -modulepath "$PWD/result-xorg-video-drivers/baseline/lib/xorg/modules,$PWD/result-xorg/lib/xorg/modules" -logfile /tmp/xorg-showopts-baseline.log

$ grep -c 'Failed to load module .*loader failed' /tmp/xorg-showopts-baseline.log
34

$ grep -c 'Driver\[[0-9]\+\]:' /tmp/xorg-showopts-baseline.log
3

$ grep 'undefined symbol:' /tmp/xorg-showopts-baseline.log | sed -E 's/.*undefined symbol: ([^ ]+).*/\1/' | sort | uniq -c | sort -nr
     12 vgaHWFreeHWRec
      4 fbdevHWSave
      3 xf86SbusHideOsHwCursor
      3 vgaHWGetIndex
      3 exaWaitSync
      2 exaDriverAlloc
      2 ShadowFBInit
      1 xf86InitInt10
      1 vbeFree
      1 shadowUpdateRotate8_90
      1 shadowRemove
      1 VBESetModeParameters
```

After this change:

```console
$ result-xorg/bin/Xorg :94 -showopts -modulepath "$PWD/result-xorg-video-drivers/fixed/lib/xorg/modules,$PWD/result-xorg/lib/xorg/modules" -logfile /tmp/xorg-showopts-fixed.log

$ grep -c 'Failed to load module .*loader failed' /tmp/xorg-showopts-fixed.log
0

$ grep -c 'Driver\[[0-9]\+\]:' /tmp/xorg-showopts-fixed.log
37

$ grep -Ec 'undefined symbol|loader failed' /tmp/xorg-showopts-fixed.log
0
```

This verifies the loader and registration path for every affected module. It does not claim hardware probing or modesetting coverage for each legacy driver.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests
  - [ ] Package tests
  - [x] All available `xf86-video-*` packages build
  - [x] All affected modules load with `Xorg -showopts`
- [ ] Ran `nixpkgs-review`
- [x] Fits `CONTRIBUTING.md`, `pkgs/README.md`, `maintainers/README.md`, and other READMEs
