### PR TITLE
python3Packages.textstat: fix build, enable __structuredAttrs and do some cleanup

### DIFF
--- a/pkgs/development/python-modules/textstat/default.nix
+++ b/pkgs/development/python-modules/textstat/default.nix
@@ -12,6 +12,8 @@ buildPythonPackage (finalAttrs: {
   pname = "textstat";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "textstat";
     repo = "textstat";

--- a/pkgs/development/python-modules/textstat/default.nix
+++ b/pkgs/development/python-modules/textstat/default.nix
@@ -6,7 +6,6 @@
   setuptools,
   pyphen,
   pytestCheckHook,
-  pytest,
 }:
 buildPythonPackage (finalAttrs: {
   version = "0.7.13";
@@ -34,21 +33,15 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [
     pytestCheckHook
-    pytest
   ];
 
   dependencies = [
-    setuptools
     pyphen
     nltk
   ];
 
   pythonImportsCheck = [
     "textstat"
-  ];
-
-  enabledTestPaths = [
-    "tests/"
   ];
 
   env.NLTK_DATA = nltk.data.cmudict;

--- a/pkgs/development/python-modules/textstat/default.nix
+++ b/pkgs/development/python-modules/textstat/default.nix
@@ -20,6 +20,14 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-VMWwhwyGMFaKNLHoDG3gw1/jzSYCDBH3Yq4pE4JZTTo=";
   };
 
+  # Version 0.7.13 still has 0.7.12 set as it's version. That makes pythonMetadataCheckPhase unhappy.
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail "0.7.12" "0.7.13"
+    substituteInPlace textstat/__init__.py \
+      --replace-fail "0, 7, 12" "0, 7, 13"
+  '';
+
   build-system = [
     setuptools
   ];


### PR DESCRIPTION
Fixes #545866

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
