### PR TITLE
sessiond: init at 0.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23316,6 +23316,11 @@
     githubId = 52847440;
     name = "Ryan Burns";
   };
+  r0chd = {
+    github = "r0chd";
+    githubId = 100892812;
+    name = "Oskar Rochowiak";
+  };
   r17x = {
     email = "hi@rin.rocks";
     github = "r17x";

--- a/pkgs/by-name/se/sessiond/package.nix
+++ b/pkgs/by-name/se/sessiond/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  linux-pam,
+  pkg-config,
+  rustPlatform,
+  withConsoleKit ? true,
+  installShellFiles,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+  pname = "sessiond";
+  version = "0.1.1";
+
+  cargoHash = "sha256-i5F9WJD6hMjgiAM43iR4+ZQKZmwtKhEY8uZ0KleNqE8=";
+
+  src = fetchgit {
+    url = "https://tangled.org/did:plc:vj3bxta3i3cp26nn46yideoh";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8NFNFuolp0zqtBmEeI5ZP4aAmzdUMHNYwvm7esOoS8A=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+  ];
+
+  buildInputs = [
+    linux-pam
+  ];
+
+  buildFeatures = lib.optionals withConsoleKit [
+    "consolekit"
+  ];
+
+  postInstall = ''
+    mkdir -p $out/lib/security
+    mv $out/lib/libpam.so $out/lib/security/pam_sessiond.so
+    mv $out/bin/daemon $out/bin/sessiond
+    mv $out/bin/ctl $out/bin/sessionctl
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd sessionctl \
+      --bash <($out/bin/sessionctl completions bash) \
+      --zsh <($out/bin/sessionctl completions zsh) \
+      --fish <($out/bin/sessionctl completions fish) \
+      --nushell <($out/bin/sessionctl completions nushell)
+  ''
+  + lib.optionalString withConsoleKit ''
+    install -Dm644 data/dbus-1/system.d/org.freedesktop.ConsoleKit.conf \
+      $out/share/dbus-1/system.d/org.freedesktop.ConsoleKit.conf
+  '';
+
+  meta = {
+    description = "Session and seat management daemon";
+    homepage = "https://tangled.org/r0chd.pl/sessiond";
+    license = lib.licenses.gpl3Only;
+    maintainers = builtins.attrValues { inherit (lib.maintainers) r0chd; };
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
[sessiond](https://tangled.org/r0chd.pl/sessiond) is a session and seat management daemon. It provides a ConsoleKit D-Bus interface and brings polkit support to systems that do not want to depend on (e)logind.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
