### PR TITLE
freenet-core: init at 0.2.106, nixos/freenet-core: add service

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16267,6 +16267,12 @@
     githubId = 72424138;
     name = "Lisanna Dettwyler";
   };
+  LisaScheers = {
+    email = "lisa@scheers.tech";
+    github = "LisaScheers";
+    githubId = 34404302;
+    name = "Lisa Scheers";
+  };
   litchipi = {
     email = "litchi.pi@proton.me";
     github = "litchipi";

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -68,6 +68,12 @@
   "module-boot-plymouth-tpm2-totp-quick-start-enable": [
     "index.html#module-boot-plymouth-tpm2-totp-quick-start-enable"
   ],
+  "module-services-freenet-core": [
+    "index.html#module-services-freenet-core"
+  ],
+  "module-services-freenet-core-quick-start": [
+    "index.html#module-services-freenet-core-quick-start"
+  ],
   "module-services-keycloak-unix-socket": [
     "index.html#module-services-keycloak-unix-socket"
   ],

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -28,10 +28,11 @@
   firewall, is available through
   [services.portmaster](#opt-services.portmaster.enable).
 
-- [Freenet](https://freenet.org/), a peer-to-peer platform for decentralized
-  applications, is now available as
-  [services.freenet-core](#opt-services.freenet-core.enable). The `-core`
-  suffix distinguishes it from the existing Java/Hyphanet service.
+- The ground-up Rust implementation of [Freenet](https://freenet.org/), formerly
+  called Locutus, is now available as
+  [services.freenet-core](#opt-services.freenet-core.enable). It is not
+  compatible with [Hyphanet](https://www.hyphanet.org/), the Java project
+  formerly named Freenet, which remains available as `services.freenet`.
 
 - [tranquil](https://tangled.org/tranquil.farm/tranquil-pds) is an ATProto PDS (personal data server) implementation in Rust. A featureful, spec conscious and community driven alternative to the Bluesky reference implementation PDS. Available as [services.tranquil-pds](#opt-services.tranquil-pds.enable).
 

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -28,6 +28,11 @@
   firewall, is available through
   [services.portmaster](#opt-services.portmaster.enable).
 
+- [Freenet](https://freenet.org/), a peer-to-peer platform for decentralized
+  applications, is now available as
+  [services.freenet-core](#opt-services.freenet-core.enable). The `-core`
+  suffix distinguishes it from the existing Java/Hyphanet service.
+
 - [tranquil](https://tangled.org/tranquil.farm/tranquil-pds) is an ATProto PDS (personal data server) implementation in Rust. A featureful, spec conscious and community driven alternative to the Bluesky reference implementation PDS. Available as [services.tranquil-pds](#opt-services.tranquil-pds.enable).
 
 - [Moonlight Qt](https://moonlight-stream.org/), a client for playing your PC games on almost any device. Available as [programs.moonlight-qt](#opt-programs.moonlight-qt.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1228,6 +1228,7 @@
   ./services/networking/firezone/relay.nix
   ./services/networking/firezone/server.nix
   ./services/networking/flannel.nix
+  ./services/networking/freenet-core.nix
   ./services/networking/freenet.nix
   ./services/networking/freeradius.nix
   ./services/networking/frp.nix

--- a/nixos/modules/services/networking/freenet-core.md
+++ b/nixos/modules/services/networking/freenet-core.md
@@ -1,0 +1,26 @@
+# Freenet {#module-services-freenet-core}
+
+[Freenet](https://freenet.org/) is a peer-to-peer platform for decentralized
+applications.
+
+## Quick start {#module-services-freenet-core-quick-start}
+
+```nix
+{
+  services.freenet-core = {
+    enable = true;
+    openFirewall = true;
+  };
+}
+```
+
+This starts a Freenet node, opens its peer-to-peer UDP port, and makes the web
+interface available at <http://127.0.0.1:7509/>.
+
+The web interface only listens on the loopback address by default. Set
+{option}`services.freenet-core.websocketAddress` explicitly to expose it to
+other hosts.
+
+Freenet's built-in updater is disabled because the package is managed by Nix.
+The module creates the configured data, configuration, and log directories with
+permissions restricted to the service user.

--- a/nixos/modules/services/networking/freenet-core.md
+++ b/nixos/modules/services/networking/freenet-core.md
@@ -17,11 +17,18 @@ applications.
 This starts a Freenet node, opens its peer-to-peer UDP port, and makes the web
 interface available at <http://127.0.0.1:7509/>.
 
-Nodes connect through existing gateways by default. To operate a publicly
-reachable gateway instead, enable
+Nodes connect through existing gateways by default and attempt UDP hole
+punching, so they do not normally need to accept unsolicited traffic from the
+public Internet. Symmetric NAT and carrier-grade NAT can still prevent direct
+connections.
+
+To operate a publicly reachable gateway instead, enable
 {option}`services.freenet-core.gateway.enable` and set
 {option}`services.freenet-core.gateway.publicAddress`. The advertised public
-port defaults to the peer-to-peer listener port.
+port defaults to the peer-to-peer listener port. The
+{option}`services.freenet-core.openFirewall` option only configures the NixOS
+host firewall; forward the advertised UDP port through any upstream router or
+NAT and ensure that the advertised address is publicly reachable.
 
 The web interface only listens on the loopback address by default. Set
 {option}`services.freenet-core.websocketAddress` explicitly to expose it to
@@ -29,4 +36,6 @@ other hosts.
 
 Freenet's built-in updater is disabled because the package is managed by Nix.
 The service runs as a dynamic user. systemd manages its private state in
-{file}`/var/lib/freenet-core` and logs in {file}`/var/log/freenet-core`.
+{file}`/var/lib/freenet-core` and its disposable web-application cache in
+{file}`/var/cache/freenet-core`. Service logs are available through
+`journalctl -u freenet-core`.

--- a/nixos/modules/services/networking/freenet-core.md
+++ b/nixos/modules/services/networking/freenet-core.md
@@ -17,10 +17,16 @@ applications.
 This starts a Freenet node, opens its peer-to-peer UDP port, and makes the web
 interface available at <http://127.0.0.1:7509/>.
 
+Nodes connect through existing gateways by default. To operate a publicly
+reachable gateway instead, enable
+{option}`services.freenet-core.gateway.enable` and set
+{option}`services.freenet-core.gateway.publicAddress`. The advertised public
+port defaults to the peer-to-peer listener port.
+
 The web interface only listens on the loopback address by default. Set
 {option}`services.freenet-core.websocketAddress` explicitly to expose it to
 other hosts.
 
 Freenet's built-in updater is disabled because the package is managed by Nix.
-The module creates the configured data, configuration, and log directories with
-permissions restricted to the service user.
+The service runs as a dynamic user. systemd manages its private state in
+{file}`/var/lib/freenet-core` and logs in {file}`/var/log/freenet-core`.

--- a/nixos/modules/services/networking/freenet-core.nix
+++ b/nixos/modules/services/networking/freenet-core.nix
@@ -1,0 +1,188 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.freenet-core;
+
+  command = [
+    (lib.getExe cfg.package)
+    "network"
+    "--disable-auto-update"
+    "--config-dir=${cfg.configDir}"
+    "--data-dir=${cfg.dataDir}"
+    "--log-dir=${cfg.logDir}"
+    "--network-address=${cfg.networkAddress}"
+    "--network-port=${toString cfg.networkPort}"
+    "--ws-api-address=${cfg.websocketAddress}"
+    "--ws-api-port=${toString cfg.websocketPort}"
+  ]
+  ++ cfg.extraArgs;
+in
+{
+  options.services.freenet-core = {
+    enable = lib.mkEnableOption "Freenet node";
+
+    package = lib.mkPackageOption pkgs "freenet-core" { };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "freenet-core";
+      example = "freenet";
+      description = "User account under which Freenet runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "freenet-core";
+      example = "freenet";
+      description = "Group under which Freenet runs.";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/freenet-core";
+      example = "/srv/freenet-core";
+      description = "Directory used to store Freenet node data.";
+    };
+
+    configDir = lib.mkOption {
+      type = lib.types.path;
+      default = "${cfg.dataDir}/config";
+      defaultText = lib.literalExpression ''"''${config.services.freenet-core.dataDir}/config"'';
+      example = "/srv/freenet-core/config";
+      description = "Directory used to store Freenet configuration.";
+    };
+
+    logDir = lib.mkOption {
+      type = lib.types.path;
+      default = "${cfg.dataDir}/logs";
+      defaultText = lib.literalExpression ''"''${config.services.freenet-core.dataDir}/logs"'';
+      example = "/var/log/freenet-core";
+      description = "Directory used to store Freenet logs.";
+    };
+
+    networkAddress = lib.mkOption {
+      type = lib.types.str;
+      default = "::";
+      example = "0.0.0.0";
+      description = "Address on which the Freenet peer-to-peer transport listens.";
+    };
+
+    networkPort = lib.mkOption {
+      type = lib.types.port;
+      default = 31337;
+      example = 31338;
+      description = "UDP port on which the Freenet peer-to-peer transport listens.";
+    };
+
+    websocketAddress = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      example = "::1";
+      description = "Address on which the Freenet HTTP and WebSocket API listens.";
+    };
+
+    websocketPort = lib.mkOption {
+      type = lib.types.port;
+      default = 7509;
+      example = 7510;
+      description = "TCP port on which the Freenet HTTP and WebSocket API listens.";
+    };
+
+    nice = lib.mkOption {
+      type = lib.types.ints.between (-20) 19;
+      default = 10;
+      example = 5;
+      description = "Nice level for the Freenet process.";
+    };
+
+    environment = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      example = {
+        RUST_LOG = "freenet=debug";
+      };
+      description = "Environment variables passed to the Freenet process.";
+    };
+
+    extraArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [
+        "--telemetry-enabled"
+        "--total-bandwidth-limit=10000000"
+      ];
+      description = "Additional command-line arguments passed to Freenet.";
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      example = true;
+      description = "Whether to open the Freenet peer-to-peer UDP port in the firewall.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    networking.firewall.allowedUDPPorts = lib.mkIf cfg.openFirewall [ cfg.networkPort ];
+
+    systemd.tmpfiles.settings."10-freenet-core" = {
+      ${cfg.dataDir}.d = {
+        user = cfg.user;
+        group = cfg.group;
+        mode = "0700";
+      };
+      ${cfg.configDir}.d = {
+        user = cfg.user;
+        group = cfg.group;
+        mode = "0700";
+      };
+      ${cfg.logDir}.d = {
+        user = cfg.user;
+        group = cfg.group;
+        mode = "0700";
+      };
+    };
+
+    systemd.services.freenet-core = {
+      description = "Freenet node";
+      documentation = [ "https://freenet.org/" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+      environment = cfg.environment;
+      serviceConfig = {
+        ExecStart = lib.escapeShellArgs command;
+        User = cfg.user;
+        Group = cfg.group;
+        WorkingDirectory = cfg.dataDir;
+        Nice = cfg.nice;
+        UMask = "0077";
+        Restart = "on-failure";
+        RestartSec = 10;
+        TimeoutStopSec = 45;
+      };
+    };
+
+    users.users = lib.mkIf (cfg.user == "freenet-core") {
+      freenet-core = {
+        isSystemUser = true;
+        group = cfg.group;
+        description = "Freenet node user";
+        home = cfg.dataDir;
+        createHome = true;
+      };
+    };
+
+    users.groups = lib.mkIf (cfg.group == "freenet-core") {
+      freenet-core = { };
+    };
+  };
+
+  meta.maintainers = [ lib.maintainers.LisaScheers ];
+  meta.doc = ./freenet-core.md;
+}

--- a/nixos/modules/services/networking/freenet-core.nix
+++ b/nixos/modules/services/networking/freenet-core.nix
@@ -7,18 +7,26 @@
 
 let
   cfg = config.services.freenet-core;
+  stateDir = "/var/lib/freenet-core";
+  configDir = "${stateDir}/config";
+  logDir = "/var/log/freenet-core";
 
   command = [
     (lib.getExe cfg.package)
     "network"
     "--disable-auto-update"
-    "--config-dir=${cfg.configDir}"
-    "--data-dir=${cfg.dataDir}"
-    "--log-dir=${cfg.logDir}"
+    "--config-dir=${configDir}"
+    "--data-dir=${stateDir}"
+    "--log-dir=${logDir}"
     "--network-address=${cfg.networkAddress}"
     "--network-port=${toString cfg.networkPort}"
     "--ws-api-address=${cfg.websocketAddress}"
     "--ws-api-port=${toString cfg.websocketPort}"
+  ]
+  ++ lib.optionals cfg.gateway.enable [
+    "--is-gateway"
+    "--public-network-address=${cfg.gateway.publicAddress}"
+    "--public-network-port=${toString cfg.gateway.publicPort}"
   ]
   ++ cfg.extraArgs;
 in
@@ -27,43 +35,6 @@ in
     enable = lib.mkEnableOption "Freenet node";
 
     package = lib.mkPackageOption pkgs "freenet-core" { };
-
-    user = lib.mkOption {
-      type = lib.types.str;
-      default = "freenet-core";
-      example = "freenet";
-      description = "User account under which Freenet runs.";
-    };
-
-    group = lib.mkOption {
-      type = lib.types.str;
-      default = "freenet-core";
-      example = "freenet";
-      description = "Group under which Freenet runs.";
-    };
-
-    dataDir = lib.mkOption {
-      type = lib.types.path;
-      default = "/var/lib/freenet-core";
-      example = "/srv/freenet-core";
-      description = "Directory used to store Freenet node data.";
-    };
-
-    configDir = lib.mkOption {
-      type = lib.types.path;
-      default = "${cfg.dataDir}/config";
-      defaultText = lib.literalExpression ''"''${config.services.freenet-core.dataDir}/config"'';
-      example = "/srv/freenet-core/config";
-      description = "Directory used to store Freenet configuration.";
-    };
-
-    logDir = lib.mkOption {
-      type = lib.types.path;
-      default = "${cfg.dataDir}/logs";
-      defaultText = lib.literalExpression ''"''${config.services.freenet-core.dataDir}/logs"'';
-      example = "/var/log/freenet-core";
-      description = "Directory used to store Freenet logs.";
-    };
 
     networkAddress = lib.mkOption {
       type = lib.types.str;
@@ -77,6 +48,23 @@ in
       default = 31337;
       example = 31338;
       description = "UDP port on which the Freenet peer-to-peer transport listens.";
+    };
+
+    gateway = {
+      enable = lib.mkEnableOption "Freenet gateway mode";
+
+      publicAddress = lib.mkOption {
+        type = lib.types.str;
+        example = "198.51.100.10";
+        description = "Publicly reachable address advertised by this gateway.";
+      };
+
+      publicPort = lib.mkOption {
+        type = lib.types.port;
+        default = cfg.networkPort;
+        defaultText = lib.literalExpression "config.services.freenet-core.networkPort";
+        description = "Publicly reachable UDP port advertised by this gateway.";
+      };
     };
 
     websocketAddress = lib.mkOption {
@@ -130,56 +118,60 @@ in
   config = lib.mkIf cfg.enable {
     networking.firewall.allowedUDPPorts = lib.mkIf cfg.openFirewall [ cfg.networkPort ];
 
-    systemd.tmpfiles.settings."10-freenet-core" = {
-      ${cfg.dataDir}.d = {
-        user = cfg.user;
-        group = cfg.group;
-        mode = "0700";
-      };
-      ${cfg.configDir}.d = {
-        user = cfg.user;
-        group = cfg.group;
-        mode = "0700";
-      };
-      ${cfg.logDir}.d = {
-        user = cfg.user;
-        group = cfg.group;
-        mode = "0700";
-      };
-    };
-
     systemd.services.freenet-core = {
       description = "Freenet node";
       documentation = [ "https://freenet.org/" ];
       after = [ "network-online.target" ];
       wants = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
-      environment = cfg.environment;
+      environment = {
+        HOME = stateDir;
+      }
+      // cfg.environment;
       serviceConfig = {
+        ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p ${configDir}";
         ExecStart = lib.escapeShellArgs command;
-        User = cfg.user;
-        Group = cfg.group;
-        WorkingDirectory = cfg.dataDir;
+        User = "freenet-core";
+        DynamicUser = true;
+        StateDirectory = "freenet-core";
+        StateDirectoryMode = "0700";
+        LogsDirectory = "freenet-core";
+        LogsDirectoryMode = "0700";
+        WorkingDirectory = stateDir;
         Nice = cfg.nice;
+        LimitNOFILE = 65536;
         UMask = "0077";
         Restart = "on-failure";
+        # Exit 42 also signals a fatal listener failure and must remain restartable.
+        RestartPreventExitStatus = [ 43 ];
         RestartSec = 10;
         TimeoutStopSec = 45;
-      };
-    };
 
-    users.users = lib.mkIf (cfg.user == "freenet-core") {
-      freenet-core = {
-        isSystemUser = true;
-        group = cfg.group;
-        description = "Freenet node user";
-        home = cfg.dataDir;
-        createHome = true;
+        CapabilityBoundingSet = "";
+        LockPersonality = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
       };
-    };
-
-    users.groups = lib.mkIf (cfg.group == "freenet-core") {
-      freenet-core = { };
     };
   };
 

--- a/nixos/modules/services/networking/freenet-core.nix
+++ b/nixos/modules/services/networking/freenet-core.nix
@@ -9,7 +9,7 @@ let
   cfg = config.services.freenet-core;
   stateDir = "/var/lib/freenet-core";
   configDir = "${stateDir}/config";
-  logDir = "/var/log/freenet-core";
+  cacheDir = "/var/cache/freenet-core";
 
   command = [
     (lib.getExe cfg.package)
@@ -17,7 +17,6 @@ let
     "--disable-auto-update"
     "--config-dir=${configDir}"
     "--data-dir=${stateDir}"
-    "--log-dir=${logDir}"
     "--network-address=${cfg.networkAddress}"
     "--network-port=${toString cfg.networkPort}"
     "--ws-api-address=${cfg.websocketAddress}"
@@ -125,7 +124,9 @@ in
       wants = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
       environment = {
+        FREENET_LOG_TO_STDERR = "1";
         HOME = stateDir;
+        XDG_CACHE_HOME = cacheDir;
       }
       // cfg.environment;
       serviceConfig = {
@@ -135,8 +136,8 @@ in
         DynamicUser = true;
         StateDirectory = "freenet-core";
         StateDirectoryMode = "0700";
-        LogsDirectory = "freenet-core";
-        LogsDirectoryMode = "0700";
+        CacheDirectory = "freenet-core";
+        CacheDirectoryMode = "0700";
         WorkingDirectory = stateDir;
         Nice = cfg.nice;
         LimitNOFILE = 65536;
@@ -149,6 +150,8 @@ in
 
         CapabilityBoundingSet = "";
         LockPersonality = true;
+        # Freenet JIT-compiles WebAssembly contracts.
+        MemoryDenyWriteExecute = false;
         NoNewPrivileges = true;
         PrivateDevices = true;
         PrivateTmp = true;
@@ -164,6 +167,7 @@ in
         ProtectSystem = "strict";
         RemoveIPC = true;
         RestrictAddressFamilies = [
+          "AF_UNIX"
           "AF_INET"
           "AF_INET6"
         ];
@@ -171,6 +175,7 @@ in
         RestrictRealtime = true;
         RestrictSUIDSGID = true;
         SystemCallArchitectures = "native";
+        SystemCallFilter = [ "@system-service" ];
       };
     };
   };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -649,6 +649,7 @@ in
     forgejoPackage = pkgs.forgejo-lts;
   };
   freenet = runTest ./freenet.nix;
+  freenet-core = runTest ./freenet-core.nix;
   freescout = import ./freescout {
     inherit runTest;
   };

--- a/nixos/tests/freenet-core.nix
+++ b/nixos/tests/freenet-core.nix
@@ -7,17 +7,19 @@
 
   nodes.machine.services.freenet-core = {
     enable = true;
-    extraArgs = [
-      "--skip-load-from-network"
-      "--is-gateway"
-      "--public-network-address=127.0.0.1"
-      "--public-network-port=31337"
-    ];
+    gateway = {
+      enable = true;
+      publicAddress = "127.0.0.1";
+    };
+    extraArgs = [ "--skip-load-from-network" ];
   };
 
   testScript = ''
     machine.wait_for_unit("freenet-core.service")
     machine.wait_for_open_port(7509)
     machine.succeed("curl --fail http://127.0.0.1:7509/")
+    machine.succeed("test $(systemctl show freenet-core.service -P DynamicUser) = yes")
+    machine.succeed("test -d /var/lib/freenet-core")
+    machine.succeed("test -d /var/log/freenet-core")
   '';
 }

--- a/nixos/tests/freenet-core.nix
+++ b/nixos/tests/freenet-core.nix
@@ -1,0 +1,23 @@
+{ lib, ... }:
+
+{
+  name = "freenet-core";
+
+  meta.maintainers = [ lib.maintainers.LisaScheers ];
+
+  nodes.machine.services.freenet-core = {
+    enable = true;
+    extraArgs = [
+      "--skip-load-from-network"
+      "--is-gateway"
+      "--public-network-address=127.0.0.1"
+      "--public-network-port=31337"
+    ];
+  };
+
+  testScript = ''
+    machine.wait_for_unit("freenet-core.service")
+    machine.wait_for_open_port(7509)
+    machine.succeed("curl --fail http://127.0.0.1:7509/")
+  '';
+}

--- a/nixos/tests/freenet-core.nix
+++ b/nixos/tests/freenet-core.nix
@@ -19,7 +19,10 @@
     machine.wait_for_open_port(7509)
     machine.succeed("curl --fail http://127.0.0.1:7509/")
     machine.succeed("test $(systemctl show freenet-core.service -P DynamicUser) = yes")
+    machine.succeed("test $(systemctl show freenet-core.service -P MemoryDenyWriteExecute) = no")
+    machine.succeed("systemctl show freenet-core.service -P RestrictAddressFamilies | grep -w AF_UNIX")
     machine.succeed("test -d /var/lib/freenet-core")
-    machine.succeed("test -d /var/log/freenet-core")
+    machine.succeed("test -d /var/cache/freenet-core")
+    machine.succeed("journalctl -u freenet-core.service -o cat | grep INFO >/dev/null")
   '';
 }

--- a/pkgs/by-name/fr/freenet-core/package.nix
+++ b/pkgs/by-name/fr/freenet-core/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  openssl,
+  versionCheckHook,
+  rustc,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "freenet-core";
+  version = "0.2.106";
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "freenet";
+    repo = "freenet-core";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-mYGBsWgju2DVACk+usSCAXJ14PzAUqabiOkoW1dN6mM=";
+  };
+
+  cargoHash = "sha256-n+Tj1zrCzAZ/7k+ZK9Wbw1L9xXZhkrOtGudZFvcDdPo=";
+
+  cargoBuildFlags = [ "--package=freenet" ];
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  # So many of the tests require network connectivity that it isn't
+  # worth trying to skip specific ones
+  doCheck = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Peer-to-peer platform for decentralized applications";
+    homepage = "https://freenet.org/";
+    donationPage = "https://freenet.org/donate/";
+    changelog = "https://github.com/freenet/freenet-core/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = [ lib.maintainers.skyesoss ];
+    mainProgram = "freenet";
+    inherit (rustc.meta) platforms;
+  };
+})

--- a/pkgs/by-name/fr/freenet-core/package.nix
+++ b/pkgs/by-name/fr/freenet-core/package.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-n+Tj1zrCzAZ/7k+ZK9Wbw1L9xXZhkrOtGudZFvcDdPo=";
 
-  # No upstream fix exists yet; avoid embedding the build machine's wall-clock time.
+  # No upstream fix exists yet; see https://github.com/freenet/freenet-core/issues/4935.
   patches = [ ./use-source-date-epoch.patch ];
 
   cargoBuildFlags = [ "--package=freenet" ];

--- a/pkgs/by-name/fr/freenet-core/package.nix
+++ b/pkgs/by-name/fr/freenet-core/package.nix
@@ -8,6 +8,7 @@
   versionCheckHook,
   rustc,
   nix-update-script,
+  nixosTests,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "freenet-core";
@@ -39,7 +40,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # worth trying to skip specific ones
   doCheck = false;
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    tests = {
+      inherit (nixosTests) freenet-core;
+    };
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Peer-to-peer platform for decentralized applications";

--- a/pkgs/by-name/fr/freenet-core/package.nix
+++ b/pkgs/by-name/fr/freenet-core/package.nix
@@ -24,6 +24,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-n+Tj1zrCzAZ/7k+ZK9Wbw1L9xXZhkrOtGudZFvcDdPo=";
 
+  # No upstream fix exists yet; avoid embedding the build machine's wall-clock time.
+  patches = [ ./use-source-date-epoch.patch ];
+
   cargoBuildFlags = [ "--package=freenet" ];
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/by-name/fr/freenet-core/package.nix
+++ b/pkgs/by-name/fr/freenet-core/package.nix
@@ -47,7 +47,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     donationPage = "https://freenet.org/donate/";
     changelog = "https://github.com/freenet/freenet-core/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.agpl3Only;
-    maintainers = [ lib.maintainers.skyesoss ];
+    maintainers = [
+      lib.maintainers.skyesoss
+      lib.maintainers.LisaScheers
+    ];
     mainProgram = "freenet";
     inherit (rustc.meta) platforms;
   };

--- a/pkgs/by-name/fr/freenet-core/use-source-date-epoch.patch
+++ b/pkgs/by-name/fr/freenet-core/use-source-date-epoch.patch
@@ -1,0 +1,21 @@
+diff --git a/crates/core/build.rs b/crates/core/build.rs
+index 59b5a42..3215e03 100644
+--- a/crates/core/build.rs
++++ b/crates/core/build.rs
+@@ -132,3 +132,15 @@ fn emit_build_metadata() {
+     // Build timestamp (ISO 8601)
+-    let timestamp = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
++    let timestamp = match std::env::var("SOURCE_DATE_EPOCH") {
++        Ok(value) => {
++            let seconds = value
++                .parse::<i64>()
++                .expect("SOURCE_DATE_EPOCH must be a Unix timestamp");
++            chrono::DateTime::<chrono::Utc>::from_timestamp(seconds, 0)
++                .expect("SOURCE_DATE_EPOCH is outside the supported range")
++        }
++        Err(_) => chrono::Utc::now(),
++    }
++    .format("%Y-%m-%dT%H:%M:%SZ")
++    .to_string();
++    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
+     println!("cargo:rustc-env=BUILD_TIMESTAMP={timestamp}");


### PR DESCRIPTION
## What

- add `freenet-core` 0.2.106
- make its embedded build timestamp honor `SOURCE_DATE_EPOCH` instead of the build wall clock
- add LisaScheers as a package maintainer alongside Skye Soss
- add the `services.freenet-core` NixOS module, documentation, and VM test
- expose peer and gateway operation, P2P and API listeners, priority, environment, extra arguments, and optional firewall setup
- run the service as a dynamic user with systemd-managed private state/cache, journal logging, and a hardened sandbox
- disable the upstream self-updater so upgrades remain managed by Nix

The `-core` suffix distinguishes this Rust Freenet implementation from the existing `services.freenet` module for the Java project now known as Hyphanet. The HTTP/WebSocket API defaults to loopback, the P2P UDP listener uses upstream port 31337, and the firewall stays closed unless explicitly enabled. The module documentation explains UDP hole punching, symmetric-NAT/CGNAT limitations, and the extra upstream forwarding/public-reachability requirements for gateways.

The package commit is cherry-picked from #545671 with Skye Soss authorship preserved. Keeping it here makes the module and VM test self-contained; it can be dropped if that PR lands first.

The matching nix-darwin module is [nix-darwin/nix-darwin#1840](https://github.com/nix-darwin/nix-darwin/pull/1840).

## Automation disclosure

This contribution was developed with assistance from an LLM (OpenAI Codex, GPT-5). The assisted commits include matching `Assisted-by:` trailers; the package commit from #545671 is preserved unchanged.

## Validation

- `nix fmt`, `git diff --check`, and `./ci/nixpkgs-vet.sh master`
- sandboxed `nix-build -A freenet-core --no-out-link --option sandbox true` on aarch64-darwin; `freenet --version` reports 0.2.106 and the deterministic `1980-01-01T00:00:00Z` timestamp
- a second sandboxed `--check` build reproduced the timestamp; the complete Darwin binary still differs because of separate embedded temporary Rust paths and Mach-O UUIDs
- `nix-build -A nixosTests.freenet-core --no-out-link` on aarch64-linux after rebasing onto current master; the VM verifies startup, the web interface, dynamic-user operation, JIT-compatible hardening, the syscall/address-family restrictions, managed state/cache directories, and journal logging
- `nix-build nixos/release.nix -A manualHTML --no-out-link`
- three successful `nixpkgs-review pr 545814` runs on x86_64-linux, aarch64-linux, and aarch64-darwin through the previous PR head; all GitHub PR checks pass on the rebased head

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
