### PR TITLE
mindwtr: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22885,6 +22885,12 @@
     matrix = "@pschmitt:one.ems.host";
     keys = [ { fingerprint = "9FBF 2ABF FB37 F7F3 F502  44E5 DC43 9C47 EACB 17F9"; } ];
   };
+  pseb = {
+    email = "sebastien.pose@gmail.com";
+    github = "pseb";
+    githubId = 983165;
+    name = "Sébastien Posé";
+  };
   pseudocc = {
     email = "pseudoc@163.com";
     github = "pseudocc";

--- a/pkgs/by-name/mi/mindwtr/package.nix
+++ b/pkgs/by-name/mi/mindwtr/package.nix
@@ -1,0 +1,141 @@
+{
+  lib,
+  stdenvNoCC,
+  rustPlatform,
+  fetchFromGitHub,
+  cargo-tauri,
+  bun,
+  writableTmpDirAsHomeHook,
+  nodejs,
+  cmake,
+  pkg-config,
+  wrapGAppsHook3,
+  webkitgtk_4_1,
+  gtk3,
+  libsoup_3,
+  glib-networking,
+  librsvg,
+  gdk-pixbuf,
+  libayatana-appindicator,
+  alsa-lib,
+  openssl,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (
+  finalAttrs:
+  let
+    # No first-class bun dependency fetcher exists in nixpkgs yet, so use the
+    # established fixed-output derivation pattern: run `bun install` and pin the
+    # resulting node_modules by outputHash. impureEnvVars lets proxy settings
+    # through, like the standard fetchers do.
+    bunDeps = stdenvNoCC.mkDerivation {
+      pname = "${finalAttrs.pname}-bun-deps";
+      inherit (finalAttrs) version src;
+
+      nativeBuildInputs = [
+        bun
+        writableTmpDirAsHomeHook
+      ];
+      dontConfigure = true;
+
+      impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
+        "GIT_PROXY_COMMAND"
+        "SOCKS_SERVER"
+      ];
+
+      buildPhase = ''
+        runHook preBuild
+
+        export BUN_INSTALL_CACHE_DIR=$TMPDIR/bun-cache
+        bun install --frozen-lockfile --no-progress --ignore-scripts --cpu="*" --os="*"
+
+        runHook postBuild
+      '';
+
+      installPhase = ''
+        runHook preInstall
+
+        mkdir -p $out
+        cp -r node_modules $out/node_modules
+
+        runHook postInstall
+      '';
+
+      dontFixup = true;
+      outputHashMode = "recursive";
+      outputHash = "sha256-whpXtZC2pIgJzly0txTjtg0QNabgRr+1qEzWZkKv3+U=";
+    };
+  in
+  {
+    pname = "mindwtr";
+    version = "1.1.0";
+
+    src = fetchFromGitHub {
+      owner = "dongdongbh";
+      repo = "Mindwtr";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-nIMMzvjW0+jcw9/VtASxniAJPDF59Cl03XPUEEqWFf8=";
+    };
+
+    __structuredAttrs = true;
+
+    cargoRoot = "apps/desktop/src-tauri";
+    buildAndTestSubdir = "apps/desktop/src-tauri";
+    cargoHash = "sha256-o1VqnlJcSRw8Zp+v45eEx/UlLtxt1treoqUVCwFqVe4=";
+
+    # A transitive crate (tauri-plugin-http -> reqwest) pulls openssl-sys with the
+    # vendored feature; link the store OpenSSL instead of building it from source.
+    env.OPENSSL_NO_VENDOR = "1";
+
+    # cmake is needed by whisper-rs-sys but there is no root CMakeLists.txt.
+    dontUseCmakeConfigure = true;
+
+    nativeBuildInputs = [
+      cargo-tauri.hook
+      bun # beforeBuildCommand runs `bun run build:vite`
+      nodejs # provides `node` for patchShebangs
+      rustPlatform.bindgenHook # libclang for bindgen (whisper-rs-sys)
+      cmake
+      pkg-config
+      wrapGAppsHook3
+    ];
+
+    buildInputs = [
+      webkitgtk_4_1
+      gtk3
+      libsoup_3
+      glib-networking
+      librsvg
+      gdk-pixbuf
+      libayatana-appindicator
+      alsa-lib
+      openssl
+    ];
+
+    preConfigure = ''
+      cp -r ${bunDeps}/node_modules ./node_modules
+      chmod -R u+w ./node_modules
+      patchShebangs node_modules
+    '';
+
+    # libappindicator is dlopen'd at runtime; inject it into the wrapper's path.
+    preFixup = ''
+      gappsWrapperArgs+=(
+        --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libayatana-appindicator ]}"
+      )
+    '';
+
+    passthru.updateScript = nix-update-script { };
+
+    meta = {
+      description = "Local-first, privacy-first GTD task manager";
+      homepage = "https://mindwtr.app";
+      changelog = "https://github.com/dongdongbh/Mindwtr/releases/tag/v${finalAttrs.version}";
+      license = lib.licenses.agpl3Only;
+      maintainers = with lib.maintainers; [ pseb ];
+      mainProgram = "mindwtr";
+      platforms = lib.platforms.linux;
+    };
+  }
+)


### PR DESCRIPTION
Adds Mindwtr, a local-first GTD task manager built with Tauri v2.

Upstream: https://github.com/dongdongbh/Mindwtr

Notes for reviewers:

- **Frontend deps**: the project is a bun workspace monorepo. Since there is
  no first-class bun dependency fetcher in nixpkgs yet, this uses the existing
  fixed-output derivation pattern (`bun install` pinned by `outputHash`).
  `--frozen-lockfile` and `--ignore-scripts` keep it as deterministic as
  possible; the hash has been verified stable across rebuilds. Happy to switch
  to `bun.fetchDeps` once it lands.
- **Build time**: the app vendors whisper.cpp (voice capture), so the Rust
  build is fairly long and needs `bindgenHook` + `cmake`.
- `OPENSSL_NO_VENDOR=1` avoids building OpenSSL from source in a transitive
  `openssl-sys`.
- `libayatana-appindicator` is `dlopen`'d at runtime for the tray icon, hence
  the `LD_LIBRARY_PATH` prefix in `preFixup`.
- Tested: builds and launches on x86_64-linux; desktop entry and icons are
  installed from the deb bundle by `cargo-tauri.hook`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
