### PR TITLE
deno: de-vendor lcms2, zstd, sqlite, libz

### DIFF
--- a/pkgs/by-name/de/deno/package.nix
+++ b/pkgs/by-name/de/deno/package.nix
@@ -101,6 +101,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # To avoid this we pre-download the file and export it via RUSTY_V8_ARCHIVE
   env.RUSTY_V8_ARCHIVE = librusty_v8;
 
+  # de-vendor SQLite
+  env.LIBSQLITE3_SYS_USE_PKG_CONFIG = true;
+
   # Don't run checks on hydra as they've been observed to be flakey for us and
   # other distros CI: https://gitlab.alpinelinux.org/alpine/aports/-/blob/bec8b026686323b496365b825ad14fdf4473adf2/community/deno/APKBUILD#L79
   # We haven't reproduced it on local machines, could be related to doing other

--- a/pkgs/by-name/de/deno/package.nix
+++ b/pkgs/by-name/de/deno/package.nix
@@ -15,6 +15,7 @@
   sqlite,
   pkg-config,
   zstd,
+  lcms2,
   lld,
   writableTmpDirAsHomeHook,
 
@@ -110,6 +111,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   env.LIBSQLITE3_SYS_USE_PKG_CONFIG = true;
   # de-vendor zstd
   env.ZSTD_SYS_USE_PKG_CONFIG = true;
+  # de-vendor lcms2
+  env.LCMS2_LIB_DIR = lib.makeLibraryPath [ lcms2 ];
 
   # Don't run checks on hydra as they've been observed to be flakey for us and
   # other distros CI: https://gitlab.alpinelinux.org/alpine/aports/-/blob/bec8b026686323b496365b825ad14fdf4473adf2/community/deno/APKBUILD#L79

--- a/pkgs/by-name/de/deno/package.nix
+++ b/pkgs/by-name/de/deno/package.nix
@@ -13,6 +13,8 @@
   librusty_v8 ? callPackage ./rusty-v8 { },
   libffi,
   sqlite,
+  pkg-config,
+  zstd,
   lld,
   writableTmpDirAsHomeHook,
 
@@ -65,6 +67,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   buildInputs = [
     libffi
     sqlite
+    zstd
   ];
 
   # uses zlib-ng but can't dynamically link yet
@@ -75,6 +78,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     yq
     # required by libz-ng-sys crate
     cmake
+    # required to de-vendor zstd
+    pkg-config
     # required by deno_kv crate
     protobuf
     installShellFiles
@@ -103,6 +108,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   # de-vendor SQLite
   env.LIBSQLITE3_SYS_USE_PKG_CONFIG = true;
+  # de-vendor zstd
+  env.ZSTD_SYS_USE_PKG_CONFIG = true;
 
   # Don't run checks on hydra as they've been observed to be flakey for us and
   # other distros CI: https://gitlab.alpinelinux.org/alpine/aports/-/blob/bec8b026686323b496365b825ad14fdf4473adf2/community/deno/APKBUILD#L79

--- a/pkgs/by-name/de/deno/package.nix
+++ b/pkgs/by-name/de/deno/package.nix
@@ -71,8 +71,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     zstd
   ];
 
-  # uses zlib-ng but can't dynamically link yet
-  # https://github.com/rust-lang/libz-sys/issues/158
   nativeBuildInputs = [
     rustPlatform.bindgenHook
     # for tomlq to adjust Cargo.toml
@@ -97,9 +95,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   # Disable the default feature `upgrade` (which controls the self-update subcommand and update checks)
   buildNoDefaultFeatures = true;
-  buildFeatures = [
-    "__vendored_zlib_ng"
-  ];
 
   # work around "error: unknown warning group '-Wunused-but-set-parameter'"
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-unknown-warning-option";


### PR DESCRIPTION
These are the libraries we can de-vendor from deno (not rusty-v8). With this, we match Arch Linux in the de-vendoring effort and also de-vendor libz.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
