### PR TITLE
fcitx5-with-addons: avoid empty path segment in `LD_LIBRARY_PATH`

### DIFF
--- a/pkgs/tools/inputmethods/fcitx5/with-addons.nix
+++ b/pkgs/tools/inputmethods/fcitx5/with-addons.nix
@@ -12,6 +12,9 @@
   addons ? [ ],
 }:
 
+let
+  extraLdLibraries = lib.flatten (map (x: x.extraLdLibraries or [ ]) addons);
+in
 symlinkJoin {
   name = "fcitx5-with-addons-${fcitx5.version}";
 
@@ -37,10 +40,11 @@ symlinkJoin {
       --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
       --prefix FCITX_ADDON_DIRS : "$out/lib/fcitx5" \
       --suffix XDG_DATA_DIRS : "$out/share" \
-      --suffix PATH : "$out/bin" \
-      --suffix LD_LIBRARY_PATH : "${
-        lib.makeLibraryPath (lib.flatten (map (x: x.extraLdLibraries or [ ]) addons))
-      }"
+      --suffix PATH : "$out/bin" ${
+        lib.optionalString (
+          extraLdLibraries != [ ]
+        ) ''--suffix LD_LIBRARY_PATH : "${lib.makeLibraryPath extraLdLibraries}"''
+      }
 
     ${lib.optionalString withConfigtool ''
       # Configtool call libexec/fcitx5-qt5-gui-wrapper for gui addons in FCITX_ADDON_DIRS


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 545592`
Commit: `7209317e65804590c7878850281ba06db59a2b94`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>kdePackages.fcitx5-with-addons (qt6Packages.fcitx5-with-addons)</li>
  </ul>
</details>