### PR TITLE
packsquash: init at 0.4.1

### DIFF
--- a/pkgs/by-name/pa/packsquash/package.nix
+++ b/pkgs/by-name/pa/packsquash/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  cmake,
+  versionCheckHook,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "packsquash";
+  version = "0.4.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    repo = "PackSquash";
+    owner = "ComunidadAylas";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-c2nVG9qjla3E5O5oD57+KxYh21Iu+fL1LFNC+rw6QR0=";
+  };
+
+  cargoHash = "sha256-dx2Cm2zNr9FARd1fc6ehynxrA1qHwtQQGMmEbGuc0dk=";
+
+  env = {
+    # Requires nightly toolchain for feature(core_intrinsics)
+    RUSTC_BOOTSTRAP = 1;
+    # if_let_guard is stable since Rust 1.95.0, but some deps still carry
+    # the stale #![feature(if_let_guard)] attribute.
+    RUSTFLAGS = "-A stable-features";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  # Fails in sandbox
+  checkFlags = [
+    "--skip=squash_zip::system_id::tests"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Resource and data pack optimizer for Minecraft: Java Edition";
+    homepage = "https://packsquash.aylas.org/";
+    changelog = "https://github.com/ComunidadAylas/PackSquash/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ nartsiss ];
+    mainProgram = "packsquash";
+  };
+})


### PR DESCRIPTION
https://github.com/ComunidadAylas/PackSquash - Minecraft: Java Edition resource and data pack optimizer which aims to achieve the best possible compression, performance and protection, improving pack distribution, storage and in-game load times.

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
