### PR TITLE
librejs-cmd: init at 0-unstable-2026-07-27

### DIFF
--- a/pkgs/by-name/li/librejs-cmd/package.nix
+++ b/pkgs/by-name/li/librejs-cmd/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromCodeberg,
+  nix-update-script,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "librejs-cmd";
+  version = "0-unstable-2026-07-27";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromCodeberg {
+    owner = "librejs";
+    repo = "librejs-cmd";
+    rev = "6a9ffd92054cacf7cb298146d44cc8a0b4f501cc";
+    hash = "sha256-1L5zmFeOYg5RiGU/SRi7pOeh2cikQPTak8u1wyYjhs8=";
+  };
+
+  npmDepsHash = "sha256-2FQs7FGr1ZXgbwiqISv7ZYOcq9VMSLQkY9P3+jPEcgE=";
+  dontNpmBuild = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Command line interface for librejs";
+    homepage = "https://codeberg.org/librejs/librejs-cmd";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "librejs-cmd";
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
