### PR TITLE
pdfalyzer: init at 1.19.6

### DIFF
--- a/pkgs/by-name/pd/pdfalyzer/package.nix
+++ b/pkgs/by-name/pd/pdfalyzer/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  pkgs,
+  nix-update-script,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "pdfalyzer";
+  version = "1.19.6";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "michelcrypt4d4mus";
+    repo = "pdfalyzer";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-pwDQtyMSbqn/DMwR+9nTnpy8X4KmjEN+HVZf1F+MYt4=";
+  };
+
+  pythonRelaxDeps = [ "pypdf" ];
+
+  build-system = with python3Packages; [ poetry-core ];
+
+  dependencies = with python3Packages; [
+    anytree
+    cairosvg
+    cryptography
+    numpy
+    pkgs.yaralyzer
+    pymupdf
+    pypdf
+    pytesseract
+    requests
+  ];
+
+  pythonImportsCheck = [ "pdfalyzer" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tool to analyze PDFs with colors";
+    homepage = "https://github.com/michelcrypt4d4mus/pdfalyzer";
+    changelog = "https://github.com/michelcrypt4d4mus/pdfalyzer/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = with lib.licenses; [
+      gpl3Only
+      gpl3Plus
+    ];
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "pdfalyzer";
+  };
+})


### PR DESCRIPTION
Tool to analyze PDFs with colors

https://github.com/michelcrypt4d4mus/pdfalyzer

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
