### PR TITLE
firefox/wrapper: inject gsettings schema paths into XDG_DATA_DIRS

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -6,6 +6,7 @@
   lndir,
   config,
   buildPackages,
+  gsettings-desktop-schemas,
   jq,
   xdg-utils,
   writeText,
@@ -134,6 +135,12 @@ let
         ++ pkcs11Modules
         ++ lib.optionals (!isDarwin) gtk_modules;
       gtk_modules = lib.optionals (!isDarwin) [ libcanberra-gtk3 ];
+      # strictDeps prevents buildInputs from populating GSETTINGS_SCHEMAS_PATH.
+      # Revert when https://github.com/NixOS/nixpkgs/pull/546281 hits stable.
+      gsettingsSchemaPaths = lib.optionals (!isDarwin) [
+        "${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}"
+        "${browser.gtk3}/share/gsettings-schemas/${browser.gtk3.name}"
+      ];
 
       # Darwin does not rename bundled binaries
       launcherName = "${applicationName}${lib.optionalString (!isDarwin) nameSuffix}";
@@ -339,6 +346,11 @@ let
         ":"
         "${adwaita-icon-theme}/share"
 
+        "--prefix"
+        "XDG_DATA_DIRS"
+        ":"
+        (lib.concatStringsSep ":" gsettingsSchemaPaths)
+
         "--set-default"
         "MOZ_ENABLE_WAYLAND"
         "1"
@@ -485,9 +497,6 @@ let
             oldExe="$executablePrefix/.${applicationName}"-old
             mv "$executablePath" "$oldExe"
           fi
-        ''
-        + lib.optionalString (!isDarwin) ''
-          appendToVar makeWrapperArgs --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
         ''
         + ''
           concatTo makeWrapperArgs oldWrapperArgs


### PR DESCRIPTION
614574d1b002e82286c68fabc39ec29a95825680 ("firefox/wrapper: enable
strictDeps") was backported to release-26.05 to allow to backport a new
Thunderbird ESR release.

This broke injection of gsettings schema paths into XDG_DATA_DIRS for
both Thunderbird and Firefox (on Linux). This resulted in empty menus
with no text or icons in both apps when running with Wayland (X11 seems
to be not affected).

The issue is not present on master which has a fix to gapps wrapper
hook: a0ee89704420278abb4c28c7b974500b0d19d39c ("wrapGAppsHook: prepare
for structuredAttrs") that fixes incorrect output being wrapped for
mozilla wrapped apps (among other things).

We can pursue a backport of the wrapGAppsHook fix in 26.05:
https://github.com/NixOS/nixpkgs/pull/546281

But since it will take some time for it to arrive to release-26.05, this
patch attempts to fix the immediate issue in the firefox wrapper
instead.

Fixes #546204

---

How I tested it: ran Thunderbird through a Wayland compositor on Linux. Menus and text are back. (I was able to reproduce the issue without the patch.)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
