### PR TITLE
nodejs: fix cross-compilation

### DIFF
--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -349,7 +349,7 @@ let
 
       dontDisableStatic = true;
 
-      configureScript = "${python.interpreter} configure.py";
+      configureScript = "${python.pythonOnBuildForHost.interpreter} configure.py";
 
       # In order to support unsupported cross configurations, we copy some intermediate executables
       # from a native build and replace all the build-system tools with a script which simply touches


### PR DESCRIPTION
## Description

`nodejs.nix` sets `configureScript` to `"${python.interpreter} configure.py"`.
`python.interpreter` is an absolute path to the hostPlatform interpreter, so
when cross-compiling it points at a binary that cannot be executed on the build
platform:

```
/nix/store/...-stdenv-linux/setup: line 1503:
  /nix/store/...-python3-aarch64-unknown-linux-musl-3.13.14/bin/python3.13:
  cannot execute binary file: Exec format error
```

`python` is also listed in `nativeBuildInputs`, where splicing substitutes the
`buildPackages` variant and puts its `bin/` on `PATH`. The code this replaced
used `python.executable`, which is a bare basename, so it resolved to that
build-platform interpreter through `PATH` and cross-compilation worked.

Use `python.pythonOnBuildForHost.interpreter` instead. It refers to the same
derivation that `nativeBuildInputs` puts on `PATH`. Native builds are
unaffected, since `pythonOnBuildForHost` is `python` itself when buildPlatform
equals hostPlatform.

This is a regression from #536002, which I authored.

The change was also backported to `staging-26.05` in #536227, so stable 26.05 is
affected and this fix will need the same backport.

Fixes #543641

## Testing

Evaluated on aarch64-darwin against `staging`:

- `pkgsCross.aarch64-multiplatform-musl.nodejs-slim.configureScript`
  - before: `/nix/store/splgv2s2...-python3-aarch64-unknown-linux-musl-3.14.6/bin/python3.14 configure.py`
  - after: `/nix/store/2qq3zj5w...-python3-3.14.6/bin/python3.14 configure.py`
- the store path after the change matches both the `python3` in
  `pkgsCross.aarch64-multiplatform-musl.nodejs-slim.nativeBuildInputs` and
  `pkgsCross.aarch64-multiplatform-musl.buildPackages.python3.interpreter`
- `nodejs-slim.configureScript` on a native build is byte-for-byte unchanged

I have not completed a full cross build locally: the aarch64-darwin to
aarch64-linux-musl path needs 276 derivations built from source on this machine.
A build on x86_64-linux would match the reporter's environment.
