### PR TITLE
harbor: init at 0.20.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11411,6 +11411,12 @@
     githubId = 1903556;
     keys = [ { fingerprint = "F1C5 760E 45B9 9A44 72E9  6BFB D65C 9AFB 4C22 4DA3"; } ];
   };
+  hobr = {
+    email = "mail@hobr.site";
+    github = "Hobr";
+    githubId = 13460388;
+    name = "Hobr";
+  };
   hogcycle = {
     email = "nate@gysli.ng";
     github = "hogcycle";

--- a/pkgs/by-name/ha/harbor-rewardkit/package.nix
+++ b/pkgs/by-name/ha/harbor-rewardkit/package.nix
@@ -1,0 +1,3 @@
+{ python3Packages }:
+
+python3Packages.toPythonApplication python3Packages.harbor-rewardkit

--- a/pkgs/by-name/ha/harbor/package.nix
+++ b/pkgs/by-name/ha/harbor/package.nix
@@ -1,0 +1,25 @@
+{
+  python3Packages,
+
+  # features
+  computer1Support ? false,
+  ec2Support ? false,
+  gkeSupport ? false,
+  wandbSupport ? false,
+
+  langsmithSupport ? false,
+  atif2otelSupport ? false,
+}:
+
+python3Packages.toPythonApplication (
+  python3Packages.harbor.override {
+    inherit
+      computer1Support
+      ec2Support
+      gkeSupport
+      wandbSupport
+      langsmithSupport
+      atif2otelSupport
+      ;
+  }
+)

--- a/pkgs/development/python-modules/dirhash/default.nix
+++ b/pkgs/development/python-modules/dirhash/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  scantree,
+  setuptools,
+  versioneer,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "dirhash";
+  version = "0.5.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "andhus";
+    repo = "dirhash-python";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-lTg9GwHArwHnZC7UwQEGa9TVdLKbkVANV84hkKsqQUo=";
+  };
+
+  build-system = [
+    setuptools
+    versioneer
+  ];
+
+  dependencies = [ scantree ];
+
+  # The CLI is installed in $out/bin rather than next to the Python interpreter.
+  postPatch = ''
+    substituteInPlace tests/test_cli.py \
+      --replace-fail 'os.path.dirname(sys.executable),' "\"$out/bin\","
+  '';
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "dirhash" ];
+
+  meta = {
+    description = "Python module and CLI for hashing file system directories";
+    homepage = "https://github.com/andhus/dirhash-python";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.hobr ];
+    mainProgram = "dirhash";
+  };
+})

--- a/pkgs/development/python-modules/harbor-atif2otel/default.nix
+++ b/pkgs/development/python-modules/harbor-atif2otel/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  opentelemetry-proto,
+
+  # optional-dependencies
+  harbor,
+
+  # tests
+  pytest-asyncio,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "harbor-atif2otel";
+  version = "0.1.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  disabled = pythonOlder "3.12";
+
+  src = fetchFromGitHub {
+    owner = "harbor-framework";
+    repo = "harbor";
+    tag = "v0.20.0";
+    hash = "sha256-uV7aWuRw+KuyGkA9srhEioZ8YWH8PzwYx5SQ7BUdV6E=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/packages/harbor-atif2otel";
+
+  build-system = [ hatchling ];
+
+  dependencies = [ opentelemetry-proto ];
+
+  optional-dependencies.plugin = [ harbor ];
+
+  nativeCheckInputs = [
+    harbor
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "harbor_atif2otel" ];
+
+  meta = {
+    description = "Converter from ATIF trajectories to OpenTelemetry spans";
+    homepage = "https://github.com/harbor-framework/harbor/tree/main/packages/harbor-atif2otel";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.hobr ];
+  };
+})

--- a/pkgs/development/python-modules/harbor-langsmith/default.nix
+++ b/pkgs/development/python-modules/harbor-langsmith/default.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+
+  # Avoid propagating two Harbor variants from plugin-enabled environments.
+  propagateHarbor ? true,
+
+  # build-system
+  uv-build,
+
+  # dependencies
+  harbor,
+  requests,
+
+  # tests
+  langsmith,
+  pytest-asyncio,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "harbor-langsmith";
+  version = "0.3.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  disabled = pythonOlder "3.12";
+
+  src = fetchFromGitHub {
+    owner = "harbor-framework";
+    repo = "harbor";
+    tag = "v0.20.0";
+    hash = "sha256-uV7aWuRw+KuyGkA9srhEioZ8YWH8PzwYx5SQ7BUdV6E=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/packages/harbor-langsmith";
+
+  # Nixpkgs has a newer uv-build than upstream allows.
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'uv_build>=0.10.8,<0.11.0' 'uv_build>=0.10.8'
+  '';
+
+  build-system = [ uv-build ];
+
+  buildInputs = lib.optionals (!propagateHarbor) [ harbor ];
+
+  dependencies = [ requests ] ++ lib.optionals propagateHarbor [ harbor ];
+
+  nativeCheckInputs = [
+    langsmith
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "harbor_langsmith" ];
+
+  meta = {
+    description = "LangSmith plugin for Harbor jobs";
+    homepage = "https://github.com/harbor-framework/harbor/tree/main/packages/harbor-langsmith";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.hobr ];
+  };
+})

