### PR TITLE
harper-desktop: init at 2.7.0

### DIFF
--- a/pkgs/by-name/ha/harper-desktop/package.nix
+++ b/pkgs/by-name/ha/harper-desktop/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  undmg,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "harper-desktop";
+  version = "2.6.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchurl {
+    url = "https://github.com/Automattic/harper/releases/download/v${finalAttrs.version}/Harper_${finalAttrs.version}_universal.dmg";
+    hash = "sha256-GmLLL+i+b07Hl5I9+n8H2BRp1bdcZJ9sf7/I0lPwqdw=";
+  };
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [
+    undmg
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications"
+    cp -R Harper.app "$out/Applications/"
+
+    runHook postInstall
+  '';
+
+  # Preserve upstream's signature and notarization, which are required for
+  # stable macOS Accessibility permissions.
+  dontFixup = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Privacy-first offline grammar checker for macOS";
+    longDescription = ''
+      Harper Desktop provides system-wide grammar checking for macOS.
+      It requires macOS 14 or later.
+      Its built-in automatic updater should be disabled when installed through
+      Nix; update Harper Desktop through Nixpkgs instead.
+    '';
+    homepage = "https://writewithharper.com/desktop";
+    changelog = "https://github.com/Automattic/harper/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    maintainers = with lib.maintainers; [ tyceherrman ];
+    platforms = lib.platforms.darwin;
+  };
+})

--- a/pkgs/by-name/ha/harper-desktop/package.nix
+++ b/pkgs/by-name/ha/harper-desktop/package.nix
@@ -8,14 +8,14 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "harper-desktop";
-  version = "2.6.0";
+  version = "2.7.0";
 
   __structuredAttrs = true;
   strictDeps = true;
 
   src = fetchurl {
     url = "https://github.com/Automattic/harper/releases/download/v${finalAttrs.version}/Harper_${finalAttrs.version}_universal.dmg";
-    hash = "sha256-GmLLL+i+b07Hl5I9+n8H2BRp1bdcZJ9sf7/I0lPwqdw=";
+    hash = "sha256-/hVrBnfCun4nmx1k8eJZHdP5pZBJ52GpKkjt9gJ8FC0=";
   };
 
   sourceRoot = ".";


### PR DESCRIPTION
# harper-desktop: init at 2.6.0

Adds [Harper Desktop](https://writewithharper.com/desktop), a privacy-first,
offline grammar checker that provides system-wide writing suggestions on
macOS.

This is separate from the existing `harper` CLI/LSP package. It packages
upstream's signed universal DMG and installs the application bundle unchanged.
`dontFixup` is intentional: modifying the bundle would invalidate its Developer
ID signature and could destabilize its macOS Accessibility identity and
permissions.

The upstream executable remains universal and contains both `arm64` and
`x86_64` slices.

Assisted-by: OpenAI Codex (gpt-5.6-sol)

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

## Validation

- `nix-shell --run treefmt` completed with no changes.
- `./ci/nixpkgs-vet.sh master` reported `Validated successfully`.
- `nixpkgs-review rev HEAD` built the single impacted package successfully.
- `nix-build -A harper-desktop` succeeded on `aarch64-darwin`.
- The fetched DMG matches the declared hash.
- The built application reports version `2.6.0`.
- `codesign --verify --deep --strict` succeeds for the built application.
- The executable contains both `arm64` and `x86_64` slices.
- The built bundle is byte-for-byte identical to the upstream-installed
  bundle.

## New package review

### Reviewed points

- [x] package path fits guidelines
- [x] package name fits guidelines
- [x] package version fits guidelines
- [x] package builds on `aarch64-darwin`
- [x] application functionality tested on `aarch64-darwin`
- [x] `meta.description` is set and fits guidelines
- [x] `meta.license` fits upstream license
- [x] `meta.platforms` is set
- [x] `meta.maintainers` is set
- [x] `meta.mainProgram` is not applicable because this package installs a macOS application bundle
- [x] build-time-only dependencies are declared in `nativeBuildInputs`
- [x] source is fetched from an official location
- [x] `fetchurl` is appropriate for the official binary release asset
- [x] the motives for the signed-binary packaging choice are documented
- [x] the list of `phases` is not overridden
- [x] `installPhase` starts with `runHook preInstall` and ends with `runHook postInstall`
- [x] no patches are included

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
