### PR TITLE
cudaPackages.setupCudaHook: include nvcc in CUDAToolkit_ROOT

### DIFF
--- a/pkgs/development/cuda-modules/packages/setupCudaHook/setup-cuda-hook.sh
+++ b/pkgs/development/cuda-modules/packages/setupCudaHook/setup-cuda-hook.sh
@@ -55,6 +55,11 @@ setupCUDAToolkit_ROOT() {
     fi
   done
 
+  local nvccExe
+  if nvccExe="$(type -P nvcc)"; then
+    addToSearchPathWithCustomDelimiter ";" CUDAToolkit_ROOT "${nvccExe%/bin/nvcc}"
+  fi
+
   # Use array form so semicolon-separated lists are passed safely.
   if [[ -n ${CUDAToolkit_INCLUDE_DIR-} ]]; then
     cmakeFlagsArray+=("-DCUDAToolkit_INCLUDE_DIR=${CUDAToolkit_INCLUDE_DIR}")


### PR DESCRIPTION
As of https://github.com/Kitware/CMake/commit/a345c0e193dc97e526b7877e0fde542b415805a5 if CUDAToolkit_ROOT is set and bin/nvcc isn't in the list then it fails, whereas before it would fall through to a search that included PATH. Since that's what happens in setup-cuda-hook.sh (cuda_nvcc is in nativeBuildInputs so the for loop at the start of setupCUDAToolkit_ROOT() misses it bc it only collects host-side deps), builds relying on nvcc fail. This broke when cmake was bumped to 4.3.4 in #529977

This fix adds the nvcc package root dir to CUDAToolkit_ROOT in setup so it can be found during the build process.

Packages that were broken which I've tested building with this change:
- ollama-cuda (Resolves #545286)
- cudaPackages.cudnn-frontend (Resolves #544701)
- openimagedenoise (Resolves #545409)

It's possible to roughly enumerate which packages are affected without building by looking for packages with `cuda_nvcc`, then looking at the cmake files to see whether they use `find_package(CUDAToolkit` somewhere, then figuring out whether that runs before or after cuda is actually enabled, but to do it precisely you'd have to grok the cmake files of each package so I haven't done that. From some approximate grepping **I would guess somewhere between 30-50 packages are affected** but honestly it could be more or less than that.

There is a WIP PR from @ConnorBaker (#545092) that will resolve this as part of a refactor of the setup hooks generally, but I think it would be good to release this change while that is in the works to fix the broken builds.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
