### PR TITLE
nixos/bird: Add birdc run0(8) wrapper

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -136,6 +136,8 @@
 
 - `security.run0.enableSudoAlias` now uses the `run0-sudo-shim` instead of a shell-script to improve compatibility.
 
+- Added `services.bird.installWrapper` which puts `birdc` behind a `sudo(8)` wrapper.
+
 - With `system.etc.overlay.mutable = false`, NixOS now ships an empty `/etc/machine-id` in the image. Previously the file was absent and systemd logged `System cannot boot: Missing /etc/machine-id and /etc/ is read-only` while `ConditionFirstBoot` fired on every boot. With this change, systemd now overlays a transient ID from `/run/machine-id` for the session, and `systemd-machine-id-commit.service` has `ConditionFirstBoot` so it writes the machine-id through to a persistent backing file when one is bind-mounted over `/etc/machine-id`. To persist the machine-id across reboots, bind-mount a writable file containing `uninitialized` over `/etc/machine-id` from the initrd, or set `systemd.machine_id=` on the kernel command line (use `systemd.machine_id=firmware` to derive a stable ID on hardware that supports it).
 
 - `security.run0.persistentAuth` options have been added to support persistent Authentication of session. Timeout configurable via `security.polkit.settings.Polkitd.ExpirationSeconds`.

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -136,7 +136,7 @@
 
 - `security.run0.enableSudoAlias` now uses the `run0-sudo-shim` instead of a shell-script to improve compatibility.
 
-- Added `services.bird.installWrapper` which puts `birdc` behind a `sudo(8)` wrapper.
+- Added `services.bird.installWrapper` which puts `birdc` behind a `run0(8)` wrapper.
 
 - With `system.etc.overlay.mutable = false`, NixOS now ships an empty `/etc/machine-id` in the image. Previously the file was absent and systemd logged `System cannot boot: Missing /etc/machine-id and /etc/ is read-only` while `ConditionFirstBoot` fired on every boot. With this change, systemd now overlays a transient ID from `/run/machine-id` for the session, and `systemd-machine-id-commit.service` has `ConditionFirstBoot` so it writes the machine-id through to a persistent backing file when one is bind-mounted over `/etc/machine-id`. To persist the machine-id across reboots, bind-mount a writable file containing `uninitialized` over `/etc/machine-id` from the initrd, or set `systemd.machine_id=` on the kernel command line (use `systemd.machine_id=firmware` to derive a stable ID on hardware that supports it).
 

--- a/nixos/modules/services/networking/bird.nix
+++ b/nixos/modules/services/networking/bird.nix
@@ -20,6 +20,14 @@ let
     "CAP_NET_BIND_SERVICE"
     "CAP_NET_RAW"
   ];
+  userWrapper = pkgs.writeShellApplication {
+    name = "birdc";
+    text = ''
+      exec sudo -u bird \
+        "${lib.getExe' cfg.package "birdc"}" \
+        "$@"
+    '';
+  };
 in
 {
   ###### interface
@@ -65,6 +73,19 @@ in
           build time checking.
         '';
       };
+      installWrapper = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to install a sudo(8) wrapper around `birdc`, ensuring that the
+          command is executed as the `bird` user and not (accidentially) as
+          root.
+
+          An alternative would be to add the respective users to the bird group
+          manually instead of using sudo(8), which may or may not be preferred
+          depending on the use case.
+        '';
+      };
     };
   };
 
