### PR TITLE
python3Packages.openexr: init at 3.4.13

### DIFF
--- a/pkgs/development/libraries/openexr/3.nix
+++ b/pkgs/development/libraries/openexr/3.nix
@@ -9,6 +9,7 @@
   pkg-config,
   libjxl,
   pkgsCross,
+  python3Packages,
 }:
 
 stdenv.mkDerivation rec {
@@ -91,11 +92,13 @@ stdenv.mkDerivation rec {
   passthru.tests = {
     inherit libjxl;
     musl = pkgsCross.musl64.openexr;
+    python = python3Packages.openexr;
   };
 
   meta = {
     description = "High dynamic-range (HDR) image file format";
     homepage = "https://www.openexr.com";
+    changelog = "https://github.com/AcademySoftwareFoundation/OpenEXR/blob/v${version}/CHANGES.md";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ paperdigits ];
     platforms = lib.platforms.all;

--- a/pkgs/development/python-modules/openexr/default.nix
+++ b/pkgs/development/python-modules/openexr/default.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  buildPythonPackage,
+  pytestCheckHook,
+  pkgs,
+  cmake,
+  ninja,
+  numpy,
+  pybind11,
+  scikit-build-core,
+  imath,
+}:
+
+buildPythonPackage {
+  pname = "openexr";
+  inherit (pkgs.openexr) version src;
+  pyproject = true;
+  __structuredAttrs = true;
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "==" ">=" \
+      --replace-fail "cmake.targets" "build.targets"
+  '';
+
+  cmakeFlags = [
+    "-DOPENEXR_FORCE_INTERNAL_IMATH=OFF"
+  ];
+
+  build-system = [
+    cmake
+    ninja
+    pybind11
+    scikit-build-core
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  buildInputs = [
+    imath
+  ];
+
+  dependencies = [
+    numpy
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  enabledTestPaths = [
+    "src/wrappers/python/tests"
+  ];
+
+  pythonImportsCheck = [
+    "OpenEXR"
+  ];
+
+  meta = {
+    description = "Python bindings for the OpenEXR image file format";
+    inherit (pkgs.openexr.meta) homepage changelog license;
+    maintainers = with lib.maintainers; [ ambossmann ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12348,6 +12348,8 @@ self: super: with self; {
 
   openevsewifi = callPackage ../development/python-modules/openevsewifi { };
 
+  openexr = callPackage ../development/python-modules/openexr { };
+
   openfga-sdk = callPackage ../development/python-modules/openfga-sdk { };
 
   openhomedevice = callPackage ../development/python-modules/openhomedevice { };


### PR DESCRIPTION
Adds the officical python wrapper for [`openexr`](https://github.com/AcademySoftwareFoundation/OpenEXR).
It is necessary to run the the tests of `pillow-jxl-plugin` added in #543307.

Ideally we would just link against the `openexr` already in nixpkgs, but the upstream build process is not designed for that.

I initially created this with `nix-init` and then tweaked it until it worked.

Fixes #277515
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
