### PR TITLE
nixos/regreet: move to services.displayManager

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -139,7 +139,7 @@ In addition to numerous new and updated packages, this release has the following
 
 - [readarr](https://github.com/Readarr/Readarr), book manager and automation (Sonarr for ebooks). Available as [services.readarr](options.html#opt-services.readarr.enable).
 
-- [ReGreet](https://github.com/rharish101/ReGreet), a clean and customizable greeter for greetd. Available as [programs.regreet](#opt-programs.regreet.enable).
+- [ReGreet](https://github.com/rharish101/ReGreet), a clean and customizable greeter for greetd. Available as `programs.regreet.enable`.
 
 - [rshim](https://github.com/Mellanox/rshim-user-space), the user-space rshim driver for the BlueField SoC. Available as [services.rshim](options.html#opt-services.rshim.enable).
 

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -117,6 +117,8 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- `programs.regreet` has been renamed to `services.displayManager.regreet`.
+
 - `komodo` has been updated to the v2 release line (2.x). See the [upstream v1 → v2 upgrade guide](https://github.com/moghtech/komodo/releases/tag/v2.0.0).
 
 - `temporal` has been updated to the 1.31 release line. Always consult the [upstream upgrade

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -307,7 +307,6 @@
   ./programs/qgroundcontrol.nix
   ./programs/qt5ct.nix
   ./programs/quark-goldleaf.nix
-  ./programs/regreet.nix
   ./programs/rog-control-center.nix
   ./programs/rush.nix
   ./programs/rust-motd.nix
@@ -634,6 +633,7 @@
   ./services/display-managers/lemurs.nix
   ./services/display-managers/ly.nix
   ./services/display-managers/plasma-login-manager.nix
+  ./services/display-managers/regreet.nix
   ./services/display-managers/sddm.nix
   ./services/editors/emacs.nix
   ./services/editors/haste.nix

--- a/nixos/modules/services/display-managers/regreet.nix
+++ b/nixos/modules/services/display-managers/regreet.nix
@@ -5,12 +5,16 @@
   ...
 }:
 let
-  cfg = config.programs.regreet;
+  cfg = config.services.displayManager.regreet;
   settingsFormat = pkgs.formats.toml { };
   user = config.services.greetd.settings.default_session.user;
 in
 {
-  options.programs.regreet = {
+  imports = [
+    (lib.mkRenamedOptionModule [ "programs" "regreet" ] [ "services" "displayManager" "regreet" ])
+  ];
+
+  options.services.displayManager.regreet = {
     enable = lib.mkEnableOption null // {
       description = ''
         Enable ReGreet, a clean and customizable greeter for greetd.
@@ -144,7 +148,7 @@ in
 
     fonts.packages = [ cfg.font.package ];
 
-    programs.regreet.settings.GTK = {
+    services.displayManager.regreet.settings.GTK = {
       cursor_theme_name = cfg.cursorTheme.name;
       font_name = "${cfg.font.name} ${toString cfg.font.size}";
       icon_theme_name = cfg.iconTheme.name;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