@@ -77,7 +98,7 @@ in
 
   ###### implementation
   config = mkIf cfg.enable {
-    environment.systemPackages = [ cfg.package ];
+    environment.systemPackages = (lib.optional cfg.installWrapper userWrapper) ++ [ cfg.package ];
 
     environment.etc."bird/bird.conf".source = pkgs.writeTextFile {
       name = "bird";

--- a/nixos/modules/services/networking/bird.nix
+++ b/nixos/modules/services/networking/bird.nix
@@ -7,12 +7,15 @@
 
 let
   inherit (lib)
+    mkBefore
     mkEnableOption
     mkIf
     mkMerge
     mkOption
+    optional
     optionalString
     types
+    warnIfNot
     ;
 
   cfg = config.services.bird;
@@ -100,7 +103,7 @@ in
   ###### implementation
   config = mkIf cfg.enable (mkMerge [
     {
-      environment.systemPackages = (lib.optional cfg.installWrapper userWrapper) ++ [ cfg.package ];
+      environment.systemPackages = [ cfg.package ];
 
       environment.etc."bird/bird.conf".source = pkgs.writeTextFile {
         name = "bird";
@@ -148,6 +151,15 @@ in
         groups.bird = { };
       };
     }
+
+    (mkIf cfg.installWrapper {
+      environment.systemPackages = mkBefore [ userWrapper ];
+
+      # Do not enable run0 without explicit consent, but warn instead.
+      warnings = optional (
+        !config.security.run0.enable
+      ) "security.run0.enable must be set to true for services.bird.installWrapper to take effect!";
+    })
   ]);
 
   meta = {

--- a/nixos/modules/services/networking/bird.nix
+++ b/nixos/modules/services/networking/bird.nix
@@ -9,6 +9,7 @@ let
   inherit (lib)
     mkEnableOption
     mkIf
+    mkMerge
     mkOption
     optionalString
     types
@@ -97,55 +98,57 @@ in
   ];
 
   ###### implementation
-  config = mkIf cfg.enable {
-    environment.systemPackages = (lib.optional cfg.installWrapper userWrapper) ++ [ cfg.package ];
+  config = mkIf cfg.enable (mkMerge [
+    {
+      environment.systemPackages = (lib.optional cfg.installWrapper userWrapper) ++ [ cfg.package ];
 
-    environment.etc."bird/bird.conf".source = pkgs.writeTextFile {
-      name = "bird";
-      text = cfg.config;
-      derivationArgs.nativeBuildInputs = lib.optional cfg.checkConfig cfg.package;
-      checkPhase = optionalString cfg.checkConfig ''
-        ln -s $out bird.conf
-        ${cfg.preCheckConfig}
-        bird -d -p -c bird.conf || { exit=$?; cat -n bird.conf; exit $exit; }
-      '';
-    };
+      environment.etc."bird/bird.conf".source = pkgs.writeTextFile {
+        name = "bird";
+        text = cfg.config;
+        derivationArgs.nativeBuildInputs = lib.optional cfg.checkConfig cfg.package;
+        checkPhase = optionalString cfg.checkConfig ''
+          ln -s $out bird.conf
+          ${cfg.preCheckConfig}
+          bird -d -p -c bird.conf || { exit=$?; cat -n bird.conf; exit $exit; }
+        '';
+      };
 
-    systemd.services.bird = {
-      description = "BIRD Internet Routing Daemon";
-      wantedBy = [ "multi-user.target" ];
-      after = [ "network.target" ];
-      reloadTriggers = lib.optional cfg.autoReload config.environment.etc."bird/bird.conf".source;
-      serviceConfig = {
-        Type = "forking";
-        Restart = "on-failure";
-        User = "bird";
-        Group = "bird";
-        ExecStart = "${lib.getExe' cfg.package "bird"} -c /etc/bird/bird.conf";
-        ExecReload = "${lib.getExe' cfg.package "birdc"} configure";
-        ExecStop = "${lib.getExe' cfg.package "birdc"} down";
-        RuntimeDirectory = "bird";
-        CapabilityBoundingSet = caps;
-        AmbientCapabilities = caps;
-        ProtectSystem = "full";
-        ProtectHome = "yes";
-        ProtectKernelTunables = true;
-        ProtectControlGroups = true;
-        PrivateTmp = true;
-        PrivateDevices = true;
-        SystemCallFilter = "~@cpu-emulation @debug @keyring @module @mount @obsolete @raw-io";
-        MemoryDenyWriteExecute = "yes";
+      systemd.services.bird = {
+        description = "BIRD Internet Routing Daemon";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" ];
+        reloadTriggers = lib.optional cfg.autoReload config.environment.etc."bird/bird.conf".source;
+        serviceConfig = {
+          Type = "forking";
+          Restart = "on-failure";
+          User = "bird";
+          Group = "bird";
+          ExecStart = "${lib.getExe' cfg.package "bird"} -c /etc/bird/bird.conf";
+          ExecReload = "${lib.getExe' cfg.package "birdc"} configure";
+          ExecStop = "${lib.getExe' cfg.package "birdc"} down";
+          RuntimeDirectory = "bird";
+          CapabilityBoundingSet = caps;
+          AmbientCapabilities = caps;
+          ProtectSystem = "full";
+          ProtectHome = "yes";
+          ProtectKernelTunables = true;
+          ProtectControlGroups = true;
+          PrivateTmp = true;
+          PrivateDevices = true;
+          SystemCallFilter = "~@cpu-emulation @debug @keyring @module @mount @obsolete @raw-io";
+          MemoryDenyWriteExecute = "yes";
+        };
       };
-    };
-    users = {
-      users.bird = {
-        description = "BIRD Internet Routing Daemon user";
-        group = "bird";
-        isSystemUser = true;
+      users = {
+        users.bird = {
+          description = "BIRD Internet Routing Daemon user";
+          group = "bird";
+          isSystemUser = true;
+        };
+        groups.bird = { };
       };
-      groups.bird = { };
-    };
-  };
+    }
+  ]);
 
   meta = {
     maintainers = with lib.maintainers; [ herbetom ];

--- a/nixos/modules/services/networking/bird.nix
+++ b/nixos/modules/services/networking/bird.nix
@@ -24,7 +24,7 @@ let
   userWrapper = pkgs.writeShellApplication {
     name = "birdc";
     text = ''
-      exec sudo -u bird \
+      exec ${pkgs.systemd}/bin/run0 -u bird \
         "${lib.getExe' cfg.package "birdc"}" \
         "$@"
     '';
@@ -78,12 +78,12 @@ in
         type = types.bool;
         default = false;
         description = ''
-          Whether to install a sudo(8) wrapper around `birdc`, ensuring that the
+          Whether to install a run0(8) wrapper around `birdc`, ensuring that the
           command is executed as the `bird` user and not (accidentially) as
           root.
 
           An alternative would be to add the respective users to the bird group
-          manually instead of using sudo(8), which may or may not be preferred
+          manually instead of using run0(8), which may or may not be preferred
           depending on the use case.
         '';
       };


### PR DESCRIPTION
This commit adds a sudo(8) wrapper similar to services.akkoma.installWrapper, which wraps the stock birdc program in a wrapper so that it gets executed with "sudo -u bird".

With this, it prevents accidential runs of this as the super user, as access to the BIRD control socket either requires being the bird user, in the bird group, or the super user.

An alternative includes simply adding the respective users to the bird group manually, although I personally dislike the idea, as it does not provide password prompts and such when touching something as critical as the BGP daemon.

For backwards compatibility, the wrapper is disabled by default right now.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
