### PR TITLE
gh-infra: init at 0.13.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25353,6 +25353,11 @@
     name = "Ryota";
     keys = [ { fingerprint = "2FAC 1A25 5175 125E F60B  BC04 B89E C8B6 EE43 39C4"; } ];
   };
+  ryuryu333 = {
+    name = "ryu";
+    github = "ryuryu333";
+    githubId = 135518701;
+  };
   ryze = {
     name = "Ryze";
     github = "ryze312";

--- a/pkgs/by-name/gh/gh-infra/package.nix
+++ b/pkgs/by-name/gh/gh-infra/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+}:
+buildGoModule (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "gh-infra";
+  version = "0.13.0";
+
+  src = fetchFromGitHub {
+    owner = "babarot";
+    repo = "gh-infra";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-aQPJFOMLnMkaJ+lfpUBY2C6eEsXzAwTW6pDlyTyF6mI=";
+
+    # main.revision is always included in --version output.
+    # Preserve the resolved tag commit before removing Git metadata.
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      git rev-parse --verify --short HEAD > ldflags_revision
+      find . -type d -name .git -print0 | xargs -0 rm -rf
+    '';
+  };
+
+  vendorHash = "sha256-w0Ix1xpJQ5H4NttZCjF1ZWE0/o2US5K76X2bxMrtBF4=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=v${finalAttrs.version}"
+  ];
+
+  preBuild = ''
+    ldflags+=" -X main.revision=$(cat ldflags_revision)"
+  '';
+
+  meta = {
+    homepage = "https://github.com/babarot/gh-infra";
+    description = "Declarative GitHub infrastructure management via YAML";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ryuryu333 ];
+    mainProgram = "gh-infra";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds gh-infra, a CLI for declaratively managing GitHub infrastructure using YAML configuration.

Homepage
https://github.com/babarot/gh-infra

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

```
> nix-build -A gh-infra
> result/bin/gh-infra --version
gh-infra version v0.13.0 (d77097a)
```


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
