### PR TITLE
brave, brave-origin: fix overriding

### DIFF
--- a/pkgs/applications/networking/browsers/brave/default.nix
+++ b/pkgs/applications/networking/browsers/brave/default.nix
@@ -28,7 +28,7 @@ let
       pkg = import release;
       fd = flavorData.${pkg.flavor or "browser"};
     in
-    callPackage ./make-brave.nix { } (pkg // fd);
+    callPackage ((import ./make-brave.nix) (pkg // fd)) { };
 
 in
 {

--- a/pkgs/applications/networking/browsers/brave/make-brave.nix
+++ b/pkgs/applications/networking/browsers/brave/make-brave.nix
@@ -1,4 +1,25 @@
 {
+  pname,
+  version,
+  # Map from Nix system strings ("x86_64-linux", "aarch64-darwin", ...) to
+  # the corresponding upstream `{ url, hash }` record. Encoding the per-system
+  # sources as data rather than positional arguments lets channel-specific
+  # package.nix files drop platforms that upstream hasn't published yet.
+  archives,
+  # Upstream product flavor: "browser" (the regular Brave) or "origin" (the
+  # stripped-down Brave Origin).
+  flavor ? "browser",
+  # Flavor-specific paths supplied by the caller (default.nix).
+  optStem,
+  fileStem,
+  appIdStem,
+  darwinStem,
+  changelogFile,
+  homepage,
+  innerBinary,
+}:
+
+{
   lib,
   stdenv,
   fetchurl,
@@ -67,27 +88,6 @@
   vulkanSupport ? false,
   addDriverRunpath,
   enableVulkan ? vulkanSupport,
-}:
-
-{
-  pname,
-  version,
-  # Map from Nix system strings ("x86_64-linux", "aarch64-darwin", ...) to
-  # the corresponding upstream `{ url, hash }` record. Encoding the per-system
-  # sources as data rather than positional arguments lets channel-specific
-  # package.nix files drop platforms that upstream hasn't published yet.
-  archives,
-  # Upstream product flavor: "browser" (the regular Brave) or "origin" (the
-  # stripped-down Brave Origin).
-  flavor ? "browser",
-  # Flavor-specific paths supplied by the caller (default.nix).
-  optStem,
-  fileStem,
-  appIdStem,
-  darwinStem,
-  changelogFile,
-  homepage,
-  innerBinary,
 }:
 
 let


### PR DESCRIPTION
Without this fix, `pkgs.brave.override { ... }` fails because there's no `override` attribute.

Previously, the `callPackage ./make-brave.nix { }` call produced a function that was immediately evaluated to produce a package. Unfortunately, because callPackage did not directly produce the package, the final package wasn't overridable (no `.override` function).

This patch instead evaluates the brave/brave-origin function first to produce the "package" function, then calls callPackage on the resulting package function.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test