### PR TITLE
libiec61850: 1.6.1 -> 1.6.2

### DIFF
--- a/pkgs/by-name/li/libiec61850/package.nix
+++ b/pkgs/by-name/li/libiec61850/package.nix
@@ -10,16 +10,21 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libiec61850";
-  version = "1.6.1";
+  version = "1.6.2";
 
   src = fetchFromGitHub {
     owner = "mz-automation";
     repo = "libiec61850";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-9UPXuZkAxr3SSjPN3VZRr6Hsz0GyDVJLUZEM+zZruik=";
+    hash = "sha256-KqgQxy/4vwFDkr9tVCVWDmbNuGivN6knf7rNHS+DTxc=";
   };
 
   separateDebugInfo = true;
+
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace src/CMakeLists.txt --replace-fail "-lrt" ""
+    substituteInPlace hal/CMakeLists.txt --replace-fail "-lrt" ""
+  '';
 
   cmakeFlags = lib.optionals withTls [
     "-DCONFIG_USE_EXTERNAL_MBEDTLS_DYNLIB=ON"


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/545309

Fixes CVE-2026-49035
Fixes CVE-2026-50039
Fixes CVE-2026-50032
Fixes CVE-2026-50103

https://github.com/mz-automation/libiec61850/releases/tag/v1.6.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 545377`
Commit: `4d16122dfeb0a8428fc9e4a2206db84c7eca8a76`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>glpi-agent</li>
    <li>libiec61850</li>
  </ul>
</details>
