### PR TITLE
neural-amp-modeler-lv2: 0.1.4 -> 0.2.3

### DIFF
--- a/pkgs/by-name/ne/neural-amp-modeler-lv2/package.nix
+++ b/pkgs/by-name/ne/neural-amp-modeler-lv2/package.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   cmake,
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "neural-amp-modeler-lv2";
   version = "0.2.3";
@@ -22,7 +21,10 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
-    maintainers = [ lib.maintainers.viraptor ];
+    maintainers = [
+      lib.maintainers.viraptor
+      lib.maintainers.gabyx
+    ];
     description = "Neural Amp Modeler LV2 plugin implementation";
     homepage = finalAttrs.src.meta.homepage;
     license = [ lib.licenses.gpl3 ];

--- a/pkgs/by-name/ne/neural-amp-modeler-lv2/package.nix
+++ b/pkgs/by-name/ne/neural-amp-modeler-lv2/package.nix
@@ -7,14 +7,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "neural-amp-modeler-lv2";
-  version = "0.1.4";
+  version = "0.2.3";
 
   src = fetchFromGitHub {
     owner = "mikeoliphant";
     repo = "neural-amp-modeler-lv2";
-    tag = finalAttrs.version;
+    tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-5BOZOocZWWSWawXJFMAgM0NR0s0CbkzDVr6fnvZMvd0=";
+    hash = "sha256-TkynGmhwnkTqieJNuC+H2rDgxYZ9IFvqukfmtbSj790=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
- Update [neural-amp-modeler-lv2](https://github.com/mikeoliphant/neural-amp-modeler-lv2).
- Add me as a maintainer.

Assisted-by: no agent.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
