### PR TITLE
text-embeddings-inference: init at 1.9.3

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -22,6 +22,8 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- [text-embeddings-inference](#opt-services.text-embeddings-inference.enable), a high-performance inference server for text embedding, reranking, and sequence-classification models.
+
 - [tranquil](https://tangled.org/tranquil.farm/tranquil-pds) is an ATProto PDS (personal data server) implementation in Rust. A featureful, spec conscious and community driven alternative to the Bluesky reference implementation PDS. Available as [services.tranquil-pds](#opt-services.tranquil-pds.enable).
 
 - [Moonlight Qt](https://moonlight-stream.org/), a client for playing your PC games on almost any device. Available as [programs.moonlight-qt](#opt-programs.moonlight-qt.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1000,6 +1000,7 @@
   ./services/misc/tautulli.nix
   ./services/misc/tdarr
   ./services/misc/tee-supplicant
+  ./services/misc/text-embeddings-inference.nix
   ./services/misc/tiddlywiki.nix
   ./services/misc/tp-auto-kbbl.nix
   ./services/misc/transfer-sh.nix

--- a/nixos/modules/services/misc/text-embeddings-inference.nix
+++ b/nixos/modules/services/misc/text-embeddings-inference.nix
@@ -1,0 +1,154 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.text-embeddings-inference;
+  inherit (lib)
+    escapeShellArgs
+    getExe
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    optional
+    types
+    ;
+in
+{
+  options.services.text-embeddings-inference = {
+    enable = mkEnableOption "Hugging Face Text Embeddings Inference server";
+
+    package = mkPackageOption pkgs "text-embeddings-inference" { };
+
+    modelId = mkOption {
+      type = types.str;
+      example = "BAAI/bge-base-en-v1.5";
+      description = ''
+        Hugging Face model id, or local path to a model directory, to serve. See
+        <https://huggingface.co/models?other=text-embeddings-inference> for
+        compatible models.
+      '';
+    };
+
+    hostname = mkOption {
+      type = types.str;
+      default = "0.0.0.0";
+      description = "Address to listen on.";
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 8080;
+      description = "Port to listen on.";
+    };
+
+    environmentFile = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "/run/secrets/text-embeddings-inference.env";
+      description = ''
+        Path to an environment file loaded by the service. Use it to provide
+        `HF_TOKEN` for gated/private models, e.g.:
+
+        ```
+        HF_TOKEN=hf_xxx
+        ```
+
+        An environment file is used instead of {manpage}`systemd.exec(5)`
+        `LoadCredential=` because the server reads `HF_TOKEN` directly from the
+        process environment.
+      '';
+    };
+
+    extraArgs = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = ''
+        Extra command-line arguments passed to `text-embeddings-router`
+        (for example `--pooling`, `--dtype`, `--max-batch-tokens`). See
+        `text-embeddings-router --help`.
+      '';
+    };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to open the firewall for the configured port.
+
+        The server has no built-in authentication, so only enable this when
+        access is otherwise restricted (e.g. bound to `127.0.0.1`, or placed
+        behind an authenticating reverse proxy).
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.text-embeddings-inference = {
+      description = "Hugging Face Text Embeddings Inference server";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+
+      environment.HF_HOME = "/var/lib/text-embeddings-inference";
+
+      serviceConfig = {
+        Type = "exec";
+        DynamicUser = true;
+        ExecStart = escapeShellArgs (
+          [
+            (getExe cfg.package)
+            "--model-id"
+            cfg.modelId
+            "--hostname"
+            cfg.hostname
+            "--port"
+            (toString cfg.port)
+          ]
+          ++ cfg.extraArgs
+        );
+        EnvironmentFile = optional (cfg.environmentFile != null) cfg.environmentFile;
+        StateDirectory = "text-embeddings-inference";
+        WorkingDirectory = "/var/lib/text-embeddings-inference";
+
+        CapabilityBoundingSet = [ "" ];
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [ "@system-service" ];
+        UMask = "0077";
+      };
+    };
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.port ];
+    };
+  };
+
+  meta.maintainers = [ lib.maintainers.gdifolco ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1748,6 +1748,7 @@ in
   temporal = runTest ./temporal.nix;
   terminal-emulators = handleTest ./terminal-emulators.nix { };
   test-containers-bittorrent = runTest ./test-containers-bittorrent.nix;
+  text-embeddings-inference = runTest ./text-embeddings-inference.nix;
   thanos = runTest ./thanos.nix;
   thelounge = handleTest ./thelounge.nix { };
   tiddlywiki = runTest ./tiddlywiki.nix;

--- a/nixos/tests/text-embeddings-inference.nix
+++ b/nixos/tests/text-embeddings-inference.nix
@@ -1,0 +1,39 @@
+{ lib, ... }:
+{
+  name = "text-embeddings-inference";
+  meta.maintainers = with lib.maintainers; [ gdifolco ];
+
+  nodes.machine =
+    { ... }:
+    {
+      services.text-embeddings-inference = {
+        enable = true;
+        # Small, publicly downloadable model (~90 MB) so cold start and warmup
+        # stay fast. all-MiniLM-L6-v2 emits 384-dimensional embeddings.
+        modelId = "sentence-transformers/all-MiniLM-L6-v2";
+        openFirewall = true;
+      };
+    };
+
+  testScript = ''
+    import json
+
+    machine.wait_for_unit("text-embeddings-inference.service")
+    machine.wait_for_open_port(8080)
+
+    # `/embed` returns a bare JSON array of embedding vectors (one per input).
+    response = machine.succeed(
+      """
+      curl -fsS -X POST http://127.0.0.1:8080/embed \
+        -H 'Content-Type: application/json' \
+        -d '{"inputs":"hello world"}'
+      """
+    )
+
+    embeddings = json.loads(response)
+    assert isinstance(embeddings, list) and len(embeddings) == 1, (
+      "unexpected /embed response: " + response[:200]
+    )
+    assert len(embeddings[0]) == 384, "expected a 384-dimensional vector"
+  '';
+}

--- a/pkgs/by-name/te/text-embeddings-inference/metrics-141402.patch
+++ b/pkgs/by-name/te/text-embeddings-inference/metrics-141402.patch
@@ -1,0 +1,15 @@
+--- a/src/recorder/mod.rs
++++ b/src/recorder/mod.rs
+@@ -72,7 +72,11 @@
+         // SAFETY: While we take a lifetime-less pointer to the given reference, the reference we
+         // derive _from_ the pointer is never given a lifetime that exceeds the lifetime of the
+         // input reference.
+-        let recorder_ptr = unsafe { NonNull::new_unchecked(recorder as *const _ as *mut _) };
++        // Rust >=1.9x rejects the lifetime-extending raw-pointer cast below
++        // (rust-lang/rust#141402); transmute bypasses that check. Soundness is
++        // unchanged: the guard clears the pointer before the reference is gone.
++        let recorder_ptr: NonNull<dyn Recorder> =
++            unsafe { std::mem::transmute(recorder as *const dyn Recorder) };
+ 
+         LOCAL_RECORDER.with(|local_recorder| {
+             local_recorder.set(Some(recorder_ptr));

--- a/pkgs/by-name/te/text-embeddings-inference/package.nix
+++ b/pkgs/by-name/te/text-embeddings-inference/package.nix
@@ -8,6 +8,7 @@
   openssl,
   versionCheckHook,
   nix-update-script,
+  nixosTests,
   testers,
 }:
 
@@ -65,7 +66,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   passthru = {
     updateScript = nix-update-script { };
-    tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
+    tests = {
+      version = testers.testVersion { package = finalAttrs.finalPackage; };
+      text-embeddings-inference = nixosTests.text-embeddings-inference;
+    };
   };
 
   meta = {

--- a/pkgs/by-name/te/text-embeddings-inference/package.nix
+++ b/pkgs/by-name/te/text-embeddings-inference/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  cmake,
+  perl,
+  pkg-config,
+  openssl,
+  versionCheckHook,
+  nix-update-script,
+  testers,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "text-embeddings-inference";
+  version = "1.9.3";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "huggingface";
+    repo = "text-embeddings-inference";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-WlgGNmp5CCQjpgaiMCzOEH3xJQiroco6/Ilx57d+qZs=";
+  };
+
+  # Build only the server binary. Scoping with -p avoids compiling the
+  # python/ort/grpc-client backends (which need Python / extra native deps).
+  # Workspace default features ["candle","http","dynamic-linking"] build the
+  # pure-CPU candle backend; "dynamic-linking" is a no-op (cudarc/mkl optional).
+  cargoHash = "sha256-mQcNRmhto6825ZtpcHF0rz2GLthytXa447ZXlUIRYiE=";
+  cargoBuildFlags = [
+    "-p"
+    "text-embeddings-router"
+  ];
+
+  # perl drives AWS-LC's cmake build; cmake + pkg-config build aws-lc-sys
+  # (reqwest rustls) and openssl-sys (reqwest native-tls).
+  nativeBuildInputs = [
+    cmake
+    perl
+    pkg-config
+  ];
+
+  buildInputs = [ openssl ];
+
+  # onig_sys 6.9.8 (tokenizers) vendors oniguruma whose K&R-style `ANYARGS`
+  # macro expands to `()`. Under GCC 15's default (C23) `()` means `(void)`,
+  # so the macro's call sites fail as "too many arguments" hard errors; use the
+  # pre-C23 semantics where `()` is an unspecified (K&R) prototype.
+  env.NIX_CFLAGS_COMPILE = "-std=gnu17";
+
+  postPatch = ''
+    # metrics 0.23.0 stores a borrowed trait object in a thread-local via a raw
+    # pointer cast; Rust >=1.9x rejects the lifetime-extending cast
+    # (rust-lang/rust#141402). transmute bypasses that check without changing
+    # soundness (the guard clears the pointer before the reference is gone).
+    patch -p1 -d "$cargoDepsCopy"/*/metrics-0.23.0 < ${./metrics-141402.patch}
+  '';
+
+  doCheck = false; # tests download models from the Hugging Face Hub (network)
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
+  };
+
+  meta = {
+    description = "Inference server for embedding, reranking, and sequence classification models";
+    homepage = "https://github.com/huggingface/text-embeddings-inference";
+    changelog = "https://github.com/huggingface/text-embeddings-inference/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.gdifolco ];
+    platforms = lib.platforms.linux;
+    mainProgram = "text-embeddings-router";
+  };
+})


### PR DESCRIPTION
Add [text-embeddings-inference](https://github.com/huggingface/text-embeddings-inference) package and module

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
