### PR TITLE
woxi: init at 0.2.0

### DIFF
--- a/pkgs/by-name/wo/woxi/package.nix
+++ b/pkgs/by-name/wo/woxi/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  testers,
+  makeBinaryWrapper,
+  curl,
+  writableTmpDirAsHomeHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "woxi";
+  version = "0.2.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "ad-si";
+    repo = "Woxi";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-iXRor0LU17ZDyFCXYwUz3vNp6+YbCpNDmnbTX/gof/s=";
+  };
+
+  cargoHash = "sha256-8FuiCitjDuWOkx06H0qjxHcPtc/F2tlaeaRwIznuWWc=";
+
+  useNextest = true;
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    curl
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/woxi \
+      --prefix PATH : ${lib.makeBinPath [ curl ]}
+  '';
+
+  # NOTE: `SetDirectory[]` tests look up the $HOME directory.
+  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      version = "v${finalAttrs.version}";
+    };
+  };
+
+  meta = {
+    description = "Wolfram Language interpreter implemented in Rust";
+    homepage = "https://woxi.ad-si.com/";
+    downloadPage = "https://github.com/ad-si/Woxi";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [
+      Dietr1ch
+    ];
+    mainProgram = "woxi";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Things done

Packaged [woxi](https://woxi.ad-si.com/). It runs tests and has a working update-script setup.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
