### PR TITLE
[Backport release-26.05] dbeaver-bin: 26.0.5 -> 26.1.3

### DIFF
--- a/pkgs/by-name/db/dbeaver-bin/package.nix
+++ b/pkgs/by-name/db/dbeaver-bin/package.nix
@@ -19,7 +19,7 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "dbeaver-bin";
-  version = "26.0.5";
+  version = "26.1.3";
 
   src =
     let
@@ -32,10 +32,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
         aarch64-darwin = "macos-aarch64.dmg";
       };
       hash = selectSystem {
-        x86_64-linux = "sha256-urgvGZNM7V5zmts+3Zv7nDtyBuyyAHjc9HDUP2CXx50=";
-        aarch64-linux = "sha256-Ye6NH8tBmSbDS3sJjTzvc9C+qyU3DA0HL0csFUzD1pc=";
-        x86_64-darwin = "sha256-iMyHZUNHzSpc2DrKSsduMx13hUY1SdHQTANR3Yj256A=";
-        aarch64-darwin = "sha256-F60zrgx2cS6HCmSznUapSgmuIxLI1Ma8WHrmawDzEUk=";
+        x86_64-linux = "sha256-cPRmReV6F+pCkrbF7d1m+bQjOaJCCFndNSThMWPGrsY=";
+        aarch64-linux = "sha256-bT1bCKzeiAMJbPa6I6fqQq7OrbkKhgDYAUEKuURHP5g=";
+        x86_64-darwin = "sha256-cT4r0QbA0mhO+fStnU7ORgvSPjNiyz3a0asins0kYaE=";
+        aarch64-darwin = "sha256-NYX651gUpEDh2O720ZKl7fUTYLFKpTJzyC/YnN4Vnys=";
       };
     in
     fetchurl {


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/544907.

Replaces https://github.com/NixOS/nixpkgs/pull/545735, which was closed and cannot be reopened after its head branch was force-pushed to an unrelated root commit.

This backport was reconstructed as exactly one commit on the latest `release-26.05` tip. It preserves the validated DBeaver 26.1.3 source hashes for `x86_64-linux`, `aarch64-linux`, `x86_64-darwin`, and `aarch64-darwin`.

Also closes https://github.com/NixOS/nixpkgs/pull/545868

Validation:
- Evaluated `dbeaver-bin` for all four supported systems.
- Verified all four expected source hashes.
- Successfully built `dbeaver-bin` for `x86_64-linux`.
- Verified the resulting DBeaver launcher reports version 26.1.3.