### PR TITLE
asmc-linux: 2.36.25 -> 2.39.07

### DIFF
--- a/pkgs/by-name/as/asmc-linux/package.nix
+++ b/pkgs/by-name/as/asmc-linux/package.nix
@@ -2,15 +2,16 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  versionCheckHook,
 }:
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "asmc-linux";
-  version = "2.36.25";
+  version = "2.39.07";
   src = fetchFromGitHub {
     owner = "nidud";
     repo = "asmc_linux";
-    rev = "4ee70bde4439bdd9c772d08527dba6d50f2e5a88";
-    hash = "sha256-/yJC1OQGRgy9T/U2VB0MohSsD1ImLnHYM/8Y8fIWhVE=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JtJsyaw4UqMf9epMLGH+iQA0FYYlE9k2NG1aPOu6pec=";
   };
 
   enableParallelBuilding = true;
@@ -23,12 +24,16 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   meta = {
     description = "MASM-compatible assembler";
     homepage = "https://github.com/nidud/asmc_linux";
+    changelog = "https://github.com/nidud/asmc/blob/v${lib.versions.majorMinor finalAttrs.version}/source/asmc/history.txt";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ ccicnce113424 ];
     platforms = with lib.systems.inspect; patternLogicalAnd patterns.isx86_64 patterns.isLinux;
     mainProgram = "asmc";
   };
-}
+})


### PR DESCRIPTION
Bumps `asmc-linux` from 2.36.25 to 2.39.07, refactors to the `finalAttrs` pattern, and adds a `versionCheckHook`.

- Changelog: https://github.com/nidud/asmc/blob/v2.39/source/asmc/history.txt

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (`./result/bin/asmc` reports `Asmc Macro Assembler Version 2.39.07`; `versionCheckPhase` passes during the build.)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
