### PR TITLE
secretspec: 0.16.0 -> 0.17.0

### DIFF
--- a/pkgs/by-name/se/secretspec/package.nix
+++ b/pkgs/by-name/se/secretspec/package.nix
@@ -2,24 +2,46 @@
   lib,
   rustPlatform,
   fetchCrate,
+  fetchurl,
   pkg-config,
   dbus,
+  sops,
   nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "secretspec";
-  version = "0.16.0";
+  version = "0.17.0";
 
   src = fetchCrate {
     inherit (finalAttrs) pname version;
-    hash = "sha256-YiKud3dfw6QmZbKVCY9FD5vrxJs9bE6++BvEeaDUiEs=";
+    hash = "sha256-3UW0j5i+2r8yWaYYCtbdtiPJe8epLKeR1cpP35Bxko4=";
   };
 
-  cargoHash = "sha256-tXZ1KUjZWgddh8wD3oyeZWDe5XqdknyEQ0eu4LXPrf0=";
+  cargoHash = "sha256-I6HFcWPB5TUSMtnk+SEHMxiKlPBxHLrj8zgzEWllV2w=";
+
+  postPatch = ''
+    mkdir -p schema
+    cp ${
+      fetchurl {
+        url = "https://raw.githubusercontent.com/cachix/secretspec/v${finalAttrs.version}/schema/resolution-report.schema.json";
+        hash = "sha256-MDuWWa05hh3g5AtaJnoe6qDvf1XVO3C29zKJDm+f+h0=";
+      }
+    } schema/resolution-report.schema.json
+    substituteInPlace src/tests.rs \
+      --replace-fail '../../schema/resolution-report.schema.json' '../schema/resolution-report.schema.json'
+  '';
 
   nativeBuildInputs = [ pkg-config ];
+  nativeCheckInputs = [ sops ];
   buildInputs = [ dbus ];
+
+  preCheck = ''
+    export HOME="$TMPDIR"
+  '';
+
+  # A test binds to localhost, which requires an explicit Darwin sandbox exception.
+  __darwinAllowLocalNetworking = true;
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
https://github.com/cachix/secretspec/releases/tag/v0.17.0


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
