### PR TITLE
exegol: refactor

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29321,6 +29321,12 @@
     githubId = 5356506;
     name = "Tricia Tan";
   };
+  tristanqtn = {
+    email = "tristan.querton@gmail.com";
+    github = "tristanqtn";
+    githubId = 77152870;
+    name = "Tristan Querton";
+  };
   trobert = {
     email = "thibaut.robert@gmail.com";
     github = "trobert";

--- a/pkgs/by-name/ex/exegol/package.nix
+++ b/pkgs/by-name/ex/exegol/package.nix
@@ -79,6 +79,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
       _0b11stan
       charB66
       macbucheron
+      tristanqtn
     ];
   };
 })

--- a/pkgs/by-name/ex/exegol/package.nix
+++ b/pkgs/by-name/ex/exegol/package.nix
@@ -50,8 +50,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   pythonImportsCheck = [ "exegol" ];
 
-  # No relevant python tests nor --version flag
-  doCheck = false;
+  doCheck = true;
 
   meta = {
     description = "Fully featured and community-driven hacking environment";


### PR DESCRIPTION
## Summary
- Bump `exegol` to [5.1.11](https://github.com/ThePorgs/Exegol/releases/tag/5.1.11).
- Upstream also tightened the `docker` dependency pin (`docker~=7.1.0`) and now requires `tzlocal` unconditionally on all platforms rather than only non-Linux, so `pythonRelaxDeps`/`dependencies` are updated to match.
- Add myself (`tristanqtn`) as a co-maintainer.

## Things done
- Built on platform(s): x86_64-linux
- Tested the built binary reports the correct version: `exegol version` -> `v5.1.11`
- Ran `nixfmt` on the changed files