### PR TITLE
minimal-bootstrap: targeted performance improvements

### DIFF
--- a/pkgs/os-specific/linux/minimal-bootstrap/bash/2.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/bash/2.nix
@@ -96,6 +96,13 @@ kaem.runCommand "${pname}-${version}"
 
           bash -eux $buildCommandPath
         '';
+        defaultBuildInputs = [
+          bash_2_05
+          coreutils
+          # provides untar, ungz, and unbz2
+          mescc-tools-extra
+        ];
+        defaultBinPath = lib.makeBinPath defaultBuildInputs;
       in
       name: env: buildCommand:
       derivationWithMeta (
@@ -109,15 +116,11 @@ kaem.runCommand "${pname}-${version}"
           passAsFile = [ "buildCommand" ];
 
           SHELL = "${bash_2_05}/bin/bash";
-          PATH = lib.makeBinPath (
-            (env.nativeBuildInputs or [ ])
-            ++ [
-              bash_2_05
-              coreutils
-              # provides untar, ungz, and unbz2
-              mescc-tools-extra
-            ]
-          );
+          PATH =
+            if !env ? nativeBuildInputs then
+              defaultBinPath
+            else
+              lib.makeBinPath (env.nativeBuildInputs ++ defaultBuildInputs);
         }
         // (removeAttrs env [ "nativeBuildInputs" ])
       );

--- a/pkgs/os-specific/linux/minimal-bootstrap/bash/2.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/bash/2.nix
@@ -80,6 +80,23 @@ kaem.runCommand "${pname}-${version}"
     ];
 
     passthru.runCommand =
+      let
+        bashBuilder = builtins.toFile "bash-builder.sh" ''
+          export CONFIG_SHELL=$SHELL
+
+          # Normalize the NIX_BUILD_CORES variable. The value might be 0, which
+          # means that we're supposed to try and auto-detect the number of
+          # available CPU cores at run-time. We don't have nproc to detect the
+          # number of available CPU cores so default to 1 if not set.
+          NIX_BUILD_CORES="''${NIX_BUILD_CORES:-1}"
+          if [ $NIX_BUILD_CORES -le 0 ]; then
+            NIX_BUILD_CORES=1
+          fi
+          export NIX_BUILD_CORES
+
+          bash -eux $buildCommandPath
+        '';
+      in
       name: env: buildCommand:
       derivationWithMeta (
         {
@@ -87,21 +104,7 @@ kaem.runCommand "${pname}-${version}"
           builder = "${bash_2_05}/bin/bash";
           args = [
             "-e"
-            (builtins.toFile "bash-builder.sh" ''
-              export CONFIG_SHELL=$SHELL
-
-              # Normalize the NIX_BUILD_CORES variable. The value might be 0, which
-              # means that we're supposed to try and auto-detect the number of
-              # available CPU cores at run-time. We don't have nproc to detect the
-              # number of available CPU cores so default to 1 if not set.
-              NIX_BUILD_CORES="''${NIX_BUILD_CORES:-1}"
-              if [ $NIX_BUILD_CORES -le 0 ]; then
-                NIX_BUILD_CORES=1
-              fi
-              export NIX_BUILD_CORES
-
-              bash -eux $buildCommandPath
-            '')
+            bashBuilder
           ];
           passAsFile = [ "buildCommand" ];
 

--- a/pkgs/os-specific/linux/minimal-bootstrap/bash/2.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/bash/2.nix
@@ -103,6 +103,7 @@ kaem.runCommand "${pname}-${version}"
           mescc-tools-extra
         ];
         defaultBinPath = lib.makeBinPath defaultBuildInputs;
+        removedAttributeNames = [ "nativeBuildInputs" ];
       in
       name: env: buildCommand:
       derivationWithMeta (
@@ -122,7 +123,7 @@ kaem.runCommand "${pname}-${version}"
             else
               lib.makeBinPath (env.nativeBuildInputs ++ defaultBuildInputs);
         }
-        // (removeAttrs env [ "nativeBuildInputs" ])
+        // (removeAttrs env removedAttributeNames)
       );
 
     passthru.tests.get-version =

--- a/pkgs/os-specific/linux/minimal-bootstrap/bash/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/bash/default.nix
@@ -55,6 +55,7 @@ bootBash.runCommand "${pname}-${version}"
           bash
           coreutils
         ];
