### PR TITLE
nixos/lidarr: harden systemd

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -85,6 +85,8 @@
 
 - When Avahi's mDNS resolver is enabled (`services.avahi.nssmdns4` or `services.avahi.nssmdns6`), only the minimal mDNS resolver is enabled by default to avoid adding a 5 second delay to every failed reverse hostname lookup (e.g., delaying ping by 5 seconds). The "full" mDNS resolver now remains disabled unless `services.avahi.nssmdnsFull` is also enabled. Users who have customized [`/etc/mdns.allow`](https://github.com/avahi/nss-mdns/tree/master#etcmdnsallow) to allow mDNS domains not ending `.local` must enable `services.avahi.nssmdnsFull` to continue to resolve such domains.
 
+- Lidarr's systemd unit hardening now requires that directories owned by Lidarr are passed to `services.lidarr.libraryPaths`, and directories not managed by Lidarr are passed to `systemd.services.lidarr.serviceConfig.BindReadOnlyPaths` or `systemd.services.lidarr.serviceConfig.BindPaths`.
+
 - String values passed to `services.phpfpm.settings`, `services.phpfpm.pools.<name>.phpEnv`, and `services.phpfpm.pools.<name>.settings` are now properly quoted and escaped, except for the `${}` syntax that is left as-is. If you are manually escaping these values, please adjust accordingly.
 
 - `systemd.user.extraConfig` has been removed in favor of the structured [](#opt-systemd.user.settings.Manager) option. Use `systemd.user.settings.Manager` to set any `systemd-user.conf(5)` option directly. For example, replace `systemd.user.extraConfig = "DefaultTimeoutStartSec=60";` with `systemd.user.settings.Manager.DefaultTimeoutStartSec = 60;`.

--- a/nixos/modules/services/misc/servarr/lidarr.nix
+++ b/nixos/modules/services/misc/servarr/lidarr.nix
@@ -48,14 +48,52 @@ in
           Group under which Lidarr runs.
         '';
       };
+
+      libraryPaths = lib.mkOption {
+        type = lib.types.listOf lib.types.path;
+        default = [ ];
+        example = [
+          "/media/music"
+          "/media/misc"
+        ];
+        description = ''
+          Absolute paths to bind-mount as mutable to the service.
+          These paths specified will be created and owned by the lidarr service {option}`user` and {option}`group`.
+          These paths must still be selected manually at initial start-up for library usage.
+
+          If additional paths are required for the service that are not owned by the lidarr user,
+          add them to {option}`config.systemd.services.lidarr.serviceConfig.BindReadOnlyPaths`
+          or {option}`config.systemd.services.lidarr.serviceConfig.BindPaths`.
+
+          Lidarr is ran inside a {manpage}`pivot_root(2)`, so any paths not bind-mounted will not be visible
+          to Lidarr.
+        '';
+      };
+
+      libraryPermissions = lib.mkOption {
+        type = lib.types.str;
+        default = "750";
+        example = "2755";
+        description = ''
+          Permissions to create the {option}`libraryPaths` with in octal format.
+        '';
+      };
     };
   };
 
   config = lib.mkIf cfg.enable {
-    systemd.tmpfiles.settings."10-lidarr".${cfg.dataDir}.d = {
-      inherit (cfg) user group;
-      mode = "0700";
-    };
+    systemd.tmpfiles.settings."10-lidarr" = {
+      ${cfg.dataDir}.d = {
+        inherit (cfg) user group;
+        mode = "0700";
+      };
+    }
+    // lib.genAttrs cfg.libraryPath (_: {
+      d = {
+        inherit (cfg) user group;
+        mode = cfg.libraryPermissions;
+      };
+    });
 
     systemd.services.lidarr = {
       description = "Lidarr";
@@ -70,6 +108,71 @@ in
         EnvironmentFile = cfg.environmentFiles;
         ExecStart = "${cfg.package}/bin/Lidarr -nobrowser -data='${cfg.dataDir}'";
         Restart = "on-failure";
+
+        # Hardening
+        RuntimeDirectory = "lidarr";
+        RootDirectory = "/run/lidarr"; # pivot_root to /run/lidarr
+        StateDirectory = "lidarr";
+        WorkingDirectory = cfg.dataDir;
+        ReadWritePaths = "";
+        BindPaths = [
+          cfg.dataDir
+        ]
+        ++ cfg.libraryPaths;
+
+        # Paths for TLS and DNS
+        BindReadOnlyPaths = [
+          builtins.storeDir
+          "/etc"
+        ]
+        ++ lib.optionals config.services.resolved.enable [
+          "/run/systemd/resolve/stub-resolv.conf"
+          "/run/systemd/resolve/resolv.conf"
+        ];
+
+        CapabilityBoundingSet = "";
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+        SystemCallFilter = [
+          "@system-service"
+          "@chown"
+          "chmod"
+          "fchmod"
+          "fchmodat"
+          "fchmodat2"
+          "~@privileged"
+        ];
+        UMask = "0007";
+
+        SystemCallArchitectures = "native";
+        ProtectSystem = "strict"; # Mount all as r/o
+        ProtectProc = "invisible";
+
+        LockPersonality = true;
+        NoNewPrivileges = true;
+        PrivateMounts = true;
+        PrivateDevices = true;
+        PrivateIPC = true;
+        PrivatePIDs = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProtectClock = true;
+        ProtectHome = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectHostname = true;
+        ProtectKernelTunables = true;
+        ProtectControlGroup = true;
+        RemoveIPC = true;
+        RestrictRealtime = true;
+        RestrictNamespaces = true;
+
+        # Networking
+        SocketBindDeny = "any";
+        SocketBindAllow = "tcp:${toString cfg.settings.server.port}"; # Only allow binding the specified port
+        SystemCallErrorNumber = "EPERM";
       };
     };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
#377827 
Will do some more testing when I get home.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
