### PR TITLE
nixos/modular-services: add portable `process.environment` using `UnsetEnvironment`

### DIFF
--- a/doc/build-helpers/testers.chapter.md
+++ b/doc/build-helpers/testers.chapter.md
@@ -741,7 +741,7 @@ Notable attributes:
 
 Compliance suite for [modular service](https://nixos.org/manual/nixos/unstable/#modular-services) integrations.
 
-Tests that a service manager integration correctly handles the portable modular services contract: `process.argv`, sub-services, assertions, and warnings.
+Tests that a service manager integration correctly handles the portable modular services contract: `process.argv`, `process.environment` (including `null` values that unset a variable), sub-services, assertions, and warnings.
 
 ### Return value {#tester-modularServiceCompliance-return}
 

--- a/lib/services/service.nix
+++ b/lib/services/service.nix
@@ -70,6 +70,26 @@ in
           Command used for reloading in the underlying service manager to reload.
         '';
       };
+
+      environment = lib.mkOption {
+        type = types.lazyAttrsOf (
+          types.nullOr (types.coercedTo (types.either types.path types.package) (x: "${x}") types.str)
+        );
+        default = { };
+        example = lib.literalExpression ''{ FOO = "bar"; PATH = null; }'';
+        description = ''
+          Environment variables passed verbatim to the service process by the
+          service manager. Entries set to `null` actively unset the variable
+          before the process starts, using the backend's native unset mechanism
+          (for the systemd backend, `UnsetEnvironment=`), so the variable is
+          absent even when the service manager or a backend-specific override
+          would otherwise supply it.
+
+          Values appear in the rendered unit and may be world-readable. For
+          secrets, use a backend-specific mechanism such as
+          `systemd.service.serviceConfig.EnvironmentFile`.
+        '';
+      };
     };
 
     notificationProtocol = mkOption {

--- a/lib/services/test.nix
+++ b/lib/services/test.nix
@@ -48,6 +48,10 @@ let
             (dummyPkg "cowsay.sh")
             "world"
           ];
+          environment = {
+            FOO = "bar";
+            DROPPED = null;
+          };
         };
       };
       service3 = {
@@ -110,9 +114,16 @@ let
                 "/usr/bin/echo"
                 "hello"
               ];
+              environment = { };
+              reloadCommand = null;
+              reloadSignal = null;
             };
             services = { };
             assertions = [
+              {
+                assertion = true;
+                message = "reloadSignal conflicts with reloadCommand. Please either use reloadSignal or reloadCommand.";
+              }
               {
                 assertion = false;
                 message = "you can't enable this for that reason";
@@ -128,14 +139,28 @@ let
                 "${dummyPkg "cowsay.sh"}"
                 "world"
               ];
+              environment = {
+                FOO = "bar";
+                DROPPED = null;
+              };
+              reloadCommand = null;
+              reloadSignal = null;
             };
             services = { };
-            assertions = [ ];
+            assertions = [
+              {
+                assertion = true;
+                message = "reloadSignal conflicts with reloadCommand. Please either use reloadSignal or reloadCommand.";
+              }
+            ];
             warnings = [ ];
           };
           service3 = {
             process = {
               argv = [ "/bin/false" ];
+              environment = { };
+              reloadCommand = null;
+              reloadSignal = null;
             };
             services.exclacow = {
               process = {
@@ -143,9 +168,16 @@ let
                   "${dummyPkg "cowsay-ng"}/bin/cowsay"
                   "!"
                 ];
+                environment = { };
+                reloadCommand = null;
+                reloadSignal = null;
               };
               services = { };
               assertions = [
+                {
+                  assertion = true;
+                  message = "reloadSignal conflicts with reloadCommand. Please either use reloadSignal or reloadCommand.";
+                }
                 {
                   assertion = false;
                   message = "you can't enable this for such reason";
@@ -153,7 +185,12 @@ let
               ];
               warnings = [ "The `bar' service is deprecated and will go away soon!" ];
             };
-            assertions = [ ];
+            assertions = [
+              {
+                assertion = true;
+                message = "reloadSignal conflicts with reloadCommand. Please either use reloadSignal or reloadCommand.";
+              }
+            ];
             warnings = [ ];
           };
         };
