### PR TITLE
python3Packages.udatetime: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/udatetime/default.nix
+++ b/pkgs/development/python-modules/udatetime/default.nix
@@ -5,13 +5,16 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "udatetime";
   version = "0.0.17";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
-    inherit pname version;
+    pname = "udatetime";
+    inherit (finalAttrs) version;
     hash = "sha256-sQvFVwaZpDinLitaZOdr2MKO4779FvIJOHpVB/oLgwE=";
   };
 
@@ -29,4 +32,4 @@ buildPythonPackage rec {
     license = lib.licenses.asl20;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/udatetime/default.nix
+++ b/pkgs/development/python-modules/udatetime/default.nix
@@ -1,8 +1,9 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   setuptools,
+  pytestCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -12,16 +13,21 @@ buildPythonPackage (finalAttrs: {
 
   __structuredAttrs = true;
 
-  src = fetchPypi {
-    pname = "udatetime";
-    inherit (finalAttrs) version;
-    hash = "sha256-sQvFVwaZpDinLitaZOdr2MKO4779FvIJOHpVB/oLgwE=";
+  src = fetchFromGitHub {
+    owner = "freach";
+    repo = "udatetime";
+    tag = finalAttrs.version;
+    hash = "sha256-1TGLdw8yq+FmdfKin2e9SKJTA1TDNmLXmKRWcq0qTnw=";
   };
 
   build-system = [ setuptools ];
 
-  # tests not included on pypi
-  doCheck = false;
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  # shadows the installed package holding the compiled extension
+  preCheck = ''
+    rm -r udatetime
+  '';
 
   pythonImportsCheck = [ "udatetime" ];
 

--- a/pkgs/development/python-modules/udatetime/default.nix
+++ b/pkgs/development/python-modules/udatetime/default.nix
@@ -2,17 +2,20 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "udatetime";
   version = "0.0.17";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-sQvFVwaZpDinLitaZOdr2MKO4779FvIJOHpVB/oLgwE=";
   };
+
+  build-system = [ setuptools ];
 
   # tests not included on pypi
   doCheck = false;


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
