### PR TITLE
 haskellPackages.haskell-language-server: build with cabal-install 3.14 

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -295,8 +295,8 @@ with haskellLib;
   cabal-add = appendPatches [
     (pkgs.fetchpatch {
       name = "cabal-add-absolute-build-tool-paths.patch";
-      url = "https://github.com/Bodigrim/cabal-add/commit/3b94b0175c294c2d0a30b6d8da3f56189216816c.patch";
-      hash = "sha256-4Nbro9Gl+RC78yprO8fYG/IWS7QvJPd0dKqSZb5jq9k=";
+      url = "https://github.com/Bodigrim/cabal-add/commit/24c3a08cedf68a4f66e1265c7bde55043b859321.patch";
+      hash = "sha256-iJjbEGTL+QcV05UZMSKpGjeEbC5w53Vq9Cuhw5QscO0=";
     })
   ] super.cabal-add;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -89,6 +89,15 @@ with haskellLib;
     Cabal = self.Cabal_3_14_2_0;
   };
 
+  cabal-install_3_14_2_0 = unmarkBroken (
+    doDistribute (
+      super.cabal-install_3_14_2_0.override {
+        cabal-install-solver = self.cabal-install-solver_3_14_2_0;
+        semaphore-compat = self.semaphore-compat_1_0_0;
+      }
+    )
+  );
+
   # cabal-install needs most recent versions of Cabal and Cabal-syntax,
   # so we need to put some extra work for non-latest GHCs
   inherit
@@ -211,8 +220,7 @@ with haskellLib;
         hls_overlay = lself: lsuper: {
           Cabal-syntax = lself.Cabal-syntax_3_14_2_0;
           Cabal = lself.Cabal_3_14_2_0;
-          # Jailbreaking cabal-install-parsers to make it pick Cabal 3.14 instead of 3.12.
-          cabal-install-parsers = doJailbreak lsuper.cabal-install-parsers;
+          cabal-install = lself.cabal-install_3_14_2_0;
           # Need a newer version of extensions to be compatible with the newer Cabal
           extensions = doJailbreak lself.extensions_0_1_1_0;
           # For most ghc versions, we overrideScope Cabal in the configuration-ghc-???.nix,

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -150,6 +150,9 @@ with haskellLib;
     hackage-db-unstable
     ;
 
+  # 2026-09-01: tar < 0.7; also Cabal-syntax etc. for other GHC versions
+  cabal-install-parsers = doJailbreak super.cabal-install-parsers;
+
   stack =
     appendPatches
       [

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -221,8 +221,6 @@ with haskellLib;
           Cabal-syntax = lself.Cabal-syntax_3_14_2_0;
           Cabal = lself.Cabal_3_14_2_0;
           cabal-install = lself.cabal-install_3_14_2_0;
-          # Need a newer version of extensions to be compatible with the newer Cabal
-          extensions = doJailbreak lself.extensions_0_1_1_0;
           # For most ghc versions, we overrideScope Cabal in the configuration-ghc-???.nix,
           # because some packages, like ormolu, need a newer Cabal version.
           # ghc-paths is special because it depends on Cabal for building

--- a/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
@@ -94,13 +94,21 @@ in
   monad-dijkstra = dontCheck super.monad-dijkstra; # needs hlint 3.10
 
   # Workaround https://github.com/haskell/haskell-language-server/issues/4674
-  haskell-language-server = haskellLib.disableCabalFlag "hlint" (
-    super.haskell-language-server.override {
-      apply-refact = null;
-      hlint = null;
-      refact = null;
-    }
-  );
+  haskell-language-server = lib.pipe super.haskell-language-server [
+    (disableCabalFlag "hlint")
+    (addBuildDepends [
+      self.stan
+      self.trial
+    ])
+    (
+      hls:
+      hls.override {
+        apply-refact = null;
+        hlint = null;
+        refact = null;
+      }
+    )
+  ];
 
   # test-suite uses MultilineStrings, which is only available in GHC 9.12+
   cabal-add = dontCheck super.cabal-add;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
@@ -101,4 +101,7 @@ in
       refact = null;
     }
   );
+
+  # test-suite uses MultilineStrings, which is only available in GHC 9.12+
+  cabal-add = dontCheck super.cabal-add;
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
@@ -79,7 +79,6 @@ with haskellLib;
       sed -i 's/time >=1.5 \&\& <1.13/time >=1.5 \&\& <=1.14/g' cpphs.cabal
     '';
   }) super.cpphs;
