### PR TITLE
python3Packages.dirty-equals: fix tests, modernize

### DIFF
--- a/pkgs/development/python-modules/dirty-equals/default.nix
+++ b/pkgs/development/python-modules/dirty-equals/default.nix
@@ -22,13 +22,19 @@ let
       hash = "sha256-JFKWrbMdxhvSBbjQ+S9HPW87CK+5ZZiXHg8Wltlv2YY=";
     };
 
+    postPatch = ''
+      # Fix pytest.PytestRemovedIn10Warning: Passing a non-Collection iterable to parametrize is deprecated.
+      substituteInPlace tests/test_docs.py \
+        --replace-fail "examples," "list(examples),"
+    '';
+
     build-system = [ hatchling ];
 
     dependencies = [ pytz ];
 
     doCheck = false;
 
-    passthru.tests.pytest = dirty-equals.overrideAttrs { doCheck = true; };
+    passthru.tests.pytest = dirty-equals.overridePythonAttrs { doCheck = true; };
 
     nativeCheckInputs = [
       pydantic

--- a/pkgs/development/python-modules/dirty-equals/default.nix
+++ b/pkgs/development/python-modules/dirty-equals/default.nix
@@ -10,7 +10,7 @@
 }:
 
 let
-  dirty-equals = buildPythonPackage rec {
+  dirty-equals = buildPythonPackage (finalAttrs: {
     pname = "dirty-equals";
     version = "0.11.0";
     pyproject = true;
@@ -18,7 +18,7 @@ let
     src = fetchFromGitHub {
       owner = "samuelcolvin";
       repo = "dirty-equals";
-      tag = "v${version}";
+      tag = "v${finalAttrs.version}";
       hash = "sha256-JFKWrbMdxhvSBbjQ+S9HPW87CK+5ZZiXHg8Wltlv2YY=";
     };
 
@@ -44,13 +44,15 @@ let
 
     pythonImportsCheck = [ "dirty_equals" ];
 
+    __structuredAttrs = true;
+
     meta = {
       description = "Module for doing dirty (but extremely useful) things with equals";
       homepage = "https://github.com/samuelcolvin/dirty-equals";
-      changelog = "https://github.com/samuelcolvin/dirty-equals/releases/tag/${src.tag}";
+      changelog = "https://github.com/samuelcolvin/dirty-equals/releases/tag/${finalAttrs.src.tag}";
       license = lib.licenses.mit;
       maintainers = with lib.maintainers; [ fab ];
     };
-  };
+  });
 in
 dirty-equals


### PR DESCRIPTION
The tests were not actually enabled with `overrideAttrs` instead of `overridePythonAttrs`.
    
Enabling them exposed a failure.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
