### PR TITLE
libvncserver: backport CVE-2026-32853 and CVE-2026-32854 fixes

### DIFF
--- a/pkgs/by-name/li/libvncserver/package.nix
+++ b/pkgs/by-name/li/libvncserver/package.nix
@@ -41,6 +41,18 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/LibVNC/libvncserver/commit/e64fa928170f22a2e21b5bbd6d46c8f8e7dd7a96.patch";
       hash = "sha256-AAZ3H34+nLqQggb/sNSx2gIGK96m4zatHX3wpyjNLOA=";
     })
+
+    (fetchpatch {
+      name = "CVE-2026-32854.patch";
+      url = "https://github.com/LibVNC/libvncserver/commit/dc78dee51a7e270e537a541a17befdf2073f5314.patch";
+      hash = "sha256-CgVfvsrgZWnjIzu/0UegoAuCqO7WHhCDVvhH8Yk1cXo=";
+    })
+
+    (fetchpatch {
+      name = "CVE-2026-32853.patch";
+      url = "https://github.com/LibVNC/libvncserver/commit/009008e2f4d5a54dd71f422070df3af7b3dbc931.patch";
+      hash = "sha256-ZgpiIS7KoRzDmVLQ0J86wTFFykCBVMt6bZwJsFvIO74=";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
Backports the canonical upstream fixes for two vulnerabilities affecting LibVNCServer 0.9.15:

- [CVE-2026-32853](https://github.com/LibVNC/libvncserver/security/advisories/GHSA-87q7-v983-qwcj), tracked by [Security Tracker Suggestion #4160](https://tracker.security.nixos.org/suggestions/by-id/4160/), adds bounds checks to UltraZip subrectangle parsing.
- [CVE-2026-32854](https://github.com/LibVNC/libvncserver/security/advisories/GHSA-xjp8-4qqv-5x4x), tracked by [Security Tracker Suggestion #4193](https://tracker.security.nixos.org/suggestions/by-id/4193/), rejects malformed HTTP proxy requests instead of dereferencing missing delimiters.

Source-level ASan fixtures reproduced both UltraZip out-of-bounds paths on 0.9.15, verified that the patched parser returns `FALSE`, and retained valid decoding. A minimal HTTP server reproduced SIGSEGV for malformed `CONNECT` and `GET` requests on 0.9.15, while the patched server rejected both and retained normal HTTP responses.

The package's enabled upstream test suite passed as part of the `libvncserver` build.

`nixpkgs-review` built 19 affected packages. `animeko` was already marked broken. `blink-qt` remains blocked by pre-existing metadata failures in `python3Packages.otr` and `python3Packages.python3-sipsimple`; both failures were reproduced on the unchanged base revision.

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

