### PR TITLE
nixos/routinator: Use /var/cache instead of /var/lib by default

### DIFF
--- a/nixos/modules/services/networking/routinator.nix
+++ b/nixos/modules/services/networking/routinator.nix
@@ -15,6 +15,7 @@ let
     mkPackageOption
     mkOption
     types
+    versionAtLeast
     ;
   inherit (utils) escapeSystemdExecArgs;
   cfg = config.services.routinator;
@@ -53,7 +54,17 @@ in
             description = ''
               The path where the collected RPKI data is stored.
             '';
-            default = "/var/lib/routinator/rpki-cache";
+            default =
+              if versionAtLeast config.system.stateVersion "26.11" then
+                "/var/cache/routinator/rpki-cache"
+              else
+                "/var/lib/routinator/rpki-cache";
+            defaultText = ''
+              if versionAtLeast config.system.stateVersion "26.11" then
+                "/var/cache/routinator/rpki-cache"
+              else
+                "/var/lib/routinator/rpki-cache";
+            '';
           };
           log-level = mkOption {
             type = types.nullOr (
@@ -180,7 +191,8 @@ in
         ];
         RestrictNamespaces = true;
         RestrictRealtime = true;
-        StateDirectory = "routinator";
+        CacheDirectory = mkIf (versionAtLeast config.system.stateVersion "26.11") "routinator";
+        StateDirectory = mkIf (!(versionAtLeast config.system.stateVersion "26.11")) "routinator";
         SystemCallArchitectures = "native";
         SystemCallErrorNumber = "EPERM";
         SystemCallFilter = "@system-service";


### PR DESCRIPTION
This commit modifies the default of where to store the RPKI data from the state directory to the cache directory.

The change is opinionated, although discussed upstream with positive feedback so far, see: NLnetLabs/routinator#1107

I am happy to delay this PR until upstream was resolved, but I am also happy in merging it already, as /var/cache seems to be the better location for this data in my opinion, as it can always be recreated by fetching the respective data sources again.  Besides, many backup systems are designed to exclude /var/cache by default and these validation files are files one really does not want to backup due to their large quantity.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
