### PR TITLE
nixos/routinator: Add support for reloading

### DIFF
--- a/nixos/modules/services/networking/routinator.nix
+++ b/nixos/modules/services/networking/routinator.nix
@@ -137,19 +137,23 @@ in
   };
 
   config = mkIf cfg.enable {
+
+    environment.etc."routinator/routinator.conf".source = settingsFormat.generate "routinator.conf" (
+      filterAttrsRecursive (n: v: v != null) cfg.settings
+    );
+
     systemd.services.routinator = {
       description = "Routinator 3000 is free, open-source RPKI Relying Party software made by NLnet Labs.";
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
+      reloadTriggers = [ config.environment.etc."routinator/routinator.conf".source ];
       path = with pkgs; [ rsync ];
       serviceConfig = {
         Type = "exec";
         ExecStart = escapeSystemdExecArgs (
           [
             (getExe cfg.package)
-            "--config=${
-              settingsFormat.generate "routinator.conf" (filterAttrsRecursive (n: v: v != null) cfg.settings)
-            }"
+            "--config=/etc/routinator/routinator.conf"
           ]
           ++ cfg.extraArgs
           ++ [
@@ -157,6 +161,7 @@ in
           ]
           ++ cfg.extraServerArgs
         );
+        ExecReload = "${pkgs.coreutils}/bin/kill -s USR1 $MAINPID";
         Restart = "on-failure";
         CapabilityBoundingSet = [ "" ];
         DynamicUser = true;


### PR DESCRIPTION
Routinator reloads the configuration when sending SIGUSR1 to it.

This commit adds support for this by storing the configuration in /etc/routinator.conf instead while adding a systemd reload trigger for it.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
