### PR TITLE
python3Packages.e2b: 1.5.1 -> 2.35.0, python3Packages.e2b-code-interpreter: 1.5.1 -> 2.9.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18694,6 +18694,12 @@
     githubId = 54669781;
     keys = [ { fingerprint = "293B 93D8 A471 059F 85D7  16A6 5BA9 2099 D9BE 2DAA"; } ];
   };
+  mishushakov = {
+    email = "mish@e2b.dev";
+    github = "mishushakov";
+    githubId = 10400064;
+    name = "Mish Ushakov";
+  };
   misilelab = {
     name = "misilelab";
     email = "misileminecord@gmail.com";

--- a/pkgs/development/python-modules/connectrpc/default.nix
+++ b/pkgs/development/python-modules/connectrpc/default.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  uv-build,
+
+  # dependencies
+  protobuf-py,
+  pyqwest,
+
+  # tests
+  asgiref,
+  brotli,
+  protobuf,
+  pytest-asyncio,
+  pytest-timeout,
+  pytestCheckHook,
+  zstandard,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "connectrpc";
+  version = "0.11.1";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "connectrpc";
+    repo = "connect-py";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Z0ltm1HZH2hFhKiAMaaoz9EVqzbxASLZ6wRpQx9XU0Q=";
+  };
+
+  build-system = [
+    uv-build
+  ];
+
+  dependencies = [
+    # Upstream pins protobuf-py to this exact version; bump the two together.
+    protobuf-py
+    pyqwest
+  ];
+
+  # The top-level module only re-exports __version__, so import the submodules
+  # that actually pull in pyqwest and protobuf.
+  pythonImportsCheck = [
+    "connectrpc.client"
+    "connectrpc.server"
+  ];
+
+  nativeCheckInputs = [
+    asgiref
+    brotli
+    # connectrpc.compat bridges to google's protobuf runtime.
+    protobuf
+    pytest-asyncio
+    pytest-timeout
+    pytestCheckHook
+    zstandard
+  ];
+
+  disabledTestPaths = [
+    # Drives the example Flask app from the unpublished `example` workspace member.
+    "test/test_example.py"
+    # Needs `pyvoy`, which is not packaged in nixpkgs.
+    "test/test_grpc.py"
+  ];
+
+  meta = {
+    description = "Server and client runtime library for Connect RPC";
+    homepage = "https://github.com/connectrpc/connect-py";
+    changelog = "https://github.com/connectrpc/connect-py/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mishushakov ];
+  };
+})

--- a/pkgs/development/python-modules/e2b-code-interpreter/default.nix
+++ b/pkgs/development/python-modules/e2b-code-interpreter/default.nix
@@ -66,6 +66,9 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://github.com/e2b-dev/code-interpreter/tree/main/python";
     changelog = "https://github.com/e2b-dev/code-interpreter/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ GaetanLepage ];
+    maintainers = with lib.maintainers; [
+      GaetanLepage
+      mishushakov
+    ];
   };
 })

--- a/pkgs/development/python-modules/e2b-code-interpreter/default.nix
+++ b/pkgs/development/python-modules/e2b-code-interpreter/default.nix
@@ -10,21 +10,27 @@
   attrs,
   e2b,
   httpx,
+
+  # tests
+  pytest-asyncio,
+  pytest-xdist,
+  pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "e2b-code-interpreter";
-  inherit (e2b) version;
+  version = "2.9.1";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "e2b-dev";
     repo = "code-interpreter";
-    tag = "@e2b/code-interpreter-python@${version}";
-    hash = "sha256-a2rc7BtV+qwtqlB+JtLCs0BKN15yfwmG3XWWO8we2LA=";
+    tag = "@e2b/code-interpreter-python@${finalAttrs.version}";
+    hash = "sha256-RIKbk0CKqP9KUyi/WDqPGFK3ce/033VwKJR/yJGLPvI=";
   };
 