-  cabal-install-parsers = doJailbreak super.cabal-install-parsers; # base, Cabal-syntax, etc.
   timezone-series = doJailbreak super.timezone-series; # time <1.14
   timezone-olson = doJailbreak super.timezone-olson; # time <1.14
   cabal-plan = doJailbreak super.cabal-plan; # base <4.21

--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -142,8 +142,6 @@ self: super: {
   # https://github.com/kowainik/relude/issues/436
   relude = dontCheck super.relude;
 
-  path = self.path_0_9_5;
-
   haskell-language-server =
     lib.throwIf pkgs.config.allowAliases
       "haskell-language-server has dropped support for ghc 9.4 in version 2.12.0.0, please use a newer ghc version or an older nixpkgs"

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -216,6 +216,10 @@ in
         hls_overlay = lself: lsuper: {
           Cabal-syntax = lself.Cabal-syntax_3_10_3_0;
           Cabal = lself.Cabal_3_10_3_0;
+          # Test suite can't find executable due to https://github.com/haskell/cabal/issues/11598
+          cabal-add = dontCheck lsuper.cabal-add_0_2;
+          # Cabal-syntax >=3.14.2.0, tar <0.7
+          cabal-install-parsers = doJailbreak lsuper.cabal-install-parsers;
           extensions = dontCheck (doJailbreak lself.extensions_0_1_0_1);
         };
       in

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -218,8 +218,6 @@ in
           Cabal = lself.Cabal_3_10_3_0;
           # Test suite can't find executable due to https://github.com/haskell/cabal/issues/11598
           cabal-add = dontCheck lsuper.cabal-add_0_2;
-          # Cabal-syntax >=3.14.2.0, tar <0.7
-          cabal-install-parsers = doJailbreak lsuper.cabal-install-parsers;
           extensions = dontCheck (doJailbreak lself.extensions_0_1_0_1);
         };
       in

--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -122,8 +122,6 @@ in
           Cabal = lself.Cabal_3_10_3_0;
           # Test suite can't find executable due to https://github.com/haskell/cabal/issues/11598
           cabal-add = dontCheck lsuper.cabal-add_0_2;
-          # Cabal-syntax >=3.14.2.0, tar <0.7
-          cabal-install-parsers = doJailbreak lsuper.cabal-install-parsers;
           extensions = dontCheck (doJailbreak lself.extensions_0_1_0_1);
         };
       in

--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -120,6 +120,10 @@ in
         hls_overlay = lself: lsuper: {
           Cabal-syntax = lself.Cabal-syntax_3_10_3_0;
           Cabal = lself.Cabal_3_10_3_0;
+          # Test suite can't find executable due to https://github.com/haskell/cabal/issues/11598
+          cabal-add = dontCheck lsuper.cabal-add_0_2;
+          # Cabal-syntax >=3.14.2.0, tar <0.7
+          cabal-install-parsers = doJailbreak lsuper.cabal-install-parsers;
           extensions = dontCheck (doJailbreak lself.extensions_0_1_0_1);
         };
       in

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -72,7 +72,6 @@ extra-packages:
   - Cabal == 3.12.*
   - Cabal == 3.14.*
   - Cabal == 3.16.*                     # version required for cabal-install and other packages
-  - cabal-add == 0.1                    # 2025-09-09: Only needed for hls 2.11 can be removed once we are past it.
   - cabal-install == 3.14.*             # 2026-07-26: required to match Cabal used when building HLS
   - cabal-install-solver == 3.14.*      # 2026-07-26: required to build cabal-install 3.14
   - Cabal-syntax == 3.6.*               # required for the GHC 9.0.2 package set
@@ -116,7 +115,6 @@ extra-packages:
   - network-run == 0.4.0                # 2024-10-20: for GHC 9.10/network == 3.1.*
   - ormolu == 0.7.2.0                   # 2023-11-13: for ghc-lib-parser 9.6 compat
   - ormolu == 0.7.4.0                   # 2023-09-21: for ghc-lib-parser 9.8 compat
-  - path == 0.9.5                       # 2025-09-21: Pin for hls on ghc 9.4
   - postgresql-binary < 0.14            # 2025-01-19: Needed for building postgrest
   - semaphore-compat == 1.0.*           # 2026-07-26: required to build cabal-install 3.14
   - shake-cabal < 0.2.2.3               # 2023-07-01: last version to support Cabal 3.6.*

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -73,6 +73,8 @@ extra-packages:
   - Cabal == 3.14.*
   - Cabal == 3.16.*                     # version required for cabal-install and other packages
   - cabal-add == 0.1                    # 2025-09-09: Only needed for hls 2.11 can be removed once we are past it.
