### PR TITLE
python3Packages: enable structuredAttrs for packages needed for Rust

### DIFF
--- a/pkgs/development/python-modules/build/default.nix
+++ b/pkgs/development/python-modules/build/default.nix
@@ -18,7 +18,7 @@
   wheel,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "build";
   version = "1.5.1";
   pyproject = true;
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "pypa";
     repo = "build";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-vm47wuSEKfU4CjonokylTyGe62jGS/5m2dhLKhY5TPc=";
   };
 
@@ -45,8 +45,8 @@ buildPythonPackage rec {
 
   passthru.tests = {
     pytest = buildPythonPackage {
-      pname = "${pname}-pytest";
-      inherit src version;
+      pname = "${finalAttrs.pname}-pytest";
+      inherit (finalAttrs) src version;
       pyproject = false;
 
       dontBuild = true;
@@ -96,6 +96,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "build" ];
 
+  __structuredAttrs = true;
+
   meta = {
     mainProgram = "pyproject-build";
     description = "Simple, correct PEP517 package builder";
@@ -104,9 +106,9 @@ buildPythonPackage rec {
       is a simple build tool and does not perform any dependency management.
     '';
     homepage = "https://github.com/pypa/build";
-    changelog = "https://github.com/pypa/build/blob/${src.tag}/CHANGELOG.rst";
+    changelog = "https://github.com/pypa/build/blob/${finalAttrs.src.tag}/CHANGELOG.rst";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.fab ];
     teams = [ lib.teams.python ];
   };
-}
+})

--- a/pkgs/development/python-modules/buildcatrust/default.nix
+++ b/pkgs/development/python-modules/buildcatrust/default.nix
@@ -30,6 +30,8 @@ buildPythonPackage (finalAttrs: {
     "buildcatrust.cli"
   ];
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Build SSL/TLS trust stores";
     mainProgram = "buildcatrust";

--- a/pkgs/development/python-modules/calver/default.nix
+++ b/pkgs/development/python-modules/calver/default.nix
@@ -8,7 +8,7 @@
 }:
 
 let
-  self = buildPythonPackage rec {
+  self = buildPythonPackage (finalAttrs: {
     pname = "calver";
     version = "2025.10.20";
     pyproject = true;
@@ -16,13 +16,13 @@ let
     src = fetchFromGitHub {
       owner = "di";
       repo = "calver";
-      tag = version;
+      tag = finalAttrs.version;
       hash = "sha256-8CfPQ4uMgKDqMMgutLdsjn/MaAVBJQAp1KqUfxzNMQw=";
     };
 
     postPatch = ''
       substituteInPlace setup.py \
-        --replace "version=calver_version(True)" 'version="${version}"'
+        --replace "version=calver_version(True)" 'version="${finalAttrs.version}"'
     '';
 
     build-system = [ setuptools ];
@@ -38,13 +38,15 @@ let
 
     passthru.tests.calver = self.overridePythonAttrs { doCheck = true; };
 
+    __structuredAttrs = true;
+
     meta = {
-      changelog = "https://github.com/di/calver/releases/tag/${src.tag}";
+      changelog = "https://github.com/di/calver/releases/tag/${finalAttrs.src.tag}";
       description = "Setuptools extension for CalVer package versions";
       homepage = "https://github.com/di/calver";
       license = lib.licenses.asl20;
       maintainers = with lib.maintainers; [ dotlambda ];
     };
-  };
+  });
 in
 self

--- a/pkgs/development/python-modules/certifi/default.nix
+++ b/pkgs/development/python-modules/certifi/default.nix
@@ -41,6 +41,8 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "certifi" ];
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://github.com/certifi/python-certifi";
     description = "Python package for providing Mozilla's CA Bundle";

--- a/pkgs/development/python-modules/cffi/default.nix
+++ b/pkgs/development/python-modules/cffi/default.nix
@@ -10,7 +10,7 @@
   stdenv,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "cffi";
   version = "2.1.0";
   pyproject = true;
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "python-cffi";
     repo = "cffi";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-17OgcPo1pYwsPV/2iHe7iXVusCp5zLTFGcHYUfX1g48=";
   };
 
@@ -44,12 +44,14 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  __structuredAttrs = true;
+
   meta = {
-    changelog = "https://github.com/python-cffi/cffi/releases/tag/v${version}";
+    changelog = "https://github.com/python-cffi/cffi/releases/tag/${finalAttrs.src.tag}";
     description = "Foreign Function Interface for Python calling C code";
     downloadPage = "https://github.com/python-cffi/cffi";
     homepage = "https://cffi.readthedocs.org/";
     license = lib.licenses.mit0;
     teams = [ lib.teams.python ];
   };
-}
+})

--- a/pkgs/development/python-modules/charset-normalizer/default.nix
+++ b/pkgs/development/python-modules/charset-normalizer/default.nix
@@ -13,7 +13,7 @@
   withMypyc ? !isPyPy && !stdenv.hostPlatform.isStatic,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "charset-normalizer";
   version = "3.4.9";
   pyproject = true;
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "jawah";
     repo = "charset_normalizer";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-YOskF90ach/qEwnMeYDEEO2H4DOoz/LZApXDRU9mvnM=";
   };
 
@@ -48,12 +48,14 @@ buildPythonPackage rec {
     inherit aiohttp requests;
   };
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Python module for encoding and language detection";
     mainProgram = "normalizer";
     homepage = "https://charset-normalizer.readthedocs.io/";
-    changelog = "https://github.com/jawah/charset_normalizer/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/jawah/charset_normalizer/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/development/python-modules/cython/default.nix
+++ b/pkgs/development/python-modules/cython/default.nix
@@ -13,7 +13,7 @@
   stdenv,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "cython";
   version = "3.2.5";
   pyproject = true;
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "cython";
     repo = "cython";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-wes7UFSWW00tKTmp3Aqk0jDpMMRVHRIhonC6CD7pwB4=";
   };
 
