### PR TITLE
prometheus-storagebox-exporter: 1.0.0 -> 1.1.0

### DIFF
--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -1757,16 +1757,6 @@ let
           enable = true;
           tokenFile = "/tmp/faketoken";
         };
-        metricProvider = {
-          networking = {
-            # The exporter tries to access Hetzner on startup and crashes.
-            # Blocking this on the firewall level allows the exporter to start.
-            extraHosts = "127.0.0.1 api.hetzner.com";
-            firewall.extraCommands = ''
-              iptables -A OUTPUT -p tcp --dport 443 -d 127.0.0.1 -j DROP
-            '';
-          };
-        };
         exporterTest = ''
           succeed(
             'echo faketoken > /tmp/faketoken'

--- a/pkgs/by-name/pr/prometheus-storagebox-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-storagebox-exporter/package.nix
@@ -6,16 +6,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "prometheus-storagebox-exporter";
-  version = "1.0.0";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "fleaz";
     repo = "prometheus-storagebox-exporter";
-    hash = "sha256-sufxNnHAdOaYEzKj9vriDrJF6Tq4Eim3Z45FEuuG97Q=";
+    hash = "sha256-eHS0/nrfl6pnB4GjbHAaQKUOHJYGy+a56N+/WNDht6Q=";
     tag = "v${finalAttrs.version}";
   };
 
-  vendorHash = "sha256-hWM7JnL0x+vsUrQsJZGM3z2jB3F1wtjKWmX8j+WnjKY=";
+  vendorHash = "sha256-NlTAmurQz7c+Gor0ExQoXUxAzcuCnk0ra3J4bojoFeU=";
 
   meta = {
     description = "Prometheus exporter for Hetzner storage boxes";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This updates the storagebox exporter to 1.1.0, which  introduces better error handling.

And therefore, the hack from #503198 to make the test work is no longer needed.

cc @Erethon 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
