### PR TITLE
octoprint: 1.11.7 -> 1.11.8

### DIFF
--- a/pkgs/by-name/oc/octoprint/package.nix
+++ b/pkgs/by-name/oc/octoprint/package.nix
@@ -4,7 +4,9 @@
   callPackage,
   lib,
   fetchFromGitHub,
-  python3,
+  # OctoPrint requires Python >=3.7, <3.14, so it cannot use the default python3
+  # while that points at 3.14.
+  python313,
   replaceVars,
   nix-update-script,
   nixosTests,
@@ -13,38 +15,21 @@
 }:
 let
 
-  py = python3.override {
+  py = python313.override {
     self = py;
     packageOverrides = lib.foldr lib.composeExtensions (self: super: { }) [
-      (
-
-        self: super: {
-          # fix tornado.httputil.HTTPInputError: Multiple host headers not allowed
-          tornado = super.tornado.overridePythonAttrs (oldAttrs: {
-            version = "6.4.2";
-            format = "setuptools";
-            pyproject = null;
-            src = fetchFromGitHub {
-              owner = "tornadoweb";
-              repo = "tornado";
-              tag = "v6.4.2";
-              hash = "sha256-qgJh8pnC1ALF8KxhAYkZFAc0DE6jHVB8R/ERJFL4OFc=";
-            };
-            doCheck = false;
-          });
-        })
       # Built-in dependency
       (self: super: {
         octoprint-filecheck = self.buildPythonPackage rec {
           pname = "OctoPrint-FileCheck";
-          version = "2024.11.12";
+          version = "2025.7.23";
           format = "setuptools";
 
           src = fetchFromGitHub {
             owner = "OctoPrint";
             repo = "OctoPrint-FileCheck";
             rev = version;
-            sha256 = "sha256-Y7yvImnYahmrf5GC4c8Ki8IsOZ8r9I4uk8mYBhEQZ28=";
+            hash = "sha256-Y3JVfbe+bZz2t65OqdjvVVqTSa0VUPoCaxvE+zQ+Qts=";
           };
           doCheck = false;
         };
@@ -54,14 +39,14 @@ let
       (self: super: {
         octoprint-firmwarecheck = self.buildPythonPackage rec {
           pname = "OctoPrint-FirmwareCheck";
-          version = "2021.10.11";
+          version = "2025.7.23";
           format = "setuptools";
 
           src = fetchFromGitHub {
             owner = "OctoPrint";
             repo = "OctoPrint-FirmwareCheck";
             rev = version;
-            hash = "sha256-wqbD82bhJDrDawJ+X9kZkoA6eqGxqJc1Z5dA0EUwgEI=";
+            hash = "sha256-QPchpyeotB5IKbfES74CJlhw3sz8Q1df/+n5dpbrHSs=";
           };
           doCheck = false;
         };
@@ -70,14 +55,14 @@ let
       (self: super: {
         octoprint-pisupport = self.buildPythonPackage rec {
           pname = "OctoPrint-PiSupport";
-          version = "2023.10.10";
+          version = "2025.7.23";
           format = "setuptools";
 
           src = fetchFromGitHub {
             owner = "OctoPrint";
             repo = "OctoPrint-PiSupport";
             rev = version;
-            hash = "sha256-VSzDoFq4Yn6KOn+RNi1uVJHzH44973kd/VoMjqzyBRA=";
+            hash = "sha256-bXjRGxIwi+UnVts2HO9viOJqa2AmZ/CL7wuoyzRbAEw=";
           };
 
           # requires octoprint itself during tests
@@ -92,20 +77,21 @@ let
       (self: super: {
         octoprint = self.buildPythonPackage rec {
           pname = "OctoPrint";
-          version = "1.11.7";
+          version = "1.11.8";
           format = "setuptools";
 
           src = fetchFromGitHub {
             owner = "OctoPrint";
             repo = "OctoPrint";
             rev = version;
-            hash = "sha256-X9+o3EpTtKAFiSmjOumRCDKNwBc9LVjvqyZqun3yDi8=";
+            hash = "sha256-yTHzBqwVxAP6EokiWqD/SR6P2X4gIGyiyzNH0UzzDB4=";
           };
 
           propagatedBuildInputs =
             with self;
             [
               argon2-cffi
+              babel
               blinker
               cachelib
               click
@@ -120,21 +106,23 @@ let
               flask-limiter
               frozendict
               itsdangerous
-              immutabledict
               jinja2
+              libpass
+              limits
               markdown
               markupsafe
               netaddr
               netifaces
               octoprint-filecheck
               octoprint-firmwarecheck
-              passlib
+              packaging
               pathvalidate
-              pkginfo
               pip
+              pkginfo
               psutil
               pylru
               pyserial
+              pytz
               pyyaml
               regex
               requests
@@ -148,6 +136,7 @@ let
               watchdog
               websocket-client
               werkzeug
+              wheel
               wrapt
               zeroconf
               zipstream-ng
@@ -179,14 +168,21 @@ let
           postPatch =
             let
               ignoreVersionConstraints = [
+                "Babel"
                 "cachelib"
+                "Click"
                 "colorlog"
                 "emoji"
-                "immutabledict"
+                "limits"
+                "markdown"
+                "netaddr"
+                "psutil"
                 "PyYAML"
+                "requests"
                 "sarge"
                 "sentry-sdk"
                 "watchdog"
+                "websocket-client"
                 "wrapt"
                 "zeroconf"
                 "Flask-Login"
@@ -199,7 +195,7 @@ let
             ''
               sed -r -i \
                 ${lib.concatStringsSep "\n" (
-                  map (e: ''-e 's@${e}[<>=]+.*@${e}",@g' \'') ignoreVersionConstraints
+                  map (e: ''-e 's@${e}[<>=!]+.*@${e}",@g' \'') ignoreVersionConstraints
                 )}
                 setup.py
             '';
@@ -214,6 +210,7 @@ let
           ]
           ++ lib.optionals stdenv.hostPlatform.isDarwin [ "test_set_external_modification" ];
           disabledTestPaths = [
+            "tests/http_api" # requires a live OctoPrint server; excluded by upstream pytest.ini
             "tests/test_octoprint_setuptools.py" # fails due to distutils and python3.12
           ];
 


### PR DESCRIPTION
Updates OctoPrint to 1.11.8 and the bundled plugins it requires.

Release notes: https://github.com/OctoPrint/OctoPrint/releases/tag/1.11.8

Changes:
- octoprint: 1.11.7 -> 1.11.8
- Bundled plugins bumped in lockstep, as required by 1.11.8 (`OctoPrint-FileCheck>=2025.7.23`, `OctoPrint-FirmwareCheck>=2025.7.23`, `OctoPrint-PiSupport>=2025.7.23`):
  - OctoPrint-FileCheck: 2024.11.12 -> 2025.7.23
  - OctoPrint-FirmwareCheck: 2021.10.11 -> 2025.7.23
  - OctoPrint-PiSupport: 2023.10.10 -> 2025.7.23
- Pin to `python313`. OctoPrint requires Python `>=3.7, <3.14`, but the default `python3` now points at 3.14, which fails to build (e.g. `class-doc`).
- Drop the `tornado` 6.4.2 override. The multiple-host-headers fix is already in the tornado 6.5.x in nixpkgs, which also satisfies OctoPrint's `tornado>=6.5.1,<6.6` requirement.
- Track upstream dependency changes: add `babel`, `libpass` (replaces `passlib`), `limits`, `packaging`, `pytz`, `wheel`; drop `immutabledict`.
- Disable `tests/http_api`. These require a live OctoPrint server and are excluded by upstream's `pytest.ini` (which the build removes).

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test