### PR TITLE
tetrd: 1.3.1-1 -> 1.3.2; redesign service and add test

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -117,6 +117,8 @@
   and [containers-registries.conf(5)](https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md)
   to migrate to the new configuration format.
 
+- [`services.tetrd`](#opt-services.tetrd.enable) no longer forces `networking.resolvconf.enable = false` or takes over host `/etc/resolv.conf`. Phone DNS is written to a private file under `/run/tetrd-dns/` and is published into resolvconf only when resolvconf is already enabled. The GUI needs this module (socket linker under `/run/wrappers` and USB rules via the `tetrd-usb` group + udev `uaccess`); prefer it over the app’s “run at startup” toggle, which does not work with the service’s DynamicUser. USB device nodes are restricted with a cgroup allow-list (`char-usb_device` and `/dev/net/tun`).
+
 - When Avahi's mDNS resolver is enabled (`services.avahi.nssmdns4` or `services.avahi.nssmdns6`), only the minimal mDNS resolver is enabled by default to avoid adding a 5 second delay to every failed reverse hostname lookup (e.g., delaying ping by 5 seconds). The "full" mDNS resolver now remains disabled unless `services.avahi.nssmdnsFull` is also enabled. Users who have customized [`/etc/mdns.allow`](https://github.com/avahi/nss-mdns/tree/master#etcmdnsallow) to allow mDNS domains not ending `.local` must enable `services.avahi.nssmdnsFull` to continue to resolve such domains.
 
 - String values passed to `services.phpfpm.settings`, `services.phpfpm.pools.<name>.phpEnv`, and `services.phpfpm.pools.<name>.settings` are now properly quoted and escaped, except for the `${}` syntax that is left as-is. If you are manually escaping these values, please adjust accordingly.

--- a/nixos/modules/services/networking/tetrd.nix
+++ b/nixos/modules/services/networking/tetrd.nix
@@ -4,109 +4,305 @@
   pkgs,
   ...
 }:
-
 let
   cfg = config.services.tetrd;
