### PR TITLE
nixos/noctalia: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -32,6 +32,8 @@
 
 - [Nezha](https://github.com/nezhahq/nezha), a self-hosted, lightweight server and website monitoring and O&M tool. Available as [services.nezha](#opt-services.nezha.enable).
 
+- [Noctalia](https://noctalia.dev), a sleek and customizable desktop shell crafted for Wayland. Available as [programs.noctalia](#opt-programs.noctalia.enable).
+
 - [Watt](https://github.com/NotAShelf/watt), a CPU frequency and power management daemon for Linux. Available as [services.watt](#opt-services.watt.enable).
 
 - [mail-tlsa-check-exporter](https://github.com/ietf-tools/mail-tlsa-check-exporter), validates SMTP / IMAP server certificates against a TLSA record as a Prometheus exporter. Available as [services.prometheus.exporters.mail-tlsa-check](#opt-services.prometheus.exporters.mail-tlsa-check.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -358,6 +358,7 @@
   ./programs/wayland/mango.nix
   ./programs/wayland/miracle-wm.nix
   ./programs/wayland/niri.nix
+  ./programs/wayland/noctalia.nix
   ./programs/wayland/pinnacle.nix
   ./programs/wayland/river.nix
   ./programs/wayland/sway.nix

--- a/nixos/modules/programs/wayland/noctalia.nix
+++ b/nixos/modules/programs/wayland/noctalia.nix
@@ -1,0 +1,67 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.noctalia;
+in
+{
+  options.programs.noctalia = {
+    enable = lib.mkEnableOption "noctalia, a sleek and customizable desktop shell for Wayland";
+
+    package = lib.mkPackageOption pkgs "noctalia" { };
+
+    systemd = {
+      enable = lib.mkEnableOption "a systemd user service for noctalia";
+
+      target = lib.mkOption {
+        type = lib.types.str;
+        default = "graphical-session.target";
+        example = "hyprland-session.target";
+        description = ''
+          The systemd user target that will automatically start the noctalia service.
+        '';
+      };
+    };
+
+    recommendedServices.enable = lib.mkEnableOption "the services used by noctalia's integrations, namely NetworkManager, bluetooth, UPower and a power profile daemon";
+  };
+
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        environment.systemPackages = [ cfg.package ];
+
+        systemd.user.services.noctalia = lib.mkIf cfg.systemd.enable {
+          description = "Noctalia Wayland desktop shell";
+          documentation = [ "https://docs.noctalia.dev/v5/" ];
+          partOf = [ cfg.systemd.target ];
+          after = [ cfg.systemd.target ];
+          wantedBy = [ cfg.systemd.target ];
+
+          enableDefaultPath = false;
+
+          serviceConfig = {
+            ExecStart = lib.getExe cfg.package;
+            Restart = "on-failure";
+          };
+        };
+      }
+
+      (lib.mkIf cfg.recommendedServices.enable {
+        networking.networkmanager.enable = lib.mkDefault true;
+        hardware.bluetooth.enable = lib.mkDefault true;
+        services.upower.enable = lib.mkDefault true;
+        services.power-profiles-daemon.enable = lib.mkDefault true;
+      })
+    ]
+  );
+
+  meta.maintainers = with lib.maintainers; [
+    samiser
+    pyrox0
+  ];
+}


### PR DESCRIPTION
Adds a module for the [noctalia wayland shell](https://noctalia.dev/)

Adapted from the [module in the noctalia repo](https://github.com/noctalia-dev/noctalia/blob/main/nix/nixos-module.nix), keeping option names the same so folks coming from using/importing their flake can migrate just by swapping the import.

Changes from the repo module:
- `package` uses `mkPackageOption` instead of `nullOr package` defaulting to `null`.
- `enableDefaultPath = false` instead of setting `environment.PATH` to null.
- Removed `restartTriggers = [ cfg.package ]` from the service since it's redundant with `ExecStart = lib.getExe cfg.package`
- Removed the `!config.services.tuned.enable` guard on power-profiles-daemon since the tuned module already sets it to `false`.

Tested in my actual Hyprland session and in a sway+uwsm VM to test the systemd service.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
