### PR TITLE
python3Packages.pythonMetadataCheckHook: add pythonMetadataCheckName escape-hatch

### DIFF
--- a/pkgs/development/interpreters/python/hooks/python-metadata-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-metadata-check-hook.sh
@@ -13,18 +13,18 @@ pythonMetadataCheckPhase() {
     pythonMetadataCheckOutput=$python
   fi
   # shellcheck disable=SC2154
-  derivationPname="$pname"
+  packageName="${pythonMetadataCheckName:-"$pname"}"
   # shellcheck disable=SC2154
   derivationVersion="$version"
   # `python -P` avoids picking up egg-info dirs in $PWD
   metadataVersion="$(PYTHONPATH="$pythonMetadataCheckOutput/@pythonSitePackages@:$PYTHONPATH" \
-    @pythonInterpreter@ -P -c 'from importlib.metadata import version; import sys; print(version(sys.argv[1]))' "$derivationPname")"
+    @pythonInterpreter@ -P -c 'from importlib.metadata import version; import sys; print(version(sys.argv[1]))' "$packageName")"
 
   # chethat both versions can be parsed
   @pythonWithPackaging@ -c "from packaging.version import Version; from sys import argv; Version(argv[1]); Version(argv[2])" "$derivationVersion" "$metadataVersion"
 
   if @pythonWithPackaging@ -c "from packaging.version import Version; from sys import argv, exit; exit(Version(argv[1]) == Version(argv[2]))" "$derivationVersion" "$metadataVersion"; then
-    echo "The '$derivationPname' derivation has version '$derivationVersion' but .dist-info/METADATA specifies version '$metadataVersion'."
+    echo "The '$packageName' package has version '$derivationVersion' in the derivation but .dist-info/METADATA specifies version '$metadataVersion'."
     echo "This usually means that the wrong version is hardcoded in pyproject.toml or setup.{py,cfg}."
     echo "Use the pyprojectVersionPatchHook or patch the version manually so that the project metadata matches the derivation's version."
     exit 1

--- a/pkgs/development/interpreters/python/hooks/python-metadata-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-metadata-check-hook.sh
@@ -7,16 +7,17 @@ pythonMetadataCheckPhase() {
   echo "Executing pythonMetadataCheckPhase"
 
   # shellcheck disable=SC2154
-  pythonMetadataCheckOutput="$out"
+  local pythonMetadataCheckOutput="$out"
   if [[ -n "${python-}" ]]; then
     echo "Using python specific output \$python for metadata check"
     pythonMetadataCheckOutput=$python
   fi
   # shellcheck disable=SC2154
-  packageName="${pythonMetadataCheckName:-"$pname"}"
+  local packageName="${pythonMetadataCheckName:-"$pname"}"
   # shellcheck disable=SC2154
-  derivationVersion="$version"
+  local derivationVersion="$version"
   # `python -P` avoids picking up egg-info dirs in $PWD
+  local metadataVersion
   metadataVersion="$(PYTHONPATH="$pythonMetadataCheckOutput/@pythonSitePackages@:$PYTHONPATH" \
     @pythonInterpreter@ -P -c 'from importlib.metadata import version; import sys; print(version(sys.argv[1]))' "$packageName")"
 

--- a/pkgs/development/interpreters/python/hooks/python-metadata-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-metadata-check-hook.sh
@@ -21,7 +21,7 @@ pythonMetadataCheckPhase() {
   metadataVersion="$(PYTHONPATH="$pythonMetadataCheckOutput/@pythonSitePackages@:$PYTHONPATH" \
     @pythonInterpreter@ -P -c 'from importlib.metadata import version; import sys; print(version(sys.argv[1]))' "$packageName")"
 
-  # chethat both versions can be parsed
+  # check that both versions can be parsed
   @pythonWithPackaging@ -c "from packaging.version import Version; from sys import argv; Version(argv[1]); Version(argv[2])" "$derivationVersion" "$metadataVersion"
 
   if @pythonWithPackaging@ -c "from packaging.version import Version; from sys import argv, exit; exit(Version(argv[1]) == Version(argv[2]))" "$derivationVersion" "$metadataVersion"; then


### PR DESCRIPTION
- **python3Packages.pythonMetadataCheckHook: add pythonMetadataCheckName escape-hatch**
- **python3Packages.pythonMetadataCheckHook: avoid leaking internal variables**
- **python3Packages.pythonMetadataCheckHook: fix typo**

Sometimes there are valid reasons to not have a match between pname and the resulting package.
This adds `pythonMetadataCheckName` as a way to set the package name that `pythonMetadataCheckHook` checks instead of relying on pname.

Reasons one might want to have a mismatch between pname and the package name:

* to handle pypi and package name mismatches
* e.g. `*-cuda` or `*-rocm` pname variants
* to help spot debug, test and intermediate builds that should not get propagated (i.e. gradio.sans-reverse-dependencies)

This was tested on pytest.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
