### PR TITLE
snowemu: 1.3.0 -> 1.5.0

### DIFF
--- a/pkgs/by-name/sn/snowemu/package.nix
+++ b/pkgs/by-name/sn/snowemu/package.nix
@@ -3,8 +3,9 @@
   rustPlatform,
   fetchFromGitHub,
   makeWrapper,
+  copyDesktopItems,
   makeDesktopItem,
-  SDL2,
+  alsa-lib,
   pkg-config,
   libxrandr,
   libxi,
@@ -13,42 +14,49 @@
   wayland,
   libxkbcommon,
   libGL,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "snowemu";
-  version = "1.3.0";
+  version = "1.5.0";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "twvd";
     repo = "snow";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/arxD1bShXqsC2If2v7ARBsjdlnhlg0wK6MLX0q4xiI=";
+    hash = "sha256-BA4uCuluSfIGXwBxE2X6Gke0ITsYEPzKoFDwx6jRYsk=";
     fetchSubmodules = true;
   };
-  cargoHash = "sha256-7cyhpiT6RL+5x+xslQzhA5W71rcZ9TJPmfUHKl7TC/M=";
+  cargoHash = "sha256-C7rCx0g77R+1f0la+j3pVW0bShGPdJD3btAIYg3yzMw=";
 
   nativeBuildInputs = [
     pkg-config
     makeWrapper
+    copyDesktopItems
   ];
 
-  buildInputs = [
-    SDL2.dev
-    libx11
-    libxcursor
-    libxrandr
-    libxi
-  ];
+  buildInputs = [ alsa-lib ];
 
   postInstall = ''
-    mv $out/bin/snow_frontend_egui $out/bin/snowemu
-
     install -Dm644 assets/snow_icon.png $out/share/icons/snowemu.png
+
+    substituteInPlace assets/dev.thomasw.snow.metainfo.xml \
+      --replace-fail "snow.desktop" "snowemu.desktop" \
+      --replace-fail "/usr/share/icons/hicolor/1024x1024/apps/snow_icon.png" \
+        "$out/share/icons/snowemu.png"
+    install -Dm644 assets/dev.thomasw.snow.metainfo.xml \
+      $out/share/metainfo/dev.thomasw.snow.metainfo.xml
 
     wrapProgram $out/bin/snowemu \
       --prefix LD_LIBRARY_PATH : ${
         lib.makeLibraryPath [
+          libx11
+          libxcursor
+          libxrandr
+          libxi
           wayland
           libxkbcommon
           libGL
@@ -56,18 +64,28 @@ rustPlatform.buildRustPackage (finalAttrs: {
       }
   '';
 
-  desktopItems = makeDesktopItem {
-    name = "snowemu";
-    exec = "snowemu";
-    icon = "snowemu";
-    desktopName = "Snow Emulator";
-    comment = finalAttrs.meta.description;
-    genericName = "Vintage Macintosh emulator";
-    categories = [
-      "Game"
-      "Emulator"
-    ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "snowemu";
+      exec = "snowemu";
+      icon = "snowemu";
+      desktopName = "Snow Emulator";
+      comment = finalAttrs.meta.description;
+      genericName = "Vintage Macintosh emulator";
+      categories = [
+        "Game"
+        "Emulator"
+      ];
+      keywords = [
+        "macintosh"
+        "emulator"
+        "vintage"
+        "68k"
+      ];
+    })
+  ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Early Macintosh emulator";


### PR DESCRIPTION
Upstream renamed the binary to snowemu and switched the default audio backend from SDL2 to cpal.

Add updater script as well as sync up metadata.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