+        defaultBinPath = lib.makeBinPath defaultBuildInputs;
       in
       name: env: buildCommand:
       derivationWithMeta (
@@ -82,7 +83,11 @@ bootBash.runCommand "${pname}-${version}"
           passAsFile = [ "buildCommand" ];
 
           SHELL = "${bash}/bin/bash";
-          PATH = lib.makeBinPath ((env.nativeBuildInputs or [ ]) ++ defaultBuildInputs);
+          PATH =
+            if !env ? nativeBuildInputs then
+              defaultBinPath
+            else
+              lib.makeBinPath (env.nativeBuildInputs ++ defaultBuildInputs);
           passthru = (env.passthru or { }) // {
             isFromMinBootstrap = true;
           };

--- a/pkgs/os-specific/linux/minimal-bootstrap/bash/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/bash/default.nix
@@ -56,6 +56,10 @@ bootBash.runCommand "${pname}-${version}"
           coreutils
         ];
         defaultBinPath = lib.makeBinPath defaultBuildInputs;
+        removedAttributeNames = [
+          "nativeBuildInputs"
+          "passthru"
+        ];
       in
       name: env: buildCommand:
       derivationWithMeta (
@@ -92,10 +96,7 @@ bootBash.runCommand "${pname}-${version}"
             isFromMinBootstrap = true;
           };
         }
-        // (removeAttrs env [
-          "nativeBuildInputs"
-          "passthru"
-        ])
+        // (removeAttrs env removedAttributeNames)
       );
     passthru.tests.get-version =
       result:

--- a/pkgs/os-specific/linux/minimal-bootstrap/bash/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/bash/default.nix
@@ -50,6 +50,12 @@ bootBash.runCommand "${pname}-${version}"
     ];
 
     passthru.runCommand =
+      let
+        defaultBuildInputs = [
+          bash
+          coreutils
+        ];
+      in
       name: env: buildCommand:
       derivationWithMeta (
         {
@@ -76,13 +82,7 @@ bootBash.runCommand "${pname}-${version}"
           passAsFile = [ "buildCommand" ];
 
           SHELL = "${bash}/bin/bash";
-          PATH = lib.makeBinPath (
-            (env.nativeBuildInputs or [ ])
-            ++ [
-              bash
-              coreutils
-            ]
-          );
+          PATH = lib.makeBinPath ((env.nativeBuildInputs or [ ]) ++ defaultBuildInputs);
           passthru = (env.passthru or { }) // {
             isFromMinBootstrap = true;
           };

--- a/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/kaem/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/kaem/default.nix
@@ -35,6 +35,7 @@ derivationWithMeta {
         mescc-tools
         mescc-tools-extra
       ];
+      defaultBinPath = lib.makeBinPath defaultBuildInputs;
     in
     name: env: buildCommand:
     derivationWithMeta (
@@ -49,7 +50,11 @@ derivationWithMeta {
           (writeText "${name}-builder" buildCommand)
         ];
 
-        PATH = lib.makeBinPath ((env.nativeBuildInputs or [ ]) ++ defaultBuildInputs);
+        PATH =
+          if !env ? nativeBuildInputs then
+            defaultBinPath
+          else
+            lib.makeBinPath (env.nativeBuildInputs ++ defaultBuildInputs);
       }
       // (removeAttrs env [ "nativeBuildInputs" ])
     );

