### PR TITLE
sssd: fix broken host keytab renewal

### DIFF
--- a/pkgs/by-name/ss/sssd/package.nix
+++ b/pkgs/by-name/ss/sssd/package.nix
@@ -5,7 +5,6 @@
   fetchpatch2,
   autoreconfHook,
   makeWrapper,
-  glibc,
   adcli,
   augeas,
   bashNonInteractive,
@@ -23,6 +22,7 @@
   python3,
   pam,
   popt,
+  realmd,
   talloc,
   tdb,
   tevent,
@@ -104,9 +104,6 @@ stdenv.mkDerivation (finalAttrs: {
   separateDebugInfo = true;
 
   env = {
-    NIX_CFLAGS_COMPILE = toString [
-      "-DRENEWAL_PROG_PATH=\"${adcli}/bin/adcli\""
-    ];
     KRB5_CONFIG = lib.getExe' (lib.getDev libkrb5) "krb5-config";
     NSUPDATE = lib.getExe' dnsutils "nsupdate";
     XMLLINT = lib.getExe' libxml2 "xmllint";
@@ -128,12 +125,12 @@ stdenv.mkDerivation (finalAttrs: {
       --with-syslog=journald
       --with-initscript=systemd
       --without-selinux
-      --without-semanage
       --with-xml-catalog-path=''${SGML_CATALOG_FILES%%:*}
       --with-ldb-lib-dir=$out/modules/ldb
-      --with-nscd=${glibc.bin}/sbin/nscd
       --with-sssd-user=root
       --with-ldb-modules-path="${placeholder "out"}/modules/ldb:${ldb}/modules/ldb"
+      --with-adcli-path=${lib.meta.getExe adcli}
+      --with-realm-path=${lib.meta.getExe realmd}
     )
   ''
   + lib.optionalString withSudo ''


### PR DESCRIPTION
SSSD uses the `adcli` command to renew the host keytab, however, the mechanism by which it discovers `adcli` changed over SSSD versions. This commit fixes the discovery so that SSSD knows where to find the `adcli` executable file.

Also, remove long-stale configure script args:

- Version 2.10.0 was the first release in which the `--with-semanage` `./configure` switch was removed; it is now fully covered by `--with-selinux` (0a254e4341d886c68394019fa610a67492f14fce).
- Version 2.6.0 was the first release in which the `-with-nscd` `./configure` switch was dropped (3e94b64daa7638fb53e3f527d4308d9d1875c517). Subsequently, version 2.11.0 was the first release in which the `--with-nscd-conf` `./configure` switch was then also dropped (5e16c957f212f7f71ed9e34a7f0dfab5f4350d6d).


We should backport this to 26.05 too, IMHO. I'm seeing AD enrolled machines falling out of the AD due to the lack of renewal.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
