### PR TITLE
onscripter: replace smpeg with smpeg2

### DIFF
--- a/pkgs/by-name/on/onscripter/package.nix
+++ b/pkgs/by-name/on/onscripter/package.nix
@@ -14,7 +14,7 @@
   libvorbis,
   lua5_1,
   runCommand,
-  smpeg,
+  smpeg2,
   stdenv,
 }:
 
@@ -53,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
       let
         commands = [
           "${lib.getDev SDL}/bin/sdl-config"
-          "${lib.getDev smpeg}/bin/smpeg-config"
+          "${lib.getDev smpeg2}/bin/smpeg2-config"
         ]
         ++ lib.optionals isDarwin [
           "${lib.getDev freetype}/bin/freetype-config"
@@ -62,6 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
       runCommand "onscripter-host-deps" { } ''
         mkdir -p $out/bin
         ln -s ${lib.escapeShellArgs commands} $out/bin
+        ln -s $out/bin/smpeg{2,}-config
       ''
     )
   ];
@@ -77,7 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
     libpng
     libvorbis
     lua5_1
-    smpeg
+    smpeg2
   ]
   ++ (if isDarwin then [ freetype ] else [ fontconfig ]);
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
