### PR TITLE
lib/services: fix test expectations for the reload options

### DIFF
--- a/lib/services/test.nix
+++ b/lib/services/test.nix
@@ -7,12 +7,6 @@ let
 
   portable-lib = import ./lib.nix { inherit lib; };
 
-  configured = portable-lib.configure {
-    serviceManagerPkgs = throw "do not use pkgs in this test";
-    extraRootModules = [ ];
-    extraRootSpecialArgs = { };
-  };
-
   dummyPkg =
     name:
     derivation {
@@ -20,6 +14,17 @@ let
       name = name;
       builder = "/bin/false";
     };
+
+  configured = portable-lib.configure {
+    # `coreutils` is the only package the portable layer legitimately needs, to derive
+    # `process.reloadCommand` from `process.reloadSignal`. Anything else reaching for
+    # `pkgs` fails on the missing attribute.
+    serviceManagerPkgs = {
+      coreutils = dummyPkg "coreutils";
+    };
+    extraRootModules = [ ];
+    extraRootSpecialArgs = { };
+  };
 
   exampleConfig = {
     services = {
@@ -48,6 +53,7 @@ let
             (dummyPkg "cowsay.sh")
             "world"
           ];
+          reloadCommand = "${dummyPkg "cowsay.sh"} reload";
         };
       };
       service3 = {
@@ -65,6 +71,7 @@ let
               ))
               "!"
             ];
+            reloadSignal = "HUP";
           };
           assertions = [
             {
@@ -148,13 +155,15 @@ let
   # Every service carries some assertions that hold; only the violated ones are of interest here.
   failures = lib.filter (a: !a.assertion);
 
+  # The goal of this test is to perform and check a complete evaluation of all options.
+  # Only filter out values that are truly infeasible to check, such as function values.
   filterEval =
     config:
     lib.optionalAttrs (config ? process) {
       inherit (config) warnings;
       assertions = failures config.assertions;
-      # Only `argv` is relevant here; `process` also carries the reload options.
-      process = { inherit (config.process) argv; };
+      # `flagFormat` is a function and cannot be compared; the rest of `process` is checked.
+      process = { inherit (config.process) argv reloadCommand reloadSignal; };
     }
     // {
       services = lib.mapAttrs (k: filterEval) config.services;
@@ -170,6 +179,8 @@ let
                 "/usr/bin/echo"
                 "hello"
               ];
+              reloadCommand = null;
+              reloadSignal = null;
             };
             services = { };
             assertions = [
@@ -188,6 +199,8 @@ let
                 "${dummyPkg "cowsay.sh"}"
                 "world"
               ];
+              reloadCommand = "${dummyPkg "cowsay.sh"} reload";
+              reloadSignal = null;
             };
             services = { };
             assertions = [ ];
@@ -196,6 +209,8 @@ let
           service3 = {
             process = {
               argv = [ "/bin/false" ];
+              reloadCommand = null;
+              reloadSignal = null;
             };
             services.exclacow = {
               process = {
@@ -203,6 +218,8 @@ let
                   "${dummyPkg "cowsay-ng"}/bin/cowsay"
                   "!"
                 ];
+                reloadCommand = "${dummyPkg "coreutils"}/bin/kill -HUP $MAINPID";
+                reloadSignal = "HUP";
               };
               services = { };
               assertions = [
@@ -228,6 +245,8 @@ let
                 "--name"
                 "example"
               ];
+              reloadCommand = null;
+              reloadSignal = null;
             };
             services = { };
             assertions = [ ];
@@ -241,6 +260,8 @@ let
                 "--quiet=false"
                 "--verbose=true"
               ];
+              reloadCommand = null;
+              reloadSignal = null;
             };
             services = { };
             assertions = [ ];
@@ -255,6 +276,8 @@ let
                 "--host"
                 "b"
               ];
+              reloadCommand = null;
+              reloadSignal = null;
             };
             services = { };
             assertions = [ ];
@@ -270,6 +293,8 @@ let
                 "a"
                 "TRAILING"
               ];
+              reloadCommand = null;
+              reloadSignal = null;
             };
             services = { };
             assertions = [ ];


### PR DESCRIPTION
fixes `nix-instantiate --eval lib/services/test.nix`, a test broken at #535695 and left behind at #540857.

Assisted-by: Claude:claude-opus-5

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
