### PR TITLE
libmodsecurity: 3.0.15 -> 3.0.16

### DIFF
--- a/pkgs/by-name/li/libmodsecurity/package.nix
+++ b/pkgs/by-name/li/libmodsecurity/package.nix
@@ -20,13 +20,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libmodsecurity";
-  version = "3.0.15";
+  version = "3.0.16";
 
   src = fetchFromGitHub {
     owner = "owasp-modsecurity";
     repo = "ModSecurity";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-gI874wkqy8VuwxUmIgb8d7fULJUQ+rKBBF492NtuRMY=";
+    hash = "sha256-KkUZ52IQ8kZPP4znvNX2kDCbYFBesmvV5i1tVgHFct8=";
     fetchSubmodules = true;
   };
 
@@ -63,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = ''
-    # https://github.com/owasp-modsecurity/ModSecurity/blob/v3.0.15/build.sh#L6-L25
+    # https://github.com/owasp-modsecurity/ModSecurity/blob/v3.0.16/build.sh#L6-L25
     echo "noinst_HEADERS = \\" > ./src/headers.mk
     ls -1 ./src/ \
         actions/*.h \


### PR DESCRIPTION
Updates libmodsecurity to [3.0.16](https://github.com/owasp-modsecurity/ModSecurity/releases/tag/v3.0.16), fixing [CVE-2026-52747](https://nvd.nist.gov/vuln/detail/CVE-2026-52747) and [CVE-2026-52761](https://nvd.nist.gov/vuln/detail/CVE-2026-52761).

Addresses #542113. A manual backport to `release-26.05` is required.

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
