### PR TITLE
jan: use stdenvNoCC on darwin

### DIFF
--- a/pkgs/by-name/ja/jan/package.nix
+++ b/pkgs/by-name/ja/jan/package.nix
@@ -5,7 +5,7 @@
   config,
   cudaPackages,
   cudaSupport ? config.cudaSupport,
-  stdenv,
+  stdenvNoCC,
   fetchzip,
   makeWrapper,
 }:
@@ -62,7 +62,7 @@ let
     inherit passthru meta;
   };
 
-  darwin = stdenv.mkDerivation {
+  darwin = stdenvNoCC.mkDerivation {
     inherit pname version;
 
     src = darwin-src;
@@ -89,4 +89,4 @@ let
     inherit passthru meta;
   };
 in
-if stdenv.hostPlatform.isDarwin then darwin else linux
+if stdenvNoCC.hostPlatform.isDarwin then darwin else linux


### PR DESCRIPTION
The darwin build only unpacks a prebuilt bundle and wraps it; nothing is compiled, so the C toolchain is unnecessary.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].