--- a/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/kaem/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/kaem/default.nix
@@ -29,6 +29,13 @@ derivationWithMeta {
   PATH = lib.makeBinPath [ mescc-tools-extra ];
 
   passthru.runCommand =
+    let
+      defaultBuildInputs = [
+        kaem
+        mescc-tools
+        mescc-tools-extra
+      ];
+    in
     name: env: buildCommand:
     derivationWithMeta (
       {
@@ -42,14 +49,7 @@ derivationWithMeta {
           (writeText "${name}-builder" buildCommand)
         ];
 
-        PATH = lib.makeBinPath (
-          (env.nativeBuildInputs or [ ])
-          ++ [
-            kaem
-            mescc-tools
-            mescc-tools-extra
-          ]
-        );
+        PATH = lib.makeBinPath ((env.nativeBuildInputs or [ ]) ++ defaultBuildInputs);
       }
       // (removeAttrs env [ "nativeBuildInputs" ])
     );

--- a/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/kaem/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/kaem/default.nix
@@ -36,6 +36,7 @@ derivationWithMeta {
         mescc-tools-extra
       ];
       defaultBinPath = lib.makeBinPath defaultBuildInputs;
+      removedAttributeNames = [ "nativeBuildInputs" ];
     in
     name: env: buildCommand:
     derivationWithMeta (
@@ -56,7 +57,7 @@ derivationWithMeta {
           else
             lib.makeBinPath (env.nativeBuildInputs ++ defaultBuildInputs);
       }
-      // (removeAttrs env [ "nativeBuildInputs" ])
+      // (removeAttrs env removedAttributeNames)
     );
 
   meta = {

--- a/pkgs/os-specific/linux/minimal-bootstrap/utils.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/utils.nix
@@ -60,6 +60,36 @@ rec {
   writeTextFile =
     let
       PATH = lib.makeBinPath [ mescc-tools-extra ];
+      builders = builtins.mapAttrs (_: builtins.toFile "write-text-file.kaem") {
+        emptyDestinationExecutable = ''
+          target=''${out}''${destination}
+          mkdir -p ''${out}''${destinationDir}
+          cp ''${textPath} ''${target}
+          chmod 555 ''${target}
+        '';
+        emptyDestinationNonExecutable = ''
+          target=''${out}''${destination}
+          mkdir -p ''${out}''${destinationDir}
+          cp ''${textPath} ''${target}
+        '';
+        nonEmptyDestinationExecutable = ''
+          target=''${out}''${destination}
+          cp ''${textPath} ''${target}
+          chmod 555 ''${target}
+        '';
+        nonEmptyDestinationNonExecutable = ''
+          target=''${out}''${destination}
+          cp ''${textPath} ''${target}
+        '';
+      };
+      getWriteTextFileBuilder =
+        destinationEmpty: executable:
+        if destinationEmpty then
+          if executable then builders.emptyDestinationExecutable else builders.emptyDestinationNonExecutable
+        else if executable then
+          builders.nonEmptyDestinationExecutable
+        else
+          builders.nonEmptyDestinationNonExecutable;
     in
     {
       name, # the name of the derivation
@@ -76,20 +106,7 @@ rec {
         "--verbose"
         "--strict"
         "--file"
-        (builtins.toFile "write-text-file.kaem" (
-          ''
-            target=''${out}''${destination}
-          ''
-          + lib.optionalString (destination == "") ''
-            mkdir -p ''${out}''${destinationDir}
-          ''
-          + ''
-            cp ''${textPath} ''${target}
-          ''
-          + lib.optionalString executable ''
-            chmod 555 ''${target}
-          ''
-        ))
+        (getWriteTextFileBuilder (destination == "") executable)
       ];
 
       inherit PATH;

--- a/pkgs/os-specific/linux/minimal-bootstrap/utils.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/utils.nix
@@ -77,7 +77,7 @@ rec {
           ''
             target=''${out}''${destination}
           ''
-          + lib.optionalString (dirOf destination == ".") ''
+          + lib.optionalString (destination == "") ''
             mkdir -p ''${out}''${destinationDir}
           ''
           + ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/utils.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/utils.nix
@@ -58,6 +58,9 @@ rec {
     ) baseDrv;
 
   writeTextFile =
+    let
+      PATH = lib.makeBinPath [ mescc-tools-extra ];
+    in
     {
       name, # the name of the derivation
       text,
@@ -89,7 +92,7 @@ rec {
         ))
       ];
 
-      PATH = lib.makeBinPath [ mescc-tools-extra ];
+      inherit PATH;
       destinationDir = dirOf destination;
       inherit destination;
     };

--- a/pkgs/os-specific/linux/minimal-bootstrap/utils.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/utils.nix
@@ -38,10 +38,13 @@ rec {
         ])
       );
       passthru' =
-        passthru
-        // lib.optionalAttrs (passthru ? tests) {
-          tests = lib.mapAttrs (_: f: f baseDrv) passthru.tests;
-        };
+        if passthru ? tests then
+          passthru
+          // {
+            tests = lib.mapAttrs (_: f: f baseDrv) passthru.tests;
+          }
+        else
+          passthru;
     in
     lib.extendDerivation validity.handled (
       {

--- a/pkgs/os-specific/linux/minimal-bootstrap/utils.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/utils.nix
@@ -20,6 +20,12 @@ rec {
   };
 
   derivationWithMeta =
+    let
+      removedAttributeNames = [
+        "meta"
+        "passthru"
+      ];
+    in
     attrs:
     let
       passthru = attrs.passthru or { };
@@ -32,10 +38,7 @@ rec {
           name = attrs.name or "${attrs.pname}-${attrs.version}";
         }
         // maybeContentAddressed
-        // (removeAttrs attrs [
-          "meta"
-          "passthru"
-        ])
+        // (removeAttrs attrs removedAttributeNames)
       );
       passthru' =
         if passthru ? tests then


