### PR TITLE
parquet-tools: relax pandas, cleanup

### DIFF
--- a/pkgs/by-name/pa/parquet-tools/package.nix
+++ b/pkgs/by-name/pa/parquet-tools/package.nix
@@ -32,7 +32,7 @@ python3Packages.buildPythonApplication rec {
   '';
 
   pythonRelaxDeps = [
-    "halo"
+    "pandas"
     "tabulate"
     "thrift"
   ];

--- a/pkgs/by-name/pa/parquet-tools/package.nix
+++ b/pkgs/by-name/pa/parquet-tools/package.nix
@@ -24,13 +24,6 @@ python3Packages.buildPythonApplication rec {
     ./moto5.patch
   ];
 
-  postPatch = ''
-    substituteInPlace tests/test_inspect.py \
-      --replace "parquet-cpp-arrow version 5.0.0" "parquet-cpp-arrow version ${python3Packages.pyarrow.version}" \
-      --replace "serialized_size: 2222" "serialized_size: 2221" \
-      --replace "format_version: 1.0" "format_version: 2.6"
-  '';
-
   pythonRelaxDeps = [
     "pandas"
     "tabulate"

--- a/pkgs/by-name/pa/parquet-tools/package.nix
+++ b/pkgs/by-name/pa/parquet-tools/package.nix
@@ -5,7 +5,7 @@
   addBinToPathHook,
 }:
 
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "parquet-tools";
   version = "0.2.16";
 
@@ -14,7 +14,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "ktrueda";
     repo = "parquet-tools";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-mV66R5ejfzH1IasmoyAWAH5vzrnLVVhOqKBMfWKIVY0=";
   };
 
@@ -30,11 +30,11 @@ python3Packages.buildPythonApplication rec {
     "thrift"
   ];
 
-  nativeBuildInputs = with python3Packages; [
+  build-system = with python3Packages; [
     poetry-core
   ];
 
-  propagatedBuildInputs = with python3Packages; [
+  dependencies = with python3Packages; [
     boto3
     colorama
     halo
@@ -67,9 +67,9 @@ python3Packages.buildPythonApplication rec {
   meta = {
     description = "CLI tool for parquet files";
     homepage = "https://github.com/ktrueda/parquet-tools";
-    changelog = "https://github.com/ktrueda/parquet-tools/releases/tag/${version}";
+    changelog = "https://github.com/ktrueda/parquet-tools/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ cpcloud ];
     mainProgram = "parquet-tools";
   };
-}
+})


### PR DESCRIPTION
## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 545690`
Commit: `79164d78d98ba2f68869354ce322f7cb16368a33`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>parquet-tools</li>
  </ul>
</details>


---
### `aarch64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>parquet-tools</li>
  </ul>
</details>


---
### `aarch64-darwin`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>parquet-tools</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test