### PR TITLE
empserver: init at 4.4.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10025,6 +10025,11 @@
     name = "Kirill Samoylenkov";
     keys = [ { fingerprint = "955B 97C5 78A3 DF03 D818  25EB 8E40 5DD2 CF84 CCE0"; } ];
   };
+  gefla = {
+    name = "Gerd Flaig";
+    github = "gefla";
+    githubId = 56790;
+  };
   genga898 = {
     email = "genga898@gmail.com";
     github = "genga898";

--- a/pkgs/by-name/em/empserver/package.nix
+++ b/pkgs/by-name/em/empserver/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoconf,
+  automake,
+  groff,
+  ncurses,
+  perl,
+  readline,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "empserver";
+  version = "4.4.1";
+
+  src = fetchFromGitHub {
+    owner = "gefla";
+    repo = "empserver";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-FhU3pkv6v1sqEaFje/lrO4hikH2gfW55e21HlOyl7WA=";
+  };
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    groff
+    perl
+  ];
+
+  buildInputs = [
+    ncurses
+    readline
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  # The git snapshot lacks generated files that upstream's distribution
+  # tarballs carry and the build requires: sources.mk (list of source
+  # files), .tarball-version (version without the leading "v" of the
+  # tag) and its stamp file .dirty-stamp.  Create them before running
+  # ./bootstrap, so its own generated files don't end up in sources.mk.
+  # .tarball-version must be in place when autoconf runs, sources.mk
+  # before configure and make.
+  postUnpack = ''
+    echo "src := $(find "$sourceRoot" -type f \
+      ! -name sources.mk ! -name .tarball-version ! -name .dirty-stamp \
+      -printf '%P\n' | sort | tr '\n' ' ')" > "$sourceRoot/sources.mk"
+    echo "${finalAttrs.version}" > "$sourceRoot/.tarball-version"
+    touch "$sourceRoot/.dirty-stamp"
+  '';
+
+  preConfigure = ''
+    ./bootstrap
+  '';
+
+  doCheck = true;
+
+  meta = {
+    description = "Multi-player, client/server Internet based war game";
+    homepage = "https://www.wolfpackempire.com/";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "empire";
+    maintainers = with lib.maintainers; [ gefla ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Add a package for Wolfpack Empire (empserver) 4.4.1, a multi-player,
client/server Internet based war game.  The package builds both the
server and the included client.

Homepage: https://www.wolfpackempire.com/
Upstream: https://github.com/gefla/empserver

Packaging notes:

- Builds from the git snapshot at tag v4.4.1, so ./bootstrap is run
  before configure, and the files upstream's dist hook generates for
  release tarballs (sources.mk, .tarball-version, .dirty-stamp) are
  recreated beforehand; the Makefile cannot determine the source list
  or version without them.
- Upstream's test suite runs in checkPhase (doCheck) and passes.
- Fetching from Github mirror instead of main repository for availability reasons. The main repository is a ForgeJo instance I run myself.
- Add myself as maintainer in a separate commit.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Assisted-by: OpenCode (moonshotai/kimi-k3)

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
