### PR TITLE
hunspellDicts.fr-*: 5.3 -> 7.7, dicollecte.org -> grammalecte.net; fr-moderne: remove

### DIFF
--- a/doc/packages/ibus.section.md
+++ b/doc/packages/ibus.section.md
@@ -21,7 +21,7 @@ On NixOS, you need to explicitly enable `ibus` with given engines before customi
 
 ## Using custom hunspell dictionaries {#sec-ibus-typing-booster-customize-hunspell}
 
-The IBus engine is based on `hunspell` to support completion in many languages. By default, the dictionaries `de-de`, `en-us`, `fr-moderne` `es-es`, `it-it`, `sv-se` and `sv-fi` are in use. To add another dictionary, the package can be overridden like this:
+The IBus engine is based on `hunspell` to support completion in many languages. By default, the dictionaries `de-de`, `en-us`, `fr-classique`, `es-es`, `it-it`, `sv-se` and `sv-fi` are in use. To add another dictionary, the package can be overridden like this:
 
 ```nix
 ibus-engines.typing-booster.override {

--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -155,6 +155,8 @@
 
 - `fittrackee` 1.0.0 now requires postgres with postgis. The [upgrade guide](https://docs.fittrackee.org/en/upgrading-to-1.0.0.html) has steps to prepare for this upgrade.
 
+- `hunspellDicts.fr-moderne` has been removed because it was removed upstream. `fr-classique` is now the default. `hunspellDicts.fr-*` packages have been updated to 7.7 and they now use [Grammalecte](https://www.grammalecte.net/).
+
 ### Deprecations {#sec-nixpkgs-release-26.11-lib-deprecations}
 
 - Setting `config.allowBrokenPredicate` is deprecated in favor of

--- a/pkgs/by-name/hu/hunspell/dictionaries.nix
+++ b/pkgs/by-name/hu/hunspell/dictionaries.nix
@@ -1,6 +1,7 @@
 # hunspell dictionaries
 
 {
+  config,
   lib,
   stdenv,
   fetchurl,
@@ -643,22 +644,9 @@ rec {
     dictFileName = "fr-classique";
     shortDescription = "French (classic)";
     longDescription = ''
-      Ce dictionnaire est une extension du dictionnaire «Moderne» et propose
-      en sus des graphies alternatives, parfois encore très usitées, parfois
-      tombées en désuétude.
+      Ce dictionnaire propose l’orthographe usuelle du français, avec en sus
+      quelques graphies nouvelles rectifiant les incohérences passées.
     '';
-  };
-
-  fr-moderne = mkDictFromGrammalecte {
-    shortName = "fr-moderne";
-    dictFileName = "fr-moderne";
-    shortDescription = "French (modern)";
-    longDescription = ''
-      Ce dictionnaire propose une sélection des graphies classiques et
-      réformées, suivant la lente évolution de l’orthographe actuelle. Ce
-      dictionnaire contient les graphies les moins polémiques de la réforme.
-    '';
-    isDefault = true;
   };
 
   fr-reforme1990 = mkDictFromGrammalecte {
@@ -1304,4 +1292,7 @@ rec {
       ];
     };
   };
+}
+// lib.optionalAttrs config.allowAliases {
+  fr-moderne = throw "'fr-moderne' was removed because it doesn't exist upstream anymore"; # Added 2026-07-27
 }

--- a/pkgs/by-name/hu/hunspell/dictionaries.nix
+++ b/pkgs/by-name/hu/hunspell/dictionaries.nix
@@ -146,7 +146,7 @@ let
       '';
     };
 
-  mkDictFromDicollecte =
+  mkDictFromGrammalecte =
     {
       shortName,
       shortDescription,
@@ -156,17 +156,17 @@ let
     }:
     mkDict rec {
       inherit dictFileName;
-      version = "5.3";
-      pname = "hunspell-dict-${shortName}-dicollecte";
+      version = "7.7";
+      pname = "hunspell-dict-${shortName}-grammalecte";
       readmeFile = "README_dict_fr.txt";
       src = fetchurl {
-        url = "http://www.dicollecte.org/download/fr/hunspell-french-dictionaries-v${version}.zip";
-        sha256 = "0ca7084jm7zb1ikwzh1frvpb97jn27i7a5d48288h2qlfp068ik0";
+        url = "https://www.grammalecte.net/dic/hunspell-french-dictionaries-v${version}.zip";
+        sha256 = "sha256-RDFNmS+UtGWMMahu8jUXJKQwZ1MbCvNkP5G/AiDu5hY=";
       };
       meta = {
         inherit longDescription;
-        description = "Hunspell dictionary for ${shortDescription} from Dicollecte";
-        homepage = "https://www.dicollecte.org/home.php?prj=fr";
+        description = "Hunspell dictionary for ${shortDescription} from Grammalecte";
+        homepage = "https://www.grammalecte.net";
         license = lib.licenses.mpl20;
         maintainers = with lib.maintainers; [ renzo ];
         platforms = lib.platforms.all;
@@ -628,7 +628,7 @@ rec {
 
   # FRENCH
 
-  fr-any = mkDictFromDicollecte {
+  fr-any = mkDictFromGrammalecte {
     shortName = "fr-any";
     dictFileName = "fr-toutesvariantes";
     shortDescription = "French (any variant)";
@@ -638,7 +638,7 @@ rec {
     '';
   };
 
-  fr-classique = mkDictFromDicollecte {
+  fr-classique = mkDictFromGrammalecte {
     shortName = "fr-classique";
     dictFileName = "fr-classique";
     shortDescription = "French (classic)";
@@ -649,7 +649,7 @@ rec {
     '';
   };
 
-  fr-moderne = mkDictFromDicollecte {
+  fr-moderne = mkDictFromGrammalecte {
     shortName = "fr-moderne";
     dictFileName = "fr-moderne";
     shortDescription = "French (modern)";
@@ -661,7 +661,7 @@ rec {
     isDefault = true;
   };
 
-  fr-reforme1990 = mkDictFromDicollecte {
+  fr-reforme1990 = mkDictFromGrammalecte {
     shortName = "fr-reforme1990";
     dictFileName = "fr-reforme1990";
     shortDescription = "French (1990 reform)";

--- a/pkgs/by-name/hu/hunspell/dictionaries.nix
+++ b/pkgs/by-name/hu/hunspell/dictionaries.nix
@@ -1293,6 +1293,3 @@ rec {
     };
   };
 }
-// lib.optionalAttrs config.allowAliases {
-  fr-moderne = throw "'fr-moderne' was removed because it doesn't exist upstream anymore"; # Added 2026-07-27
-}

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-typing-booster/wrapper.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-typing-booster/wrapper.nix
@@ -9,7 +9,7 @@
     "en-gb-ise"
     "en-us"
     "es-es"
-    "fr-moderne"
+    "fr-classique"
     "it-it"
     "sv-se"
     "sv-fi"


### PR DESCRIPTION
Updated french hunspell dictionaries. Now it fetches them from grammalecte.net instead of dicollecte.org because the website is gone. Closes #480639

- hunspellDicts.fr-*: 5.3 -> 7.7
- hunspellDicts.fr-moderne: remove
- Update ibus-typing-booster's default dictionary list: switch from fr-moderne to fr-classique


The readme the old dictionary says that classique is a superset of moderne, so it shouldn't cause many problems. The readme of both the old and the new dictionary recommends using classique.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`. (none)
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality. (none)
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (no binary files)
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes (not applicable)
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test