### PR TITLE
google-chrome: add aarch64-linux support

### DIFF
--- a/pkgs/by-name/go/google-chrome/package.nix
+++ b/pkgs/by-name/go/google-chrome/package.nix
@@ -181,10 +181,24 @@ let
     inherit pname meta passthru;
     version = "150.0.7871.186";
 
-    src = fetchurl {
-      url = "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${finalAttrs.version}-1_amd64.deb";
-      hash = "sha256-QZPgC21dWWnuY/emlZaGj1RqoOjLB3s+C/nMHixxnQA=";
-    };
+    src =
+      let
+        debArch =
+          {
+            aarch64-linux = "arm64";
+            x86_64-linux = "amd64";
+          }
+          .${stdenvNoCC.hostPlatform.system};
+      in
+      fetchurl {
+        url = "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${finalAttrs.version}-1_${debArch}.deb";
+        hash =
+          {
+            amd64 = "sha256-QZPgC21dWWnuY/emlZaGj1RqoOjLB3s+C/nMHixxnQA=";
+            arm64 = "sha256-AllqLQfbFu7EJCK5Xeo3TuItGMnOqunpMBKY4OJnj7M=";
+          }
+          .${debArch};
+      };
 
     # With strictDeps on, some shebangs were not being patched correctly
     # ie, $out/share/google/chrome/google-chrome
@@ -338,7 +352,10 @@ let
       iedame
       mdaniels5757
     ];
-    platforms = lib.platforms.darwin ++ [ "x86_64-linux" ];
+    platforms = lib.platforms.darwin ++ [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     mainProgram = "google-chrome-stable";
   };

--- a/pkgs/by-name/go/google-chrome/update.sh
+++ b/pkgs/by-name/go/google-chrome/update.sh
@@ -27,8 +27,10 @@ update_linux() {
     local version_info
     local version
     local current_version
+    local arch
+    local download_url
     local new_hash
-    local new_sri_hash
+    local -A new_hashes
 
     read -ra version_info <<< "$(get_version_info "linux" "linux = stdenvNoCC.mkDerivation" "});")"
     version="${version_info[0]}"
@@ -39,14 +41,18 @@ update_linux() {
         return 0
     fi
 
-    local download_url="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}-1_amd64.deb"
-    new_hash="$(nix-prefetch-url "$download_url" 2>/dev/null)"
-    new_sri_hash="$(nix --extra-experimental-features nix-command hash convert --hash-algo sha256 --to sri "$new_hash")"
+    for arch in amd64 arm64; do
+        download_url="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}-1_${arch}.deb"
+        new_hash="$(nix-prefetch-url "$download_url" 2>/dev/null)"
+        new_hashes["$arch"]="$(nix --extra-experimental-features nix-command hash convert --hash-algo sha256 --to sri "$new_hash")"
+    done
 
     sed -i "/^  linux = stdenvNoCC.mkDerivation/,/^  });/s/version = \".*\"/version = \"$version\"/" "$DEFAULT_NIX"
-    sed -i "/^  linux = stdenvNoCC.mkDerivation/,/^  });/s|hash = \".*\"|hash = \"$new_sri_hash\"|" "$DEFAULT_NIX"
 
-    echo "[Nix] Linux google-chrome: $current_version -> $version with hash $new_hash"
+    for arch in amd64 arm64; do
+        sed -i "/^  linux = stdenvNoCC.mkDerivation/,/^  });/s|^\([[:space:]]*\)${arch} = \".*\";|\1${arch} = \"${new_hashes[$arch]}\";|" "$DEFAULT_NIX"
+        echo "[Nix] Linux ${arch} google-chrome: $current_version -> $version with hash ${new_hashes[$arch]}"
+    done
 }
 
 update_darwin() {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

A revival of #376786.

Google now publishes ARM64 Linux builds for Google Chrome: https://blog.google/chromium/bringing-chrome-to-arm64-linux-devices/. This PR adds aarch64-linux Google Chrome packaging and made changes to update.sh to handle its automatic updates.

Assisted with gpt-5.6. Working screenshot in NixOS Parallels Desktop VM on Apple Silicon Mac:

<img width="3128" height="1826" alt="image" src="https://github.com/user-attachments/assets/6d0e92ad-a0f3-4450-b444-351bb9be184c" />


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
