### PR TITLE
libcap_ng: support building python bindings

### DIFF
--- a/pkgs/by-name/li/libcap_ng/package.nix
+++ b/pkgs/by-name/li/libcap_ng/package.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   strictDeps = true;
+  __structuredAttrs = true;
   enableParallelBuilding = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libcap_ng/package.nix
+++ b/pkgs/by-name/li/libcap_ng/package.nix
@@ -66,6 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
     updateScript = nix-update-script { };
     tests = {
       pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+      python = python3Packages.libcap_ng;
     };
   };
 

--- a/pkgs/by-name/li/libcap_ng/package.nix
+++ b/pkgs/by-name/li/libcap_ng/package.nix
@@ -7,6 +7,9 @@
   swig,
   testers,
   nix-update-script,
+  linuxHeaders,
+  python3Packages,
+  withPython ? false,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -35,6 +38,17 @@ stdenv.mkDerivation (finalAttrs: {
     autoreconfHook
     pkg-config
     swig
+  ]
+  ++ lib.optionals withPython [
+    python3Packages.python # m4
+  ];
+
+  buildInputs = lib.optionals withPython [
+    python3Packages.python
+  ];
+
+  nativeCheckInputs = lib.optionals withPython [
+    python3Packages.pythonImportsCheckHook
   ];
 
   outputs = [
@@ -44,7 +58,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   configureFlags = [
-    "--without-python"
+    (lib.withFeature withPython "python")
+    "--with-capability_header='${linuxHeaders}/include/linux/capability.h'" # required to link bindings
   ];
 
   passthru = {
@@ -58,7 +73,18 @@ stdenv.mkDerivation (finalAttrs: {
   # see https://github.com/stevegrubb/libcap-ng?tab=readme-ov-file#note-to-distributions
   doCheck = true;
 
+  pythonImportsCheck = [
+    "capng"
+  ];
+
+  preCheck = ''
+    patchShebangs bindings/test bindings/python3/test
+  '';
+
   meta = {
+    broken =
+      # m4 python include script fails if cpu bit depth is different across build/host architectures
+      withPython && (stdenv.hostPlatform.parsed.cpu.bits != stdenv.buildPlatform.parsed.cpu.bits);
     changelog = "https://people.redhat.com/sgrubb/libcap-ng/ChangeLog";
     description = "Library for working with POSIX capabilities";
     homepage = "https://people.redhat.com/sgrubb/libcap-ng/";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9210,6 +9210,19 @@ self: super: with self; {
 
   libbs = callPackage ../development/python-modules/libbs { };
 
+  libcap_ng = callPackage (
+    {
+      python,
+      pythonImportsCheckHook,
+    }@python3Packages:
+    toPythonModule (
+      pkgs.libcap_ng.override {
+        withPython = true;
+        inherit python3Packages;
+      }
+    )
+  ) { };
+
   libcloud = callPackage ../development/python-modules/libcloud { };
 
   libcomps = lib.pipe pkgs.libcomps [


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
