### PR TITLE
dbus-broker: fix CVE-2026-16730

### DIFF
--- a/pkgs/by-name/db/dbus-broker/package.nix
+++ b/pkgs/by-name/db/dbus-broker/package.nix
@@ -127,6 +127,16 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/bus1/dbus-broker/commit/fd5c6e191bffcf5b3e6c9abb8b0b03479accc04b.patch";
       hash = "sha256-+QgZzm/qRnVSr0wDNw9Np3LRreRKl6CQXJextLPy6fc=";
     })
+    (fetchpatch {
+      name = "CVE-2026-16730-1.patch";
+      url = "https://github.com/bus1/dbus-broker/commit/c4a3c886366f7bd566ec9a55b3855ade8290fa17.patch";
+      hash = "sha256-8O4YX83NI6ztS5oR2JY1++QrWLVCCSCNTpwcp2bu9LE=";
+    })
+    (fetchpatch {
+      name = "CVE-2026-16730-2.patch";
+      url = "https://github.com/bus1/dbus-broker/commit/aaa9fd6bbc2d5d7bfeca039f9c457b7f88a50dde.patch";
+      hash = "sha256-f0p5oDw/6Wxe26fcqfKua766ylMg5NydywFM3MZYV8I=";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
Backport both accepted fixes from https://github.com/bus1/dbus-broker/pull/439 for [CVE-2026-16730](https://nvd.nist.gov/vuln/detail/CVE-2026-16730). The first commit accounts peer pidfds to the connecting peer, and the second raises the broker's soft `RLIMIT_NOFILE` to its hard limit. Both are required to prevent connection pressure from terminating the session bus.

Upstream issue: https://github.com/bus1/dbus-broker/issues/435

Addresses #545679

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
