### PR TITLE
python3Packages.reflex: 0.9.4 -> 0.9.7

### DIFF
--- a/pkgs/development/python-modules/reflex/default.nix
+++ b/pkgs/development/python-modules/reflex/default.nix
@@ -449,10 +449,12 @@ buildPythonPackage (finalAttrs: {
     );
 
     tests = {
+      # overridePythonAttrs does not exist for finalAttrs.finalPackage
       reflex-no-checks = finalAttrs.finalPackage.overrideAttrs (old: {
-        pname = "${old.pname}-sans-checks-phase";
+        pname = "${old.pname}-sans-check-phase";
         doCheck = false;
-        nativeCheckInputs = [ ];
+        doInstallCheck = false;
+        dontCheckPythonMetadata = true;
       });
     }
     // finalAttrs.passthru.subPkgs;

--- a/pkgs/development/python-modules/reflex/default.nix
+++ b/pkgs/development/python-modules/reflex/default.nix
@@ -47,6 +47,7 @@
   ruff,
   starlette-admin,
   uvicorn,
+  gitMinimal,
   versionCheckHook,
   writableTmpDirAsHomeHook,
 }:
@@ -81,6 +82,8 @@ let
       ]
       ++ lib.optional (pname != "hatch-reflex-pyi") subPkgs.hatch-reflex-pyi;
 
+      pythonRelaxDeps = [ "rich" ];
+
       preBuild = ''
         # for .ruff_cache and whatnot, written by hatch-reflex-pyi
         chmod -R +w ../..
@@ -98,20 +101,39 @@ in
 
 buildPythonPackage (finalAttrs: {
   pname = "reflex";
-  version = "0.9.4";
+  version = "0.9.7";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "reflex-dev";
     repo = "reflex";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-CTW8p8cPSZnTMgXk9F6oHvbfIiTtgKZVvRygUZbccJw=";
+    hash = "sha256-r7lajRhNXe+cquCT6zzP/0lnnTZ6xN2BFaediUFCafQ=";
   };
 
   build-system = [
     hatchling
     uv-dynamic-versioning
   ];
+
+  pythonRelaxDeps = [
+    # pinned to satisfy pyright
+    # https://github.com/reflex-dev/reflex/commit/67489196035bacb2e4bb2fe6ae165088bc6db988
+    "wrapt"
+    # preemptive upper bound, doesn't seem breaking
+    "redis"
+    "rich"
+  ];
+  # pythonRelaxDeps is not sufficient
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail \
+        '"redis >=6.4,<8.0"' \
+        '"redis >=6.4,<9.0"' \
+      --replace-fail \
+        '"wrapt >=1.17.0,<2.2"' \
+        '"wrapt >=1.17.0"'
+  '';
 
   nativeBuildInputs = [
     ruff
@@ -168,6 +190,7 @@ buildPythonPackage (finalAttrs: {
     starlette-admin
     uvicorn
     versionCheckHook
+    gitMinimal
     writableTmpDirAsHomeHook
   ];
   versionCheckProgramArg = "--version";
@@ -210,8 +233,14 @@ buildPythonPackage (finalAttrs: {
     "tests/units/docgen/test_class_and_component.py"
     "tests/units/docgen/test_markdown.py"
     "tests/units/docgen/test_reflex_transformer.py"
+    "docs/app/tests/test_breadcrumbs.py"
+    "docs/app/tests/test_changelogs.py"
+    "docs/app/tests/test_doc_description.py"
     "docs/app/tests/test_doc_links.py"
     "docs/app/tests/test_docgen_double_eval.py"
+
+    # circular imports (reflex-integrations-docs)
+    "docs/app/tests/test_integrations.py"
 
     # circular imports (reflex-site-shared)
     "docs/app/tests/test_routes.py"


### PR DESCRIPTION
fixes https://hydra.nixos.org/build/338604874

Changelog:
https://github.com/reflex-dev/reflex/releases/tag/v0.9.7
https://github.com/reflex-dev/reflex/releases/tag/v0.9.6
https://github.com/reflex-dev/reflex/releases/tag/v0.9.5


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
