### PR TITLE
gnomeExtensions.copyous: use libgda5

### DIFF
--- a/pkgs/desktops/gnome/extensions/extensionOverrides.nix
+++ b/pkgs/desktops/gnome/extensions/extensionOverrides.nix
@@ -13,7 +13,7 @@
   gobject-introspection,
   gsound,
   hddtemp,
-  libgda6,
+  libgda5,
   libgtop,
   libhandy,
   liquidctl,
@@ -71,12 +71,12 @@ lib.trivial.pipe super [
 
   (patchExtension "copyous@boerdereinar.dev" (old: {
     buildInputs = [
-      libgda6
+      libgda5
       gsound
     ];
     preInstall = ''
-      sed -i "1i import GIRepository from 'gi://GIRepository';\nGIRepository.Repository.dup_default().prepend_search_path('${libgda6}/lib/girepository-1.0');\nGIRepository.Repository.dup_default().prepend_search_path('${gsound}/lib/girepository-1.0');\n" lib/preferences/dependencies/dependencies.js
-      sed -i "1i import GIRepository from 'gi://GIRepository';\nGIRepository.Repository.dup_default().prepend_search_path('${libgda6}/lib/girepository-1.0');\n" lib/database/entryTracker.js
+      sed -i "1i import GIRepository from 'gi://GIRepository';\nGIRepository.Repository.dup_default().prepend_search_path('${libgda5}/lib/girepository-1.0');\nGIRepository.Repository.dup_default().prepend_search_path('${gsound}/lib/girepository-1.0');\n" lib/preferences/dependencies/dependencies.js
+      sed -i "1i import GIRepository from 'gi://GIRepository';\nGIRepository.Repository.dup_default().prepend_search_path('${libgda5}/lib/girepository-1.0');\n" lib/database/entryTracker.js
       sed -i "1i import GIRepository from 'gi://GIRepository';\nGIRepository.Repository.dup_default().prepend_search_path('${gsound}/lib/girepository-1.0');\n" lib/common/sound.js
       sed -i "1i import GIRepository from 'gi://GIRepository';\nGIRepository.Repository.dup_default().prepend_search_path('${gsound}/lib/girepository-1.0');\n" lib/preferences/general/feedbackSettings.js
     '';


### PR DESCRIPTION
Assisted-by: ChatGPT (OpenAI GPT-5)
Reviewed and tested by myself

Some users, myself included, experience a GNOME shell crash when copyous starts using Gda 6. Copyous officially supports both Gda 5 and Gda 6, and using Gda 5 avoids the crash in my testing.

I have simply replaced all mentions of libgda6 with libgda5, built it, and then tested it by installing it under `.local/share/gnome-shell/extensions` and enabling it as a user extension. With the fix I experience no issues.

relevant reports:
- https://github.com/boerdereinar/copyous/issues/67
- https://github.com/boerdereinar/copyous/issues/98
- https://github.com/NixOS/nixpkgs/issues/490431

`nixpkgs-review` report:
```
--------- Report for 'x86_64-linux' ---------
1 package built:
gnomeExtensions.copyous
```

relevant part of log from failing libgda6 configuration:
```
lip 25 22:11:42 zephyr .gnome-shell-wr[21710]: [Copyous] Using Gda 6.0 database
lip 25 22:11:42 zephyr gnome-shell[21710]: JS ERROR: ImportError: Unable to load file async from: file:///home/krecony/.local/share/copyous@boerdereinar.dev/highlight.min.js (Error opening >
                                           @resource:///org/gnome/shell/ui/init.js:20:20
lip 25 22:11:42 zephyr kernel: gdaWrkrTh0[22194]: segfault at 0 ip 0000000000000000 sp 000074128b7fd338 error 14 likely on CPU 1 (core 1, socket 0)
lip 25 22:11:42 zephyr kernel: Code: Unable to access opcode bytes at 0xffffffffffffffd6.
lip 25 22:11:42 zephyr kernel: coredump: 21710(gdaWrkrTh0): |/bin/false pipe failed
lip 25 22:11:42 zephyr gnome-shell[22005]: Failed to dispatch Wayland display
lip 25 22:11:42 zephyr gnome-shell[22005]: EGL setup failed, disabling glamor
lip 25 22:11:42 zephyr gnome-shell[22005]: Failed to initialize glamor, falling back to sw
lip 25 22:11:42 zephyr gnome-shell[22005]: (EE) could not connect to wayland server
lip 25 22:11:42 zephyr xdg-desktop-portal-gnome[22068]: Non-compatible display server, exposing settings only.
lip 25 22:11:42 zephyr evolution-alarm-notify[22027]: cannot open display: :0
lip 25 22:11:42 zephyr systemd[2369]: org.gnome.Shell@user.service: Main process exited, code=killed, status=11/SEGV
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test