### PR TITLE
siyuan: 3.7.1 -> 3.7.3

### DIFF
--- a/pkgs/by-name/si/siyuan/package.nix
+++ b/pkgs/by-name/si/siyuan/package.nix
@@ -34,20 +34,20 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "siyuan";
-  version = "3.7.1";
+  version = "3.7.3";
 
   src = fetchFromGitHub {
     owner = "siyuan-note";
     repo = "siyuan";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-K31h2noDpTn7vCXj16K2dxRPww5z+HC/nA4Gn5MAVms=";
+    hash = "sha256-7Uoo8vYaci8ROk5pqs14dNrU3q7UsadDXyw1mW8Mx5I=";
   };
 
   kernel = buildGoModule {
     name = "${finalAttrs.pname}-${finalAttrs.version}-kernel";
     inherit (finalAttrs) src;
     sourceRoot = "${finalAttrs.src.name}/kernel";
-    vendorHash = "sha256-fZLVqrWTWUHo6BhixB6+krXaM7WCiZpusHA8T2SicgQ=";
+    vendorHash = "sha256-weg5MRidW8JId13Ug1VaVgaIcJqydGBR/EquFOS3QO4=";
 
     patches = [
       (replaceVars ./set-pandoc-path.patch {
@@ -70,6 +70,9 @@ stdenv.mkDerivation (finalAttrs: {
       "-X 'github.com/siyuan-note/siyuan/kernel/util.Mode=prod'"
     ];
     tags = [ "fts5" ];
+
+    # filepath.ToSlash does not convert Windows path separators on Unix.
+    checkFlags = [ "-skip=^TestSyObjectBase/windows_backslash$" ];
   };
 
   nativeBuildInputs = [
@@ -95,7 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
       ;
     inherit pnpm;
     fetcherVersion = 4;
-    hash = "sha256-1QIGx0Zm6v4FIR1EYgXQzmBMZBa9Bi24vouT1K6v9EQ=";
+    hash = "sha256-i7llORlVU1CCmyVCvJr7xCQffTmbmIA9rT68Raqg5y8=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/app";


### PR DESCRIPTION
Updates SiYuan to the latest stable release. Version 3.7.2 includes fixes for CVE-2026-65605, CVE-2026-65606, CVE-2026-65607, CVE-2026-66012, CVE-2026-66395, and CVE-2026-66396. Version 3.7.3 contains those fixes and additionally fixes CVE-2026-66394.

Changelog: https://github.com/siyuan-note/siyuan/releases/tag/v3.7.3
Security release: https://github.com/siyuan-note/siyuan/releases/tag/v3.7.2

The upstream `TestSyObjectBase/windows_backslash` subtest is skipped because `filepath.ToSlash` does not convert Windows path separators on the Unix platforms supported by this package. All remaining Go tests run during the kernel build.

fixes #545310

fixes #546267

fixes #546673

fixes #546676

fixes #546678

**A manual backport to release-26.05 is required because its pnpm dependency setup differs from master.**

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] Upstream Go test suite through the `siyuan.kernel` build.
  - [x] Embedded kernel version smoke test.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md