@@ -89,6 +89,8 @@ buildPythonPackage rec {
   # https://github.com/cython/cython/issues/5089
   setupHook = ./setup-hook.sh;
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://cython.org";
     description = "Optimising static compiler for both the Python and the extended Cython programming languages";
@@ -117,10 +119,10 @@ buildPythonPackage rec {
       attributes. This allows the compiler to generate very efficient C code
       from Cython code.
     '';
-    changelog = "https://github.com/cython/cython/blob/${src.tag}/CHANGES.rst";
+    changelog = "https://github.com/cython/cython/blob/${finalAttrs.src.tag}/CHANGES.rst";
     license = lib.licenses.asl20;
     mainProgram = "cython";
     maintainers = [ ];
   };
-}
+})
 # TODO: investigate recursive loop when doCheck is true

--- a/pkgs/development/python-modules/editables/default.nix
+++ b/pkgs/development/python-modules/editables/default.nix
@@ -6,13 +6,13 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "editables";
   version = "0.6";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-EWODSQI4HEYTeHlRxZFIAP3xVa4IhIo3O46lAGeAl3w=";
   };
 
@@ -25,11 +25,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "editables" ];
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Editable installations";
     homepage = "https://github.com/pfmoore/editables";
-    changelog = "https://github.com/pfmoore/editables/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/pfmoore/editables/blob/${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ getchoo ];
   };
-}
+})

--- a/pkgs/development/python-modules/execnet/default.nix
+++ b/pkgs/development/python-modules/execnet/default.nix
@@ -9,13 +9,13 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "execnet";
   version = "2.1.2";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-Y9g7/dmiPjW5xqMmFBIyT5ZMLsjc2NPGkW7pNz4L780=";
   };
 
@@ -56,11 +56,13 @@ buildPythonPackage rec {
 
   __darwinAllowLocalNetworking = true;
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Distributed Python deployment and communication";
     homepage = "https://execnet.readthedocs.io/";
-    changelog = "https://github.com/pytest-dev/execnet/blob/v${version}/CHANGELOG.rst";
+    changelog = "https://github.com/pytest-dev/execnet/blob/v${finalAttrs.version}/CHANGELOG.rst";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ getchoo ];
   };
-}
+})

--- a/pkgs/development/python-modules/filelock/default.nix
+++ b/pkgs/development/python-modules/filelock/default.nix
@@ -44,6 +44,8 @@ buildPythonPackage (finalAttrs: {
     "tests/test_read_write.py"
   ];
 
+  __structuredAttrs = true;
+
   meta = {
     changelog = "https://github.com/tox-dev/filelock/releases/tag/${finalAttrs.version}";
     description = "Platform independent file lock for Python";

--- a/pkgs/development/python-modules/flake8/default.nix
+++ b/pkgs/development/python-modules/flake8/default.nix
@@ -10,7 +10,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "flake8";
   version = "7.3.0";
   pyproject = true;
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "PyCQA";
     repo = "flake8";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-dZFIGyjqkd+MRz9NoOEcMuR9ZshFb/h+zO2OJZsQajc=";
   };
 
@@ -38,12 +38,14 @@ buildPythonPackage rec {
     "test_tokenization_error_but_not_syntax_error"
   ];
 
+  __structuredAttrs = true;
+
   meta = {
-    changelog = "https://github.com/PyCQA/flake8/blob/${src.tag}/docs/source/release-notes/${version}.rst";
+    changelog = "https://github.com/PyCQA/flake8/blob/${finalAttrs.src.tag}/docs/source/release-notes/${finalAttrs.version}.rst";
     description = "Modular source code checker: pep8, pyflakes and co";
     homepage = "https://github.com/PyCQA/flake8";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ dotlambda ];
     mainProgram = "flake8";
   };
-}
+})

--- a/pkgs/development/python-modules/flit-core/default.nix
+++ b/pkgs/development/python-modules/flit-core/default.nix
@@ -4,7 +4,7 @@
   flit,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "flit-core";
   inherit (flit) version;
   pyproject = true;
@@ -20,11 +20,13 @@ buildPythonPackage rec {
     inherit flit;
   };
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Distribution-building parts of Flit. See flit package for more information";
     homepage = "https://github.com/pypa/flit";
-    changelog = "https://github.com/pypa/flit/blob/${src.rev}/doc/history.rst";
+    changelog = "https://github.com/pypa/flit/blob/${finalAttrs.src.tag}/doc/history.rst";
     license = lib.licenses.bsd3;
     teams = [ lib.teams.python ];
   };
-}
+})

--- a/pkgs/development/python-modules/flit/default.nix
+++ b/pkgs/development/python-modules/flit/default.nix
@@ -23,7 +23,7 @@
 # python-packages.nix. When it will be used to build wheels,
 # care should be taken that there is no mingling of PYTHONPATH.
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "flit";
   version = "3.12.0";
   pyproject = true;
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "pypa";
     repo = "flit";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-oWV+KK22+iK99iCOCKCV1OCLq2Ef1bcYRKXT5GHwiL8=";
   };
 
@@ -61,11 +61,13 @@ buildPythonPackage rec {
     "test_symlink_module_pep621"
   ];
 
+  __structuredAttrs = true;
+
   meta = {
-    changelog = "https://github.com/pypa/flit/blob/${version}/doc/history.rst";
+    changelog = "https://github.com/pypa/flit/blob/${finalAttrs.version}/doc/history.rst";
     description = "Simple packaging tool for simple packages";
     mainProgram = "flit";
     homepage = "https://github.com/pypa/flit";
     license = lib.licenses.bsd3;
   };
-}
+})

--- a/pkgs/development/python-modules/gevent/default.nix
+++ b/pkgs/development/python-modules/gevent/default.nix
@@ -22,13 +22,13 @@
   pika,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "gevent";
   version = "26.5.0";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-FlXrBMHiDXGyqko8dSgWLdWP9sxGoDevHwH1NMgP77o=";
   };
 
@@ -75,6 +75,8 @@ buildPythonPackage rec {
   }
   // lib.filterAttrs (k: v: lib.hasInfix "gevent" k) python.pkgs;
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Coroutine-based networking library";
     homepage = "http://www.gevent.org/";
