### PR TITLE
chronicler: init at 0.56.3-alpha

### DIFF
--- a/lib/licenses/licenses.nix
+++ b/lib/licenses/licenses.nix
@@ -1309,7 +1309,7 @@ lib.mapAttrs mkLicense (
       fullName = "PHP License v3.01";
     };
 
-    polyFormShieldd100 = {
+    polyFormShield100 = {
       shortName = "polyform-shield-1.0.0";
       fullName = "PolyForm Shield License 1.0.0";
       url = "https://raw.githubusercontent.com/mak-kirkland/chronicler/v0.56.3-alpha/LICENSE";

--- a/lib/licenses/licenses.nix
+++ b/lib/licenses/licenses.nix
@@ -1309,6 +1309,14 @@ lib.mapAttrs mkLicense (
       fullName = "PHP License v3.01";
     };
 
+    polyFormShieldd100 = {
+      shortName = "polyform-shield-1.0.0";
+      fullName = "PolyForm Shield License 1.0.0";
+      url = "https://raw.githubusercontent.com/mak-kirkland/chronicler/v0.56.3-alpha/LICENSE";
+      free = false;
+      redistributable = true;
+    };
+
     postgresql = {
       spdxId = "PostgreSQL";
       fullName = "PostgreSQL License";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8250,7 +8250,7 @@
     name = "Emily Trau";
     email = "emily+nix@downunderctf.com";
     github = "emilytrau";
-    githubId = 13267947;
+    githubId = 13267947;flaming
   };
   Emin017 = {
     email = "cchuqiming@gmail.com";
@@ -8283,6 +8283,12 @@
     email = "me@encode42.dev";
     github = "encode42";
     githubId = 34699884;
+  };
+  enderfare = {
+    email = "ender.fare.md@gmail.com";
+    github = "enderfare";
+    githubId = 135335132;
+    name = "Ender Fare";
   };
   enderger = {
     email = "endergeryt@gmail.com";
@@ -9614,6 +9620,12 @@
     github = "frostplexx";
     githubId = 62436912;
     name = "Daniel Inama";
+  };
+  frozenoverthemoon = {
+    email = "frozenoverthemoon@gmail.com";
+    github = "FrozenOverTheMoon";
+    githubId = 120668955;
+    name = "Frozen Moon";
   };
   fryuni = {
     name = "Luiz Ferraz";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8250,7 +8250,7 @@
     name = "Emily Trau";
     email = "emily+nix@downunderctf.com";
     github = "emilytrau";
-    githubId = 13267947;flaming
+    githubId = 13267947;
   };
   Emin017 = {
     email = "cchuqiming@gmail.com";

--- a/pkgs/by-name/ch/chronicler/package.nix
+++ b/pkgs/by-name/ch/chronicler/package.nix
@@ -4,8 +4,31 @@
 , autoPatchelfHook
 , dpkg
 , wrapGAppsHook3
+, makeWrapper
+, glib
 , gtk3
 , webkitgtk_4_1
+, libsoup_3
+, openssl
+, zlib
+, pango
+, cairo
+, gdk-pixbuf
+, atk
+, libappindicator-gtk3
+, libX11
+, libXcomposite
+, libXdamage
+, libXext
+, libXfixes
+, libXrender
+, libXrandr
+, libxcb
+, libxkbcommon
+, libdrm
+, mesa
+, gsettings-desktop-schemas
+, fontconfig
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -20,22 +43,65 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     dpkg
     autoPatchelfHook
+    makeWrapper
     wrapGAppsHook3
   ];
 
   buildInputs = [
+    glib
     gtk3
     webkitgtk_4_1
+    libsoup_3
+    openssl
+    zlib
+    pango
+    cairo
+    gdk-pixbuf
+    atk
+    libappindicator-gtk3
+    libX11
+    libXcomposite
+    libXdamage
+    libXext
+    libXfixes
+    libXrender
+    libXrandr
+    libxcb
+    libxkbcommon
+    libdrm
+    mesa
+    gsettings-desktop-schemas
+    fontconfig
+    stdenv.cc.cc.lib
   ];
 
   unpackPhase = "dpkg-deb -x $src .";
 
   installPhase = ''
     runHook preInstall
-    mkdir -p $out
-    cp -r usr/* $out/
+
+    mkdir -p $out/bin $out/share $out/lib
+    
+    # Copy binaries, icons/desktop files, and internal libraries
+    cp -r usr/bin/*       $out/bin/
+    cp -r usr/share/*     $out/share/ 2>/dev/null || true
+    cp -r usr/lib/*       $out/lib/   2>/dev/null || true
+
+    # Fix .desktop file: set Exec to the Nix store path (Ender's good idea)
+    for f in $out/share/applications/*.desktop; do
+      if [ -f "$f" ]; then
+        substituteInPlace "$f" --replace-fail "Exec=chronicler" "Exec=$out/bin/chronicler"
+      fi
+    done
+
     runHook postInstall
   '';
+
+  # Ensures the app finds its own internal libraries and C++ libs
+  appendRunpaths = [ 
+    "${stdenv.cc.cc.lib}/lib"
+    "$out/lib/chronicler"
+  ];
 
   meta = {
     description = "A free, offline worldbuilding tool and local wiki for writers and RPG creators";

--- a/pkgs/by-name/ch/chronicler/package.nix
+++ b/pkgs/by-name/ch/chronicler/package.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, dpkg
+, wrapGAppsHook3
+, gtk3
+, webkitgtk_4_1
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "chronicler";
+  version = "0.56.3-alpha";
+
+  src = fetchurl {
+    url = "https://github.com/mak-kirkland/chronicler/releases/download/v${finalAttrs.version}/Chronicler_${lib.versions.majorMinorPatch finalAttrs.version}_amd64.deb";
+    hash = "sha256-0MEh1Zp2hmfBZI2WcpNh58AHOnmLexteIVSllmzefnM=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    gtk3
+    webkitgtk_4_1
+  ];
+
+  unpackPhase = "dpkg-deb -x $src .";
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    cp -r usr/* $out/
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A free, offline worldbuilding tool and local wiki for writers and RPG creators";
+    homepage = "https://chronicler.pro/";
+    license = lib.licenses.polyFormShield100;
+    maintainers = with lib.maintainers; [ enderfare frozenoverthemoon ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    mainProgram = "chronicler";
+  };
+})

--- a/pkgs/by-name/ch/chronicler/package.nix
+++ b/pkgs/by-name/ch/chronicler/package.nix
@@ -16,7 +16,7 @@
 , gdk-pixbuf
 , atk
 , libappindicator-gtk3
-, libX11
+, libx11
 , libXcomposite
 , libXdamage
 , libXext
@@ -61,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
     atk
     at-spi2-atk
     libappindicator-gtk3
-    libX11
+    libx11
     libXcomposite
     libXdamage
     libXext

--- a/pkgs/by-name/ch/chronicler/package.nix
+++ b/pkgs/by-name/ch/chronicler/package.nix
@@ -1,35 +1,36 @@
-{ lib
-, stdenv
-, fetchurl
-, autoPatchelfHook
-, dpkg
-, wrapGAppsHook3
-, makeWrapper
-, glib
-, gtk3
-, webkitgtk_4_1
-, libsoup_3
-, openssl
-, zlib
-, pango
-, cairo
-, gdk-pixbuf
-, atk
-, libappindicator-gtk3
-, libx11
-, libxcomposite
-, libxdamage
-, libxext
-, libxfixes
-, libxrender
-, libxrandr
-, libxcb
-, libxkbcommon
-, libdrm
-, mesa
-, gsettings-desktop-schemas
-, fontconfig
-, at-spi2-atk
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  dpkg,
+  wrapGAppsHook3,
+  makeWrapper,
+  glib,
+  gtk3,
+  webkitgtk_4_1,
+  libsoup_3,
+  openssl,
+  zlib,
+  pango,
+  cairo,
+  gdk-pixbuf,
+  atk,
+  libappindicator-gtk3,
+  libx11,
+  libxcomposite,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxrender,
+  libxrandr,
+  libxcb,
+  libxkbcommon,
+  libdrm,
+  mesa,
+  gsettings-desktop-schemas,
+  fontconfig,
+  at-spi2-atk,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -77,17 +78,20 @@ stdenv.mkDerivation (finalAttrs: {
     stdenv.cc.cc.lib
   ];
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   unpackPhase = "dpkg-deb -x $src .";
 
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/bin $out/share $out/lib/chronicler
-    
+
     # 1. Copy the internal app files to our private lib directory
     cp -r usr/lib/chronicler/* $out/lib/chronicler/ 2>/dev/null || true
-    
-    # 2. Copy the actual binary (found in usr/bin) into our private lib
+
+    # 2. Copy the actual binary into our private lib
     cp usr/bin/chronicler $out/lib/chronicler/chronicler-bin 2>/dev/null || cp usr/bin/* $out/lib/chronicler/chronicler-bin
 
     # 3. Create a clean symlink from bin to the real binary
@@ -111,7 +115,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "A free, offline worldbuilding tool and local wiki for writers and RPG creators";
     homepage = "https://chronicler.pro/";
     license = lib.licenses.polyFormShield100;
-    maintainers = with lib.maintainers; [ enderfare frozenoverthemoon ];
+    maintainers = with lib.maintainers; [
+      enderfare
+      frozenoverthemoon
+    ];
     platforms = [ "x86_64-linux" ];
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
     mainProgram = "chronicler";

--- a/pkgs/by-name/ch/chronicler/package.nix
+++ b/pkgs/by-name/ch/chronicler/package.nix
@@ -17,12 +17,12 @@
 , atk
 , libappindicator-gtk3
 , libx11
-, libXcomposite
-, libXdamage
-, libXext
-, libXfixes
-, libXrender
-, libXrandr
+, libxcomposite
+, libxdamage
+, libxext
+, libxfixes
+, libxrender
+, libxrandr
 , libxcb
 , libxkbcommon
 , libdrm
@@ -62,12 +62,12 @@ stdenv.mkDerivation (finalAttrs: {
     at-spi2-atk
     libappindicator-gtk3
     libx11
-    libXcomposite
-    libXdamage
-    libXext
-    libXfixes
-    libXrender
-    libXrandr
+    libxcomposite
+    libxdamage
+    libxext
+    libxfixes
+    libxrender
+    libxrandr
     libxcb
     libxkbcommon
     libdrm

--- a/pkgs/by-name/ch/chronicler/package.nix
+++ b/pkgs/by-name/ch/chronicler/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.56.3-alpha";
 
   src = fetchurl {
-    url = "https://github.com/mak-kirkland/chronicler/releases/download/v${finalAttrs.version}/Chronicler_${lib.versions.pad 3 finalAttrs.version}_amd64.deb";
+    url = "https://github.com/mak-kirkland/chronicler/releases/download/v${finalAttrs.version}/Chronicler_${lib.head (lib.splitString "-" finalAttrs.version)}_amd64.deb";
     hash = "sha256-0MEh1Zp2hmfBZI2WcpNh58AHOnmLexteIVSllmzefnM=";
   };
 

--- a/pkgs/by-name/ch/chronicler/package.nix
+++ b/pkgs/by-name/ch/chronicler/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.56.3-alpha";
 
   src = fetchurl {
-    url = "https://github.com/mak-kirkland/chronicler/releases/download/v${finalAttrs.version}/Chronicler_${lib.versions.majorMinorPatch finalAttrs.version}_amd64.deb";
+    url = "https://github.com/mak-kirkland/chronicler/releases/download/v${finalAttrs.version}/Chronicler_${lib.versions.pad 3 finalAttrs.version}_amd64.deb";
     hash = "sha256-0MEh1Zp2hmfBZI2WcpNh58AHOnmLexteIVSllmzefnM=";
   };
 

--- a/pkgs/by-name/ch/chronicler/package.nix
+++ b/pkgs/by-name/ch/chronicler/package.nix
@@ -29,6 +29,7 @@
 , mesa
 , gsettings-desktop-schemas
 , fontconfig
+, at-spi2-atk
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -58,6 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
     cairo
     gdk-pixbuf
     atk
+    at-spi2-atk
     libappindicator-gtk3
     libX11
     libXcomposite
@@ -80,28 +82,30 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/bin $out/share $out/lib
+    mkdir -p $out/bin $out/share $out/lib/chronicler
     
-    # Copy binaries, icons/desktop files, and internal libraries
-    cp -r usr/bin/*       $out/bin/
-    cp -r usr/share/*     $out/share/ 2>/dev/null || true
-    cp -r usr/lib/*       $out/lib/   2>/dev/null || true
+    # 1. Copy the internal app files to our private lib directory
+    cp -r usr/lib/chronicler/* $out/lib/chronicler/ 2>/dev/null || true
+    
+    # 2. Copy the actual binary (found in usr/bin) into our private lib
+    cp usr/bin/chronicler $out/lib/chronicler/chronicler-bin 2>/dev/null || cp usr/bin/* $out/lib/chronicler/chronicler-bin
 
-    # Fix .desktop file: set Exec to the Nix store path (Ender's good idea)
-    for f in $out/share/applications/*.desktop; do
-      if [ -f "$f" ]; then
-        substituteInPlace "$f" --replace-fail "Exec=chronicler" "Exec=$out/bin/chronicler"
-      fi
-    done
+    # 3. Create a clean symlink from bin to the real binary
+    ln -s $out/lib/chronicler/chronicler-bin $out/bin/chronicler
+
+    # 4. Copy icons and desktop files
+    cp -r usr/share/* $out/share/ 2>/dev/null || true
+
+    # 5. Fix .desktop file path
+    if [ -f "$out/share/applications/chronicler.desktop" ]; then
+      substituteInPlace "$out/share/applications/chronicler.desktop" \
+        --replace-fail "Exec=chronicler" "Exec=$out/bin/chronicler"
+    fi
 
     runHook postInstall
   '';
 
-  # Ensures the app finds its own internal libraries and C++ libs
-  appendRunpaths = [ 
-    "${stdenv.cc.cc.lib}/lib"
-    "$out/lib/chronicler"
-  ];
+  appendRunpaths = [ "${stdenv.cc.cc.lib}/lib" ];
 
   meta = {
     description = "A free, offline worldbuilding tool and local wiki for writers and RPG creators";


### PR DESCRIPTION
### Summary
This PR initializes 'chronicler' at version '0.56.3-alpha'. It supercedes #495625 .

Chronicler is a free, offline worldbuilding tool and local wiki for writers and RPG creators. 

Homepage: https://chronicler.pro/

**Changes from previous attempt (#495625):**
- Updated version from 0.47.0 to 0.56.3-alpha.
- Moved to the modern 'pkgs/by-name' directory structure.
- Fixed the unstable PolyForm Shield license URL by using a stable, tag-specific Github raw link.
- Added @enderfare and myself to the maintainers list.
- Expanded 'buildInputs' to include missing Tauri/GTK dependencies to ensure the binary launches correctly on NixOS. 
 
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Verified that `./result/bin/chronicler` launches correctly on NixOS Unstable.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].