### PR TITLE
maintainers: fix myul GitHub account and add email

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19492,8 +19492,9 @@
     keys = [ { fingerprint = "086E EF20 D54E D348 E5BA  6263 16E9 43E6 596F FB4E"; } ];
   };
   myul = {
-    github = "myul";
-    githubId = 27887735;
+    email = "hdx0729@gmail.com";
+    github = "mtul0729";
+    githubId = 52401682;
     name = "myul";
   };
   myypo = {


### PR DESCRIPTION
## Description of changes

The original PR [#520307](https://github.com/NixOS/nixpkgs/pull/520307) accidentally used the wrong GitHub account. Fix `github` from `myul` to `mtul0729` and add email.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- [ ] Tested via `nix-build lib/tests/maintainers.nix`
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).