### PR TITLE
ocelot-desktop: avoid putting empty segments in PATH and LD_LIBRARY_PATH

### DIFF
--- a/pkgs/by-name/oc/ocelot-desktop/package.nix
+++ b/pkgs/by-name/oc/ocelot-desktop/package.nix
@@ -81,9 +81,13 @@ stdenv.mkDerivation (finalAttrs: {
       install -Dm644 ${finalAttrs.src} $out/share/ocelot-desktop/ocelot-desktop.jar
 
       makeBinaryWrapper ${jre}/bin/java $out/bin/ocelot-desktop \
-        --set JAVA_HOME ${jre.home} \
-        --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath runtimeLibs}" \
-        --prefix PATH : "${lib.makeBinPath runtimePrograms}" \
+        --set JAVA_HOME ${jre.home} ${
+          lib.optionalString (
+            runtimeLibs != [ ]
+          ) "--prefix LD_LIBRARY_PATH : \"${lib.makeLibraryPath runtimeLibs}\""
+        } ${
+          lib.optionalString (runtimePrograms != [ ]) "--prefix PATH : \"${lib.makeBinPath runtimePrograms}\""
+        } \
         --add-flags "-jar $out/share/ocelot-desktop/ocelot-desktop.jar"
 
       # copy icons from zip file


### PR DESCRIPTION
Only Darwin can be impacted and aarch64 is marked as badPlatorms, mainly doing the change for 26.05.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
