### PR TITLE
js8call: 2.5.2 -> 3.0.3

### DIFF
--- a/pkgs/by-name/js/js8call/package.nix
+++ b/pkgs/by-name/js/js8call/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "js8call";
-  version = "2.5.2";
+  version = "3.0.3";
 
   src = fetchFromGitHub {
     owner = "JS8Call-improved";
     repo = "JS8Call-improved";
-    tag = "release/${finalAttrs.version}";
-    hash = "sha256-dpPh3+s29ksdVGc1I5JOJrqzS51Bda8afgU5RrO6B3w=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-yT+0nZQqNHQrc2biL2Qneg6CdNC2yy7bs+NvdQ3I1gQ=";
   };
 
   nativeBuildInputs = [
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     cp JS8Call $out/bin/js8call
     cp ../LICENSE ../README.md $out/share/doc/js8call
     cp ../artwork/js8call_icon.png $out/share/icons/hicolor/128x128/apps
-    cp ../JS8Call.desktop $out/share/applications
+    cp ../.github/workflows/misc/JS8Call.desktop $out/share/applications
     runHook postInstall
   '';
 


### PR DESCRIPTION
Also fixes the fetchFromGitHub tag: release/<version> is only a branch upstream, not a git tag, so refs/tags resolution 404s against codeload (this already affected 2.5.2, masked by the cached store path). Use the real vX.Y.Z tag instead. The 3.x reorg also moved the .desktop file out of the repo root into .github/workflows/misc/.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
