### PR TITLE
cargo-features-manager: 0.11.0 -> 0.12.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29126,6 +29126,12 @@
     githubId = 858790;
     name = "Tobias Mayer";
   };
+  tobinio = {
+    email = "tobias.frischmann@proton.me";
+    github = "ToBinio";
+    githubId = 81473300;
+    name = "Tobias Frischmann";
+  };
   tobz619 = {
     email = "toloke@yahoo.co.uk";
     github = "tobz619";

--- a/pkgs/by-name/ca/cargo-features-manager/package.nix
+++ b/pkgs/by-name/ca/cargo-features-manager/package.nix
@@ -1,27 +1,26 @@
 {
   lib,
   rustPlatform,
-  fetchFromGitHub,
+  fetchFromTangled,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-features-manager";
-  version = "0.11.0";
+  version = "0.12.0";
 
-  src = fetchFromGitHub {
-    owner = "ToBinio";
-    repo = "cargo-features-manager";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-ay6nhRmGRBURisfr7qnnWCKn8JCnFh9x0TJ7vK2p4PU=";
+  src = fetchFromTangled {
+    did = "did:plc:ecwggpjedavt2waazmc4nuft";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-bfBSnC2qk19w6G81NdplPuiZvS1PRUNjCP8ozwuoTac=";
   };
 
-  cargoHash = "sha256-QB+0ezc7IQPzSym/Lfqjnh24tHKKwLqIpnGPNFQxI5M=";
+  cargoHash = "sha256-MwfeVPmS4KE1vJ9aEUXZpT+AbPaOP8Rs65vSFarKal0=";
 
   meta = {
     description = "TUI-like cli tool to manage the features of your rust-projects dependencies";
-    homepage = "https://github.com/ToBinio/cargo-features-manager";
-    changelog = "https://github.com/ToBinio/cargo-features-manager/blob/v${finalAttrs.version}/CHANGELOG.md";
+    homepage = "https://tangled.org/tobinio.dev/cargo-features-manager";
+    changelog = "https://tangled.org/tobinio.dev/cargo-features-manager/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ luftmensch-luftmensch ];
+    maintainers = with lib.maintainers; [ tobinio ];
     mainProgram = "cargo-features";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This updates the tool to the [latest version](https://tangled.org/tobinio.dev/cargo-features-manager/blob/v0.12.0/CHANGELOG.md) and changes the git remote from GitHub to Tangled since the project has [moved](https://github.com/ToBinio/cargo-features-manager#this-project-has-moved-to-tangled)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