@@ -82,4 +84,4 @@ buildPythonPackage rec {
     maintainers = with lib.maintainers; [ bjornfor ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/development/python-modules/greenlet/default.nix
+++ b/pkgs/development/python-modules/greenlet/default.nix
@@ -15,13 +15,13 @@
 }:
 
 let
-  greenlet = buildPythonPackage rec {
+  greenlet = buildPythonPackage (finalAttrs: {
     pname = "greenlet";
     version = "3.5.3";
     pyproject = true;
 
     src = fetchPypi {
-      inherit pname version;
+      inherit (finalAttrs) pname version;
       hash = "sha256-ph78AY/T6zF+7KMaupDunn8m8iiEp5tsbscVv3G7YvE=";
     };
 
@@ -55,8 +55,10 @@ let
       doCheck = true;
     });
 
+    __structuredAttrs = true;
+
     meta = {
-      changelog = "https://github.com/python-greenlet/greenlet/blob/${version}/CHANGES.rst";
+      changelog = "https://github.com/python-greenlet/greenlet/blob/${finalAttrs.version}/CHANGES.rst";
       homepage = "https://github.com/python-greenlet/greenlet";
       description = "Module for lightweight in-process concurrent programming";
       license = with lib.licenses; [
@@ -64,6 +66,6 @@ let
         mit
       ];
     };
-  };
+  });
 in
 greenlet

--- a/pkgs/development/python-modules/hatch-vcs/default.nix
+++ b/pkgs/development/python-modules/hatch-vcs/default.nix
@@ -8,14 +8,14 @@
   setuptools-scm,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "hatch-vcs";
   version = "0.5.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "hatch_vcs";
-    inherit version;
+    inherit (finalAttrs) version;
     hash = "sha256-A5X6EmlANAIVCQw0Siv04qd7y+faqxb0Gze5jJWAn/k=";
   };
 
@@ -38,11 +38,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "hatch_vcs" ];
 
+  __structuredAttrs = true;
+
   meta = {
-    changelog = "https://github.com/ofek/hatch-vcs/releases/tag/v${version}";
+    changelog = "https://github.com/ofek/hatch-vcs/releases/tag/v${finalAttrs.version}";
     description = "Plugin for Hatch that uses your preferred version control system (like Git) to determine project versions";
     homepage = "https://github.com/ofek/hatch-vcs";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ cpcloud ];
   };
-}
+})

--- a/pkgs/development/python-modules/hatchling/default.nix
+++ b/pkgs/development/python-modules/hatchling/default.nix
@@ -61,6 +61,8 @@ buildPythonPackage (finalAttrs: {
     runHook postCheck
   '';
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Modern, extensible Python build backend";
     mainProgram = "hatchling";

--- a/pkgs/development/python-modules/idna/default.nix
+++ b/pkgs/development/python-modules/idna/default.nix
@@ -24,6 +24,8 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://github.com/kjd/idna/";
     changelog = "https://github.com/kjd/idna/blob/${finalAttrs.src.tag}/HISTORY.md";

--- a/pkgs/development/python-modules/importlib-metadata/default.nix
+++ b/pkgs/development/python-modules/importlib-metadata/default.nix
@@ -11,14 +11,14 @@
   sage,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "importlib-metadata";
   version = "9.0.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "importlib_metadata";
-    inherit version;
+    inherit (finalAttrs) version;
     hash = "sha256-pPV6tZnmouMBbXWVz9cutGYaUQbnh6lbzJDHEFuDHvw=";
   };
 
@@ -45,6 +45,8 @@ buildPythonPackage rec {
     inherit sage;
   };
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Read metadata from Python packages";
     homepage = "https://importlib-metadata.readthedocs.io/";
@@ -53,4 +55,4 @@ buildPythonPackage rec {
       fab
     ];
   };
-}
+})

--- a/pkgs/development/python-modules/iniconfig/default.nix
+++ b/pkgs/development/python-modules/iniconfig/default.nix
@@ -6,13 +6,13 @@
   setuptools-scm,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "iniconfig";
   version = "2.3.0";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-x2MVx32waGUNScW1YxR3SngE3xb+5EAsHxnW0V2MRzA=";
   };
 
@@ -27,10 +27,12 @@ buildPythonPackage rec {
   # recursion. See also: https://github.com/NixOS/nixpkgs/issues/63168
   doCheck = false;
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Brain-dead simple parsing of ini files";
     homepage = "https://github.com/pytest-dev/iniconfig";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/installer/default.nix
+++ b/pkgs/development/python-modules/installer/default.nix
@@ -8,7 +8,7 @@
   mock,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "installer";
   version = "1.0.1";
   pyproject = true;
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "pypa";
     repo = "installer";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-GkHLZfzHfTcBL8wQmIGlNkVodEw9Pih4i1SS36mSfBo=";
   };
 
@@ -34,8 +34,8 @@ buildPythonPackage rec {
 
   passthru.tests = {
     pytest = buildPythonPackage {
-      pname = "${pname}-pytest";
-      inherit version;
+      pname = "${finalAttrs.pname}-pytest";
+      inherit (finalAttrs) version;
       pyproject = false;
 
       dontBuild = true;
@@ -49,12 +49,14 @@ buildPythonPackage rec {
     };
   };
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Low-level library for installing a Python package from a wheel distribution";
     homepage = "https://github.com/pypa/installer";
-    changelog = "https://github.com/pypa/installer/blob/${src.rev}/docs/changelog.md";
+    changelog = "https://github.com/pypa/installer/blob/${finalAttrs.src.rev}/docs/changelog.md";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.cpcloud ];
     teams = [ lib.teams.python ];
   };
-}
+})

