### PR TITLE
apache-orc: explicitly specify C++17 for abseil-cpp

### DIFF
--- a/pkgs/by-name/ap/apache-orc/package.nix
+++ b/pkgs/by-name/ap/apache-orc/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   fetchurl,
   cmake,
+  abseil-cpp,
   gtest,
   lz4,
   protobuf,
@@ -13,6 +14,11 @@
 }:
 
 let
+  # This standard needs to match the version that orc uses, or compilation
+  # fails if the C++ standard version is different from the compiler's default.
+  # https://github.com/apache/orc/blob/3738b82366ba64cacae450e7e0e1702c66148afe/CMakeLists.txt#L108
+  protobuf' = protobuf.override { abseil-cpp = abseil-cpp.override { cxxStandard = "17"; }; };
+
   orc-format =
     let
       version = "1.1.1";
@@ -52,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     gtest
     lz4
-    protobuf
+    protobuf'
     snappy
     zlib
     zstd
@@ -76,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
     GTEST_HOME = gtest.dev;
     LZ4_HOME = lz4;
     ORC_FORMAT_URL = orc-format;
-    PROTOBUF_HOME = protobuf;
+    PROTOBUF_HOME = protobuf';
     SNAPPY_HOME = snappy.dev;
     ZLIB_HOME = zlib.dev;
     ZSTD_HOME = zstd.dev;


### PR DESCRIPTION
failing build logs: https://hydra.nixos.org/build/339162714/log

abseil exposes different interfaces depending on what is available in `std` in a given C++ standard. gcc 16 defaults to C++20, thus causing the default abseil-cpp to expose a different interface than the one apache-orc (built with C++17) expects. this leads to a great deal of "error: 'partial_ordering' has not been declared in 'std'" and similar originating from abseil's types/compare.h. thus, we explicitly override abseil to specify the desired C++ standard. this happens through protobuf as abseil-cpp is in its propagatedBuildInputs.

we're not 100% sure that this the correct solution, but it seems to fix things. an alternative would be to unpin the C++ standard that apache-orc uses.

working towards #537781.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
