### PR TITLE
edopro: Fix passthru.updateScript

### DIFF
--- a/pkgs/by-name/ed/edopro/update.py
+++ b/pkgs/by-name/ed/edopro/update.py
@@ -1,20 +1,37 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -i python -p nix-prefetch-github python3Packages.githubkit
+#! nix-shell -i python -p nix-prefetch-github python3Packages.githubkit python3Packages.packaging
 import json
 import subprocess
 import sys
 
 from githubkit import GitHub, UnauthAuthStrategy
-from githubkit.versions.latest.models import (
-    Commit,
-    ContentSubmodule,
-    Tag,
-)
+from githubkit.versions.latest.models import Commit, ContentSubmodule, Tag
+from packaging.version import InvalidVersion, Version
 
 DEPS_PATH: str = "./pkgs/by-name/ed/edopro/deps.nix"
 
+
+def parse_tag(parsed_tag_data) -> Version | None:
+    # The GitHub REST API does not guarantee that tags are returned newest-first,
+    # and it also returns non-version tags such as "old-core" from 2015. Parse each
+    # tag as a version so we can drop the ones that aren't versions and sort the rest.
+    try:
+        return Version(parsed_tag_data.name)
+    except InvalidVersion:
+        return None
+
+
 with GitHub(UnauthAuthStrategy()) as github:
-    edopro: Tag = github.rest.repos.list_tags("edo9300", "edopro").parsed_data[0]
+    edopro_tags: list[Tag] = github.rest.repos.list_tags(
+        "edo9300", "edopro"
+    ).parsed_data
+    versioned_tags: list[Tag] = [
+        tag for tag in edopro_tags if parse_tag(tag) is not None
+    ]
+    if not versioned_tags:
+        print("Error: No valid version tags found.", file=sys.stderr)
+        exit(3)
+    edopro: Tag = max(versioned_tags, key=lambda tag: Version(tag.name))
 
     # This dep is not versioned in any way and is why we check below to see if this is a new version.
     irrlicht: Commit = github.rest.repos.list_commits(


### PR DESCRIPTION
GitHub REST API currently returns a tag called "old-core" from 2015 as the first result. Filter that out.

I'm not a Python person, so if you have suggestions for how to do this better, please LMK…

Tested by running:

```
env NIX_PATH=nixpkgs=$PWD nix-shell maintainers/scripts/update.nix --argstr package edopro
```

...which resulted in no change, since there's no new edopro version yet (good). Then tested further by changing the values in `pkgs/by-name/ed/edopro/deps.nix` to nonsense and running the above command again, which gave the same `assets-hash` and `edopro-*` details as we currently have.
(`irrlicht-*` will be different since upstream does no pinning there, so any updates to that are fine)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
