### PR TITLE
tomboy-ng: build Qt 6 instead of GTK 2 version

### DIFF
--- a/pkgs/by-name/to/tomboy-ng/package.nix
+++ b/pkgs/by-name/to/tomboy-ng/package.nix
@@ -3,16 +3,13 @@
   stdenv,
   fetchFromGitHub,
   fpc,
-  lazarus,
+  lazarus-qt6,
   autoPatchelfHook,
 
-  glib,
   cairo,
   pango,
-  gtk2,
+  qt6Packages,
   gdk-pixbuf,
-  at-spi2-atk,
-  libx11,
   libnotify,
 
   nix-update-script,
@@ -37,24 +34,31 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     fpc
-    lazarus
+    lazarus-qt6
     autoPatchelfHook
+    qt6Packages.wrapQtAppsHook
   ];
 
   buildInputs = [
-    glib
     cairo
     pango
-    gtk2
+    qt6Packages.qtbase
+    qt6Packages.libqtpas
     gdk-pixbuf
-    at-spi2-atk
-    libx11
     libnotify
   ];
 
   patches = [ ./simplify-build-script.patch ];
 
   postPatch = "ln -s ${finalAttrs.kcontrols} kcontrols";
+
+  # The build script checks for magic files like `Qt5` or `Qt6`
+  # in order to determine which graphical toolkit tomboy-ng will
+  # be built on. Yes, this is something that upstream actually does:
+  # https://github.com/tomboy-notes/tomboy-ng/blob/619da85e4e11a7d20cd7f050b6b9d960a0e11a38/scripts/PKGBUILD.Qt6#L74
+  preBuild = ''
+    touch Qt6
+  '';
 
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
@@ -68,7 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   env = {
     COMPILER = lib.getExe' fpc "fpc";
-    LAZ_DIR = "${lazarus}/share/lazarus";
+    LAZ_DIR = "${lazarus-qt6}/share/lazarus";
   };
 
   meta = {
@@ -77,6 +81,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [ pluiedev ];
     mainProgram = "tomboy-ng";
-    platforms = lib.platforms.unix ++ lib.platforms.windows;
+    platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
tomboy-ng was always able to build with Qt 6 libs instead of GTK 2 ones, so getting rid of GTK 2 was pretty painless.

Part of #410814


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
