### PR TITLE
nixos/feishin: init module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23971,6 +23971,12 @@
     githubId = 12279531;
     name = "Ricardo Guevara";
   };
+  rharish = {
+    email = "harish.rajagopals@gmail.com";
+    github = "rharish101";
+    githubId = 25344287;
+    name = "Harish Rajagopal";
+  };
   rhelmot = {
     name = "Audrey Dutcher";
     github = "rhelmot";

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -38,6 +38,8 @@
 
 - [mail-tlsa-check-exporter](https://github.com/ietf-tools/mail-tlsa-check-exporter), validates SMTP / IMAP server certificates against a TLSA record as a Prometheus exporter. Available as [services.prometheus.exporters.mail-tlsa-check](#opt-services.prometheus.exporters.mail-tlsa-check.enable).
 
+- [feishin](https://github.com/jeffvli/feishin), a modern self-hosted music player. Available as [services.feishin](#opt-services.feishin.enable).
+
 - [CastSponsorSkip](https://github.com/gabe565/CastSponsorSkip/), skips YouTube sponsorships (and sometimes ads) on all local Google Cast devices.
 
 - [Stump](https://www.stumpapp.dev/), a free and open source comics, manga and digital book server with OPDS support. Available as [services.stump](#opt-services.stump.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1671,6 +1671,7 @@
   ./services/web-apps/engelsystem.nix
   ./services/web-apps/ente.nix
   ./services/web-apps/fediwall.nix
+  ./services/web-apps/feishin.nix
   ./services/web-apps/fider.nix
   ./services/web-apps/filebrowser.nix
   ./services/web-apps/firefly-iii-data-importer.nix

--- a/nixos/modules/services/web-apps/feishin.nix
+++ b/nixos/modules/services/web-apps/feishin.nix
@@ -1,0 +1,156 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.feishin;
+in
+{
+  options.services.feishin = {
+    enable = lib.mkEnableOption "the web version of Feishin";
+
+    package = lib.mkPackageOption pkgs "feishin-web" { };
+
+    domain = lib.mkOption {
+      description = "Domain to use for the virtualhost.";
+      type = lib.types.str;
+    };
+
+    pathbase = lib.mkOption {
+      description = "URL path base to use for the virtualhost.";
+      type = lib.types.str;
+      default = "";
+      example = "/music";
+    };
+
+    settings = lib.mkOption {
+      description = ''
+        Configuration for the web version of Feishin, specified as key-value pairs.
+
+        Refer to <https://github.com/jeffvli/feishin#configuration>, and
+        <https://github.com/jeffvli/feishin/blob/development/settings.js.template>
+        for the template.
+      '';
+      type = lib.types.attrsOf lib.types.str;
+      default = {
+        ANALYTICS_DISABLED = "true";
+      };
+      example = {
+        ANALYTICS_DISABLED = "true";
+        SERVER_NAME = "My Server";
+        SERVER_LOCK = "true";
+      };
+    };
+
+    nginx = {
+      enable = lib.mkEnableOption "a virtualhost to serve Feishin through nginx";
+
+      virtualHost = lib.mkOption {
+        description = "Extra configuration for the nginx virtualhost for Feishin.";
+        type = lib.types.submodule (import ../web-servers/nginx/vhost-options.nix { inherit config lib; });
+        default = { };
+        example = lib.literalExpression ''
+          {
+            serverAliases = [ "feishin.''${config.networking.domain}" ];
+          }
+        '';
+      };
+    };
+
+    caddy = {
+      enable = lib.mkEnableOption "a virtualhost to serve Feishin through Caddy";
+
+      virtualHost = lib.mkOption {
+        description = "Extra configuration for the Caddy virtualhost for Feishin.";
+        type = lib.types.submodule (
+          import ../web-servers/caddy/vhost-options.nix { cfg = config.services.caddy; }
+        );
+        default = { };
+        example = lib.literalExpression ''
+          {
+            serverAliases = [ "feishin.''${config.networking.domain}" ];
+          }
+        '';
+      };
+    };
+  };
+
+  config =
+    let
+      resolvedSettings =
+        cfg.settings // lib.optionalAttrs (cfg.pathbase != "") { PUBLIC_PATH = cfg.pathbase; };
+      settingsJs = ''
+        "use strict";
+        ${lib.concatMapAttrsStringSep "\n" (name: value: ''window.${name} = "${value}";'') resolvedSettings}
+      '';
+      settingsJsDir = pkgs.writeTextDir "settings.js" settingsJs;
+    in
+    lib.mkIf cfg.enable {
+      services.nginx = lib.mkIf cfg.nginx.enable {
+        enable = lib.mkDefault true;
+        virtualHosts."${cfg.domain}" = lib.mkMerge [
+          cfg.nginx.virtualHost
+          {
+            root = lib.mkForce "${cfg.package}";
+            extraConfig = ''
+              gzip on;
+              gzip_vary    on;
+              gzip_proxied any;
+              gzip_types   text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+            '';
+            locations."${cfg.pathbase}/" = {
+              tryFiles = "$uri $uri/ /index.html =404";
+            };
+            locations."=${cfg.pathbase}/settings.js" = {
+              alias = settingsJsDir + "/settings.js";
+              extraConfig = ''
+                add_header Cache-Control "no-store";
+              '';
+            };
+          }
+        ];
+      };
+
+      services.caddy = lib.mkIf cfg.caddy.enable {
+        enable = lib.mkDefault true;
+        virtualHosts."${cfg.domain}" = lib.mkMerge [
+          cfg.caddy.virtualHost
+          {
+            hostName = lib.mkForce cfg.domain;
+            extraConfig =
+              let
+                baseConfig = ''
+                  encode
+                  handle /settings.js {
+                    header Cache-Control no-store
+                    root ${settingsJsDir}
+                    file_server
+                  }
+                  handle {
+                    root ${cfg.package}
+                    try_files {path} /index.html
+                    file_server
+                  }
+                '';
+              in
+              if (cfg.pathbase == "") then
+                baseConfig
+              else
+                ''
+                  handle_path ${cfg.pathbase}/* {
+                    ${baseConfig}
+                  }
+                '';
+          }
+        ];
+      };
+    };
+
+  meta.maintainers = with lib.maintainers; [
+    rharish
+    BatteredBunny
+  ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -577,6 +577,7 @@ in
   fastnetmon-advanced = runTest ./fastnetmon-advanced.nix;
   fcitx5 = runTest ./fcitx5;
   fedimintd = runTest ./fedimintd.nix;
+  feishin = handleTest ./feishin { };
   ferm = runTest ./ferm.nix;
   ferretdb = import ./ferretdb.nix { inherit pkgs runTest; };
   fider = runTest ./fider.nix;

--- a/nixos/tests/feishin/caddy.nix
+++ b/nixos/tests/feishin/caddy.nix
@@ -1,0 +1,36 @@
+import ../make-test-python.nix (
+  { lib, ... }:
+
+  {
+    name = "feishin-caddy";
+    meta.maintainers = with lib.maintainers; [
+      rharish
+      BatteredBunny
+    ];
+
+    nodes.machine =
+      { pkgs, ... }:
+      {
+        services.feishin = {
+          enable = true;
+          domain = "localhost:80";
+          pathbase = "/feishin";
+          settings = {
+            ANALYTICS_DISABLED = "true";
+          };
+          caddy.enable = true;
+          caddy.virtualHost.extraConfig = "tls internal";
+        };
+        # disable letsencrypt cert fetching
+        services.caddy.globalConfig = "auto_https disable_certs";
+      };
+
+    testScript = ''
+      machine.wait_for_unit("caddy.service")
+      machine.wait_for_open_port(80)
+      machine.succeed("curl -vvv --fail --show-error --silent --location --insecure http://localhost/feishin/")
+      assert "<title>Feishin</title>" in machine.succeed("curl --fail --show-error --silent --location --insecure http://localhost/feishin/")
+      assert "window.ANALYTICS_DISABLED = \"true\";" in machine.succeed("curl --fail --show-error --silent --location --insecure http://localhost/feishin/settings.js")
+    '';
+  }
+)

--- a/nixos/tests/feishin/default.nix
+++ b/nixos/tests/feishin/default.nix
@@ -1,0 +1,6 @@
+{ system, pkgs, ... }:
+
+{
+  caddy = import ./caddy.nix { inherit system pkgs; };
+  nginx = import ./nginx.nix { inherit system pkgs; };
+}

--- a/nixos/tests/feishin/nginx.nix
+++ b/nixos/tests/feishin/nginx.nix
@@ -1,0 +1,33 @@
+import ../make-test-python.nix (
+  { lib, ... }:
+
+  {
+    name = "feishin-nginx";
+    meta.maintainers = with lib.maintainers; [
+      rharish
+      BatteredBunny
+    ];
+
+    nodes.machine =
+      { pkgs, ... }:
+      {
+        services.feishin = {
+          enable = true;
+          domain = "localhost";
+          pathbase = "/feishin";
+          settings = {
+            ANALYTICS_DISABLED = "true";
+          };
+          nginx.enable = true;
+        };
+      };
+
+    testScript = ''
+      machine.wait_for_unit("nginx.service")
+      machine.wait_for_open_port(80)
+      machine.succeed("curl -vvv --fail --show-error --silent --location --insecure http://localhost/feishin/")
+      assert "<title>Feishin</title>" in machine.succeed("curl --fail --show-error --silent --location --insecure http://localhost/feishin/")
+      assert "window.ANALYTICS_DISABLED = \"true\";" in machine.succeed("curl --fail --show-error --silent --location --insecure http://localhost/feishin/settings.js")
+    '';
+  }
+)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds a module for the web version of Feishin, inspired by the BentoPDF module. The web version is basically a static website that's to be served by a reverse proxy like nginx or Caddy. The configurations were inspired by the nginx config template from upstream: <https://github.com/jeffvli/feishin/blob/development/ng.conf.template>.

I've already tested this on my server, both using the exact module file from this PR as well as a customised version (here's the Caddy config: <https://github.com/rharish101/nix-configs/blob/d5cffe96026488594f130a1065323fd157f0584d/modules/containers/caddy-wg-client.nix#L185-L212>).

Tagging @BatteredBunny for review as requested in <https://github.com/NixOS/nixpkgs/pull/539062#pullrequestreview-4678541496>. I've also added you as a maintainer of this module, although let me know if you'd rather not maintain it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test