--- a/pkgs/development/python-modules/lxml/default.nix
+++ b/pkgs/development/python-modules/lxml/default.nix
@@ -57,6 +57,8 @@ buildPythonPackage (finalAttrs: {
     "lxml.etree"
   ];
 
+  __structuredAttrs = true;
+
   meta = {
     changelog = "https://github.com/lxml/lxml/blob/${finalAttrs.src.tag}/CHANGES.txt";
     description = "Pythonic binding for the libxml2 and libxslt libraries";

--- a/pkgs/development/python-modules/mccabe/default.nix
+++ b/pkgs/development/python-modules/mccabe/default.nix
@@ -5,13 +5,13 @@
   pytest,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "mccabe";
   version = "0.7.0";
   format = "setuptools";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-NI4CQMM7YLvfTlIxku+RnyjLLD19XHeU90AJKQ8jYyU=";
   };
 
@@ -20,10 +20,12 @@ buildPythonPackage rec {
   # https://github.com/PyCQA/mccabe/issues/93
   doCheck = false;
 
+  __structuredAttrs = true;
+
   meta = {
     description = "McCabe checker, plugin for flake8";
     homepage = "https://github.com/flintwork/mccabe";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/packaging/default.nix
+++ b/pkgs/development/python-modules/packaging/default.nix
@@ -45,6 +45,8 @@ buildPythonPackage (finalAttrs: {
     doCheck = true;
   });
 
+  __structuredAttrs = true;
+
   meta = {
     changelog = "https://github.com/pypa/packaging/blob/${finalAttrs.version}/CHANGELOG.rst";
     description = "Core utilities for Python packages";

--- a/pkgs/development/python-modules/pathspec/default.nix
+++ b/pkgs/development/python-modules/pathspec/default.nix
@@ -12,21 +12,21 @@
   yamllint,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pathspec";
   version = "1.1.1";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-F9tezVJBBKEg4XOBTJA2epapjQfEWy4QwvORn/+Rv1o=";
   };
 
-  nativeBuildInputs = [ flit-core ];
+  build-system = [ flit-core ];
 
   pythonImportsCheck = [ "pathspec" ];
 
-  checkInputs = [ unittestCheckHook ];
+  nativeCheckInputs = [ unittestCheckHook ];
 
   passthru.tests = {
     inherit
@@ -37,11 +37,13 @@ buildPythonPackage rec {
       ;
   };
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Utility library for gitignore-style pattern matching of file paths";
     homepage = "https://github.com/cpburnz/python-path-specification";
-    changelog = "https://github.com/cpburnz/python-pathspec/blob/v${version}/CHANGES.rst";
+    changelog = "https://github.com/cpburnz/python-pathspec/blob/v${finalAttrs.version}/CHANGES.rst";
     license = lib.licenses.mpl20;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/pexpect/default.nix
+++ b/pkgs/development/python-modules/pexpect/default.nix
@@ -9,13 +9,13 @@
   sage,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pexpect";
   version = "4.9.0";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-7n1BEj88mREFDqLC2sEHVo3EOy07DHVXozISw5jq0w8=";
   };
 
@@ -29,6 +29,8 @@ buildPythonPackage rec {
   passthru.tests = {
     inherit sage;
   };
+
+  __structuredAttrs = true;
 
   meta = {
     homepage = "http://www.noah.org/wiki/Pexpect";
@@ -53,4 +55,4 @@ buildPythonPackage rec {
       any platform that supports the standard Python pty module.
     '';
   };
-}
+})

--- a/pkgs/development/python-modules/pluggy/default.nix
+++ b/pkgs/development/python-modules/pluggy/default.nix
@@ -6,7 +6,7 @@
   callPackage,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pluggy";
   version = "1.6.0";
 
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "pytest-dev";
     repo = "pluggy";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-pkQjPJuSASWmzwzp9H/UTJBQDr2r2RiofxpF135lAgc=";
   };
 
@@ -27,11 +27,13 @@ buildPythonPackage rec {
     pytest = callPackage ./tests.nix { };
   };
 
+  __structuredAttrs = true;
+
   meta = {
-    changelog = "https://github.com/pytest-dev/pluggy/blob/${src.rev}/CHANGELOG.rst";
+    changelog = "https://github.com/pytest-dev/pluggy/blob/${finalAttrs.src.tag}/CHANGELOG.rst";
     description = "Plugin and hook calling mechanisms for Python";
     homepage = "https://github.com/pytest-dev/pluggy";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ dotlambda ];
   };
-}
+})

--- a/pkgs/development/python-modules/psutil/default.nix
+++ b/pkgs/development/python-modules/psutil/default.nix
@@ -10,7 +10,7 @@
   gitUpdater,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "psutil";
   version = "7.2.2";
   pyproject = true;
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "giampaolo";
     repo = "psutil";
-    tag = "release-${version}";
+    tag = "release-${finalAttrs.version}";
     hash = "sha256-plBv24QgNzmVMV2lFxCbNwHKtd620thJayWdjs4estw=";
   };
 
@@ -74,11 +74,13 @@ buildPythonPackage rec {
     rev-prefix = "release-";
   };
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Process and system utilization information interface";
     homepage = "https://github.com/giampaolo/psutil";
-    changelog = "https://github.com/giampaolo/psutil/blob/${src.tag}/HISTORY.rst";
+    changelog = "https://github.com/giampaolo/psutil/blob/${finalAttrs.src.tag}/HISTORY.rst";
     license = lib.licenses.bsd3;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/ptyprocess/default.nix
+++ b/pkgs/development/python-modules/ptyprocess/default.nix
@@ -7,13 +7,13 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "ptyprocess";
   version = "0.7.0";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-XF0KO0jO7gtISF4MJgN8Cs19KXZco/u1yzgx00dCMiA=";
   };
 
@@ -35,11 +35,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "ptyprocess" ];
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Run a subprocess in a pseudo terminal";
     homepage = "https://github.com/pexpect/ptyprocess";
-    changelog = "https://github.com/pexpect/ptyprocess/releases/tag/${version}";
+    changelog = "https://github.com/pexpect/ptyprocess/releases/tag/${finalAttrs.version}";
     license = lib.licenses.isc;
     maintainers = with lib.maintainers; [ getchoo ];
   };
-}
+})

