### PR TITLE
Fix spike of packet loss during wireguard refresh

### DIFF
--- a/nixos/modules/services/networking/wireguard-networkd.nix
+++ b/nixos/modules/services/networking/wireguard-networkd.nix
@@ -21,7 +21,7 @@ let
     ;
   inherit (lib.modules) mkIf;
   inherit (lib.options) literalExpression mkOption;
-  inherit (lib.strings) hasInfix replaceStrings;
+  inherit (lib.strings) concatStringsSep hasInfix replaceStrings;
   inherit (lib.trivial) flip pipe;
 
   removeNulls = filterAttrs (_: v: v != null);
@@ -98,28 +98,22 @@ let
 
   generateRefreshService =
     name: interface:
+    let
+      peersWithEndpoint = filter (peer: peer.endpoint != null) interface.peers;
+      refreshPeer = peer: ''wg set ${name} peer "${peer.publicKey}" endpoint "${peer.endpoint}"'';
+    in
     nameValuePair "wireguard-dynamic-refresh-${name}" {
       description = "Wireguard dynamic endpoint refresh (${name})";
       after = [ "network-online.target" ];
       wants = [ "network-online.target" ];
-      path = with pkgs; [
-        iproute2
-        systemd
-      ];
+      path = [ pkgs.wireguard-tools ];
       # networkd doesn't automatically refresh peer endpoints.
       # See: https://github.com/systemd/systemd/issues/9911
-      script = ''
-        touch /etc/systemd/network/40-${name}.netdev
-        networkctl reload
-      '';
-    };
-
-  # netdev config must be a real file (not a symlink to a store file)
-  # so the refresh service can 'touch' it.
-  generateRefreshNetdevMode =
-    name: interface:
-    nameValuePair "systemd/network/40-${name}.netdev" {
-      mode = "0444";
+      #
+      # In case the DNS entry changes, or we roam to a different network,
+      # `wg set wg0 peer <pubkey> endpoint <host:ip>` reestablishes connection.
+      # If nothing changed, this is a cheap no-op.
+      script = concatStringsSep "\n" (map refreshPeer peersWithEndpoint);
     };
 
 in
@@ -237,7 +231,6 @@ in
       networks = mapAttrs' generateNetwork cfg.interfaces;
     };
 
-    environment.etc = mapAttrs' generateRefreshNetdevMode refreshEnabledInterfaces;
     systemd.timers = mapAttrs' generateRefreshTimer refreshEnabledInterfaces;
     systemd.services = (mapAttrs' generateRefreshService refreshEnabledInterfaces) // {
       systemd-networkd.serviceConfig.LoadCredential = flatten (


### PR DESCRIPTION
When remote Wireguard peer's DNS entry changes, or when the client roams into a different network, the Wireguard connection dies, by default.

There is the option [networking.wireguard.interfaces.<name>.dynamicEndpointRefreshSeconds](https://search.nixos.org/options?channel=26.05&query=wireguard&sort=alpha_asc&type=options#show=option%253Anetworking.wireguard.interfaces.%253Cname%253E.dynamicEndpointRefreshSeconds) that attempts to fix this. However, this option causes multi-second packet loss / lag spikes during every refresh interval, due to how destructively the refresh is implemented, making it undesirable, bordering on unusable.

This PR changes the implementation to be lighter - the Wireguard network interface gets poked directly, without reloading the whole network.

(Somewhat) related issues: #459531 #419807 #140890

Patch created with the help of Claude Sonnet 5, cleaned up manually and tested manually.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