+  - cabal-install == 3.14.*             # 2026-07-26: required to match Cabal used when building HLS
+  - cabal-install-solver == 3.14.*      # 2026-07-26: required to build cabal-install 3.14
   - Cabal-syntax == 3.6.*               # required for the GHC 9.0.2 package set
   - Cabal-syntax == 3.10.*
   - Cabal-syntax == 3.12.*
@@ -116,6 +118,7 @@ extra-packages:
   - ormolu == 0.7.4.0                   # 2023-09-21: for ghc-lib-parser 9.8 compat
   - path == 0.9.5                       # 2025-09-21: Pin for hls on ghc 9.4
   - postgresql-binary < 0.14            # 2025-01-19: Needed for building postgrest
+  - semaphore-compat == 1.0.*           # 2026-07-26: required to build cabal-install 3.14
   - shake-cabal < 0.2.2.3               # 2023-07-01: last version to support Cabal 3.6.*
   - ShellCheck == 0.10.0                # 2026-05-30: pinned by haskell-ci
   - simple-get-opt < 0.5                # 2025-05-01: for crux-0.7.2

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -72,6 +72,7 @@ extra-packages:
   - Cabal == 3.12.*
   - Cabal == 3.14.*
   - Cabal == 3.16.*                     # version required for cabal-install and other packages
+  - cabal-add < 0.2.1                   # 2026-09-05: required for HLS with GHC <= 9.8
   - cabal-install == 3.14.*             # 2026-07-26: required to match Cabal used when building HLS
   - cabal-install-solver == 3.14.*      # 2026-07-26: required to build cabal-install 3.14
   - Cabal-syntax == 3.6.*               # required for the GHC 9.0.2 package set

--- a/pkgs/development/haskell-modules/hackage-packages.nix
+++ b/pkgs/development/haskell-modules/hackage-packages.nix
@@ -126754,67 +126754,6 @@ self: {
     }
   ) { youProbablyWantCapitalCabal = null; };
 
-  cabal-add_0_1 = callPackage (
-    {
-      mkDerivation,
-      base,
-      bytestring,
-      Cabal,
-      cabal-install-parsers,
-      Cabal-syntax,
-      containers,
-      Diff,
-      directory,
-      filepath,
-      mtl,
-      optparse-applicative,
-      process,
-      string-qq,
-      tasty,
-      temporary,
-    }:
-    mkDerivation {
-      pname = "cabal-add";
-      version = "0.1";
-      sha256 = "1szbi0z8yf98641rwnj856gcfsvvflxwrfxraxy6rl60m7i0mab1";
-      revision = "3";
-      editedCabalFile = "0siv5ajqxcbs9c0ky94p5qk51w6cgf1zyc3rckxvlc25f4kygw4v";
-      isLibrary = true;
-      isExecutable = true;
-      libraryHaskellDepends = [
-        base
-        bytestring
-        Cabal
-        Cabal-syntax
-        containers
-        mtl
-      ];
-      executableHaskellDepends = [
-        base
-        bytestring
-        Cabal
-        cabal-install-parsers
-        directory
-        filepath
-        optparse-applicative
-        process
-      ];
-      testHaskellDepends = [
-        base
-        Diff
-        directory
-        process
-        string-qq
-        tasty
-        temporary
-      ];
-      description = "Extend Cabal build-depends from the command line";
-      license = lib.meta.getLicenseFromSpdxId "BSD-3-Clause";
-      hydraPlatforms = lib.platforms.none;
-      mainProgram = "cabal-add";
-    }
-  ) { };
-
   cabal-add = callPackage (
     {
       mkDerivation,
@@ -530707,60 +530646,6 @@ self: {
       license = lib.licenses.bsd3;
       hydraPlatforms = lib.platforms.none;
       broken = true;
-    }
-  ) { };
-
-  path_0_9_5 = callPackage (
-    {
-      mkDerivation,
-      aeson,
-      base,
-      bytestring,
-      deepseq,
-      exceptions,
-      filepath,
-      genvalidity,
-      genvalidity-hspec,
-      genvalidity-property,
-      hashable,
-      hspec,
-      mtl,
-      QuickCheck,
-      template-haskell,
-      text,
-      validity,
-    }:
-    mkDerivation {
-      pname = "path";
-      version = "0.9.5";
-      sha256 = "0cy4vilmhzhi5nfh4v2kyvizhjzjpjib3bvgm1sgmvjzj40dfgrd";
-      libraryHaskellDepends = [
-        aeson
-        base
-        deepseq
-        exceptions
-        filepath
-        hashable
-        template-haskell
-        text
-      ];
-      testHaskellDepends = [
-        aeson
-        base
-        bytestring
-        filepath
-        genvalidity
-        genvalidity-hspec
-        genvalidity-property
-        hspec
-        mtl
-        QuickCheck
-        template-haskell
-        validity
-      ];
-      description = "Support for well-typed paths";
-      license = lib.licenses.bsd3;
-      hydraPlatforms = lib.platforms.none;
     }
   ) { };
 

--- a/pkgs/development/haskell-modules/hackage-packages.nix
+++ b/pkgs/development/haskell-modules/hackage-packages.nix
@@ -128323,6 +128323,161 @@ self: {
     }
   ) { };
 
