### PR TITLE
sage: fix segfaults and test timeout on darwin

### DIFF
--- a/pkgs/by-name/sa/sage/package.nix
+++ b/pkgs/by-name/sa/sage/package.nix
@@ -30,6 +30,7 @@ let
         # `sagelib`, i.e. all of sage except some wrappers and runtime dependencies
         sagelib = self.callPackage ./sagelib.nix {
           inherit flint;
+          inherit eclib;
           inherit ntl;
           inherit sage-src env-locations singular;
           inherit (maxima) lisp-compiler;
@@ -92,6 +93,8 @@ let
       python3
       singular
       palp
+      eclib
+      giac
       flint
       ntl
       pythonEnv
@@ -108,6 +111,8 @@ let
   # sagelib with added wrappers and a dependency on sage-tests to make sure thet tests were run.
   sage-with-env = callPackage ./sage-with-env.nix {
     inherit python3 pythonEnv;
+    inherit eclib;
+    inherit giac;
     inherit ntl;
     inherit sage-env;
     inherit singular maxima;
@@ -157,7 +162,7 @@ let
       extraLibs = pythonRuntimeDeps;
     }; # make the libs accessible
 
-  singular = pkgs.singular.override { inherit flint; };
+  singular = pkgs.singular.override { inherit flint ntl; };
 
   maxima = pkgs.maxima-ecl.override {
     lisp-compiler = pkgs.ecl.override {
@@ -179,7 +184,18 @@ let
   # openblas instead of openblasCompat. Apparently other packages somehow use flints
   # blas when it is available. Alternative would be to override flint to use
   # openblasCompat.
-  flint = pkgs.flint.override { withBlas = false; };
+  flint = pkgs.flint.override {
+    inherit ntl;
+    withBlas = false;
+  };
+
+  eclib = pkgs.eclib.override {
+    inherit ntl;
+  };
+
+  giac = pkgs.giac.override {
+    inherit ntl;
+  };
 
   # Multiple palp dimensions need to be available and sage expects them all to be
   # in the same folder.


### PR DESCRIPTION
After #541155 disabled `ntl` threading on Darwin to bypass a compilation failure, the sage tests started failing with segfaults caused by with-threading and without-threading `ntl` assumptions present in the graph of libraries installed by the build. This change ensures that all dependencies that link against `ntl` use the same copy, that is, the no-threading copy on Darwin.

With these change the tests now pass.

Fixes #545650

Besides fixing tests this likely resolves end-user segfaults in the sage build.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