--- a/pkgs/development/python-modules/harbor-rewardkit/default.nix
+++ b/pkgs/development/python-modules/harbor-rewardkit/default.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+
+  # build-system
+  uv-build,
+
+  # dependencies
+  litellm,
+
+  # optional-dependencies
+  markitdown,
+  pillow,
+
+  # tests
+  pytest-asyncio,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "harbor-rewardkit";
+  version = "0.1.7";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  disabled = pythonOlder "3.12";
+
+  src = fetchFromGitHub {
+    owner = "harbor-framework";
+    repo = "harbor";
+    tag = "v0.20.0";
+    hash = "sha256-uV7aWuRw+KuyGkA9srhEioZ8YWH8PzwYx5SQ7BUdV6E=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/packages/rewardkit";
+
+  # Nixpkgs has a newer uv-build than upstream allows.
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'uv_build>=0.10.8,<0.11.0' 'uv_build>=0.10.8'
+  '';
+
+  build-system = [ uv-build ];
+
+  dependencies = [ litellm ];
+
+  optional-dependencies = {
+    documents = [ markitdown ];
+    image = [ pillow ];
+    all = [
+      markitdown
+      pillow
+    ];
+  };
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "rewardkit" ];
+
+  meta = {
+    description = "Toolkit for defining and running task verifiers";
+    homepage = "https://github.com/harbor-framework/harbor/tree/main/packages/rewardkit";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.hobr ];
+    mainProgram = "rewardkit";
+  };
+})

