### PR TITLE
diesel-guard: init at 0.12.0

### DIFF
--- a/pkgs/by-name/di/diesel-guard/package.nix
+++ b/pkgs/by-name/di/diesel-guard/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  fetchCrate,
+  nix-update-script,
+  diesel-guard,
+  testers,
+  libpq,
+  pkg-config,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "diesel-guard";
+  version = "0.12.0";
+
+  __structuredAttrs = true;
+
+  src = fetchCrate {
+    inherit (finalAttrs) version;
+    crateName = "diesel-guard";
+    hash = "sha256-sU6qKWlR44m19MeOEO/8L8R8dUJCUq6NbA4D3uJ15bM=";
+  };
+
+  cargoHash = "sha256-ZKJZnvv0EcGCljpjAVor9vt/eeN9ferw67z/RPTCcVU=";
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [ libpq ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion { package = diesel-guard; };
+  };
+
+  meta = {
+    description = "Linter for dangerous Postgres migration patterns in Diesel and SQLx";
+    homepage = "https://github.com/ayarotsky/diesel-guard";
+    changelog = "https://github.com/ayarotsky/diesel-guard/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ Dietr1ch ];
+    mainProgram = "diesel-guard";
+  };
+})


### PR DESCRIPTION
## Things done

Package [diesel-guard](https://ayarotsky.github.io/diesel-guard/)

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
