### PR TITLE
poppler: fix mat2 build on Darwin by backporting upstream bugfix

### DIFF
--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   fetchFromGitLab,
+  fetchpatch,
   cairo,
   clang-tools,
   cmake,
@@ -62,7 +63,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "poppler-${suffix}";
-  version = "26.06.0"; # beware: updates often break cups-filters build, check scribus too!
+  version = "26.06.0";
 
   outputs = [
     "out"
@@ -73,6 +74,16 @@ stdenv.mkDerivation (finalAttrs: {
     url = "https://poppler.freedesktop.org/poppler-${finalAttrs.version}.tar.xz";
     hash = "sha256-TLTlo9yMte7HUciiPIuhn2H5be3AzQfSruawyOLPa6Q=";
   };
+
+  patches = [
+    # Backports Darwin crash fix from upstream
+    # https://gitlab.freedesktop.org/poppler/poppler/-/work_items/1743
+    (fetchpatch {
+      name = "darwin-mutex-lock-crash.patch";
+      url = "https://gitlab.freedesktop.org/poppler/poppler/-/commit/08f4bca6a669f9fce75dbab743db559a86591738.patch";
+      hash = "sha256-+eWqVK/v3Ys9k2+z/dCoS2o82m039UER1StMUW4PIgM=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -40,6 +40,7 @@
   cups-filters,
   gdal,
   gegl,
+  gtk3,
   inkscape,
   scribus,
   vips,
@@ -195,9 +196,17 @@ stdenv.mkDerivation (finalAttrs: {
       gdal = gdal.override { usePoppler = true; };
       python-poppler-qt5 = python3.pkgs.poppler-qt5;
 
-      pkg-config = testers.hasPkgConfigModules {
-        package = finalAttrs.finalPackage;
-      };
+      pkg-config =
+        testers.hasPkgConfigModules {
+          package = finalAttrs.finalPackage;
+        }
+        // lib.optionalAttrs (!minimal) {
+          # Poppler skips tests unless GTK3 is detected; add to closure
+          poppler-with-gtk-tests = finalAttrs.finalPackage.overrideAttrs (old: {
+            pname = "${old.pname}-gtk-tests";
+            buildInputs = old.buildInputs ++ [ gtk3 ];
+          });
+        };
     };
   };
 


### PR DESCRIPTION
mat2 fails due to a bug in upstream Poppler now fixed, but bumping the version number breaks Inkscape which seems historically fiddly, so I just backported that commit which comes in clean.

Resolves: #546115 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
