### PR TITLE
python3Packages.nftables: fix version & modernize

### DIFF
--- a/pkgs/os-specific/linux/nftables/python.nix
+++ b/pkgs/os-specific/linux/nftables/python.nix
@@ -4,13 +4,16 @@
   nftables,
 }:
 
-buildPythonPackage {
+buildPythonPackage (finalAttrs: {
   pname = "nftables";
   inherit (nftables) version src;
   pyproject = true;
 
+  __structuredAttrs = true;
+
   postPatch = ''
     substituteInPlace "src/nftables.py" \
+      --replace-fail 'NFTABLES_VERSION = "0.1"' 'NFTABLES_VERSION = "${finalAttrs.version}"' \
       --replace-fail "libnftables.so.1" "${nftables}/lib/libnftables.so.1"
   '';
 
@@ -29,4 +32,4 @@ buildPythonPackage {
       maintainers
       ;
   };
-}
+})


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/545233.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
