### PR TITLE
apache-airflow: 3.3.0 -> 3.3.1

### DIFF
--- a/pkgs/by-name/ap/apache-airflow/package.nix
+++ b/pkgs/by-name/ap/apache-airflow/package.nix
@@ -12,31 +12,6 @@ let
   python = python3.override {
     self = python;
     packageOverrides = pySelf: pySuper: {
-      smmap = pySuper.smmap.overridePythonAttrs rec {
-        version = "5.0.2";
-        src = fetchFromGitHub {
-          owner = "gitpython-developers";
-          repo = "smmap";
-          tag = "v${version}";
-          hash = "sha256-0Y175kjv/8UJpSxtLpWH4/VT7JrcVPAq79Nf3rtHZZM=";
-        };
-      };
-      structlog = pySuper.structlog.overridePythonAttrs (o: rec {
-        version = "25.4.0";
-        src = fetchFromGitHub {
-          owner = "hynek";
-          repo = "structlog";
-          tag = version;
-          hash = "sha256-iNnUogcICQJvHBZO2J8uk4NleQY/ra3ZzxQgnSRKr30=";
-        };
-        nativeCheckInputs =
-          with pySelf;
-          o.nativeCheckInputs
-          ++ [
-            freezegun
-            pretend
-          ];
-      });
       apache-airflow = pySelf.callPackage ./python-package.nix { inherit enabledProviders; };
     };
   };

--- a/pkgs/by-name/ap/apache-airflow/providers.nix
+++ b/pkgs/by-name/ap/apache-airflow/providers.nix
@@ -923,7 +923,7 @@
   };
 
   pinecone = {
-    deps = [ ];
+    deps = [ "pinecone" ];
     imports = [
       "airflow.providers.pinecone"
       "airflow.providers.pinecone.get_provider_info"

--- a/pkgs/by-name/ap/apache-airflow/python-package.nix
+++ b/pkgs/by-name/ap/apache-airflow/python-package.nix
@@ -115,7 +115,7 @@ buildPythonPackage (
         pnpm = pnpm_10;
         sourceRoot = uiAttrs.sourceRoot;
         fetcherVersion = 3;
-        hash = "sha256-bKdZ4Y+enrXYuSpJ85eFHl2EM+QfZsMTGqQZ9yLfGEc=";
+        hash = "sha256-dn8DRI2uRlc5FKNiP2nL1RlZOs7NSH+66qHyUKP5KBc=";
       };
 
       buildPhase = ''
@@ -148,7 +148,7 @@ buildPythonPackage (
         pnpm = pnpm_10;
         sourceRoot = simpleUiAttrs.sourceRoot;
         fetcherVersion = 3;
-        hash = "sha256-Ye8jRs9jgsf3YUd3JPldEcTzQFmgS4cvkOVP6tuZw+8=";
+        hash = "sha256-KcWxcWPhtoZIfa1DZdIjTDik28cTk86HQnCBg8e2xWg=";
       };
 
       buildPhase = ''
@@ -179,6 +179,8 @@ buildPythonPackage (
         version = providers.${provider}.version;
         pyproject = true;
 
+        dontCheckPythonMetadata = true;
+
         inherit src;
         sourceRoot = "${src.name}/providers/${lib.replaceStrings [ "_" ] [ "/" ] provider}";
 
@@ -196,9 +198,11 @@ buildPythonPackage (
       };
 
     taskSdk = buildPythonPackage {
-      pname = "task-sdk";
+      pname = "apache-airflow-task-sdk";
       inherit src version;
       pyproject = true;
+
+      dontCheckPythonMetadata = true;
 
       sourceRoot = "${src.name}/task-sdk";
 
@@ -252,6 +256,8 @@ buildPythonPackage (
       pname = "apache-airflow-core";
       inherit src version;
       pyproject = true;
+
+      dontCheckPythonMetadata = true;
 
       sourceRoot = "${src.name}/airflow-core";
 
@@ -347,12 +353,15 @@ buildPythonPackage (
       ]
       ++ (map buildProvider requiredProviders);
 
-      pythonRelaxDeps = [ "starlette" ];
+      pythonRelaxDeps = [
+        "starlette"
+        "fastapi"
+      ];
     };
   in
   {
     pname = "apache-airflow";
-    version = "3.3.0";
+    version = "3.3.1";
 
     strictDeps = true;
     __structuredAttrs = true;
@@ -361,7 +370,7 @@ buildPythonPackage (
       owner = "apache";
       repo = "airflow";
       tag = finalAttrs.version;
-      hash = "sha256-1DRaJCJ488BKUOEFaFMGnZjS2yxBx4pwHvIP67juu54=";
+      hash = "sha256-ezEeO14GdaD7ZAl5VCiiIqkyoccHQ76QrThA3NeGP78=";
     };
 
     pyproject = true;


### PR DESCRIPTION


internal package apache-airflow-task-sdk used wrong name which caused pythonMetadataCheckHook to fail
disable pythonMetadataCheckHook for all subpackages (as they are not public packages but internal AF's code organization)
~currently building fails due to dependency which is fixed in #545491~ the fix is merged
fixes #552152 


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
