### PR TITLE
whatcable: 1.1.9 -> 1.2.1

### DIFF
--- a/pkgs/by-name/wh/whatcable/package.nix
+++ b/pkgs/by-name/wh/whatcable/package.nix
@@ -10,14 +10,14 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "whatcable";
-  version = "1.1.9";
+  version = "1.2.1";
 
   strictDeps = true;
   __structuredAttrs = true;
 
   src = fetchzip {
     url = "https://github.com/darrylmorley/whatcable/releases/download/v${finalAttrs.version}/WhatCable.zip";
-    hash = "sha256-0taHQE4aUJrbRdWXZZyHfJ+2EzpEiXpsj8HWg04lgXg=";
+    hash = "sha256-znu0y7rj7HYxTs3Kr9hR44461NoROMKGX0KHsaNfAes=";
   };
 
   dontPatch = true;


### PR DESCRIPTION
Updates WhatCable from 1.1.9 to 1.2.1.

Release highlights:

- [v1.2.0](https://github.com/darrylmorley/whatcable/releases/tag/v1.2.0) improves desktop USB-C port grouping and Thunderbolt dock topology, and adds a switch to skip deep USB probing.
- [v1.2.1](https://github.com/darrylmorley/whatcable/releases/tag/v1.2.1) fixes charger wattage reporting and improves Intel Mac, updater, and diagnostic-probe behavior.

The packaged app's version check, nested code signatures, CLI version output, and JSON output were validated on aarch64-darwin.

AI disclosure: OpenAI Codex (GPT-5) assisted with the package update, validation, and this pull request description.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
