### PR TITLE
opencv4: drop gtk2 support for highgui

### DIFF
--- a/pkgs/by-name/ap/apriltag/package.nix
+++ b/pkgs/by-name/ap/apriltag/package.nix
@@ -9,7 +9,6 @@
 
 let
   opencv4WithGtk = python3Packages.opencv4.override {
-    enableGtk2 = true; # For GTK2 support
     enableGtk3 = true; # For GTK3 support
   };
 in

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -54,8 +54,6 @@
   enableIpp ? false,
   enablePython ? false,
   pythonPackages,
-  enableGtk2 ? false,
-  gtk2,
   enableGtk3 ? false,
   gtk3,
   enableVtk ? false,
@@ -360,9 +358,6 @@ effectiveStdenv.mkDerivation {
   ++ optionals (effectiveStdenv.buildPlatform == effectiveStdenv.hostPlatform) [
     hdf5
   ]
-  ++ optionals enableGtk2 [
-    gtk2
-  ]
   ++ optionals enableGtk3 [
     gtk3
   ]
@@ -649,7 +644,6 @@ effectiveStdenv.mkDerivation {
       opencv4-tests = callPackage ./tests.nix {
         inherit
           enableGStreamer
-          enableGtk2
           enableGtk3
           runAccuracyTests
           runPerformanceTests

--- a/pkgs/development/libraries/opencv/tests.nix
+++ b/pkgs/development/libraries/opencv/tests.nix
@@ -1,6 +1,5 @@
 {
   enableGStreamer,
-  enableGtk2,
   enableGtk3,
   gst_all_1,
   lib,
@@ -76,7 +75,7 @@ runCommand "opencv4-tests"
       #"dnn" #- some caffe tests failed, probably because github workflow also downloads additional models
     ]
     ++ optionals (!isAarch64 && enableGStreamer) [ "gapi" ]
-    ++ optionals (enableGtk2 || enableGtk3) [ "highgui" ];
+    ++ optionals enableGtk3 [ "highgui" ];
 
     inherit runPerformanceTests;
 

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -3140,7 +3140,7 @@ let
     opencv =
       let
         opencvGtk = pkgs.opencv.override (old: {
-          enableGtk2 = true;
+          enableGtk3 = true;
         });
       in
       old.opencv.overrideAttrs (attrs: {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12235,7 +12235,6 @@ self: super: with self; {
       enableLto = !stdenv.hostPlatform.isLinux; # https://github.com/NixOS/nixpkgs/issues/343123
       enableUnfree = false; # prevents cache
       enableIpp = true;
-      enableGtk2 = true;
       enableGtk3 = true;
       enableVtk = true;
       enableFfmpeg = true;


### PR DESCRIPTION
Part of #410814

OpenCV 4 highgui can build with GTK3 and also prefers it: https://docs.opencv.org/4.13.0/db/d05/tutorial_config_reference.html#tutorial_config_reference_highgui

Leaf impacted packages:

* `apriltags`: enables both GTK2 and GTK3, will actually use GTK3 at runtime so should have no loss
* `howdy`, `linux-enable-ir-emitter`: all depends on `python3Packages.opencv4Full`. as above the built OpenCV 4 will use GTK3, not GTK2. They also directly depends on GTK3.
* `rPackages.opencv`: I don't think this would require GTK2 in any way, and should work with GTK3 highgui.

```
--------- Impacted packages on 'x86_64-linux' ---------
5 packages updated:
apriltags howdy linux-enable-ir-emitter opencv opencv
```

Closes #545102

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
