### PR TITLE
mq: init at 0.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10843,6 +10843,12 @@
     name = "Martin Hardselius";
     keys = [ { fingerprint = "3F35 E4CA CBF4 2DE1 2E90  53E5 03A6 E6F7 8693 6619"; } ];
   };
+  harehare = {
+    email = "harehare1110@gmail.com";
+    github = "harehare";
+    githubId = 533078;
+    name = "Takahiro Sato";
+  };
   HarisDotParis = {
     name = "Haris";
     email = "git@haris.paris";

--- a/pkgs/by-name/mq/mq/package.nix
+++ b/pkgs/by-name/mq/mq/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "mq";
+  version = "0.7.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "harehare";
+    repo = "mq";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-33MTLqMxxnOtqiBNqov9H91oK11OAqusAXMAuM4u7vQ=";
+  };
+
+  cargoHash = "sha256-fxKi1X0lzv+TLSH/HerUn9tOov0++ug8KeSUGhTord4=";
+
+  cargoBuildFlags = [
+    "--package"
+    "mq-run"
+    "--bin"
+    "mq"
+  ];
+
+  cargoTestFlags = [
+    "--package"
+    "mq-run"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "jq-like command-line tool for markdown processing";
+    longDescription = ''
+      mq is a command-line tool that processes Markdown using a syntax
+      similar to jq. It allows you to easily slice, filter, map, and
+      transform Markdown documents.
+    '';
+    homepage = "https://mqlang.org";
+    changelog = "https://github.com/harehare/mq/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ harehare ];
+    mainProgram = "mq";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Summary

Adds `mq`, a jq-like command-line tool for querying, filtering, and transforming Markdown documents. 

- Homepage: https://mqlang.org
- Repository: https://github.com/harehare/mq

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Assisted-by: Claude Code (claude-sonnet-5)