### PR TITLE
bcachefs-tools: Fetch patch to fix compile-time assertion failure on big-endian

### DIFF
--- a/pkgs/by-name/bc/bcachefs-tools/package.nix
+++ b/pkgs/by-name/bc/bcachefs-tools/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   pkg-config,
   libuuid,
   libsodium,
@@ -44,6 +45,15 @@ stdenv.mkDerivation (finalAttrs: {
     inherit (finalAttrs) src;
     hash = "sha256-F1+FeAlYSqOxeWJI8vHShpXrOZqYXjNGvty/s6f6u8w=";
   };
+
+  patches = [
+    # Fix compile-time assertion failure on big-endian
+    (fetchpatch {
+      name = "0001-bcachefs-tools-debug-copy-packed-bkey-fields-before-asserting.patch";
+      url = "https://evilpiepirate.org/git/bcachefs-tools.git/patch/?id=79f119c4cd6900ab9ea27b0aa671f68300d9d38e";
+      hash = "sha256-ACrpad93wrZOXhc73otnXBNQvyoDeZSfgtwze5nKaUE=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace Makefile \


### PR DESCRIPTION
https://evilpiepirate.org/git/bcachefs-tools.git/commit/?id=79f119c4cd6900ab9ea27b0aa671f68300d9d38e

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] powerpc64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
