### PR TITLE
nixos/nspawn-container: fix build

### DIFF
--- a/nixos/modules/virtualisation/nspawn-container/run-nspawn/src/run_nspawn/__init__.py
+++ b/nixos/modules/virtualisation/nspawn-container/run-nspawn/src/run_nspawn/__init__.py
@@ -158,7 +158,7 @@ def mk_veth(
 def run(
     container_name: str,
     root_dir_str: str,
-    shared_dir_str: typing.Optional[str],
+    shared_dir_str: str | None,
     interfaces: dict,
     nspawn_options: list[str],
     init: str,
@@ -193,13 +193,6 @@ def run(
                 )
             )
 
-        def print_pid() -> None:
-            print(
-                f"systemd-nspawn's PID is {os.getpid()}",
-                # Need to flush stdout before systemd-nspawn gets exec-ed.
-                flush=True,
-            )
-
         shared_dir = Path(shared_dir_str) if shared_dir_str else None
 
         cp = subprocess.Popen(
@@ -216,7 +209,11 @@ def run(
                 init,
                 *cmdline,
             ],
-            preexec_fn=print_pid,
+        )
+        print(
+            f"systemd-nspawn's PID is {cp.pid}",
+            # Need to flush stdout before systemd-nspawn gets exec-ed.
+            flush=True,
         )
 
         try:


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

#545026 introduced some lints that broke the build

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
