### PR TITLE
pokeclicker-desktop: init at 1.2.0-unstable-2022-12-31

### DIFF
--- a/pkgs/by-name/po/pokeclicker-desktop/package.nix
+++ b/pkgs/by-name/po/pokeclicker-desktop/package.nix
@@ -1,0 +1,103 @@
+{
+  lib,
+  buildNpmPackage,
+  dpkg,
+  electron,
+  fetchFromGitHub,
+  fpm,
+  makeWrapper,
+  nix-update-script,
+}:
+
+buildNpmPackage (_finalAttrs: {
+  pname = "pokeclicker-desktop";
+  version = "1.2.0-unstable-2022-12-31";
+
+  src = fetchFromGitHub {
+    owner = "RedSparr0w";
+    repo = "Pokeclicker-desktop";
+    # The release artifacts include two follow-up icon commits made after the
+    # tag. Switch to using `tag` instead of `rev` after 1.2.1+.
+    rev = "0d35925a70241bb4b507ea2f606b37eb87d06220";
+    hash = "sha256-sGIH8E8yZNy9kcQSjWygF3PYykIPUrlfHQxdSTTP8SE=";
+  };
+
+  npmDepsHash = "sha256-FA5S4u6XV8B5474fwcORwlZq+eo5FsdMGDQuM+fesaQ=";
+
+  __structuredAttrs = true;
+
+  # Required solely for discord-rpc's optional register-scheme Git dependency,
+  # which has an install script but no lock file.
+  forceGitDeps = true;
+
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+    USE_SYSTEM_FPM = "true";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    fpm
+    makeWrapper
+  ];
+
+  postPatch = ''
+    # The application itself is updated through Nix. The separately downloaded
+    # game data continues to use the upstream runtime updater.
+    substituteInPlace src/main.js \
+      --replace-fail 'autoUpdater.checkForUpdatesAndNotify()' '// Desktop updates are managed by Nix.'
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    # Build upstream's deb target so Electron Builder remains the source of
+    # truth for the desktop entry and complete icon layout extracted below.
+    npm exec electron-builder -- \
+      --linux \
+      --config.electronDist=${electron.dist} \
+      --config.electronVersion=${electron.version}
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/pokeclicker-desktop $out/bin
+    cp -r dist/*-unpacked/resources/app.asar* $out/share/pokeclicker-desktop
+
+    deb_root=$(mktemp -d)
+    dpkg-deb --extract dist/*.deb "$deb_root"
+    cp -r "$deb_root/usr/share/applications" "$out/share"
+    cp -r "$deb_root/usr/share/icons" "$out/share"
+
+    substituteInPlace "$out/share/applications/pokeclicker-desktop.desktop" \
+      --replace-fail '/opt/PokéClicker/pokeclicker-desktop' "$out/bin/pokeclicker-desktop"
+
+    makeWrapper ${lib.getExe electron} $out/bin/pokeclicker-desktop \
+      --add-flags $out/share/pokeclicker-desktop/app.asar \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+      --inherit-argv0
+
+    runHook postInstall
+  '';
+
+  # TODO remove `extraArgs` after 1.2.1+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version"
+      "branch"
+    ];
+  };
+
+  meta = {
+    description = "Desktop client for PokeClicker";
+    homepage = "https://github.com/RedSparr0w/Pokeclicker-desktop";
+    changelog = "https://github.com/RedSparr0w/Pokeclicker-desktop/releases/tag/v1.2.0"; # TODO use `finalAttrs.src.tag` after 1.2.1+
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ ilkecan ];
+    platforms = lib.platforms.linux;
+    mainProgram = "pokeclicker-desktop";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Packages https://github.com/RedSparr0w/Pokeclicker-desktop, which is a custom Electron based shell around the game, https://github.com/pokeclicker/pokeclicker, by the main developer.

As explained, the latest revision had to be used, because it contains asset files not included in the latest tag. These icon files were included in the ".deb" asset of the [said release](https://github.com/RedSparr0w/Pokeclicker-desktop/releases/tag/v1.2.0); which is why I decided to also include them by targeting the correct revision, hence the "-unstable-*` versioning.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