+  cabal-install_3_14_2_0 =
+    callPackage
+      (
+        {
+          mkDerivation,
+          array,
+          async,
+          base,
+          base16-bytestring,
+          binary,
+          bytestring,
+          Cabal,
+          Cabal-described,
+          cabal-install-solver,
+          Cabal-QuickCheck,
+          Cabal-syntax,
+          Cabal-tests,
+          Cabal-tree-diff,
+          containers,
+          cryptohash-sha256,
+          directory,
+          echo,
+          edit-distance,
+          exceptions,
+          filepath,
+          hackage-security,
+          HTTP,
+          lukko,
+          mtl,
+          network-uri,
+          open-browser,
+          parsec,
+          pretty,
+          pretty-show,
+          process,
+          QuickCheck,
+          random,
+          regex-base,
+          regex-posix,
+          resolv,
+          safe-exceptions,
+          semaphore-compat,
+          stm,
+          tagged,
+          tar,
+          tasty,
+          tasty-expected-failure,
+          tasty-golden,
+          tasty-hunit,
+          tasty-quickcheck,
+          text,
+          time,
+          tree-diff,
+          unix,
+          zlib,
+        }:
+        mkDerivation {
+          pname = "cabal-install";
+          version = "3.14.2.0";
+          sha256 = "1nvv3h9kq92ifyqqma88538579v7898pd9b52hras2h489skv8g8";
+          revision = "6";
+          editedCabalFile = "1c87f3lnz94x7fnb8km35dbgnb0idwca16yhnr3h2g6jgfxq7v0y";
+          isLibrary = true;
+          isExecutable = true;
+          libraryHaskellDepends = [
+            array
+            async
+            base
+            base16-bytestring
+            binary
+            bytestring
+            Cabal
+            cabal-install-solver
+            Cabal-syntax
+            containers
+            cryptohash-sha256
+            directory
+            echo
+            edit-distance
+            exceptions
+            filepath
+            hackage-security
+            HTTP
+            lukko
+            mtl
+            network-uri
+            open-browser
+            parsec
+            pretty
+            process
+            random
+            regex-base
+            regex-posix
+            resolv
+            safe-exceptions
+            semaphore-compat
+            stm
+            tar
+            text
+            time
+            unix
+            zlib
+          ];
+          executableHaskellDepends = [ base ];
+          testHaskellDepends = [
+            array
+            base
+            bytestring
+            Cabal
+            Cabal-described
+            cabal-install-solver
+            Cabal-QuickCheck
+            Cabal-syntax
+            Cabal-tests
+            Cabal-tree-diff
+            containers
+            directory
+            filepath
+            mtl
+            network-uri
+            pretty-show
+            process
+            QuickCheck
+            random
+            tagged
+            tar
+            tasty
+            tasty-expected-failure
+            tasty-golden
+            tasty-hunit
+            tasty-quickcheck
+            time
+            tree-diff
+            zlib
+          ];
+          doCheck = false;
+          postInstall = ''
+            mkdir -p $out/share/bash-completion
+            mv bash-completion $out/share/bash-completion/completions
+          '';
+          description = "The command-line interface for Cabal and Hackage";
+          license = lib.meta.getLicenseFromSpdxId "BSD-3-Clause";
+          hydraPlatforms = lib.platforms.none;
+          mainProgram = "cabal";
+          maintainers = [ lib.maintainers.sternenseemann ];
+          broken = true;
+        }
+      )
+      {
+        Cabal-QuickCheck = null;
+        Cabal-described = null;
+        Cabal-tests = null;
+        Cabal-tree-diff = null;
+      };
+
   cabal-install =
     callPackage
       (
@@ -128707,6 +128862,62 @@ self: {
       ];
       description = "Utilities to work with cabal-install files";
       license = "GPL-2.0-or-later AND BSD-3-Clause";
+    }
+  ) { };
+
+  cabal-install-solver_3_14_2_0 = callPackage (
+    {
+      mkDerivation,
+      array,
+      base,
+      bytestring,
+      Cabal,
+      Cabal-syntax,
+      containers,
+      directory,
+      edit-distance,
+      filepath,
+      mtl,
+      network-uri,
+      pretty,
+      tasty,
+      tasty-hunit,
+      tasty-quickcheck,
+      text,
+      transformers,
+    }:
+    mkDerivation {
+      pname = "cabal-install-solver";
+      version = "3.14.2.0";
+      sha256 = "0551cvrkbnjfqjd3byq7pczlwjdb0n1jrfsrb0j8axagylbif7g1";
+      revision = "1";
+      editedCabalFile = "14jrs9q52vp9slb5pm66a9xrjdgkjypwssnnjc5pamlykakrjqa1";
+      libraryHaskellDepends = [
+        array
+        base
+        bytestring
+        Cabal
+        Cabal-syntax
+        containers
+        directory
+        edit-distance
+        filepath
+        mtl
+        network-uri
+        pretty
+        text
+        transformers
+      ];
+      testHaskellDepends = [
+        base
+        Cabal-syntax
+        tasty
+        tasty-hunit
+        tasty-quickcheck
+      ];
+      description = "The solver component of cabal-install";
+      license = lib.meta.getLicenseFromSpdxId "BSD-3-Clause";
+      hydraPlatforms = lib.platforms.none;
     }
   ) { };
 
