### PR TITLE
libresidfp: 1.1.1 -> 1.1.2

### DIFF
--- a/pkgs/by-name/li/libresidfp/package.nix
+++ b/pkgs/by-name/li/libresidfp/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libresidfp";
-  version = "1.1.1";
+  version = "1.1.2";
 
   src = fetchFromGitHub {
     owner = "libsidplayfp";
     repo = "libresidfp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-xPIyJZWL5+tW3xk9b4dlL4klxXM6+cy38cALuhsH1zk=";
+    hash = "sha256-pczQkgx7YedPzMVUKpvLi0qtn6zs14OEe/N48OSc06c=";
   };
 
   strictDeps = true;
@@ -33,12 +33,6 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals withDocumentation [
     "doc"
   ];
-
-  # https://github.com/libsidplayfp/libresidfp/pull/41
-  postPatch = ''
-    substituteInPlace configure.ac \
-      --replace-fail 'AC_SUBST([LIB_MAJOR])NEWS.md' 'AC_SUBST([LIB_MAJOR])'
-  '';
 
   nativeBuildInputs = [
     autoreconfHook


### PR DESCRIPTION
https://github.com/libsidplayfp/libresidfp/releases/tag/v1.1.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  (of some players using this library for SID emulation)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
