### PR TITLE
jirafeau: 4.4.0 -> 4.7.2

### DIFF
--- a/nixos/modules/services/web-apps/jirafeau.nix
+++ b/nixos/modules/services/web-apps/jirafeau.nix
@@ -52,7 +52,7 @@ in
       '';
       description =
         let
-          documentationLink = "https://gitlab.com/mojo42/Jirafeau/-/blob/${cfg.package.version}/lib/config.original.php";
+          documentationLink = "https://gitlab.com/jirafeau/Jirafeau/-/blob/${cfg.package.version}/lib/config.original.php";
         in
         ''
           Jirefeau configuration. Refer to <${documentationLink}> for supported

--- a/nixos/tests/jirafeau.nix
+++ b/nixos/tests/jirafeau.nix
@@ -18,5 +18,20 @@
     machine.wait_for_unit("nginx.service")
     machine.wait_for_open_port(80)
     machine.succeed("curl -sSfL http://localhost/ | grep 'Jirafeau'")
+
+    machine.succeed("printf '%s' '<svg xmlns=\"http://www.w3.org/2000/svg\"><script>alert(1)</script></svg>' > /tmp/preview.svg")
+    link = machine.succeed(
+        "curl --fail --silent --show-error "
+        "-F time=month -F 'file=@/tmp/preview.svg;type=image' "
+        "http://localhost/script.php"
+    ).splitlines()[0]
+    headers = machine.succeed(
+        f"curl --fail --silent --show-error --dump-header - "
+        f"--output /tmp/preview-response 'http://localhost/f.php?h={link}&p=1'"
+    )
+    header_lines = {line.lower() for line in headers.splitlines()}
+    assert "x-content-type-options: nosniff" in header_lines
+    assert "content-type: image" in header_lines
+    machine.succeed("cmp /tmp/preview.svg /tmp/preview-response")
   '';
 }

--- a/pkgs/by-name/ji/jirafeau/package.nix
+++ b/pkgs/by-name/ji/jirafeau/package.nix
@@ -14,13 +14,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "jirafeau";
-  version = "4.4.0";
+  version = "4.7.2";
 
   src = fetchFromGitLab {
-    owner = "mojo42";
+    owner = "jirafeau";
     repo = "Jirafeau";
     rev = finalAttrs.version;
-    hash = "sha256-jJ2r8XTtAzawTVo2A2pDwy7Z6KHeyBkgXXaCPY0w/rg=";
+    hash = "sha256-zCmSdlHkYQVQXBeVk8AUPoC0UBxz3hWIdM2tGmnLTrw=";
   };
 
   installPhase = ''
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Website permitting upload of a file in a simple way and giving a unique link to it";
     license = lib.licenses.agpl3Plus;
-    homepage = "https://gitlab.com/mojo42/Jirafeau";
+    homepage = "https://gitlab.com/jirafeau/Jirafeau";
     platforms = lib.platforms.all;
     maintainers = [ ];
   };


### PR DESCRIPTION
Updates Jirafeau from 4.4.0 to 4.7.2 and moves source and documentation links to the continued official `jirafeau/Jirafeau` project. Its 4.4.0 tag resolves to the same commit as the previous namespace.

Version 4.7.2 contains the upstream fix for [CVE-2026-1466](https://nvd.nist.gov/vuln/detail/CVE-2026-1466), tracked by [Security Tracker Suggestion #1913](https://tracker.security.nixos.org/suggestions/by-id/1913/). The NixOS regression test uploads an SVG with the invalid MIME type `image` and verifies that preview responses retain the content type and exact body while sending `X-Content-Type-Options: nosniff`.

[Changelog](https://gitlab.com/jirafeau/Jirafeau/-/blob/4.7.2/CHANGELOG.md) · [Upstream fix](https://gitlab.com/jirafeau/Jirafeau/-/commit/747afb20bfcff14bb67e40e7035d47a6311ba3e1)

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
