### PR TITLE
nixos-option: implement `--extra-experimental-features` flag

### DIFF
--- a/pkgs/by-name/ni/nixos-option/nixos-option.8
+++ b/pkgs/by-name/ni/nixos-option/nixos-option.8
@@ -15,6 +15,7 @@
 .br
 .Op Fl -no-flake
 .Op Fl -show-trace
+.Op Fl -extra-experimental-features Ar features
 .Ar option.name
 .
 .
@@ -75,6 +76,11 @@ if
 .Pa /etc/nixos/flake.nix
 exists. With this option, it is possible to show options in non-flake NixOS
 configurations even if the current NixOS systems uses flakes.
+.
+.It Fl -extra-experimental-features
+Specify additional experimental feature flags to enable. This option is passed to the underlying
+.Xr nix-instantiate 1
+invocation.
 .
 .El
 .

--- a/pkgs/by-name/ni/nixos-option/nixos-option.sh
+++ b/pkgs/by-name/ni/nixos-option/nixos-option.sh
@@ -69,6 +69,11 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
 
+    --extra-experimental-features)
+      nix_args+=("$1" "$2")
+      shift 2
+      ;;
+
     -*)
       echo >&2 "Unsupported option $1"
       exit 1


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I added an `--extra-experimental-features` flag to `nixos-option` and updated its man page accordingly.

I did this so that `nixos-option` could be used to inspect flakes in environments that do not have `experimental-features` configured to allow it, such as the NixOS live CD.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
