### PR TITLE
filen-cli-rs: init at 0.2.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2851,6 +2851,11 @@
     githubId = 1222;
     name = "Aaron VonderHaar";
   };
+  avhb = {
+    name = "avhb";
+    github = "avhb";
+    githubId = 66175168;
+  };
   aviallon = {
     email = "antoine-nixos@lesviallon.fr";
     github = "aviallon";

--- a/pkgs/by-name/fi/filen-cli-rs/package.nix
+++ b/pkgs/by-name/fi/filen-cli-rs/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  makeWrapper,
+}:
+
+let
+  version = "0.2.7";
+
+  srcs = {
+    "x86_64-linux" = fetchurl {
+      url = "https://github.com/FilenCloudDienste/filen-cli-releases/releases/download/${version}/filen-cli-${version}-x86_64-unknown-linux-gnu";
+      hash = "sha256-0Fw6SnWFy7/pNtp6R5c4mCko30lXa9I3TItgi02IkYk=";
+    };
+    "aarch64-linux" = fetchurl {
+      url = "https://github.com/FilenCloudDienste/filen-cli-releases/releases/download/${version}/filen-cli-${version}-aarch64-unknown-linux-gnu";
+      hash = "sha256-7NqNNgVuUdiJTHA0APdFuqBwdUGcPNwFgWTMJ3CIssc=";
+    };
+    "x86_64-darwin" = fetchurl {
+      url = "https://github.com/FilenCloudDienste/filen-cli-releases/releases/download/${version}/filen-cli-${version}-x86_64-apple-darwin";
+      hash = "sha256-dD2smdtJKK+fmZ8dI7w794tqDE6jiMuRqAr/p2ThdU8=";
+    };
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "filen-cli-rs";
+  inherit version;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src =
+    srcs.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  nativeBuildInputs = [
+    makeWrapper
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    stdenv.cc.cc.lib
+  ];
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 $src $out/bin/filen
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "CLI tool for interacting with Filen cloud storage (Rust rewrite)";
+    homepage = "https://github.com/FilenCloudDienste/filen-rs";
+    changelog = "https://github.com/FilenCloudDienste/filen-cli-releases/releases/tag/${version}";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.agpl3Only;
+    mainProgram = "filen";
+    maintainers = with lib.maintainers; [ avhb ];
+    platforms = builtins.attrNames srcs;
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests
  - [ ] Package tests
  - [ ] Tests in lib/tests or pkgs/test
- [ ] Ran nixpkgs-review on this PR
- [x] Tested basic functionality of all binary files, usually in ./result/bin/
- [ ] Nixpkgs Release Notes
- [ ] NixOS Release Notes
- [x] Fits CONTRIBUTING.md
- [x] Follows the automation/AI policy