### PR TITLE
modsecurity_standalone: pcre -> pcre2

### DIFF
--- a/pkgs/by-name/mo/modsecurity_standalone/package.nix
+++ b/pkgs/by-name/mo/modsecurity_standalone/package.nix
@@ -6,7 +6,7 @@
   autoreconfHook,
   curl,
   apacheHttpd,
-  pcre,
+  pcre2,
   apr,
   aprutil,
   libxml2,
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     curl
     apacheHttpd
-    pcre
+    pcre2
     apr
     aprutil
     libxml2
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--enable-static"
     "--with-curl=${curl.dev}"
     "--with-apxs=${apacheHttpd.dev}/bin/apxs"
-    "--with-pcre=${pcre.dev}"
+    "--with-pcre2=${lib.getDev pcre2}/bin/pcre2-config"
     "--with-apr=${apr.dev}"
     "--with-apu=${aprutil.dev}/bin/apu-1-config"
     "--with-libxml=${libxml2.dev}"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

pcre has been replaced with pcre2 in https://github.com/owasp-modsecurity/ModSecurity/pull/3383. pcre2 doesn't get picked up automatically (for the version we carry, and I'm only interested in removal of old pcre, not updating the package), as can be seen [here](https://github.com/owasp-modsecurity/ModSecurity/blob/v2.9.12/build/find_pcre2.m4#L44), so we need to help with providing the path.

Relates to https://github.com/NixOS/nixpkgs/issues/356387

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
