### PR TITLE
pcloud: 2.1.1 -> 2.2.1

### DIFF
--- a/pkgs/by-name/pc/pcloud/package.nix
+++ b/pkgs/by-name/pc/pcloud/package.nix
@@ -41,13 +41,13 @@
 
 let
   pname = "pcloud";
-  version = "2.1.1";
-  code = "XZtwII5Zjf5noLYtDwJ1qkyAXaqujuvVKBbX";
+  version = "2.2.1";
+  code = "XZopbc5ZpqOBs9mkVRk4zDHD7TjDJpQBcfzk";
 
   # Archive link's codes: https://www.pcloud.com/release-notes/linux.html
   src = fetchzip {
     url = "https://api.pcloud.com/getpubzip?code=${code}&filename=pcloud-${version}.zip";
-    hash = "sha256-x7nlJ/kLfEbEKUso8p0dj3WM6o0EsQ0ZBaTnaxxuI6s=";
+    hash = "sha256-/T2AcvK2pxu+/f1ehheSE4CaXMobzdbA+AJ6SKQowVw=";
   };
 
 in


### PR DESCRIPTION
[upstream changelog:](https://www.pcloud.com/release-notes/linux.html)

>   - This update adds context menu integration for Nautilus, Caja, Nemo, Dolphin and Thunar file managers. We've also fixed an issue where the AppImage failed to launch after being renamed, along with additional improvements for a smoother experience.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
