### PR TITLE
caffeine: sign app bundle with stable identifier for TCC persistence

### DIFF
--- a/pkgs/by-name/ca/caffeine/package.nix
+++ b/pkgs/by-name/ca/caffeine/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   apple-sdk,
-  darwin,
+  rcodesign,
   xcbuildHook,
 }:
 
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     xcbuildHook
-    darwin.autoSignDarwinBinariesHook
+    rcodesign
   ];
 
   buildInputs = [
@@ -49,6 +49,10 @@ stdenv.mkDerivation (finalAttrs: {
     cp -r Products/Release/Caffeine.app $out/Applications
 
     runHook postInstall
+  '';
+
+  postFixup = ''
+    ${lib.getExe rcodesign} sign "$out/Applications/Caffeine.app"
   '';
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The previous `autoSignDarwinBinariesHook` signed only the Mach-O binary with an ad-hoc signature using the filename as the identifier, which produced a linker-signed signature that macOS TCC (Accessibility permissions) could not persist across rebuilds — every store-path change invalidated the permission grant.

Replace it with rcodesign signing the complete app bundle, which reads `CFBundleIdentifier` from `Info.plist` and uses it as a stable ad-hoc signing identifier, sealing `Info.plist` and resources into the signature. This lets Accessibility permissions persist across rebuilds.

Fixes #514418

## Testing

```console
$ codesign -dvv "/Applications/Nix Apps/Caffeine.app" # before
Executable=/Applications/Nix Apps/Caffeine.app/Contents/MacOS/Caffeine
Identifier=Caffeine
Format=app bundle with Mach-O thin (arm64)
CodeDirectory v=20400 size=769 flags=0x2(adhoc) hashes=19+2 location=embedded
Signature=adhoc
Info.plist=not bound
TeamIdentifier=not set
Sealed Resources=none
Internal requirements count=0 size=12

$ nix build .#caffeine

$ codesign -dvv result/Applications/Caffeine.app
﻿﻿﻿﻿﻿﻿Executable=/nix/store/2fdm529vms2aa0hk18rahrayixrsvv8j-caffeine-1.1.4/Applications/Caffeine.app/Contents/MacOS/Caffeine
Identifier=com.intelliscapesolutions.caffeine
Format=app bundle with Mach-O thin (arm64)
CodeDirectory v=20400 size=827 flags=0x2(adhoc) hashes=19+3 location=embedded
Signature=adhoc
Info.plist entries=28
TeamIdentifier=not set
Sealed Resources version=2 rules=13 files=17
Internal requirements count=0 size=12

$ open -n result/Applications/Caffeine.app

$ sudo rm -rf "/Applications/Nix Apps/Caffeine.app" # Test relocation like nix-darwin
$ sudo cp -R result/Applications/Caffeine.app "/Applications/Nix Apps/Caffeine.app"

$ codesign -dvv "/Applications/Nix Apps/Caffeine.app" # after
Executable=/Applications/Nix Apps/Caffeine.app/Contents/MacOS/Caffeine
Identifier=com.intelliscapesolutions.caffeine
Format=app bundle with Mach-O thin (arm64)
CodeDirectory v=20400 size=827 flags=0x2(adhoc) hashes=19+3 location=embedded
Signature=adhoc
Info.plist entries=28
TeamIdentifier=not set
Sealed Resources version=2 rules=13 files=17
Internal requirements count=0 size=12

```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

## Disclosure

This PR was prepared with assistance from OpenCode (GLM 5.2); the changes and test results were manually reviewed.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