--- a/pkgs/development/python-modules/harbor/default.nix
+++ b/pkgs/development/python-modules/harbor/default.nix
@@ -1,0 +1,331 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  python,
+  pythonOlder,
+
+  # build-system
+  bun,
+  nodejs,
+  stdenvNoCC,
+  uv-build,
+
+  # dependencies
+  dirhash,
+  fastapi,
+  filelock,
+  httpx,
+  jinja2,
+  litellm,
+  packaging,
+  pathspec,
+  platformdirs,
+  pydantic,
+  pyjwt,
+  python-dotenv,
+  pyyaml,
+  requests,
+  rich,
+  shortuuid,
+  supabase,
+  tenacity,
+  toml,
+  typer,
+  uvicorn,
+
+  # tests
+  cwsandbox,
+  dockerfile-parse,
+  hypothesis,
+  pandas,
+  pytest-asyncio,
+  pytestCheckHook,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+
+  # runtime tools
+  docker-client,
+  git,
+  uv,
+
+  # passthru
+  nix-update-script,
+
+  runCommand,
+
+  # features
+  computer1Support ? false,
+  anthropic,
+  google-genai,
+  openai,
+
+  ec2Support ? false,
+  boto3,
+
+  gkeSupport ? false,
+  kubernetes,
+
+  wandbSupport ? false,
+  wandb,
+
+  langsmithSupport ? false,
+  langsmith,
+  harbor-langsmith,
+
+  atif2otelSupport ? false,
+  harbor-atif2otel,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "harbor";
+  version = "0.20.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  disabled = pythonOlder "3.12";
+
+  src = fetchFromGitHub {
+    owner = "harbor-framework";
+    repo = "harbor";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-uV7aWuRw+KuyGkA9srhEioZ8YWH8PzwYx5SQ7BUdV6E=";
+  };
+
+  viewerNodeModules = stdenvNoCC.mkDerivation {
+    pname = "${finalAttrs.pname}-viewer-node_modules";
+    inherit (finalAttrs) version src;
+
+    sourceRoot = "${finalAttrs.src.name}/apps/viewer";
+
+    impureEnvVars = lib.fetchers.proxyImpureEnvVars;
+
+    nativeBuildInputs = [
+      bun
+      writableTmpDirAsHomeHook
+    ];
+
+    dontConfigure = true;
+    dontFixup = true;
+
+    buildPhase = ''
+      runHook preBuild
+
+      export BUN_INSTALL_CACHE_DIR=$(mktemp -d)
+      bun install \
+        --backend=copyfile \
+        --cpu="*" \
+        --os="*" \
+        --frozen-lockfile \
+        --ignore-scripts \
+        --no-progress
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      cp -R node_modules $out/node_modules
+
+      runHook postInstall
+    '';
+
+    outputHash = "sha256-vYzs0TNeXeNSCgk4ggTk72rZ7rpAEUWebYyYsiJhLbg=";
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+  };
+
+  # Nixpkgs has a newer uv-build than upstream allows.
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'uv_build>=0.8.4,<0.9.0' 'uv_build>=0.8.4'
+
+    cp -R ${finalAttrs.viewerNodeModules}/node_modules apps/viewer/
+    chmod -R u+w apps/viewer/node_modules
+    patchShebangs apps/viewer/node_modules
+  '';
+
+  build-system = [ uv-build ];
+
+  nativeBuildInputs = [
+    bun
+    nodejs
+  ];
+
+  preBuild = ''
+    pushd apps/viewer
+    bun run build
+    popd
+
+    rm -rf src/harbor/viewer/static
+    mkdir -p src/harbor/viewer/static
+    cp -R apps/viewer/build/client/* src/harbor/viewer/static/
+  '';
+
+  dependencies = [
+    dirhash
+    fastapi
+    filelock
+    httpx
+    jinja2
+    litellm
+    packaging
+    pathspec
+    platformdirs
+    pydantic
+    pyjwt
+    python-dotenv
+    pyyaml
+    requests
+    rich
+    shortuuid
+    supabase
+    tenacity
+    toml
+    typer
+    uvicorn
+  ]
+  ++ lib.optionals computer1Support [
+    anthropic
+    google-genai
+    openai
+  ]
+  ++ lib.optionals computer1Support anthropic.optional-dependencies.bedrock
+  ++ lib.optionals ec2Support [ boto3 ]
+  ++ lib.optionals gkeSupport [ kubernetes ]
+  ++ lib.optionals wandbSupport [
+    cwsandbox
+    wandb
+  ]
+  ++ lib.optionals langsmithSupport [
+    (harbor-langsmith.override { propagateHarbor = false; })
+    langsmith
+  ]
+  ++ lib.optionals atif2otelSupport [ harbor-atif2otel ];
+
+  makeWrapperArgs = [
+    "--prefix"
+    "PATH"
+    ":"
+    (lib.makeBinPath [
+      docker-client
+      git
+      uv
+    ])
+  ];
+
+  nativeCheckInputs = [
+    cwsandbox
+    dockerfile-parse
+    git
+    hypothesis
+    pandas
+    pytest-asyncio
+    pytestCheckHook
+    uv
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+
+  preCheck = ''
+    export UV_NO_MANAGED_PYTHON=1
+    export UV_PYTHON=${python.interpreter}
+    export UV_PYTHON_DOWNLOADS=never
+  '';
+
+  # Docker tests require a daemon unavailable in the sandbox.
+  enabledTestPaths = [
+    "tests/unit"
+    "tests/runtime/test_installed_agent.py"
+  ];
+
+  disabledTestPaths = [
+    # Optional SDKs unavailable in nixpkgs.
+    "tests/unit/environments/test_blaxel.py"
+
+    "tests/unit/environments/test_daytona.py"
+    "tests/unit/environments/test_environment_definition.py::TestProviderValidation::test_daytona_accepts_docker_image_without_dockerfile"
+    "tests/unit/environments/test_environment_definition.py::TestProviderValidation::test_missing_definition_raises[DaytonaEnvironment]"
+
+    "tests/unit/environments/test_environment_definition.py::TestProviderValidation::test_e2b_accepts_docker_image_without_dockerfile"
+    "tests/unit/environments/test_environment_definition.py::TestProviderValidation::test_missing_definition_raises[E2BEnvironment]"
+
+    "tests/unit/environments/test_islo.py"
+
+    "tests/unit/environments/test_novita.py"
+    "tests/unit/environments/test_environment_definition.py::TestProviderValidation::test_novita_accepts_docker_image_without_dockerfile"
+
+    "tests/unit/environments/test_runloop.py"
+    "tests/unit/environments/test_environment_definition.py::TestProviderValidation::test_runloop_accepts_docker_image_without_dockerfile"
+    "tests/unit/environments/test_environment_definition.py::TestProviderValidation::test_runloop_defaults_workdir_when_dockerfile_has_no_workdir"
+    "tests/unit/environments/test_environment_definition.py::TestProviderValidation::test_missing_definition_raises[RunloopEnvironment]"
+
+    "tests/unit/environments/test_tensorlake.py"
+  ]
+  ++ lib.optionals (!computer1Support) [
+    "tests/unit/agents/computer_1"
+    "tests/unit/agents/test_factory_computer_1.py"
+  ]
+  ++ lib.optionals (!gkeSupport) [
+    "tests/unit/environments/test_gke.py"
+  ]
+  ++ lib.optionals (!langsmithSupport) [
+    "tests/unit/test_langsmith_environment.py"
+  ]
+  ++ lib.optionals (!wandbSupport) [
+    "tests/unit/environments/cwsandbox/test_wandb.py"
+  ];
+
+  disabledTests = [
+    # Blaxel SDK is unavailable.
+    "test_blaxel_preflight_missing_auth"
+    "test_blaxel_preflight_ok"
+
+    # Requires network access.
+    "test_relative_path_without_dot_slash_hints"
+
+    # Installed distributions report "package", not "source".
+    "test_install_source_uses_source_import_fallback"
+  ]
+  ++ lib.optionals (!ec2Support) [
+    "test_ec2_preflight_no_ssh"
+    "test_ec2_preflight_ok"
+  ]
+  ++ lib.optionals (!langsmithSupport) [
+    "test_langsmith_preflight_missing_auth"
+    "test_langsmith_preflight_ok_api_key"
+    "test_langsmith_preflight_ok_profile"
+    "test_run_delivers_nesting_handle_from_registry_into_env"
+  ]
+  ++ lib.optionals (!wandbSupport) [
+    "test_wandb_preflight_rejects_invalid_credentials"
+    "test_wandb_preflight_ok"
+  ];
+
+  pythonImportsCheck = [ "harbor" ];
+
+  passthru.tests.viewer = runCommand "${finalAttrs.pname}-viewer-test" { } ''
+    test -f "${finalAttrs.finalPackage}/${python.sitePackages}/harbor/viewer/static/index.html"
+    test -d "${finalAttrs.finalPackage}/${python.sitePackages}/harbor/viewer/static/assets"
+    touch $out
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--use-github-releases"
+      "--version-regex=^v([0-9]+\\.[0-9]+\\.[0-9]+)$"
+    ];
+  };
+
+  meta = {
+    description = "Framework for evaluating and optimizing agents and models";
+    homepage = "https://github.com/harbor-framework/harbor";
+    changelog = "https://github.com/harbor-framework/harbor/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.hobr ];
+    mainProgram = "harbor";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7435,6 +7435,8 @@ self: super: with self; {
 
   hap-python = callPackage ../development/python-modules/hap-python { };
 
+  harbor-rewardkit = callPackage ../development/python-modules/harbor-rewardkit { };
+
   harlequin-bigquery = callPackage ../development/python-modules/harlequin-bigquery { };
 
   harlequin-postgres = callPackage ../development/python-modules/harlequin-postgres { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7437,6 +7437,12 @@ self: super: with self; {
 
   hap-python = callPackage ../development/python-modules/hap-python { };
 
+  harbor = callPackage ../development/python-modules/harbor { inherit (pkgs) uv; };
+
+  harbor-atif2otel = callPackage ../development/python-modules/harbor-atif2otel { };
+
+  harbor-langsmith = callPackage ../development/python-modules/harbor-langsmith { };
+
   harbor-rewardkit = callPackage ../development/python-modules/harbor-rewardkit { };
 
   harlequin-bigquery = callPackage ../development/python-modules/harlequin-bigquery { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4380,6 +4380,8 @@ self: super: with self; {
 
   directv = callPackage ../development/python-modules/directv { };
 
+  dirhash = callPackage ../development/python-modules/dirhash { };
+
   dirigera = callPackage ../development/python-modules/dirigera { };
 
   dirsearch = callPackage ../development/python-modules/dirsearch { };


### PR DESCRIPTION
[Harbor](https://github.com/harbor-framework/harbor) is a framework for specifying sandboxed agent tasks for evaluation and optimization.

This PR introduces the following packages:

- `harbor` and `python3Packages.harbor`: the standalone Harbor CLI and its importable Python package.
- [`harbor-rewardkit`](https://github.com/harbor-framework/harbor/tree/main/packages/rewardkit) and `python3Packages.harbor-rewardkit`: the standalone RewardKit CLI and its importable Python library for defining and running verifiers.
- [`python3Packages.harbor-atif2otel`](https://github.com/harbor-framework/harbor/tree/main/packages/harbor-atif2otel): an optional Harbor plugin that converts ATIF trajectories into OpenTelemetry spans.
- [`python3Packages.harbor-langsmith`](https://github.com/harbor-framework/harbor/tree/main/packages/harbor-langsmith): an optional Harbor plugin providing LangSmith integration for Harbor jobs.
- [`python3Packages.dirhash`](https://github.com/andhus/dirhash-python): a directory hashing library required by Harbor.

Optional Harbor integrations are disabled by default and can be enabled through `harbor.override` like:

```nix
(pkgs.harbor.override {
  computer1Support = true;
  ec2Support = true;
  gkeSupport = true;
  wandbSupport = true;
  langsmithSupport = true;
  atif2otelSupport = true;
})
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