+  useResolvconf = config.networking.resolvconf.enable;
+
+  runtimeDir = "/run/tetrd";
+  # Outside the chroot: RootDirectory is read-only, so DNS must live here.
+  resolvDir = "/run/tetrd-dns";
+  privateResolv = "${resolvDir}/resolv.conf";
+  # GUI runs outside the chroot and expects this path.
+  privateResolvState = "${runtimeDir}/resolv.conf.state";
+
+  resolvconfBin = "${config.networking.resolvconf.package}/bin/resolvconf";
+  systemctl = "${config.systemd.package}/bin/systemctl";
+
+  ensureChrootTree = pkgs.writeShellScript "tetrd-ensure-chroot-tree" ''
+    set -euo pipefail
+    rd=${runtimeDir}
+    rvd=${resolvDir}
+    mkdir -p "$rd/run" "$rd/etc" "$rvd"
+
+    # Create only if missing. chmod/chown on every run re-fires path units.
+    ensure() {
+      local f=$1 init=$2 ref=$3 mode=$4
+      [[ -e $f ]] && return 0
+      if [[ -n $init ]]; then
+        printf '%s' "$init" >"$f"
+      else
+        : >"$f"
+      fi
+      [[ -d $ref ]] && chown --reference="$ref" "$f" 2>/dev/null || true
+      chmod "$mode" "$f" 2>/dev/null || true
+    }
+
+    ensure ${privateResolv} "" "$rvd" 660
+    # Empty mountpoint for BindPaths privateResolv → chroot /etc/resolv.conf.
+    ensure "$rd/etc/resolv.conf" "" "$rd" 660
+    ensure ${privateResolvState} "{}" "$rd" 644
+    chown --reference="$rd" "$rd/run" "$rd/etc" 2>/dev/null || true
+  '';
+
+  applyDns = pkgs.writeShellScript "tetrd-apply-dns" ''
+    set -euo pipefail
+    f=${privateResolv}
+    if [[ -s $f ]] && grep -qE '^[[:space:]]*nameserver[[:space:]]+' "$f"; then
+      ${resolvconfBin} -a tetrd -m 0 <"$f"
+    else
+      ${resolvconfBin} -d tetrd 2>/dev/null || true
+    fi
+    [[ -e /etc/resolv.conf ]] || ${resolvconfBin} -u
+  '';
+
+  removeDns = pkgs.writeShellScript "tetrd-remove-dns" ''
+    set -euo pipefail
+    ${resolvconfBin} -d tetrd 2>/dev/null || true
+  '';
+
+  ensureHostResolv = pkgs.writeShellScript "tetrd-ensure-host-resolv" ''
+    set -euo pipefail
+    [[ -e /etc/resolv.conf ]] || ${resolvconfBin} -u
+  '';
+
+  helperSandbox = {
+    PrivateTmp = true;
+    ProtectHome = true;
+    SystemCallArchitectures = "native";
+  };
+
+  oneshot = extra: {
+    startLimitIntervalSec = 0;
+    serviceConfig =
+      helperSandbox
+      // {
+        Type = "oneshot";
+      }
+      // extra;
+  };
+
+  # partOf alone for the debounce timer: requiredBy + RemainAfterElapse=false
+  # would stop tetrd when the timer finishes.
+  partOfTetrd = {
+    partOf = [ "tetrd.service" ];
+  };
+  pathTiedToTetrd = partOfTetrd // {
+    requiredBy = [ "tetrd.service" ];
+  };
 in
 {
   options.services.tetrd = {
-    enable = lib.mkEnableOption "tetrd";
+    # mkEnableOption string only — do not touch pkgs.tetrd (unfree) at eval.
+    enable = lib.mkEnableOption "USB tethering and reverse-tethering";
     package = lib.mkPackageOption pkgs "tetrd" { };
   };
 
-  config = lib.mkIf cfg.enable {
-    environment = {
-      systemPackages = [ cfg.package ];
-      # etc."resolv.conf".source = "/etc/tetrd/resolv.conf"; # Disabled overwriting of resolve.conf since otherwise tetrd disables your dns when its not connected to a device.
-    };
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        environment.systemPackages = [ cfg.package ];
 
-    # Our resolv.conf will override resolvconf's version.
-    networking.resolvconf.enable = false;
+        users.groups.tetrd-usb = { };
 
-    systemd = {
-      tmpfiles.rules = [ "f /etc/tetrd/resolv.conf - - -" ];
+        # Daemon needs the group; uaccess keeps desktop seats on USB (adb, etc.).
+        services.udev.extraRules = ''
+          SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", MODE="0660", GROUP="tetrd-usb", TAG+="uaccess"
+        '';
 
-      services.tetrd = {
-        description = cfg.package.meta.description;
-        wantedBy = [ "multi-user.target" ];
-
-        serviceConfig = {
-          ExecStart = "${cfg.package}/opt/Tetrd/bin/tetrd";
-          Restart = "always";
-          RuntimeDirectory = "tetrd";
-          RootDirectory = "/run/tetrd";
-          DynamicUser = true;
-          UMask = "006";
-          DeviceAllow = "usb_device";
-          LockPersonality = true;
-          MemoryDenyWriteExecute = true;
-          NoNewPrivileges = true;
-          PrivateMounts = true;
-          PrivateNetwork = lib.mkDefault false;
-          PrivateTmp = true;
-          PrivateUsers = lib.mkDefault false;
-          ProtectClock = lib.mkDefault false;
-          ProtectControlGroups = true;
-          ProtectHome = true;
-          ProtectHostname = true;
-          ProtectKernelLogs = true;
-          ProtectKernelModules = true;
-          ProtectKernelTunables = true;
-          ProtectProc = "invisible";
-          ProtectSystem = "strict";
-          RemoveIPC = true;
-          RestrictAddressFamilies = [
-            "AF_UNIX"
-            "AF_INET"
-            "AF_INET6"
-            "AF_NETLINK"
-          ];
-          RestrictNamespaces = true;
-          RestrictRealtime = true;
-          RestrictSUIDSGID = true;
-          SystemCallArchitectures = "native";
-
-          SystemCallFilter = [
-            "@system-service"
-            "~@aio"
-            "~@chown"
-            "~@clock"
-            "~@cpu-emulation"
-            "~@debug"
-            "~@keyring"
-            "~@memlock"
-            "~@module"
-            "~@mount"
-            "~@obsolete"
-            "~@pkey"
-            "~@raw-io"
-            "~@reboot"
-            "~@swap"
-            "~@sync"
-          ];
-
-          BindReadOnlyPaths = [
-            builtins.storeDir
-            "/etc/ssl"
-            "/etc/static/ssl"
-            "${pkgs.net-tools}/bin/route:/usr/bin/route"
-            "${pkgs.net-tools}/bin/ifconfig:/usr/bin/ifconfig"
-          ];
-
-          BindPaths = [
-            "/etc/tetrd/resolv.conf:/etc/resolv.conf"
-            "/run/tetrd:/run"
-          ];
-
-          CapabilityBoundingSet = [
-            "CAP_NET_ADMIN"
-          ];
-
-          AmbientCapabilities = [
-            "CAP_NET_ADMIN"
-          ];
+        security.wrappers.tetrd-lnsock = {
+          source = "${cfg.package}/opt/Tetrd/bin/lnsock";
+          owner = "root";
+          group = "root";
+          capabilities = "cap_dac_override+ep";
         };
-      };
-    };
-  };
+
+        systemd = {
+          services = {
+            tetrd-chroot-tree = {
+              description = "Ensure tetrd runtime directories and files";
+              before = [ "tetrd.service" ];
+              requiredBy = [ "tetrd.service" ];
+            }
+            // oneshot {
+              ExecStart = ensureChrootTree;
+              PrivateNetwork = true;
+            };
+
+            tetrd = {
+              description = cfg.package.meta.description;
+              wantedBy = [ "multi-user.target" ];
+              after = [
+                "dbus.service"
+                "network.target"
+                "tetrd-chroot-tree.service"
+              ];
+              requires = [ "tetrd-chroot-tree.service" ];
+
+              serviceConfig = {
+                ExecStartPre = "+${ensureChrootTree}";
+                ExecStart = "${cfg.package}/bin/tetrd-service";
+                Restart = "always";
+                RestartSec = "2s";
+
+                RuntimeDirectory = [
+                  "tetrd"
+                  "tetrd-dns"
+                ];
+                # GUI (not DynamicUser) must traverse here for resolv.conf.state.
+                RuntimeDirectoryMode = "0755";
+                RootDirectory = runtimeDir;
+                StateDirectory = "Tetrd";
+                StateDirectoryMode = "0700";
+                LogsDirectory = "Tetrd";
+                LogsDirectoryMode = "0750";
+
+                DynamicUser = true;
+                SupplementaryGroups = [ "tetrd-usb" ];
+                UMask = "0077";
+
+                CapabilityBoundingSet = [ "CAP_NET_ADMIN" ];
+                AmbientCapabilities = [ "CAP_NET_ADMIN" ];
+
+                # USB device nodes + TUN (tetrd0). Use char-usb_device, not bare usb_device.
+                DevicePolicy = "closed";
+                DeviceAllow = [
+                  "char-usb_device rwm"
+                  "/dev/net/tun rw"
+                ];
+
+                LockPersonality = true;
+                MemoryDenyWriteExecute = true;
+                NoNewPrivileges = true;
+                PrivateIPC = true;
+                PrivateMounts = true;
+                PrivateNetwork = lib.mkDefault false;
+                PrivateTmp = true;
+                PrivateUsers = lib.mkDefault false;
+                ProtectClock = true;
+                ProtectControlGroups = true;
+                ProtectHome = true;
+                ProtectHostname = true;
+                ProtectKernelLogs = true;
+                ProtectKernelModules = true;
+                ProtectKernelTunables = true;
+                ProtectProc = "invisible";
+                # ProcSubset=pid hides /proc/net and breaks phone connect.
+                ProtectSystem = "strict";
+                RemoveIPC = true;
+                RestrictNamespaces = true;
+                RestrictRealtime = true;
+                RestrictSUIDSGID = true;
+                SystemCallArchitectures = "native";
+                SystemCallErrorNumber = "EPERM";
+                KeyringMode = "private";
+
+                RestrictAddressFamilies = [
+                  "AF_UNIX"
+                  "AF_INET"
+                  "AF_INET6"
+                  "AF_NETLINK"
+                ];
+
+                SystemCallFilter = [
+                  "@system-service"
+                  "~@aio"
+                  "~@chown"
+                  "~@clock"
+                  "~@cpu-emulation"
+                  "~@debug"
+                  "~@keyring"
+                  "~@memlock"
+                  "~@module"
+                  "~@mount"
+                  "~@obsolete"
+                  "~@pkey"
+                  "~@raw-io"
+                  "~@reboot"
+                  "~@swap"
+                  "~@sync"
+                ];
+
+                BindReadOnlyPaths = [
+                  builtins.storeDir
+                  "/etc/ssl"
+                  "/etc/static/ssl"
+                  "${pkgs.net-tools}/bin/route:/usr/bin/route"
+                  "${pkgs.net-tools}/bin/ifconfig:/usr/bin/ifconfig"
+                  "${pkgs.dbus}/bin/dbus-launch:/usr/bin/dbus-launch"
+                ];
+
+                BindPaths = [
+                  "${privateResolv}:/etc/resolv.conf"
+                  "${runtimeDir}/run:/run"
+                  # Whole /run/dbus is not a directory tree on NixOS — socket only.
+                  "/run/dbus/system_bus_socket:/run/dbus/system_bus_socket"
+                ];
+              };
+            };
+          };
+
+          # Seeded-file parents only. Watching run/ thrashes on socket traffic.
+          paths.tetrd-chroot-tree = pathTiedToTetrd // {
+            pathConfig = {
+              PathChanged = [
+                runtimeDir
+                "${runtimeDir}/etc"
+                resolvDir
+              ];
+              Unit = "tetrd-chroot-tree.service";
+            };
+          };
+        };
+      }
+
+      (lib.mkIf useResolvconf {
+        systemd = {
+          services = {
+            tetrd-dns-apply = {
+              description = "Push tetrd DNS into resolvconf";
+            }
+            // oneshot { ExecStart = applyDns; };
+
+            # Restart the timer so each resolv write resets the 300ms debounce.
+            tetrd-dns-arm = {
+              description = "Schedule tetrd DNS apply";
+            }
+            // oneshot {
+              ExecStart = "${systemctl} restart tetrd-dns-apply.timer";
+              PrivateNetwork = true;
+              RestrictAddressFamilies = [ "AF_UNIX" ];
+            };
+
+            tetrd-dns = {
+              description = "tetrd resolvconf lifecycle";
+              after = [ "tetrd.service" ];
+              bindsTo = [ "tetrd.service" ];
+              wantedBy = [ "tetrd.service" ];
+            }
+            // oneshot {
+              RemainAfterExit = true;
+              ExecStart = ensureHostResolv;
+              ExecStop = removeDns;
+            };
+          };
+
+          timers.tetrd-dns-apply = partOfTetrd // {
+            timerConfig = {
+              OnActiveSec = "300ms";
+              AccuracySec = "100ms";
+              RemainAfterElapse = false;
+            };
+          };
+
+          # Watch the directory: a file watch dies if resolv.conf is deleted.
+          paths.tetrd-dns = pathTiedToTetrd // {
+            pathConfig = {
+              PathModified = resolvDir;
+              Unit = "tetrd-dns-arm.service";
+            };
+          };
+        };
+      })
+    ]
+  );
 }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1757,6 +1757,7 @@ in
   temporal = runTest ./temporal.nix;
   terminal-emulators = handleTest ./terminal-emulators.nix { };
   test-containers-bittorrent = runTest ./test-containers-bittorrent.nix;
