### PR TITLE
aseprite: 1.3.17.2 -> 1.3.18.1

### DIFF
--- a/pkgs/by-name/as/aseprite/package.nix
+++ b/pkgs/by-name/as/aseprite/package.nix
@@ -32,29 +32,29 @@
   zlib,
 }:
 
-let
-  asepriteStrings = fetchFromGitHub {
-    owner = "aseprite";
-    repo = "strings";
-    rev = "0f49265d7e7aea4b862b7d1e670ed969e8a469b8";
-    hash = "sha256-S3YkWA5ECvyyqGvojDhIZci04CTjbJzTQiJ5FZsB4lU=";
-  };
-in
 clangStdenv.mkDerivation (finalAttrs: {
   pname = "aseprite";
-  version = "1.3.17.2";
+  version = "1.3.18.1";
 
   src = fetchFromGitHub {
     owner = "aseprite";
     repo = "aseprite";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-+rLrk/c3WLqNhXQ7J0eeqZ3h4PsbZad61Cxw0RubWgk=";
+    hash = "sha256-uItjmYg21Ph2QIYFKm0N6kVwJtedH0aVKm8hSbQcJIM=";
   };
 
-  # Translation files are copied without overwriting existing ones to preserve the potentially more up-to-date English file from the main source.
+  asepriteStrings = fetchFromGitHub {
+    owner = "aseprite";
+    repo = "strings";
+    rev = "417074f649f359f98511fc87a707c276d87f5739";
+    hash = "sha256-5bB7yK4eJHhkUwGYtIFYdFXpRrBt69VBbTh7EmPFI08=";
+  };
+
+  # Translation files are copied without overwriting existing ones to preserve
+  # the potentially more up-to-date English file from the main source.
   postUnpack = ''
-    cp --no-clobber ${asepriteStrings}/* "$sourceRoot/data/strings"
+    cp --no-clobber ${finalAttrs.asepriteStrings}/* "$sourceRoot/data/strings"
   '';
 
   nativeBuildInputs = [
@@ -174,6 +174,8 @@ clangStdenv.mkDerivation (finalAttrs: {
     # Keep $out/bin clean on Darwin; the bundle lives under $out/Applications.
     rmdir "$out/bin" 2>/dev/null || true
   '';
+
+  passthru.updateScript = ./update.sh;
 
   meta = {
     homepage = "https://www.aseprite.org/";

--- a/pkgs/by-name/as/aseprite/update.sh
+++ b/pkgs/by-name/as/aseprite/update.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p common-updater-scripts curl jq nix nix-update
+
+set -euo pipefail
+
+curl_github() {
+  curl -fsSL -H 'Accept: application/vnd.github+json' ${GITHUB_TOKEN:+--user ":$GITHUB_TOKEN"} "$@"
+}
+
+nix-update aseprite
+
+version=$(nix eval --raw --file . aseprite.version)
+release_date=$(
+  curl_github "https://api.github.com/repos/aseprite/aseprite/releases/tags/v$version" \
+  | jq --exit-status --raw-output '.published_at'
+)
+
+strings_rev=$(
+  curl_github "https://api.github.com/repos/aseprite/strings/commits?until=$release_date&per_page=1" \
+  | jq --exit-status --raw-output '.[0].sha'
+)
+
+current_strings_rev=$(nix eval --raw --file . aseprite.asepriteStrings.rev)
+if [[ $strings_rev != "$current_strings_rev" ]]; then
+  update-source-version aseprite \
+    --source-key=asepriteStrings \
+    --rev="$strings_rev" \
+    --ignore-same-version
+fi


### PR DESCRIPTION
Changelog
https://github.com/aseprite/aseprite/releases/tag/v1.3.18
https://github.com/aseprite/aseprite/releases/tag/v1.3.18.1
https://github.com/aseprite/aseprite/compare/v1.3.17.2...v1.3.18.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
