### PR TITLE
vimPlugins: add transitive dependencies to check environment

### DIFF
--- a/doc/languages-frameworks/neovim.section.md
+++ b/doc/languages-frameworks/neovim.section.md
@@ -384,6 +384,8 @@ It accepts a single string for a module, or a list of module strings to test.
 When `nvimRequireCheck` is not specified, we will search the plugin's directory for lua modules to attempt loading. This quick smoke test can catch obvious dependency errors that might be missed.
 The check hook will fail the build if any modules cannot be loaded. This encourages inspecting the logs to identify potential issues.
 
+Vim plugins listed in `dependencies` or `checkInputs`, along with their transitive `dependencies` and `requiredLuaModules`, are added to the check environment. Use `checkInputs` for plugins needed only during checks, such as optional integrations.
+
 To only check a specific module, add it manually to the plugin definition [overrides](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/editors/vim/plugins/overrides.nix).
 
 ```nix

--- a/pkgs/applications/editors/vim/plugins/hooks/neovim-require-check-hook.sh
+++ b/pkgs/applications/editors/vim/plugins/hooks/neovim-require-check-hook.sh
@@ -60,9 +60,23 @@ run_require_checks() {
     successful_modules=()
 
     export HOME="$TMPDIR"
-    local deps="${dependencies[*]}"
-    local nativeCheckInputs="${nativeBuildInputs[*]}"
-    local checkInputs="${buildInputs[*]}"
+
+    local -a dependencyPathArgs=()
+    local -a dependencyLoadArgs=()
+
+    if [ -n "${nvimRequireCheckPackPath:-}" ]; then
+        dependencyPathArgs=(--cmd "set packpath^=$nvimRequireCheckPackPath")
+        dependencyLoadArgs=(--cmd "packloadall")
+    else
+        local deps="${dependencies[*]}"
+        local nativeCheckInputs="${nativeBuildInputs[*]}"
+        local checkInputs="${buildInputs[*]}"
+        dependencyPathArgs=(
+            --cmd "set rtp+=${deps// /,}"
+            --cmd "set rtp+=${nativeCheckInputs// /,}"
+            --cmd "set rtp+=${checkInputs// /,}"
+        )
+    fi
 
     local -a luaPathArgs=()
     if [ -n "${nvimRequireCheckLuaPath:-}" ] || [ -n "${nvimRequireCheckLuaCPath:-}" ]; then
@@ -98,10 +112,9 @@ run_require_checks() {
         if [ "$skip" = false ]; then
             echo "Attempting to require module: $name"
             if @nvimBinary@ -es --headless -n -u NONE -i NONE --clean -V1 \
-                --cmd "set rtp+=${deps// /,}" \
-                --cmd "set rtp+=${nativeCheckInputs// /,}" \
-                --cmd "set rtp+=${checkInputs// /,}" \
+                "${dependencyPathArgs[@]}" \
                 "${luaPathArgs[@]}" \
+                "${dependencyLoadArgs[@]}" \
                 --cmd "set packpath^=$packPathDir" \
                 --cmd "packadd testPlugin" \
                 --cmd "lua require('$name')"; then

--- a/pkgs/applications/editors/vim/plugins/utils/vim-utils.nix
+++ b/pkgs/applications/editors/vim/plugins/utils/vim-utils.nix
@@ -15,6 +15,7 @@
   makeSetupHook,
   linkFarm,
   config,
+  neovimUtils,
 }:
 
 /*
@@ -523,7 +524,14 @@ rec {
       finalAttrs: oldAttrs:
       let
         getRequiredLuaModules = attrs: attrs.requiredLuaModules or attrs.passthru.requiredLuaModules or [ ];
-        modules = getRequiredLuaModules finalAttrs;
+        checkPlugins = lib.filter (p: p.passthru.vimPlugin or false) (finalAttrs.checkInputs or [ ]);
+        checkDependencies = lib.unique (
+          findDependenciesRecursively ((finalAttrs.dependencies or [ ]) ++ checkPlugins)
+        );
+        vimPackageInfo = neovimUtils.makeVimPackageInfo (
+          lib.filter (p: p.passthru.vimPlugin or false) checkDependencies
+        );
+        modules = lib.unique (getRequiredLuaModules finalAttrs ++ vimPackageInfo.luaDependencies);
         luaEnv = lua.withPackages (_: modules);
       in
       {
@@ -552,6 +560,9 @@ rec {
 
         nvimRequireCheckLuaPath = lib.optionalString (modules != [ ]) (lua.pkgs.getLuaPath luaEnv);
         nvimRequireCheckLuaCPath = lib.optionalString (modules != [ ]) (lua.pkgs.getLuaCPath luaEnv);
+        nvimRequireCheckPackPath = neovimUtils.packDir {
+          plugins = vimPackageInfo.vimPackage;
+        };
 
         passthru = (oldAttrs.passthru or { }) // {
           vimPlugin = true;


### PR DESCRIPTION
I was trying to cleanup `plenary-nvim` dependencies and noticed alot of uses in `overrides.nix` to workaround #394939.

This PR adds transitive Vim plugin dependencies to the nvim require check environment.

Previously, only direct plugins in `dependencies` and `checkInputs` were added to Nvim runtimepath during checks. If plugin `A` depends on plugin `B`, which depends on plugin `C`, plugin `C` will be missing from plugin `A`'s check environment.

The check environment now recursively finds runtime `dependencies` and filtered Vim plugins in `checkInputs`.

I plan to remove the existing transitive dependency workarounds in e.g. `overrides.nix` that will no longer be needed in a follow up PR.

Closes #394939, and resolves the plugin dependency portion of #352742 (transitive `requiredLuaModules` handling remains unfixed)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
