### PR TITLE
tectonic-unwrapped: 0.16.9 -> 0.17.0

### DIFF
--- a/pkgs/by-name/te/tectonic-unwrapped/package.nix
+++ b/pkgs/by-name/te/tectonic-unwrapped/package.nix
@@ -28,16 +28,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tectonic";
-  version = "0.16.9";
+  version = "0.17.0";
 
   src = fetchFromGitHub {
     owner = "tectonic-typesetting";
     repo = "tectonic";
     rev = "tectonic@${finalAttrs.version}";
-    sha256 = "sha256-5yphhmrrfgFwQ952eWpToyGfIJVJfV6y5w0BgznSOe0=";
+    sha256 = "sha256-7CdPo/tZSbBjRNCSr6IYLDsKjnzQzAsXbKBcFGCTfZg=";
   };
 
-  cargoHash = "sha256-22Hy51zCzY2DRytcYHgwkI9+e/g52o1jy4eosvEm3KY=";
+  cargoHash = "sha256-5Vx5rwRHNGQXg3WmUQO+612YqxxwHp4R72P4agWI8Kk=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
https://github.com/tectonic-typesetting/tectonic/releases/tag/tectonic%400.17.0

This release fixes https://github.com/tectonic-typesetting/tectonic/issues/1371 which also affects the version on stable.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