+  tetrd = runTest ./tetrd.nix;
   thanos = runTest ./thanos.nix;
   thelounge = handleTest ./thelounge.nix { };
   tiddlywiki = runTest ./tiddlywiki.nix;

--- a/nixos/tests/tetrd.nix
+++ b/nixos/tests/tetrd.nix
@@ -1,0 +1,133 @@
+{ ... }: {
+  name = "tetrd";
+
+  node.pkgsReadOnly = false;
+
+  nodes.machine = {
+    nixpkgs.config.allowUnfreePackages = [ "tetrd" ];
+    services.tetrd.enable = true;
+    networking.resolvconf.enable = true;
+  };
+
+  testScript = ''
+    # Fail fast: wait_until_* defaults to 900s.
+    DNS_TIMEOUT = 30
+
+    def start_tetrd():
+        machine.systemctl("start tetrd.service")
+        machine.wait_until_succeeds(
+            "systemctl is-active --quiet tetrd.service", timeout=DNS_TIMEOUT
+        )
+
+    def stop_tetrd():
+        machine.systemctl("stop tetrd.service")
+        machine.wait_until_fails(
+            "systemctl is-active --quiet tetrd.service", timeout=DNS_TIMEOUT
+        )
+
+    def assert_owner(path, ref):
+        machine.succeed(f'test "$(stat -c %u {path})" = "$(stat -c %u {ref})"')
+
+    def unit_has(unit, *needles):
+        text = machine.succeed(f"systemctl cat {unit}")
+        for n in needles:
+            if n not in text:
+                raise Exception(f"{unit} missing {n!r}")
+
+    def write_dns(ns):
+        machine.succeed(f"printf 'nameserver {ns}\\n' > /run/tetrd-dns/resolv.conf")
+
+    def wait_dns(ns, present=True):
+        cmd = f"resolvconf -l tetrd | grep -q {ns}"
+        if present:
+            machine.wait_until_succeeds(cmd, timeout=DNS_TIMEOUT)
+        else:
+            machine.wait_until_fails(cmd, timeout=DNS_TIMEOUT)
+
+    machine.wait_for_unit("multi-user.target")
+
+    with subtest("package and lnsock"):
+        for bin in ("tetrd", "tetrd-app", "tetrd-service"):
+            machine.succeed(f"test -x /run/current-system/sw/bin/{bin}")
+        machine.succeed("test -x /run/wrappers/bin/tetrd-lnsock")
+        machine.succeed("getent group tetrd-usb")
+
+        machine.succeed("mkdir -p /run/tetrd/run && touch /run/tetrd/run/tetrd.sock")
+        machine.succeed("/run/wrappers/bin/tetrd-lnsock /run/tetrd-deadbeef.sock")
+        machine.succeed("test -L /run/tetrd-deadbeef.sock")
+        machine.succeed("test \"$(readlink /run/tetrd-deadbeef.sock)\" = /run/tetrd/run/tetrd.sock")
+        for bad in (
+            "/run/tetrd-NOTHEX00.sock",  # uppercase
+            "/run/tetrd-abcd.sock",  # too short
+            "/tmp/evil.sock",
+            "/run/other.sock",
+        ):
+            machine.fail(f"/run/wrappers/bin/tetrd-lnsock {bad}")
+        machine.fail(
+            "/run/wrappers/bin/tetrd-lnsock /run/tetrd-"
+            + ("a" * 65)
+            + ".sock"
+        )
+        machine.succeed("ln -sfn /run/tetrd/run/tetrd.sock /run/tetrd-nothex.sock")
+        machine.succeed("/run/wrappers/bin/tetrd-lnsock --cleanup")
+        machine.fail("test -e /run/tetrd-deadbeef.sock")
+        machine.succeed("test -L /run/tetrd-nothex.sock")
+        machine.succeed("rm -f /run/tetrd-nothex.sock")
+
+    with subtest("service layout"):
+        start_tetrd()
+        unit_has(
+            "tetrd.service",
+            "CAP_NET_ADMIN",
+            "tetrd-usb",
+            "DevicePolicy=closed",
+            "DeviceAllow=char-usb_device",
+            "DeviceAllow=/dev/net/tun",
+            "/run/tetrd-dns/resolv.conf",
+        )
+        machine.fail("systemctl cat tetrd.service | grep -q CAP_DAC_OVERRIDE")
+        machine.succeed("test -d /run/tetrd/run -a -d /run/tetrd/etc")
+        machine.succeed("test -f /run/tetrd-dns/resolv.conf -a -f /run/tetrd/resolv.conf.state")
+        machine.fail("readlink /etc/resolv.conf | grep -q /run/tetrd")
+        machine.succeed("test -e /etc/resolv.conf")
+        assert_owner("/run/tetrd-dns/resolv.conf", "/run/tetrd-dns")
+        assert_owner("/run/tetrd/resolv.conf.state", "/run/tetrd")
+
+    with subtest("dns units present"):
+        machine.succeed("systemctl is-active --quiet tetrd-dns.path")
+        machine.succeed("systemctl is-active --quiet tetrd-dns.service")
+        unit_has("tetrd-dns.path", "PathModified=/run/tetrd-dns")
+        unit_has("tetrd-dns-arm.service", "tetrd-dns-apply.timer")
+
+    with subtest("resolvconf publish and clear"):
+        write_dns("1.1.1.1")
+        wait_dns("1.1.1.1")
+        machine.succeed("grep -q 1.1.1.1 /etc/resolv.conf")
+        machine.succeed(": > /run/tetrd-dns/resolv.conf")
+        wait_dns("1.1.1.1", present=False)
+
+    with subtest("apply oneshot"):
+        write_dns("8.8.8.8")
+        machine.systemctl("start tetrd-dns-apply.service")
+        wait_dns("8.8.8.8")
+        machine.succeed("grep -q 8.8.8.8 /etc/resolv.conf")
+
+    with subtest("stop clears resolvconf stanza"):
+        stop_tetrd()
+        machine.fail("resolvconf -l tetrd | grep -q 8.8.8.8")
+
+    with subtest("recreate missing resolv file keeps DNS watch"):
+        start_tetrd()
+        machine.wait_until_succeeds(
+            "test -f /run/tetrd-dns/resolv.conf", timeout=DNS_TIMEOUT
+        )
+        machine.succeed("rm -f /run/tetrd-dns/resolv.conf")
+        machine.wait_until_succeeds(
+            "test -f /run/tetrd-dns/resolv.conf", timeout=DNS_TIMEOUT
+        )
+        assert_owner("/run/tetrd-dns/resolv.conf", "/run/tetrd-dns")
+        write_dns("9.9.9.9")
+        wait_dns("9.9.9.9")
+        stop_tetrd()
+  '';
+}

