### PR TITLE
moraine: init at 0.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28147,6 +28147,12 @@
     github = "thegu5";
     githubId = 58223632;
   };
+  thejonaz = {
+    name = "Jonaz Thern";
+    email = "info@thern.io";
+    github = "TheJonaz";
+    githubId = 44526342;
+  };
   thekostins = {
     name = "Konstantin";
     email = "anisimovkosta19@gmail.com";

--- a/pkgs/by-name/mo/moraine/package.nix
+++ b/pkgs/by-name/mo/moraine/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  wrapGAppsHook4,
+  gtk4,
+  glib,
+  rsync,
+  openssh,
+  rclone,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "moraine";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "TheJonaz";
+    repo = "moraine-backup";
+    tag = "v${version}";
+    hash = "sha256-0IrD43U7N0mAVr/YPP2NIMPWDxJGLCpeZG16X3kVARU=";
+  };
+
+  cargoHash = "sha256-06puLUEUckzKFPdySP1A1E739VwK1FKDpxrsHB+a8O4=";
+
+  __structuredAttrs = true;
+
+  buildFeatures = [ "gui" ];
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook4
+  ];
+  buildInputs = [
+    gtk4
+    glib
+  ];
+
+  # Requires moraine >= 0.1.19: assets are resolved via XDG_DATA_DIRS, which
+  # wrapGAppsHook4 points at $out/share.
+  postInstall = ''
+    install -Dm644 assets/moraine-gui.desktop \
+      $out/share/applications/io.thern.moraine.desktop
+    install -Dm644 assets/moraine.svg \
+      $out/share/icons/hicolor/scalable/apps/moraine.svg
+    install -Dm644 assets/moraine-256.png \
+      $out/share/icons/hicolor/256x256/apps/moraine.png
+    for a in hero-bg.png moraine-64.png moraine-256.png; do
+      install -Dm644 "assets/$a" "$out/share/moraine/assets/$a"
+    done
+  '';
+
+  # rsync / ssh / rclone on the runtime PATH (wrapGAppsHook4 applies these when
+  # it wraps both binaries — no separate wrapProgram, so no double-wrapping).
+  makeWrapperArgs = [
+    "--prefix"
+    "PATH"
+    ":"
+    (lib.makeBinPath [
+      rsync
+      openssh
+      rclone
+    ])
+  ];
+
+  meta = {
+    description = "Snapshot-based backup over SSH/rsync and rclone (CLI + GTK app)";
+    homepage = "https://moraine.thern.io";
+    changelog = "https://github.com/TheJonaz/moraine-backup/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    mainProgram = "moraine";
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ thejonaz ];
+  };
+}


### PR DESCRIPTION
Adds **moraine**, a snapshot backup tool written in Rust — hard-linked snapshots over SSH/rsync, plus an rclone backend for cloud/SFTP/FTP/SMB/WebDAV/S3. It ships the `moraine` CLI and the `moraine-gui` GTK 4 desktop app (`buildFeatures = [ "gui" ]`); `wrapGAppsHook4` puts `rsync`/`openssh`/`rclone` on the runtime PATH. Homepage: https://moraine.thern.io — source: https://github.com/TheJonaz/moraine-backup (MIT).

Also adds `thejonaz` (the upstream author) to the maintainer list.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests]
  - [ ] [Package tests] at `passthru.tests`
  - [ ] Tests in [lib/tests] or [pkgs/test]
- [ ] Ran `nixpkgs-review` on this PR.
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - The derivation builds and both binaries are wrapped correctly; I did not run them from the `result` in the (sandboxed) build environment used here. The same v0.2.2 code runs fine from a native build.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs (by-name layout, maintainer added).
- [x] Follows the [automation/AI policy].

### Automation/AI disclosure
Prepared with **Claude Code (Claude Opus 4.8)** — disclosed via `Assisted-by:` trailers on both commits. The `src`/`cargoHash` were computed and the derivation was **built and verified locally** (via nix); the packaging was reviewed for correctness. The maintainer is the upstream author (@TheJonaz), who is accountable for the submission and will answer review questions directly.
