### PR TITLE
kawkab-mono-font: 20151015 -> 0.501

### DIFF
--- a/pkgs/by-name/ka/kawkab-mono-font/package.nix
+++ b/pkgs/by-name/ka/kawkab-mono-font/package.nix
@@ -23,8 +23,10 @@ stdenvNoCC.mkDerivation {
   '';
 
   meta = {
-    description = "Arab fixed-width font";
+    description = "Monospaced Arabic typeface designed for code and text-editing";
     homepage = "https://makkuk.com/kawkab-mono/";
+    downloadPage = "https://github.com/aiaf/kawkab-mono";
+    changelog = "https://github.com/aiaf/kawkab-mono/releases/tag/v${version}";
     license = lib.licenses.ofl;
   };
 }

--- a/pkgs/by-name/ka/kawkab-mono-font/package.nix
+++ b/pkgs/by-name/ka/kawkab-mono-font/package.nix
@@ -28,5 +28,6 @@ stdenvNoCC.mkDerivation {
     downloadPage = "https://github.com/aiaf/kawkab-mono";
     changelog = "https://github.com/aiaf/kawkab-mono/releases/tag/v${version}";
     license = lib.licenses.ofl;
+    maintainers = with lib.maintainers; [ talal ];
   };
 }

--- a/pkgs/by-name/ka/kawkab-mono-font/package.nix
+++ b/pkgs/by-name/ka/kawkab-mono-font/package.nix
@@ -3,16 +3,16 @@
   stdenvNoCC,
   fetchzip,
 }:
-
-stdenvNoCC.mkDerivation {
+let
   pname = "kawkab-mono";
-  version = "20151015";
-
+  version = "0.501";
   src = fetchzip {
-    url = "https://makkuk.com/kawkab-mono/downloads/kawkab-mono-0.1.zip";
-    stripRoot = false;
-    hash = "sha256-arZTzXj7Ba5G4WF3eZVGNaONhOsYVPih9iBgsN/lg14=";
+    url = "https://github.com/aiaf/kawkab-mono/releases/download/v${version}/kawkab-mono-${version}.zip";
+    hash = "sha256-cDpQGTu3XzLrDtInAZtnCw6BymX7fupbbr7L4bd7kN8=";
   };
+in
+stdenvNoCC.mkDerivation {
+  inherit pname version src;
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Updated the font to the latest version.
- Changed the download URL to GitHub releases instead of website since website doesn't have the latest version.
- Improved metadata.
- Added myself as maintainer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
