### PR TITLE
stremio-service: init at 0.1.21

### DIFF
--- a/pkgs/by-name/st/stremio-service/package.nix
+++ b/pkgs/by-name/st/stremio-service/package.nix
@@ -1,0 +1,181 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  fetchFromGitHub,
+  rustPlatform,
+
+  pkg-config,
+  makeBinaryWrapper,
+  desktop-file-utils,
+  librsvg,
+
+  openssl,
+  glib,
+  gtk3,
+
+  libayatana-appindicator,
+  jellyfin-ffmpeg, # stremio docs: "We use a specific version of ffmpeg-jellyfin"
+  nodejs,
+  procps,
+}:
+let
+  # if updating this package, make sure this matches
+  # the version specified in Cargo.toml's package.metadata.server
+  server = fetchurl rec {
+    pname = "stremio-server";
+    version = "4.20.17";
+    url = "https://dl.strem.io/server/v${version}/desktop/server.js";
+    hash = "sha256-Vno5e7EbeIVxvxdQ/QXdeJJ/l77Ayd3qptnMHszuOSI=";
+    meta.license = lib.licenses.unfree;
+  };
+  os = if stdenv.hostPlatform.isDarwin then "macos" else stdenv.hostPlatform.parsed.kernel.name;
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "stremio-service";
+  version = "0.1.21";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Stremio";
+    repo = "stremio-service";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-aHkPtfkwe9/ulRb9ZjRd/7/r4xQSTZXF4I4Yb2rLeLY=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    makeBinaryWrapper
+    librsvg
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    desktop-file-utils
+  ];
+
+  buildInputs = [
+    openssl
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    gtk3.dev
+    glib
+  ];
+
+  cargoHash = "sha256-5y7CQmIyNBe8DzyDPAiI4I7SznL/zJG0nT7s8X02ZJ0=";
+  buildFeatures = [
+    "offline-build"
+    "bundled"
+  ];
+
+  postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
+    # fix desktop file path
+    substituteInPlace ./src/constants.rs \
+      --replace-fail "/usr/share/applications" "${placeholder "out"}/share/applications";
+  '';
+
+  preBuild = ''
+    # run pre-build checks
+    # check for server.js version mismatch
+    server_version=$(sed -n '/package.metadata.server/,$p' Cargo.toml | grep -m 1 'version =' | awk -F'"' '{print $2}');
+    if [ "$server_version" != "v${finalAttrs.passthru.server.version}" ]; then
+      echo "Server version mismatch: expected $server_version, got v${finalAttrs.passthru.server.version}"
+      exit 1
+    fi
+
+    # replace binary nodejs/ffmpeg with symlinks to the system versions
+    rm -rf ./resources/bin/${os}/{ffmpeg,ffprobe,stremio-runtime}
+    ln -s ${jellyfin-ffmpeg}/bin/ffmpeg ./resources/bin/${os}/ffmpeg
+    ln -s ${jellyfin-ffmpeg}/bin/ffprobe ./resources/bin/${os}/ffprobe
+    ln -s ${nodejs}/bin/node ./resources/bin/${os}/stremio-runtime
+
+    # create server.js symlink and server_version.txt
+    ln -s ${finalAttrs.passthru.server} ./resources/bin/${os}/server.js
+    echo "v${finalAttrs.passthru.server.version}" > ./resources/bin/${os}/server_version.txt
+  '';
+
+  dontCargoInstall = true;
+  installPhase = ''
+    runHook preInstall
+
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      # install desktop/icon files
+      mkdir -p $out/share/{applications,metainfo}
+      install -Dm 644 \
+        ./resources/com.stremio.service.desktop \
+        $out/share/applications/com.stremio.service.desktop;
+      install -Dm 644 \
+        ./resources/com.stremio.service.metainfo.xml \
+        $out/share/metainfo/com.stremio.service.metainfo.xml;
+      install -Dm 644 \
+        ./resources/com.stremio.service.svg \
+        $out/share/icons/hicolor/scalable/apps/com.stremio.service.svg;
+
+      # render non-scalable icons
+      for size in 16 32 64 128 256; do
+        mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
+        rsvg-convert \
+          -w $size -h $size \
+          ./resources/com.stremio.service.svg \
+          -o $out/share/icons/hicolor/"$size"x"$size"/apps/com.stremio.service.png
+      done
+
+      # patch desktop file
+      desktop-file-edit \
+        --set-key="Exec" --set-value="stremio-service" \
+        --set-key="TryExec" --set-value="stremio-service" \
+        $out/share/applications/com.stremio.service.desktop
+    ''}
+
+    # install data directory (/share/stremio-service)
+    mkdir -p $out/{bin,share/stremio-service}
+    cp -r ./resources/bin/${os}/* $out/share/stremio-service
+
+    # locate compiled binary dynamically across architectures/cross-compilation
+    compiled_binary=$(find target -name "stremio-service" -type f -path "*/release/*" | head -n 1)
+    install -Dm 755 "$compiled_binary" $out/share/stremio-service/stremio-service;
+    install -Dm 644 ./LICENSE.md $out/share/stremio-service/LICENSE.md;
+
+    # create /bin wrapper
+    makeBinaryWrapper \
+      $out/share/stremio-service/stremio-service \
+      $out/bin/stremio-service \
+      --add-flags "--skip-updater" \
+      --set NODE_ENV production \
+      --prefix PATH : "${lib.makeBinPath [ procps ]}" \
+      ${lib.optionalString stdenv.hostPlatform.isLinux ''
+        --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libayatana-appindicator ]}"
+      ''}
+
+    runHook postInstall
+  '';
+
+  checkFlags = [
+    # Skip test that fails in hermetic build sandbox due to missing git repository history
+    "--skip=copyright"
+  ];
+
+  passthru = {
+    inherit server;
+  };
+
+  meta = {
+    mainProgram = "stremio-service";
+    description = "Modern media center that gives you the freedom to watch everything you want (Service only)";
+    homepage = "https://www.stremio.com/";
+    license =
+      with lib.licenses;
+      AND [
+        gpl2Only
+        unfree # server.js is unfree
+      ];
+    maintainers = with lib.maintainers; [
+      griffi-gh
+      rachalaraj
+    ];
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+  };
+})


### PR DESCRIPTION
This PR packages **`stremio-service`** at version **`0.1.21`** (with `stremio-server` **`v4.20.17`**).

Supersedes #460557  
Closes #238550  
Closes #244595  

**`stremio-service`** is the lightweight companion daemon written in **Rust** for the [Stremio](https://www.stremio.com/) media center ecosystem. It runs in the background to host the core streaming engine (`stremio-server` / `server.js`), handling BitTorrent peer-to-peer streaming, local HTTP server operations (`http://127.0.0.1:11470`), and media transcoding via FFmpeg.

This package enables Linux and macOS users to use **[Stremio Web](https://web.stremio.com)** and PWA setups natively without needing the full legacy Qt desktop application.

This PR builds upon earlier community efforts (#460557, #418703, #244595), bringing the package to the latest stable release (`v0.1.21`) with enhanced platform compatibility and Nixpkgs packaging standards.

---

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test