### PR TITLE
code-cursor: 3.12.30 -> 3.13.10

### DIFF
--- a/pkgs/by-name/co/code-cursor/sources.json
+++ b/pkgs/by-name/co/code-cursor/sources.json
@@ -1,18 +1,18 @@
 {
-  "version": "3.12.30",
+  "version": "3.13.10",
   "vscodeVersion": "1.128.0",
   "sources": {
     "x86_64-linux": {
-      "url": "https://downloads.cursor.com/production/63a2996a10d9e476b6c28e951dd7691d9c0cf480/linux/x64/Cursor-3.12.30-x86_64.AppImage",
-      "hash": "sha256-7gyF8YtWLjFOjAxhqip2fVxTbaBj/4FtLsjw2JpTOD8="
+      "url": "https://downloads.cursor.com/production/4f02290ccd9304f0e6bf8ee85f6e9106f02ac1f7/linux/x64/Cursor-3.13.10-x86_64.AppImage",
+      "hash": "sha256-pZq2rQnIbFLejOkK2y0GZEVRmuNKZvI+oxaviK/vpXQ="
     },
     "aarch64-linux": {
-      "url": "https://downloads.cursor.com/production/63a2996a10d9e476b6c28e951dd7691d9c0cf480/linux/arm64/Cursor-3.12.30-aarch64.AppImage",
-      "hash": "sha256-UKPf2q4py0pN5FlgdwGbTEKA52T7iJpM63z2kemz9h8="
+      "url": "https://downloads.cursor.com/production/4f02290ccd9304f0e6bf8ee85f6e9106f02ac1f7/linux/arm64/Cursor-3.13.10-aarch64.AppImage",
+      "hash": "sha256-fqQbQZqOAXxumAErlKK+1Z19mY3GitfVAwy6vNePcZA="
     },
     "aarch64-darwin": {
-      "url": "https://downloads.cursor.com/production/63a2996a10d9e476b6c28e951dd7691d9c0cf480/darwin/arm64/Cursor-darwin-arm64.dmg",
-      "hash": "sha256-uxAWl5wJISEbGSv7yHys29NZDquLe7z6wMNb61HC/7g="
+      "url": "https://downloads.cursor.com/production/4f02290ccd9304f0e6bf8ee85f6e9106f02ac1f7/darwin/arm64/Cursor-darwin-arm64.dmg",
+      "hash": "sha256-d/bdi67FN3BBjIG5GI+O2GtYUeHLKW0iZRjOGxwuS0o="
     }
   }
 }


### PR DESCRIPTION
## Summary
- Update code-cursor from 3.12.30 to 3.13.10

https://cursor.com/changelog

## Things done

- Built on platform:
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests
  - [ ] Package tests at `passthru.tests` (none defined: `tests = { }`)
- [x] Ran `nixpkgs-review` on this PR
- [x] Tested basic functionality of all binary files (verified app bundle version `3.13.10` and notarized signature via `spctl`)
- [x] Fits CONTRIBUTING.md, pkgs/README.md
- [x] Follows the automation/AI policy

## Test plan
- [x] `nix-build -A code-cursor` on aarch64-darwin
- [x] `./result/bin/cursor --version` reports `3.13.10`
- [x] `spctl --assess --type execute -v` reports accepted / Notarized Developer ID
- [x] `nixpkgs-review pr 546232` — 1 package built (`code-cursor`)