### PR TITLE
python313Packages.pulsectl-asyncio: 1.2.2 -> 1.3.2

### DIFF
--- a/pkgs/development/python-modules/pulsectl-asyncio/default.nix
+++ b/pkgs/development/python-modules/pulsectl-asyncio/default.nix
@@ -6,7 +6,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pulsectl-asyncio";
   version = "1.3.2";
   pyproject = true;
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "mhthies";
     repo = "pulsectl-asyncio";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-SbNDX5tcNSfifT1Bpv5haKrPtkupH+bwM8Yc4jNbnz8=";
   };
 
@@ -35,8 +35,8 @@ buildPythonPackage rec {
   meta = {
     description = "Python bindings library for PulseAudio";
     homepage = "https://github.com/mhthies/pulsectl-asyncio";
-    changelog = "https://github.com/mhthies/pulsectl-asyncio/releases/tag/v${src.tag}";
+    changelog = "https://github.com/mhthies/pulsectl-asyncio/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/development/python-modules/pulsectl-asyncio/default.nix
+++ b/pkgs/development/python-modules/pulsectl-asyncio/default.nix
@@ -8,18 +8,19 @@
 
 buildPythonPackage rec {
   pname = "pulsectl-asyncio";
-  version = "1.2.2";
+  version = "1.3.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mhthies";
     repo = "pulsectl-asyncio";
     tag = "v${version}";
-    hash = "sha256-lHVLrkFdNM8Y4t6TcXYnX8sQ4COrW3vV2sTDWeI4xZU=";
+    hash = "sha256-SbNDX5tcNSfifT1Bpv5haKrPtkupH+bwM8Yc4jNbnz8=";
   };
 
   postPatch = ''
-    substituteInPlace setup.cfg --replace-fail "pulsectl >=23.5.0,<=24.11.0" "pulsectl >=23.5.0"
+    substituteInPlace pyproject.toml \
+      --replace-fail "pulsectl >=23.5.0,<=24.12.0" "pulsectl >=23.5.0"
   '';
 
   build-system = [ setuptools ];
@@ -34,7 +35,7 @@ buildPythonPackage rec {
   meta = {
     description = "Python bindings library for PulseAudio";
     homepage = "https://github.com/mhthies/pulsectl-asyncio";
-    changelog = "https://github.com/mhthies/pulsectl-asyncio/releases/tag/v${version}";
+    changelog = "https://github.com/mhthies/pulsectl-asyncio/releases/tag/v${src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };


### PR DESCRIPTION
Changelog: https://github.com/mhthies/pulsectl-asyncio/releases/tag/vv1.3.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
