### PR TITLE
mpz: init at 2.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4316,6 +4316,12 @@
     githubId = 1001709;
     name = "William Bezuidenhout";
   };
+  burntpineapple12 = {
+    email = "burntpineapple123@posteo.com";
+    github = "burntpineapple12";
+    githubId = 291952771;
+    name = "BurntPineapple123";
+  };
   buurro = {
     email = "marcoburro98@gmail.com";
     github = "buurro";

--- a/pkgs/by-name/mp/mpz/package.nix
+++ b/pkgs/by-name/mp/mpz/package.nix
@@ -1,0 +1,43 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  qt6,
+  lib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mpz";
+  version = "2.1.1";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "olegantonyan";
+    repo = "mpz";
+    tag = finalAttrs.version;
+    hash = "sha256-DCA7zMMmcNB10HJdfmn3xHN59yivqUyWAN6cNPuG63Y=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    qt6.wrapQtAppsHook
+  ];
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtmultimedia
+    qt6.qtsvg
+  ];
+
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-include xlocale.h";
+
+  meta = {
+    description = "Folder player for big local music collections";
+    homepage = "https://github.com/olegantonyan/mpz";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "mpz";
+    maintainers = [
+      lib.maintainers.burntpineapple12
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Init package [mpz](https://github.com/olegantonyan/mpz)
Added myself to maintainers list

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].