### PR TITLE
coreutils: security patches

### DIFF
--- a/pkgs/tools/misc/coreutils/CVE-2026-56391.patch
+++ b/pkgs/tools/misc/coreutils/CVE-2026-56391.patch
@@ -1,0 +1,45 @@
+From d64e35a8a4c0e4608321433e0d84d917e4e36371 Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Tue, 28 Apr 2026 11:25:00 -0700
+Subject: [PATCH] uniq: fix read overrun with -w
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Problem reported by Michał Majchrowicz.
+* src/uniq.c (find_field): Fix typo.
+* tests/uniq/uniq.pl (add_z_variants): Test for the bug.
+---
+ src/uniq.c         | 4 ++--
+ tests/uniq/uniq.pl | 3 +++
+ 2 files changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/src/uniq.c b/src/uniq.c
+index 30463598a5..5834596f98 100644
+--- a/src/uniq.c
++++ b/src/uniq.c
+@@ -285,8 +285,8 @@ find_field (struct linebuffer const *line, idx_t *plen)
+   else
+     {
+       char *ep = lp;
+-      for (idx_t i = check_chars; 0 < i && lp < lim; i--)
+-        ep += mcel_scan (lp, lim).len;
++      for (idx_t i = check_chars; 0 < i && ep < lim; i--)
++        ep += mcel_scan (ep, lim).len;
+       len = ep - lp;
+     }
+ 
+diff --git a/tests/uniq/uniq.pl b/tests/uniq/uniq.pl
+index b558fb3ee2..0df7ec62d7 100755
+--- a/tests/uniq/uniq.pl
++++ b/tests/uniq/uniq.pl
+@@ -234,6 +234,9 @@ ($)
+         "  - 'separate'\n" .
+         "  - 'both'\n" .
+         "Try '$prog --help' for more information.\n"}],
++ # Test for read buffer overrun.
++ do { my $longline = "\360\237\230\200" . "A" x 255 . "\n";
++      ['146', '-w256', {IN  => $longline x 2}, {OUT => $longline}] },
+ );
+ 
+ # Locale related tests

--- a/pkgs/tools/misc/coreutils/CVE-2026-56392.patch
+++ b/pkgs/tools/misc/coreutils/CVE-2026-56392.patch
@@ -1,0 +1,57 @@
+From b60a159fdc5bfcf9988d3a4cb6f53abe8ad5d35d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?P=C3=A1draig=20Brady?= <P@draigBrady.com>
+Date: Tue, 28 Apr 2026 20:33:10 +0100
+Subject: [PATCH] unexpand: fix heap overflow
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+* src/unexpand.c (unexpand): Use xinmalloc() to gracefully
+handle overflow.  Also use the runtime locale specific MB_CUR_MAX
+rather than the worst case MB_LEN_MAX.
+* tests/unexpand/mb.sh: Add a test case that fails in a default
+glibc build with either MB_CUR_MAX or MB_LEN_MAX.
+* NEWS: Mention the bug fix.
+Reported by Michał Majchrowicz.
+---
+ src/unexpand.c       | 2 +-
+ tests/unexpand/mb.sh | 8 ++++++++
+ 3 files changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/src/unexpand.c b/src/unexpand.c
+index 3cbff1b129..c859c17a3e 100644
+--- a/src/unexpand.c
++++ b/src/unexpand.c
+@@ -131,7 +131,7 @@ unexpand (void)
+   /* The worst case is a non-blank character, then one blank, then a
+      tab stop, then MAX_COLUMN_WIDTH - 1 blanks, then a non-blank; so
+      allocate MAX_COLUMN_WIDTH bytes to store the blanks.  */
+-  pending_blank = ximalloc (max_column_width * sizeof (char) * MB_LEN_MAX);
++  pending_blank = xinmalloc (max_column_width, MB_CUR_MAX);
+ 
+   while (true)
+     {
+diff --git a/tests/unexpand/mb.sh b/tests/unexpand/mb.sh
+index 76a2679035..076a1c1ae5 100755
+--- a/tests/unexpand/mb.sh
++++ b/tests/unexpand/mb.sh
+@@ -17,6 +17,7 @@
+ 
+ . "${srcdir=.}/tests/init.sh"; path_prepend_ ./src
+ print_ver_ unexpand printf
++getlimits_
+ 
+ test "$LOCALE_FR_UTF8" != none || skip_ "French UTF-8 locale not available"
+ export LC_ALL="$LOCALE_FR_UTF8"
+@@ -161,4 +162,11 @@ EOF
+ unexpand -a ./in ./in > out || fail=1
+ compare exp out > /dev/null 2>&1 || fail=1
+ 
++# Ensure overflow is handed gracefully
++# coreutils v9.11 induced a buffer overflow with mb_mul=4 (or 16).
++for mb_mul in 4 6; do
++  printf '   \n' | unexpand -t $(expr $SIZE_MAX / $mb_mul + 1) 2>err; ret=$?
++  test "$ret" = 1 || test "$ret" = 0 || { cat err; fail=1; }
++done
++
+ Exit $fail

--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -52,6 +52,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-OUAk7aCllVIXztqc0SAeZdyPo6opwpURNaSVIdV8PMM=";
   };
 
+  patches = [
+    ./CVE-2026-56391.patch
+    ./CVE-2026-56392.patch
+  ];
+
   postPatch = ''
     # The test tends to fail on btrfs, f2fs and maybe other unusual filesystems.
     sed '2i echo Skipping dd sparse test && exit 77' -i ./tests/dd/sparse.sh


### PR DESCRIPTION
Fixes CVE-2026-56391, CVE-2026-56392, NIXPKGS-2026-2271, and #545665


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
