### PR TITLE
sage: rename python package from sagelib to sagemath

### DIFF
--- a/pkgs/by-name/sa/sage/sagelib.nix
+++ b/pkgs/by-name/sa/sage/sagelib.nix
@@ -92,7 +92,9 @@ assert (!blas.isILP64) && (!lapack.isILP64);
 
 buildPythonPackage rec {
   version = src.version;
-  pname = "sagelib";
+  # Sage publishes Python metadata as "sagemath" even though this nixpkgs
+  # attribute is exposed as `sagelib`.
+  pname = "sagemath";
   src = sage-src;
   pyproject = true;
 


### PR DESCRIPTION
This change fixes `nix build .#sage`. The regression is due to a new check, pythonMetadataCheckHook, introduced in #532778; the check enforces that pname matches the metadata name of the underlying Python project being built, typically in pyproject.toml; in this case the underlying name is "sagemath".

Testing: I have tested that `sage` works on aarch64-darwin; but unfortunately I was not able to complete the sage-tests run in 24hrs on my laptop CPU. I think it was making progress but very slowly. Profiling showed that it was spending time in an elliptic-curve `mwrank/eclib` computation, but I was not able to isolate the exact test. It appears hydra builds have also been failing for a while.

Fixes https://github.com/NixOS/nixpkgs/issues/545171

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
