### PR TITLE
npm-cache-prefetch: allow to fetch multiple lock files into single cache

### DIFF
--- a/pkgs/build-support/node/prefetch-npm-deps/src/cacache.rs
+++ b/pkgs/build-support/node/prefetch-npm-deps/src/cacache.rs
@@ -1,14 +1,18 @@
+use anyhow::anyhow;
 use data_encoding::BASE64;
 use digest::{Digest, Update};
 use serde::{Deserialize, Serialize};
 use sha1::Sha1;
 use sha2::{Sha256, Sha512};
 use std::{
+    collections::HashMap,
     fmt::Write as FmtWrite,
-    fs::{self, File},
+    fs,
     io::Write,
-    path::PathBuf,
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
 };
+use tempfile::NamedTempFile;
 use url::Url;
 
 #[allow(clippy::struct_field_names)]
@@ -29,7 +33,7 @@ pub(super) struct Metadata {
     pub(super) options: Options,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct ReqHeaders {
     pub accept: String,
 }
@@ -39,7 +43,11 @@ pub(super) struct Options {
     pub(super) compress: bool,
 }
 
-pub struct Cache(PathBuf);
+pub struct Cache {
+    path: PathBuf,
+    /// Per-bucket-file locks to serialise concurrent upserts within one process (rayon threads).
+    locks: Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>,
+}
 
 fn push_hash_segments(path: &mut PathBuf, hash: &str) {
     path.push(&hash[0..2]);
@@ -47,16 +55,104 @@ fn push_hash_segments(path: &mut PathBuf, hash: &str) {
     path.push(&hash[4..]);
 }
 
+fn hex_string(bytes: &[u8]) -> String {
+    bytes.iter().fold(String::new(), |mut out, n| {
+        let _ = write!(out, "{n:02x}");
+        out
+    })
+}
+
+/// Compare two `req_headers` values for equivalence (both None, or both Some with same accept).
+fn req_headers_match(a: &Option<ReqHeaders>, b: &Option<ReqHeaders>) -> bool {
+    match (a, b) {
+        (None, None) => true,
+        (Some(a), Some(b)) => a.accept == b.accept,
+        _ => false,
+    }
+}
+
 impl Cache {
     pub fn new(path: PathBuf) -> Cache {
-        Cache(path)
+        Cache {
+            path,
+            locks: Mutex::new(HashMap::new()),
+        }
     }
 
     pub fn init(&self) -> anyhow::Result<()> {
-        fs::create_dir_all(self.0.join("content-v2"))?;
-        fs::create_dir_all(self.0.join("index-v5"))?;
+        fs::create_dir_all(self.path.join("content-v2"))?;
+        fs::create_dir_all(self.path.join("index-v5"))?;
 
         Ok(())
+    }
+
+    /// Compute the index-v5 bucket file path for a given cache key.
+    fn index_path(&self, key: &str) -> PathBuf {
+        let mut p = self.path.join("index-v5");
+        push_hash_segments(&mut p, &hex_string(&Sha256::new().chain(key).finalize()));
+        p
+    }
+
+    /// Get (or create) the per-bucket mutex for serialising upserts.
+    fn bucket_lock(&self, path: &Path) -> Arc<Mutex<()>> {
+        let mut locks = self.locks.lock().unwrap();
+        locks.entry(path.to_path_buf()).or_default().clone()
+    }
+
+    /// Read all index entries for a given key from its bucket file.
+    ///
+    /// Returns an empty vec if the bucket file does not exist yet.
+    pub(super) fn read_index(&self, key: &str) -> anyhow::Result<Vec<Key>> {
+        let index_path = self.index_path(key);
+        let content = match fs::read_to_string(&index_path) {
+            Ok(c) => c,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => return Err(e.into()),
+        };
+
+        let mut entries = Vec::new();
+        for line in content.lines() {
+            if line.is_empty() {
+                continue;
+            }
+            let json_part = line
+                .split_once('\t')
+                .map(|(_, json)| json)
+                .ok_or_else(|| anyhow!("invalid cache index entry: missing tab separator"))?;
+            let entry: Key = serde_json::from_str(json_part)?;
+            if entry.key == key {
+                entries.push(entry);
+            }
+        }
+        Ok(entries)
+    }
+
+    /// Check whether an entry for `key` exists in the cache.
+    ///
+    /// If `integrity` is `Some`, only returns true if an entry with that exact
+    /// integrity string exists. If `integrity` is `None`, returns true if any
+    /// entry for the key exists (used for git deps where integrity is computed
+    /// from the tarball data).
+    pub fn has(&self, key: &str, integrity: Option<&str>) -> bool {
+        match self.read_index(key) {
+            Ok(entries) => entries
+                .iter()
+                .any(|e| integrity.map_or(true, |i| e.integrity == i)),
+            Err(_) => false,
+        }
+    }
+
+    /// Check whether an entry for `key` with a specific `accept` header exists.
+    ///
+    /// Used for packuments, which are cached under the same key but with
+    /// different `req_headers.accept` values (corgi vs full doc).
+    pub fn has_with_headers(&self, key: &str, accept: &str) -> bool {
+        match self.read_index(key) {
+            Ok(entries) => entries
+                .iter()
+                .any(|e| e.metadata.req_headers.as_ref().is_some_and(|h| h.accept == accept)),
+            Err(_) => false,
+        }
     }
 
     pub fn put(
@@ -83,41 +179,27 @@ impl Cache {
             )
         };
 
+        // --- Content write (idempotent, content-addressed) ---
         let content_path = {
-            let mut p = self.0.join("content-v2");
+            let mut p = self.path.join("content-v2");
 
             p.push(algo);
 
-            push_hash_segments(
-                &mut p,
-                &hash.into_iter().fold(String::new(), |mut out, n| {
-                    let _ = write!(out, "{n:02x}");
-                    out
-                }),
-            );
+            push_hash_segments(&mut p, &hex_string(&hash));
 
             p
         };
 
         fs::create_dir_all(content_path.parent().unwrap())?;
 
-        fs::write(content_path, data)?;
+        fs::write(&content_path, data)?;
 
-        let index_path = {
-            let mut p = self.0.join("index-v5");
-
-            push_hash_segments(
-                &mut p,
-                &format!("{:x}", Sha256::new().chain(&key).finalize()),
-            );
-
-            p
-        };
-
+        // --- Index write (upsert: read-modify-write with atomic rename) ---
+        let index_path = self.index_path(&key);
         fs::create_dir_all(index_path.parent().unwrap())?;
 
-        let data = serde_json::to_string(&Key {
-            key,
+        let key_struct = Key {
+            key: key.clone(),
             integrity,
             time: 0,
             size: data.len(),
@@ -126,25 +208,239 @@ impl Cache {
                 req_headers,
                 options: Options { compress: true },
             },
-        })?;
+        };
+        let serialized = serde_json::to_string(&key_struct)?;
+        let new_line = format!(
+            "{:x}\t{serialized}",
+            Sha1::new().chain(&serialized).finalize()
+        );
 
-        let mut file = File::options()
-            .append(true)
-            .create(true)
-            .open(&index_path)?;
+        // Serialise upserts to the same bucket file across rayon threads.
+        let lock = self.bucket_lock(&index_path);
+        let _guard = lock.lock().unwrap();
 
-        // cacache format uses newline as entry separator (see cacache entry-index.js)
-        // Only add newline prefix if file already has content, to maintain backwards compatibility with previous versions of prefetch-npm-deps, which handled this case incorrectly.
-        let needs_newline = fs::metadata(&index_path)
-            .map(|m| m.len() > 0)
-            .unwrap_or(false);
-        let prefix = if needs_newline { "\n" } else { "" };
-        write!(
-            file,
-            "{prefix}{:x}\t{data}",
-            Sha1::new().chain(&data).finalize()
-        )?;
+        // Read existing bucket content (may not exist yet).
+        let existing = fs::read_to_string(&index_path).unwrap_or_default();
+
+        // Rebuild: keep all lines except those matching (key, req_headers),
+        // then append our single new line.
+        // cacache format uses newline as entry separator (see cacache entry-index.js).
+        // First entry has no leading newline; subsequent entries are \n-separated.
+        let mut new_content = String::new();
+        let mut first = true;
+        for line in existing.lines() {
+            if line.is_empty() {
+                continue;
+            }
+            let json_part = match line.split_once('\t') {
+                Some((_, json)) => json,
+                None => continue, // skip malformed lines
+            };
+            let entry: Key = match serde_json::from_str(json_part) {
+                Ok(e) => e,
+                Err(_) => continue, // skip malformed lines
+            };
+            // Drop entries with same key AND same req_headers (upsert).
+            if entry.key == key && req_headers_match(&entry.metadata.req_headers, &key_struct.metadata.req_headers)
+            {
+                continue;
+            }
+            if !first {
+                new_content.push('\n');
+            }
+            new_content.push_str(line);
+            first = false;
+        }
+        if !first {
+            new_content.push('\n');
+        }
+        new_content.push_str(&new_line);
+
+        // Atomic write: temp file in same dir, then rename.
+        let dir = index_path.parent().unwrap();
+        let mut tmp = NamedTempFile::new_in(dir)?;
+        tmp.write_all(new_content.as_bytes())?;
+        tmp.as_file().sync_all()?;
+        tmp.persist(&index_path)
+            .map_err(|e| anyhow!("failed to persist index file: {e}"))?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_cache() -> (tempfile::TempDir, Cache) {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = Cache::new(dir.path().join("_cacache"));
+        cache.init().unwrap();
+        (dir, cache)
+    }
+
+    #[test]
+    fn put_same_key_twice_has_one_entry() {
+        let (_dir, cache) = make_cache();
+        let url = Url::parse("https://example.com/foo.tgz").unwrap();
+        let key = String::from("make-fetch-happen:request-cache:https://example.com/foo.tgz");
+
+        cache
+            .put(
+                key.clone(),
+                url.clone(),
+                b"data1",
+                Some("sha512-aaaa".into()),
+                None,
+            )
+            .unwrap();
+        cache
+            .put(key.clone(), url, b"data1", Some("sha512-aaaa".into()), None)
+            .unwrap();
+
+        let entries = cache.read_index(&key).unwrap();
+        assert_eq!(entries.len(), 1, "duplicate put should result in one entry");
+    }
+
+    #[test]
+    fn put_different_headers_both_present() {
+        let (_dir, cache) = make_cache();
+        let url = Url::parse("https://registry.npmjs.org/foo").unwrap();
+        let key = String::from("make-fetch-happen:request-cache:https://registry.npmjs.org/foo");
+
+        cache
+            .put(
+                key.clone(),
+                url.clone(),
+                b"data",
+                None,
+                Some(ReqHeaders {
+                    accept: "corgi".into(),
+                }),
+            )
+            .unwrap();
+        cache
+            .put(
+                key.clone(),
+                url,
+                b"data",
+                None,
+                Some(ReqHeaders {
+                    accept: "full".into(),
+                }),
+            )
+            .unwrap();
+
+        let entries = cache.read_index(&key).unwrap();
+        assert_eq!(
+            entries.len(),
+            2,
+            "different req_headers should coexist under same key"
+        );
+    }
+
+    #[test]
+    fn has_returns_correct() {
+        let (_dir, cache) = make_cache();
+        let url = Url::parse("https://example.com/foo.tgz").unwrap();
+        let key = String::from("make-fetch-happen:request-cache:https://example.com/foo.tgz");
+
+        assert!(!cache.has(&key, Some("sha512-aaaa")));
+        assert!(!cache.has(&key, None));
+
+        cache
+            .put(
+                key.clone(),
+                url,
+                b"data",
+                Some("sha512-aaaa".into()),
+                None,
+            )
+            .unwrap();
+
+        assert!(cache.has(&key, Some("sha512-aaaa")));
+        assert!(cache.has(&key, None));
+        assert!(!cache.has(&key, Some("sha512-bbbb")));
+    }
+
+    #[test]
+    fn has_with_headers_returns_correct() {
+        let (_dir, cache) = make_cache();
+        let url = Url::parse("https://registry.npmjs.org/foo").unwrap();
+        let key = String::from("make-fetch-happen:request-cache:https://registry.npmjs.org/foo");
+
+        assert!(!cache.has_with_headers(&key, "corgi"));
+        assert!(!cache.has_with_headers(&key, "full"));
+
+        cache
+            .put(
+                key.clone(),
+                url,
+                b"data",
+                None,
+                Some(ReqHeaders {
+                    accept: "corgi".into(),
+                }),
+            )
+            .unwrap();
+
+        assert!(cache.has_with_headers(&key, "corgi"));
+        assert!(!cache.has_with_headers(&key, "full"));
+    }
+
+    #[test]
+    fn two_different_keys_both_survive() {
+        let (_dir, cache) = make_cache();
+        let url1 = Url::parse("https://example.com/foo.tgz").unwrap();
+        let url2 = Url::parse("https://example.com/bar.tgz").unwrap();
+        let key1 = String::from("make-fetch-happen:request-cache:https://example.com/foo.tgz");
+        let key2 = String::from("make-fetch-happen:request-cache:https://example.com/bar.tgz");
+
+        cache
+            .put(
+                key1.clone(),
+                url1,
+                b"data1",
+                Some("sha512-aaaa".into()),
+                None,
+            )
+            .unwrap();
+        cache
+            .put(
+                key2.clone(),
+                url2,
+                b"data2",
+                Some("sha512-bbbb".into()),
+                None,
+            )
+            .unwrap();
+
+        assert!(cache.has(&key1, Some("sha512-aaaa")));
+        assert!(cache.has(&key2, Some("sha512-bbbb")));
+    }
+
+    #[test]
+    fn put_replaces_stale_entry() {
+        // Putting with different integrity for the same key should replace, not duplicate.
+        let (_dir, cache) = make_cache();
+        let url = Url::parse("https://example.com/foo.tgz").unwrap();
+        let key = String::from("make-fetch-happen:request-cache:https://example.com/foo.tgz");
+
+        cache
+            .put(
+                key.clone(),
+                url.clone(),
+                b"data1",
+                Some("sha512-aaaa".into()),
+                None,
+            )
+            .unwrap();
+        cache
+            .put(key.clone(), url, b"data2", Some("sha512-bbbb".into()), None)
+            .unwrap();
+
+        let entries = cache.read_index(&key).unwrap();
+        assert_eq!(entries.len(), 1, "upsert should replace, not duplicate");
+        assert_eq!(entries[0].integrity, "sha512-bbbb");
     }
 }

--- a/pkgs/build-support/node/prefetch-npm-deps/src/main.rs
+++ b/pkgs/build-support/node/prefetch-npm-deps/src/main.rs
@@ -145,45 +145,58 @@ fn fetch_packuments(
         .into_par_iter()
         .try_for_each(|(package_name, requested_versions)| {
             let packument_url = get_packument_url("https://registry.npmjs.org", &package_name)?;
+            let key = format!("make-fetch-happen:request-cache:{packument_url}");
+
+            // Skip the network fetch entirely if both corgi and full variants
+            // are already in the cache (reentrant prefetch).
+            if cache.has_with_headers(&key, CORGI_DOC) && cache.has_with_headers(&key, FULL_DOC) {
+                return Ok(());
+            }
 
             match util::get_url_body_with_retry(&packument_url) {
                 Ok(packument_data) => {
                     let normalized_data =
                         normalize_packument(&package_name, &packument_data, &requested_versions)?;
 
+                    // Write whichever variant is missing (upsert handles dedup).
                     // npm's make-fetch-happen uses the URL-encoded form for cache keys
                     // e.g., "https://registry.npmjs.org/@types%2freact-dom" not "@types/react-dom"
                     // We must use the encoded form in both the cache key string AND the metadata URL
+                    if !cache.has_with_headers(&key, CORGI_DOC) {
+                        cache
+                            .put(
+                                key.clone(),
+                                packument_url.clone(),
+                                &normalized_data,
+                                None, // Packuments don't have integrity hashes
+                                Some(ReqHeaders {
+                                    accept: String::from(CORGI_DOC),
+                                }),
+                            )
+                            .map_err(|e| {
+                                anyhow!(
+                                    "couldn't insert packument cache entry (corgi) for {package_name}: {e:?}"
+                                )
+                            })?;
+                    }
 
-                    // Cache with corgiDoc header (for initial requests)
-                    cache
-                        .put(
-                            format!("make-fetch-happen:request-cache:{packument_url}"),
-                            packument_url.clone(),
-                            &normalized_data,
-                            None, // Packuments don't have integrity hashes
-                            Some(ReqHeaders {
-                                accept: String::from(CORGI_DOC),
-                            }),
-                        )
-                        .map_err(|e| {
-                            anyhow!("couldn't insert packument cache entry (corgi) for {package_name}: {e:?}")
-                        })?;
-
-                    // Cache with fullDoc header (for workspace/full metadata requests)
-                    cache
-                        .put(
-                            format!("make-fetch-happen:request-cache:{packument_url}"),
-                            packument_url.clone(),
-                            &normalized_data,
-                            None,
-                            Some(ReqHeaders {
-                                accept: String::from(FULL_DOC),
-                            }),
-                        )
-                        .map_err(|e| {
-                            anyhow!("couldn't insert packument cache entry (full) for {package_name}: {e:?}")
-                        })?;
+                    if !cache.has_with_headers(&key, FULL_DOC) {
+                        cache
+                            .put(
+                                key.clone(),
+                                packument_url.clone(),
+                                &normalized_data,
+                                None,
+                                Some(ReqHeaders {
+                                    accept: String::from(FULL_DOC),
+                                }),
+                            )
+                            .map_err(|e| {
+                                anyhow!(
+                                    "couldn't insert packument cache entry (full) for {package_name}: {e:?}"
+                                )
+                            })?;
+                    }
                 }
                 Err(e) => {
                     // Log but don't fail - some packages might not need packuments
@@ -449,14 +462,22 @@ fn main() -> anyhow::Result<()> {
 
     // Fetch and cache tarballs
     packages.into_par_iter().try_for_each(|package| {
+        let key = format!("make-fetch-happen:request-cache:{}", package.url);
+        let integrity = package.integrity().map(ToString::to_string);
+
+        // Skip download if this dependency is already in the cache (reentrant prefetch).
+        if cache.has(&key, integrity.as_deref()) {
+            info!("Skipping already-cached dependency: {}", package.name);
+            return Ok(());
+        }
+
         let tarball = package
             .tarball()
             .map_err(|e| anyhow!("couldn't fetch {} at {}: {e:?}", package.name, package.url))?;
-        let integrity = package.integrity().map(ToString::to_string);
 
         cache
             .put(
-                format!("make-fetch-happen:request-cache:{}", package.url),
+                key,
                 package.url,
                 &tarball,
                 integrity,


### PR DESCRIPTION
Fix https://github.com/NixOS/nixpkgs/issues/471535

Target staging due to rebuilding many npm-based packages.

No change needed for content-v2, because in that, files are strictly content hashed. However, index-v5 buckets chunk index desriptors into files, by hash prefix, which can lead to collisions when doing multiple fetches to a single cache.

This commit replaces the unconditional write to the cache index with upsert logic.

**Disclosure**: This PR has been vibe coded.

I'm putting it up in Draft, in order to hopefully get some co-ownership and I'll do a self-review to the best of my abilities.

I've built openvscode-server with it, and the effect is undeniable:

Before:
```
± nix-build . -A openvscode-server.npmCache
± du -hs result/
7.4G    result/
```

With https://github.com/NixOS/nixpkgs/commit/130801c0a9e29c023c0e0227cf6afc25459e9b00 and https://github.com/NixOS/nixpkgs/commit/6f3340592f54cc01c25c3eeb93d4ab147b63cb7c
```
± nix-build . -A openvscode-server.npmCache
± du -hs result/
3.7G    result/
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