--- a/pkgs/by-name/te/tetrd/lnsock.c
+++ b/pkgs/by-name/te/tetrd/lnsock.c
@@ -1,0 +1,91 @@
+/* Symlink GUI client paths to the daemon socket:
+ *   /run/tetrd-<hex>.sock → /run/tetrd/run/tetrd.sock
+ */
+
+#include <errno.h>
+#include <glob.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+static const char *const SERVICE_SOCK = "/run/tetrd/run/tetrd.sock";
+static const char PREFIX[] = "/run/tetrd-";
+static const char SUFFIX[] = ".sock";
+/* Bound so a world-executable cap wrapper cannot flood /run with long names. */
+static const size_t HEX_MIN = 8;
+static const size_t HEX_MAX = 64;
+
+static int path_allowed(const char *path) {
+    size_t len, hex_lo, hex_hi, hex_len, i;
+
+    if (strncmp(path, PREFIX, sizeof(PREFIX) - 1) != 0)
+        return 0;
+
+    len = strlen(path);
+    hex_lo = sizeof(PREFIX) - 1;
+    if (len <= hex_lo + sizeof(SUFFIX) - 1)
+        return 0;
+
+    hex_hi = len - (sizeof(SUFFIX) - 1);
+    if (strcmp(path + hex_hi, SUFFIX) != 0)
+        return 0;
+
+    hex_len = hex_hi - hex_lo;
+    if (hex_len < HEX_MIN || hex_len > HEX_MAX)
+        return 0;
+
+    /* App logs lowercase hex only. */
+    for (i = hex_lo; i < hex_hi; i++) {
+        char c = path[i];
+        if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')))
+            return 0;
+    }
+    return 1;
+}
+
+static void cleanup_old_sockets(void) {
+    glob_t gl = {0};
+
+    if (glob("/run/tetrd-*.sock", 0, NULL, &gl) != 0)
+        return;
+
+    for (size_t i = 0; i < gl.gl_pathc; i++) {
+        if (!path_allowed(gl.gl_pathv[i]))
+            continue;
+        if (unlink(gl.gl_pathv[i]) != 0 && errno != ENOENT)
+            fprintf(stderr, "tetrd-lnsock: warning: could not remove %s: %s\n",
+                    gl.gl_pathv[i], strerror(errno));
+    }
+    globfree(&gl);
+}
+
+int main(int argc, char *argv[]) {
+    if (argc != 2) {
+        fprintf(stderr, "usage: tetrd-lnsock /run/tetrd-<hash>.sock | --cleanup\n");
+        return 1;
+    }
+
+    if (strcmp(argv[1], "--cleanup") == 0) {
+        cleanup_old_sockets();
+        return 0;
+    }
+
+    if (!path_allowed(argv[1])) {
+        fprintf(stderr, "tetrd-lnsock: refusing invalid target: %s\n", argv[1]);
+        return 1;
+    }
+
+    cleanup_old_sockets();
+
+    if (unlink(argv[1]) != 0 && errno != ENOENT) {
+        perror("tetrd-lnsock: unlink");
+        return 1;
+    }
+
+    if (symlink(SERVICE_SOCK, argv[1]) != 0) {
+        perror("tetrd-lnsock: symlink");
+        return 1;
+    }
+
+    return 0;
+}