--- a/pkgs/development/python-modules/pycodestyle/default.nix
+++ b/pkgs/development/python-modules/pycodestyle/default.nix
@@ -8,7 +8,7 @@
   isPyPy,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pycodestyle";
   version = "2.14.0";
   pyproject = true;
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "PyCQA";
     repo = "pycodestyle";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-1EEQp/QEulrdU9tTe28NerQ33IWlAiSlicpmNYciW88=";
   };
 
@@ -36,12 +36,14 @@ buildPythonPackage rec {
     "test_check_nullbytes"
   ];
 
+  __structuredAttrs = true;
+
   meta = {
-    changelog = "https://github.com/PyCQA/pycodestyle/blob/${src.tag}/CHANGES.txt";
+    changelog = "https://github.com/PyCQA/pycodestyle/blob/${finalAttrs.src.tag}/CHANGES.txt";
     description = "Python style guide checker";
     mainProgram = "pycodestyle";
     homepage = "https://pycodestyle.pycqa.org/";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ kamadorueda ];
   };
-}
+})

--- a/pkgs/development/python-modules/pycparser/default.nix
+++ b/pkgs/development/python-modules/pycparser/default.nix
@@ -8,7 +8,7 @@
   unittestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pycparser";
   version = "3.00";
   pyproject = true;
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "eliben";
     repo = "pycparser";
-    tag = "release_v${version}";
+    tag = "release_v${finalAttrs.version}";
     hash = "sha256-6eKc+p3xLyRPo3oCWP/dbMpHlkBXLy8XiGR0gTEHI2E=";
   };
 
@@ -39,11 +39,13 @@ buildPythonPackage rec {
     rev-prefix = "release_v";
   };
 
+  __structuredAttrs = true;
+
   meta = {
-    changelog = "https://github.com/eliben/pycparser/releases/tag/${src.tag}";
+    changelog = "https://github.com/eliben/pycparser/releases/tag/${finalAttrs.src.tag}";
     description = "C parser in Python";
     homepage = "https://github.com/eliben/pycparser";
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.dotlambda ];
   };
-}
+})

--- a/pkgs/development/python-modules/pyelftools/default.nix
+++ b/pkgs/development/python-modules/pyelftools/default.nix
@@ -7,7 +7,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pyelftools";
   version = "0.32";
   pyproject = true;
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "eliben";
     repo = "pyelftools";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-58Twjf7ECOPynQ5KPCTDQWdD3nb7ADJZISozWGRGoXM=";
   };
 
@@ -32,10 +32,12 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "elftools" ];
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Python library for analyzing ELF files and DWARF debugging information";
     homepage = "https://github.com/eliben/pyelftools";
-    changelog = "https://github.com/eliben/pyelftools/blob/v${version}/CHANGES";
+    changelog = "https://github.com/eliben/pyelftools/blob/${finalAttrs.src.tag}/CHANGES";
     license = with lib.licenses; [
       # Public domain with Unlicense waiver.
       unlicense
@@ -49,4 +51,4 @@ buildPythonPackage rec {
     ];
     mainProgram = "readelf.py";
   };
-}
+})

--- a/pkgs/development/python-modules/pyflakes/default.nix
+++ b/pkgs/development/python-modules/pyflakes/default.nix
@@ -7,7 +7,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pyflakes";
   version = "3.4.0";
   pyproject = true;
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "PyCQA";
     repo = "pyflakes";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-4UEJjn9Eey1vHeaG468x/nMlbfGu3ohZX1R7RR2R5ik=";
   };
 
@@ -33,12 +33,14 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pyflakes" ];
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://github.com/PyCQA/pyflakes";
-    changelog = "https://github.com/PyCQA/pyflakes/blob/${src.tag}/NEWS.rst";
+    changelog = "https://github.com/PyCQA/pyflakes/blob/${finalAttrs.src.tag}/NEWS.rst";
     description = "Simple program which checks Python source files for errors";
     mainProgram = "pyflakes";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ dotlambda ];
   };
-}
+})

--- a/pkgs/development/python-modules/pygments/default.nix
+++ b/pkgs/development/python-modules/pygments/default.nix
@@ -45,6 +45,8 @@ let
       });
     };
 
+    __structuredAttrs = true;
+
     meta = {
       changelog = "https://github.com/pygments/pygments/releases/tag/${finalAttrs.version}";
       homepage = "https://pygments.org/";

--- a/pkgs/development/python-modules/pyproject-hooks/default.nix
+++ b/pkgs/development/python-modules/pyproject-hooks/default.nix
@@ -9,14 +9,14 @@
   testpath,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pyproject-hooks";
   version = "1.2.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "pyproject_hooks";
-    inherit version;
+    inherit (finalAttrs) version;
     hash = "sha256-HoWb1cQPrpRIZC3Yca30WeXiCEGG6NLCp5qCTJcNofg=";
   };
 
@@ -28,8 +28,8 @@ buildPythonPackage rec {
 
   passthru.tests = {
     pytest = buildPythonPackage {
-      pname = "${pname}-pytest";
-      inherit version;
+      pname = "${finalAttrs.pname}-pytest";
+      inherit (finalAttrs) version;
       pyproject = false;
 
       dontBuild = true;
@@ -52,11 +52,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pyproject_hooks" ];
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Low-level library for calling build-backends in `pyproject.toml`-based project";
     homepage = "https://github.com/pypa/pyproject-hooks";
-    changelog = "https://github.com/pypa/pyproject-hooks/blob/v${version}/docs/changelog.rst";
+    changelog = "https://github.com/pypa/pyproject-hooks/blob/v${finalAttrs.version}/docs/changelog.rst";
     license = lib.licenses.mit;
     teams = [ lib.teams.python ];
   };
-}
+})

--- a/pkgs/development/python-modules/pysocks/default.nix
+++ b/pkgs/development/python-modules/pysocks/default.nix
@@ -4,22 +4,24 @@
   fetchPypi,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pysocks";
   version = "1.7.1";
   format = "setuptools";
 
   src = fetchPypi {
     pname = "PySocks";
-    inherit version;
+    inherit (finalAttrs) version;
     sha256 = "184sg65mbmih6ljblfsxcmq5js5l7dj3gpn618w9q5dy3rbh921z";
   };
 
   doCheck = false;
