### PR TITLE
nix-cl: avoid empty path segments in prefixed env variables

### DIFF
--- a/pkgs/development/lisp-modules/nix-cl.nix
+++ b/pkgs/development/lisp-modules/nix-cl.nix
@@ -365,18 +365,36 @@ let
         nativeBuildInputs = [ pkgs.makeBinaryWrapper ];
         installPhase = ''
           mkdir -pv $out/bin
-          makeWrapper \
-            ${o.pkg}/bin/${o.program} \
-            $out/bin/${o.program} \
-            --add-flags "${toString o.flags}" \
-            --set ASDF "${o.asdfFasl}/asdf.${o.faslExt}" \
-            --prefix CL_SOURCE_REGISTRY : "$CL_SOURCE_REGISTRY''${CL_SOURCE_REGISTRY:+:}" \
-            --prefix ASDF_OUTPUT_TRANSLATIONS : "$(echo $CL_SOURCE_REGISTRY | sed s,//:,::,g):" \
-            --prefix LD_LIBRARY_PATH : "$LD_LIBRARY_PATH" \
-            --prefix DYLD_LIBRARY_PATH : "$DYLD_LIBRARY_PATH" \
-            --prefix CLASSPATH : "$CLASSPATH" \
-            --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
-            --prefix PATH : "${makeBinPath (o.propagatedBuildInputs or [ ])}"
+
+          wrapperArgs=(
+            "${o.pkg}/bin/${o.program}"
+            "$out/bin/${o.program}"
+            --add-flags "${toString o.flags}"
+            --set ASDF "${o.asdfFasl}/asdf.${o.faslExt}"
+          )
+          if [ -n "$CL_SOURCE_REGISTRY" ]; then
+            wrapperArgs+=(
+              --prefix CL_SOURCE_REGISTRY : "$CL_SOURCE_REGISTRY:"
+              --prefix ASDF_OUTPUT_TRANSLATIONS : "$(echo $CL_SOURCE_REGISTRY | sed s,//:,::,g):"
+            )
+          fi
+          if [ -n "$LD_LIBRARY_PATH" ]; then
+            wrapperArgs+=(--prefix LD_LIBRARY_PATH : "$LD_LIBRARY_PATH")
+          fi
+          if [ -n "$DYLD_LIBRARY_PATH" ]; then
+            wrapperArgs+=(--prefix DYLD_LIBRARY_PATH : "$DYLD_LIBRARY_PATH")
+          fi
+          if [ -n "$CLASSPATH" ]; then
+            wrapperArgs+=(--prefix CLASSPATH : "$CLASSPATH")
+          fi
+          if [ -n "$GI_TYPELIB_PATH" ]; then
+            wrapperArgs+=(--prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH")
+          fi
+          ${lib.optionalString ((o.propagatedBuildInputs or [ ]) != [ ]) ''
+            wrapperArgs+=(--prefix PATH : "${makeBinPath (o.propagatedBuildInputs or [ ])}")
+          ''}
+
+          makeWrapper "''${wrapperArgs[@]}"
         '';
       });
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `6bf6d4c64fa3673ec19b33aef7481938d05a5cbb`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>stumpwm</li>
  </ul>
</details>