-  sourceRoot = "${src.name}/python";
+  sourceRoot = "${finalAttrs.src.name}/python";
 
   build-system = [
     poetry-core
@@ -32,20 +38,34 @@ buildPythonPackage rec {
 
   dependencies = [
     attrs
+    # Upstream requires e2b >=2.39.1,<3.0.0; enforced by pythonRuntimeDepsCheck.
     e2b
     httpx
   ];
 
   pythonImportsCheck = [ "e2b_code_interpreter" ];
 
-  # Tests require an API key
-  # e2b.exceptions.AuthenticationException: API key is required, please visit the Team tab at https://e2b.dev/dashboard to get your API key.
-  doCheck = false;
+  nativeCheckInputs = [
+    pytest-asyncio
+    # upstream's pytest.ini passes --numprocesses
+    pytest-xdist
+    pytestCheckHook
+  ];
+
+  # Everything else under tests/ drives a real sandbox and needs an API key --
+  # including tests/charts, which renders the charts inside one.
+  enabledTestPaths = [ "tests/test_sandbox_url.py" ];
+
+  # Import e2b_code_interpreter from $out rather than the source tree.
+  preCheck = ''
+    rm -r e2b_code_interpreter
+  '';
 
   meta = {
-    description = "E2B Code Interpreter - Stateful code execution";
+    description = "Stateful code execution in cloud sandboxes";
     homepage = "https://github.com/e2b-dev/code-interpreter/tree/main/python";
-    license = lib.licenses.asl20;
+    changelog = "https://github.com/e2b-dev/code-interpreter/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ GaetanLepage ];
   };
-}
+})

--- a/pkgs/development/python-modules/e2b/default.nix
+++ b/pkgs/development/python-modules/e2b/default.nix
@@ -4,60 +4,93 @@
   fetchFromGitHub,
 
   # build-system
-  poetry-core,
+  uv-build,
 
   # dependencies
   attrs,
-  httpcore,
+  connectrpc,
+  dockerfile-parse,
+  h2,
   httpx,
   packaging,
-  protobuf,
+  protobuf-py,
+  pyqwest,
   python-dateutil,
+  rich,
   typing-extensions,
+  wcmatch,
+
+  # tests
+  pytest-asyncio,
+  pytest-timeout,
+  pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "e2b";
-  version = "1.5.1";
+  version = "2.39.1";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "e2b-dev";
     repo = "E2B";
-    tag = "@e2b/python-sdk@${version}";
-    hash = "sha256-6THRc4rv/mzOWbsN1FpUu56kjvHvVBssK2glNoGdSzI=";
+    tag = "@e2b/python-sdk@${finalAttrs.version}";
+    hash = "sha256-bB5MGXd3W66/hjodSqTAmlnr6iJjGx/5ET6nOofdkrI=";
   };
 
-  sourceRoot = "${src.name}/packages/python-sdk";
+  sourceRoot = "${finalAttrs.src.name}/packages/python-sdk";
+
+  # Upstream caps the build backend at uv_build<0.11.0; ours is newer.
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.10.0,<0.11.0" "uv_build"
+  '';
 
   build-system = [
-    poetry-core
-  ];
-
-  pythonRelaxDeps = [
-    "protobuf"
+    uv-build
   ];
 
   dependencies = [
     attrs
-    httpcore
+    connectrpc
+    dockerfile-parse
+    h2
     httpx
     packaging
-    protobuf
+    protobuf-py
+    pyqwest
     python-dateutil
+    rich
     typing-extensions
+    wcmatch
   ];
 
   pythonImportsCheck = [ "e2b" ];
 
