### PR TITLE
freecad: 1.1.1 -> 1.1.3

### DIFF
--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -33,6 +33,8 @@
   which,
   gtk3,
   gsettings-desktop-schemas,
+  versionCheckHook,
+  writeShellScript,
 }:
 let
   pythonDeps = with python3Packages; [
@@ -158,6 +160,28 @@ freecad-utils.makeCustomizable (
         ];
       };
     };
+
+    nativeInstallCheckInputs = [ versionCheckHook ];
+    doInstallCheck = true;
+
+    versionCheckProgram = writeShellScript "version-check.sh" ''
+      # As of 2026-07-26, the way FreeCAD handles `--version` is awful.
+      # - The main program, `freecad`, opens a GUI prompt for `--version`,
+      # unless `--console` is also given.
+      # - Even with `--version --console`, `freecad` crashes if there is no
+      # display server, so we need to use `freecadcmd` instead, which is a
+      # separate binary, for unknown reasons.
+      # - `freecadcmd --version` crashes if it cannot create a directory under
+      # `$HOME/.local/share/FreeCAD/`
+      #   Adding `--safe-mode` appears to fix this, but `versionCheckProgramArg`
+      #  only allows for a single argument (as a list gets concaternated),
+      #  so we need this script.
+
+      # The path to `freecadcmd` gets passed in via $1, to allow the `out`
+      # placeholder to function properly
+      exec "$1" --version --safe-mode
+    '';
+    versionCheckProgramArg = "${placeholder "out"}/bin/freecadcmd";
 
     # 6.9k object files, cuts down build time from 2-3 hours to 15 minutes
     requiredSystemFeatures = [ "big-parallel" ];

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -209,6 +209,7 @@ freecad-utils.makeCustomizable (
       maintainers = with lib.maintainers; [
         srounce
         grimmauld
+        acuteaangle
       ];
       platforms = lib.platforms.linux;
       mainProgram = "freecad";

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -61,13 +61,13 @@ in
 freecad-utils.makeCustomizable (
   stdenv.mkDerivation (finalAttrs: {
     pname = "freecad";
-    version = "1.1.1";
+    version = "1.1.3";
 
     src = fetchFromGitHub {
       owner = "FreeCAD";
       repo = "FreeCAD";
       tag = finalAttrs.version;
-      hash = "sha256-7/VEbs8YDM1Xwc819ab6av5fgRSIbbB6LeCM0V08vRU=";
+      hash = "sha256-RP68rd19wX4gDD5PuRQ1J4Z9Qmp5HpEg6sC94RRMEdI=";
       fetchSubmodules = true;
     };
 

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -211,6 +211,7 @@ freecad-utils.makeCustomizable (
         grimmauld
       ];
       platforms = lib.platforms.linux;
+      mainProgram = "freecad";
     };
   })
 )


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