--- a/pkgs/by-name/te/tetrd/package.nix
+++ b/pkgs/by-name/te/tetrd/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchurl,
+  writeShellApplication,
   autoPatchelfHook,
   makeWrapper,
   c-ares,
@@ -22,20 +23,20 @@
   udev,
   libgbm,
   libGL,
+  coreutils,
+  nixosTests,
 }:
-
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tetrd";
-  version = "1.3.1-1";
+  version = "1.3.2";
 
   src = fetchurl {
-    url = "https://web.archive.org/web/20260108185127/https://download.tetrd.app/files/tetrd.linux_amd64.pkg.tar.xz";
-    sha256 = "0mpixs20jrxkbxvd7nl0p664jgqfp3m6qf7kmsj7frkhky697fbm";
+    url = "https://web.archive.org/web/20260718025953/https://download.tetrd.app/files/tetrd.linux_amd64.pkg.tar.xz";
+    hash = "sha256-hn3p+iUF7JYQ+TFGbJqvqwDvzgoCfc5SduBgtAExHS0=";
   };
 
   sourceRoot = ".";
   dontConfigure = true;
-  dontBuild = true;
 
   nativeBuildInputs = [
     autoPatchelfHook
@@ -43,15 +44,14 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    libGL
     c-ares
     ffmpeg
     libevent
     libvpx
     libxslt
+    libxtst
     libxscrnsaver
     libxdamage
-    libxtst
     minizip
     nss
     re2
@@ -61,34 +61,94 @@ stdenv.mkDerivation rec {
     libappindicator
     udev
     libgbm
+    libGL
   ];
 
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/opt
-    cp -r $sourceRoot/opt/Tetrd $out/opt
-    cp -r $sourceRoot/usr/share $out
-
-    wrapProgram $out/opt/Tetrd/tetrd \
-      --prefix LD_LIBRARY_PATH ":" ${lib.makeLibraryPath buildInputs}
-
-    mkdir $out/bin
-    ln -s $out/opt/Tetrd/tetrd $out/bin/tetrd
-
-    runHook postInstall
+  buildPhase = ''
+    runHook preBuild
+    mkdir -p opt/Tetrd/bin
+    $CC -O2 -Wall -Wextra -o opt/Tetrd/bin/lnsock ${./lnsock.c}
+    runHook postBuild
   '';
+
+  installPhase =
+    let
+      # Scrapes GUI logs for /run/tetrd-*.sock and links them to the service.
+      # Needs services.tetrd.enable (security.wrappers.tetrd-lnsock).
+      appWrapper = writeShellApplication {
+        name = "tetrd-app-wrapper";
+        runtimeInputs = [ coreutils ];
+        text = ''
+          LNSOCK=/run/wrappers/bin/tetrd-lnsock
+          TETRD="''${TETRD:?TETRD must be set by the outer wrapper}"
+
+          if [[ ! -e $LNSOCK ]]; then
+            echo "tetrd: enable services.tetrd.enable for the socket linker" >&2
+            exit 1
+          fi
+
+          trap '"$LNSOCK" --cleanup || true' EXIT
+
+          # Link only the first path the app prints this run.
+          created=false
+          set +e
+          stdbuf -oL -eL "$TETRD" "$@" 2>&1 | while IFS= read -r line || [[ -n $line ]]; do
+            printf '%s\n' "$line"
+            if ! $created && [[ $line =~ (/run/tetrd-[0-9a-f]+\.sock) ]]; then
+              target="''${BASH_REMATCH[1]}"
+              echo "tetrd: linking $target → /run/tetrd/run/tetrd.sock" >&2
+              "$LNSOCK" "$target" && created=true
+            fi
+          done
+          status=''${PIPESTATUS[0]}
+          set -e
+          exit "$status"
+        '';
+      };
+    in
+    ''
+      runHook preInstall
+
+      mkdir -p $out/bin
+      cp -a opt $out
+      cp -a usr/share $out
+
+      ln -s /var/lib/Tetrd/config.toml $out/opt/Tetrd/bin/config.toml
+      ln -s /var/lib/Tetrd/devices.json $out/opt/Tetrd/bin/devices.json
+
+      mv $out/opt/Tetrd/tetrd $out/opt/Tetrd/.tetrd-wrapped
+      makeWrapper ${lib.getExe appWrapper} $out/opt/Tetrd/tetrd \
+        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath finalAttrs.buildInputs} \
+        --set TETRD $out/opt/Tetrd/.tetrd-wrapped
+
+      ln -s $out/opt/Tetrd/tetrd $out/bin/tetrd-app
+      ln -s $out/bin/tetrd-app $out/bin/tetrd
+      ln -s $out/opt/Tetrd/bin/tetrd $out/bin/tetrd-service
+
+      runHook postInstall
+    '';
 
   postFixup = ''
