### PR TITLE
stdenv-bootstrap-tools: Fix lib*_asneeded problem on gcc16

### DIFF
--- a/pkgs/stdenv/linux/stdenv-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/stdenv-bootstrap-tools.nix
@@ -135,6 +135,9 @@ stdenv.mkDerivation (finalAttrs: {
     cp -d ${bootGCC.lib}/lib/libstdc++.so* $out/lib
     cp -d ${bootGCC.out}/lib/libssp.a* $out/lib
     cp -d ${bootGCC.out}/lib/libssp_nonshared.a $out/lib
+    cp -d ${bootGCC.lib}/lib/libgcc_s_asneeded.so $out/lib
+    cp -d ${bootGCC.lib}/lib/libatomic_asneeded.so $out/lib
+    cp -d ${bootGCC.out}/lib/libatomic.a* $out/lib
     cp -rd ${bootGCC.out}/lib/gcc $out/lib
     chmod -R u+w $out/lib
     rm -f $out/lib/gcc/*/*/include*/linux
@@ -156,15 +159,6 @@ stdenv.mkDerivation (finalAttrs: {
     cp -d ${mpfr.out}/lib/libmpfr*.so* $out/lib
     cp -d ${libmpc.out}/lib/libmpc*.so* $out/lib
     cp -d ${zlib.out}/lib/libz.so* $out/lib
-
-  ''
-  + lib.optionalString (stdenv.hostPlatform.isRiscV) ''
-    # libatomic is required on RiscV platform for C/C++ atomics and pthread
-    # even though they may be translated into native instructions.
-    cp -d ${bootGCC.out}/lib/libatomic.a* $out/lib
-
-  ''
-  + ''
     cp -d ${bzip2.out}/lib/libbz2.so* $out/lib
 
     # Copy binutils.


### PR DESCRIPTION
GCC 16 added and starts using -latomic_asneeded and -lgcc_s_asneeded to pull in the corresponding libraries as if --as-needed. Add these linker scripts.

After fixing this, gcc in turn wants libatomic, so reuse the existing line copying it for riscv, and use it for all platforms.

See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=123650 for why this was added.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux (`-f pkgs/top-level/release.nix stdenvBootstrapTools.aarch64-unknown-linux-gnu.test`)
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
