### PR TITLE
ultimate-doom-builder: drop gtk2, link libxfixes directly

### DIFF
--- a/pkgs/by-name/ul/ultimate-doom-builder/package.nix
+++ b/pkgs/by-name/ul/ultimate-doom-builder/package.nix
@@ -8,7 +8,7 @@
   libGL,
   libpng,
   libx11,
-  gtk2-x11,
+  libxfixes,
   makeDesktopItem,
   copyDesktopItems,
   unstableGitUpdater,
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     libGL
     libpng
     libx11
-    gtk2-x11
+    libxfixes
   ];
 
   postPatch =
@@ -77,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
       Source/Native/*.cpp \
       Source/Native/OpenGL/*.cpp \
       Source/Native/OpenGL/gl_load/*.c \
-      -lX11 -ldl
+      -lX11 -lXfixes -ldl
 
     runHook postBuild
   '';
@@ -92,11 +92,10 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace $out/opt/UltimateDoomBuilder/builder --replace-fail mono ${mono}/bin/mono
     substituteInPlace $out/opt/UltimateDoomBuilder/builder --replace-fail Builder.exe $out/opt/UltimateDoomBuilder/Builder.exe
 
-    # GTK, OpenGL, and other libraries are loaded dynamically by Mono at runtime
+    # OpenGL and other libraries are loaded dynamically by Mono at runtime
     wrapProgram $out/opt/UltimateDoomBuilder/builder \
       --prefix LD_LIBRARY_PATH : "${
         lib.makeLibraryPath [
-          gtk2-x11
           libGL
           libpng
           libx11


### PR DESCRIPTION
`ultimate-doom-builder` is listed as a direct GTK 2 dependent in #410814. UDB has no GTK code of its own, but `gtk2-x11` turned out to be covering for a missing `libxfixes` dependency in two ways.

`RawMouse.cpp` includes `X11/extensions/Xfixes.h`, which was reaching the compiler through gtk2's propagated inputs. Dropping `gtk2-x11` on its own fails the build:

```
Source/Native/RawMouse.cpp:198:10: fatal error: X11/extensions/Xfixes.h: No such file or directory
```

More subtly, `libBuilderNative.so` calls `XFixesShowCursor` and `XFixesHideCursor` but is linked with only `-lX11 -ldl`, so both symbols are undefined in the shipped library:

```
$ ldd -r libBuilderNative.so   # current master
undefined symbol: XFixesShowCursor
undefined symbol: XFixesHideCursor
```

They resolve today only because Mono dlopens `libgtk-x11-2.0.so.0` from `X11DesktopColors` (to read desktop theme colors), which pulls `libXfixes.so.3` into the process global scope. Loading the library with immediate binding fails without GTK present:

```
$ ./probe libBuilderNative.so   # dlopen(RTLD_NOW) + call MouseInput_ShowCursor
dlopen FAILED: .../libBuilderNative.so: undefined symbol: XFixesShowCursor
```

So this depends on `libxfixes` directly and adds `-lXfixes` to the native build, rather than just removing `gtk2-x11`.

After the change:

```
$ readelf -d libBuilderNative.so | grep NEEDED
 ... [libX11.so.6]
 ... [libXfixes.so.3]
 ...
$ ldd -r libBuilderNative.so
(no unresolved symbols)
$ ./probe libBuilderNative.so
dlopen(RTLD_NOW) + dlsym OK
MouseInput_ShowCursor(hide/show) returned OK
```

The only user-visible change is Windows Forms falling back to its built-in color scheme instead of picking up GTK theme colors:

```
Gtk not found (missing LD_LIBRARY_PATH to libgtk-x11-2.0.so.0?), using built-in colorscheme
```

The editor starts and the window is functional. `gtk2` is gone from the closure entirely, which takes it from 540.1 MiB to 446.0 MiB.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Disclosure per the automation/AI policy: the investigation, the patch and this summary were produced with Claude Code (claude-opus-5). I reviewed the change and the verification output before submitting; the `ldd -r`, `readelf` and dlopen probe results above are reproducible checks rather than model claims.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