-    substituteInPlace $out/share/applications/tetrd.desktop --replace /opt $out/opt
+    substituteInPlace $out/share/applications/tetrd.desktop \
+      --replace-fail /opt/Tetrd/tetrd $out/bin/tetrd
   '';
 
+  passthru.tests = { inherit (nixosTests) tetrd; };
+
   meta = {
-    description = "Share your internet connection from your device to your PC and vice versa through a USB cable";
+    description = "USB tethering and reverse-tethering";
+    longDescription = ''
+      USB tethering and reverse-tethering between a PC and a mobile device.
+
+      Enable `services.tetrd.enable` so the GUI can talk to the daemon (socket
+      linker under `/run/wrappers`) and so USB access and optional resolvconf
+      DNS integration are set up. Prefer that over the app's "run at startup"
+      toggle, which does not work with the service's dynamic user account.
+    '';
     homepage = "https://tetrd.app";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
     platforms = [ "x86_64-linux" ];
     mainProgram = "tetrd";
   };
-}
+})


### PR DESCRIPTION
## Summary

Update `tetrd` to 1.3.2 and redesign `services.tetrd` so it no longer takes over host DNS, and so the GUI can talk to a hardened DynamicUser daemon.

Commits:

1. **`tetrd: 1.3.1-1 -> 1.3.2`** — package bump, `lnsock` helper, GUI wrapper.
2. **`nixos/tetrd: redesign sandbox and optional resolvconf DNS`** — module + VM test.
3. **`nixos/tetrd: document 26.11 breaking changes`** — release notes.

