### PR TITLE
gildas: build with gtk3, fix homepage

### DIFF
--- a/pkgs/by-name/gi/gildas/package.nix
+++ b/pkgs/by-name/gi/gildas/package.nix
@@ -2,7 +2,8 @@
   lib,
   stdenv,
   fetchurl,
-  gtk2-x11,
+  gtk3,
+  gtk3-x11,
   pkg-config,
   python3,
   gfortran,
@@ -21,6 +22,7 @@ let
       setuptools
     ]
   );
+  gtk3' = if stdenv.hostPlatform.isDarwin then gtk3-x11 else gtk3;
 in
 
 stdenv.mkDerivation rec {
@@ -48,7 +50,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    gtk2-x11
+    gtk3'
     cfitsio
     python3Env
     ncurses
@@ -105,7 +107,7 @@ stdenv.mkDerivation rec {
       extensible. GILDAS is written in Fortran-90, with a
       few parts in C/C++ (mainly keyboard interaction,
       plotting, widgets).'';
-    homepage = "http://www.iram.fr/IRAMFR/GILDAS/gildas.html";
+    homepage = "https://www.iram.fr/IRAMFR/GILDAS/";
     license = lib.licenses.free;
     maintainers = [
       lib.maintainers.bzizou


### PR DESCRIPTION
Part of #410814 

https://www.iram.fr/IRAMFR/GILDAS/install.html#3---needed-tools-to-build-executables-from-sources

This package's GTK2 support is obsolescent.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
