### PR TITLE
top-level/by-name-overlay: don't set _internalCallByNamePackageFile attr

### DIFF
--- a/maintainers/scripts/build.nix
+++ b/maintainers/scripts/build.nix
@@ -15,29 +15,9 @@
 # nix-build build.nix --argstr maintainer <yourname> --argstr system aarch64-linux
 
 let
-  # This avoids a common situation for maintainers, where due to Git's behavior of not tracking
-  # directories, they have an empty directory somewhere in `pkgs/by-name`. Because that directory
-  # exists, `pkgs/top-level/by-name-overlay.nix` picks it up and attempts to read `package.nix` out
-  # of it... which doesn't exist, since it's empty.
-  #
-  # We don't want to run the code below on every instantiation of `nixpkgs`, as the `pkgs/by-name`
-  # eval machinery is quite performance sensitive. So we use the internals of the `by-name` overlay
-  # to implement our own way to avoid an evaluation failure for this script.
-  #
-  # See <https://github.com/NixOS/nixpkgs/issues/338227> for more motivation for this code block.
-  overlay = self: super: {
-    _internalCallByNamePackageFile =
-      file: if builtins.pathExists file then super._internalCallByNamePackageFile file else null;
-  };
-
-  nixpkgsArgs =
-    removeAttrs args [
-      "maintainer"
-      "overlays"
-    ]
-    // {
-      overlays = args.overlays or [ ] ++ [ overlay ];
-    };
+  nixpkgsArgs = removeAttrs args [
+    "maintainer"
+  ];
 
   pkgs = import ./../../default.nix nixpkgsArgs;
 

--- a/pkgs/top-level/by-name-overlay.nix
+++ b/pkgs/top-level/by-name-overlay.nix
@@ -4,7 +4,7 @@
 # and validity checks are done by CI on PRs.
 
 # Type: Path -> Overlay
-baseDirectory:
+
 let
   # Because of Nix's import-value cache, importing lib is free
   lib = import ../../lib;
@@ -22,13 +22,19 @@ let
   inherit (lib.trivial)
     flip
     ;
-
+in
+baseDirectory:
+let
   # Package files for a single shard
   # Type: String -> String -> AttrsOf Path
   namesForShard =
     shard: type:
-    if type != "directory" then
-      # Ignore all non-directories. Technically only README.md is allowed as a file in the base directory, so we could alternatively:
+    let
+      result = readDir (baseDirectory + "/${shard}");
+    in
+    if type != "directory" || result == { } then
+      # Ignore all non-directories and empty directories
+      # Technically only README.md is allowed as a file in the base directory, so we could alternatively:
       # - Assume that README.md is the only file and change the condition to `shard == "README.md"` for a minor performance improvement.
       #   This would however cause very poor error messages if there's other files.
       # - Ensure that README.md is the only file, throwing a better error message if that's not the case.
@@ -36,9 +42,7 @@ let
       # Additionally in either of those alternatives, we would have to duplicate the hardcoding of "README.md"
       { }
     else
-      mapAttrs (name: _: baseDirectory + "/${shard}/${name}/package.nix") (
-        readDir (baseDirectory + "/${shard}")
-      );
+      mapAttrs (name: _: baseDirectory + "/${shard}/${name}/package.nix") result;
 
   # The attribute set mapping names to the package files defining them
   # This is defined up here in order to allow reuse of the value (it's kind of expensive to compute)
@@ -46,13 +50,8 @@ let
   packageFiles = mergeAttrsList (mapAttrsToList namesForShard (readDir baseDirectory));
 in
 self: super:
-{
-  # This attribute is necessary to allow CI to ensure that all packages defined in `pkgs/by-name`
-  # don't have an overriding definition in `all-packages.nix` with an empty (`{ }`) second `callPackage` argument.
-  # It achieves that with an overlay that modifies both `callPackage` and this attribute to signal whether `callPackage` is used
-  # and whether it's defined by this file here or `all-packages.nix`.
-  # TODO: This can be removed once `pkgs/by-name` can handle custom `callPackage` arguments without `all-packages.nix` (or any other way of achieving the same result).
-  # Because at that point the code in ./stage.nix can be changed to not allow definitions in `all-packages.nix` to override ones from `pkgs/by-name` anymore and throw an error if that happens instead.
-  _internalCallByNamePackageFile = flip self.callPackage { };
-}
-// mapAttrs (name: self._internalCallByNamePackageFile) packageFiles
+let
+  # Avoid allocating `{ }` for every package.
+  flippedCallPackage = flip self.callPackage { };
+in
+mapAttrs (_attrName: flippedCallPackage) packageFiles

--- a/pkgs/top-level/by-name-overlay.nix
+++ b/pkgs/top-level/by-name-overlay.nix
@@ -49,9 +49,9 @@ let
   # if the overlay has to be applied multiple times
   packageFiles = mergeAttrsList (mapAttrsToList namesForShard (readDir baseDirectory));
 in
-self: super:
+self:
 let
   # Avoid allocating `{ }` for every package.
   flippedCallPackage = flip self.callPackage { };
 in
-mapAttrs (_attrName: flippedCallPackage) packageFiles
+super: mapAttrs (_attrName: flippedCallPackage) packageFiles


### PR DESCRIPTION
No longer needed, see #483820 and NixOS/nixpkgs-vet#189


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
