### PR TITLE
python3Packages.datamodel-code-generator: 0.68.1 -> 0.71.0

### DIFF
--- a/pkgs/development/python-modules/datamodel-code-generator/default.nix
+++ b/pkgs/development/python-modules/datamodel-code-generator/default.nix
@@ -36,14 +36,14 @@
 
 buildPythonPackage rec {
   pname = "datamodel-code-generator";
-  version = "0.68.1";
+  version = "0.71.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "koxudaxi";
     repo = "datamodel-code-generator";
     tag = version;
-    hash = "sha256-fYnI7S4FJ927qZXyAsWQzxhLTrcpscYqJunmcSt/gkk=";
+    hash = "sha256-0vh/iynZzmMzvdUXNScb+JWANdSrzPLT1qt+jyKleg4=";
   };
 
   pythonRelaxDeps = [


### PR DESCRIPTION
Updates datamodel-code-generator to the latest stable release, which includes the fix for CVE-2026-63720 by rejecting unsafe schema-controlled `customBasePath` values before emitting Python imports.

Changelog: https://github.com/koxudaxi/datamodel-code-generator/blob/0.71.0/CHANGELOG.md

fixes #546268

The `release-26.05` branch remains affected and needs a separate fix because its test dependency set differs from `master`.

`nixpkgs-review` built the application, Python 3.13 and 3.14 libraries, `openccu-loom-types`, and `tree-sitter-config`. `python314Packages.compliance-trestle` fails identically on unmodified `master` because it requires `paramiko==4.0.0` while nixpkgs provides 5.0.0.

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
