### PR TITLE
eiskaltdcpp: pcre-cpp -> pcre2

### DIFF
--- a/pkgs/by-name/ei/eiskaltdcpp/package.nix
+++ b/pkgs/by-name/ei/eiskaltdcpp/package.nix
@@ -9,7 +9,7 @@
   libx11,
   libsForQt5,
   libiconv,
-  pcre-cpp,
+  pcre2,
   libidn,
   lua5,
   miniupnpc,
@@ -34,6 +34,10 @@ stdenv.mkDerivation rec {
       url = "https://github.com/eiskaltdcpp/eiskaltdcpp/commit/5ab5e1137a46864b6ecd1ca302756da8b833f754.patch?full_index=1";
       hash = "sha256-GIdcIHKXNSbHxbiMGRPgfq2w/zNSfR/FhyyXayFWfg8=";
     })
+    (fetchpatch2 {
+      url = "https://github.com/eiskaltdcpp/eiskaltdcpp/commit/39f27cdbaefb3d0c18e6d33f340ef31c9061dc84.patch?full_index=1";
+      hash = "sha256-yxIdJSPtn3HDS5kXqpVLkDavUBhpdywm+X4M7B9g6Vo=";
+    })
   ];
 
   nativeBuildInputs = [
@@ -48,7 +52,7 @@ stdenv.mkDerivation rec {
     libsForQt5.qtscript
     bzip2
     libx11
-    pcre-cpp
+    pcre2
     libidn
     lua5
     miniupnpc


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The old pcre has a cpp variant, but pcre2 works out of the box without specifically having to enable cpp. Just replacing pcre-cpp with pcre2 didn't work for this specific package, but the solution was easy to find in [the upstream changelog](https://github.com/eiskaltdcpp/eiskaltdcpp/blob/master/ChangeLog.txt). They have a version 2.4.3 with "Port ADL search from PCRECPP to PCRE2". There's no official release for 2.4.3 so I just opted for a patch of that commit.

Relates to: https://github.com/NixOS/nixpkgs/issues/356387

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