### Package

- Archived upstream tarball → 1.3.2.
- Add `lnsock` (path-checked; `CAP_DAC_OVERRIDE` only via `security.wrappers`) to symlink `/run/tetrd-<hex>.sock` → `/run/tetrd/run/tetrd.sock`.
- App wrapper scrapes the first logged socket path when `services.tetrd.enable` is set.

### Module

- No longer forces `networking.resolvconf.enable = false` or hijacks host `/etc/resolv.conf`.
- Private resolv at `/run/tetrd-dns/resolv.conf` (bound into the chroot); publish into resolvconf only if resolvconf is already enabled (path unit + 300 ms debounce).
- `DevicePolicy=closed` with `char-usb_device` + `/dev/net/tun` (USB + TUN `tetrd0`).
- USB via `tetrd-usb` group and udev `TAG+="uaccess"` for local seats.
- NixOS VM test: layout, lnsock checks, DNS path/apply/stop.

Homepage: https://tetrd.app

### Breaking changes

Documented under **NixOS 26.11 → Backward Incompatibilities** in
`nixos/doc/manual/release-notes/rl-2611.section.md`. In short:

- Host DNS is not replaced; phone DNS is optional via resolvconf.
- GUI needs the module (socket linker + USB rules), not the app autostart toggle under DynamicUser.
- USB/device access uses group + uaccess and a cgroup device allow-list.

### Automation / AI disclosure

Per [CONTRIBUTING.md § Automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy):

- **Tooling:** Grok (xAI), Grok 4.5 — drafting/iterating package, module, test, release notes, and this PR text.
- **Human accountability:** I am the author of record. I reviewed the changes, ran `nixosTests.tetrd`, and validated phone connect / TUN / device FDs on a real `x86_64-linux` machine.
- **Commits:** each commit has an `Assisted-by: Grok 4.5 (xAI)` trailer (not `Co-authored-by`).

### Other
As a side-note, for me the last PR (1.0.4 -> 1.3.1-1) doesn't work.
1.3.2 seems to change a lot of things, so things like the security wrapper are definitely needed.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests] (`nix-build -A nixosTests.tetrd`).
  - [x] [Package tests] at `passthru.tests` (wired to `nixosTests.tetrd`).
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Built package; live GUI + daemon (connect, `tetrd0`, USB + tun under closed device policy).
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test