### PR TITLE
python3Packages.xstatic-*: pin to setuptools_80 to fix build

### DIFF
--- a/pkgs/development/python-modules/xstatic-asciinema-player/default.nix
+++ b/pkgs/development/python-modules/xstatic-asciinema-player/default.nix
@@ -2,7 +2,7 @@
   buildPythonPackage,
   lib,
   fetchPypi,
-  setuptools,
+  setuptools_80,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -18,7 +18,7 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-yA6WC067St82Dm6StaCKdWrRBhmNemswetIO8iodfcw=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [ setuptools_80 ];
 
   # no tests implemented
   doCheck = false;

--- a/pkgs/development/python-modules/xstatic-bootbox/default.nix
+++ b/pkgs/development/python-modules/xstatic-bootbox/default.nix
@@ -2,7 +2,7 @@
   buildPythonPackage,
   lib,
   fetchPypi,
-  setuptools,
+  setuptools_80,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -18,7 +18,7 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-SyEguzOh2K2o+eBTKtmZh6oDh5sXsIv9xrgybW63wgU=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [ setuptools_80 ];
 
   # no tests implemented
   doCheck = false;

--- a/pkgs/development/python-modules/xstatic-bootstrap/default.nix
+++ b/pkgs/development/python-modules/xstatic-bootstrap/default.nix
@@ -2,7 +2,7 @@
   buildPythonPackage,
   lib,
   fetchPypi,
-  setuptools,
+  setuptools_80,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -18,7 +18,7 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-BPXMlbvlQ40ehR0GxMoa1/hL02oJtN5aH1S1JOhQaFk=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [ setuptools_80 ];
 
   # no tests implemented
   doCheck = false;

--- a/pkgs/development/python-modules/xstatic-font-awesome/default.nix
+++ b/pkgs/development/python-modules/xstatic-font-awesome/default.nix
@@ -2,6 +2,7 @@
   buildPythonPackage,
   lib,
   fetchPypi,
+  setuptools_80,
 }:
 
 buildPythonPackage rec {
@@ -14,6 +15,9 @@ buildPythonPackage rec {
     inherit version;
     hash = "sha256-8HWHEJYShjjy4VOQINgid1TD2IXdaOfubemgEjUHaCg=";
   };
+
+  # xstatic uses pkg_resources.declare_namespace, removed in setuptools 83.
+  build-system = [ setuptools_80 ];
 
   # no tests implemented
   doCheck = false;

--- a/pkgs/development/python-modules/xstatic-jquery-file-upload/default.nix
+++ b/pkgs/development/python-modules/xstatic-jquery-file-upload/default.nix
@@ -2,7 +2,7 @@
   buildPythonPackage,
   lib,
   fetchPypi,
-  setuptools,
+  setuptools_80,
   xstatic-jquery,
 }:
 
@@ -19,7 +19,7 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-fXFvJqyhRzLDXFTwum04GHYAq0cvyYqR2XLRLFpw2yc=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [ setuptools_80 ];
 
   # no tests implemented
   doCheck = false;

--- a/pkgs/development/python-modules/xstatic-jquery-ui/default.nix
+++ b/pkgs/development/python-modules/xstatic-jquery-ui/default.nix
@@ -2,7 +2,7 @@
   buildPythonPackage,
   lib,
   fetchPypi,
-  setuptools,
+  setuptools_80,
   xstatic-jquery,
 }:
 
@@ -19,7 +19,7 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-Npfl8O81W49KHHJCIVkmg8LbAxk1y7V7RiJO70dL0pQ=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [ setuptools_80 ];
 
   # no tests implemented
   doCheck = false;

--- a/pkgs/development/python-modules/xstatic-jquery/default.nix
+++ b/pkgs/development/python-modules/xstatic-jquery/default.nix
@@ -2,7 +2,7 @@
   buildPythonPackage,
   lib,
   fetchPypi,
-  setuptools,
+  setuptools_80,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -18,7 +18,7 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-4K6PjsW70oBFukvKBnZ6OL1fwnz5tx9DRYn1k3Dc0yM=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [ setuptools_80 ];
 
   # no tests implemented
   doCheck = false;

--- a/pkgs/development/python-modules/xstatic-pygments/default.nix
+++ b/pkgs/development/python-modules/xstatic-pygments/default.nix
@@ -2,7 +2,7 @@
   buildPythonPackage,
   lib,
   fetchPypi,
