### PR TITLE
inko: 0.20.0 -> 0.21.1

### DIFF
--- a/pkgs/by-name/in/inko/package.nix
+++ b/pkgs/by-name/in/inko/package.nix
@@ -15,16 +15,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "inko";
-  version = "0.20.0";
+  version = "0.21.1";
 
   src = fetchFromGitHub {
     owner = "inko-lang";
     repo = "inko";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Bisw84MwdLb2pgzwQ5zpZiyNHSWtdJ2QpaFn40x+SdI=";
+    hash = "sha256-UbIBifuAMSeTwUYaD8l/kN1jd9nIQLp1Z7gf7/92G4o=";
   };
 
-  cargoHash = "sha256-+3U3rMVF3qwyTIGOb/6NIxSBdiLuf/uY/VL3tYHte+c=";
+  cargoHash = "sha256-5mtmwr3Cfn/nOpZyEfwONkcxBqMArQT23AhS04iS6LA=";
 
   buildInputs = [
     libffi

--- a/pkgs/by-name/in/inko/test.nix
+++ b/pkgs/by-name/in/inko/test.nix
@@ -1,6 +1,7 @@
 {
   inko,
   writeText,
+  writableTmpDirAsHomeHook,
   runCommand,
   ...
 }:
@@ -39,8 +40,12 @@ let
       '';
 in
 
-runCommand "inko-test" { } ''
-  ${inko}/bin/inko run ${source} > $out
-  cat $out | grep -q Hello
-  cat $out | grep -q world
-''
+runCommand "inko-test"
+  {
+    nativeBuildInputs = [ writableTmpDirAsHomeHook ];
+  }
+  ''
+    ${inko}/bin/inko run ${source} > $out
+    cat $out | grep -q Hello
+    cat $out | grep -q world
+  ''


### PR DESCRIPTION
- **inko: 0.20.0 -> 0.21.1**
- **inko.tests: fix build**

Replacing https://github.com/NixOS/nixpkgs/pull/545369

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
