### PR TITLE
python3Packages.pulumi-python: Mark tests to be re-enabled with v3.255.0

### DIFF
--- a/pkgs/development/python-modules/pulumi/default.nix
+++ b/pkgs/development/python-modules/pulumi/default.nix
@@ -77,7 +77,7 @@ buildPythonPackage {
   ];
 
   disabledTestPaths = [
-    # Fail due to missing `pytest.mark.asyncio`, as of v3.253.0
+    # To be removed in v3.255.0; see https://github.com/pulumi/pulumi/issues/24048#issuecomment-5077378071
     "lib/test/test_deprecated.py::DeprecatedTests::test_non_deprecated_can_be_called"
     "lib/test/test_deprecated.py::DeprecatedTests::test_deprecated_can_be_called"
     "lib/test/test_deprecated.py::DeprecatedTests::test_deprecated_can_passthrough"


### PR DESCRIPTION
In `python3Packages.pulumi-python`, update an (incorrect!) comment to note that tests should be re-enabled with the next upstream release.

## Things done

- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  No drv changed, nothing requires further testing.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