-  setuptools,
+  setuptools_80,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -18,7 +18,7 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-CCwen+YG+770dPeLb9sZ6aLvzHqbfZQWPPZve/rnV2I=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [ setuptools_80 ];
 
   # no tests implemented
   doCheck = false;

--- a/pkgs/development/python-modules/xstatic/default.nix
+++ b/pkgs/development/python-modules/xstatic/default.nix
@@ -2,7 +2,7 @@
   buildPythonPackage,
   lib,
   fetchPypi,
-  setuptools,
+  setuptools_80,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -18,7 +18,7 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-QCVEzJ4XlIlEEFTwnIB4BOEV6iRpB96HwDVftPWjEmg=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [ setuptools_80 ];
 
   # no tests implemented
   doCheck = false;


### PR DESCRIPTION
`xstatic-*` packages are failing to build due to setuptools 83 removing `pkgs_resources`:

```bash
python3.14-xstatic> Running phase: buildPhase
python3.14-xstatic> Executing pypaBuildPhase
python3.14-xstatic> Creating a wheel...
python3.14-xstatic> pypa build flags: --no-isolation --outdir dist/ --wheel
python3.14-xstatic> * Getting build dependencies for wheel...
python3.14-xstatic> Traceback (most recent call last):
python3.14-xstatic>   File "/nix/store/gxrvc2gq4kzz54dqi1mlqw7h4zy4l6aw-python3.14-pyproject-hooks-1.2.0/lib/python3.14/site-packages/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
python3.14-xstatic>     main()
python3.14-xstatic>     ~~~~^^
python3.14-xstatic>   File "/nix/store/gxrvc2gq4kzz54dqi1mlqw7h4zy4l6aw-python3.14-pyproject-hooks-1.2.0/lib/python3.14/site-packages/pyproject_hooks/_in_process/_in_process.py", line 373, in main
python3.14-xstatic>     json_out["return_val"] = hook(**hook_input["kwargs"])
python3.14-xstatic>                              ~~~~^^^^^^^^^^^^^^^^^^^^^^^^
python3.14-xstatic>   File "/nix/store/gxrvc2gq4kzz54dqi1mlqw7h4zy4l6aw-python3.14-pyproject-hooks-1.2.0/lib/python3.14/site-packages/pyproject_hooks/_in_process/_in_process.py", line 143, in get_requires_for_build_wheel
python3.14-xstatic>     return hook(config_settings)
python3.14-xstatic>   File "/nix/store/xv8alksljvbyk0mrbf9xvl16ygx27ajn-python3.14-setuptools-83.0.0/lib/python3.14/site-packages/setuptools/build_meta.py", line 333, in get_requires_for_build_wheel
python3.14-xstatic>     return self._get_build_requires(config_settings, requirements=[])
python3.14-xstatic>            ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
python3.14-xstatic>   File "/nix/store/xv8alksljvbyk0mrbf9xvl16ygx27ajn-python3.14-setuptools-83.0.0/lib/python3.14/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
python3.14-xstatic>     self.run_setup()
python3.14-xstatic>     ~~~~~~~~~~~~~~^^
python3.14-xstatic>   File "/nix/store/xv8alksljvbyk0mrbf9xvl16ygx27ajn-python3.14-setuptools-83.0.0/lib/python3.14/site-packages/setuptools/build_meta.py", line 520, in run_setup
python3.14-xstatic>     super().run_setup(setup_script=setup_script)
python3.14-xstatic>     ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
python3.14-xstatic>   File "/nix/store/xv8alksljvbyk0mrbf9xvl16ygx27ajn-python3.14-setuptools-83.0.0/lib/python3.14/site-packages/setuptools/build_meta.py", line 317, in run_setup
python3.14-xstatic>     exec(code, locals())
python3.14-xstatic>     ~~~~^^^^^^^^^^^^^^^^
python3.14-xstatic>   File "<string>", line 11, in <module>
python3.14-xstatic> ModuleNotFoundError: No module named 'pkg_resources'
python3.14-xstatic> 
python3.14-xstatic> TIP pass --env-dir and --sdist-extract-dir to keep the build environment and sources, then see https://build.pypa.io/en/stable/how-to/troubleshooting.html#debug-a-failed-build for help debugging a failed build
python3.14-xstatic> ERROR Backend subprocess exited when trying to invoke get_requires_for_build_wheel
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
