### PR TITLE
vermouth: init at 1.9.7

### DIFF
--- a/pkgs/by-name/ve/vermouth/package.nix
+++ b/pkgs/by-name/ve/vermouth/package.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  cmake,
+  nix-update-script,
+  kdePackages,
+  qt6,
+  SDL2,
+  versionCheckHook,
+  umu-launcher,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vermouth";
+  version = "1.9.7";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "dekomote";
+    repo = "vermouth";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hcsvTvvuzuqTGgOdWt3sxyoJqjZjlUPlnlYJUgNpV4g=";
+  };
+
+  patches = [
+    # backport fix for desktop file generation
+    # FIXME: remove in next update
+    (fetchpatch {
+      url = "https://github.com/dekomote/vermouth/commit/436a201091505c142a88848135fe04e1ec996a1a.diff";
+      hash = "sha256-fIgcewbJOpi+qHPgOJRCr+67RbziPPGP4sC1dclydgQ=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    qt6.qtbase
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtdeclarative
+
+    kdePackages.extra-cmake-modules
+    kdePackages.kcoreaddons
+    kdePackages.ki18n
+    kdePackages.kirigami
+    kdePackages.qqc2-desktop-style
+
+    SDL2
+  ];
+
+  preFixup = ''
+    patchelf --add-needed ${SDL2}/lib/libSDL2-2.0.so.0 $out/bin/vermouth
+  '';
+
+  qtWrapperArgs = [
+    "--prefix"
+    "PATH"
+    ":"
+    "${umu-launcher}/bin"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  env.QT_QPA_PLATFORM = "offscreen";
+  versionCheckKeepEnvironment = [ "QT_QPA_PLATFORM" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Game and app launcher for Linux - native, Windows, and retro. KDE-first, lightweight, no frills";
+    homepage = "https://github.com/dekomote/vermouth";
+    changelog = "https://github.com/dekomote/vermouth/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ k900 ];
+    mainProgram = "vermouth";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
It's kinda like Faugus, but Kirigami. https://github.com/dekomote/vermouth

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
