### PR TITLE
[Backport release-26.05] jetbrains.*: oss: mark as insecure; others: 2026.1.* -> 2026.2.0.*

### DIFF
--- a/pkgs/applications/editors/jetbrains/builder/linux.nix
+++ b/pkgs/applications/editors/jetbrains/builder/linux.nix
@@ -86,6 +86,8 @@ lib.extendMkDerivation {
         fontconfig
         libGL
         libx11
+        # required for the bundled jcef-plugin
+        udev
       ];
 
       nativeBuildInputs = nativeBuildInputs ++ [
@@ -184,6 +186,10 @@ lib.extendMkDerivation {
         ln -s "$item/share/applications" $out/share
 
         runHook postInstall
+      '';
+
+      preFixup = ''
+        addAutoPatchelfSearchPath "${jdk.home}/lib"
       '';
 
       preferLocalBuild = !(finalAttrs.meta.license.free or true);

--- a/pkgs/applications/editors/jetbrains/ides/clion.nix
+++ b/pkgs/applications/editors/jetbrains/ides/clion.nix
@@ -21,20 +21,20 @@ let
   # update-script-start: urls
   urls = {
     x86_64-linux = {
-      url = "https://download.jetbrains.com/cpp/CLion-2026.1.4.tar.gz";
-      hash = "sha256-uOhFuDqVw3pxtqBvOQH+FpJTFrneaD/R0VcpJZRYD2o=";
+      url = "https://download.jetbrains.com/cpp/CLion-2026.2.0.1.tar.gz";
+      hash = "sha256-3/SNgt6bpr0aIQWmTJnvkgftdZE0M5wcE/LDS1Hk4R0=";
     };
     aarch64-linux = {
-      url = "https://download.jetbrains.com/cpp/CLion-2026.1.4-aarch64.tar.gz";
-      hash = "sha256-I6IKQng4lNtRlQIq08K5bueqgKI/q1awX4EuRnyAnOk=";
+      url = "https://download.jetbrains.com/cpp/CLion-2026.2.0.1-aarch64.tar.gz";
+      hash = "sha256-IG2U2v9mTk+GCbB9jJVoX5hKju37+DfqRiMtxu8b8bo=";
     };
     x86_64-darwin = {
       url = "https://download.jetbrains.com/cpp/CLion-2026.1.4.dmg";
       hash = "sha256-AJt+K1zv4eyjdzubUeFGwB9mqzvOeb3ffA2k0MajPBs=";
     };
     aarch64-darwin = {
-      url = "https://download.jetbrains.com/cpp/CLion-2026.1.4-aarch64.dmg";
-      hash = "sha256-i3stX7dyRgSOJkFTMD9/hkw6e2mGNqn13S7X/vJ66RQ=";
+      url = "https://download.jetbrains.com/cpp/CLion-2026.2.0.1-aarch64.dmg";
+      hash = "sha256-nkkJ80rc1bApEBMZT0ZjZQcnhkzAG3i1p9GhQUA4gT4=";
     };
   };
   # update-script-end: urls
@@ -48,8 +48,8 @@ in
   product = "CLion";
 
   # update-script-start: version
-  version = "2026.1.4";
-  buildNumber = "261.26222.59";
+  version = "2026.2.0.1";
+  buildNumber = "262.8665.321";
   # update-script-end: version
 
   src = fetchurl (urls.${system} or (throw "Unsupported system: ${system}"));

--- a/pkgs/applications/editors/jetbrains/ides/datagrip.nix
+++ b/pkgs/applications/editors/jetbrains/ides/datagrip.nix
@@ -12,20 +12,20 @@ let
   # update-script-start: urls
   urls = {
     x86_64-linux = {
-      url = "https://download.jetbrains.com/datagrip/datagrip-2026.1.3.tar.gz";
-      hash = "sha256-XxwvXiaWAfK318BjbzKPLVDeMBlOr5BFuD2bqU8+12o=";
+      url = "https://download.jetbrains.com/datagrip/datagrip-2026.2.1.tar.gz";
+      hash = "sha256-t3ZYBjpQR11jRTJX5LQx4q6j+Nro6wEi4y0DXsY5ZkU=";
     };
     aarch64-linux = {
-      url = "https://download.jetbrains.com/datagrip/datagrip-2026.1.3-aarch64.tar.gz";
-      hash = "sha256-G+tinD/+qM5HVR4u2E0cNXtdVsbwgK8/PdZ3ic6hf4M=";
+      url = "https://download.jetbrains.com/datagrip/datagrip-2026.2.1-aarch64.tar.gz";
+      hash = "sha256-m3XfF56WjiWyJjWg0wN0mCJ3oeBfZvy01V566xGUm3U=";
     };
     x86_64-darwin = {
       url = "https://download.jetbrains.com/datagrip/datagrip-2026.1.3.dmg";
       hash = "sha256-vW2LEonl0D9S0VxbeJX4jRrwhELGBwlOXwiHslvh06E=";
     };
     aarch64-darwin = {
-      url = "https://download.jetbrains.com/datagrip/datagrip-2026.1.3-aarch64.dmg";
-      hash = "sha256-Kyt3fYPXzwTVxPFVKd+atiHWb/i7gjGahz1MJ4iXxy8=";
+      url = "https://download.jetbrains.com/datagrip/datagrip-2026.2.1-aarch64.dmg";
+      hash = "sha256-1sMqgNPSAGTE3qjT3Dbp5MKJ6mCif1LHjyjnk4ixDUY=";
     };
   };
   # update-script-end: urls
@@ -39,8 +39,8 @@ mkJetBrainsProduct {
   product = "DataGrip";
 
   # update-script-start: version
-  version = "2026.1.3";
-  buildNumber = "261.24374.56";
+  version = "2026.2.1";
+  buildNumber = "262.8665.339";
   # update-script-end: version
 
   src = fetchurl (urls.${system} or (throw "Unsupported system: ${system}"));

--- a/pkgs/applications/editors/jetbrains/ides/gateway.nix
+++ b/pkgs/applications/editors/jetbrains/ides/gateway.nix
@@ -12,20 +12,20 @@ let
   # update-script-start: urls
   urls = {
     x86_64-linux = {
-      url = "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2026.1.3.tar.gz";
-      hash = "sha256-HizogKH6goX1NdcI/Fj4YsCRzDWfFvQGYSaMM9wVDCA=";
+      url = "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2026.2.tar.gz";
+      hash = "sha256-FdjMPo4SyWAojyqKm+FFdt3f7NuEfSFvH8I2ctygxjE=";
     };
     aarch64-linux = {
-      url = "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2026.1.3-aarch64.tar.gz";
-      hash = "sha256-CSe04BBo4jS1cIhu4NfZqaSHMaNue2eFUPa+1gOxuoo=";
+      url = "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2026.2-aarch64.tar.gz";
+      hash = "sha256-bYLMkv7/aNFyZOBLFp0SBFA44YCzFjqArTWEpJO+jmo=";
     };
     x86_64-darwin = {
       url = "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2026.1.3.dmg";
       hash = "sha256-WKwIP19y5EKO98JgEm468ofaRp/JO5z8lqNhtpsH4tY=";
     };
     aarch64-darwin = {
-      url = "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2026.1.3-aarch64.dmg";
-      hash = "sha256-AHY/lY0ARkW0VoSgy0t7LLNXA965PLooWBSWxBKBV5M=";
+      url = "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2026.2-aarch64.dmg";
+      hash = "sha256-FUus7mjiYWAiyIihEjhpEILYupLAFdjrA8xClovJU2o=";
     };
   };
   # update-script-end: urls
@@ -40,8 +40,8 @@ mkJetBrainsProduct {
   productShort = "Gateway";
 
   # update-script-start: version
-  version = "2026.1.3";
-  buildNumber = "261.25134.98";
+  version = "2026.2";
+  buildNumber = "262.8665.250";
   # update-script-end: version
 
   src = fetchurl (urls.${system} or (throw "Unsupported system: ${system}"));

--- a/pkgs/applications/editors/jetbrains/ides/goland.nix
+++ b/pkgs/applications/editors/jetbrains/ides/goland.nix
@@ -12,20 +12,20 @@ let
   # update-script-start: urls
   urls = {
     x86_64-linux = {
-      url = "https://download.jetbrains.com/go/goland-2026.1.4.tar.gz";
-      hash = "sha256-pHSbmAZ+tSfa0wdtDp/3Ib/GNMP30OFNQlHWUfMwrW0=";
+      url = "https://download.jetbrains.com/go/goland-2026.2.0.1.tar.gz";
+      hash = "sha256-nT/jmw0WFNwmtWR5be0KBUHJpM48phhYN7oUNOMCrok=";
     };
     aarch64-linux = {
-      url = "https://download.jetbrains.com/go/goland-2026.1.4-aarch64.tar.gz";
-      hash = "sha256-7s98kY08aKjdRGQLDkffeVhgj1FWurLmTTYmtb5Qx6c=";
+      url = "https://download.jetbrains.com/go/goland-2026.2.0.1-aarch64.tar.gz";
+      hash = "sha256-t6vH7fxtysgprc1EHH3XiIdHD6oCMcY/a1hu5aiYMxE=";
     };
     x86_64-darwin = {
       url = "https://download.jetbrains.com/go/goland-2026.1.4.dmg";
       hash = "sha256-RbvcLpLVyeL4B1DJ2/9Ub/6Cz6fJGXMPCHsJ705GsAo=";
     };
     aarch64-darwin = {
-      url = "https://download.jetbrains.com/go/goland-2026.1.4-aarch64.dmg";
-      hash = "sha256-y7mEke0z0MvQs+kMtrmrq7EeAtJUbgo6sGZrOB0MraM=";
+      url = "https://download.jetbrains.com/go/goland-2026.2.0.1-aarch64.dmg";
+      hash = "sha256-zrQAsOOR4OhAXnebwnRk3da4h4Gi0t8f+SIaEAiwM0Q=";
     };
   };
   # update-script-end: urls
@@ -39,8 +39,8 @@ in
   product = "Goland";
 
   # update-script-start: version
-  version = "2026.1.4";
-  buildNumber = "261.26222.72";
+  version = "2026.2.0.1";
+  buildNumber = "262.8665.336";
   # update-script-end: version
 
   src = fetchurl (urls.${system} or (throw "Unsupported system: ${system}"));

--- a/pkgs/applications/editors/jetbrains/ides/idea-oss.nix
+++ b/pkgs/applications/editors/jetbrains/ides/idea-oss.nix
@@ -70,5 +70,11 @@ mkJetBrainsProduct {
     ];
     license = lib.licenses.asl20;
     sourceProvenance = [ lib.sourceTypes.fromSource ];
+    knownVulnerabilities = [
+      ''
+        This version of IDEA has multiple known security vulnerabilities, see NIXPKGS-2026-2269: https://tracker.security.nixos.org/issues/NIXPKGS-2026-2269.
+        The package `jetbrains.idea-oss` is currently not receiving updates in nixpkgs, consider using `jetbrains.idea`.
+      ''
+    ];
   };
 }

--- a/pkgs/applications/editors/jetbrains/ides/idea.nix
+++ b/pkgs/applications/editors/jetbrains/ides/idea.nix
@@ -15,20 +15,20 @@ let
   # update-script-start: urls
   urls = {
     x86_64-linux = {
-      url = "https://download.jetbrains.com/idea/ideaIU-2026.1.4.tar.gz";
-      hash = "sha256-MQTYXZUH/4ggZeP465UGQCtKgSkJLSaCZiu26cTwY/w=";
+      url = "https://download.jetbrains.com/idea/ideaIU-2026.2.0.1.tar.gz";
+      hash = "sha256-kU4x4xtOEoXVOM8/rlswCvCLz/NrwpisYgBQS74S8YA=";
     };
     aarch64-linux = {
-      url = "https://download.jetbrains.com/idea/ideaIU-2026.1.4-aarch64.tar.gz";
-      hash = "sha256-MDZFuLrUxcCIc0Zhi4QhgKPeU7Pgs9oJ/FxQH1n3gBM=";
+      url = "https://download.jetbrains.com/idea/ideaIU-2026.2.0.1-aarch64.tar.gz";
+      hash = "sha256-HkRhBq1vh1iRjshmX+D9cT1iSRZk/NEz6YkTwWhKl0g=";
     };
     x86_64-darwin = {
       url = "https://download.jetbrains.com/idea/ideaIU-2026.1.4.dmg";
       hash = "sha256-8K+LiewiINP4S9eqV0kGWtfy2Ff/zvBwX89iX7mYZ78=";
     };
     aarch64-darwin = {
-      url = "https://download.jetbrains.com/idea/ideaIU-2026.1.4-aarch64.dmg";
-      hash = "sha256-XIBK/+Lxaz9dX+Lxl7HXsl+Z3Z7GBzSuDxNssb/4A2s=";
+      url = "https://download.jetbrains.com/idea/ideaIU-2026.2.0.1-aarch64.dmg";
+      hash = "sha256-vN2wVaM5V9H5Xnrjv9MIKT0PgSJQqrk5kWQWOqEYOZ8=";
     };
   };
   # update-script-end: urls
@@ -43,8 +43,8 @@ mkJetBrainsProduct {
   productShort = "IDEA";
 
   # update-script-start: version
-  version = "2026.1.4";
-  buildNumber = "261.26222.65";
+  version = "2026.2.0.1";
+  buildNumber = "262.8665.337";
   # update-script-end: version
 
   src = fetchurl (urls.${system} or (throw "Unsupported system: ${system}"));

--- a/pkgs/applications/editors/jetbrains/ides/mps.nix
+++ b/pkgs/applications/editors/jetbrains/ides/mps.nix
@@ -12,20 +12,20 @@ let
   # update-script-start: urls
   urls = {
     x86_64-linux = {
-      url = "https://download.jetbrains.com/mps/2025.3/MPS-2025.3.tar.gz";
-      hash = "sha256-xAI+UrTheCTWHSdoI4YZvhTlrlc121M+OVFkfzd7a3k=";
+      url = "https://download.jetbrains.com/mps/2026.1/MPS-2026.1.tar.gz";
+      hash = "sha256-NbURKu1jTPoJQvV8FpMacBa+FehF7XfF6xZmIhFlb2A=";
     };
     aarch64-linux = {
-      url = "https://download.jetbrains.com/mps/2025.3/MPS-2025.3.tar.gz";
-      hash = "sha256-xAI+UrTheCTWHSdoI4YZvhTlrlc121M+OVFkfzd7a3k=";
+      url = "https://download.jetbrains.com/mps/2026.1/MPS-2026.1.tar.gz";
+      hash = "sha256-NbURKu1jTPoJQvV8FpMacBa+FehF7XfF6xZmIhFlb2A=";
     };
     x86_64-darwin = {
       url = "https://download.jetbrains.com/mps/2025.3/MPS-2025.3-macos.dmg";
       hash = "sha256-whYAjKkF79mrknHflZnvOOy2bLosYUguelZDSuPt3uY=";
     };
     aarch64-darwin = {
-      url = "https://download.jetbrains.com/mps/2025.3/MPS-2025.3-macos-aarch64.dmg";
-      hash = "sha256-3HnEHOhRRI9IYjBhc5FO7h5j4jBBDtZTVkmO/S1fBEQ=";
+      url = "https://download.jetbrains.com/mps/2026.1/MPS-2026.1-macos-aarch64.dmg";
+      hash = "sha256-5VtPS26/vCKa+mfDAQKgd9x5A+Cqv39Kz+2EKkgul+I=";
     };
   };
   # update-script-end: urls
@@ -39,8 +39,8 @@ mkJetBrainsProduct {
   product = "MPS";
 
   # update-script-start: version
-  version = "2025.3";
-  buildNumber = "253.28294.432";
+  version = "2026.1";
+  buildNumber = "261.25134.779";
   # update-script-end: version
 
   src = fetchurl (urls.${system} or (throw "Unsupported system: ${system}"));

--- a/pkgs/applications/editors/jetbrains/ides/phpstorm.nix
+++ b/pkgs/applications/editors/jetbrains/ides/phpstorm.nix
@@ -12,20 +12,20 @@ let
   # update-script-start: urls
   urls = {
     x86_64-linux = {
-      url = "https://download.jetbrains.com/webide/PhpStorm-2026.1.4.tar.gz";
-      hash = "sha256-SF25D7dDn7b6AzcXEDLKwhpjTnCqYz1fEmvND5dl8Is=";
+      url = "https://download.jetbrains.com/webide/PhpStorm-2026.2.0.1.tar.gz";
+      hash = "sha256-SZr1Qd3ISuTsMuuoLFc0O79kvPMrSz26PmLeKvRJLbQ=";
     };
     aarch64-linux = {
-      url = "https://download.jetbrains.com/webide/PhpStorm-2026.1.4-aarch64.tar.gz";
-      hash = "sha256-T9q3/nxv/AA6y7CHWtOhUibR7bnKN8OZmfN3NWYTsIQ=";
+      url = "https://download.jetbrains.com/webide/PhpStorm-2026.2.0.1-aarch64.tar.gz";
+      hash = "sha256-W+59PmLs47hhAtjbM+4ARb1WQS1MmPiL/GuIoQ887mU=";
     };
     x86_64-darwin = {
       url = "https://download.jetbrains.com/webide/PhpStorm-2026.1.4.dmg";
       hash = "sha256-W7EwYu7S3hs1564tXq8H1Uok/Gwx/8QJO4brUGOfFY4=";
     };
     aarch64-darwin = {
-      url = "https://download.jetbrains.com/webide/PhpStorm-2026.1.4-aarch64.dmg";
-      hash = "sha256-XGcfEWHHeLugvkT/WlQDsVRN33F46b1PCNhINQitqSY=";
+      url = "https://download.jetbrains.com/webide/PhpStorm-2026.2.0.1-aarch64.dmg";
+      hash = "sha256-fI60xJ94onmXAzJBy3+GUHnJH+/ukQTCuU2j3s1ZI5o=";
     };
   };
   # update-script-end: urls
@@ -39,8 +39,8 @@ mkJetBrainsProduct {
   product = "PhpStorm";
 
   # update-script-start: version
-  version = "2026.1.4";
-  buildNumber = "261.26222.71";
+  version = "2026.2.0.1";
+  buildNumber = "262.8665.325";
   # update-script-end: version
 
   src = fetchurl (urls.${system} or (throw "Unsupported system: ${system}"));

--- a/pkgs/applications/editors/jetbrains/ides/pycharm-oss.nix
+++ b/pkgs/applications/editors/jetbrains/ides/pycharm-oss.nix
@@ -63,6 +63,12 @@ in
     ];
     license = lib.licenses.asl20;
     sourceProvenance = [ lib.sourceTypes.fromSource ];
+    knownVulnerabilities = [
+      ''
+        This version of PyCharm has multiple known security vulnerabilities, see NIXPKGS-2026-2269: https://tracker.security.nixos.org/issues/NIXPKGS-2026-2269.
+        The package `jetbrains.pycharm-oss` is currently not receiving updates in nixpkgs, consider using `jetbrains.pycharm`.
+      ''
+    ];
   };
 }).overrideAttrs
   pyCharmCommonOverrides

--- a/pkgs/applications/editors/jetbrains/ides/pycharm.nix
+++ b/pkgs/applications/editors/jetbrains/ides/pycharm.nix
@@ -13,20 +13,20 @@ let
   # update-script-start: urls
   urls = {
     x86_64-linux = {
-      url = "https://download.jetbrains.com/python/pycharm-2026.1.4.tar.gz";
-      hash = "sha256-RIufgZhg/n+D1uEdcDyYRjTDfh8Jicyz4h0B1kTbVXs=";
+      url = "https://download.jetbrains.com/python/pycharm-2026.2.tar.gz";
+      hash = "sha256-rDb3wHQ0ZSFb+CJwebdycpRTOMSFwdprkk5WRoBGvVo=";
     };
     aarch64-linux = {
-      url = "https://download.jetbrains.com/python/pycharm-2026.1.4-aarch64.tar.gz";
-      hash = "sha256-71FbYpN0seJ5k/yZA7aoXgU4W/N1BhjtKl7W7Hic9UE=";
+      url = "https://download.jetbrains.com/python/pycharm-2026.2-aarch64.tar.gz";
+      hash = "sha256-O2PS9JDBTFQcmK/YUfIYBpo8iFzq7dm9sA5aByhc+AI=";
     };
     x86_64-darwin = {
       url = "https://download.jetbrains.com/python/pycharm-2026.1.4.dmg";
       hash = "sha256-Q5hTcYoNUzmAxwcsXJNS4medQjFKWc/Sgkybt4PQPfg=";
     };
     aarch64-darwin = {
-      url = "https://download.jetbrains.com/python/pycharm-2026.1.4-aarch64.dmg";
-      hash = "sha256-qxSgp8r4S0KXjCCTIoAiEZFCn3uBE/0pWLLA6td0Fq0=";
+      url = "https://download.jetbrains.com/python/pycharm-2026.2-aarch64.dmg";
+      hash = "sha256-wiOQISfsvBnlpjeyzAPXUJfXOwYwrZ8nGoiRRvQ4YUY=";
     };
   };
   # update-script-end: urls
@@ -40,8 +40,8 @@ in
   product = "PyCharm";
 
   # update-script-start: version
-  version = "2026.1.4";
-  buildNumber = "261.26222.68";
+  version = "2026.2";
+  buildNumber = "262.8665.309";
   # update-script-end: version
 
   src = fetchurl (urls.${system} or (throw "Unsupported system: ${system}"));

--- a/pkgs/applications/editors/jetbrains/ides/rider.nix
+++ b/pkgs/applications/editors/jetbrains/ides/rider.nix
@@ -24,20 +24,20 @@ let
   # update-script-start: urls
   urls = {
     x86_64-linux = {
-      url = "https://download.jetbrains.com/rider/JetBrains.Rider-2026.1.4.tar.gz";
-      hash = "sha256-K+X2M4idv+oDqC/dkbzMTX3W3zx0b0e8ZTsxkP7rAfI=";
+      url = "https://download.jetbrains.com/rider/JetBrains.Rider-2026.2.tar.gz";
+      hash = "sha256-7rvEnimFJJbLx/Y5nrR7VuipX8khxNrnwFzKay9tIqc=";
     };
     aarch64-linux = {
-      url = "https://download.jetbrains.com/rider/JetBrains.Rider-2026.1.4-aarch64.tar.gz";
-      hash = "sha256-GXmyBrqxUpwK4djjwllvK+pnfktDrDHpLJKoe4D2xFo=";
+      url = "https://download.jetbrains.com/rider/JetBrains.Rider-2026.2-aarch64.tar.gz";
+      hash = "sha256-fvdgV1Q8gLgYB/ihrpukJW9DqLupZ45JGKad7vovAIo=";
     };
     x86_64-darwin = {
       url = "https://download.jetbrains.com/rider/JetBrains.Rider-2026.1.4.dmg";
       hash = "sha256-GfQ5WpKunJ+JhE1VcArm3UxZ5udCbfnS1Kw3D4gZorA=";
     };
     aarch64-darwin = {
-      url = "https://download.jetbrains.com/rider/JetBrains.Rider-2026.1.4-aarch64.dmg";
-      hash = "sha256-cfwT22BN1jzKZzrZHMQqYFJPGuRwta/sqoOJOp+PfBE=";
+      url = "https://download.jetbrains.com/rider/JetBrains.Rider-2026.2-aarch64.dmg";
+      hash = "sha256-Y+hXTTMqHHGm5pJhQ8yepmZmAzkiF7ylOxroOa9BG6Q=";
     };
   };
   # update-script-end: urls
@@ -51,8 +51,8 @@ in
   product = "Rider";
 
   # update-script-start: version
-  version = "2026.1.4";
-  buildNumber = "261.26222.60";
+  version = "2026.2";
+  buildNumber = "262.8665.328";
   # update-script-end: version
 
   src = fetchurl (urls.${system} or (throw "Unsupported system: ${system}"));

--- a/pkgs/applications/editors/jetbrains/ides/ruby-mine.nix
+++ b/pkgs/applications/editors/jetbrains/ides/ruby-mine.nix
@@ -12,20 +12,20 @@ let
   # update-script-start: urls
   urls = {
     x86_64-linux = {
-      url = "https://download.jetbrains.com/ruby/RubyMine-2026.1.4.tar.gz";
-      hash = "sha256-0EhtU4XKWI9i7ij+m5uvxHSYnbQaYJy8Sa6S1OW4CFU=";
+      url = "https://download.jetbrains.com/ruby/RubyMine-2026.2.tar.gz";
+      hash = "sha256-k+T5QDCIcuqHWrjhoCGcym/Q9v4YBviacg9rnNFBIRM=";
     };
     aarch64-linux = {
-      url = "https://download.jetbrains.com/ruby/RubyMine-2026.1.4-aarch64.tar.gz";
-      hash = "sha256-oSu19pkGVWt31vWBdAffSZsu4QzsUznVbUSwDy98nug=";
+      url = "https://download.jetbrains.com/ruby/RubyMine-2026.2-aarch64.tar.gz";
+      hash = "sha256-2T6thTMYAlfb6yJKbpuIyVtj7Af/P3AjQAVl16H35nM=";
     };
     x86_64-darwin = {
       url = "https://download.jetbrains.com/ruby/RubyMine-2026.1.4.dmg";
       hash = "sha256-BLo2weIJK8gQAcMtAiETM7FMdhw9aoFIGh5Yqjv3k7s=";
     };
     aarch64-darwin = {
-      url = "https://download.jetbrains.com/ruby/RubyMine-2026.1.4-aarch64.dmg";
-      hash = "sha256-4wEnwcPRtwp0wxePUMiLow6sMxirwndRMdmJL8LBh9k=";
+      url = "https://download.jetbrains.com/ruby/RubyMine-2026.2-aarch64.dmg";
+      hash = "sha256-rgskPMKLtgPpdSbbENJcE4g75VzqeWPLzxoXqzln67k=";
     };
   };
   # update-script-end: urls
@@ -39,8 +39,8 @@ mkJetBrainsProduct {
   product = "RubyMine";
 
   # update-script-start: version
-  version = "2026.1.4";
-  buildNumber = "261.26222.67";
+  version = "2026.2";
+  buildNumber = "262.8665.308";
   # update-script-end: version
 
   src = fetchurl (urls.${system} or (throw "Unsupported system: ${system}"));

--- a/pkgs/applications/editors/jetbrains/ides/rust-rover.nix
+++ b/pkgs/applications/editors/jetbrains/ides/rust-rover.nix
@@ -18,20 +18,20 @@ let
   # update-script-start: urls
   urls = {
     x86_64-linux = {
-      url = "https://download.jetbrains.com/rustrover/RustRover-2026.1.4.tar.gz";
-      hash = "sha256-8x/AP6uKSVJavwjA9tYT1IM1xVspOZZzwmcwpGloIcw=";
+      url = "https://download.jetbrains.com/rustrover/RustRover-2026.2.tar.gz";
+      hash = "sha256-xHg0d7wdlcXy3c/5STlWaeouV3rMBENRB1lLqZSulqE=";
     };
     aarch64-linux = {
-      url = "https://download.jetbrains.com/rustrover/RustRover-2026.1.4-aarch64.tar.gz";
-      hash = "sha256-KpF3jCnLKCEeEXkBdB8ZsPPqP9FOVRTwRV/FQLKyh1Q=";
+      url = "https://download.jetbrains.com/rustrover/RustRover-2026.2-aarch64.tar.gz";
+      hash = "sha256-WU+OeMZp9f8QkNbA2ZKYyYG5kt65KOvaA003SkskCow=";
     };
     x86_64-darwin = {
       url = "https://download.jetbrains.com/rustrover/RustRover-2026.1.4.dmg";
       hash = "sha256-2BwgAD0xF9IxRJh+gW4vLzBW13rFQSzQPbEwdmQGvLU=";
     };
     aarch64-darwin = {
-      url = "https://download.jetbrains.com/rustrover/RustRover-2026.1.4-aarch64.dmg";
-      hash = "sha256-Hly4NBv9mg/RMmxCM6m9w5eS/CQ7ycxp7V2VQZwyGQE=";
+      url = "https://download.jetbrains.com/rustrover/RustRover-2026.2-aarch64.dmg";
+      hash = "sha256-/cdvXf0qYXxgIi+uh9O6I0KIAOV7Z7QQ+lV5Y2xUNy0=";
     };
   };
   # update-script-end: urls
@@ -45,8 +45,8 @@ in
   product = "RustRover";
 
   # update-script-start: version
-  version = "2026.1.4";
-  buildNumber = "261.26222.73";
+  version = "2026.2";
+  buildNumber = "262.8665.323";
   # update-script-end: version
 
   src = fetchurl (urls.${system} or (throw "Unsupported system: ${system}"));

--- a/pkgs/applications/editors/jetbrains/ides/webstorm.nix
+++ b/pkgs/applications/editors/jetbrains/ides/webstorm.nix
@@ -12,20 +12,20 @@ let
   # update-script-start: urls
   urls = {
     x86_64-linux = {
-      url = "https://download.jetbrains.com/webstorm/WebStorm-2026.1.4.tar.gz";
-      hash = "sha256-BPuMTwZ3Xkk4SBRCdgZ8vCoEYjhTa3d8CFOqrGlcGg0=";
+      url = "https://download.jetbrains.com/webstorm/WebStorm-2026.2.0.1.tar.gz";
+      hash = "sha256-FEe4EDYWJwGt5hEdbf0A6g2+ZyIrX4ztzQYmZe5GZPg=";
     };
     aarch64-linux = {
-      url = "https://download.jetbrains.com/webstorm/WebStorm-2026.1.4-aarch64.tar.gz";
-      hash = "sha256-f9KenMq1gtldzpBraSBwOb/186WQwh1ps5Ypj5JoOU0=";
+      url = "https://download.jetbrains.com/webstorm/WebStorm-2026.2.0.1-aarch64.tar.gz";
+      hash = "sha256-pt1MwGNXHT1QlePbVdtkwtYpenKlf53DGDG24+PM9tc=";
     };
     x86_64-darwin = {
       url = "https://download.jetbrains.com/webstorm/WebStorm-2026.1.4.dmg";
       hash = "sha256-SGdo6WYMCcCBuZUjvURcMTbJUqhZ4MzFlSLg6Zjr84I=";
     };
     aarch64-darwin = {
-      url = "https://download.jetbrains.com/webstorm/WebStorm-2026.1.4-aarch64.dmg";
-      hash = "sha256-ZYen6Ew0GYbBAmuGCDACPBsygxZ6sT787o6gqF9DJzw=";
+      url = "https://download.jetbrains.com/webstorm/WebStorm-2026.2.0.1-aarch64.dmg";
+      hash = "sha256-WtvL7DLrchsKlMPrsYeluxoPo/sXBaUw0WO1mlxtHkc=";
     };
   };
   # update-script-end: urls
@@ -39,8 +39,8 @@ mkJetBrainsProduct {
   product = "WebStorm";
 
   # update-script-start: version
-  version = "2026.1.4";
-  buildNumber = "261.26222.58";
+  version = "2026.2.0.1";
+  buildNumber = "262.8665.341";
   # update-script-end: version
 
   src = fetchurl (urls.${system} or (throw "Unsupported system: ${system}"));

--- a/pkgs/applications/editors/jetbrains/ides/webstorm.nix
+++ b/pkgs/applications/editors/jetbrains/ides/webstorm.nix
@@ -12,20 +12,20 @@ let
   # update-script-start: urls
   urls = {
     x86_64-linux = {
-      url = "https://download.jetbrains.com/webstorm/WebStorm-2026.1.3.tar.gz";
-      hash = "sha256-lryIoVxoytyDyfgjnobQ3e94wIIohmIKL88fwf2I49w=";
+      url = "https://download.jetbrains.com/webstorm/WebStorm-2026.1.4.tar.gz";
+      hash = "sha256-BPuMTwZ3Xkk4SBRCdgZ8vCoEYjhTa3d8CFOqrGlcGg0=";
     };
     aarch64-linux = {
-      url = "https://download.jetbrains.com/webstorm/WebStorm-2026.1.3-aarch64.tar.gz";
-      hash = "sha256-oZQaxpVV0O4WlDE6Ia+KzHIF0SfWQBubBFIopSRMbvE=";
+      url = "https://download.jetbrains.com/webstorm/WebStorm-2026.1.4-aarch64.tar.gz";
+      hash = "sha256-f9KenMq1gtldzpBraSBwOb/186WQwh1ps5Ypj5JoOU0=";
     };
     x86_64-darwin = {
-      url = "https://download.jetbrains.com/webstorm/WebStorm-2026.1.3.dmg";
-      hash = "sha256-KUcQRWYUD/+4HHWnkGuqoltqL2an0WQkUEfUcttwjCI=";
+      url = "https://download.jetbrains.com/webstorm/WebStorm-2026.1.4.dmg";
+      hash = "sha256-SGdo6WYMCcCBuZUjvURcMTbJUqhZ4MzFlSLg6Zjr84I=";
     };
     aarch64-darwin = {
-      url = "https://download.jetbrains.com/webstorm/WebStorm-2026.1.3-aarch64.dmg";
-      hash = "sha256-1N1RtN1QLvuJ1QL8jbN5TdbOHAHSN84W9XEK2PEPijI=";
+      url = "https://download.jetbrains.com/webstorm/WebStorm-2026.1.4-aarch64.dmg";
+      hash = "sha256-ZYen6Ew0GYbBAmuGCDACPBsygxZ6sT787o6gqF9DJzw=";
     };
   };
   # update-script-end: urls
@@ -39,8 +39,8 @@ mkJetBrainsProduct {
   product = "WebStorm";
 
   # update-script-start: version
-  version = "2026.1.3";
-  buildNumber = "261.25134.101";
+  version = "2026.1.4";
+  buildNumber = "261.26222.58";
   # update-script-end: version
 
   src = fetchurl (urls.${system} or (throw "Unsupported system: ${system}"));


### PR DESCRIPTION
manual backport of #545759 containing a missed commit for an update for WebStorm that we didn't backport before.

Fixes #545332 for NixOS 26.05.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
