### PR TITLE
scryer: init at 0.17.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12385,6 +12385,12 @@
     githubId = 10690970;
     name = "James Duff";
   };
+  jagu-sayan = {
+    name = "Jacob Zak";
+    github = "jagu-sayan";
+    githubId = 1262860;
+    email = "dv64dq9qc@mozmail.com";
+  };
   jakecleary = {
     email = "shout@jakecleary.net";
     github = "jakecleary";

--- a/pkgs/by-name/sc/scryer/package.nix
+++ b/pkgs/by-name/sc/scryer/package.nix
@@ -6,6 +6,7 @@
   nodejs,
   nix-update-script,
   nasm,
+  cacert,
 }:
 let
   pname = "scryer";
@@ -42,9 +43,24 @@ rustPlatform.buildRustPackage {
 
   nativeBuildInputs = [ nasm ];
 
-  preConfigure = ''
-    export SCRYER_EMBED_UI_DIR=${webui}
-  '';
+  nativeCheckInputs = [ cacert ];
+
+  # Upstream's own CI runs its test suite on the plain `dev` profile rather
+  # than `release`, which compiles far faster and needs no LTO.
+  checkType = "debug";
+
+  checkFlags = [
+    # The embedded Sigstore TUF trust root has a hardcoded expiry date that
+    # has passed, so this fails regardless of the sandbox/environment.
+    "--skip=plugins::catalog::tests::sigstore_trust_root_rekor_keys_parse_as_der"
+    # Expects chmod/chown of a freshly created file to fully apply a setgid
+    # mask, which the build sandbox's permission model doesn't allow.
+    "--skip=workflow::file_importer::tests::enabled_permissions_apply_file_mask_and_created_folder_mask"
+    # Hardcodes /usr/bin/env, which doesn't exist on NixOS/Nix (no FHS paths).
+    "--skip=process_host::tests::execute_strips_dynamic_linker_env_and_forces_clean_path"
+  ];
+
+  env.SCRYER_EMBED_UI_DIR = webui;
 
   passthru = {
     inherit webui;

--- a/pkgs/by-name/sc/scryer/package.nix
+++ b/pkgs/by-name/sc/scryer/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  buildNpmPackage,
+  nodejs,
+  nix-update-script,
+  nasm,
+}:
+let
+  pname = "scryer";
+  version = "0.17.2";
+
+  src = fetchFromGitHub {
+    owner = "scryer-media";
+    repo = "scryer";
+    tag = "scryer-v${version}";
+    hash = "sha256-zIz9qsH+nTgfrpE6Aikd/fVp0wfTSzKQdE6clpVejy8=";
+  };
+
+  webui = buildNpmPackage {
+    pname = "scryer-webui";
+    inherit version src nodejs;
+
+    sourceRoot = "${src.name}/apps/scryer-web";
+
+    npmDepsHash = "sha256-5vKgjayikva5RxF7C8vI+iwRHs1fXV2QG55rpL51KaA=";
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out
+      cp -r dist/* $out/
+      runHook postInstall
+    '';
+  };
+in
+rustPlatform.buildRustPackage {
+  inherit pname version src;
+  __structuredAttrs = true;
+
+  cargoHash = "sha256-82AQ90QHNpTExip9y/Lp7I1UNIYNdrnmLHTYNtObTYM=";
+
+  nativeBuildInputs = [ nasm ];
+
+  preConfigure = ''
+    export SCRYER_EMBED_UI_DIR=${webui}
+  '';
+
+  passthru = {
+    inherit webui;
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Self-hosted media management application for movies, TV series, and anime";
+    homepage = "https://www.scryer.media";
+    changelog = "https://github.com/scryer-media/scryer/releases/tag/${src.tag}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ jagu-sayan ];
+    mainProgram = "scryer";
+  };
+}


### PR DESCRIPTION
[Scryer](https://github.com/scryer-media/scryer), a media management application for movies, series and animes.

## Things done
- [x] Required rustc v1.96.0
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - ~~[ ] Package update: when the change is major or breaking.~~
- NixOS Release Notes
  - ~~[ ] Module addition: when adding a new NixOS module.~~
  - ~~[ ] Module update: when the change is significant.~~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy]. -> Got inspiration from [rqbit package](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/rq/rqbit/package.nix)

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test