+
+  __structuredAttrs = true;
 
   meta = {
     description = "SOCKS module for Python";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ thoughtpolice ];
   };
-}
+})

--- a/pkgs/development/python-modules/pytest-asyncio/default.nix
+++ b/pkgs/development/python-modules/pytest-asyncio/default.nix
@@ -9,7 +9,7 @@
   typing-extensions,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pytest-asyncio";
   version = "1.4.0"; # N.B.: when updating, tests bleak and aioesphomeapi tests
   pyproject = true;
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "pytest-dev";
     repo = "pytest-asyncio";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-MuTLCRHCuD9TwJkMiFIC5Xv5Xz6NL8j4JZpW8BA45SI=";
   };
 
@@ -46,11 +46,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pytest_asyncio" ];
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Library for testing asyncio code with pytest";
     homepage = "https://github.com/pytest-dev/pytest-asyncio";
-    changelog = "https://github.com/pytest-dev/pytest-asyncio/blob/${src.tag}/docs/reference/changelog.rst";
+    changelog = "https://github.com/pytest-dev/pytest-asyncio/blob/${finalAttrs.src.tag}/docs/reference/changelog.rst";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ dotlambda ];
   };
-}
+})

--- a/pkgs/development/python-modules/pytest-instafail/default.nix
+++ b/pkgs/development/python-modules/pytest-instafail/default.nix
@@ -6,13 +6,13 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pytest-instafail";
   version = "0.5.0";
   format = "setuptools";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-M6YG9+DI5kbcO/7g1eOkt7eO98NhaM+h89k698pwbJ4=";
   };
 
@@ -22,11 +22,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pytest_instafail" ];
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Pytest plugin that shows failures and errors instantly instead of waiting until the end of test session";
     homepage = "https://github.com/pytest-dev/pytest-instafail";
-    changelog = "https://github.com/pytest-dev/pytest-instafail/blob/v${version}/CHANGES.rst";
+    changelog = "https://github.com/pytest-dev/pytest-instafail/blob/v${finalAttrs.version}/CHANGES.rst";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ jacg ];
   };
-}
+})

--- a/pkgs/development/python-modules/pytest-mock/default.nix
+++ b/pkgs/development/python-modules/pytest-mock/default.nix
@@ -10,7 +10,7 @@
   setuptools-scm,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pytest-mock";
   version = "3.15.1";
   pyproject = true;
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "pytest-dev";
     repo = "pytest-mock";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-9h5/cssWs4F0LKnFLjWDsEjB2AYczLvnSjiUdsaEcBQ=";
   };
 
@@ -44,11 +44,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pytest_mock" ];
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Thin wrapper around the mock package for easier use with pytest";
     homepage = "https://github.com/pytest-dev/pytest-mock";
-    changelog = "https://github.com/pytest-dev/pytest-mock/blob/${src.tag}/CHANGELOG.rst";
+    changelog = "https://github.com/pytest-dev/pytest-mock/blob/${finalAttrs.src.tag}/CHANGELOG.rst";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ dotlambda ];
   };
-}
+})

--- a/pkgs/development/python-modules/pytest-timeout/default.nix
+++ b/pkgs/development/python-modules/pytest-timeout/default.nix
@@ -8,7 +8,7 @@
   pexpect,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pytest-timeout";
   version = "2.4.0";
   pyproject = true;
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "pytest-dev";
     repo = "pytest-timeout";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-NGTy3Hua6yEMWXQDJQO2Z5DD3clXTZXEH6DNQBMSGtQ=";
   };
 
@@ -31,11 +31,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pytest_timeout" ];
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Pytest plugin to abort hanging tests";
     homepage = "https://github.com/pytest-dev/pytest-timeout/";
-    changelog = "https://github.com/pytest-dev/pytest-timeout/tree/${src.tag}#changelog";
+    changelog = "https://github.com/pytest-dev/pytest-timeout/tree/${finalAttrs.src.tag}#changelog";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ makefu ];
   };
-}
+})

--- a/pkgs/development/python-modules/pytest-xdist/default.nix
+++ b/pkgs/development/python-modules/pytest-xdist/default.nix
@@ -13,7 +13,7 @@
   setproctitle,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pytest-xdist";
   version = "3.8.0";
   pyproject = true;
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "pytest-dev";
     repo = "pytest-xdist";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-2x3znm92wo8DCshf5sYK0stnESg0oVXbxsWRAaTj6oQ=";
   };
 
@@ -80,11 +80,13 @@ buildPythonPackage rec {
 
   setupHook = ./setup-hook.sh;
 
+  __structuredAttrs = true;
+
   meta = {
-    changelog = "https://github.com/pytest-dev/pytest-xdist/blob/${src.tag}/CHANGELOG.rst";
+    changelog = "https://github.com/pytest-dev/pytest-xdist/blob/${finalAttrs.src.tag}/CHANGELOG.rst";
     description = "Pytest plugin for distributed testing";
     homepage = "https://github.com/pytest-dev/pytest-xdist";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ dotlambda ];
   };
-}
+})

--- a/pkgs/development/python-modules/pytest/7.nix
+++ b/pkgs/development/python-modules/pytest/7.nix
@@ -25,13 +25,13 @@
 }:
 
 let
-  self = buildPythonPackage rec {
+  self = buildPythonPackage (finalAttrs: {
     pname = "pytest";
     version = "7.4.4";
     pyproject = true;
 
     src = fetchPypi {
-      inherit pname version;
+      inherit (finalAttrs) pname version;
       hash = "sha256-LPAAWSLGrOSj4uyLQIDrDZdT/ckxB0FTMvUM6eeZQoA=";
     };
 
@@ -95,15 +95,17 @@ let
 
     pythonImportsCheck = [ "pytest" ];
 
+    __structuredAttrs = true;
+
     meta = {
       description = "Framework for writing tests";
       homepage = "https://docs.pytest.org";
-      changelog = "https://github.com/pytest-dev/pytest/releases/tag/${version}";
+      changelog = "https://github.com/pytest-dev/pytest/releases/tag/${finalAttrs.version}";
       maintainers = with lib.maintainers; [
         madjar
       ];
       license = lib.licenses.mit;
     };
-  };
+  });
 in
 self

