### PR TITLE
nixos/tailscale-serve: wait for backend readiness

### DIFF
--- a/nixos/modules/services/networking/tailscale-serve.nix
+++ b/nixos/modules/services/networking/tailscale-serve.nix
@@ -125,6 +125,12 @@ in
     systemd.services.tailscale-serve = {
       description = "Tailscale Serve Configuration";
 
+      path = [
+        config.services.tailscale.package
+        pkgs.coreutils
+        pkgs.jq
+      ];
+
       after = [
         "tailscaled.service"
         "tailscaled-autoconnect.service"
@@ -134,6 +140,13 @@ in
       wantedBy = [ "multi-user.target" ];
 
       restartTriggers = [ configFile ];
+
+      preStart = ''
+        until tailscale status --json --peers=false \
+          | jq --exit-status '.BackendState == "Running"' > /dev/null; do
+          sleep 0.5
+        done
+      '';
 
       serviceConfig = {
         Type = "oneshot";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1738,6 +1738,7 @@ in
   systemd-varlink = runTest ./systemd-varlink.nix;
   systemtap = handleTest ./systemtap.nix { };
   szurubooru = handleTest ./szurubooru.nix { };
+  tailscale-serve = runTest ./tailscale-serve.nix;
   taler = handleTest ./taler { };
   tandoor-recipes = runTest ./tandoor-recipes.nix;
   tandoor-recipes-media = runTest ./tandoor-recipes-media.nix;

--- a/nixos/tests/tailscale-serve.nix
+++ b/nixos/tests/tailscale-serve.nix
@@ -1,0 +1,49 @@
+{ pkgs, ... }:
+
+let
+  # Verify that Serve waits for backend readiness before applying its configuration.
+  # Mock the CLI to control the backend state without overriding the service under test.
+  tailscaleCli = pkgs.writeShellScriptBin "tailscale" ''
+    if [[ "$1" == status ]]; then
+      if [[ -e /run/backend-ready ]]; then
+        state=Running
+      else
+        state=NoState
+        touch /run/status-checked
+      fi
+      printf '{"BackendState":"%s"}\n' "$state"
+    else
+      touch /run/serve-configured
+    fi
+  '';
+  tailscaleTestPackage = pkgs.symlinkJoin {
+    name = "tailscale-test";
+    paths = [ pkgs.tailscale ];
+    postBuild = ''
+      rm $out/bin/tailscale
+      ln -s ${tailscaleCli}/bin/tailscale $out/bin/tailscale
+    '';
+    meta.mainProgram = "tailscale";
+  };
+in
+{
+  name = "tailscale-serve";
+
+  nodes.machine = {
+    services.tailscale = {
+      enable = true;
+      disableUpstreamLogging = true;
+      package = tailscaleTestPackage;
+      serve.enable = true;
+      serve.services.test.endpoints."tcp:80" = "http://127.0.0.1:8080";
+    };
+  };
+
+  testScript = ''
+    machine.wait_until_succeeds("test -e /run/status-checked")
+    machine.succeed("test ! -e /run/serve-configured")
+    machine.succeed("touch /run/backend-ready")
+    machine.wait_for_unit("tailscale-serve.service")
+    machine.succeed("test -e /run/serve-configured")
+  '';
+}


### PR DESCRIPTION
`tailscale serve set-config` can fail with `unexpected state: NoState` because `After=tailscaled.service` does not guarantee backend readiness.
Wait for `BackendState` to become `Running` before applying the configuration, and add a NixOS test covering this behavior.

Assisted-by: OpenCode (GPT-5.6-sol)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-packages
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
