### PR TITLE
shell: cleanup 26.05 x86_64-darwin special case

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -13,15 +13,10 @@
 #
 {
   system ? builtins.currentSystem,
-  nixpkgs ? null,
-}:
-let
-  version = builtins.readFile ./.version;
-
-  # On 26.05 we need a CI-pinned Nixpkgs revision that supports x86_64-darwin.
-  # TODO: remove after 26.05 support ends.
-  nixpkgs' =
-    if nixpkgs == null && system == "x86_64-darwin" && version == "26.05" then
+  nixpkgs ? (
+    # On 26.05 we need a CI-pinned Nixpkgs revision that supports x86_64-darwin.
+    # TODO: remove after 26.05 support ends.
+    if system == "x86_64-darwin" && (builtins.readFile ./.version) == "26.05" then
       let
         pinned = (builtins.fromJSON (builtins.readFile ./ci/pinned.json)).pins;
         warn = builtins.warn or (import ./lib).warn;
@@ -44,16 +39,11 @@ let
         sha256 = hash;
       }
     else
-      nixpkgs;
-
-  inherit
-    (import ./ci {
-      inherit system;
-      nixpkgs = nixpkgs';
-    })
-    pkgs
-    fmt
-    ;
+      null
+  ),
+}:
+let
+  inherit (import ./ci { inherit nixpkgs system; }) pkgs fmt;
 
   # For `nix-shell -A hello`
   curPkgs = removeAttrs (import ./. { inherit system; }) [


### PR DESCRIPTION
Followup to #545390

Move the 26.05 x86_64-darwin special case directly into the `nixpkgs` parameter default, avoiding the need for a `nixpkgs'` binding.

This allows reverting the formatting change to the `inherit (import ./ci { … })` line, making post-26.05 cleanup easier.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] Used `shell.nix`
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
