### PR TITLE
open-webui: 0.10.2 -> 0.11.0

### DIFF
--- a/pkgs/by-name/op/open-webui/package.nix
+++ b/pkgs/by-name/op/open-webui/package.nix
@@ -9,13 +9,13 @@
 }:
 let
   pname = "open-webui";
-  version = "0.10.2";
+  version = "0.11.0";
 
   src = fetchFromGitHub {
     owner = "open-webui";
     repo = "open-webui";
     tag = "v${version}";
-    hash = "sha256-tJ9b5up5FoX5TrmpwMWevyA/o3Ai/lKsHu+nahc2Ttc=";
+    hash = "sha256-SP5Huefj35PHvVzqS8R/DGSBci/hCHoueEb5RupGVqY=";
   };
 
   frontend = buildNpmPackage rec {
@@ -24,13 +24,13 @@ let
 
     # the backend for run-on-client-browser python execution
     # must match the version that is locked in package-lock.json
-    pyodideVersion = "0.28.3";
+    pyodideVersion = "314.0.3";
     pyodide = fetchurl {
-      hash = "sha256-fcqubT8VmGoJ8PnmxHE6DA8kv/DJDHToWoFyPxvGCUA=";
+      hash = "sha256-oCgELZDbqedP377PNuqn1X6IvwrWGNnFBZ6xBAqnYSo=";
       url = "https://github.com/pyodide/pyodide/releases/download/${pyodideVersion}/pyodide-${pyodideVersion}.tar.bz2";
     };
 
-    npmDepsHash = "sha256-yw/1n1jBCUtt8wUqJmIkB3W53wsXTKuAFG/EMwcTpx8=";
+    npmDepsHash = "sha256-9Wa6gP0asGPCoBJh8ufpweOg4zNf7onzBu08iQwgqis=";
 
     npmFlags = [ "--force" ];
 
@@ -84,6 +84,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     [
       accelerate
       aiocache
+      aiodns
       aiofiles
       aiohttp
       aiosqlite
@@ -121,14 +122,17 @@ python3Packages.buildPythonApplication (finalAttrs: {
       google-cloud-storage
       google-genai
       googleapis-common-protos
+      hiredis
       httpx
       itsdangerous
+      joserfc
       langchain
       langchain-classic
       langchain-community
       langchain-text-splitters
       ldap3
       loguru
+      lxml
       markdown
       mcp
       msoffcrypto-tool
@@ -149,12 +153,14 @@ python3Packages.buildPythonApplication (finalAttrs: {
       opentelemetry-sdk
       openpyxl
       opensearch-py
+      orjson
       pandas
       pillow
       psutil
       psycopg
       pyarrow
       pycrdt
+      pydantic
       pydub
       pyjwt
       pymdown-extensions
@@ -162,7 +168,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
       pypandoc
       pypdf
       python-dotenv
-      python-jose
       python-mimeparse
       python-multipart
       python-pptx
@@ -171,8 +176,9 @@ python3Packages.buildPythonApplication (finalAttrs: {
       pytz
       pyxlsb
       rank-bm25
-      rapidocr-onnxruntime
+      rapidocr
       redis
+      regex
       requests
       restrictedpython
       sentence-transformers
@@ -188,6 +194,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
       xlrd
       youtube-transcript-api
     ]
+    ++ (with httpx.optional-dependencies; brotli ++ cli ++ http2 ++ socks ++ zstd)
+    ++ uvicorn.optional-dependencies.standard
     ++ psycopg.optional-dependencies.c
     ++ pyjwt.optional-dependencies.crypto
     ++ sqlalchemy.optional-dependencies.asyncio
@@ -211,7 +219,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
       azure-search-documents
       colbert-ai
       elasticsearch
-      gcp-storage-emulator
       moto
       oracledb
       pinecone


### PR DESCRIPTION
Updates Open WebUI to 0.11.0 and synchronizes its Nix dependencies with upstream, including the `joserfc` and `rapidocr` migrations, new runtime dependencies, npm dependencies, and Pyodide 314.0.3.

Diff: https://github.com/open-webui/open-webui/compare/v0.10.2...v0.11.0

Changelog: https://github.com/open-webui/open-webui/blob/v0.11.0/CHANGELOG.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test