### PR TITLE
gcli: 2.11.0 -> 2.12.0, point to sourcehut, use finalAttrs

### DIFF
--- a/pkgs/by-name/gc/gcli/package.nix
+++ b/pkgs/by-name/gc/gcli/package.nix
@@ -1,23 +1,22 @@
 {
   lib,
-  fetchFromGitHub,
+  fetchFromSourcehut,
   stdenv,
   curl,
   pkg-config,
   byacc,
   flex,
-  fetchpatch,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gcli";
-  version = "2.11.0";
+  version = "2.12.0";
 
-  src = fetchFromGitHub {
-    owner = "herrhotzenplotz";
+  src = fetchFromSourcehut {
+    owner = "~herrhotzenplotz";
     repo = "gcli";
-    rev = "v${version}";
-    hash = "sha256-KTXAmwLTOGvFlJ52w6PplVlF72CC5JJheGlhJirh2+I=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-k691ocg5rkvGJZDp6X9PRIDaNvVPLcJRoXvwPbyxjLE=";
   };
 
   nativeBuildInputs = [
@@ -30,10 +29,10 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Portable Git(Hub|Lab|ea) CLI tool";
     homepage = "https://herrhotzenplotz.de/gcli/";
-    changelog = "https://github.com/herrhotzenplotz/gcli/releases/tag/v${version}";
+    changelog = "https://git.sr.ht/~herrhotzenplotz/gcli/tree/v${finalAttrs.version}/item/Changelog.md";
     license = lib.licenses.bsd2;
     mainProgram = "gcli";
     maintainers = with lib.maintainers; [ kenran ];
     platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
The GitHub repo seems to exists purely as a mirror and secondary issue
tracker with SourceHut being the preferred platform.

---

I'm aware of https://github.com/NixOS/nixpkgs/pull/525984, but since this patch
changes `src` anyway, I thought it might make sense to include the version bump.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
