### PR TITLE
q6voiced: init at 0.3.1

### DIFF
--- a/pkgs/by-name/q6/q6voiced/package.nix
+++ b/pkgs/by-name/q6/q6voiced/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  meson,
+  ninja,
+  systemd,
+  alsa-lib,
+  dbus,
+  pkg-config,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "q6voiced";
+  version = "0.3.1";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitLab {
+    domain = "gitlab.postmarketos.org";
+    owner = "postmarketOS";
+    repo = "q6voiced";
+    tag = finalAttrs.version;
+    hash = "sha256-VvhDaejcvCERU8oDgsjl3IuV5a8RjkA+pH8PJRHJWJs=";
+  };
+
+  mesonFlags = [
+    # point to /etc/q6voiced/q6voiced.conf at runtime
+    "--datadir=/etc"
+  ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    systemd
+    dbus
+    alsa-lib
+  ];
+
+  meta = {
+    description = "Userspace daemon for the QDSP6 voice call audio driver";
+    homepage = "https://gitlab.postmarketos.org/postmarketOS/q6voiced";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ matthewcroughan ];
+    mainProgram = "q6voiced";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This enables regular non volte calls on mobile devices. 

The `--data-dir=/etc` in `mesonFlags` allows setting something like

```
  environment.etc."q6voiced/q6voiced.conf".text = ''
    q6voice_card=0
    q6voice_device=6
  '';
```

If you want to configure it, using the upstream systemd units.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
