### PR TITLE
imgcrypt: 1.1.10 -> 2.0.2

### DIFF
--- a/pkgs/by-name/im/imgcrypt/package.nix
+++ b/pkgs/by-name/im/imgcrypt/package.nix
@@ -6,24 +6,26 @@
 
 buildGoModule (finalAttrs: {
   pname = "imgcrypt";
-  version = "1.1.10";
+  version = "2.0.2";
 
   src = fetchFromGitHub {
     owner = "containerd";
     repo = "imgcrypt";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-81jfoWHYYenGQFcQI9kk8uPnv6FcyOtcJjpo1ykdtOI=";
+    hash = "sha256-xHL+vxjGkjkDCEHMVOQsT6uokZq50iFAqGyDj6dDuG4=";
   };
 
-  vendorHash = null;
+  modRoot = "cmd";
+
+  vendorHash = "sha256-tTRYEvqhQm1XpSvXDDXEx5piZYOxAtmcjf2dLL9fGck=";
 
   ldflags = [
     "-X github.com/containerd/containerd/version.Version=${finalAttrs.version}"
   ];
 
   subPackages = [
-    "cmd/ctd-decoder"
-    "cmd/ctr"
+    "ctd-decoder"
+    "ctr"
   ];
 
   postFixup = ''


### PR DESCRIPTION
update to 2.0.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
