### PR TITLE
polkit: add ConsoleKit backend

### DIFF
--- a/pkgs/by-name/po/polkit/package.nix
+++ b/pkgs/by-name/po/polkit/package.nix
@@ -21,6 +21,7 @@
   docbook_xml_dtd_412,
   gtk-doc,
   coreutils,
+  useConsoleKit ? false,
   useSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
   systemdLibs,
   elogind,
@@ -42,6 +43,8 @@ in
 stdenv.mkDerivation (finalAttrs: {
   pname = "polkit";
   version = "127";
+
+  disallowedReferences = lib.optional useConsoleKit systemdLibs;
 
   outputs = [
     "bin"
@@ -94,7 +97,7 @@ stdenv.mkDerivation (finalAttrs: {
     dbus
     duktape
   ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && !useConsoleKit) [
     # On Linux, fall back to elogind when systemd support is off.
     (if useSystemd then systemdLibs else elogind)
   ];
@@ -145,7 +148,14 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dsystemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
-    "-Dsession_tracking=${if useSystemd then "logind" else "elogind"}"
+    "-Dsession_tracking=${
+      if useSystemd then
+        "logind"
+      else if useConsoleKit then
+        "ConsoleKit"
+      else
+        "elogind"
+    }"
   ];
 
   inherit doCheck;

--- a/pkgs/by-name/po/polkit/package.nix
+++ b/pkgs/by-name/po/polkit/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   pkg-config,
   glib,
   expat,
@@ -40,7 +39,7 @@ let
   system = "/run/current-system/sw";
   setuid = "/run/wrappers/bin";
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "polkit";
   version = "127";
 
@@ -54,7 +53,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "polkit-org";
     repo = "polkit";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-YTugETy0rqu/bv53jV1UeGqSK79bRXR52EJNcTblvzo=";
   };
 
@@ -193,4 +192,4 @@ stdenv.mkDerivation rec {
     ];
     teams = [ lib.teams.freedesktop ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test