### PR TITLE
sleek-todo: 2.0.14 -> 2.0.26

### DIFF
--- a/pkgs/by-name/sl/sleek-todo/package.nix
+++ b/pkgs/by-name/sl/sleek-todo/package.nix
@@ -10,17 +10,28 @@
 let
 
   pname = "sleek-todo";
-  version = "2.0.14";
+  version = "2.0.26";
 
-  src =
-    fetchurl
+  suffixMap = {
+    aarch64-darwin = "mac-arm64.dmg";
+    aarch64-linux = "linux-arm64.AppImage";
+    x86_64-linux = "linux-x86_64.AppImage";
+  };
+
+  suffix =
+    suffixMap.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  src = fetchurl {
+    url = "https://github.com/ransome1/sleek/releases/download/v${version}/sleek-${version}-${suffix}";
+    sha256 =
       {
-        x86_64-linux = {
-          url = "https://github.com/ransome1/sleek/releases/download/v${version}/sleek-2.0.14.AppImage";
-          hash = "sha256-d2fLsCI7peuNBtjgHs1qumgPAF9eJeBYiIIffoSv9Jk=";
-        };
+        aarch64-darwin = "sha256-cQ5c9qs3Icl5vwSoU0tCM5QbrqftYUwlBBzDGaggyOE=";
+        aarch64-linux = "sha256-zcMUCLzIseipG15PQXsECNz/baAYBEzOGxh3hvw6pdg=";
+        x86_64-linux = "sha256-QpeWbnSJTCFXrj/sy+Ava7dk2OlHCzaiDoIM29q9r44=";
       }
       .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.system}");
+  };
 
   meta = {
     description = "Todo manager based on todo.txt syntax";
@@ -30,9 +41,10 @@ let
     mainProgram = "sleek-todo";
     platforms = [
       "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
     ];
   };
-  appimageContents = appimageTools.extract { inherit pname version src; };
 in
 if stdenv.hostPlatform.isDarwin then
   stdenv.mkDerivation {
@@ -54,7 +66,7 @@ if stdenv.hostPlatform.isDarwin then
     '';
   }
 else
-  appimageTools.wrapType2 {
+  appimageTools.wrapType2 (finalAttr: {
     inherit
       pname
       version
@@ -66,11 +78,11 @@ else
       wrapProgram $out/bin/sleek-todo \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
       mkdir -p $out/share/{applications,sleek}
-      cp -a ${appimageContents}/{locales,resources} $out/share/sleek
-      cp -a ${appimageContents}/usr/share/icons $out/share
-      install -Dm 444 ${appimageContents}/sleek.desktop $out/share/applications
+      cp -a ${finalAttr.contents}/{locales,resources} $out/share/sleek
+      cp -a ${finalAttr.contents}/usr/share/icons $out/share
+      install -Dm 444 ${finalAttr.contents}/sleek.desktop $out/share/applications
       substituteInPlace $out/share/applications/sleek.desktop \
       --replace-warn 'Exec=AppRun' 'Exec=${pname}'
     '';
 
-  }
+  })


### PR DESCRIPTION
Upgrades sleek-todo from 2.0.14 to 2.0.26.

Release notes: https://github.com/ransome1/sleek/releases/tag/v2.0.26

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test