### PR TITLE
nixos/iscsi-root-initiator: support systemd stage 1

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -136,6 +136,8 @@
     and the default changed to a UNIX domain socket.
   - A cookie-cutter nginx vhost can be enabled at [](#opt-services.netbox.nginx.enable).
 
+- [boot.iscsi-initiator](#opt-boot.iscsi-initiator.name) now supports systemd stage 1 and no longer asserts against it. The iSCSI login runs as ordered initrd units instead of a script in `preLVMCommands`, so it no longer races DHCP. Initrd networking is left to [boot.initrd.network.enable](#opt-boot.initrd.network.enable) with networkd, configured from the `ip=` kernel parameter or the `networking.*` options. No options changed, and the scripted initrd path still works.
+
 - `security.run0.enableSudoAlias` now uses the `run0-sudo-shim` instead of a shell-script to improve compatibility.
 
 - With `system.etc.overlay.mutable = false`, NixOS now ships an empty `/etc/machine-id` in the image. Previously the file was absent and systemd logged `System cannot boot: Missing /etc/machine-id and /etc/ is read-only` while `ConditionFirstBoot` fired on every boot. With this change, systemd now overlays a transient ID from `/run/machine-id` for the session, and `systemd-machine-id-commit.service` has `ConditionFirstBoot` so it writes the machine-id through to a persistent backing file when one is bind-mounted over `/etc/machine-id`. To persist the machine-id across reboots, bind-mount a writable file containing `uninitialized` over `/etc/machine-id` from the initrd, or set `systemd.machine_id=` on the kernel command line (use `systemd.machine_id=firmware` to derive a stable ID on hardware that supports it).

--- a/nixos/modules/services/networking/iscsi/root-initiator.nix
+++ b/nixos/modules/services/networking/iscsi/root-initiator.nix
@@ -7,6 +7,65 @@
 with lib;
 let
   cfg = config.boot.iscsi-initiator;
+
+  useSystemd = config.boot.initrd.systemd.enable;
+
+  # The static portion of the initrd iscsid.conf: the upstream default plus any
+  # `extraConfig`, and `node.startup = automatic` when logging into all targets.
+  # Built as a normal derivation to avoid import-from-derivation. Secrets from
+  # `extraConfigFile` are appended at runtime, not here.
+  iscsidConf = pkgs.runCommand "iscsid-initrd.conf" { } ''
+    cat ${pkgs.openiscsi}/etc/iscsi/iscsid.conf > "$out"
+    cat >> "$out" <<'EOF'
+
+    ${optionalString (cfg.extraConfig != null) cfg.extraConfig}
+    ${optionalString cfg.loginAll "node.startup = automatic"}
+    EOF
+  '';
+
+  # Assemble /etc/iscsi/{iscsid.conf,initiatorname.iscsi} in the (writable)
+  # initrd /etc before iscsid starts. Kept out of the login unit so it also runs
+  # for the systemd path's iscsid ExecStartPre.
+  prepConf = pkgs.writeShellScript "iscsi-initrd-prep" ''
+    set -eu
+    mkdir -p /etc/iscsi /run/lock/iscsi
+    cp ${iscsidConf} /etc/iscsi/iscsid.conf
+    chmod +w /etc/iscsi/iscsid.conf
+    echo "InitiatorName=${cfg.name}" > /etc/iscsi/initiatorname.iscsi
+    ${optionalString (cfg.extraConfigFile != null) ''
+      if [ -f "${cfg.extraConfigFile}" ]; then
+        printf '\n# The following is from ${cfg.extraConfigFile}:\n' >> /etc/iscsi/iscsid.conf
+        cat "${cfg.extraConfigFile}" >> /etc/iscsi/iscsid.conf
+      else
+        echo "Warning: boot.iscsi-initiator.extraConfigFile ${cfg.extraConfigFile} does not exist!" >&2
+      fi
+    ''}
+  '';
+
+  # Discover the portal and log into the root target. Wrapped in a retry because
+  # iscsid may not have opened its socket the instant this unit starts.
+  loginScript = pkgs.writeShellScript "iscsi-root-login" ''
+    set -eu
+    ${pkgs.openiscsi}/bin/iscsiadm -m discovery -t sendtargets \
+      -p ${escapeShellArg cfg.discoverPortal} --debug ${toString cfg.logLevel} || true
+    n=0
+    until ${
+      if cfg.loginAll then
+        "${pkgs.openiscsi}/bin/iscsiadm -m node --loginall all"
+      else
+        "${pkgs.openiscsi}/bin/iscsiadm -m node -T ${escapeShellArg cfg.target} -p ${escapeShellArg cfg.discoverPortal} --login"
+    }; do
+      n=$((n + 1))
+      if [ "$n" -ge 30 ]; then
+        echo "iscsi-root-login: giving up after $n attempts" >&2
+        exit 1
+      fi
+      sleep 1
+      ${pkgs.openiscsi}/bin/iscsiadm -m discovery -t sendtargets \
+        -p ${escapeShellArg cfg.discoverPortal} --debug ${toString cfg.logLevel} || true
+    done
+    ${cfg.extraIscsiCommands}
+  '';
 in
 {
   # If you're booting entirely off another machine you may want to add
@@ -106,103 +165,156 @@ in
     networking.useNetworkd = true;
     networking.useDHCP = false; # Required to set useNetworkd = true
 
-    boot.initrd = {
-      network.enable = true;
-
-      # By default, the stage-1 disables the network and resets the interfaces
-      # on startup. Since our startup disks are on the network, we can't let
-      # the network not work.
-      network.flushBeforeStage2 = false;
-
-      kernelModules = [ "iscsi_tcp" ];
-
-      extraUtilsCommands = ''
-        copy_bin_and_libs ${pkgs.openiscsi}/bin/iscsid
-        copy_bin_and_libs ${pkgs.openiscsi}/bin/iscsiadm
-        ${optionalString (
-          !config.boot.initrd.network.ssh.enable
-        ) "cp -pv ${pkgs.glibc.out}/lib/libnss_files.so.* $out/lib"}
-
-        mkdir -p $out/etc/iscsi
-        cp ${config.environment.etc.hosts.source} $out/etc/hosts
-        cp ${pkgs.openiscsi}/etc/iscsi/iscsid.conf $out/etc/iscsi/iscsid.fragment.conf
-        chmod +w $out/etc/iscsi/iscsid.fragment.conf
-        cat << 'EOF' >> $out/etc/iscsi/iscsid.fragment.conf
-        ${optionalString (cfg.extraConfig != null) cfg.extraConfig}
-        EOF
-      '';
-
-      extraUtilsCommandsTest = ''
-        $out/bin/iscsiadm --version
-      '';
-
-      preLVMCommands =
-        let
-          extraCfgDumper = optionalString (cfg.extraConfigFile != null) ''
-            if [ -f "${cfg.extraConfigFile}" ]; then
-              printf "\n# The following is from ${cfg.extraConfigFile}:\n"
-              cat "${cfg.extraConfigFile}"
-            else
-              echo "Warning: boot.iscsi-initiator.extraConfigFile ${cfg.extraConfigFile} does not exist!" >&2
-            fi
-          '';
-        in
-        ''
-          ${optionalString (!config.boot.initrd.network.ssh.enable) ''
-            # stolen from initrd-ssh.nix
-            echo 'root:x:0:0:root:/root:/bin/ash' > /etc/passwd
-            echo 'passwd: files' > /etc/nsswitch.conf
-          ''}
-
-          cp -f $extraUtils/etc/hosts /etc/hosts
-
-          mkdir -p /etc/iscsi /run/lock/iscsi
-          echo "InitiatorName=${cfg.name}" > /etc/iscsi/initiatorname.iscsi
-
-          (
-            cat "$extraUtils/etc/iscsi/iscsid.fragment.conf"
-            printf "\n"
-            ${optionalString cfg.loginAll ''echo "node.startup = automatic"''}
-            ${extraCfgDumper}
-          ) > /etc/iscsi/iscsid.conf
-
-          iscsid --foreground --no-pid-file --debug ${toString cfg.logLevel} &
-          iscsiadm --mode discoverydb \
-            --type sendtargets \
-            --discover \
-            --portal ${escapeShellArg cfg.discoverPortal} \
-            --debug ${toString cfg.logLevel}
-
-          ${
-            if cfg.loginAll then
-              ''
-                iscsiadm --mode node --loginall all
-              ''
-            else
-              ''
-                iscsiadm --mode node --targetname ${escapeShellArg cfg.target} --login
-              ''
-          }
-
-          ${cfg.extraIscsiCommands}
-
-          pkill -9 iscsid
-        '';
-    };
-
     services.openiscsi = {
       enable = true;
       inherit (cfg) name;
     };
 
+    boot.initrd = mkMerge [
+      {
+        network.enable = true;
+        # By default, the stage-1 disables the network and resets the interfaces
+        # on startup. Since our startup disks are on the network, we can't let
+        # the network not work. (systemd stage 1 already defaults this to false.)
+        network.flushBeforeStage2 = false;
+
+        kernelModules = [ "iscsi_tcp" ];
+      }
+
+      # Scripted (non-systemd) stage 1: bring iscsid up, discover and log in
+      # from preLVMCommands, exactly as this module always has.
+      (mkIf (!useSystemd) {
+        extraUtilsCommands = ''
+          copy_bin_and_libs ${pkgs.openiscsi}/bin/iscsid
+          copy_bin_and_libs ${pkgs.openiscsi}/bin/iscsiadm
+          ${optionalString (
+            !config.boot.initrd.network.ssh.enable
+          ) "cp -pv ${pkgs.glibc.out}/lib/libnss_files.so.* $out/lib"}
+
+          mkdir -p $out/etc/iscsi
+          cp ${config.environment.etc.hosts.source} $out/etc/hosts
+          cp ${pkgs.openiscsi}/etc/iscsi/iscsid.conf $out/etc/iscsi/iscsid.fragment.conf
+          chmod +w $out/etc/iscsi/iscsid.fragment.conf
+          cat << 'EOF' >> $out/etc/iscsi/iscsid.fragment.conf
+          ${optionalString (cfg.extraConfig != null) cfg.extraConfig}
+          EOF
+        '';
+
+        extraUtilsCommandsTest = ''
+          $out/bin/iscsiadm --version
+        '';
+
+        preLVMCommands =
+          let
+            extraCfgDumper = optionalString (cfg.extraConfigFile != null) ''
+              if [ -f "${cfg.extraConfigFile}" ]; then
+                printf "\n# The following is from ${cfg.extraConfigFile}:\n"
+                cat "${cfg.extraConfigFile}"
+              else
+                echo "Warning: boot.iscsi-initiator.extraConfigFile ${cfg.extraConfigFile} does not exist!" >&2
+              fi
+            '';
+          in
+          ''
+            ${optionalString (!config.boot.initrd.network.ssh.enable) ''
+              # stolen from initrd-ssh.nix
+              echo 'root:x:0:0:root:/root:/bin/ash' > /etc/passwd
+              echo 'passwd: files' > /etc/nsswitch.conf
+            ''}
+
+            cp -f $extraUtils/etc/hosts /etc/hosts
+
+            mkdir -p /etc/iscsi /run/lock/iscsi
+            echo "InitiatorName=${cfg.name}" > /etc/iscsi/initiatorname.iscsi
+
+            (
+              cat "$extraUtils/etc/iscsi/iscsid.fragment.conf"
+              printf "\n"
+              ${optionalString cfg.loginAll ''echo "node.startup = automatic"''}
+              ${extraCfgDumper}
+            ) > /etc/iscsi/iscsid.conf
+
+            iscsid --foreground --no-pid-file --debug ${toString cfg.logLevel} &
+            iscsiadm --mode discoverydb \
+              --type sendtargets \
+              --discover \
+              --portal ${escapeShellArg cfg.discoverPortal} \
+              --debug ${toString cfg.logLevel}
+
+            ${
+              if cfg.loginAll then
+                ''
+                  iscsiadm --mode node --loginall all
+                ''
+              else
+                ''
+                  iscsiadm --mode node --targetname ${escapeShellArg cfg.target} --login
+                ''
+            }
+
+            ${cfg.extraIscsiCommands}
+
+            pkill -9 iscsid
+          '';
+      })
+
+      # systemd stage 1: run iscsid and the login as real units, ordered on the
+      # dependency graph (network-online.target -> iscsid -> iscsi-login ->
+      # initrd-root-device.target -> sysroot.mount) instead of a one-shot script.
+      # Networking itself is provided by boot.initrd.network.enable + networkd
+      # (configured from the `ip=` kernel parameter or the networking.* options),
+      # so this module only owns the iSCSI session.
+      (mkIf useSystemd {
+        # makeInitrdNG only follows ELF dependencies, so every store path the
+        # scripts below reference has to be listed explicitly.
+        systemd.storePaths = [
+          pkgs.openiscsi
+          iscsidConf
+          prepConf
+          loginScript
+        ];
+
+        systemd.services.iscsid = {
+          description = "Open-iSCSI daemon (initrd)";
+          wantedBy = [ "initrd.target" ];
+          wants = [ "network-online.target" ];
+          after = [ "network-online.target" ];
+          before = [ "iscsi-login.service" ];
+          unitConfig.DefaultDependencies = false;
+          serviceConfig = {
+            Type = "simple";
+            ExecStartPre = prepConf;
+            ExecStart = "${pkgs.openiscsi}/bin/iscsid --foreground --no-pid-file --debug ${toString cfg.logLevel}";
+          };
+        };
+
+        systemd.services.iscsi-login = {
+          description = "Discover and log into the iSCSI root target (initrd)";
+          wantedBy = [ "initrd-root-device.target" ];
+          requires = [ "iscsid.service" ];
+          wants = [ "network-online.target" ];
+          after = [
+            "iscsid.service"
+            "network-online.target"
+          ];
+          before = [
+            "initrd-root-device.target"
+            "sysroot.mount"
+          ];
+          unitConfig.DefaultDependencies = false;
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            ExecStart = loginScript;
+          };
+        };
+      })
+    ];
+
     assertions = [
       {
         assertion = cfg.loginAll -> cfg.target == null;
         message = "iSCSI target name is set while login on all portals is enabled.";
-      }
-      {
-        assertion = !config.boot.initrd.systemd.enable;
-        message = "systemd stage 1 does not support iscsi yet.";
       }
     ];
   };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -857,6 +857,7 @@ in
   irqbalance = runTest ./irqbalance.nix;
   iscsi-multipath-root = runTest ./iscsi-multipath-root.nix;
   iscsi-root = runTest ./iscsi-root.nix;
+  iscsi-root-systemd = runTest ./iscsi-root-systemd.nix;
   isolate = runTest ./isolate.nix;
   isso = runTest ./isso.nix;
   jackett = runTest ./jackett.nix;

--- a/nixos/tests/iscsi-root-systemd.nix
+++ b/nixos/tests/iscsi-root-systemd.nix
@@ -1,0 +1,196 @@
+# iSCSI root on a systemd stage-1 initrd.
+#
+# `target` exports a block device over iSCSI, `initiatorAuto` installs a NixOS
+# system onto it, and `initiatorRootDisk` (whose initrd is a systemd initrd)
+# boots with that iSCSI LUN as its root filesystem.
+{ pkgs, lib, ... }:
+let
+  initiatorName = "iqn.2020-08.org.linux-iscsi.initiatorhost:example";
+  targetName = "iqn.2003-01.org.linux-iscsi.target.x8664:sn.acf8fd9c23af";
+in
+{
+  name = "iscsi-root-systemd";
+  meta.maintainers = with lib.maintainers; [
+    sochotnicky
+  ];
+
+  nodes = {
+    target =
+      {
+        config,
+        pkgs,
+        lib,
+        ...
+      }:
+      {
+        services.target = {
+          enable = true;
+          config = {
+            fabric_modules = [ ];
+            storage_objects = [
+              {
+                dev = "/dev/vdb";
+                name = "test";
+                plugin = "block";
+                write_back = true;
+                wwn = "92b17c3f-6b40-4168-b082-ceeb7b495522";
+              }
+            ];
+            targets = [
+              {
+                fabric = "iscsi";
+                tpgs = [
+                  {
+                    enable = true;
+                    attributes = {
+                      authentication = 0;
+                      generate_node_acls = 1;
+                    };
+                    luns = [
+                      {
+                        alias = "94dfe06967";
+                        alua_tg_pt_gp_name = "default_tg_pt_gp";
+                        index = 0;
+                        storage_object = "/backstores/block/test";
+                      }
+                    ];
+                    node_acls = [
+                      {
+                        mapped_luns = [
+                          {
+                            alias = "d42f5bdf8a";
+                            index = 0;
+                            tpg_lun = 0;
+                            write_protect = false;
+                          }
+                        ];
+                        node_wwn = initiatorName;
+                      }
+                    ];
+                    portals = [
+                      {
+                        ip_address = "[::]";
+                        iser = false;
+                        offload = false;
+                        port = 3260;
+                      }
+                    ];
+                    tag = 1;
+                  }
+                ];
+                wwn = targetName;
+              }
+            ];
+          };
+        };
+
+        networking.firewall.allowedTCPPorts = [ 3260 ];
+        networking.firewall.allowedUDPPorts = [ 3260 ];
+
+        virtualisation.memorySize = 2048;
+        virtualisation.emptyDiskImages = [ 2048 ];
+      };
+
+    initiatorAuto =
+      {
+        nodes,
+        config,
+        pkgs,
+        ...
+      }:
+      {
+        services.openiscsi = {
+          enable = true;
+          enableAutoLoginOut = true;
+          discoverPortal = "target";
+          name = initiatorName;
+        };
+
+        environment.systemPackages = with pkgs; [
+          xfsprogs
+        ];
+
+        system.extraDependencies = [ nodes.initiatorRootDisk.system.build.toplevel ];
+
+        nix.settings = {
+          substituters = lib.mkForce [ ];
+          hashed-mirrors = null;
+          connect-timeout = 1;
+        };
+      };
+
+    initiatorRootDisk =
+      {
+        nodes,
+        config,
+        pkgs,
+        modulesPath,
+        lib,
+        ...
+      }:
+      {
+        boot.loader.grub.enable = false;
+
+        # The device under test: a systemd stage-1 initrd.
+        boot.initrd.systemd.enable = true;
+
+        boot.kernelParams = lib.mkOverride 5 [
+          "boot.shell_on_fail"
+          "console=tty1"
+          # Configure eth1 statically in the initrd. systemd-networkd's
+          # network-generator turns this into an initrd .network file.
+          "ip=${config.networking.primaryIPAddress}:::255.255.255.0::eth1:none"
+        ];
+
+        # defaults to true, puts some code in the initrd that tries to mount an overlayfs on /nix/store
+        virtualisation.writableStore = false;
+
+        fileSystems = lib.mkOverride 5 {
+          "/" = {
+            fsType = "xfs";
+            device = "/dev/sda";
+            options = [ "_netdev" ];
+          };
+        };
+
+        boot.iscsi-initiator = {
+          # No initrd DNS, so point at the target's IP rather than its hostname.
+          discoverPortal = "${nodes.target.networking.primaryIPAddress}:3260";
+          name = initiatorName;
+          target = targetName;
+        };
+      };
+  };
+
+  testScript =
+    { nodes, ... }:
+    ''
+      target.start()
+      target.wait_for_unit("iscsi-target.service")
+
+      initiatorAuto.start()
+
+      initiatorAuto.wait_for_unit("iscsid.service")
+      initiatorAuto.wait_for_unit("iscsi.service")
+      initiatorAuto.get_unit_info("iscsi")
+
+      initiatorAuto.succeed("set -x; while ! test -e /dev/sda; do sleep 1; done")
+
+      initiatorAuto.succeed("mkfs.xfs /dev/sda")
+      initiatorAuto.succeed("mkdir /mnt && mount /dev/sda /mnt")
+      initiatorAuto.succeed(
+          "nixos-install --no-bootloader --no-root-passwd --system ${nodes.initiatorRootDisk.system.build.toplevel}"
+      )
+      initiatorAuto.succeed("umount /mnt && rmdir /mnt")
+      initiatorAuto.shutdown()
+
+      # Boot the systemd-stage-1 machine off its iSCSI root.
+      initiatorRootDisk.start()
+      initiatorRootDisk.wait_for_unit("multi-user.target")
+      initiatorRootDisk.wait_for_unit("iscsid")
+      # Confirm we are really running off the network disk.
+      initiatorRootDisk.succeed("test \"$(findmnt -no SOURCE /)\" = /dev/sda")
+      initiatorRootDisk.succeed("touch /test")
+      initiatorRootDisk.shutdown()
+    '';
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The scripted initrd is no longer the default and is slated for removal in 26.11 (https://github.com/NixOS/nixpkgs/issues/287308),
but boot.iscsi-initiator asserted against systemd stage 1, leaving no supported
way to boot from iSCSI root.

Add a systemd stage 1 code path that runs iscsid and the target login as real
units ordered on the dependency graph (network-online.target -> iscsid ->
iscsi-login -> initrd-root-device.target -> sysroot.mount), rather than a
one-shot script in preLVMCommands. This also removes the race the scripted path
has between iSCSI login and DHCP, since networkd ordering is a real dependency
instead of an enumerate-at-an-instant loop.

Initrd networking itself is left to boot.initrd.network.enable and networkd,
configured from the `ip=` kernel parameter or the networking.* options, so the
module only owns the iSCSI session.

Worth noting - if dhcp is used both initrd and stage2 boot need to use the same mac to get same IP (or bad things happen :tm:) i.e. `dhcpV4Config.ClientIdentifier = "mac";` on given device makes sure they don't generate different client IDs. Not sure how to best communicate - we could add an assertion/warning.

The scripted path is unchanged and no module options were added, removed or
renamed. Add a nixos test covering the systemd stage 1 case: one node exports a
LUN, another installs onto it, and a third boots from it with a systemd initrd.

Note that there's already https://github.com/NixOS/nixpkgs/pull/263417 but it's been almost 3 years. Approach is similar, I didn't touch multipath since I have don't use it and it's harder for me to validate.



TODO:
- [x] Test in my homelab confirmed 
- [ ] Not sure how to communicate `networkConfig.KeepConfiguration = "yes";` requirement in stage2 so things don't get disrupted?
- [ ] Shall we wipe the scripted config completely? I think yes, but for now I kept it
- [ ] Worth a release notes update I think (wait until previous is decided)

Assisted-by: Claude Opus 5 (High)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

<!-- Message of single commit: -->