### PR TITLE
skawarePackages: simplify/modernize packaging and use pkg-config

### DIFF
--- a/pkgs/development/skaware-packages/build-skaware-man-pages.nix
+++ b/pkgs/development/skaware-packages/build-skaware-man-pages.nix
@@ -3,47 +3,46 @@
   stdenv,
   fetchFromSourcehut,
 }:
-
-{
-  # : string
-  pname,
-  # : string
-  version,
-  # : string
-  sha256,
-  # : string
-  description,
-  # : list Maintainer
-  maintainers,
-  # : license
-  license ? lib.licenses.isc,
-  # : string
-  owner ? "~humm",
-  # : string
-  rev ? "v${version}",
-}:
-
-let
-  manDir = "${placeholder "out"}/share/man";
-
-  src = fetchFromSourcehut {
-    inherit owner rev sha256;
-    repo = pname;
-  };
-in
-
-stdenv.mkDerivation {
-  inherit pname version src;
-
-  makeFlags = [
-    "MAN_DIR=${manDir}"
+lib.extendMkDerivation {
+  constructDrv = stdenv.mkDerivation;
+  excludeDrvArgNames = [
+    "sha256"
+    "description"
+    "maintainers"
+    "license"
+    "owner"
+    "rev"
   ];
-
-  dontBuild = true;
-
-  meta = {
-    inherit description license maintainers;
-    inherit (src.meta) homepage;
-    platforms = lib.platforms.all;
-  };
+  extendDrvArgs =
+    finalAttrs:
+    {
+      sha256,
+      description,
+      maintainers,
+      license ? lib.licenses.isc,
+      owner ? "~humm",
+      rev ? "v${finalAttrs.version}",
+      meta ? { },
+      ...
+    }:
+    let
+      manDir = "${placeholder "out"}/share/man";
+      src = fetchFromSourcehut {
+        inherit owner rev sha256;
+        repo = finalAttrs.pname;
+      };
+    in
+    {
+      inherit src;
+      makeFlags = [
+        "MAN_DIR=${manDir}"
+      ];
+      dontBuild = true;
+      meta = {
+        inherit description license maintainers;
+        inherit (src.meta) homepage;
+        platforms = lib.platforms.all;
+      }
+      // meta;
+    };
 }

--- a/pkgs/development/skaware-packages/build-skaware-package.nix
+++ b/pkgs/development/skaware-packages/build-skaware-package.nix
@@ -69,6 +69,8 @@ let
     "CONTRIBUTING"
   ];
 
+  libraryOutput = if lib.elem "lib" outputs then "lib" else "out";
+
 in
 stdenv.mkDerivation {
   inherit pname version;
@@ -146,6 +148,14 @@ stdenv.mkDerivation {
   '';
 
   postFixup = ''
+    if [ -d "$dev/lib/pkgconfig" ]; then
+      for pc in "$dev"/lib/pkgconfig/*.pc; do
+        sed -i "s|^libdir=.*|libdir=${placeholder libraryOutput}/lib|" "$pc"
+        if ! grep -q '^Libs.private:' "$pc"; then
+          sed -i "/^Libs:/a Libs.private: -L${placeholder libraryOutput}/lib" "$pc"
+        fi
+      done
+    fi
     ${cleanPackaging.checkForRemainingFiles}
   '';
 

--- a/pkgs/development/skaware-packages/build-skaware-package.nix
+++ b/pkgs/development/skaware-packages/build-skaware-package.nix
@@ -42,6 +42,7 @@ lib.extendMkDerivation {
         "tools/**/*"
         "package/**/*"
         "config.mak"
+        "*.pc"
       ];
       # File globs that should be moved to $doc
       commonMetaFiles = [
@@ -84,9 +85,19 @@ lib.extendMkDerivation {
         configureFlags
         ++ [
           "--enable-absolute-paths"
+          # We assume every Nix-based cross target has urandom.
+          # This might not hold for e.g. BSD.
           "--with-sysdep-devurandom=yes"
           (if stdenv.hostPlatform.isDarwin then "--disable-shared" else "--enable-shared")
+          # Use pkg-config
+          "--with-pkgconfig=pkg-config"
+          "--enable-pkgconfig"
         ]
+        # On Darwin, the target triplet from -dumpmachine includes version number,
+        # but skarnet.org software uses the triplet to test binary compatibility.
+        # Explicitly setting target ensures code can be compiled against a skalibs
+        # binary built on a different version of Darwin.
+        # http://www.skarnet.org/cgi-bin/archive.cgi?1:mss:623:heiodchokfjdkonfhdph
         ++ (lib.optional stdenv.hostPlatform.isDarwin "--build=${stdenv.hostPlatform.system}");
       makeFlags = lib.optionals stdenv.cc.isClang [
         "AR=${stdenv.cc.targetPrefix}ar"

--- a/pkgs/development/skaware-packages/build-skaware-package.nix
+++ b/pkgs/development/skaware-packages/build-skaware-package.nix
@@ -4,186 +4,151 @@
   cleanPackaging,
   fetchurl,
   nix-update-script,
+  pkg-config,
 }:
-{
-  # : string
-  pname,
-  # : string
-  version,
-  # : string
-  sha256 ? lib.fakeSha256,
-  # : drv | null
-  manpages ? null,
-  # : string
-  description,
-  # : list Platform
-  platforms ? lib.platforms.all,
-  # : list string
-  outputs ? [
-    "bin"
-    "lib"
-    "dev"
-    "doc"
-    "out"
-  ],
-  # TODO(Profpatsch): automatically infer most of these
-  # : list string
-  configureFlags,
-  # : string
-  postConfigure ? null,
-  # mostly for moving and deleting files from the build directory
-  # : lines
-  postInstall,
-  # : list Maintainer
-  maintainers ? [ ],
-  # : passthru arguments (e.g. tests)
-  passthru ? { },
-  # : attributes to be merged into meta
-  broken ? false,
-}:
-
-let
-
-  # File globs that can always be deleted
-  commonNoiseFiles = [
-    ".gitignore"
-    "Makefile"
-    "INSTALL"
-    "configure"
-    "patch-for-solaris"
-    "src/**/*"
-    "tools/**/*"
-    "package/**/*"
-    "config.mak"
+lib.extendMkDerivation {
+  constructDrv = stdenv.mkDerivation;
+  excludeDrvArgNames = [
+    "sha256"
+    "manpages"
   ];
-
-  # File globs that should be moved to $doc
-  commonMetaFiles = [
-    "COPYING"
-    "AUTHORS"
-    "NEWS"
-    "CHANGELOG"
-    "README"
-    "README.*"
-    "DCO"
-    "CONTRIBUTING"
-  ];
-
-  libraryOutput = if lib.elem "lib" outputs then "lib" else "out";
-
-in
-stdenv.mkDerivation {
-  inherit pname version;
-
-  src = fetchurl {
-    url = "https://skarnet.org/software/${pname}/${pname}-${version}.tar.gz";
-    inherit sha256;
-  };
-
-  outputs =
-    if manpages == null then
-      outputs
-    else
-      assert (
-        lib.assertMsg (!lib.elem "man" outputs)
-          "If you pass `manpages` to `skawarePackages.buildPackage`, you cannot have a `man` output already!"
-      );
-      # insert as early as possible, but keep the first element
-      if lib.length outputs > 0 then
-        [
-          (lib.head outputs)
-          "man"
-        ]
-        ++ lib.tail outputs
-      else
-        [ "man" ];
-
-  dontDisableStatic = true;
-  enableParallelBuilding = true;
-
-  configureFlags =
-    configureFlags
-    ++ [
-      "--enable-absolute-paths"
-      # We assume every nix-based cross target has urandom.
-      # This might not hold for e.g. BSD.
-      "--with-sysdep-devurandom=yes"
-      (if stdenv.hostPlatform.isDarwin then "--disable-shared" else "--enable-shared")
-    ]
-    # On darwin, the target triplet from -dumpmachine includes version number,
-    # but skarnet.org software uses the triplet to test binary compatibility.
-    # Explicitly setting target ensures code can be compiled against a skalibs
-    # binary built on a different version of darwin.
-    # http://www.skarnet.org/cgi-bin/archive.cgi?1:mss:623:heiodchokfjdkonfhdph
-    ++ (lib.optional stdenv.hostPlatform.isDarwin "--build=${stdenv.hostPlatform.system}");
-
-  inherit postConfigure;
-
-  makeFlags = lib.optionals stdenv.cc.isClang [
-    "AR=${stdenv.cc.targetPrefix}ar"
-    "RANLIB=${stdenv.cc.targetPrefix}ranlib"
-  ];
-
-  # TODO(Profpatsch): ensure that there is always a $doc output!
-  postInstall = ''
-    echo "Cleaning & moving common files"
-    ${
-      cleanPackaging.commonFileActions {
-        noiseFiles = commonNoiseFiles;
-        docFiles = commonMetaFiles;
-      }
-    } $doc/share/doc/${pname}
-
-    ${
-      if manpages == null then
-        ''echo "no manpages for this package"''
-      else
-        ''
-          echo "copying manpages"
-          cp -vr ${manpages} $man
-        ''
-    }
-
-    ${postInstall}
-  '';
-
-  postFixup = ''
-    if [ -d "$dev/lib/pkgconfig" ]; then
-      for pc in "$dev"/lib/pkgconfig/*.pc; do
-        sed -i "s|^libdir=.*|libdir=${placeholder libraryOutput}/lib|" "$pc"
-        if ! grep -q '^Libs.private:' "$pc"; then
-          sed -i "/^Libs:/a Libs.private: -L${placeholder libraryOutput}/lib" "$pc"
-        fi
-      done
-    fi
-    ${cleanPackaging.checkForRemainingFiles}
-  '';
-
-  passthru = {
-    updateScript = nix-update-script {
-      extraArgs = [
-        "--url"
-        "https://github.com/skarnet/${pname}"
-        "--override-filename"
-        "pkgs/development/skaware-packages/${pname}/default.nix"
+  extendDrvArgs =
+    finalAttrs:
+    {
+      sha256 ? lib.fakeSha256,
+      manpages ? null,
+      meta ? { },
+      outputs ? [
+        "bin"
+        "lib"
+        "dev"
+        "doc"
+        "out"
+      ],
+      nativeBuildInputs ? [ ],
+      configureFlags,
+      passthru ? { },
+      ...
+    }@args:
+    let
+      # File globs that can always be deleted
+      commonNoiseFiles = [
+        ".gitignore"
+        "Makefile"
+        "INSTALL"
+        "configure"
+        "patch-for-solaris"
+        "src/**/*"
+        "tools/**/*"
+        "package/**/*"
+        "config.mak"
       ];
+      # File globs that should be moved to $doc
+      commonMetaFiles = [
+        "COPYING"
+        "AUTHORS"
+        "NEWS"
+        "CHANGELOG"
+        "README"
+        "README.*"
+        "DCO"
+        "CONTRIBUTING"
+      ];
+      libraryOutput = if lib.elem "lib" outputs then "lib" else "out";
+    in
+    {
+      src = fetchurl {
+        url = "https://skarnet.org/software/${finalAttrs.pname}/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
+        inherit sha256;
+      };
+      outputs =
+        if manpages == null then
+          outputs
+        else
+          assert (
+            lib.assertMsg (!lib.elem "man" outputs)
+              "If you pass `manpages` to `skawarePackages.buildPackage`, you cannot have a `man` output already!"
+          );
+          if lib.length outputs > 0 then
+            [
+              (lib.head outputs)
+              "man"
+            ]
+            ++ lib.tail outputs
+          else
+            [ "man" ];
+      dontDisableStatic = true;
+      enableParallelBuilding = true;
+      nativeBuildInputs = [ pkg-config ] ++ nativeBuildInputs;
+      configureFlags =
+        configureFlags
+        ++ [
+          "--enable-absolute-paths"
+          "--with-sysdep-devurandom=yes"
+          (if stdenv.hostPlatform.isDarwin then "--disable-shared" else "--enable-shared")
+        ]
+        ++ (lib.optional stdenv.hostPlatform.isDarwin "--build=${stdenv.hostPlatform.system}");
+      makeFlags = lib.optionals stdenv.cc.isClang [
+        "AR=${stdenv.cc.targetPrefix}ar"
+        "RANLIB=${stdenv.cc.targetPrefix}ranlib"
+      ];
+      postInstall = ''
+        echo "Cleaning & moving common files"
+        ${
+          cleanPackaging.commonFileActions {
+            noiseFiles = commonNoiseFiles;
+            docFiles = commonMetaFiles;
+          }
+        } $doc/share/doc/${finalAttrs.pname}
+
+        ${
+          if manpages == null then
+            ''echo "no manpages for this package"''
+          else
+            ''
+              echo "copying manpages"
+              cp -vr ${manpages} $man
+            ''
+        }
+
+        ${args.postInstall or ""}
+      '';
+      postFixup = ''
+        if [ -d "$dev/lib/pkgconfig" ]; then
+          for pc in "$dev"/lib/pkgconfig/*.pc; do
+            sed -i "s|^libdir=.*|libdir=${placeholder libraryOutput}/lib|" "$pc"
+            if ! grep -q '^Libs.private:' "$pc"; then
+              sed -i "/^Libs:/a Libs.private: -L${placeholder libraryOutput}/lib" "$pc"
+            fi
+          done
+        fi
+        ${cleanPackaging.checkForRemainingFiles}
+      '';
+      passthru = {
+        updateScript = nix-update-script {
+          extraArgs = [
+            "--url"
+            "https://github.com/skarnet/${finalAttrs.pname}"
+            "--override-filename"
+            "pkgs/development/skaware-packages/${finalAttrs.pname}/default.nix"
+          ];
+        };
+      }
+      // passthru
+      // (if manpages == null then { } else { inherit manpages; });
+      meta = {
+        homepage = "https://skarnet.org/software/${finalAttrs.pname}/";
+        platforms = lib.platforms.all;
+        license = lib.licenses.isc;
+        maintainers =
+          with lib.maintainers;
+          [
+            pmahoney
+            Profpatsch
+            qyliss
+          ]
+          ++ (meta.maintainers or [ ]);
+      }
+      // meta;
     };
-  }
-  // passthru
-  // (if manpages == null then { } else { inherit manpages; });
-
-  meta = {
-    homepage = "https://skarnet.org/software/${pname}/";
-    inherit broken description platforms;
-    license = lib.licenses.isc;
-    maintainers =
-      with lib.maintainers;
-      [
-        pmahoney
-        Profpatsch
-        qyliss
-      ]
-      ++ maintainers;
-  };
-
 }

--- a/pkgs/development/skaware-packages/execline/default.nix
+++ b/pkgs/development/skaware-packages/execline/default.nix
@@ -40,10 +40,12 @@ skawarePackages.buildPackage {
 
   # TODO: nsss support
   configureFlags = [
-    "--libdir=\${lib}/lib"
-    "--dynlibdir=\${lib}/lib"
-    "--bindir=\${bin}/bin"
-    "--includedir=\${dev}/include"
+    "--libdir=${placeholder "lib"}/lib"
+    "--dynlibdir=${placeholder "out"}/lib"
+    "--libexecdir=${placeholder "lib"}/libexec"
+    "--bindir=${placeholder "bin"}/bin"
+    "--includedir=${placeholder "dev"}/include"
+    "--pkgconfdir=${placeholder "dev"}/lib/pkgconfig"
     "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
     "--with-include=${skalibs.dev}/include"
     "--with-lib=${skalibs.lib}/lib"

--- a/pkgs/development/skaware-packages/execline/default.nix
+++ b/pkgs/development/skaware-packages/execline/default.nix
@@ -37,6 +37,7 @@ skawarePackages.buildPackage {
     "doc"
     "out"
   ];
+  buildInputs = [ skalibs ];
 
   # TODO: nsss support
   configureFlags = [
@@ -47,9 +48,6 @@ skawarePackages.buildPackage {
     "--includedir=${placeholder "dev"}/include"
     "--pkgconfdir=${placeholder "dev"}/lib/pkgconfig"
     "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
-    "--with-include=${skalibs.dev}/include"
-    "--with-lib=${skalibs.lib}/lib"
-    "--with-dynlib=${skalibs.lib}/lib"
   ];
 
   postInstall = ''
@@ -72,11 +70,10 @@ skawarePackages.buildPackage {
       -Wall -Wpedantic \
       -D "EXECLINEB_PATH()=\"$bin/bin/.execlineb-wrapped\"" \
       -D "EXECLINE_BIN_PATH()=\"$bin/bin\"" \
-      -I "${skalibs.dev}/include" \
-      -L "${skalibs.lib}/lib" \
+      $(pkg-config --cflags libskarnet) \
       -o "$bin/bin/execlineb" \
       ${./execlineb-wrapper.c} \
-      -lskarnet
+      $(pkg-config --libs libskarnet)
   '';
 
   # Write an execline script.

--- a/pkgs/development/skaware-packages/execline/default.nix
+++ b/pkgs/development/skaware-packages/execline/default.nix
@@ -28,7 +28,7 @@ skawarePackages.buildPackage {
     maintainers = [ lib.maintainers.sternenseemann ];
   };
 
-  description = "Small scripting language, to be used in place of a shell in non-interactive scripts";
+  meta.description = "Small scripting language, to be used in place of a shell in non-interactive scripts";
 
   outputs = [
     "bin"

--- a/pkgs/development/skaware-packages/mdevd/default.nix
+++ b/pkgs/development/skaware-packages/mdevd/default.nix
@@ -20,6 +20,12 @@ skawarePackages.buildPackage {
   ];
 
   configureFlags = [
+    "--libdir=${placeholder "out"}/lib"
+    "--dynlibdir=${placeholder "out"}/lib"
+    "--libexecdir=${placeholder "out"}/libexec"
+    "--bindir=${placeholder "bin"}/bin"
+    "--includedir=${placeholder "dev"}/include"
+    "--pkgconfdir=${placeholder "dev"}/lib/pkgconfig"
     "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
     "--with-include=${skalibs.dev}/include"
     "--with-lib=${skalibs.lib}/lib"

--- a/pkgs/development/skaware-packages/mdevd/default.nix
+++ b/pkgs/development/skaware-packages/mdevd/default.nix
@@ -9,8 +9,8 @@ skawarePackages.buildPackage {
   version = "0.1.8.2";
   sha256 = "sha256-zhrgFJtqV6NPYIIY/WGBqmqmgTXKwvTZMbW0F7By4kQ=";
 
-  description = "mdev-compatible Linux hotplug manager daemon";
-  platforms = lib.platforms.linux;
+  meta.description = "mdev-compatible Linux hotplug manager daemon";
+  meta.platforms = lib.platforms.linux;
 
   outputs = [
     "bin"

--- a/pkgs/development/skaware-packages/mdevd/default.nix
+++ b/pkgs/development/skaware-packages/mdevd/default.nix
@@ -19,6 +19,8 @@ skawarePackages.buildPackage {
     "doc"
   ];
 
+  buildInputs = [ skalibs ];
+
   configureFlags = [
     "--libdir=${placeholder "out"}/lib"
     "--dynlibdir=${placeholder "out"}/lib"
@@ -27,8 +29,6 @@ skawarePackages.buildPackage {
     "--includedir=${placeholder "dev"}/include"
     "--pkgconfdir=${placeholder "dev"}/lib/pkgconfig"
     "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
-    "--with-include=${skalibs.dev}/include"
-    "--with-lib=${skalibs.lib}/lib"
   ];
 
   postInstall = ''

--- a/pkgs/development/skaware-packages/nsss/default.nix
+++ b/pkgs/development/skaware-packages/nsss/default.nix
@@ -9,10 +9,12 @@ skawarePackages.buildPackage {
 
   # TODO: nsss support
   configureFlags = [
-    "--libdir=\${lib}/lib"
-    "--dynlibdir=\${lib}/lib"
-    "--bindir=\${bin}/bin"
-    "--includedir=\${dev}/include"
+    "--libdir=${placeholder "lib"}/lib"
+    "--dynlibdir=${placeholder "out"}/lib"
+    "--libexecdir=${placeholder "lib"}/libexec"
+    "--bindir=${placeholder "bin"}/bin"
+    "--includedir=${placeholder "dev"}/include"
+    "--pkgconfdir=${placeholder "dev"}/lib/pkgconfig"
     "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
     "--with-include=${skalibs.dev}/include"
     "--with-lib=${skalibs.lib}/lib"

--- a/pkgs/development/skaware-packages/nsss/default.nix
+++ b/pkgs/development/skaware-packages/nsss/default.nix
@@ -9,7 +9,6 @@ skawarePackages.buildPackage {
 
   buildInputs = [ skalibs ];
 
-  # TODO: nsss support
   configureFlags = [
     "--libdir=${placeholder "lib"}/lib"
     "--dynlibdir=${placeholder "out"}/lib"
@@ -18,9 +17,6 @@ skawarePackages.buildPackage {
     "--includedir=${placeholder "dev"}/include"
     "--pkgconfdir=${placeholder "dev"}/lib/pkgconfig"
     "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
-    "--with-include=${skalibs.dev}/include"
-    "--with-lib=${skalibs.lib}/lib"
-    "--with-dynlib=${skalibs.lib}/lib"
   ];
 
   postInstall = ''

--- a/pkgs/development/skaware-packages/nsss/default.nix
+++ b/pkgs/development/skaware-packages/nsss/default.nix
@@ -5,7 +5,9 @@ skawarePackages.buildPackage {
   version = "0.2.1.3";
   sha256 = "sha256-FNpESoNtJLaihvrIilAr2qKWpNMo8J1Sl1aK07PgJoU=";
 
-  description = "Implementation of a subset of the pwd.h, group.h and shadow.h family of functions";
+  meta.description = "Implementation of a subset of the pwd.h, group.h and shadow.h family of functions";
+
+  buildInputs = [ skalibs ];
 
   # TODO: nsss support
   configureFlags = [

--- a/pkgs/development/skaware-packages/s6-dns/default.nix
+++ b/pkgs/development/skaware-packages/s6-dns/default.nix
@@ -16,11 +16,12 @@ skawarePackages.buildPackage {
   ];
 
   configureFlags = [
-    "--libdir=\${lib}/lib"
-    "--libexecdir=\${lib}/libexec"
-    "--dynlibdir=\${lib}/lib"
-    "--bindir=\${bin}/bin"
-    "--includedir=\${dev}/include"
+    "--libdir=${placeholder "lib"}/lib"
+    "--dynlibdir=${placeholder "out"}/lib"
+    "--libexecdir=${placeholder "lib"}/libexec"
+    "--bindir=${placeholder "bin"}/bin"
+    "--includedir=${placeholder "dev"}/include"
+    "--pkgconfdir=${placeholder "dev"}/lib/pkgconfig"
     "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
     "--with-include=${skalibs.dev}/include"
     "--with-lib=${skalibs.lib}/lib"

--- a/pkgs/development/skaware-packages/s6-dns/default.nix
+++ b/pkgs/development/skaware-packages/s6-dns/default.nix
@@ -15,6 +15,8 @@ skawarePackages.buildPackage {
     "out"
   ];
 
+  buildInputs = [ skalibs ];
+
   configureFlags = [
     "--libdir=${placeholder "lib"}/lib"
     "--dynlibdir=${placeholder "out"}/lib"
@@ -23,9 +25,6 @@ skawarePackages.buildPackage {
     "--includedir=${placeholder "dev"}/include"
     "--pkgconfdir=${placeholder "dev"}/lib/pkgconfig"
     "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
-    "--with-include=${skalibs.dev}/include"
-    "--with-lib=${skalibs.lib}/lib"
-    "--with-dynlib=${skalibs.lib}/lib"
   ];
 
   postInstall = ''

--- a/pkgs/development/skaware-packages/s6-dns/default.nix
+++ b/pkgs/development/skaware-packages/s6-dns/default.nix
@@ -5,7 +5,7 @@ skawarePackages.buildPackage {
   version = "2.4.1.3";
   sha256 = "sha256-+enetGSMVQeoSFVINkvRxW2r2jlLye4tfxy7FqA2zXY=";
 
-  description = "Suite of DNS client programs and libraries for Unix systems";
+  meta.description = "Suite of DNS client programs and libraries for Unix systems";
 
   outputs = [
     "bin"

--- a/pkgs/development/skaware-packages/s6-linux-init/default.nix
+++ b/pkgs/development/skaware-packages/s6-linux-init/default.nix
@@ -24,8 +24,12 @@ skawarePackages.buildPackage {
   ];
 
   configureFlags = [
-    "--bindir=\${bin}/bin"
-    "--includedir=\${dev}/include"
+    "--libdir=${placeholder "out"}/lib"
+    "--dynlibdir=${placeholder "out"}/lib"
+    "--libexecdir=${placeholder "out"}/libexec"
+    "--bindir=${placeholder "bin"}/bin"
+    "--includedir=${placeholder "dev"}/include"
+    "--pkgconfdir=${placeholder "dev"}/lib/pkgconfig"
     "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
     "--with-include=${skalibs.dev}/include"
     "--with-include=${execline.dev}/include"

--- a/pkgs/development/skaware-packages/s6-linux-init/default.nix
+++ b/pkgs/development/skaware-packages/s6-linux-init/default.nix
@@ -13,8 +13,8 @@ skawarePackages.buildPackage {
   version = "1.2.0.2";
   sha256 = "sha256-b60BTaFiwMgZJBl8V9FuGnXBM7NKIOQjQxobdB6Qex0=";
 
-  description = "Set of minimalistic tools used to create a s6-based init system, including a /sbin/init binary, on a Linux kernel";
-  platforms = lib.platforms.linux;
+  meta.description = "Set of minimalistic tools used to create a s6-based init system, including a /sbin/init binary, on a Linux kernel";
+  meta.platforms = lib.platforms.linux;
 
   outputs = [
     "bin"

--- a/pkgs/development/skaware-packages/s6-linux-init/default.nix
+++ b/pkgs/development/skaware-packages/s6-linux-init/default.nix
@@ -22,6 +22,11 @@ skawarePackages.buildPackage {
     "doc"
     "out"
   ];
+  buildInputs = [
+    skalibs
+    execline
+    s6
+  ];
 
   configureFlags = [
     "--libdir=${placeholder "out"}/lib"
@@ -31,15 +36,6 @@ skawarePackages.buildPackage {
     "--includedir=${placeholder "dev"}/include"
     "--pkgconfdir=${placeholder "dev"}/lib/pkgconfig"
     "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
-    "--with-include=${skalibs.dev}/include"
-    "--with-include=${execline.dev}/include"
-    "--with-include=${s6.dev}/include"
-    "--with-lib=${skalibs.lib}/lib"
-    "--with-lib=${s6.out}/lib"
-    "--with-lib=${execline.lib}/lib"
-    "--with-dynlib=${skalibs.lib}/lib"
-    "--with-dynlib=${execline.lib}/lib"
-    "--with-dynlib=${s6.out}/lib"
   ];
 
   # See ../s6-rc/default.nix for an explanation

--- a/pkgs/development/skaware-packages/s6-linux-utils/default.nix
+++ b/pkgs/development/skaware-packages/s6-linux-utils/default.nix
@@ -22,8 +22,12 @@ skawarePackages.buildPackage {
 
   # TODO: nsss support
   configureFlags = [
-    "--bindir=\${bin}/bin"
-    "--includedir=\${dev}/include"
+    "--libdir=${placeholder "out"}/lib"
+    "--dynlibdir=${placeholder "out"}/lib"
+    "--libexecdir=${placeholder "out"}/libexec"
+    "--bindir=${placeholder "bin"}/bin"
+    "--includedir=${placeholder "dev"}/include"
+    "--pkgconfdir=${placeholder "dev"}/lib/pkgconfig"
     "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
     "--with-include=${skalibs.dev}/include"
     "--with-include=${execline.dev}/include"

--- a/pkgs/development/skaware-packages/s6-linux-utils/default.nix
+++ b/pkgs/development/skaware-packages/s6-linux-utils/default.nix
@@ -20,6 +20,11 @@ skawarePackages.buildPackage {
     "out"
   ];
 
+  buildInputs = [
+    skalibs
+    execline
+  ];
+
   # TODO: nsss support
   configureFlags = [
     "--libdir=${placeholder "out"}/lib"
@@ -29,12 +34,6 @@ skawarePackages.buildPackage {
     "--includedir=${placeholder "dev"}/include"
     "--pkgconfdir=${placeholder "dev"}/lib/pkgconfig"
     "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
-    "--with-include=${skalibs.dev}/include"
-    "--with-include=${execline.dev}/include"
-    "--with-lib=${skalibs.lib}/lib"
-    "--with-lib=${execline.lib}/lib"
-    "--with-dynlib=${skalibs.lib}/lib"
-    "--with-dynlib=${execline.lib}/lib"
   ];
 
   postInstall = ''

--- a/pkgs/development/skaware-packages/s6-linux-utils/default.nix
+++ b/pkgs/development/skaware-packages/s6-linux-utils/default.nix
@@ -10,8 +10,8 @@ skawarePackages.buildPackage {
   version = "2.6.4.1";
   sha256 = "sha256-FuGltaK0qYZ0tKlxlhKtt5WI48IMQIM2AnjqOPLTISk=";
 
-  description = "Set of minimalistic Linux-specific system utilities";
-  platforms = lib.platforms.linux;
+  meta.description = "Set of minimalistic Linux-specific system utilities";
+  meta.platforms = lib.platforms.linux;
 
   outputs = [
     "bin"

--- a/pkgs/development/skaware-packages/s6-networking/default.nix
+++ b/pkgs/development/skaware-packages/s6-networking/default.nix
@@ -48,11 +48,12 @@ skawarePackages.buildPackage {
 
   # TODO: nsss support
   configureFlags = [
-    "--libdir=\${lib}/lib"
-    "--libexecdir=\${lib}/libexec"
-    "--dynlibdir=\${lib}/lib"
-    "--bindir=\${bin}/bin"
-    "--includedir=\${dev}/include"
+    "--libdir=${placeholder "lib"}/lib"
+    "--dynlibdir=${placeholder "out"}/lib"
+    "--libexecdir=${placeholder "lib"}/libexec"
+    "--bindir=${placeholder "bin"}/bin"
+    "--includedir=${placeholder "dev"}/include"
+    "--pkgconfdir=${placeholder "dev"}/lib/pkgconfig"
     "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
     "--with-include=${skalibs.dev}/include"
     "--with-include=${execline.dev}/include"

--- a/pkgs/development/skaware-packages/s6-networking/default.nix
+++ b/pkgs/development/skaware-packages/s6-networking/default.nix
@@ -45,6 +45,13 @@ skawarePackages.buildPackage {
     "doc"
     "out"
   ];
+  buildInputs = [
+    skalibs
+    execline
+    s6
+    s6-dns
+  ]
+  ++ lib.optional sslSupportEnabled sslLibs.${sslSupport};
 
   # TODO: nsss support
   configureFlags = [
@@ -55,25 +62,8 @@ skawarePackages.buildPackage {
     "--includedir=${placeholder "dev"}/include"
     "--pkgconfdir=${placeholder "dev"}/lib/pkgconfig"
     "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
-    "--with-include=${skalibs.dev}/include"
-    "--with-include=${execline.dev}/include"
-    "--with-include=${s6.dev}/include"
-    "--with-include=${s6-dns.dev}/include"
-    "--with-lib=${skalibs.lib}/lib"
-    "--with-lib=${execline.lib}/lib"
-    "--with-lib=${s6.out}/lib"
-    "--with-lib=${s6-dns.lib}/lib"
-    "--with-dynlib=${skalibs.lib}/lib"
-    "--with-dynlib=${execline.lib}/lib"
-    "--with-dynlib=${s6.out}/lib"
-    "--with-dynlib=${s6-dns.lib}/lib"
   ]
-  ++ (lib.optionals sslSupportEnabled [
-    "--enable-ssl=${sslSupport}"
-    "--with-include=${lib.getDev sslLibs.${sslSupport}}/include"
-    "--with-lib=${lib.getLib sslLibs.${sslSupport}}/lib"
-    "--with-dynlib=${lib.getLib sslLibs.${sslSupport}}/lib"
-  ]);
+  ++ lib.optional sslSupportEnabled "--enable-ssl=${sslSupport}";
 
   postInstall = ''
     # remove all s6 executables from build directory

--- a/pkgs/development/skaware-packages/s6-networking/default.nix
+++ b/pkgs/development/skaware-packages/s6-networking/default.nix
@@ -36,7 +36,7 @@ skawarePackages.buildPackage {
     maintainers = [ lib.maintainers.sternenseemann ];
   };
 
-  description = "Suite of small networking utilities for Unix systems";
+  meta.description = "Suite of small networking utilities for Unix systems";
 
   outputs = [
     "bin"

--- a/pkgs/development/skaware-packages/s6-portable-utils/default.nix
+++ b/pkgs/development/skaware-packages/s6-portable-utils/default.nix
@@ -27,8 +27,12 @@ skawarePackages.buildPackage {
   ];
 
   configureFlags = [
-    "--bindir=\${bin}/bin"
-    "--includedir=\${dev}/include"
+    "--libdir=${placeholder "out"}/lib"
+    "--dynlibdir=${placeholder "out"}/lib"
+    "--libexecdir=${placeholder "out"}/libexec"
+    "--bindir=${placeholder "bin"}/bin"
+    "--includedir=${placeholder "dev"}/include"
+    "--pkgconfdir=${placeholder "dev"}/lib/pkgconfig"
     "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
     "--with-include=${skalibs.dev}/include"
     "--with-lib=${skalibs.lib}/lib"

--- a/pkgs/development/skaware-packages/s6-portable-utils/default.nix
+++ b/pkgs/development/skaware-packages/s6-portable-utils/default.nix
@@ -17,7 +17,7 @@ skawarePackages.buildPackage {
     maintainers = [ lib.maintainers.somasis ];
   };
 
-  description = "Set of tiny general Unix utilities optimized for simplicity and small size";
+  meta.description = "Set of tiny general Unix utilities optimized for simplicity and small size";
 
   outputs = [
     "bin"

--- a/pkgs/development/skaware-packages/s6-portable-utils/default.nix
+++ b/pkgs/development/skaware-packages/s6-portable-utils/default.nix
@@ -26,6 +26,8 @@ skawarePackages.buildPackage {
     "out"
   ];
 
+  buildInputs = [ skalibs ];
+
   configureFlags = [
     "--libdir=${placeholder "out"}/lib"
     "--dynlibdir=${placeholder "out"}/lib"
@@ -34,9 +36,6 @@ skawarePackages.buildPackage {
     "--includedir=${placeholder "dev"}/include"
     "--pkgconfdir=${placeholder "dev"}/lib/pkgconfig"
     "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
-    "--with-include=${skalibs.dev}/include"
-    "--with-lib=${skalibs.lib}/lib"
-    "--with-dynlib=${skalibs.lib}/lib"
   ];
 
   postInstall = ''

--- a/pkgs/development/skaware-packages/s6-rc/default.nix
+++ b/pkgs/development/skaware-packages/s6-rc/default.nix
@@ -32,11 +32,12 @@ skawarePackages.buildPackage {
   ];
 
   configureFlags = [
-    "--libdir=\${out}/lib"
-    "--libexecdir=\${out}/libexec"
-    "--dynlibdir=\${out}/lib"
-    "--bindir=\${out}/bin"
-    "--includedir=\${dev}/include"
+    "--libdir=${placeholder "out"}/lib"
+    "--dynlibdir=${placeholder "out"}/lib"
+    "--libexecdir=${placeholder "out"}/libexec"
+    "--bindir=${placeholder "out"}/bin"
+    "--includedir=${placeholder "dev"}/include"
+    "--pkgconfdir=${placeholder "dev"}/lib/pkgconfig"
     "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
     "--with-include=${skalibs.dev}/include"
     "--with-include=${execline.dev}/include"

--- a/pkgs/development/skaware-packages/s6-rc/default.nix
+++ b/pkgs/development/skaware-packages/s6-rc/default.nix
@@ -21,8 +21,8 @@ skawarePackages.buildPackage {
     maintainers = [ lib.maintainers.qyliss ];
   };
 
-  description = "Service manager for s6-based systems";
-  platforms = lib.platforms.unix;
+  meta.description = "Service manager for s6-based systems";
+  meta.platforms = lib.platforms.unix;
 
   outputs = [
     # "bin" "lib"

--- a/pkgs/development/skaware-packages/s6-rc/default.nix
+++ b/pkgs/development/skaware-packages/s6-rc/default.nix
@@ -30,6 +30,11 @@ skawarePackages.buildPackage {
     "dev"
     "doc"
   ];
+  buildInputs = [
+    skalibs
+    execline
+    s6
+  ];
 
   configureFlags = [
     "--libdir=${placeholder "out"}/lib"
@@ -39,15 +44,6 @@ skawarePackages.buildPackage {
     "--includedir=${placeholder "dev"}/include"
     "--pkgconfdir=${placeholder "dev"}/lib/pkgconfig"
     "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
-    "--with-include=${skalibs.dev}/include"
-    "--with-include=${execline.dev}/include"
-    "--with-include=${s6.dev}/include"
-    "--with-lib=${skalibs.lib}/lib"
-    "--with-lib=${execline.lib}/lib"
-    "--with-lib=${s6.out}/lib"
-    "--with-dynlib=${skalibs.lib}/lib"
-    "--with-dynlib=${execline.lib}/lib"
-    "--with-dynlib=${s6.out}/lib"
   ];
 
   # s6-rc-compile generates built-in service definitions containing

--- a/pkgs/development/skaware-packages/s6/default.nix
+++ b/pkgs/development/skaware-packages/s6/default.nix
@@ -32,11 +32,12 @@ skawarePackages.buildPackage {
 
   # TODO: nsss support
   configureFlags = [
-    "--libdir=\${out}/lib"
-    "--libexecdir=\${out}/libexec"
-    "--dynlibdir=\${out}/lib"
-    "--bindir=\${out}/bin"
-    "--includedir=\${dev}/include"
+    "--libdir=${placeholder "out"}/lib"
+    "--dynlibdir=${placeholder "out"}/lib"
+    "--libexecdir=${placeholder "out"}/libexec"
+    "--bindir=${placeholder "out"}/bin"
+    "--includedir=${placeholder "dev"}/include"
+    "--pkgconfdir=${placeholder "dev"}/lib/pkgconfig"
     "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
     "--with-include=${skalibs.dev}/include"
     "--with-include=${execline.dev}/include"

--- a/pkgs/development/skaware-packages/s6/default.nix
+++ b/pkgs/development/skaware-packages/s6/default.nix
@@ -30,6 +30,11 @@ skawarePackages.buildPackage {
     "doc"
   ];
 
+  buildInputs = [
+    skalibs
+    execline
+  ];
+
   # TODO: nsss support
   configureFlags = [
     "--libdir=${placeholder "out"}/lib"
@@ -39,12 +44,6 @@ skawarePackages.buildPackage {
     "--includedir=${placeholder "dev"}/include"
     "--pkgconfdir=${placeholder "dev"}/lib/pkgconfig"
     "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
-    "--with-include=${skalibs.dev}/include"
-    "--with-include=${execline.dev}/include"
-    "--with-lib=${skalibs.lib}/lib"
-    "--with-lib=${execline.lib}/lib"
-    "--with-dynlib=${skalibs.lib}/lib"
-    "--with-dynlib=${execline.lib}/lib"
   ];
 
   postInstall = ''

--- a/pkgs/development/skaware-packages/s6/default.nix
+++ b/pkgs/development/skaware-packages/s6/default.nix
@@ -18,7 +18,7 @@ skawarePackages.buildPackage {
     maintainers = [ lib.maintainers.sternenseemann ];
   };
 
-  description = "skarnet.org's small & secure supervision software suite";
+  meta.description = "skarnet.org's small & secure supervision software suite";
 
   # NOTE lib: cannot split lib from bin at the moment,
   # since some parts of lib depend on executables in bin.

--- a/pkgs/development/skaware-packages/skalibs/2_10.nix
+++ b/pkgs/development/skaware-packages/skalibs/2_10.nix
@@ -15,6 +15,11 @@ skawarePackages.buildPackage {
   ];
 
   configureFlags = [
+    "--libdir=${placeholder "lib"}/lib"
+    "--dynlibdir=${placeholder "out"}/lib"
+    "--libexecdir=${placeholder "lib"}/libexec"
+    "--includedir=${placeholder "dev"}/include"
+    "--pkgconfdir=${placeholder "dev"}/lib/pkgconfig"
     # assume /dev/random works
     "--enable-force-devr"
     "--libdir=\${lib}/lib"

--- a/pkgs/development/skaware-packages/skalibs/2_10.nix
+++ b/pkgs/development/skaware-packages/skalibs/2_10.nix
@@ -22,9 +22,6 @@ skawarePackages.buildPackage {
     "--pkgconfdir=${placeholder "dev"}/lib/pkgconfig"
     # assume /dev/random works
     "--enable-force-devr"
-    "--libdir=\${lib}/lib"
-    "--dynlibdir=\${lib}/lib"
-    "--includedir=\${dev}/include"
     "--sysdepdir=\${lib}/lib/skalibs/sysdeps"
     # Empty the default path, which would be "/usr/bin:bin".
     # It would be set when PATH is empty. This hurts hermeticity.

--- a/pkgs/development/skaware-packages/skalibs/2_10.nix
+++ b/pkgs/development/skaware-packages/skalibs/2_10.nix
@@ -5,7 +5,7 @@ skawarePackages.buildPackage {
   version = "2.10.0.3";
   sha256 = "0ka6n5rnxd5sn5lycarf596d5wlak5s535zqqlz0rnhdcnpb105p";
 
-  description = "Set of general-purpose C programming libraries";
+  meta.description = "Set of general-purpose C programming libraries";
 
   outputs = [
     "lib"

--- a/pkgs/development/skaware-packages/skalibs/default.nix
+++ b/pkgs/development/skaware-packages/skalibs/default.nix
@@ -20,6 +20,11 @@ skawarePackages.buildPackage {
   ];
 
   configureFlags = [
+    "--libdir=${placeholder "lib"}/lib"
+    "--dynlibdir=${placeholder "out"}/lib"
+    "--libexecdir=${placeholder "lib"}/libexec"
+    "--includedir=${placeholder "dev"}/include"
+    "--pkgconfdir=${placeholder "dev"}/lib/pkgconfig"
     # assume /dev/random works
     "--enable-force-devr"
     "--libdir=\${lib}/lib"

--- a/pkgs/development/skaware-packages/skalibs/default.nix
+++ b/pkgs/development/skaware-packages/skalibs/default.nix
@@ -27,9 +27,6 @@ skawarePackages.buildPackage {
     "--pkgconfdir=${placeholder "dev"}/lib/pkgconfig"
     # assume /dev/random works
     "--enable-force-devr"
-    "--libdir=\${lib}/lib"
-    "--dynlibdir=\${lib}/lib"
-    "--includedir=\${dev}/include"
     "--sysdepdir=\${lib}/lib/skalibs/sysdeps"
     # Empty the default path, which would be "/usr/bin:bin".
     # It would be set when PATH is empty. This hurts hermeticity.

--- a/pkgs/development/skaware-packages/skalibs/default.nix
+++ b/pkgs/development/skaware-packages/skalibs/default.nix
@@ -10,7 +10,7 @@ skawarePackages.buildPackage {
   version = "2.15.1.0";
   sha256 = "sha256-+ckF50k1xv6RHH40Tj6J1fvSAUwaBGULUksVzptWNdE=";
 
-  description = "Set of general-purpose C programming libraries";
+  meta.description = "Set of general-purpose C programming libraries";
 
   outputs = [
     "lib"

--- a/pkgs/development/skaware-packages/tipidee/default.nix
+++ b/pkgs/development/skaware-packages/tipidee/default.nix
@@ -14,17 +14,18 @@ skawarePackages.buildPackage {
   outputs = [
     "bin"
     "lib"
-    "out"
     "dev"
     "doc"
+    "out"
   ];
 
   configureFlags = [
-    "--libdir=\${lib}/lib"
-    "--libexecdir=\${lib}/libexec"
-    "--dynlibdir=\${lib}/lib"
-    "--bindir=\${bin}/bin"
-    "--includedir=\${dev}/include"
+    "--libdir=${placeholder "lib"}/lib"
+    "--dynlibdir=${placeholder "out"}/lib"
+    "--libexecdir=${placeholder "lib"}/libexec"
+    "--bindir=${placeholder "bin"}/bin"
+    "--includedir=${placeholder "dev"}/include"
+    "--pkgconfdir=${placeholder "dev"}/lib/pkgconfig"
     "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
     "--with-include=${skalibs.dev}/include"
     "--with-lib=${skalibs.lib}/lib"

--- a/pkgs/development/skaware-packages/tipidee/default.nix
+++ b/pkgs/development/skaware-packages/tipidee/default.nix
@@ -9,7 +9,7 @@ skawarePackages.buildPackage {
   version = "0.0.8.0";
   sha256 = "sha256-GjllM2YqxwvCsKC4xlYW/6f6IBUIhZMA67mtM82mEC0=";
 
-  description = "HTTP 1.1 webserver, serving static files and CGI/NPH";
+  meta.description = "HTTP 1.1 webserver, serving static files and CGI/NPH";
 
   outputs = [
     "bin"
@@ -46,5 +46,5 @@ skawarePackages.buildPackage {
     mv examples $doc/share/doc/tipidee/examples
   '';
 
-  broken = stdenv.hostPlatform.isDarwin;
+  meta.broken = stdenv.hostPlatform.isDarwin;
 }

--- a/pkgs/development/skaware-packages/tipidee/default.nix
+++ b/pkgs/development/skaware-packages/tipidee/default.nix
@@ -19,6 +19,8 @@ skawarePackages.buildPackage {
     "out"
   ];
 
+  buildInputs = [ skalibs ];
+
   configureFlags = [
     "--libdir=${placeholder "lib"}/lib"
     "--dynlibdir=${placeholder "out"}/lib"
@@ -27,9 +29,6 @@ skawarePackages.buildPackage {
     "--includedir=${placeholder "dev"}/include"
     "--pkgconfdir=${placeholder "dev"}/lib/pkgconfig"
     "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
-    "--with-include=${skalibs.dev}/include"
-    "--with-lib=${skalibs.lib}/lib"
-    "--with-dynlib=${skalibs.lib}/lib"
 
     # we set sysconfdir to /etc here to allow tipidee-config
     # to look in the global paths for its configs.

--- a/pkgs/development/skaware-packages/utmps/default.nix
+++ b/pkgs/development/skaware-packages/utmps/default.nix
@@ -8,10 +8,12 @@ skawarePackages.buildPackage {
   description = "Secure utmpx and wtmp implementation";
 
   configureFlags = [
-    "--libdir=\${lib}/lib"
-    "--dynlibdir=\${lib}/lib"
-    "--bindir=\${bin}/bin"
-    "--includedir=\${dev}/include"
+    "--libdir=${placeholder "lib"}/lib"
+    "--dynlibdir=${placeholder "out"}/lib"
+    "--libexecdir=${placeholder "lib"}/libexec"
+    "--bindir=${placeholder "bin"}/bin"
+    "--includedir=${placeholder "dev"}/include"
+    "--pkgconfdir=${placeholder "dev"}/lib/pkgconfig"
     "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
     "--with-include=${skalibs.dev}/include"
     "--with-lib=${skalibs.lib}/lib"

--- a/pkgs/development/skaware-packages/utmps/default.nix
+++ b/pkgs/development/skaware-packages/utmps/default.nix
@@ -17,9 +17,6 @@ skawarePackages.buildPackage {
     "--includedir=${placeholder "dev"}/include"
     "--pkgconfdir=${placeholder "dev"}/lib/pkgconfig"
     "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
-    "--with-include=${skalibs.dev}/include"
-    "--with-lib=${skalibs.lib}/lib"
-    "--with-dynlib=${skalibs.lib}/lib"
   ];
 
   postInstall = ''

--- a/pkgs/development/skaware-packages/utmps/default.nix
+++ b/pkgs/development/skaware-packages/utmps/default.nix
@@ -5,7 +5,9 @@ skawarePackages.buildPackage {
   version = "0.1.3.4";
   sha256 = "sha256-EtzBAq1qyB+BrsxJUHM9uU81CBlHBUubFHPKxckIELw=";
 
-  description = "Secure utmpx and wtmp implementation";
+  meta.description = "Secure utmpx and wtmp implementation";
+
+  buildInputs = [ skalibs ];
 
   configureFlags = [
     "--libdir=${placeholder "lib"}/lib"


### PR DESCRIPTION
- Forward all attributes to the derivation with `...}@attrs` 
- Use `pkg-config` (Fixes https://github.com/NixOS/nixpkgs/issues/544293)
- use `placeholder`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
