### PR TITLE
sarin: init at 1.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2930,6 +2930,12 @@
     githubId = 135230;
     name = "Aycan iRiCAN";
   };
+  aykhans = {
+    email = "aykhan.shahs@gmail.com";
+    github = "aykhans";
+    githubId = 88669260;
+    name = "Aykhan Shahsuvarov";
+  };
   aynish = {
     github = "Chickensoupwithrice";
     githubId = 22575913;

--- a/pkgs/by-name/sa/sarin/package.nix
+++ b/pkgs/by-name/sa/sarin/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "sarin";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "aykhans";
+    repo = "sarin";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-FOII7kTQW5ywBTQZaAtLVWii6yZPtQceK8tKkhg25Tw=";
+  };
+
+  vendorHash = "sha256-/r2mioVoMbrboumF0sjHhharkGImQAShmiOQtdS5DaE=";
+
+  __structuredAttrs = true;
+
+  subPackages = [ "cmd/cli" ];
+
+  env.CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=go.aykhans.me/sarin/internal/version.Version=v${finalAttrs.version}"
+  ];
+
+  # GoVersion is read from the build toolchain so it never drifts. The value
+  # contains spaces, so it is single-quoted: `go build` splits -ldflags
+  # shell-style and honours the quotes, keeping it as one -X value.
+  preBuild = ''
+    ldflags+=("-X 'go.aykhans.me/sarin/internal/version.GoVersion=$(go version)'")
+  '';
+
+  # cmd/cli produces a binary named "cli"; rename it to "sarin".
+  postInstall = ''
+    mv $out/bin/cli $out/bin/sarin
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "High-performance HTTP load testing tool built with Go and fasthttp";
+    homepage = "https://github.com/aykhans/sarin";
+    changelog = "https://github.com/aykhans/sarin/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "sarin";
+    maintainers = with lib.maintainers; [ aykhans ];
+  };
+})


### PR DESCRIPTION
New package: **sarin**, a high-performance HTTP load testing tool built with Go
and [fasthttp](https://github.com/valyala/fasthttp). It supports count/duration
based tests, templated dynamic requests (340+ functions), Lua/JS request
scripting, multiple proxy protocols (HTTP/HTTPS/SOCKS5/SOCKS5H), and
configuration via CLI, YAML and environment variables.

Homepage: https://github.com/aykhans/sarin

The project has published releases and a Docker image on Docker Hub (see the
release-downloads and Docker-pulls badges in the README).

Notes:
- `passthru.updateScript = nix-update-script { }` for automated version bumps.
- `versionCheckHook` verifies the installed binary reports its version.
- Also cross-compiles cleanly for aarch64-linux (`pkgsCross.aarch64-multiplatform.sarin`).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
