### PR TITLE
ubus: unstable-202-10-17 -> 0-unstable-2025-10-17

### DIFF
--- a/pkgs/by-name/ub/ubus/package.nix
+++ b/pkgs/by-name/ub/ubus/package.nix
@@ -9,7 +9,7 @@
 
 stdenv.mkDerivation {
   pname = "ubus";
-  version = "unstable-202-10-17";
+  version = "0-unstable-2025-10-17";
 
   src = fetchgit {
     url = "https://git.openwrt.org/project/ubus.git";


### PR DESCRIPTION
## Description of changes

`ubus` is pinned to revision `60e04048a0e2f3e33651c19e62861b41be4c290f`, whose committer date is **2025-10-17**, but the version string reads `unstable-202-10-17` — the year is missing a digit.

This corrects the date and adopts the `0-unstable-<date>` convention that the sibling OpenWrt packages already follow:

- `libubox` → `0-unstable-2025-10-14`
- `ustream-ssl` → `0-unstable-2025-10-03`

The `0-` prefix also keeps version comparisons ordering correctly against any future tagged release.

No functional change — the source revision and hash are untouched.

## Things done

- Built on platform(s): **x86_64-linux** via `nix-build -A ubus`. Only the `ubus` derivation rebuilds; `ubus` and `ubusd` run and `libubus.so` is installed as before.

cc @mkg20001