@@ -621186,6 +621397,30 @@ self: {
       ];
       description = "Semantic Version";
       license = lib.licenses.bsd3;
+      hydraPlatforms = lib.platforms.none;
+    }
+  ) { };
+
+  semaphore-compat_1_0_0 = callPackage (
+    {
+      mkDerivation,
+      base,
+      exceptions,
+      unix,
+    }:
+    mkDerivation {
+      pname = "semaphore-compat";
+      version = "1.0.0";
+      sha256 = "1qnrdqayrdazmsflh37p1igd25nh1cfgn4k1v3jwwb0w0amnyvhw";
+      revision = "4";
+      editedCabalFile = "1sgk940k24ig1r50ycz4w79591hqjys4sdmfifgsr6zcq3183zrd";
+      libraryHaskellDepends = [
+        base
+        exceptions
+        unix
+      ];
+      description = "Cross-platform abstraction for system semaphores";
+      license = lib.meta.getLicenseFromSpdxId "BSD-3-Clause";
       hydraPlatforms = lib.platforms.none;
     }
   ) { };

--- a/pkgs/development/haskell-modules/hackage-packages.nix
+++ b/pkgs/development/haskell-modules/hackage-packages.nix
@@ -126754,6 +126754,69 @@ self: {
     }
   ) { youProbablyWantCapitalCabal = null; };
 
+  cabal-add_0_2 = callPackage (
+    {
+      mkDerivation,
+      base,
+      bytestring,
+      Cabal,
+      cabal-install-parsers,
+      Cabal-syntax,
+      containers,
+      Diff,
+      directory,
+      filepath,
+      mtl,
+      optparse-applicative,
+      process,
+      string-qq,
+      tasty,
+      temporary,
+    }:
+    mkDerivation {
+      pname = "cabal-add";
+      version = "0.2";
+      sha256 = "0fd098gkfmxrhq0k4j1ll5g4xwwzgmhdx0mj9hnp5xanj7z1laxg";
+      revision = "1";
+      editedCabalFile = "03z75dp7mf471mm40mfb157ng2fgp66nkyhaa6fsb3j2qfwg5wz4";
+      isLibrary = true;
+      isExecutable = true;
+      libraryHaskellDepends = [
+        base
+        bytestring
+        Cabal
+        Cabal-syntax
+        containers
+        mtl
+      ];
+      executableHaskellDepends = [
+        base
+        bytestring
+        cabal-install-parsers
+        Cabal-syntax
+        directory
+        filepath
+        optparse-applicative
+        process
+      ];
+      testHaskellDepends = [
+        base
+        bytestring
+        Cabal
+        Diff
+        directory
+        process
+        string-qq
+        tasty
+        temporary
+      ];
+      description = "Extend Cabal build-depends from the command line";
+      license = lib.meta.getLicenseFromSpdxId "BSD-3-Clause";
+      hydraPlatforms = lib.platforms.none;
+      mainProgram = "cabal-add";
+    }
+  ) { };
+
   cabal-add = callPackage (
     {
       mkDerivation,


### PR DESCRIPTION
On top of https://github.com/NixOS/nixpkgs/pull/543503 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
