### PR TITLE
nginxStable: apply patches for gcc 16 in rtmp module

### DIFF
--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -6,6 +6,7 @@
   fetchFromGitHub,
   fetchFromGitLab,
   fetchhg,
+  fetchpatch,
   runCommand,
   stdenv,
 
@@ -657,12 +658,29 @@ let
 
     rtmp = {
       name = "rtmp";
-      src = fetchFromGitHub {
-        name = "rtmp";
-        owner = "arut";
-        repo = "nginx-rtmp-module";
-        rev = "v1.2.2";
-        sha256 = "0y45bswk213yhkc2v1xca2rnsxrhx8v6azxz9pvi71vvxcggqv6h";
+      src = applyPatches {
+        src = fetchFromGitHub {
+          name = "rtmp";
+          owner = "arut";
+          repo = "nginx-rtmp-module";
+          rev = "v1.2.2";
+          sha256 = "0y45bswk213yhkc2v1xca2rnsxrhx8v6azxz9pvi71vvxcggqv6h";
+        };
+
+        patches = [
+          # GCC 16's improved unused variable analysis detects some unused
+          # variables which were fixed upstream but not released.
+          (fetchpatch {
+            name = "remove-unused-variables-ngx-rtmp-handler.patch";
+            url = "https://github.com/arut/nginx-rtmp-module/commit/6c7719d0ba32e00b563ec70bd43dad11960fa9c4.patch";
+            hash = "sha256-c2hSp4CamBYMwkU9EOUSnfXvCYVOIxm1WzMR/M7Ojcc=";
+          })
+          (fetchpatch {
+            name = "remove-unused-variables-ngx-rtmp-eval.patch";
+            url = "https://github.com/arut/nginx-rtmp-module/commit/c56fd73def3eb407155ecebc28af84ea83dc99e5.patch";
+            hash = "sha256-APXdEsRp3SSUKM9ud8tbZEPsfOe/055TRD7FFHE2k9w=";
+          })
+        ];
       };
 
       meta = {


### PR DESCRIPTION
The rtmp module has some unused variables which are detected by GCC 16's improved unused variable analysis. Since nginx builds with -Werror, this causes build failures. Accordingly, we fetch the commits that were made upstream (but not yet released) to fix these issues.

failing build logs: https://hydra.nixos.org/build/339192193/log

working towards #537781

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