### PR DESCRIPTION
Cleanups for the builder functions.
Note that the last commit is the only one I consider "gross". I can drop it if requested.

I profiled `pkgs.hello` to represent this work. Here's the stats diff for all the commits:
```json
{
  "attrset": {
    "lookups": "-5.1%",
    "merges": "-2.92%",
    "mergeCopies": null
  },
  "list": {
    "concats": "-4.11%"
  },
  "parser": {
    "expressions": "+0.1%"
  },
  "memoryBytes": {
    "envs": "-2.04%",
    "list": "-7.36%",
    "sets": "+0%",
    "symbols": "+0.06%",
    "values": "-0.43%",
    "total": "-0.23%"
  },
  "speed": {
    "primops": "-1.95%",
    "functionCalls": "-3.37%",
    "thunksMade": "-1.77%",
    "thunksAvoided": "-1.78%"
  }
}
```

`perf` stats before:
```
 Performance counter stats for 'result/bin/nix-instantiate --eval -A hello.outPath --impure' (50 runs):

                 0      context-switches:u               #      0.0 cs/sec  cs_per_second     
                 0      cpu-migrations:u                 #      0.0 migrations/sec  migrations_per_second
            14,600      page-faults:u                    #  99300.5 faults/sec  page_faults_per_second  ( +-  0.00% )
            147.03 msec task-clock:u                     #      0.9 CPUs  CPUs_utilized         ( +-  0.27% )
         3,313,612      branch-misses:u                  #      1.7 %  branch_miss_rate         ( +-  0.35% )  (50.36%)
       188,211,055      branches:u                       #   1280.1 M/sec  branch_frequency     ( +-  0.35% )  (50.30%)
       467,009,926      cpu-cycles:u                     #      3.2 GHz  cycles_frequency       ( +-  0.32% )  (67.28%)
       981,960,606      instructions:u                   #      2.1 instructions  insn_per_cycle  ( +-  0.33% )  (49.81%)
        95,434,614      stalled-cycles-frontend:u        #     0.20 frontend_cycles_idle        ( +-  0.44% )  (50.10%)

       0.165444546 +- 0.000745557 seconds time elapsed  ( +-  0.45% )
```
And after:
```

                 0      context-switches:u               #      0.0 cs/sec  cs_per_second     
                 0      cpu-migrations:u                 #      0.0 migrations/sec  migrations_per_second
            14,508      page-faults:u                    #  99505.0 faults/sec  page_faults_per_second  ( +-  0.00% )
            145.80 msec task-clock:u                     #      0.9 CPUs  CPUs_utilized         ( +-  0.50% )
         3,307,434      branch-misses:u                  #      1.8 %  branch_miss_rate         ( +-  0.31% )  (49.33%)
       185,305,274      branches:u                       #   1270.9 M/sec  branch_frequency     ( +-  0.22% )  (50.75%)
       462,976,048      cpu-cycles:u                     #      3.2 GHz  cycles_frequency       ( +-  0.56% )  (67.42%)
       979,612,904      instructions:u                   #      2.1 instructions  insn_per_cycle  ( +-  0.21% )  (51.12%)
        93,936,496      stalled-cycles-frontend:u        #     0.20 frontend_cycles_idle        ( +-  0.61% )  (49.40%)

       0.162560310 +- 0.001069408 seconds time elapsed  ( +-  0.66% )
```

Looks to be about a 1% real-time improvement.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
