### PR TITLE
maia3: init at 0.1.0-unstable-2026-05-25

### DIFF
--- a/pkgs/by-name/ma/maia3/package.nix
+++ b/pkgs/by-name/ma/maia3/package.nix
@@ -1,0 +1,3 @@
+{ python3Packages }:
+
+python3Packages.toPythonApplication python3Packages.maia3

--- a/pkgs/development/python-modules/maia3/default.nix
+++ b/pkgs/development/python-modules/maia3/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  huggingface-hub,
+  numpy,
+  chess,
+  torch,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "maia3";
+  version = "0.1.0-unstable-2026-05-25";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "CSSLab";
+    repo = "maia3";
+    rev = "1e13597c42d4858b7cfd7cfdae01e297263364b2";
+    hash = "sha256-gDgZTetHVB+KVKNJvAdcgjfvUBNwvWbDra1D8gQDvw8=";
+  };
+
+  __structuredAttrs = true;
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"python-chess"' '"chess"'
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    huggingface-hub
+    numpy
+    chess
+    torch
+  ];
+
+  pythonImportsCheck = [ "maia3" ];
+
+  meta = {
+    description = "Inference tools for Maia3 chess models";
+    homepage = "https://github.com/CSSLab/maia3";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ malix ];
+    mainProgram = "maia3-uci";
+  };
+})

--- a/pkgs/development/python-modules/maia3/default.nix
+++ b/pkgs/development/python-modules/maia3/default.nix
@@ -23,6 +23,7 @@ buildPythonPackage (finalAttrs: {
 
   __structuredAttrs = true;
 
+  # to be updated and removed when https://github.com/CSSLab/maia3/pull/10 is merged
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail '"python-chess"' '"chess"'

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10302,6 +10302,8 @@ self: super: with self; {
 
   mahotas = callPackage ../development/python-modules/mahotas { };
 
+  maia3 = callPackage ../development/python-modules/maia3 { };
+
   mail-parser = callPackage ../development/python-modules/mail-parser { };
 
   mailbits = callPackage ../development/python-modules/mailbits { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/CSSLab/maia3

The best human-like chess engine, with an UCI adapter included

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy] : Tried with Gemini 3.6 Flash on Antigravity-CLI (don't use it), basically rewrote by my hand after an initial scaffold

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