--- a/pkgs/development/python-modules/pytest/8_3.nix
+++ b/pkgs/development/python-modules/pytest/8_3.nix
@@ -24,13 +24,13 @@
   xmlschema,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pytest";
   version = "8.3.5";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-9O/nDMFOURVlrEdrV8J54SqFWxH0jyEq8QgO8iY9OEU=";
   };
 
@@ -94,11 +94,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pytest" ];
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Framework for writing tests";
     homepage = "https://docs.pytest.org";
-    changelog = "https://github.com/pytest-dev/pytest/releases/tag/${version}";
+    changelog = "https://github.com/pytest-dev/pytest/releases/tag/${finalAttrs.version}";
     teams = [ lib.teams.python ];
     license = lib.licenses.mit;
   };
-}
+})

--- a/pkgs/development/python-modules/pytest/9_0.nix
+++ b/pkgs/development/python-modules/pytest/9_0.nix
@@ -24,13 +24,13 @@
   xmlschema,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pytest";
   version = "9.0.3";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-uGraUIr4HRnt6yE8aBsdSCRsGpHTBMbIGkJ2dMF+uRw=";
   };
 
@@ -94,11 +94,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pytest" ];
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Framework for writing tests";
     homepage = "https://docs.pytest.org";
-    changelog = "https://github.com/pytest-dev/pytest/releases/tag/${version}";
+    changelog = "https://github.com/pytest-dev/pytest/releases/tag/${finalAttrs.version}";
     teams = [ lib.teams.python ];
     license = lib.licenses.mit;
   };
-}
+})

--- a/pkgs/development/python-modules/pytest/default.nix
+++ b/pkgs/development/python-modules/pytest/default.nix
@@ -24,13 +24,13 @@
   xmlschema,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pytest";
   version = "9.1.1";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-EIj73o8rSdlaVJoZVwevp6dqPOm8rcJrbXHw/9pf4xM=";
   };
 
@@ -94,11 +94,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pytest" ];
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Framework for writing tests";
     homepage = "https://docs.pytest.org";
-    changelog = "https://github.com/pytest-dev/pytest/releases/tag/${version}";
+    changelog = "https://github.com/pytest-dev/pytest/releases/tag/${finalAttrs.version}";
     teams = [ lib.teams.python ];
     license = lib.licenses.mit;
   };
-}
+})

--- a/pkgs/development/python-modules/requests/default.nix
+++ b/pkgs/development/python-modules/requests/default.nix
@@ -79,6 +79,8 @@ buildPythonPackage (finalAttrs: {
 
   __darwinAllowLocalNetworking = true;
 
+  __structuredAttrs = true;
+
   meta = {
     description = "HTTP library for Python";
     homepage = "http://docs.python-requests.org/";

--- a/pkgs/development/python-modules/setuptools-scm/default.nix
+++ b/pkgs/development/python-modules/setuptools-scm/default.nix
@@ -14,14 +14,14 @@
   rich,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "setuptools-scm";
   version = "10.0.5";
   pyproject = true;
 
   src = fetchPypi {
     pname = "setuptools_scm";
-    inherit version;
+    inherit (finalAttrs) version;
     hash = "sha256-u7qP51RRbN79AX9EVnIXdebvlmK9eIf7Uq4mgT1IOMM=";
   };
 
@@ -49,11 +49,13 @@ buildPythonPackage rec {
 
   setupHook = ./setup-hook.sh;
 
+  __structuredAttrs = true;
+
   meta = {
-    changelog = "https://github.com/pypa/setuptools_scm/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/pypa/setuptools_scm/blob/${finalAttrs.version}/CHANGELOG.md";
     homepage = "https://github.com/pypa/setuptools_scm/";
     description = "Handles managing your python package versions in scm metadata";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ nickcao ];
   };
-}
+})

--- a/pkgs/development/python-modules/setuptools/80.nix
+++ b/pkgs/development/python-modules/setuptools/80.nix
@@ -43,6 +43,8 @@ buildPythonPackage (finalAttrs: {
     inherit distutils_80;
   };
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Utilities to facilitate the installation of Python packages";
     homepage = "https://github.com/pypa/setuptools";

--- a/pkgs/development/python-modules/setuptools/default.nix
+++ b/pkgs/development/python-modules/setuptools/default.nix
@@ -43,6 +43,8 @@ buildPythonPackage (finalAttrs: {
     inherit distutils;
   };
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Utilities to facilitate the installation of Python packages";
     homepage = "https://github.com/pypa/setuptools";

--- a/pkgs/development/python-modules/toml/default.nix
+++ b/pkgs/development/python-modules/toml/default.nix
@@ -4,13 +4,13 @@
   fetchPypi,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "toml";
   version = "0.10.2";
   format = "setuptools";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     sha256 = "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f";
   };
 
@@ -19,10 +19,12 @@ buildPythonPackage rec {
   # git to download a test suite.
   doCheck = false;
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Python library for parsing and creating TOML";
     homepage = "https://github.com/uiri/toml";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ twey ];
   };
-}
+})

--- a/pkgs/development/python-modules/tomli-w/default.nix
+++ b/pkgs/development/python-modules/tomli-w/default.nix
@@ -7,7 +7,7 @@
   tomli,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "tomli-w";
   version = "1.2.0";
   pyproject = true;
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "hukkin";
     repo = "tomli-w";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-Du37ySvAL9iwGec5wbWxwLTYm+kcDSOs5OJ5Sw7R87g=";
   };
 
@@ -28,11 +28,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "tomli_w" ];
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Write-only counterpart to Tomli, which is a read-only TOML parser";
     homepage = "https://github.com/hukkin/tomli-w";
