### PR TITLE
nixos/services.ente Configure virtual host for albums instead of alias

### DIFF
--- a/nixos/modules/services/web-apps/ente.nix
+++ b/nixos/modules/services/web-apps/ente.nix
@@ -342,10 +342,17 @@ in
               '';
             };
           };
+          virtualHosts.${domainFor "albums"} = {
+            forceSSL = mkDefault true;
+            locations."/" = {
+              root = webPackage "albums";
+              tryFiles = "$uri $uri.html /index.html";
+              extraConfig = ''
+                add_header Access-Control-Allow-Origin 'https://${cfgWeb.domains.api}';
+              '';
+            };
+          };
           virtualHosts.${domainFor "photos"} = {
-            serverAliases = [
-              (domainFor "albums") # the albums app is shared with the photos frontend
-            ];
             forceSSL = mkDefault true;
             locations."/" = {
               root = webPackage "photos";

--- a/pkgs/by-name/en/ente-web/package.nix
+++ b/pkgs/by-name/en/ente-web/package.nix
@@ -84,7 +84,7 @@ buildNpmPackage (finalAttrs: {
     # Replace hardcoded links pointing to the public ente instance so that
     # users of a self-hosted instance are not accidentally redirected there
     + lib.optionalString (enteMainUrl != null) ''
-      for pattern in "https://web.ente.io" "https://ente.com" "https://ente.io"; do
+      for pattern in "https://web.ente.io" "https://ente.com" "https://ente.io" "https://photos.ente.com"; do
         mapfile -d "" -t files < <(grep -rlFZ -- "$pattern" apps/)
         ${lib.getExe sd} -F -- "$pattern" ${lib.escapeShellArg enteMainUrl} "''${files[@]}"
       done


### PR DESCRIPTION
Add virtual host configuration for albums sharing app, instead of redirecting the album-set URL to the main app

Following #545451, this allows running the `albums` app for sharing albums publicly. 

The set URL for the `albums` app used to redirect to the main web app of Ente. 
Now it redirects to the actual `albums` app.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
