### PR TITLE
llama-swap: define cache directories

### DIFF
--- a/nixos/modules/services/networking/llama-swap.nix
+++ b/nixos/modules/services/networking/llama-swap.nix
@@ -42,15 +42,6 @@ in
       '';
     };
 
-    useLlamaCppCacheDir = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = ''
-        Whether to use {file}`/var/cache/llama-cpp` as {env}`LLAMA_CACHE` instead
-        of {file}`/var/cache/llama-swap` to share models and other cache with {option}`services.llama-cpp`.
-      '';
-    };
-
     tls = {
       enable = lib.mkEnableOption "TLS encryption";
 
@@ -122,8 +113,9 @@ in
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
 
-      environment = {
-        LLAMA_CACHE = lib.mkDefault "/var/cache/${config.systemd.services.llama-swap.serviceConfig.CacheDirectory}";
+      environment = rec {
+        XDG_CACHE_HOME = "/var/cache/${config.systemd.services.llama-swap.serviceConfig.CacheDirectory}";
+        LLAMA_CACHE = "${XDG_CACHE_HOME}/huggingface/hub";
       };
 
       serviceConfig = {
@@ -143,11 +135,7 @@ in
         Restart = "on-failure";
         RestartSec = 3;
 
-        CacheDirectory =
-          if cfg.useLlamaCppCacheDir then
-            config.systemd.services.llama-cpp.serviceConfig.CacheDirectory
-          else
-            "llama-swap";
+        CacheDirectory = "llama-swap";
 
         # for GPU acceleration
         PrivateDevices = false;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
There is something we both missed, if llama-cpp module is not enabled the entire service is undefined and it's values can't be referenced and this results in an undefined error if useLlamaCppCacheDir is true. Fortunately lazy evaluation means that people won't experience issues if they don't try to enable the new option. This means that this option is essentially dead on arrival with nobody relying on it as just setting it will not let you evaluate so in this unique circumstance there also shouldn't be any problem just removing it if we decide that it's not worth it having it.

My end goal is making something that fills the same niche as `services.ollama.loadModels` but in `llama-swap` in #541069 .
Having an option to share llama-cpp cache and llama-swap cache is good to ease migration for people using `llama-cpp` already but it is possible to also manually migrate files so it's not really essential. The primary reason for having it at the moment is because per https://github.com/NixOS/nixpkgs/pull/541069#pullrequestreview-4686582256 I have to implement the `loadModels` part either in `llama-cpp` module or as a completely separate module. If this requirement is dropped the need for `useLlamaCppCache` isn't so strict.

If we embrace the `llama-swap` cache directory as it's own independent thing we can point `LLAMA_CACHE` to the directory that llama-cpp would write to under a normal user which is `/var/cache/llama-swap/huggingface/hub` if we assume `/var/cache/llama-swap` is our equivalent of `XDG_CACHE_HOME`. This will avoid mixture of cache data with other possible llama-swap backends. Of course if one needs to do this the variables can still be overridden with `lib.mkForce`.
I think doing it like that would probably be better In the end for all backends.

Regarding my `loadModels` goal, I think to truly replicate the ollama experience of having models immediately available but updating in the background one has to work with `llama-swap` and maybe even `llama-cpp` upstreams so I will explore that path instead because NixOS scripts despite coming close just don't cut it.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
