### PR TITLE
oneclient: init at 2.2.3

### DIFF
--- a/pkgs/by-name/on/oneclient/package.nix
+++ b/pkgs/by-name/on/oneclient/package.nix
@@ -1,0 +1,264 @@
+{
+  addDriverRunpath,
+  alsa-lib,
+  clangStdenv,
+  copyDesktopItems,
+  cctools,
+  fetchFromGitHub,
+  fetchgit,
+  flite,
+  fontconfig,
+  gn,
+  jdk21,
+  jdk25,
+  lib,
+  libGL,
+  libjack2,
+  libpulseaudio,
+  libx11,
+  libxcb,
+  libxcursor,
+  libxi,
+  libxkbcommon,
+  libxrandr,
+  linkFarm,
+  makeDesktopItem,
+  makeWrapper,
+  ninja,
+  nix-update-script,
+  openal,
+  pipewire,
+  pkg-config,
+  python3,
+  rcodesign,
+  removeReferencesTo,
+  runCommand,
+  rustPlatform,
+  stdenv,
+  wayland,
+
+  additionalLibs ? [ ],
+  jdks ? [
+    jdk25
+    jdk21
+  ],
+  textToSpeechSupport ? stdenv.hostPlatform.isLinux,
+}:
+
+assert lib.assertMsg (
+  textToSpeechSupport -> stdenv.hostPlatform.isLinux
+) "textToSpeechSupport only has an effect on Linux.";
+
+let
+  infoPlist =
+    version:
+    lib.generators.toPlist { escape = true; } {
+      CFBundleDevelopmentRegion = "en";
+      CFBundleDisplayName = "OneClient";
+      CFBundleExecutable = "oneclient_app";
+      CFBundleIconFile = "icon.icns";
+      CFBundleIdentifier = "org.polyfrost.OneClient";
+      CFBundleInfoDictionaryVersion = "6.0";
+      CFBundleName = "OneClient";
+      CFBundlePackageType = "APPL";
+      CFBundleShortVersionString = version;
+      CFBundleSupportedPlatforms = [ "MacOSX" ];
+      CFBundleVersion = version;
+
+      LSEnvironment = {
+        ONECLIENT_DISABLE_AUTOUPDATE = "1";
+      };
+
+      LSApplicationCategoryType = "public.app-category.games";
+      LSMinimumSystemVersion = "10.14";
+      NSHighResolutionCapable = true;
+
+      CFBundleURLTypes = [
+        {
+          CFBundleURLName = "OneClient";
+          CFBundleURLSchemes = [ "oneclient" ];
+        }
+      ];
+
+      NSCameraUsageDescription = "A Minecraft mod is requesting access to your camera.";
+      NSMicrophoneUsageDescription = "A Minecraft mod is requesting access to your microphone.";
+    };
+in
+rustPlatform.buildRustPackage.override { stdenv = clangStdenv; } (finalAttrs: {
+  pname = "oneclient";
+  version = "2.2.3";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Polyfrost";
+    repo = "OneLauncher";
+    tag = "oneclient-${finalAttrs.version}";
+    hash = "sha256-OMwbPJBLJo1yCRQD+ZWJoWpWxuCP2/7C/djE/vcRdOY=";
+  };
+
+  cargoHash = "sha256-m++q3uiAvNXloA0fHLweCO9FMPtaGZblLhqR5ZCqLKQ=";
+
+  env = {
+    SKIA_SOURCE_DIR =
+      let
+        repo = fetchFromGitHub {
+          owner = "rust-skia";
+          repo = "skia";
+          # see rust-skia:skia-bindings/Cargo.toml#package.metadata skia
+          tag = "m148-0.97.0";
+          hash = "sha256-uFnYX6ZDg+cJwLyCe6IGB6M3aCyI/+q2aYP4JfHm544=";
+        };
+        # The externals for skia are taken from skia/DEPS
+        externals = linkFarm "skia-externals" (
+          lib.mapAttrsToList (name: value: {
+            inherit name;
+            path = fetchgit value;
+          }) (lib.importJSON ./skia-externals.json)
+        );
+      in
+      runCommand "source" { } ''
+        cp -R ${repo} $out
+        chmod -R +w $out
+        ln -s ${externals} $out/third_party/externals
+      '';
+
+    SKIA_GN_COMMAND = lib.getExe gn;
+    SKIA_NINJA_COMMAND = lib.getExe ninja;
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    pkg-config
+    python3
+    removeReferencesTo
+    rustPlatform.bindgenHook
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    cctools.libtool
+    rcodesign
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    copyDesktopItems
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    fontconfig
+    libGL
+    wayland
+  ];
+
+  cargoBuildFlags = [
+    "--package"
+    "oneclient_app"
+  ];
+
+  cargoTestFlags = [
+    "--package"
+    "oneclient_app"
+  ];
+
+  disallowedReferences = [ finalAttrs.env.SKIA_SOURCE_DIR ];
+
+  postInstall = ''
+    # Skia embeds the path to its sources
+    remove-references-to -t "$SKIA_SOURCE_DIR" \
+      $out/bin/oneclient_app
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    app="$out/Applications/OneClient.app"
+    mkdir -p "$app/Contents/"{MacOS,Resources}
+
+    mv "$out/bin/oneclient_app" "$app/Contents/MacOS/oneclient_app"
+    makeWrapper "$app/Contents/MacOS/oneclient_app" "$out/bin/oneclient_app" \
+      --set ONECLIENT_DISABLE_AUTOUPDATE 1
+
+    printf '%s' ${lib.escapeShellArg (infoPlist finalAttrs.version)} > "$app/Contents/Info.plist"
+    printf 'APPL????' > "$app/Contents/PkgInfo"
+
+    install -m444 packages/oneclient_app/icons/icon.icns \
+      "$app/Contents/Resources/icon.icns"
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    for size in 32x32 64x64 128x128 512x512; do
+      install -Dm444 "packages/oneclient_app/icons/$size.png" \
+        "$out/share/icons/hicolor/$size/apps/oneclient_app.png"
+    done
+  '';
+
+  postFixup =
+    let
+      libPath = lib.makeLibraryPath (
+        [
+          fontconfig
+          (lib.getLib stdenv.cc.cc)
+
+          # openal
+          openal
+          alsa-lib
+          libjack2
+          libpulseaudio
+          pipewire
+
+          # glfw
+          libGL
+          libx11
+          libxcb
+          libxcursor
+          libxi
+          libxkbcommon
+          libxrandr
+          wayland
+        ]
+        ++ lib.optional textToSpeechSupport flite
+        ++ additionalLibs
+      );
+    in
+    lib.optionalString stdenv.hostPlatform.isDarwin ''
+      ${lib.getExe rcodesign} sign \
+        --code-signature-flags runtime \
+        --entitlements-xml-file ${finalAttrs.src}/packages/oneclient_app/distribution/App.entitlements \
+        "$out/Applications/OneClient.app"
+    ''
+    + lib.optionalString stdenv.hostPlatform.isLinux ''
+      wrapProgram "$out/bin/oneclient_app" \
+        --set ONECLIENT_DISABLE_AUTOUPDATE 1 \
+        --set LD_LIBRARY_PATH "${addDriverRunpath.driverLink}/lib:${libPath}" \
+        --prefix PATH : "${lib.makeBinPath jdks}"
+    '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "oneclient_app";
+      desktopName = "OneClient";
+      comment = "Next-generation open source Minecraft launcher";
+      exec = "oneclient_app";
+      icon = "oneclient_app";
+      terminal = false;
+      startupNotify = true;
+      startupWMClass = "oneclient_app";
+      categories = [
+        "Game"
+        "ActionGame"
+        "AdventureGame"
+        "Simulation"
+      ];
+      keywords = [
+        "mc"
+        "minecraft"
+        "game"
+      ];
+    })
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Next-generation open source Minecraft launcher";
+    homepage = "https://polyfrost.org/projects/oneclient";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "oneclient_app";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ saadndm ];
+  };
+})

