### PR TITLE
activate-linux: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/by-name/ac/activate-linux/package.nix
+++ b/pkgs/by-name/ac/activate-linux/package.nix
@@ -12,6 +12,7 @@
   libx11,
   xorgproto,
   cairo,
+  pango,
   wayland,
   wayland-protocols,
   wayland-scanner,
@@ -20,13 +21,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "activate-linux";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "MrGlockenspiel";
     repo = "activate-linux";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-6XnoAoZwAs2hKToWlDqkaGqucmV1VMkEc4QO0G0xmrg=";
+    hash = "sha256-zTZZb4zFbhwZPN1B2c6ZIfiJOGxjXxxIXBBAteIWt1Q=";
   };
 
   makeFlags = [ "PREFIX=$(out)" ];
@@ -38,6 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     cairo
+    pango
     libx11
     libxext
     libxfixes
@@ -60,10 +62,8 @@ stdenv.mkDerivation (finalAttrs: {
     cp activate-linux $out/bin
     cp activate-linux.1 $out/share/man/man1
 
-    install -Dm444 res/icon.png $out/share/icons/hicolor/128x128/apps/activate-linux.png
+    install -Dm444 res/activate-linux.png $out/share/icons/hicolor/128x128/apps/activate-linux.png
     install -Dm444 res/activate-linux.desktop -t $out/share/applications
-    substituteInPlace $out/share/applications/activate-linux.desktop \
-      --replace-fail 'Icon=icon' 'Icon=activate-linux'
 
     runHook postInstall
   '';
@@ -71,6 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "\"Activate Windows\" watermark ported to Linux";
     homepage = "https://github.com/MrGlockenspiel/activate-linux";
+    changelog = "https://github.com/MrGlockenspiel/activate-linux/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [
       alexnortung


### PR DESCRIPTION
Bumps `activate-linux` from 1.1.0 to 1.2.0.

- Changelog: https://github.com/MrGlockenspiel/activate-linux/releases/tag/v1.2.0
- Diff: https://github.com/MrGlockenspiel/activate-linux/compare/v1.1.0...v1.2.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (Builds and installs cleanly; `./result/bin/activate-linux --help` runs.)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
