### PR TITLE
haskellPackages.text-icu: skip flaky t_blockCode test 

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1724,6 +1724,14 @@ with haskellLib;
         hash = "sha256-gi6ilqgN/1PLGdVNxXE217J+c0reaitLWND8X6VsV1U=";
       })
     ])
+    # Skip flaky test with ICU >= 74 (likely outdated assumptions)
+    # https://github.com/haskell/text-icu/issues/103
+    (overrideCabal (drv: {
+      testFlags = drv.testFlags or [ ] ++ [
+        "-t"
+        "!t_blockCode"
+      ];
+    }))
   ];
 
   hercules-ci-agent = self.generateOptparseApplicativeCompletions [

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1714,14 +1714,17 @@ with haskellLib;
   shh = doJailbreak super.shh;
   shh-extras = doJailbreak super.shh-extras;
 
-  # Disable test cases that were broken by insignificant changes in icu 76
-  # https://github.com/haskell/text-icu/issues/108
-  text-icu = overrideCabal (drv: {
-    testFlags = drv.testFlags or [ ] ++ [
-      "-t"
-      "!Test cases"
-    ];
-  }) super.text-icu;
+  text-icu = lib.pipe super.text-icu [
+    (appendPatches [
+      # Fix time rendering test with ICU >= 76
+      # https://github.com/haskell/text-icu/issues/108
+      (pkgs.fetchpatch {
+        name = "text-icu-time-tests-icu-76.patch";
+        url = "https://github.com/haskell/text-icu/commit/921287b296ff781051c7bff45bb9adb04ee3a6a7.patch";
+        hash = "sha256-gi6ilqgN/1PLGdVNxXE217J+c0reaitLWND8X6VsV1U=";
+      })
+    ])
+  ];
 
   hercules-ci-agent = self.generateOptparseApplicativeCompletions [
     "hercules-ci-agent"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
