### PR TITLE
tailscale{,-gitops-pusher}: modernize

### DIFF
--- a/pkgs/by-name/ta/tailscale-gitops-pusher/package.nix
+++ b/pkgs/by-name/ta/tailscale-gitops-pusher/package.nix
@@ -6,30 +6,23 @@
 
 buildGoModule {
   pname = "tailscale-gitops-pusher";
-  inherit (tailscale) version;
+  __structuredAttrs = true;
 
   # It's hosted in the `tailscale` monorepo.
-  inherit (tailscale) src vendorHash;
-
-  env = {
-    inherit (tailscale) CGO_ENABLED;
-  };
+  inherit (tailscale)
+    version
+    src
+    vendorHash
+    ldflags
+    env
+    ;
 
   subPackages = [
     "cmd/gitops-pusher"
   ];
 
-  ldflags = [
-    "-w"
-    "-s"
-    "-X tailscale.com/version.longStamp=${tailscale.version}"
-    "-X tailscale.com/version.shortStamp=${tailscale.version}"
-  ];
-
-  meta = {
-    homepage = "https://tailscale.com";
+  meta = (tailscale.meta or { }) // {
     description = "Allows users to use a GitOps flow for managing Tailscale ACLs";
-    license = lib.licenses.bsd3;
     mainProgram = "gitops-pusher";
     maintainers = with lib.maintainers; [
       e1mo

--- a/pkgs/by-name/ta/tailscale/package.nix
+++ b/pkgs/by-name/ta/tailscale/package.nix
@@ -26,6 +26,8 @@ buildGoModule (finalAttrs: {
   pname = "tailscale";
   version = "1.98.9";
 
+  __structuredAttrs = true;
+
   outputs = [
     "out"
     "derper"
@@ -64,7 +66,6 @@ buildGoModule (finalAttrs: {
   ];
 
   ldflags = [
-    "-w"
     "-s"
     "-X tailscale.com/version.longStamp=${finalAttrs.version}"
     "-X tailscale.com/version.shortStamp=${finalAttrs.version}"


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