@@ -167,6 +204,10 @@ let
     assert
       portable-lib.getAssertions [ "service1" ] exampleEval.config.services.service1 == [
         {
+          message = "in service1: reloadSignal conflicts with reloadCommand. Please either use reloadSignal or reloadCommand.";
+          assertion = true;
+        }
+        {
           message = "in service1: you can't enable this for that reason";
           assertion = false;
         }
@@ -178,6 +219,14 @@ let
       ];
     assert
       portable-lib.getAssertions [ "service3" ] exampleEval.config.services.service3 == [
+        {
+          message = "in service3: reloadSignal conflicts with reloadCommand. Please either use reloadSignal or reloadCommand.";
+          assertion = true;
+        }
+        {
+          message = "in service3.services.exclacow: reloadSignal conflicts with reloadCommand. Please either use reloadSignal or reloadCommand.";
+          assertion = true;
+        }
         {
           message = "in service3.services.exclacow: you can't enable this for such reason";
           assertion = false;

--- a/nixos/modules/system/service/systemd/service.nix
+++ b/nixos/modules/system/service/systemd/service.nix
@@ -209,7 +209,15 @@ in
     systemd.services."" = {
       # TODO description;
       wantedBy = lib.mkDefault [ "multi-user.target" ];
+      environment = lib.mapAttrs (_: lib.mkDefault) (
+        lib.filterAttrs (_: v: v != null) config.process.environment
+      );
       serviceConfig = {
+        UnsetEnvironment =
+          let
+            nullEnvKeys = lib.attrNames (lib.filterAttrs (_: v: v == null) config.process.environment);
+          in
+          lib.mkIf (nullEnvKeys != [ ]) (lib.concatStringsSep " " nullEnvKeys);
         ExecReload = lib.mkIf (config.systemd.mainExecReload != null) config.systemd.mainExecReload;
         Type = lib.mkDefault (if config.notificationProtocol.systemd then "notify" else "simple");
         Restart = lib.mkDefault "always";

--- a/nixos/modules/system/service/systemd/test.nix
+++ b/nixos/modules/system/service/systemd/test.nix
@@ -76,6 +76,41 @@ let
         };
       };
 
+      # Test that `process.environment` becomes `Environment=` entries on the unit,
+      # that null values are dropped from `Environment=` and listed in
+      # `UnsetEnvironment=`.
+      system.services.envvars = {
+        process = {
+          argv = [ hello' ];
+          environment = {
+            FOO = "bar";
+            BAZ = "qux";
+            DROPPED = null;
+          };
+        };
+      };
+
+      # Test that an explicit `systemd.service.environment` override wins over
+      # the portable default produced by `process.environment`.
+      system.services.envvars-override = {
+        process = {
+          argv = [ hello' ];
+          environment.FOO = "from-process";
+        };
+        systemd.service.environment.FOO = "from-systemd";
+      };
+
+      # Test that `process.environment` `null` unsets via `UnsetEnvironment=` even
+      # when the systemd layer sets the same key (true unset, not just "skip
+      # setting").
+      system.services.envvars-unset = {
+        process = {
+          argv = [ hello' ];
+          environment.FOO = null;
+        };
+        systemd.service.environment.FOO = "leaked";
+      };
+
       # Test extending process.argv with systemd specifiers
       system.services.argv-extended =
         { config, ... }:
@@ -136,6 +171,24 @@ runCommand "test-modular-service-systemd-units"
       # Test extending process.argv with systemd specifiers
       # The base command should be escaped ($1 -> $$1, m%n -> m%%n), but the appended --systemd-unit %n should not be
       grep -F 'ExecStart="${hello}/bin/hello" "--greeting" "Fun $$1 fact, remainder is often expressed as m%%n" --systemd-unit %n' ${toplevel}/etc/systemd/system/argv-extended.service >/dev/null
+
+      # process.environment becomes Environment= entries; null values are dropped
+      # from Environment= and listed in UnsetEnvironment=.
+      grep -F 'Environment="FOO=bar"' ${toplevel}/etc/systemd/system/envvars.service >/dev/null
+      grep -F 'Environment="BAZ=qux"' ${toplevel}/etc/systemd/system/envvars.service >/dev/null
+      ! grep -F 'Environment=.*DROPPED' ${toplevel}/etc/systemd/system/envvars.service
+      grep -F 'UnsetEnvironment=DROPPED' ${toplevel}/etc/systemd/system/envvars.service >/dev/null
+
+      # systemd.service.environment override wins over process.environment.
+      grep -F 'Environment="FOO=from-systemd"' ${toplevel}/etc/systemd/system/envvars-override.service >/dev/null
+      ! grep -F 'FOO=from-process' ${toplevel}/etc/systemd/system/envvars-override.service
+
+      # process.environment null uses UnsetEnvironment= for true unset, even when
+      # the systemd layer has an Environment= entry for the same key. The
+      # Environment= entry is still emitted; UnsetEnvironment= removes it as the
+      # final step at runtime.
+      grep -F 'Environment="FOO=leaked"' ${toplevel}/etc/systemd/system/envvars-unset.service >/dev/null
+      grep -F 'UnsetEnvironment=FOO' ${toplevel}/etc/systemd/system/envvars-unset.service >/dev/null
 
       [[ ! -e ${toplevel}/etc/systemd/system/foo.socket ]]
       [[ ! -e ${toplevel}/etc/systemd/system/bar.socket ]]

--- a/pkgs/build-support/testers/modular-service-compliance.nix
+++ b/pkgs/build-support/testers/modular-service-compliance.nix
@@ -29,6 +29,10 @@ let
     services = {
       svc = {
         process.argv = [ "${coreutils}/bin/true" ];
+        process.environment = {
+          FOO = "bar";
+          DROPPED = null;
+        };
         assertions = [
           {
             assertion = true;
@@ -68,6 +72,19 @@ let
       testSubServiceArgv = {
         expr = c.services.child.process.argv;
         expected = [ "${coreutils}/bin/true" ];
+      };
+
+      # A set environment variable round-trips through process.environment.
+      testProcessEnvironment = {
+        expr = c.process.environment.FOO;
+        expected = "bar";
+      };
+
+      # A null environment variable is preserved as null (unset request),
+      # rather than coerced to a string or dropped from the attrset.
+      testProcessEnvironmentNull = {
+        expr = c.process.environment.DROPPED;
+        expected = null;
       };
 
       testAssertions = {
@@ -186,6 +203,9 @@ let
     mkdir -p "$dir"
     echo "$$" > "$dir/pid"
     printf '%s\n' "$@" > "$dir/args"
+    # Record the process's own environment as received from the service
+    # manager (NUL-delimited, as the kernel stores it).
+    "${coreutils}/bin/cat" "/proc/$$/environ" > "$dir/environ"
     exec "${coreutils}/bin/sleep" infinity
   '';
 
@@ -237,6 +257,31 @@ let
       grep -qxF -- ${lib.escapeShellArg arg} "${sharedDir}/${id}/args" \
         || { echo "${id}: expected arg ${lib.escapeShellArg arg} not found"; cat "${sharedDir}/${id}/args"; exit 1; }
     '') expectedArgs;
+
+  /**
+    Shell snippet: assert that the service's recorded environment contains
+    each `present` entry (an exact `KEY=value` string) and contains no
+    variable named in `absent`.
+  */
+  checkEnv =
+    id:
+    {
+      present ? [ ],
+      absent ? [ ],
+    }:
+    ''
+      # The recorded environ is NUL-delimited; render one entry per line.
+      tr '\0' '\n' < "${sharedDir}/${id}/environ" > "${sharedDir}/${id}/environ.lines"
+    ''
+    + lib.concatMapStrings (entry: ''
+      grep -qxF -- ${lib.escapeShellArg entry} "${sharedDir}/${id}/environ.lines" \
+        || { echo "${id}: expected env ${lib.escapeShellArg entry} not found"; cat "${sharedDir}/${id}/environ.lines"; exit 1; }
+    '') present
+    + lib.concatMapStrings (key: ''
+      if grep -qE ${lib.escapeShellArg "^${key}="} "${sharedDir}/${id}/environ.lines"; then
+        echo "${id}: env variable ${lib.escapeShellArg key} should be unset"; exit 1
+      fi
+    '') absent;
 
   mkTestScript =
     name: text:
@@ -327,6 +372,24 @@ in
         "--greeting"
         "hello"
       ]
+    );
+  };
+
+  environment = mkTest {
+    name = "${namePrefix}-environment";
+    services.test = {
+      process.argv = mkArgv "env" [ ];
+      process.environment = {
+        FOO = "bar";
+        DROPPED = null;
+      };
+    };
+    testExe = mkTestScript "environment" (
+      waitAndCheck "env" [ ]
+      + checkEnv "env" {
+        present = [ "FOO=bar" ];
+        absent = [ "DROPPED" ];
+      }
     );
   };
 


### PR DESCRIPTION
Adds modular service option `process.environment` to pass an attrset of env vars to the service manager.
`null` values actively unset the variable before the process starts.

Differs from the earlier approach at #518860 in that unsetting env vars is done using `UnsetEnvironment` (as [suggested by](https://github.com/NixOS/nixpkgs/pull/518860#discussion_r3648915333) @mvnetbiz) over `pkgs.execline`, removing its `pkgs` closure that broke usage for downstream consumers depending on the prior interface.

Note that making downstream consumption more robust against the types of low-level interface changes that rendered #51860 a breaking change is handled at #507052.

Disclaimer: I used a coding agent in the creation of this patch.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
      - `nix-build -A nixosTests.modularService`
      - `nix-build -A nixosTests.system-services-compliance.eval`
      - `(cd nixos/; nix-build release.nix -A manual.x86_64-linux)`
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
