### PR TITLE
fetchurl: small performance cleanups

### DIFF
--- a/pkgs/build-support/fetchurl/boot.nix
+++ b/pkgs/build-support/fetchurl/boot.nix
@@ -7,8 +7,9 @@ let
     match
     ;
 
-  # Since <nix/fetchurl.nix> currently supports only one URI,
-  # use the first listed mirror.
+  # Handle mirror:// URIs. Since <nix/fetchurl.nix> currently
+  # supports only one URI, use the first listed mirror.
+  matchMirror = match "mirror://([a-z]+)/(.*)";
   mirrors = mapAttrs (_: head) (import ./mirrors.nix);
 in
 
@@ -51,10 +52,9 @@ import <nix/fetchurl.nix> {
     ;
 
   url =
-    # Handle mirror:// URIs.
     let
       url_ = handleUrl url;
-      m = match "mirror://([a-z]+)/(.*)" url_;
+      m = matchMirror url_;
     in
     if m == null then url_ else mirrors.${head m} + (elemAt m 1);
 }

--- a/pkgs/build-support/fetchurl/boot.nix
+++ b/pkgs/build-support/fetchurl/boot.nix
@@ -1,11 +1,15 @@
 let
-  mirrors = import ./mirrors.nix;
   inherit (builtins)
     elemAt
     head
     isString
+    mapAttrs
     match
     ;
+
+  # Since <nix/fetchurl.nix> currently supports only one URI,
+  # use the first listed mirror.
+  mirrors = mapAttrs (_: head) (import ./mirrors.nix);
 in
 
 {
@@ -47,11 +51,10 @@ import <nix/fetchurl.nix> {
     ;
 
   url =
-    # Handle mirror:// URIs. Since <nix/fetchurl.nix> currently
-    # supports only one URI, use the first listed mirror.
+    # Handle mirror:// URIs.
     let
       url_ = handleUrl url;
       m = match "mirror://([a-z]+)/(.*)" url_;
     in
-    if m == null then url_ else head (mirrors.${head m}) + (elemAt m 1);
+    if m == null then url_ else mirrors.${head m} + (elemAt m 1);
 }

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -218,12 +218,12 @@ lib.extendMkDerivation {
 
     let
       preRewriteUrls =
-        if urls != [ ] && url == "" then
-          (if isList urls then urls else throw "`urls` is not a list: ${lib.generators.toPretty { } urls}")
-        else if urls == [ ] && url != "" then
+        if urls == [ ] && url != "" then
           (
             if isString url then [ url ] else throw "`url` is not a string: ${lib.generators.toPretty { } urls}"
           )
+        else if urls != [ ] && url == "" then
+          (if isList urls then urls else throw "`urls` is not a list: ${lib.generators.toPretty { } urls}")
         else
           throw "fetchurl requires either `url` or `urls` to be set: ${lib.generators.toPretty { } args}";
 

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -87,10 +87,10 @@ let
       map (mirror: mirror + elemAt mirrorSplit 1) mirrorList;
 
   rewriteAllUrls =
-    urls:
     if rewriteURL == null then
-      urls
+      urls: urls
     else
+      urls:
       let
         u = concatMap (
           url:


### PR DESCRIPTION
Minor stuff. Noticed the change from the first commit, and decided to throw a few small things in.

Stats diff for `pkgs.hello`:

```json
{
  "attrset": {
    "lookups": "+0%",
    "merges": null,
    "mergeCopies": null
  },
  "list": {
    "concats": null
  },
  "parser": {
    "expressions": "+0.01%"
  },
  "memoryBytes": {
    "envs": "+0.01%",
    "list": null,
    "sets": "+0%",
    "symbols": "+0%",
    "values": "-0.02%",
    "total": "-0%"
  },
  "speed": {
    "primops": "-0.66%",
    "functionCalls": "+0.01%",
    "thunksMade": "-0.14%",
    "thunksAvoided": "-0.29%"
  }
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
