### PR TITLE
[26.05] shell: pin a Nixpkgs that supports x86_64-darwin

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -49,7 +49,8 @@ jobs:
             ci/github-script
 
       - name: Install dependencies
-        run: npm install @actions/artifact@6.2.1 bottleneck@2.19.5
+        run: npm ci --package-lock-only=false @actions/artifact bottleneck
+        working-directory: ci/github-script
 
       # Use a GitHub App, because it has much higher rate limits: 12,500 instead of 5,000 req / hour.
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -51,7 +51,8 @@ jobs:
             ci/github-script
 
       - name: Install dependencies
-        run: npm install bottleneck@2.19.5
+        run: npm ci --package-lock-only=false bottleneck
+        working-directory: trusted/ci/github-script
 
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         if: github.event_name != 'pull_request' && vars.NIXPKGS_COMMIT_CHECK_CLIENT_ID

--- a/.github/workflows/teams.yml
+++ b/.github/workflows/teams.yml
@@ -38,7 +38,8 @@ jobs:
             maintainers/github-teams.json
 
       - name: Install dependencies
-        run: npm install bottleneck@2.19.5
+        run: npm ci --package-lock-only=false bottleneck
+        working-directory: ci/github-script
 
       - name: Synchronise teams
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/ci/github-script/package-lock.json
+++ b/ci/github-script/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "github-script",
       "dependencies": {
         "@actions/artifact": "6.2.1",
         "@actions/core": "1.10.1",

--- a/ci/github-script/package.json
+++ b/ci/github-script/package.json
@@ -2,9 +2,7 @@
   "private": true,
   "//": [
     "Keep `@actions/core` and `@actions/github` in sync with",
-    "https://github.com/actions/github-script/blob/main/package.json.",
-    "Keep `@actions/artifact` and `bottleneck` in sync with",
-    "`.github/workflows/bot.yml`."
+    "https://github.com/actions/github-script/blob/main/package.json."
   ],
   "dependencies": {
     "@actions/artifact": "6.2.1",

--- a/ci/pinned.json
+++ b/ci/pinned.json
@@ -12,6 +12,19 @@
       "revision": "6edbf1a6a03e75886a6609c088801a0856449e88",
       "url": "https://github.com/NixOS/nixpkgs/archive/6edbf1a6a03e75886a6609c088801a0856449e88.tar.gz",
       "hash": "sha256-0lkauQbtrljJqwtzTCILPAiHAJyMvn6XDo264moDv30="
+    },
+    "nixpkgs-26.05-darwin": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "NixOS",
+        "repo": "nixpkgs"
+      },
+      "branch": "nixpkgs-26.05-darwin",
+      "submodules": false,
+      "revision": "51fe96f9107566e6b8eeb7fc4ba696c01e548b04",
+      "url": "https://github.com/NixOS/nixpkgs/archive/51fe96f9107566e6b8eeb7fc4ba696c01e548b04.tar.gz",
+      "hash": "sha256-yj0LPLnsmYoLmA3FGANjeTEwej0/DHjZBXWnDQDUuIs="
     }
   },
   "version": 8

--- a/flake.nix
+++ b/flake.nix
@@ -199,7 +199,8 @@
         && system != "riscv64-linux"
         # Exclude x86_64-freebsd because "Package ‘go-1.22.12-freebsd-amd64-bootstrap’ in /nix/store/0yw40qnrar3lvc5hax5n49abl57apjbn-source/pkgs/development/compilers/go/binary.nix:50 is not available on the requested hostPlatform"
         && system != "x86_64-freebsd"
-      ) (forAllSystems (system: (import ./ci { inherit system; }).fmt.pkg));
+        # TODO: revert to importing fmt.pkg directly from ./ci when support for 26.05 ends
+      ) (forAllSystems (system: (import ./shell.nix { inherit system; }).formatter));
 
       /**
         A nested structure of [packages](https://nix.dev/manual/nix/latest/glossary#package-attribute-set) and other values.

--- a/shell.nix
+++ b/shell.nix
@@ -16,7 +16,44 @@
   nixpkgs ? null,
 }:
 let
-  inherit (import ./ci { inherit nixpkgs system; }) pkgs fmt;
+  version = builtins.readFile ./.version;
+
+  # On 26.05 we need a CI-pinned Nixpkgs revision that supports x86_64-darwin.
+  # TODO: remove after 26.05 support ends.
+  nixpkgs' =
+    if nixpkgs == null && system == "x86_64-darwin" && version == "26.05" then
+      let
+        pinned = (builtins.fromJSON (builtins.readFile ./ci/pinned.json)).pins;
+        warn = builtins.warn or (import ./lib).warn;
+
+        inherit (pinned."nixpkgs-26.05-darwin")
+          url
+          hash
+          revision
+          branch
+          ;
+
+        withWarning = warn (toString [
+          "The currently pinned Nixpkgs (${pinned.nixpkgs.revision}) does not support ${system},"
+          "using revision (${revision}) from ${branch}."
+          "You may experience some differences to CI."
+        ]);
+      in
+      withWarning fetchTarball {
+        inherit url;
+        sha256 = hash;
+      }
+    else
+      nixpkgs;
+
+  inherit
+    (import ./ci {
+      inherit system;
+      nixpkgs = nixpkgs';
+    })
+    pkgs
+    fmt
+    ;
 
   # For `nix-shell -A hello`
   curPkgs = removeAttrs (import ./. { inherit system; }) [
@@ -38,4 +75,7 @@ curPkgs
     # treefmt wrapper
     fmt.pkg
   ];
+}
+// {
+  formatter = fmt.pkg;
 }


### PR DESCRIPTION
- **workflows: appease zizmor by installing npm pkgs from lockfile** (from #544224)
- **shell: pin a Nixpkgs that supports x86_64-darwin** (from #545390)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