-  # Tests require an API key
-  # e2b.exceptions.AuthenticationException: API key is required, please visit the Team tab at https://e2b.dev/dashboard to get your API key.
-  doCheck = false;
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-timeout
+    pytestCheckHook
+  ];
+
+  # Everything under tests/{async,sync,bugs} drives a real sandbox and needs an
+  # API key. The rest runs offline against an in-process envd frame server.
+  enabledTestPaths = [ "tests/test_*.py" ];
+
+  # Import e2b from $out rather than the source tree.
+  preCheck = ''
+    rm -r e2b
+  '';
+
+  # The offline tests exercise the transport against an in-process server.
+  __darwinAllowLocalNetworking = true;
 
   meta = {
-    description = "E2B SDK that give agents cloud environments";
+    description = "Cloud environments for AI agents";
     homepage = "https://github.com/e2b-dev/E2B/blob/main/packages/python-sdk";
-    license = lib.licenses.asl20;
+    changelog = "https://github.com/e2b-dev/E2B/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ GaetanLepage ];
   };
-}
+})

--- a/pkgs/development/python-modules/e2b/default.nix
+++ b/pkgs/development/python-modules/e2b/default.nix
@@ -91,6 +91,9 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://github.com/e2b-dev/E2B/blob/main/packages/python-sdk";
     changelog = "https://github.com/e2b-dev/E2B/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ GaetanLepage ];
+    maintainers = with lib.maintainers; [
+      GaetanLepage
+      mishushakov
+    ];
   };
 })

--- a/pkgs/development/python-modules/protobuf-py-ext/default.nix
+++ b/pkgs/development/python-modules/protobuf-py-ext/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  rustPlatform,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "protobuf-py-ext";
+  version = "0.1.1";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  # No tag on GitHub for this release: bufbuild/protobuf-py's only tag is v0.2.0.
+  # This has to stay in lockstep with protobuf-py, which is held at 0.1.1.
+  src = fetchPypi {
+    pname = "protobuf_py_ext";
+    inherit (finalAttrs) version;
+    hash = "sha256-6Fv9/bPtUGNNuMzHQp3ZKGUgEJSJxzVGOXGkGHB7T+8=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-oC9LPNUDVigOVqTHm3bRZlK0ToEHKlEpCtBRxqViFtg=";
+  };
+
+  nativeBuildInputs = [
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+  ];
+
+  pythonImportsCheck = [ "protobuf_ext" ];
+
+  # The test suite lives in the protobuf-py repository and covers this extension
+  # only through protobuf-py's own tests, which the sdist does not ship.
+  # pythonImportsCheck confirms the extension loads for this interpreter, which
+  # is what packaging can get wrong.
+  doCheck = false;
+
+  meta = {
+    description = "Native accelerator for the protobuf-py runtime";
+    homepage = "https://github.com/bufbuild/protobuf-py";
+    # The sdist declares no license; the source repository is Apache-2.0.
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mishushakov ];
+  };
+})

--- a/pkgs/development/python-modules/protobuf-py/default.nix
+++ b/pkgs/development/python-modules/protobuf-py/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  uv-build,
+
+  # dependencies
+  protobuf-py-ext,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "protobuf-py";
+  # connectrpc requires this exact version and e2b requires <0.2; bump all three
+  # together.
+  version = "0.1.1";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  # No tag on GitHub for this release: bufbuild/protobuf-py's only tag is v0.2.0,
+  # which connectrpc (`protobuf-py==0.1.1`) and e2b (`<0.2`) do not accept yet.
+  src = fetchPypi {
+    pname = "protobuf_py";
+    inherit (finalAttrs) version;
+    hash = "sha256-a9CKxNjxZhllu+JoVCnXkENwTN0e5yCnqJYXMxdCJAs=";
+  };
+
+  build-system = [
+    uv-build
+  ];
+
+  dependencies = [
+    protobuf-py-ext
+  ];
+
+  pythonImportsCheck = [ "protobuf" ];
+
+  # The test suite is not part of the PyPI sdist and there is no git tag for this
+  # release. Note that protobuf swallows an ImportError from protobuf_ext and
+  # falls back to pure Python, so a broken accelerator would not surface here —
+  # protobuf-py-ext's own pythonImportsCheck is what guards that.
+  doCheck = false;
+
+  meta = {
+    description = "Idiomatic Protocol Buffers for Python";
+    homepage = "https://github.com/bufbuild/protobuf-py";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mishushakov ];
+  };
+})

