### PR TITLE
zellij: avoid putting empty path segment into PATH when `extraPackages` is empty

### DIFF
--- a/pkgs/by-name/ze/zellij/package.nix
+++ b/pkgs/by-name/ze/zellij/package.nix
@@ -3,24 +3,36 @@
   zellij-unwrapped,
   makeBinaryWrapper,
   stdenvNoCC,
+  symlinkJoin,
 
   extraPackages ? [ ],
 }:
-stdenvNoCC.mkDerivation {
-  inherit (zellij-unwrapped) version meta;
-  pname = "zellij";
+if extraPackages == [ ] then
+  symlinkJoin {
+    inherit (zellij-unwrapped) version meta;
+    pname = "zellij";
 
-  __structuredAttrs = true;
-  strictDeps = true;
+    __structuredAttrs = true;
+    strictDeps = true;
 
-  src = zellij-unwrapped;
-  dontUnpack = true;
+    paths = [ zellij-unwrapped ];
+  }
+else
+  stdenvNoCC.mkDerivation {
+    inherit (zellij-unwrapped) version meta;
+    pname = "zellij";
 
-  nativeBuildInputs = [ makeBinaryWrapper ];
-  buildPhase = ''
-    cp -rs --no-preserve=mode "$src" "$out"
+    __structuredAttrs = true;
+    strictDeps = true;
 
-    wrapProgram "$out/bin/zellij" \
-      --prefix PATH : '${lib.makeBinPath extraPackages}'
-  '';
-}
+    src = zellij-unwrapped;
+    dontUnpack = true;
+
+    nativeBuildInputs = [ makeBinaryWrapper ];
+    buildPhase = ''
+      cp -rs --no-preserve=mode "$src" "$out"
+
+      wrapProgram "$out/bin/zellij" \
+        --prefix PATH : '${lib.makeBinPath extraPackages}'
+    '';
+  }


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 545564`
Commit: `d782d6e1dbe7df9e300307b8ef154305c1ea43c0`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>zellij</li>
    <li>zmate</li>
  </ul>
</details>
