### PR TITLE
python3Packages.github3-py: fix build

### DIFF
--- a/pkgs/development/python-modules/github3-py/0001-fix-tests-with-requests-2.34.patch
+++ b/pkgs/development/python-modules/github3-py/0001-fix-tests-with-requests-2.34.patch
@@ -1,0 +1,43 @@
+From d3882be89d276646281de9aadc2b6fbcfbca0f08 Mon Sep 17 00:00:00 2001
+From: phanirithvij <phanirithvij2000@gmail.com>
+Date: Sun, 26 Jul 2026 19:30:35 +0530
+Subject: [PATCH] fix tests with requests 2.34
+
+Signed-off-by: phanirithvij <phanirithvij2000@gmail.com>
+---
+ tests/unit/test_github_session.py | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/tests/unit/test_github_session.py b/tests/unit/test_github_session.py
+index d57e9b41..d7b4a051 100644
+--- a/tests/unit/test_github_session.py
++++ b/tests/unit/test_github_session.py
+@@ -40,7 +40,7 @@ class TestGitHubSession:
+         r = s.get("http://example.com")
+         assert r is response
+         request_mock.assert_called_once_with(
+-            "GET", "http://example.com", allow_redirects=True, timeout=(4, 10)
++            "GET", "http://example.com", params=None, allow_redirects=True, timeout=(4, 10)
+         )
+ 
+     @unittest.mock.patch.object(requests.Session, "request")
+@@ -57,6 +57,7 @@ class TestGitHubSession:
+         request_mock.assert_called_once_with(
+             "GET",
+             "http://example.com",
++            params=None,
+             allow_redirects=True,
+             timeout=(300, 400),
+         )
+@@ -148,7 +149,7 @@ class TestGitHubSession:
+         r = s.get("http://example.com")
+         assert r is response
+         request_mock.assert_called_once_with(
+-            "GET", "http://example.com", allow_redirects=True, timeout=(4, 10)
++            "GET", "http://example.com", params=None, allow_redirects=True, timeout=(4, 10)
+         )
+ 
+     @unittest.mock.patch.object(requests.Session, "request")
+-- 
+2.54.0
+

--- a/pkgs/development/python-modules/github3-py/default.nix
+++ b/pkgs/development/python-modules/github3-py/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   requests,
   uritemplate,
   python-dateutil,
@@ -11,27 +11,19 @@
   betamax,
   betamax-matchers,
   hatchling,
-  fetchpatch,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "github3-py";
-  version = "4.0.1";
+  version = "4.0.1-unstable-2026-04-22";
   pyproject = true;
 
-  src = fetchPypi {
-    pname = "github3.py";
-    inherit version;
-    hash = "sha256-MNVxB2dT78OJ7cf5qu8zik/LJLVNiWjV85sTQvRd3TY=";
+  src = fetchFromGitHub {
+    owner = "sigmavirus24";
+    repo = "github3.py";
+    rev = "9eeac0ddb241bf3099a6c904411e3aa23b62fd0d";
+    hash = "sha256-iaI9FqsPGM5R7JGoG+qRdQygMzbYUDX28j1S/IeLfrA=";
   };
-
-  patches = [
-    (fetchpatch {
-      # disable tests with "AttributeError: 'MockHTTPResponse' object has no attribute 'close'", due to betamax
-      url = "https://github.com/sigmavirus24/github3.py/commit/9d6124c09b0997b5e83579549bcf22b3e901d7e5.patch";
-      hash = "sha256-8Z4vN7iKl/sOcEJptsH5jsqijZgvL6jS7kymZ8+m6bY=";
-    })
-  ];
 
   build-system = [ hatchling ];
 
@@ -55,8 +47,8 @@ buildPythonPackage rec {
   meta = {
     homepage = "https://github3py.readthedocs.org/en/master/";
     description = "Wrapper for the GitHub API written in python";
-    changelog = "https://github.com/sigmavirus24/github3.py/blob/${version}/docs/source/release-notes/${version}.rst";
+    changelog = "https://github.com/sigmavirus24/github3.py/blob/${finalAttrs.version}/docs/source/release-notes/${finalAttrs.version}.rst";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ pSub ];
   };
-}
+})

--- a/pkgs/development/python-modules/github3-py/default.nix
+++ b/pkgs/development/python-modules/github3-py/default.nix
@@ -25,6 +25,11 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-iaI9FqsPGM5R7JGoG+qRdQygMzbYUDX28j1S/IeLfrA=";
   };
 
+  patches = [
+    # https://github.com/sigmavirus24/github3.py/pull/1359
+    ./0001-fix-tests-with-requests-2.34.patch
+  ];
+
   build-system = [ hatchling ];
 
   dependencies = [


### PR DESCRIPTION
https://hydra.nixos.org/job/nixpkgs/unstable/python314Packages.github3-py.x86_64-linux/all

I update it to the latest unstable commit as the tag is from 2023. But this is not needed to fix the tests breakage, I can drop the update to unstable if not desired.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
