### PR TITLE
himalaya: 1.2.0 -> 2.0.0

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -64,6 +64,8 @@
 
 - `uhttpmock` providing 0.0 ABI was removed. `uhttpmock_1_0` providing 1.0 ABI was renamed to `uhttpmock` and `uhttpmock_1_0` was kept as an alias.
 
+- `himalaya` has been updated from `v1.2.0` to `v2.0.0`, which introduces breaking changes. See the [release notes](https://github.com/pimalaya/himalaya/releases/tag/v2.0.0) and the [migration guide](https://github.com/pimalaya/himalaya/blob/master/MIGRATION.md).
+
 - `nix-serve-ng` (and `haskellPackages.nix-serve-ng`) is now built against Lix instead of CppNix, following upstream which has switched to Lix as its supported Nix implementation.
 
 - Linux kernel configuration has been moved out of the `linux-kernel` field of the platform structure into the kernel builders:

--- a/pkgs/by-name/hi/himalaya/package.nix
+++ b/pkgs/by-name/hi/himalaya/package.nix
@@ -1,53 +1,33 @@
 {
-  apple-sdk,
   buildFeatures ? [ ],
   buildNoDefaultFeatures ? false,
   buildPackages,
-  dbus,
   fetchFromGitHub,
-  gpgme,
   installManPages ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
   installShellCompletions ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
   installShellFiles,
   lib,
-  notmuch,
+  openssl,
   pkg-config,
   rustPlatform,
   stdenv,
 }:
 
 let
-  version = "1.2.0";
-  hash = "sha256-BBzfDeNu7s010ARCYuydCyR7QWrbeI3/B4CxA6d4olw=";
-  cargoHash = "sha256-IkvRiU9NuD6n7aCF8J235u2LjjmLftnF1n874IWVcN0=";
+  version = "2.0.0";
+  hash = "sha256-rOCMjJV0lFSIlvstkSMqGwXKDZsBkWtTYhvXpA73ucA=";
+  cargoHash = "sha256-ppZYlGWNS5lXQZNt7RcwJIvU5jp07cXhEpmFJ9UtxRE=";
 
-  inherit (stdenv.hostPlatform)
-    isLinux
-    isWindows
-    isAarch64
-    ;
-
+  withOpenssl = stdenv.hostPlatform.isLinux && builtins.elem "native-tls" buildFeatures;
   emulator = stdenv.hostPlatform.emulator buildPackages;
   exe = stdenv.hostPlatform.extensions.executable;
-
-  hasPgpGpgFeature = builtins.elem "pgp-gpg" buildFeatures;
-  hasKeyringFeature = builtins.elem "keyring" buildFeatures;
-  hasNotmuchFeature = builtins.elem "notmuch" buildFeatures;
-
-  dbus' = dbus.overrideAttrs (old: {
-    env = (old.env or { }) // {
-      NIX_CFLAGS_COMPILE =
-        (old.env.NIX_CFLAGS_COMPILE or "")
-        # required for D-Bus on Linux AArch64
-        + lib.optionalString (isLinux && isAarch64) " -mno-outline-atomics";
-    };
-  });
 
 in
 rustPlatform.buildRustPackage {
   inherit
     version
     cargoHash
+    buildFeatures
     buildNoDefaultFeatures
     ;
 
@@ -60,29 +40,14 @@ rustPlatform.buildRustPackage {
     rev = "v${version}";
   };
 
-  env = {
-    # OpenSSL should not be provided by vendors, not even on Windows
-    OPENSSL_NO_VENDOR = "1";
-  };
+  env.OPENSSL_NO_VENDOR = 1;
 
-  nativeBuildInputs =
-    [ ]
-    ++ lib.optional (hasPgpGpgFeature || hasKeyringFeature || hasNotmuchFeature) pkg-config
-    ++ lib.optional (installManPages || installShellCompletions) installShellFiles;
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+  ];
 
-  buildInputs =
-    [ ]
-    ++ lib.optional hasPgpGpgFeature gpgme
-    ++ lib.optional (hasKeyringFeature && !isWindows) dbus'
-    ++ lib.optional hasNotmuchFeature notmuch;
-
-  buildFeatures =
-    buildFeatures
-    # D-Bus is provided by vendors on Windows
-    ++ lib.optional (hasKeyringFeature && isWindows) "vendored";
-
-  # most of the tests are lib side
-  doCheck = false;
+  buildInputs = lib.optional withOpenssl openssl;
 
   postInstall =
     lib.optionalString (lib.hasInfix "wine" emulator) ''
@@ -90,20 +55,20 @@ rustPlatform.buildRustPackage {
       mkdir -p $WINEPREFIX
     ''
     + ''
-      mkdir -p $out/share/{applications,completions,man}
+      mkdir -p $out/share/{applications,completions,man,schemas}
       cp assets/himalaya.desktop "$out"/share/applications/
-      ${emulator} "$out"/bin/himalaya${exe} man "$out"/share/man
-      ${emulator} "$out"/bin/himalaya${exe} completion bash > "$out"/share/completions/himalaya.bash
-      ${emulator} "$out"/bin/himalaya${exe} completion elvish > "$out"/share/completions/himalaya.elvish
-      ${emulator} "$out"/bin/himalaya${exe} completion fish > "$out"/share/completions/himalaya.fish
-      ${emulator} "$out"/bin/himalaya${exe} completion powershell > "$out"/share/completions/himalaya.powershell
-      ${emulator} "$out"/bin/himalaya${exe} completion zsh > "$out"/share/completions/himalaya.zsh
+      ${emulator} "$out"/bin/himalaya${exe} completion -d "$out"/share/completions bash elvish fish powershell zsh
+      ${emulator} "$out"/bin/himalaya${exe} manual "$out"/share/man
+      ${emulator} "$out"/bin/himalaya${exe} json-schema "$out"/share/schemas
     ''
     + lib.optionalString installManPages ''
       installManPage "$out"/share/man/*
     ''
     + lib.optionalString installShellCompletions ''
-      installShellCompletion "$out"/share/completions/himalaya.{bash,fish,zsh}
+      installShellCompletion --cmd himalaya \
+        --bash "$out"/share/completions/himalaya.bash \
+        --fish "$out"/share/completions/himalaya.fish \
+        --zsh "$out"/share/completions/_himalaya
     '';
 
   meta = {
@@ -111,7 +76,10 @@ rustPlatform.buildRustPackage {
     mainProgram = "himalaya";
     homepage = "https://github.com/pimalaya/himalaya";
     changelog = "https://github.com/pimalaya/himalaya/blob/v${version}/CHANGELOG.md";
-    license = lib.licenses.mit;
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
     maintainers = with lib.maintainers; [
       soywod
       yanganto


### PR DESCRIPTION
https://github.com/pimalaya/himalaya/blob/v2.0.0/CHANGELOG.md

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
