### PR TITLE
python3Packages.anyio: Disable test_keyboard_interrupt_does_not_resume_test

### DIFF
--- a/pkgs/development/python-modules/anyio/default.nix
+++ b/pkgs/development/python-modules/anyio/default.nix
@@ -92,6 +92,8 @@ buildPythonPackage rec {
     #  3 second timeout expired
     "test_keyboardinterrupt_during_test"
     "test_dynamic_async_fixture_access_does_not_hang"
+    # 5 second timeout expires on weak hardware
+    "test_keyboard_interrupt_does_not_resume_test"
     # racy with high thread count, see https://github.com/NixOS/nixpkgs/issues/448125
     "test_multiple_threads"
 


### PR DESCRIPTION
Times out when run on a 21yo machine.

Added to `disabledTests` because it already had tests that were getting disabled for timeout reasons. Patching the timeout value from 5s to 15s would also make it pass. From [skimming the test code](https://github.com/agronholm/anyio/commit/f821c3712a7eb208b17d04f2df9f0168366ead3b) with my limited Python knowledge, I think that shouldn't mess with the test logic…

(It's starting a subprocess that queues up an interruption for itself, then enters a sleep that it expects to get interrupted out of. If execution continues past the sleep, then the subprocess prints a string that the main process will see and error out on.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] powerpc64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
