### PR TITLE
sage: use threaded ntl on darwin but patch to appease linker

### DIFF
--- a/pkgs/by-name/sa/sage/package.nix
+++ b/pkgs/by-name/sa/sage/package.nix
@@ -13,24 +13,12 @@
 let
   inherit (pkgs) symlinkJoin callPackage mathjax;
 
-  ntl = (
-    if stdenv.hostPlatform.isDarwin then
-      (pkgs.ntl.overrideAttrs (old: {
-        configureFlags = (old.configureFlags or [ ]) ++ [
-          "NTL_THREADS=off"
-        ];
-      }))
-    else
-      pkgs.ntl
-  );
-
   python3 = pkgs.python3 // {
     pkgs = pkgs.python3.pkgs.overrideScope (
       self: super: {
         # `sagelib`, i.e. all of sage except some wrappers and runtime dependencies
         sagelib = self.callPackage ./sagelib.nix {
           inherit flint;
-          inherit ntl;
           inherit sage-src env-locations singular;
           inherit (maxima) lisp-compiler;
           linbox = pkgs.linbox;
@@ -93,7 +81,6 @@ let
       singular
       palp
       flint
-      ntl
       pythonEnv
       maxima
       ;
@@ -108,7 +95,6 @@ let
   # sagelib with added wrappers and a dependency on sage-tests to make sure thet tests were run.
   sage-with-env = callPackage ./sage-with-env.nix {
     inherit python3 pythonEnv;
-    inherit ntl;
     inherit sage-env;
     inherit singular maxima;
     inherit three;

--- a/pkgs/by-name/sa/sage/patches/link-ntl-directly-for-ntl-cython-extensions.patch
+++ b/pkgs/by-name/sa/sage/patches/link-ntl-directly-for-ntl-cython-extensions.patch
@@ -1,0 +1,32 @@
+diff --git a/src/sage/libs/eclib/meson.build b/src/sage/libs/eclib/meson.build
+index 03eeac28d34..5e67b0e7f1c 100644
+--- a/src/sage/libs/eclib/meson.build
++++ b/src/sage/libs/eclib/meson.build
+@@ -22,7 +22,7 @@ foreach name, pyx : extension_data_cpp
+     install: true,
+     override_options: ['cython_language=cpp'],
+     include_directories: [inc_cpython, inc_ext, inc_flint, inc_ntl, inc_rings],
+-    dependencies: [py_dep, cysignals, ec, ecl, flint, gmp],
++    dependencies: [py_dep, cysignals, ec, ecl, flint, gmp, ntl],
+   )
+ endforeach
+
+diff --git a/src/sage/rings/polynomial/meson.build b/src/sage/rings/polynomial/meson.build
+index 5c2aaf2ae0a..2e7c574c33d 100644
+--- a/src/sage/rings/polynomial/meson.build
++++ b/src/sage/rings/polynomial/meson.build
+@@ -196,11 +196,11 @@ foreach name, pyx : extension_data_cpp
+   elif name == 'plural'
+     deps += [singular]
+   elif name == 'polynomial_zz_pex'
+-    deps += [cypari2]
++    deps += [cypari2, ntl]
+   elif name == 'polynomial_integer_dense_ntl' or name == 'polynomial_modn_dense_ntl'
+-    deps += [cypari2]
++    deps += [cypari2, ntl]
+   elif name == 'polynomial_gf2x'
+-    deps += [cypari2]
++    deps += [cypari2, ntl]
+   elif name == 'evaluation_ntl'
+     deps += [ntl, mpfr, mpfi]    # Runtime dependencies
+   endif

--- a/pkgs/by-name/sa/sage/sage-src.nix
+++ b/pkgs/by-name/sa/sage/sage-src.nix
@@ -53,6 +53,10 @@ stdenv.mkDerivation rec {
     # "undefined symbol: cblas_ctrmv" errors.
     ./patches/revert-blas-mesonification.patch
 
+    # Darwin linkers fail unless some NTL-backed Cython C++ extensions link
+    # NTL directly instead of relying on transitive linkage.
+    ./patches/link-ntl-directly-for-ntl-cython-extensions.patch
+
     # https://github.com/sagemath/sage/pull/41637 causes problems when
     # docbuilding.
     (fetchpatch2 {


### PR DESCRIPTION
After #541155 disabled `ntl` threading on Darwin to bypass a compilation failure, the sage tests started failing with segfaults caused by with-threading and without-threading `ntl` assumptions present in the graph of libraries installed by the build.

The original failure:

```
clang++  -o src/sage/libs/eclib/mwrank.cpython-314-darwin.so src/sage/libs/eclib/mwrank.cpython-314-darwin.so.p/meson-generated_src_sage_libs_eclib_mwrank.pyx.cpp.o -Wl,-dead_strip_dylibs -Wl,-headerpad_max_install_names -Wl,-undefined,dynamic_lookup -bundle -Wl,-undefined,dynamic_lookup 
/nix/store/rdygrnmrxhmzsrg63wb6m8mx8mcmad7n-eclib-20250627/lib/libec.dylib -lecl 
/nix/store/saaj0vlz8bmxd8z5l3a6wm85ss8fdbv8-flint-3.6.0/lib/libflint.dylib 
/nix/store/c8i80yixjlm4ljgyg96bx57nalcbpsly-gmp-with-cxx-6.3.0/lib/libgmp.dylib 
/nix/store/72vjb4bvkbb0ykglvdndvqplrhpsl8v7-mpfr-4.2.2/lib/libmpfr.dylib
ld: illegal thread local variable reference to regular symbol __ZN3NTL2RR4precE for architecture arm64
```

While it is possible to work out a correct darwin build along  #541155 lines using without-threading `ntl` (we explored this in #545925), this change instead makes the threaded version work on darwin by minimally patching upstream sage itself to ensure the linker gets to reference this library directly during compilation. This seems to be less heavy-handed than #541155 - all the patches do is making sure clang++ receives an explicit reference to the `ntl` library so it can resolve the thread local symbols correctly.

Still checking:
[ ] With these change the tests now pass.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
