### PR TITLE
dracut: add patch for CVE-2026-6893

### DIFF
--- a/pkgs/by-name/dr/dracut/CVE-2026-6893.patch
+++ b/pkgs/by-name/dr/dracut/CVE-2026-6893.patch
@@ -1,0 +1,126 @@
+diff --git a/modules.d/35network-legacy/dhclient-script.sh b/modules.d/35network-legacy/dhclient-script.sh
+index 0cb00ab..ae68952 100755
+--- a/modules.d/35network-legacy/dhclient-script.sh
++++ b/modules.d/35network-legacy/dhclient-script.sh
+@@ -20,11 +20,11 @@ setup_interface() {
+     mask=$new_subnet_mask
+     bcast=$new_broadcast_address
+     gw=${new_routers%%,*}
+-    domain=$new_domain_name
++    domain=$(printf -- "%s" "$new_domain_name" | tr -d '[:cntrl:]')
+     # get rid of control chars
+     search=$(printf -- "%s" "$new_domain_search" | tr -d '[:cntrl:]')
+     namesrv=$new_domain_name_servers
+-    hostname=$new_host_name
++    hostname=$(printf '%s' "$new_host_name" | tr -d -c 'a-zA-Z0-9.-')
+     [ -n "$new_dhcp_lease_time" ] && lease_time=$new_dhcp_lease_time
+     [ -n "$new_max_life" ] && lease_time=$new_max_life
+     preferred_lft=$lease_time
+@@ -56,20 +56,32 @@ setup_interface() {
+         ${preferred_lft:+preferred_lft ${preferred_lft}}
+ 
+     if [ -n "$gw" ]; then
+-        if [ "$mask" = "255.255.255.255" ]; then
+-            # point-to-point connection => set explicit route to gateway
+-            echo ip route add "$gw" dev "$netif" > /tmp/net."$netif".gw
+-        fi
++        gw_check=0
++        for g in $gw; do
++            case "$g" in
++                *[!0-9.]*)
++                    gw_check=1
++                    break
++                    ;;
++            esac
++        done
+ 
+-        echo "$gw" | {
+-            IFS=' ' read -r main_gw other_gw
+-            echo ip route replace default via "$main_gw" dev "$netif" >> /tmp/net."$netif".gw
+-            if [ -n "$other_gw" ]; then
+-                for g in $other_gw; do
+-                    echo ip route add default via "$g" dev "$netif" >> /tmp/net."$netif".gw
+-                done
+-            fi
+-        }
++        if [ $gw_check -eq 0 ]; then
++            if [ "$mask" = "255.255.255.255" ]; then
++                # point-to-point connection => set explicit route to gateway
++                echo ip route add "$gw" dev "$netif" > /tmp/net."$netif".gw
++            fi
++
++            echo "$gw" | {
++                IFS=' ' read -r main_gw other_gw
++                echo ip route replace default via "$main_gw" dev "$netif" >> /tmp/net."$netif".gw
++                if [ -n "$other_gw" ]; then
++                    for g in $other_gw; do
++                        echo ip route add default via "$g" dev "$netif" >> /tmp/net."$netif".gw
++                    done
++                fi
++            }
++        fi
+     fi
+ 
+     if getargbool 1 rd.peerdns; then
+@@ -82,15 +94,15 @@ setup_interface() {
+     fi
+     # Note: hostname can be fqdn OR short hostname, so chop off any
+     # trailing domain name and explicitly add any domain if set.
+-    [ -n "$hostname" ] && echo "echo ${hostname%."$domain"}${domain:+.$domain} > /proc/sys/kernel/hostname" > /tmp/net."$netif".hostname
++    [ -n "$hostname" ] && echo "echo '${hostname%."$domain"}${domain:+.$domain}' > /proc/sys/kernel/hostname" > /tmp/net."$netif".hostname
+ }
+ 
+ setup_interface6() {
+-    domain=$new_domain_name
++    domain=$(printf -- "%s" "$new_domain_name" | tr -d '[:cntrl:]')
+     # get rid of control chars
+     search=$(printf -- "%s" "$new_dhcp6_domain_search" | tr -d '[:cntrl:]')
+     namesrv=$new_dhcp6_name_servers
+-    hostname=$new_host_name
++    hostname=$(printf '%s' "$new_host_name" | tr -d -c 'a-zA-Z0-9.-')
+     [ -n "$new_dhcp_lease_time" ] && lease_time=$new_dhcp_lease_time
+     [ -n "$new_max_life" ] && lease_time=$new_max_life
+     preferred_lft=$lease_time
+@@ -105,7 +117,7 @@ setup_interface6() {
+ 
+     # Note: hostname can be fqdn OR short hostname, so chop off any
+     # trailing domain name and explicitly add any domain if set.
+-    [ -n "$hostname" ] && echo "echo ${hostname%."$domain"}${domain:+.$domain} > /proc/sys/kernel/hostname" > /tmp/net."$netif".hostname
++    [ -n "$hostname" ] && echo "echo '${hostname%."$domain"}${domain:+.$domain}' > /proc/sys/kernel/hostname" > /tmp/net."$netif".hostname
+ }
+ 
+ parse_option_121() {
+@@ -113,16 +125,18 @@ parse_option_121() {
+     # Each route is: <mask_width> <dest_octets...> <gateway_4_octets>
+     # mask_width determines how many destination octets follow (0-4)
+     #
+-    # This version validates arguments before operations to prevent
+-    # "integer expression expected" and "shift count out of range" errors.
++    # Validate all arguments are numeric upfront to prevent
++    # shell injection via crafted octets in destination/gateway.
++    for _octet in "$@"; do
++        case "$_octet" in
++            '' | *[!0-9]*) return 0 ;;
++        esac
++    done
+ 
+     while [ $# -ge 5 ]; do
+         mask="$1"
+ 
+         # Validate mask is a number between 0-32
+-        case "$mask" in
+-            '' | *[!0-9]*) return 0 ;;
+-        esac
+         if [ "$mask" -lt 0 ] 2> /dev/null || [ "$mask" -gt 32 ] 2> /dev/null; then
+             return 0
+         fi
+@@ -150,9 +164,6 @@ parse_option_121() {
+         # Check if destination is multicast (224.0.0.0 - 239.255.255.255)
+         multicast=0
+         if [ $need_dest -ge 1 ]; then
+-            case "$1" in
+-                '' | *[!0-9]*) return 0 ;;
+-            esac
+             if [ "$1" -ge 224 ] 2> /dev/null && [ "$1" -lt 240 ] 2> /dev/null; then
+                 multicast=1
+             fi

--- a/pkgs/by-name/dr/dracut/package.nix
+++ b/pkgs/by-name/dr/dracut/package.nix
@@ -38,6 +38,12 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-2jdS7/LGuLSBBXv1R/o8yjgwdXl2l2wNbZWxq01wSb0";
   };
 
+  # Patch from https://github.com/dracut-ng/dracut/commit/11577739221ff38c1fd29abbba51a6c797376ed6 included in main branch.
+  # Adapted to version 111 (line number and small formatting diff)
+  patches = [
+    ./CVE-2026-6893.patch
+  ];
+
   strictDeps = true;
   __structuredAttrs = true;
 


### PR DESCRIPTION
Add patch for CVE-2026-6893
Patch is included in main branch of upstream: https://github.com/dracut-ng/dracut/commit/11577739221ff38c1fd29abbba51a6c797376ed6
Slightly adapted to apply to 111 (line numbers + formatting)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
