### PR TITLE
python3Packages.pyexiv2: init at 2.16.0

### DIFF
--- a/pkgs/development/python-modules/pyexiv2/default.nix
+++ b/pkgs/development/python-modules/pyexiv2/default.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  setuptools,
+  pybind11,
+  psutil,
+  pkgs,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pyexiv2";
+  version = "2.16.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "LeoHsiao1";
+    repo = "pyexiv2";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-FH5nbbh0vaErJzBl6L2HPh0SQXkQ558abTBml7nSLU8=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  buildInputs = [
+    pybind11
+    pkgs.exiv2
+  ];
+
+  preBuild = ''
+    ln -s ${lib.getLib pkgs.exiv2}/lib/libexiv2${stdenv.hostPlatform.extensions.sharedLibrary} pyexiv2/lib/libexiv2${stdenv.hostPlatform.extensions.sharedLibrary}
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    psutil
+  ];
+
+  # Remove source to prevent it trying to import from it instead of the built package
+  preCheck = ''
+    shopt -s extglob
+    rm -r pyexiv2/!(tests)
+  '';
+
+  disabledTests = [
+    # Asserts a specific exiv2 version
+    "test_version"
+  ];
+
+  pythonImportsCheck = [
+    "pyexiv2"
+  ];
+
+  meta = {
+    description = "Python library for reading and writing image metadata, including EXIF, IPTC, XMP, ICC Profile";
+    homepage = "https://github.com/LeoHsiao1/pyexiv2";
+    changelog = "https://github.com/LeoHsiao1/pyexiv2/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ ambossmann ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14523,6 +14523,8 @@ self: super: with self; {
 
   pyexiftool = callPackage ../development/python-modules/pyexiftool { };
 
+  pyexiv2 = callPackage ../development/python-modules/pyexiv2 { };
+
   pyexpect = callPackage ../development/python-modules/pyexpect { };
 
   pyexploitdb = callPackage ../development/python-modules/pyexploitdb { };


### PR DESCRIPTION
Adds [`pyexiv2`](https://github.com/LeoHsiao1/pyexiv2), a library for reading and writing image metadata, based on `exiv2`.
This is different from the python2 package of the same name removed in #141794, `python3Packages.py3exiv2` which is based upon the aforementioned python2 package and also `python3Packages.exiv2`.

It is necessary to run the the tests of `pillow-jxl-plugin` added in #543307.

I initially created this with `nix-init` and then tweaked it until it worked.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
