### PR TITLE
fatou: init at 0.6.0

### DIFF
--- a/pkgs/by-name/fa/fatou/package.nix
+++ b/pkgs/by-name/fa/fatou/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  installShellFiles,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "fatou";
+  version = "0.6.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "jolars";
+    repo = "fatou";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-lbMT9CQV/nEfjxfnnpRDPhWmSbyD1nESp797hkWE1iA=";
+  };
+
+  cargoHash = "sha256-FOID5+PfNFFCCl5zG7NwZRwAg4KjuByjhtXRC5QUBW4=";
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  postInstall = ''
+    installShellCompletion --cmd fatou \
+      --bash target/completions/fatou.bash \
+      --fish target/completions/fatou.fish \
+      --zsh target/completions/_fatou
+
+    installManPage target/man/*
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Language server, formatter, and linter for Julia";
+    homepage = "https://fatou.dev/";
+    changelog = "https://github.com/jolars/fatou/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jolars ];
+    mainProgram = "fatou";
+  };
+})


### PR DESCRIPTION
Add Fatou: a language server, formatter, and linter for Julia. The homepage is <https://fatou.dev> and the repo is at <https://github.com/jolars/fatou>.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
