### PR TITLE
snowflake-connector-python: 4.3.0 -> 4.7.1

### DIFF
--- a/pkgs/development/python-modules/snowflake-connector-python/default.nix
+++ b/pkgs/development/python-modules/snowflake-connector-python/default.nix
@@ -2,7 +2,9 @@
   lib,
   aioboto3,
   aiohttp,
+  anyio,
   asn1crypto,
+  azure-identity,
   buildPythonPackage,
   boto3,
   botocore,
@@ -21,6 +23,7 @@
   pyarrow,
   pyjwt,
   pyopenssl,
+  python,
   pytest-asyncio,
   pytest-xdist,
   pytestCheckHook,
@@ -35,14 +38,14 @@
 
 buildPythonPackage rec {
   pname = "snowflake-connector-python";
-  version = "4.3.0";
+  version = "4.7.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "snowflakedb";
     repo = "snowflake-connector-python";
     tag = "v${version}";
-    hash = "sha256-bJK6U5lomcPMGeKEmv+9m+uM5+3GJKKUA3dEwP/ynVo=";
+    hash = "sha256-YH4hXGwgQxDliFWOWa+Nw+PychZzpqIP1/J0AcShREA=";
   };
 
   build-system = [
@@ -91,6 +94,8 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     aioboto3
     aiohttp
+    anyio
+    azure-identity
     numpy
     pytest-asyncio
     pytest-xdist
@@ -130,6 +135,18 @@ buildPythonPackage rec {
     # snowflake.connector.errors.ProgrammingError: 251008: 251008: Failed to load private key:
     # argument 'password': Cannot convert "<class 'int'>" instance to a buffer.
     "test/unit/aio/test_auth_keypair_async.py::test_auth_keypair"
+    # `AssertionError: /build/source/.wiremock/wiremock-standalone.jar` does not exist
+    "test/unit/test_redirect_retry.py"
+    # Mock is set up on `mock_wic.return_value.get_token`, but the code calls
+    # get_token() through the async context manager `(__aenter__().get_token())`,
+    # so it gets an unconfigured `AsyncMock` instead of the fixture's JWT --
+    # upstream test/mock mismatch; the sync equivalent test passes fine.
+    "test/unit/aio/test_auth_workload_identity_async.py::test_aks_path_plumbs_mi_token_to_api"
+  ]
+  # `asyncio.get_event_loop()` no longer implicitly creates a loop outside of a
+  # running one on 3.14, and this whole file relies on that in its fixtures
+  ++ lib.optionals (python.pythonAtLeast "3.14") [
+    "test/unit/aio/test_connection_async_unit.py"
   ];
 
   disabledTests = [
@@ -138,6 +155,9 @@ buildPythonPackage rec {
     "test_test_socket_get_cert"
     # Missing .wiremock/wiremock-standalone.jar
     "test_wiremock"
+    # `OperationalError: ... 'Mock' object is not iterable`. Upstream test/mock mismatch
+    "test_request_throws_http_exception_for_non_retryable"
+    "test_request_throws_http_exception_for_retryable"
   ];
 
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bump `snowflake-connector-python` to 4.7.1 as per [newly released advisory by Snowflake](https://community.snowflake.com/s/article/Snowflake-Clients-Vulnerability-Advisory). Versions between 4.0.0- 4.7.1 need to be upgraded to 4.7.1. [CVE link](https://www.cve.org/CVERecord?id=CVE-2026-15925).

[Release notes for 4.7.1](https://github.com/snowflakedb/snowflake-connector-python/releases/tag/v4.7.1).

Some failing tests have been disabled due to mismatch of dependencies between upstream and what's in nixpkgs.

Disabled-test rationale in this commit was diagnosed with AI-assistance (Claude
Code); all findings independently verified by `nixpkgs-review` and manual tests of `snowcli` functionality.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

## `nixpkgs-review`
Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `b25fb9fa30d8b7c074444349739bcb8e10bdcd96`

---
### `x86_64-linux`
<details>
  <summary>:x: 2 packages failed to build:</summary>
  <ul>
    <li>python313Packages.dbt-snowflake</li>
    <li>snowflake-cli</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 6 packages built:</summary>
  <ul>
    <li>python313Packages.snowflake-connector-python</li>
    <li>python313Packages.snowflake-core</li>
    <li>python313Packages.snowflake-sqlalchemy</li>
    <li>python314Packages.snowflake-connector-python</li>
    <li>python314Packages.snowflake-core</li>
    <li>python314Packages.snowflake-sqlalchemy</li>
  </ul>
</details>


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

