### PR TITLE
ckan: remove gtk2

### DIFF
--- a/pkgs/by-name/ck/ckan/package.nix
+++ b/pkgs/by-name/ck/ckan/package.nix
@@ -4,8 +4,6 @@
   fetchurl,
   makeWrapper,
   mono,
-  gtk2,
-  curl,
   imagemagick,
   copyDesktopItems,
   makeDesktopItem,
@@ -36,11 +34,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ mono ];
 
-  libraries = lib.makeLibraryPath [
-    gtk2
-    curl
-  ];
-
   dontBuild = true;
 
   installPhase = ''
@@ -51,8 +44,7 @@ stdenv.mkDerivation rec {
     done
     install -m 644 -D $src $out/bin/ckan.exe
     makeWrapper ${mono}/bin/mono $out/bin/ckan \
-      --add-flags $out/bin/ckan.exe \
-      --set LD_LIBRARY_PATH $libraries
+      --add-flags $out/bin/ckan.exe
     runHook postInstall
   '';
 


### PR DESCRIPTION


## Things done

- https://github.com/NixOS/nixpkgs/issues/410814

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
