### PR TITLE
haskellPackages.jose-jwt: use crypton 1.1 and ram

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2537,6 +2537,16 @@ with haskellLib;
   # https://github.com/diogob/postgres-websockets/issues/116
   postgres-websockets = doJailbreak super.postgres-websockets;
 
+  jose-jwt = appendPatches [
+    # https://github.com/tekul/jose-jwt/issues/49
+    (pkgs.fetchpatch {
+      name = "crypton-1.1-and-ram.patch";
+      url = "https://github.com/tekul/jose-jwt/commit/f93bd9436d798eb81618fa0f699f677194efcf8c.patch";
+      includes = [ "jose-jwt.cabal" ];
+      sha256 = "sha256-XEqDEUtYOcWieHOoczbtucQsLKS12ini2SL94hG4w+o=";
+    })
+  ] ((warnAfterVersion "0.10.0") super.jose-jwt);
+
   postgrest =
     lib.pipe
       (super.postgrest.overrideScope (


### PR DESCRIPTION


## Things done

- Built on platform:
  - [x] x86_64-linux
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
