### PR TITLE
cider-2: prefer RPATH injection to LD_LIBRARY_PATH

### DIFF
--- a/pkgs/by-name/ci/cider-2/package.nix
+++ b/pkgs/by-name/ci/cider-2/package.nix
@@ -35,9 +35,14 @@ stdenv.mkDerivation (finalAttrs: {
     alsa-lib
     gtk3
     libgbm
-    libGL
     nspr
     nss
+  ];
+  # appendRunpaths is applied to every ELF, including shared libraries.
+  # runtimeDependencies wouldn't work here because autoPatchelfHook rewrites
+  # the RPATH of dynamic executables only, not of shared libraries.
+  appendRunpaths = lib.makeLibraryPath [
+    libGL # libEGL.so.1 is dlopen'd by ANGLE from libGLESv2.so
   ];
 
   unpackPhase = ''
@@ -55,12 +60,11 @@ stdenv.mkDerivation (finalAttrs: {
 
     chmod +x $out/lib/cider/Cider
 
-    # The prefixes that follow LD_LIBRARY_PATH are typically injected via wrapGAppsHook3.
+    # The prefixes that follow --add-flags are typically injected via wrapGAppsHook3.
     # We append them manually instead to avoid a double-wrapping.
     makeWrapper $out/lib/cider/Cider $out/bin/cider-2 \
       --add-flags "\$\{NIXOS_OZONE_WL:+\$\{WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true\}\}" \
       --add-flags "--no-sandbox --disable-gpu-sandbox" \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libGL ]}" \
       --prefix XDG_DATA_DIRS : "${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}" \
       --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}" \
       --prefix GIO_EXTRA_MODULES : "${dconf.lib}/lib/gio/modules" \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Appends libGL's `lib/` directory to the application libraries' `RPATH` instead of exporting it in `LD_LIBRARY_PATH`.

The only reason for us to have libGL as a dependency in Cider is because ANGLE `dlopen`'s it in the `--type=gpu-process` subprocess spawned by the main Cider application.

The `LD_LIBRARY_PATH` approach works, but it is leaky: those paths are inherited by every child process and they apply to all `dlopen`s, including the ones by processes Cider spawns which are unrelated to `gpu-process`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test