--- a/pkgs/development/python-modules/pyqwest/default.nix
+++ b/pkgs/development/python-modules/pyqwest/default.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  cmake,
+  rustPlatform,
+
+  # dependencies
+  opentelemetry-api,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pyqwest";
+  version = "0.9.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "curioswitch";
+    repo = "pyqwest";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-K/zkPD7x3qKRPo7YJDWFrTLczaXvayKc8Zf/SQr2xL0=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-ztlUPsqEJz1WB2pXuoUyyhmUWY6MoWI/gErgg+6Fkcg=";
+  };
+
+  # reqwest' http3 feature refuses to compile without these cfgs, which upstream
+  # sets under `[build]`. Cargo ignores that section once cargoSetupHook has
+  # appended its own `[target.<host>]` rustflags, and setting RUSTFLAGS instead
+  # would shadow those. Flags from `cfg(...)` and `<triple>` sections are joined,
+  # so retargeting upstream's section keeps both sets.
+  postPatch = ''
+    substituteInPlace .cargo/config.toml \
+      --replace-fail '[build]' "[target.'cfg(all())']"
+  '';
+
+  nativeBuildInputs = [
+    # Only invoked by aws-lc-sys' build script; there is no top-level
+    # CMakeLists.txt to configure.
+    cmake
+    rustPlatform.bindgenHook
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  dependencies = [
+    opentelemetry-api
+  ];
+
+  pythonImportsCheck = [ "pyqwest" ];
+
+  # The test suite spins up local HTTP/1, HTTP/2 and HTTP/3 servers through
+  # `pyvoy`, which is not packaged in nixpkgs. Nothing it covers is
+  # nixpkgs-specific: the packaging risk here is that the Rust extension fails
+  # to build or load, which pythonImportsCheck catches.
+  doCheck = false;
+
+  meta = {
+    description = "Modern, high-performance HTTP client for Python built on reqwest";
+    homepage = "https://github.com/curioswitch/pyqwest";
+    changelog = "https://github.com/curioswitch/pyqwest/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mishushakov ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13663,6 +13663,8 @@ self: super: with self; {
   # If a protobuf upgrade causes many Python packages to fail, please pin it here to the previous version.
   protobuf = protobuf7;
 
+  protobuf-py = callPackage ../development/python-modules/protobuf-py { };
+
   protobuf-py-ext = callPackage ../development/python-modules/protobuf-py-ext { };
 
   protobuf3-to-dict = callPackage ../development/python-modules/protobuf3-to-dict { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15557,6 +15557,8 @@ self: super: with self; {
 
   pyqvrpro = callPackage ../development/python-modules/pyqvrpro { };
 
+  pyqwest = callPackage ../development/python-modules/pyqwest { };
+
   pyqwikswitch = callPackage ../development/python-modules/pyqwikswitch { };
 
   pyrabbit2 = callPackage ../development/python-modules/pyrabbit2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13663,6 +13663,8 @@ self: super: with self; {
   # If a protobuf upgrade causes many Python packages to fail, please pin it here to the previous version.
   protobuf = protobuf7;
 
+  protobuf-py-ext = callPackage ../development/python-modules/protobuf-py-ext { };
+
   protobuf3-to-dict = callPackage ../development/python-modules/protobuf3-to-dict { };
 
   # Protobuf 4.x

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3543,6 +3543,8 @@ self: super: with self; {
 
   connection-pool = callPackage ../development/python-modules/connection-pool { };
 
+  connectrpc = callPackage ../development/python-modules/connectrpc { };
+
   connexion = callPackage ../development/python-modules/connexion { };
 
   connio = callPackage ../development/python-modules/connio { };


### PR DESCRIPTION
Updates the E2B Python SDK packages, which have been stuck on 1.5.1 since they were
introduced in #416767 (June 2025), to the current releases:

- `python3Packages.e2b`: 1.5.1 -> 2.39.1 ([changelog](https://github.com/e2b-dev/E2B/releases))
- `python3Packages.e2b-code-interpreter`: 1.5.1 -> 2.9.1 ([changelog](https://github.com/e2b-dev/code-interpreter/releases))

The 2.x SDK replaced its transport stack, so four new dependencies are packaged first:

- `python3Packages.pyqwest`: init at 0.9.0 — reqwest-based HTTP client (Rust extension via maturin)
- `python3Packages.protobuf-py`: init at 0.1.1 — Buf's idiomatic protobuf runtime for Python
- `python3Packages.protobuf-py-ext`: init at 0.1.1 — the Rust codec accelerator `protobuf-py`
  declares as a dependency
- `python3Packages.connectrpc`: init at 0.11.1 — Connect RPC runtime, used by the SDK to talk
  to the in-sandbox agent

`e2b` also moved from poetry-core to uv-build, and dropped `httpcore` and google's `protobuf`.

## Sources

Four of the six fetch from the repo by tag; the two that cannot say why in the expression:

| package | source | reason |
| --- | --- | --- |
| `pyqwest` | `fetchFromGitHub` (tag) | |
| `connectrpc` | `fetchFromGitHub` (tag) | |
| `e2b` | `fetchFromGitHub` (tag) | |
| `e2b-code-interpreter` | `fetchFromGitHub` (tag) | |
| `protobuf-py` | `fetchPypi` | No tag on GitHub for 0.1.1 — upstream's only tag is `v0.2.0`, which neither `connectrpc` (`protobuf-py==0.1.1`) nor `e2b` (`<0.2`) accepts yet |
| `protobuf-py-ext` | `fetchPypi` | Same repo, same missing tag; held in lockstep with `protobuf-py` |

Both e2b repositories used to tag one commit *before* the version bump, which is why an earlier
revision of this PR used `fetchPypi`. That is fixed upstream in both now, and the versions here
are the first correctly-tagged releases of each: `@e2b/python-sdk@2.36.0` onwards and
`@e2b/code-interpreter-python@2.9.1`. Note the versions are load-bearing on each other —
`e2b-code-interpreter` 2.9.1 requires `e2b ^2.39.1`, which in turn requires
`pyqwest >=0.9.0,<0.10`, so all three move together.

## Other changes worth calling out

- `e2b-code-interpreter` no longer inherits its version from `e2b`. The two packages live in
  separate repositories and version independently (2.9.1 vs 2.39.1), so the `inherit` produced
  a nonexistent tag as soon as they diverged.
- `meta.license` corrected from `asl20` to `mit` for both. The SDK sources
  (`packages/python-sdk/LICENSE`, `python/LICENSE`) and the PyPI metadata are MIT; only the
  monorepo root is Apache-2.0.
- `meta.description` reworded on both e2b packages — the previous values started with the
  package name, which `pkgs/README.md` disallows (and the `e2b` one was ungrammatical).
- `protobuf-py`'s accelerator `protobuf-py-ext` is packaged rather than stripped. Its
  environment markers cover every platform nixpkgs builds for, so it is a required dependency
  there, not an optional extra; `protobuf` silently falls back to a pure Python codec when it
  is absent, which would have put nixpkgs users on a slower path than upstream's wheels with
  no signal. Verified that `protobuf._native_message.NativeMessageClass` is
  `protobuf_ext.NativeMessage` in the built environment, and that the SDK's generated envd
  message classes really do inherit the native base.
- `pyqwest` needs `--cfg reqwest_unstable --cfg tokio_unstable`; reqwest's `http3` feature does
  not compile without them. Upstream sets them under `[build]` in `.cargo/config.toml`, which
  cargo ignores once `cargoSetupHook` has appended its own `[target.<host>]` rustflags — cargo
  picks exactly one rustflags source. Rather than set `RUSTFLAGS` (which wins over *all* config
  sources and so drops nixpkgs' `-Cforce-frame-pointers=yes`, and `-Ctarget-feature=±crt-static`
  when cross-compiling), the expression retargets upstream's section to `cfg(all())`, which
  cargo joins with the host section. Checked with a real cargo that all three flags reach
  rustc under the joined form and that the `RUSTFLAGS` form drops the frame-pointer flag.
- `pyqwest` deliberately does *not* carry the `-Wno-error=stringop-overflow` workaround that
  `aws-lc` and the tree's other aws-lc-sys consumers (`qh3`, `albyhub`) apply on GNU compilers.
  I checked: `aws-lc-sys` 0.41.0 compiles clean with GCC 15.3 (the version in nixpkgs) even
  with `-D_FORTIFY_SOURCE=3` and `-Werror=stringop-overflow` forced on. `aws-lc`'s own comment
  says the flag was "Needed with GCC 12", so those look stale rather than load-bearing.

Nothing else in nixpkgs depends on either e2b package.

## Tests

Three of the six run part of upstream's suite:

- **`e2b`: 256 tests pass.** Everything under `tests/{async,sync,bugs}` drives a real sandbox
  and needs an API key, but the tests at the root of `tests/` exercise the new transport stack
  — envd codec, retry transport, stream reset, plain-HTTP errors, interceptors, request
  timeouts — against an in-process envd frame server.
- **`connectrpc`: 219 tests pass.** Two files are skipped: `test_grpc.py` needs `pyvoy` and
  `test_example.py` drives a Flask app from the unpublished `example` workspace member.
- **`e2b-code-interpreter`: 6 tests pass** (`tests/test_sandbox_url.py`). The rest of that suite,
  `tests/charts` included, renders inside a real sandbox and needs an API key.

The other three are `pythonImportsCheck` only, each with the reason in the expression:

- `pyqwest` — the suite spins up local HTTP/1, HTTP/2 and HTTP/3 servers through `pyvoy`, which
  is not packaged in nixpkgs.
- `protobuf-py` / `protobuf-py-ext` — the suite is not in the sdist and there is no git tag for
  0.1.1. Note that `protobuf` swallows an `ImportError` from `protobuf_ext`, so
  `protobuf-py-ext`'s own import check is what guards the accelerator.

`connectrpc`'s import check is on `connectrpc.client` and `connectrpc.server` rather than the
top-level module, which only re-exports `__version__` and would not have loaded pyqwest or
protobuf.

Beyond that, the built packages were exercised against the live E2B API — sandbox create,
remote command execution (including a 200-line streamed-output run, which is the protobuf hot
path), file write/read/list, `get_info`, and `e2b_code_interpreter`'s `run_code`.

## On maintainership

I'm listed on all six: alongside @GaetanLepage on the two e2b packages, which I work on
upstream, and as sole maintainer of the four new dependencies. None of those four upstreams
currently has any Nix presence, so if anyone on the Python team would like to co-maintain
`pyqwest`, `protobuf-py`, `protobuf-py-ext` or `connectrpc`, please do — they are all thin
expressions, but they are third-party libraries I don't control.

### Automation disclosure

Per the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy):
these expressions, the commit messages, and this summary were drafted with Claude Code
(Claude Opus 5), as disclosed by the `Assisted-by:` trailer on each commit. Every package was
built and its behaviour checked as described above before submission, and I am accountable for
the contents.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. Each of the six packages was built individually instead,
      and every commit was checked to evaluate on its own. The set evaluates for Python 3.12
      through 3.14; on 3.11 `pyqwest` cannot evaluate because `opentelemetry-api` pulls in a
      sphinx that does not support 3.11, which is pre-existing on master.
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`. (No binaries;
      the library functionality was exercised against the live API as described above.)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.
- [x] Follows the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy).
