### PR TITLE
arity: init at 0.13.0

### DIFF
--- a/pkgs/by-name/ar/arity/package.nix
+++ b/pkgs/by-name/ar/arity/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  installShellFiles,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "arity";
+  version = "0.13.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "jolars";
+    repo = "arity";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-PveNcJisds0obKzUDzZ409kinWvhFO8qpvwCzhfdla8=";
+  };
+
+  cargoHash = "sha256-7Mvw9reJFmBPs8Ksn/mbSbeizdT8GhwvXT06NMlCXxc=";
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  postInstall = ''
+    installShellCompletion --cmd arity \
+      --bash target/completions/arity.bash \
+      --fish target/completions/arity.fish \
+      --zsh target/completions/_arity
+
+    installManPage target/man/*
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Language server, formatter, and linter for R";
+    homepage = "https://arity.cc";
+    changelog = "https://github.com/jolars/arity/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jolars ];
+    mainProgram = "arity";
+  };
+})


### PR DESCRIPTION
Add Arity: a language server, formatter, and linter for the R programming language. The upstream repo is at <https://github.com/jolars/arity> and the docs are at <https://arity.cc>.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
