### PR TITLE
cider-2: rename icon to match app name

### DIFF
--- a/pkgs/by-name/ci/cider-2/package.nix
+++ b/pkgs/by-name/ci/cider-2/package.nix
@@ -72,10 +72,11 @@ stdenv.mkDerivation (finalAttrs: {
   postFixup = ''
     mv $out/share/applications/cider.desktop $out/share/applications/cider-2.desktop
     substituteInPlace $out/share/applications/cider-2.desktop \
-      --replace-fail Exec=cider Exec=cider-2
+      --replace-fail Exec=cider Exec=cider-2 \
+      --replace-fail Icon=cider Icon=cider-2
 
     install -Dm444 $out/share/pixmaps/cider.png \
-      $out/share/icons/hicolor/256x256/apps/cider.png
+      $out/share/icons/hicolor/256x256/apps/cider-2.png
 
     rm -r $out/share/{pixmaps,lintian}
   '';

--- a/pkgs/by-name/ci/cider-2/package.nix
+++ b/pkgs/by-name/ci/cider-2/package.nix
@@ -79,6 +79,8 @@ stdenv.mkDerivation (finalAttrs: {
       $out/share/icons/hicolor/256x256/apps/cider-2.png
 
     rm -r $out/share/{pixmaps,lintian}
+    rm $out/lib/cider/resources/Cider{,.flatpak}.desktop
+    rm $out/lib/cider/resources/public/icon{.icns,-osx-previous.icns,.ico}
   '';
 
   passthru.updateScript = ./updater.sh;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
:recycle: Rename the app's icon to `cider-2`, for the same reason that this package uses the app name `cider-2`: it prevents a naming conflict with the `cider` package.

:broom: Additionally, remove superfluous files from the package:
- `.icns` and `.ico` files are specific to macOS and Windows respectively.
- `.desktop` files under `lib/` are unused artifacts left over from upstream packaging.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
