### PR TITLE
sonic-server: 1.4.9 -> 1.7.4

### DIFF
--- a/pkgs/by-name/so/sonic-server/package.nix
+++ b/pkgs/by-name/so/sonic-server/package.nix
@@ -5,8 +5,7 @@
   nix-update-script,
   nixosTests,
   rustPlatform,
-  sonic-server,
-  testers,
+  versionCheckHook,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -43,14 +42,11 @@ rustPlatform.buildRustPackage rec {
   # Found argument '--test-threads' which wasn't expected, or isn't valid in this context
   doCheck = false;
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
-    tests = {
-      inherit (nixosTests) sonic-server;
-      version = testers.testVersion {
-        command = "sonic --version";
-        package = sonic-server;
-      };
-    };
+    tests.sonic-server = nixosTests.sonic-server;
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/so/sonic-server/package.nix
+++ b/pkgs/by-name/so/sonic-server/package.nix
@@ -11,33 +11,29 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "sonic-server";
-  version = "1.4.9";
+  version = "1.7.4";
 
   src = fetchFromGitHub {
     owner = "valeriansaliou";
     repo = "sonic";
     tag = "v${version}";
-    hash = "sha256-PTujR3ciLRvbpiqStNMx3W5fkUdW2dsGmCj/iFRTKJM=";
+    hash = "sha256-T+t9zEOUZ/5yBG1M4sok+jXh9qiIeL1Rq8Dj7ppa3uk=";
   };
 
-  cargoHash = "sha256-RO4wY7FMwczZeR4GOxA3mwfBJZKPToOJJKGZb48yHJA=";
+  cargoHash = "sha256-dmmwklL+KTSgJzWPcKUmILA3fpZe4lW1Xq4plTtHf/o=";
 
   nativeBuildInputs = [
     rustPlatform.bindgenHook
   ];
 
   postPatch = ''
-    substituteInPlace src/main.rs \
+    substituteInPlace server/src/main.rs \
       --replace-fail "./config.cfg" "$out/etc/sonic/config.cfg"
   '';
 
-  # Fix GCC 15 compatibility
-  # error: unknown type name 'uint32_t'
-  env.CXXFLAGS = "-include cstdint";
-
   postInstall = ''
     install -Dm444 -t $out/etc/sonic config.cfg
-    install -Dm444 -t $out/lib/systemd/system debian/sonic.service
+    install -Dm444 -t $out/lib/systemd/system packaging/debian/sonic.service
 
     substituteInPlace $out/lib/systemd/system/sonic.service \
       --replace-fail /usr/bin/sonic $out/bin/sonic \


### PR DESCRIPTION
* Bump 1.4.9 -> 1.7.4: https://github.com/valeriansaliou/sonic/compare/v1.4.9...v1.7.4
* Drop GCC 15 workaround (no longer needed)
* Switch version check to `versionCheckHook`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
