### PR TITLE
artalk: switch to finalAttrs; 2.9.1 -> 2.10.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -62,6 +62,11 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- Artalk has been updated to 2.10.0. Its default configuration and data
+  directory discovery changed; see the [upstream migration
+  guide](https://artalk.js.org/en/guide/releases/v2.10.0.html) when invoking
+  `artalk` directly. The `services.artalk` module is unaffected.
+
 - `boot.vesa` has been removed. It was deprecated in 2020 because Xorg now works better with kernel modesetting. If you still need the legacy VESA 800x600 fallback, set `boot.kernelParams = [ "vga=0x317" "nomodeset" ];` directly.
 
 - `authentik` has been updated to 2026.5.3, which changes the default listen address from `0.0.0.0` to `[::]`.

--- a/pkgs/by-name/ar/artalk/frontend.nix
+++ b/pkgs/by-name/ar/artalk/frontend.nix
@@ -1,0 +1,52 @@
+{
+  stdenvNoCC,
+  nodejs,
+  pnpmConfigHook,
+  pnpm_10,
+  fetchPnpmDeps,
+
+  artalk,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "${artalk.pname}-frontend";
+
+  inherit (artalk) src version;
+
+  nativeBuildInputs = [
+    nodejs
+    pnpmConfigHook
+    pnpm_10
+  ];
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-RSz/bx8/BAqLZH3/yQ6/H/nnwGvcCg8EzIEJ4/xkQgQ=";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm build:all
+    pnpm build:auth
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{dist/{i18n,plugins},sidebar}
+
+    # dist
+    cp ./ui/artalk/dist/{Artalk,ArtalkLite}.{css,js} $out/dist
+    cp ./ui/artalk/dist/i18n/*.js $out/dist/i18n
+    cp ./ui/plugin-*/dist/*.js $out/dist/plugins
+
+    # sidebar
+    cp -r ./ui/artalk-sidebar/dist/* $out/sidebar
+
+    runHook postInstall
+  '';
+})

--- a/pkgs/by-name/ar/artalk/frontend.nix
+++ b/pkgs/by-name/ar/artalk/frontend.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   stdenvNoCC,
   nodejs,
   pnpmConfigHook,
@@ -22,13 +23,18 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
     fetcherVersion = 4;
-    hash = "sha256-RSz/bx8/BAqLZH3/yQ6/H/nnwGvcCg8EzIEJ4/xkQgQ=";
+    hash = "sha256-rs3isWKlV+RGA3shYZZpNImn9xJ67vpXoJmQoO6y2cE=";
   };
+
+  # vite-plugin-checker spawns a chokidar watcher during the build, which on
+  # Darwin exhausts the file descriptor limit with native fs.watch.
+  env.CHOKIDAR_USEPOLLING = lib.optionalString stdenvNoCC.hostPlatform.isDarwin "true";
 
   buildPhase = ''
     runHook preBuild
 
     pnpm build:all
+    pnpm build:plugin-kit
     pnpm build:auth
 
     runHook postBuild

--- a/pkgs/by-name/ar/artalk/package.nix
+++ b/pkgs/by-name/ar/artalk/package.nix
@@ -1,84 +1,33 @@
 {
   lib,
   buildGoModule,
+  callPackage,
   fetchFromGitHub,
-  nodejs,
-  pnpm_10,
-  fetchPnpmDeps,
-  pnpmConfigHook,
   installShellFiles,
   versionCheckHook,
   stdenv,
   nixosTests,
 }:
 
-let
+buildGoModule (finalAttrs: {
   pname = "artalk";
   version = "2.9.1";
 
   src = fetchFromGitHub {
     owner = "ArtalkJS";
     repo = "artalk";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-gzagE3muNpX/dwF45p11JAN9ElsGXNFQ3fCvF1QhvdU=";
   };
-
-  frontend = stdenv.mkDerivation (finalAttrs: {
-    pname = "${pname}-frontend";
-
-    inherit src version;
-
-    nativeBuildInputs = [
-      nodejs
-      pnpmConfigHook
-      pnpm_10
-    ];
-
-    pnpmDeps = fetchPnpmDeps {
-      inherit (finalAttrs) pname version src;
-      pnpm = pnpm_10;
-      fetcherVersion = 4;
-      hash = "sha256-RSz/bx8/BAqLZH3/yQ6/H/nnwGvcCg8EzIEJ4/xkQgQ=";
-    };
-
-    buildPhase = ''
-      runHook preBuild
-
-      pnpm build:all
-      pnpm build:auth
-
-      runHook postBuild
-    '';
-
-    installPhase = ''
-      runHook preInstall
-
-      mkdir -p $out/{dist/{i18n,plugins},sidebar}
-
-      # dist
-      cp ./ui/artalk/dist/{Artalk,ArtalkLite}.{css,js} $out/dist
-      cp ./ui/artalk/dist/i18n/*.js $out/dist/i18n
-      cp ./ui/plugin-*/dist/*.js $out/dist/plugins
-
-      # sidebar
-      cp -r ./ui/artalk-sidebar/dist/* $out/sidebar
-
-      runHook postInstall
-    '';
-  });
-in
-buildGoModule {
-  inherit src pname version;
 
   vendorHash = "sha256-oAqYQzOUjly97H5L5PQ9I2SO2KqiUVxdJA+eoPrHD6Q=";
 
   ldflags = [
     "-s"
-    "-w"
   ];
 
-  preBuild = ''
-    cp -r ${frontend}/* ./public
+  preConfigure = ''
+    cp -r ${finalAttrs.passthru.frontend}/* ./public
   '';
 
   nativeBuildInputs = [ installShellFiles ];
@@ -94,16 +43,19 @@ buildGoModule {
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "-v";
 
-  passthru.tests = {
-    inherit (nixosTests) artalk;
+  passthru = {
+    tests = {
+      inherit (nixosTests) artalk;
+    };
+    frontend = callPackage ./frontend.nix { artalk = finalAttrs.finalPackage; };
   };
 
   meta = {
     description = "Self-hosted comment system";
     homepage = "https://github.com/ArtalkJS/Artalk";
-    changelog = "https://github.com/ArtalkJS/Artalk/releases/tag/v${version}";
+    changelog = "https://github.com/ArtalkJS/Artalk/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ moraxyc ];
     mainProgram = "artalk";
   };
-}
+})

--- a/pkgs/by-name/ar/artalk/package.nix
+++ b/pkgs/by-name/ar/artalk/package.nix
@@ -4,23 +4,24 @@
   callPackage,
   fetchFromGitHub,
   installShellFiles,
-  versionCheckHook,
   stdenv,
   nixosTests,
+  versionCheckHook,
+  nix-update-script,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "artalk";
-  version = "2.9.1";
+  version = "2.10.0";
 
   src = fetchFromGitHub {
     owner = "ArtalkJS";
     repo = "artalk";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-gzagE3muNpX/dwF45p11JAN9ElsGXNFQ3fCvF1QhvdU=";
+    hash = "sha256-gtWnXRDGFjpw9W1ze6fBn/WXMQStqeyQpQHTr3wu5AU=";
   };
 
-  vendorHash = "sha256-oAqYQzOUjly97H5L5PQ9I2SO2KqiUVxdJA+eoPrHD6Q=";
+  vendorHash = "sha256-xSIkJKlWGbdBlez7jPaoeHuYbyO+2237sZ/yxjUcHf8=";
 
   ldflags = [
     "-s"
@@ -30,7 +31,12 @@ buildGoModule (finalAttrs: {
     cp -r ${finalAttrs.passthru.frontend}/* ./public
   '';
 
+  env.CGO_ENABLED = 0;
+
   nativeBuildInputs = [ installShellFiles ];
+
+  # TestAuthSSOExchange
+  __darwinAllowLocalNetworking = true;
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd artalk \
@@ -41,13 +47,16 @@ buildGoModule (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "-v";
+  versionCheckProgramArg = "version";
+  versionCheckKeepEnvironment = [ "XDG_DATA_HOME" ];
+  preVersionCheck = "XDG_DATA_HOME=$TMPDIR";
 
   passthru = {
     tests = {
       inherit (nixosTests) artalk;
     };
     frontend = callPackage ./frontend.nix { artalk = finalAttrs.finalPackage; };
+    updateScript = nix-update-script { extraArgs = [ "--subpackage=frontend" ]; };
   };
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
