### PR TITLE
plugp100: 5.1.5 -> 6.0.0.dev2

### DIFF
--- a/pkgs/development/python-modules/plugp100/default.nix
+++ b/pkgs/development/python-modules/plugp100/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
   certifi,
   scapy,
   urllib3,
@@ -17,24 +18,28 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "plugp100";
-  version = "5.1.5";
-  format = "setuptools";
+  version = "6.0.0.dev2";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "petretiandrea";
     repo = "plugp100";
-    tag = finalAttrs.version;
-    sha256 = "sha256-bPjgyScHxiUke/M5S6BOw7df7wbNuSy5ouVIK5guWxw=";
+    tag = lib.replaceStrings [ ".dev" ] [ "-dev." ] finalAttrs.version;
+    hash = "sha256-wYt51HwoRJzuJ+YW+mmB6ZosJGEz7DcRGfkFGQZ0DJE=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    aiohttp
     certifi
+    cryptography
     jsons
     requests
-    aiohttp
-    semantic-version
-    cryptography
     scapy
+    semantic-version
     urllib3
   ];
 
@@ -47,7 +52,7 @@ buildPythonPackage (finalAttrs: {
     "tests/integration/"
     "tests/unit/hub_child/"
     "tests/unit/test_plug_strip.py"
-    "tests/unit/test_hub.py "
+    "tests/unit/test_hub.py"
     "tests/unit/test_klap_protocol.py"
   ];
 


### PR DESCRIPTION
Update `python3Packages.plugp100` to 6.0.0.dev2 (GitHub tag `6.0.0-dev.2`).

### Motivation & Downstream Context
- Required by the [home-assistant-tapo-p100](https://github.com/petretiandrea/home-assistant-tapo-p100) Home Assistant custom integration (v3.5.0), which explicitly pins `plugp100==6.0.0.dev2` in `manifest.json`.
- PyPI carries `6.0.0.dev2`. We accept packaging this dev pre-release in Nixpkgs as `plugp100` has no other downstream dependents in Nixpkgs, avoiding breaking changes across the package set while enabling Tapo HA integration.

### Derivation Modernization
- Migrate derivation from legacy `format = "setuptools";` to `pyproject = true;` with `build-system = [ setuptools ];`, aligning with Nixpkgs hygiene tracking issue NixOS/nixpkgs#515974.
- Convert source hash to SRI `hash`.
- Preserve `finalAttrs.version` recursion in `tag` via `lib.replaceStrings`.
- Fix trailing space typo in `disabledTestPaths` (`"tests/unit/test_hub.py"`).

### Disclosure
Assisted-by: Pi (antigravity/gemini-3.6-flash)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage