### PR TITLE
risp: init at 0.1.0

### DIFF
--- a/pkgs/by-name/ri/risp/package.nix
+++ b/pkgs/by-name/ri/risp/package.nix
@@ -14,7 +14,7 @@ python3Packages.buildPythonApplication rec {
     owner = "vksarchy";
     repo = "risp";
     rev = "v${version}";
-    hash = "sha256-l7wGc6OKt0UvreH84+hRA6FLZguYjidV3hxpRWd1dvo=";
+    hash = "sha256-U62Hm1Po6m41+T0b2xvKqMQnQFEkcIAAUlcANRjplz8=";
   };
 
   build-system = with python3Packages; [

--- a/pkgs/by-name/ri/risp/package.nix
+++ b/pkgs/by-name/ri/risp/package.nix
@@ -8,6 +8,7 @@ python3Packages.buildPythonApplication rec {
   pname = "risp";
   version = "0.1.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "vksarchy";

--- a/pkgs/by-name/ri/risp/package.nix
+++ b/pkgs/by-name/ri/risp/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "risp";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "vksarchy";
+    repo = "risp";
+    rev = "v${version}";
+    hash = "sha256-l7wGc6OKt0UvreH84+hRA6FLZguYjidV3hxpRWd1dvo=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    rich
+    ebooklib
+    pypdf
+  ];
+
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "risp"
+    "risp.cli"
+  ];
+
+  meta = {
+    description = "Terminal RSVP speed reader for text, Markdown, Org, PDF, and EPUB";
+    longDescription = ''
+      risp (Rapid Interactive Serial Presentation) shows documents as a
+      per-word RSVP stream with an optical recognition point (ORP) focus
+      letter, adjustable WPM, ETA, and sentence context on pause.
+    '';
+    homepage = "https://github.com/vksarchy/risp";
+    license = lib.licenses.mit;
+    mainProgram = "risp";
+    platforms = lib.platforms.unix;
+    maintainers = [ ];
+  };
+}


### PR DESCRIPTION
## Description

Adds **risp** (Rapid Interactive Serial Presentation), a terminal RSVP speed reader for plain text, Markdown, Org, PDF, and EPUB.

- Upstream: https://github.com/vksarchy/risp
- Release: `v0.1.0`
- Similar in spirit to existing `speedread`, with multi-format support and a Rich TUI (WPM control, ETA, sentence context on pause)

## Things done

- Built on x86_64-linux: `nix-build -A risp` (from package expression)
- Ran `./result/bin/risp --help`
- `pythonImportsCheck` for `risp` / `risp.cli`
- Meta: MIT, `mainProgram = "risp"`, no personal maintainer entry yet (empty `maintainers`)

## Checklist

- [x] Package builds
- [x] `meta` fields set
- [x] Source pinned to tagged release with SRI hash
- [ ] ofborg / CI (to be filled by bots)