### PR TITLE
python3Packages.pygame-gui: fix METADATA version

### DIFF
--- a/pkgs/development/python-modules/pygame-gui/default.nix
+++ b/pkgs/development/python-modules/pygame-gui/default.nix
@@ -17,20 +17,19 @@
   writableTmpDirAsHomeHook,
 
   # passthru
-  nix-update-script,
+  writeScript,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "pygame-gui";
-  version = "0614";
+  version = "0.6.14";
   pyproject = true;
   __structuredAttrs = true;
-  # nixpkgs-update: no auto update
 
   src = fetchFromGitHub {
     owner = "MyreMylar";
     repo = "pygame_gui";
-    tag = "v_${finalAttrs.version}";
+    tag = "v_${lib.replaceString "." "" finalAttrs.version}";
     hash = "sha256-wLvWaJuXMXk7zOaSZfIpsXhQt+eCjOtlh8IRuKbR75o=";
   };
 
@@ -93,12 +92,14 @@ buildPythonPackage (finalAttrs: {
 
   disabledTestPaths = [ "tests/test_performance/test_text_performance.py" ];
 
-  passthru.updateScript = nix-update-script {
-    extraArgs = [
-      "--version-regex"
-      "v_(.*)"
-    ];
-  };
+  passthru.updateScript = writeScript "update.sh" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell --pure -i bash -p curl cacert jq nix-update git
+    set -xeuo pipefail
+
+    version=$(curl -s https://pypi.org/pypi/pygame-gui/json | jq -r '.info.version')
+    nix-update --version "$version" python3Packages.pygame-gui
+  '';
 
   meta = {
     description = "GUI system for pygame";


### PR DESCRIPTION
I tested the new updateScript

fixes https://hydra.nixos.org/build/338580660

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
