### PR TITLE
qrtr: 0-unstable-2025-03-01 -> 1.2

### DIFF
--- a/pkgs/by-name/qr/qrtr/package.nix
+++ b/pkgs/by-name/qr/qrtr/package.nix
@@ -3,21 +3,21 @@
   lib,
   fetchFromGitHub,
   meson,
-  cmake,
   pkg-config,
   systemd,
   ninja,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "qrtr";
-  version = "0-unstable-2025-03-01";
+  version = "1.2";
 
   src = fetchFromGitHub {
     owner = "linux-msm";
     repo = "qrtr";
-    rev = "5923eea97377f4a3ed9121b358fd919e3659db7b";
-    hash = "sha256-iHjF/2SQsvB/qC/UykNITH/apcYSVD+n4xA0S/rIfnM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-plVPR3BKtMLSVgTK8TPFbt5vuo9ZovEGz6qJzUZ33G4=";
   };
 
   nativeBuildInputs = [
@@ -29,6 +29,8 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [ systemd ];
 
   installFlags = [ "prefix=$(out)" ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     maintainers = with lib.maintainers; [ matthewcroughan ];

--- a/pkgs/by-name/qr/qrtr/package.nix
+++ b/pkgs/by-name/qr/qrtr/package.nix
@@ -37,6 +37,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "QMI IDL compiler";
     homepage = "https://github.com/linux-msm/qrtr";
     license = lib.licenses.bsd3;
-    platforms = lib.platforms.aarch64;
+    platforms = [ "aarch64-linux" ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Additionally adds the `nix-update-script` so r-ryantm can interact.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
