### PR TITLE
tutanota-desktop: add darwin support

### DIFF
--- a/pkgs/by-name/tu/tutanota-desktop/package.nix
+++ b/pkgs/by-name/tu/tutanota-desktop/package.nix
@@ -8,11 +8,11 @@
 
 appimageTools.wrapType2 rec {
   pname = "tutanota-desktop";
-  version = "355.260710.0";
+  version = "355.260720.0";
 
   src = fetchurl {
     url = "https://github.com/tutao/tutanota/releases/download/tutanota-desktop-release-${version}/tutanota-desktop-linux.AppImage";
-    hash = "sha256-HlR9dXXxnXwUTM0Xlovu1+G5rgH87dYxLgbp2qyAFbM=";
+    hash = "sha256-sdKth9sy5yQ9cs4xQg4/zsgdvitxByKl8NCJgo3lL4o=";
   };
 
   extraPkgs = pkgs: [ pkgs.libsecret ];

--- a/pkgs/by-name/tu/tutanota-desktop/package.nix
+++ b/pkgs/by-name/tu/tutanota-desktop/package.nix
@@ -1,38 +1,26 @@
 {
   lib,
+  stdenvNoCC,
   appimageTools,
   fetchurl,
   makeWrapper,
+  undmg,
   gitUpdater,
 }:
 
-appimageTools.wrapType2 rec {
+let
   pname = "tutanota-desktop";
   version = "355.260720.0";
 
-  src = fetchurl {
+  linuxSrc = fetchurl {
     url = "https://github.com/tutao/tutanota/releases/download/tutanota-desktop-release-${version}/tutanota-desktop-linux.AppImage";
     hash = "sha256-sdKth9sy5yQ9cs4xQg4/zsgdvitxByKl8NCJgo3lL4o=";
   };
 
-  extraPkgs = pkgs: [ pkgs.libsecret ];
-
-  nativeBuildInputs = [ makeWrapper ];
-
-  extraInstallCommands =
-    let
-      appimageContents = appimageTools.extract { inherit pname version src; };
-    in
-    ''
-      install -Dm 444 ${appimageContents}/tutanota-desktop.desktop -t $out/share/applications
-      cp -r ${appimageContents}/usr/share/icons/. $out/share/icons
-
-      substituteInPlace $out/share/applications/tutanota-desktop.desktop \
-        --replace 'Exec=AppRun' 'Exec=${pname}'
-
-      wrapProgram $out/bin/tutanota-desktop \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
-    '';
+  darwinSrc = fetchurl {
+    url = "https://github.com/tutao/tutanota/releases/download/tutanota-desktop-release-${version}/tutanota-desktop-mac.dmg";
+    hash = "sha256-oVipeWX6kuy0JqlB92hjcVl3Szwve7Lz5gd/mC7ieVg=";
+  };
 
   passthru.updateScript = gitUpdater {
     url = "https://github.com/tutao/tutanota";
@@ -48,6 +36,66 @@ appimageTools.wrapType2 rec {
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     maintainers = with lib.maintainers; [ s0ssh ];
     mainProgram = "tutanota-desktop";
-    platforms = [ "x86_64-linux" ];
+    platforms = lib.platforms.darwin ++ [ "x86_64-linux" ];
   };
-}
+
+  linux = appimageTools.wrapType2 {
+    inherit
+      pname
+      version
+      passthru
+      meta
+      ;
+    src = linuxSrc;
+
+    extraPkgs = pkgs: [ pkgs.libsecret ];
+
+    nativeBuildInputs = [ makeWrapper ];
+
+    extraInstallCommands =
+      let
+        appimageContents = appimageTools.extract {
+          inherit pname version;
+          src = linuxSrc;
+        };
+      in
+      ''
+        install -Dm 444 ${appimageContents}/tutanota-desktop.desktop -t $out/share/applications
+        cp -r ${appimageContents}/usr/share/icons/. $out/share/icons
+
+        substituteInPlace $out/share/applications/tutanota-desktop.desktop \
+          --replace 'Exec=AppRun' 'Exec=${pname}'
+
+        wrapProgram $out/bin/tutanota-desktop \
+          --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+      '';
+  };
+
+  darwin = stdenvNoCC.mkDerivation {
+    inherit
+      pname
+      version
+      passthru
+      meta
+      ;
+    src = darwinSrc;
+
+    sourceRoot = ".";
+
+    nativeBuildInputs = [
+      undmg
+      makeWrapper
+    ];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p "$out/Applications"
+      cp -R "Tuta Mail.app" "$out/Applications/"
+      makeWrapper "$out/Applications/Tuta Mail.app/Contents/MacOS/Tuta Mail" "$out/bin/tutanota-desktop"
+
+      runHook postInstall
+    '';
+  };
+in
+if stdenvNoCC.hostPlatform.isDarwin then darwin else linux

--- a/pkgs/by-name/tu/tutanota-desktop/package.nix
+++ b/pkgs/by-name/tu/tutanota-desktop/package.nix
@@ -5,7 +5,6 @@
   fetchurl,
   makeWrapper,
   undmg,
-  gitUpdater,
 }:
 
 let
@@ -22,11 +21,7 @@ let
     hash = "sha256-oVipeWX6kuy0JqlB92hjcVl3Szwve7Lz5gd/mC7ieVg=";
   };
 
-  passthru.updateScript = gitUpdater {
-    url = "https://github.com/tutao/tutanota";
-    rev-prefix = "tutanota-desktop-release-";
-    allowedVersions = ".+\\.[0-9]{6}\\..+";
-  };
+  passthru.updateScript = ./update.sh;
 
   meta = {
     description = "Tuta official desktop client";

--- a/pkgs/by-name/tu/tutanota-desktop/update.sh
+++ b/pkgs/by-name/tu/tutanota-desktop/update.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash curl jq common-updater-scripts nixVersions.latest
+
+set -euo pipefail
+
+repo="tutao/tutanota"
+tagPrefix="tutanota-desktop-release-"
+
+latestTag=$(curl ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} -sSf \
+  "https://api.github.com/repos/$repo/releases?per_page=100" \
+  | jq -r --arg p "$tagPrefix" \
+    '[.[] | select(.prerelease == false) | select(.tag_name | startswith($p))] | .[0].tag_name')
+version="${latestTag#"$tagPrefix"}"
+
+currentVersion=$(nix-instantiate --eval -E "with import ./. { }; tutanota-desktop.version" | tr -d '"')
+
+echo "tutanota-desktop: current=$currentVersion latest=$version"
+if [[ "$version" == "$currentVersion" ]]; then
+  echo "tutanota-desktop: already up to date"
+  exit 0
+fi
+
+base="https://github.com/$repo/releases/download/$tagPrefix$version"
+
+linuxHash=$(nix --extra-experimental-features nix-command hash convert --hash-algo sha256 --to sri \
+  "$(nix-prefetch-url "$base/tutanota-desktop-linux.AppImage")")
+update-source-version tutanota-desktop "$version" "$linuxHash" --system=x86_64-linux --ignore-same-version
+
+darwinHash=$(nix --extra-experimental-features nix-command hash convert --hash-algo sha256 --to sri \
+  "$(nix-prefetch-url "$base/tutanota-desktop-mac.dmg")")
+update-source-version tutanota-desktop "$version" "$darwinHash" --system=aarch64-darwin --ignore-same-version


### PR DESCRIPTION
Adds macOS (darwin) support

Changelog: https://github.com/tutao/tutanota/releases/tag/tutanota-desktop-release-355.260720.0

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].