-    changelog = "https://github.com/hukkin/tomli-w/blob/${src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/hukkin/tomli-w/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ lovesegfault ];
   };
-}
+})

--- a/pkgs/development/python-modules/tomli/default.nix
+++ b/pkgs/development/python-modules/tomli/default.nix
@@ -12,7 +12,7 @@
   setuptools-scm,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "tomli";
   version = "2.4.1";
   pyproject = true;
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "hukkin";
     repo = "tomli";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-MBcmp0SeK/wum3c2c/eu8VEofXDguolHI30QwKahAGE=";
   };
 
@@ -40,10 +40,12 @@ buildPythonPackage rec {
       ;
   };
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Python library for parsing TOML, fully compatible with TOML v1.0.0";
     homepage = "https://github.com/hukkin/tomli";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ veehaitch ];
   };
-}
+})

--- a/pkgs/development/python-modules/trove-classifiers/default.nix
+++ b/pkgs/development/python-modules/trove-classifiers/default.nix
@@ -36,6 +36,8 @@ buildPythonPackage (finalAttrs: {
 
   passthru.tests.trove-classifiers = finalAttrs.finalPackage.overrideAttrs { doInstallCheck = true; };
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Canonical source for classifiers on PyPI";
     homepage = "https://github.com/pypa/trove-classifiers";

--- a/pkgs/development/python-modules/urllib3/default.nix
+++ b/pkgs/development/python-modules/urllib3/default.nix
@@ -93,6 +93,8 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "urllib3" ];
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Powerful, user-friendly HTTP client for Python";
     homepage = "https://github.com/urllib3/urllib3";

--- a/pkgs/development/python-modules/vcs-versioning/default.nix
+++ b/pkgs/development/python-modules/vcs-versioning/default.nix
@@ -50,6 +50,8 @@ buildPythonPackage (finalAttrs: {
 
   passthru.tests.pytest = vcs-versioning.overridePythonAttrs { doCheck = true; };
 
+  __structuredAttrs = true;
+
   meta = {
     changelog = "https://github.com/pypa/setuptools-scm/releases/tag/${finalAttrs.src.tag}";
     description = "The blessed package to manage your versions by scm tags";

--- a/pkgs/development/python-modules/wheel/default.nix
+++ b/pkgs/development/python-modules/wheel/default.nix
@@ -5,7 +5,7 @@
   flit-core,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "wheel";
   version = "0.47.0";
   pyproject = true;
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "pypa";
     repo = "wheel";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-/5OxFySesdsFsuUbhdhcgFPsry8RSy5ZshG0TWGncVY=";
   };
 
@@ -23,6 +23,8 @@ buildPythonPackage rec {
   doCheck = false;
 
   pythonImportsCheck = [ "wheel" ];
+
+  __structuredAttrs = true;
 
   meta = {
     homepage = "https://github.com/pypa/wheel";
@@ -43,4 +45,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ siriobalmelli ];
   };
-}
+})

--- a/pkgs/development/python-modules/zipp/default.nix
+++ b/pkgs/development/python-modules/zipp/default.nix
@@ -9,7 +9,7 @@
 }:
 
 let
-  zipp = buildPythonPackage rec {
+  zipp = buildPythonPackage (finalAttrs: {
     pname = "zipp";
     version = "4.1.0";
     pyproject = true;
@@ -17,7 +17,7 @@ let
     src = fetchFromGitHub {
       owner = "jaraco";
       repo = "zipp";
-      tag = "v${version}";
+      tag = "v${finalAttrs.version}";
       hash = "sha256-qFsCud+fKDULbIF3LLGh6su/Sm1YjcvKe0+R9GH/Ies=";
     };
 
@@ -47,12 +47,14 @@ let
       });
     };
 
+    __structuredAttrs = true;
+
     meta = {
       description = "Pathlib-compatible object wrapper for zip files";
       homepage = "https://github.com/jaraco/zipp";
       license = lib.licenses.mit;
       maintainers = [ ];
     };
-  };
+  });
 in
 zipp

--- a/pkgs/development/python-modules/zope-event/default.nix
+++ b/pkgs/development/python-modules/zope-event/default.nix
@@ -28,6 +28,8 @@ buildPythonPackage (finalAttrs: {
 
   pythonNamespaces = [ "zope" ];
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Event publishing system";
     homepage = "https://github.com/zopefoundation/zope.event";

--- a/pkgs/development/python-modules/zope-interface/default.nix
+++ b/pkgs/development/python-modules/zope-interface/default.nix
@@ -5,7 +5,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "zope-interface";
   version = "8.2";
   pyproject = true;
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "zopefoundation";
     repo = "zope.interface";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-hOcg41lcdVWfmT2DqaYzzu4bJZYiG2y5boylJevBv6k=";
   };
 
@@ -25,11 +25,13 @@ buildPythonPackage rec {
 
   pythonNamespaces = [ "zope" ];
 
+  __structuredAttrs = true;
+
   meta = {
-    changelog = "https://github.com/zopefoundation/zope.interface/blob/${src.tag}/CHANGES.rst";
+    changelog = "https://github.com/zopefoundation/zope.interface/blob/${finalAttrs.src.tag}/CHANGES.rst";
     description = "Implementation of object interfaces, a mechanism for labeling objects as conforming to a given API or contract";
     homepage = "https://github.com/zopefoundation/zope.interface";
     license = lib.licenses.zpl21;
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
I've been experimenting with setting `__structuredAttrs = true;` in `mkPythonDerivation`, since I expect that Python packages in general have relatively few issues with it, but of course it causes an enormous number of rebuilds (trying to run nixpkgs-review on the branch reported ~90k). So I wanted to try and get a bunch of low-level stuff explicitly migrated to structuredAttrs to reduce thtat number and in particular I - somewhat arbitrarily - chose the packages that are needed to set up the Rust compiler chain (tested with the `dust` package with this branch on top of master).

In principle all these commits should be individually viable, but maybe this saves time on rebuilds on Hydra to do it in one go?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
