### PR TITLE
python3Packages.textual-slider: 91e64baf -> 0.2.0 (fix build of isponsorblocktv)

### DIFF
--- a/pkgs/development/python-modules/textual-slider/default.nix
+++ b/pkgs/development/python-modules/textual-slider/default.nix
@@ -6,15 +6,15 @@
   textual,
 }:
 
-buildPythonPackage {
+buildPythonPackage (finalAttrs: {
   pname = "textual-slider";
   version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "TomJGooding";
     repo = "textual-slider";
-    rev = "91e64bafe3aa72f8d875e76b437d6af9320e039e";
-    hash = "sha256-lwN7igiEB8uC9e7qBSVLuKCpF41+Ni7ZJ3cVK19cEY8=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Y/QKN89IWEdO9bTBQ3RFhrYShganUBQ6O5+HgsITFH0=";
   };
 
   pyproject = true;
@@ -29,4 +29,4 @@ buildPythonPackage {
     license = lib.licenses.gpl3Only;
     maintainers = [ lib.maintainers.lukegb ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

fixes build of isponsorblocktv:

```
/nix/store/s49vn2bkzlzbli55bgmyg7jm0vk3zxvh-python3.14-textual-slider-0.2.0-dist
       > Executing pythonRemoveTestsDir
       > Finished executing pythonRemoveTestsDir
       > Running phase: installCheckPhase
       > no Makefile or custom installCheckPhase, doing nothing
       > Running phase: pythonCatchConflictsPhase
       > Running phase: pythonRemoveBinBytecodePhase
       > Running phase: pythonImportsCheckPhase
       > Executing pythonImportsCheckPhase
       > Running phase: pythonMetadataCheckPhase
       > Executing pythonMetadataCheckPhase
       > The 'textual-slider' derivation has version '0.2.0' but .dist-info/METADATA specifies version '0.1.2'.
       > This usually means that the wrong version is hardcoded in pyproject.toml or setup.{py,cfg}.
       > Use the pyprojectVersionPatchHook or patch the version manually so that the project metadata matches the derivation's version.
       For full logs, run:
         nix log /nix/store/hv1gkf7p6wbngc938pnn7c5az2irm1xq-python3.14-textual-slider-0.2.0.drv
```

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
