### PR TITLE
archon-lite: use finalAttrs pattern

### DIFF
--- a/pkgs/by-name/ar/archon-lite/package.nix
+++ b/pkgs/by-name/ar/archon-lite/package.nix
@@ -4,26 +4,23 @@
   fetchurl,
   nix-update-script,
 }:
-let
+
+appimageTools.wrapType2 (finalAttrs: {
   pname = "archon-lite";
   version = "9.4.36";
+
   src = fetchurl {
-    url = "https://github.com/RPGLogs/Uploaders-archon-lite/releases/download/v${version}/archon-lite-v${version}.AppImage";
+    url = "https://github.com/RPGLogs/Uploaders-archon-lite/releases/download/v${finalAttrs.version}/archon-lite-v${finalAttrs.version}.AppImage";
     hash = "sha256-th48nSDIi2iugtiqjgkI7/QZtBq+BRQjRs1pKweDArI=";
   };
-
-  extracted = appimageTools.extractType2 { inherit pname version src; };
-in
-appimageTools.wrapType2 {
-  inherit pname version src;
 
   extraInstallCommands = ''
     mkdir -p $out/share/applications
     mkdir -p $out/share/icons/hicolor/512x512/apps
-    cp -r ${extracted}/usr/share/icons/hicolor/512x512/apps/'Archon App Lite.png' $out/share/icons/hicolor/512x512/apps/archon-lite.png
+    cp -r ${finalAttrs.contents}/usr/share/icons/hicolor/512x512/apps/'Archon App Lite.png' $out/share/icons/hicolor/512x512/apps/archon-lite.png
     chmod -R +w $out/share/
     test ! -e $out/share/icons/hicolor/0x0 # check for regression of https://github.com/electron-userland/electron-builder/issues/5294
-    cp ${extracted}/'Archon App Lite.desktop' $out/share/applications/archon-lite.desktop
+    cp ${finalAttrs.contents}/'Archon App Lite.desktop' $out/share/applications/archon-lite.desktop
     substituteInPlace $out/share/applications/archon-lite.desktop \
       --replace-fail "Exec=AppRun --no-sandbox" "Exec=archon-lite" \
       --replace-fail "Icon=Archon App Lite" "Icon=archon-lite"
@@ -34,7 +31,7 @@ appimageTools.wrapType2 {
   meta = {
     description = "Application for uploading MMORPG combat logs";
     homepage = "https://www.archon.gg/download";
-    downloadPage = "https://github.com/RPGLogs/Uploaders-archon-lite/releases/tag/v${version}";
+    downloadPage = "https://github.com/RPGLogs/Uploaders-archon-lite/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.unfree; # no license listed
     mainProgram = "archon-lite";
     platforms = lib.platforms.linux;
@@ -44,4 +41,4 @@ appimageTools.wrapType2 {
     ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
-}
+})


### PR DESCRIPTION
updates archon-lite to use the finalAttrs pattern now that it is supported for appimageTools
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
