### PR TITLE
haskell.packages.ghc948.cabal2nix: fix deps

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -104,9 +104,6 @@ self: super: {
     ++ drv.testFlags or [ ];
   }) (doJailbreak super.hpack);
 
-  # Later versions require unix >= 2.8 which is tricky to provide with GHC 9.4
-  crypton-x509-store = doDistribute self.crypton-x509-store_1_6_11;
-
   # 2022-08-01: Tests are broken on ghc 9.2.4: https://github.com/wz1000/HieDb/issues/46
   hiedb = dontCheck super.hiedb;
 
@@ -176,4 +173,5 @@ self: super: {
 
   # Too strict lower bound on base
   primitive-addr = doJailbreak super.primitive-addr;
+  base64 = doJailbreak super.base64;
 }

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -79,7 +79,6 @@ extra-packages:
   - Cabal-syntax == 3.12.*
   - Cabal-syntax == 3.14.*
   - Cabal-syntax == 3.16.*              # version required for cabal-install and other packages
-  - crypton-x509-store < 1.6.12         # 2025-11-22: requires unix >= 2.8 which isn't available for GHC < 9.6
   - extensions == 0.1.0.1               # 2025-09-21: needed for Cabal 3.10 (fourmolo/ormolu with ghc 9.8)
   - fourmolu == 0.14.0.0                # 2023-11-13: for ghc-lib-parser 9.6 compat
   - fourmolu == 0.15.0.0                # 2025-09-21: for ghc-lib-parser 9.8 compat

--- a/pkgs/development/haskell-modules/hackage-packages.nix
+++ b/pkgs/development/haskell-modules/hackage-packages.nix
@@ -175049,55 +175049,6 @@ self: {
     }
   ) { };
 
-  crypton-x509-store_1_6_11 = callPackage (
-    {
-      mkDerivation,
-      asn1-encoding,
-      asn1-types,
-      base,
-      bytestring,
-      containers,
-      crypton,
-      crypton-x509,
-      directory,
-      filepath,
-      mtl,
-      pem,
-      tasty,
-      tasty-hunit,
-    }:
-    mkDerivation {
-      pname = "crypton-x509-store";
-      version = "1.6.11";
-      sha256 = "07vq7f883cm5krqz2kc0qkh9ks54jknrwdqvfqsk91s12b693a83";
-      revision = "1";
-      editedCabalFile = "02cjsx9pijk2wlhk2i977dr1ak647yywl71fcw1b6j54k1swafm6";
-      libraryHaskellDepends = [
-        asn1-encoding
-        asn1-types
-        base
-        bytestring
-        containers
-        crypton
-        crypton-x509
-        directory
-        filepath
-        mtl
-        pem
-      ];
-      testHaskellDepends = [
-        base
-        bytestring
-        crypton-x509
-        tasty
-        tasty-hunit
-      ];
-      description = "X.509 collection accessing and storing methods";
-      license = lib.licenses.bsd3;
-      hydraPlatforms = lib.platforms.none;
-    }
-  ) { };
-
   crypton-x509-store = callPackage (
     {
       mkDerivation,


### PR DESCRIPTION
base64 only bumped the lower bounds on base in
https://github.com/emilypi/base64/pull/67 via revision, no code changes. Safe to jailbreak.

crypton-x509-store only depends on unix without a version bound today, so no need to downgrade.

## Things done

- Built on platform:
  - [x] x86_64-linux
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
