### PR TITLE
shell: pin a Nixpkgs that supports x86_64-darwin

### DIFF
--- a/ci/pinned.json
+++ b/ci/pinned.json
@@ -12,6 +12,19 @@
       "revision": "7525d999cd850b9a488817abc89c75dc733acf17",
       "url": "https://github.com/NixOS/nixpkgs/archive/7525d999cd850b9a488817abc89c75dc733acf17.tar.gz",
       "hash": "sha256-4IHyyLgLBdKefkljdKod4IMn023pQiDXAWJA187cmdY="
+    },
+    "nixpkgs-26.05-darwin": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "NixOS",
+        "repo": "nixpkgs"
+      },
+      "branch": "nixpkgs-26.05-darwin",
+      "submodules": false,
+      "revision": "51fe96f9107566e6b8eeb7fc4ba696c01e548b04",
+      "url": "https://github.com/NixOS/nixpkgs/archive/51fe96f9107566e6b8eeb7fc4ba696c01e548b04.tar.gz",
+      "hash": "sha256-yj0LPLnsmYoLmA3FGANjeTEwej0/DHjZBXWnDQDUuIs="
     }
   },
   "version": 8

--- a/flake.nix
+++ b/flake.nix
@@ -199,7 +199,8 @@
         && system != "riscv64-linux"
         # Exclude x86_64-freebsd because "Package ‘go-1.22.12-freebsd-amd64-bootstrap’ in /nix/store/0yw40qnrar3lvc5hax5n49abl57apjbn-source/pkgs/development/compilers/go/binary.nix:50 is not available on the requested hostPlatform"
         && system != "x86_64-freebsd"
-      ) (forAllSystems (system: (import ./ci { inherit system; }).fmt.pkg));
+        # TODO: revert to importing fmt.pkg directly from ./ci when support for 26.05 ends
+      ) (forAllSystems (system: (import ./shell.nix { inherit system; }).formatter));
 
       /**
         A nested structure of [packages](https://nix.dev/manual/nix/latest/glossary#package-attribute-set) and other values.

--- a/shell.nix
+++ b/shell.nix
@@ -16,7 +16,44 @@
   nixpkgs ? null,
 }:
 let
-  inherit (import ./ci { inherit nixpkgs system; }) pkgs fmt;
+  version = builtins.readFile ./.version;
+
+  # On 26.05 we need a CI-pinned Nixpkgs revision that supports x86_64-darwin.
+  # TODO: remove after 26.05 support ends.
+  nixpkgs' =
+    if nixpkgs == null && system == "x86_64-darwin" && version == "26.05" then
+      let
+        pinned = (builtins.fromJSON (builtins.readFile ./ci/pinned.json)).pins;
+        warn = builtins.warn or (import ./lib).warn;
+
+        inherit (pinned."nixpkgs-26.05-darwin")
+          url
+          hash
+          revision
+          branch
+          ;
+
+        withWarning = warn (toString [
+          "The currently pinned Nixpkgs (${pinned.nixpkgs.revision}) does not support ${system},"
+          "using revision (${revision}) from ${branch}."
+          "You may experience some differences to CI."
+        ]);
+      in
+      withWarning fetchTarball {
+        inherit url;
+        sha256 = hash;
+      }
+    else
+      nixpkgs;
+
+  inherit
+    (import ./ci {
+      inherit system;
+      nixpkgs = nixpkgs';
+    })
+    pkgs
+    fmt
+    ;
 
   # For `nix-shell -A hello`
   curPkgs = removeAttrs (import ./. { inherit system; }) [
@@ -38,4 +75,7 @@ curPkgs
     # treefmt wrapper
     fmt.pkg
   ];
+}
+// {
+  formatter = fmt.pkg;
 }


### PR DESCRIPTION
When instantiating a dev-shell for x86_64-darwin, we cannot use CI's pinned 26.11 revision. Instead, we must use a revision that still supports x86_64-darwin.

Print a warning when we need to use that revision, because it is likely there will be subtle formatting & linting differences vs CI.

Unblocks backporting https://github.com/NixOS/nixpkgs/pull/544224 and https://github.com/NixOS/nixpkgs/pull/545265.

Initially opened this PR against `release-26.05` to see CI working. I've since rebased & re-targeted to `master`. Once merged we will backport as normal.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - `nix flake check --all-systems --no-build`
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
  - No AI used.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