--- a/pkgs/by-name/on/oneclient/skia-externals.json
+++ b/pkgs/by-name/on/oneclient/skia-externals.json
@@ -1,0 +1,67 @@
+{
+  "brotli": {
+    "url": "https://skia.googlesource.com/external/github.com/google/brotli.git",
+    "rev": "6d03dfbedda1615c4cba1211f8d81735575209c8",
+    "sha256": "0l1wk83y471766n0snqv4i7h9fvqj92rbi63n0y2wqfdix0w8wf2"
+  },
+  "d3d12allocator": {
+    "url": "https://skia.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator.git",
+    "rev": "169895d529dfce00390a20e69c2f516066fe7a3b",
+    "sha256": "1r7m8lf0nnzmpkciz5yd1b8l5g9rb75yqpvklh0y7lfvfbzx2dp4"
+  },
+  "expat": {
+    "url": "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git",
+    "rev": "6154446fccefbf3ca644894f598969113b0c7bcd",
+    "sha256": "1h2rq5ww26xy9yfcf5rmbg3lmhlawpjjllpm4wi7zx5f8ms07ww9"
+  },
+  "freetype": {
+    "url": "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git",
+    "rev": "264b5fbf5b912b39f98d038bf75d39be0a73f21b",
+    "sha256": "1y8vkdyfkvabzq7xb3jbyrn8v625xrar3jdz9i0v5pisbmfi66j5"
+  },
+  "harfbuzz": {
+    "url": "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git",
+    "rev": "9cb1fee51069b206effb4736e443b038d230789d",
+    "sha256": "0hyb2m0413czq5f5j47bdm74qzxmhk67r2b88fv8l1xgwm12v0hi"
+  },
+  "icu": {
+    "url": "https://chromium.googlesource.com/chromium/deps/icu.git",
+    "rev": "364118a1d9da24bb5b770ac3d762ac144d6da5a4",
+    "sha256": "1y4y24xamafvghs4n2rjz477r7zsg5fgf15va122q5i2hg0jdfvy"
+  },
+  "libjpeg-turbo": {
+    "url": "https://chromium.googlesource.com/chromium/deps/libjpeg_turbo.git",
+    "rev": "e14cbfaa85529d47f9f55b0f104a579c1061f9ad",
+    "sha256": "1ywl6j1pcmx799h4jr3xmg2mnsmgv8sgrxnfzigzj3nrkadas3r2"
+  },
+  "libpng": {
+    "url": "https://skia.googlesource.com/third_party/libpng.git",
+    "rev": "d5515b5b8be3901aac04e5bd8bd5c89f287bcd33",
+    "sha256": "0f8mlsh2vsn9zmn5cdjvg5ck8bsplm23g46wvl4pnpd3bj03p79p"
+  },
+  "libwebp": {
+    "url": "https://chromium.googlesource.com/webm/libwebp.git",
+    "rev": "845d5476a866141ba35ac133f856fa62f0b7445f",
+    "sha256": "0fp9nxxddhxvikjn51r46sjrc3iiggr7mivabfgz02426skp0zll"
+  },
+  "vulkanmemoryallocator": {
+    "url": "https://chromium.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator",
+    "rev": "a6bfc237255a6bac1513f7c1ebde6d8aed6b5191",
+    "sha256": "1hpzjwl5bgqv9hmf1fdldihfllcbdg515f391a200klg0rnixdds"
+  },
+  "spirv-cross": {
+    "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Cross",
+    "rev": "b8fcf307f1f347089e3c46eb4451d27f32ebc8d3",
+    "sha256": "021x72k68z4q7idqf5ljhdnq8hlkz4vawfpspa5fq4nz6pscr38z"
+  },
+  "wuffs": {
+    "url": "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git",
+    "rev": "e3f919ccfe3ef542cfc983a82146070258fb57f8",
+    "sha256": "0b04ksbkf4dcm9myvf1sx9aclyh8jbpkrgja3h1chkfjbzcdvgfz"
+  },
+  "zlib": {
+    "url": "https://chromium.googlesource.com/chromium/src/third_party/zlib",
+    "rev": "646b7f569718921d7d4b5b8e22572ff6c76f2596",
+    "sha256": "0d3pv2vazr8haw4gcc8d2dyybx23nwaqfn5vfaxzdryrwi5gmn4c"
+  }
+}


### PR DESCRIPTION
Adds [oneclient](https://polyfrost.org/projects/oneclient): Next-generation open source Minecraft launcher written in Rust using Skia.

- The skia source is packaged following [Neovide](https://github.com/NixOS/nixpkgs/blob/7de57b0a62f56ccdcfbbc0a8f59ab844fe4b0562/pkgs/by-name/ne/neovide/package.nix), with its external dependencies pinned in `skia-externals.json`.
- Auto updates are disabled via `ONECLIENT_DISABLE_AUTOUPDATE`

Tested on aarch64-dawin and x86_64-linux, launcher starts and launches minecraft successfully.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
