### PR TITLE
[26.05] nodejs: fix cross-compilation

### DIFF
--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -348,7 +348,7 @@ let
 
       dontDisableStatic = true;
 
-      configureScript = "${python.interpreter} configure.py";
+      configureScript = "${python.pythonOnBuildForHost.interpreter} configure.py";
 
       # In order to support unsupported cross configurations, we copy some intermediate executables
       # from a native build and replace all the build-system tools with a script which simply touches


### PR DESCRIPTION
Backport of #546154 to 26.05.

The regression came from #536002, which was backported to `staging-26.05` in
#536227, so `release-26.05` is affected as well. `configureScript` currently uses
`python.interpreter`, the hostPlatform interpreter, which cannot be executed on
the build platform when cross-compiling:

```
/nix/store/...-stdenv-linux/setup: line 1503:
  /nix/store/...-python3-aarch64-unknown-linux-musl-3.13.14/bin/python3.13:
  cannot execute binary file: Exec format error
```

See #543641 for the report and #546154 for the full analysis.

Targeting `release-26.05` rather than `staging-26.05` because this causes no
rebuilds: `pythonOnBuildForHost` is `python` itself when buildPlatform equals
hostPlatform, so `configureScript` is unchanged for native builds. The eval on
#546154 reported `Rebuild: linux 0, darwin 0`.

## Testing

On #546154, ofborg built both `nodejs-slim` and
`pkgsCross.aarch64-multiplatform-musl.nodejs-slim` successfully on x86_64-linux,
which is the same build platform as in the report.
