### PR TITLE
treewide: Update upgrade scripts to use pcre2grep instead of pcregrep

### DIFF
--- a/pkgs/by-name/ar/argyllcms/package.nix
+++ b/pkgs/by-name/ar/argyllcms/package.nix
@@ -171,13 +171,13 @@ stdenv.mkDerivation rec {
   passthru = {
     updateScript = writeScript "update-argyllcms" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -eu -o pipefail
 
       # Expect the text in format of 'Current Version 3.0.1 (19th October 2023)'
       new_version="$(curl -s https://www.argyllcms.com/ |
-          pcregrep -o1 '>Current Version ([0-9.]+) ')"
+          pcre2grep -o1 '>Current Version ([0-9.]+) ')"
       update-source-version ${pname} "$new_version"
     '';
   };

--- a/pkgs/by-name/di/diffoscope/package.nix
+++ b/pkgs/by-name/di/diffoscope/package.nix
@@ -332,12 +332,12 @@ python.pkgs.buildPythonApplication rec {
   passthru = {
     updateScript = writeScript "update-diffoscope" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -eu -o pipefail
 
       # Expect the text in format of "Latest release: 198 (31 Dec 2021)"'.
-      newVersion="$(curl -s https://diffoscope.org/ | pcregrep -o1 'Latest release: ([0-9]+)')"
+      newVersion="$(curl -s https://diffoscope.org/ | pcre2grep -o1 'Latest release: ([0-9]+)')"
       update-source-version ${pname} "$newVersion"
     '';
   };

--- a/pkgs/by-name/gd/gdb/package.nix
+++ b/pkgs/by-name/gd/gdb/package.nix
@@ -206,13 +206,13 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     updateScript = writeScript "update-gdb" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -eu -o pipefail
 
       # Expect the text in format of '<h3>GDB version 12.1</h3>'
       new_version="$(curl -s https://www.sourceware.org/gdb/ |
-          pcregrep -o1 '<h3>GDB version ([0-9.]+)</h3>')"
+          pcre2grep -o1 '<h3>GDB version ([0-9.]+)</h3>')"
       update-source-version ${pname} "$new_version"
     '';
   };

--- a/pkgs/by-name/mc/mc/package.nix
+++ b/pkgs/by-name/mc/mc/package.nix
@@ -92,12 +92,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = writeScript "update-mc" ''
     #!/usr/bin/env nix-shell
-    #!nix-shell -i bash -p curl pcre common-updater-scripts
+    #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
     set -eu -o pipefail
 
     # Expect the text in format of "Current version is: 4.8.27; ...".
-    new_version="$(curl -s https://midnight-commander.org/ | pcregrep -o1 'Current version is: (([0-9]+\.?)+);')"
+    new_version="$(curl -s https://midnight-commander.org/ | pcre2grep -o1 'Current version is: (([0-9]+\.?)+);')"
     update-source-version mc "$new_version"
   '';
 

--- a/pkgs/by-name/mp/mpfr/package.nix
+++ b/pkgs/by-name/mp/mpfr/package.nix
@@ -60,13 +60,13 @@ stdenv.mkDerivation rec {
   passthru = {
     updateScript = writeScript "update-mpfr" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -eu -o pipefail
 
       # Expect the text in format of '<title>GNU MPFR version 4.1.1</title>'
       new_version="$(curl -s https://www.mpfr.org/mpfr-current/ |
-          pcregrep -o1 '<title>GNU MPFR version ([0-9.]+)</title>')"
+          pcre2grep -o1 '<title>GNU MPFR version ([0-9.]+)</title>')"
       update-source-version ${pname} "$new_version"
     '';
   };

--- a/pkgs/by-name/mp/mpg123/package.nix
+++ b/pkgs/by-name/mp/mpg123/package.nix
@@ -81,13 +81,13 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     updateScript = writeScript "update-mpg123" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -eu -o pipefail
 
       # Expect the text in format of '<a href="download/mpg123-1.32.6.tar.bz2">'
       new_version="$(curl -s https://mpg123.org/download.shtml |
-          pcregrep -o1 '<a href="download/mpg123-([0-9.]+).tar.bz2">')"
+          pcre2grep -o1 '<a href="download/mpg123-([0-9.]+).tar.bz2">')"
       update-source-version ${finalAttrs.pname} "$new_version"
     '';
   };

--- a/pkgs/by-name/mu/mutt/package.nix
+++ b/pkgs/by-name/mu/mutt/package.nix
@@ -115,13 +115,13 @@ stdenv.mkDerivation rec {
   passthru = {
     updateScript = writeScript "update-mutt" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -euo pipefail
 
       # Expect the text in format of "The current stable public release version is 2.2.6."
       new_version="$(curl -s http://www.mutt.org/download.html |
-          pcregrep -o1 'The current stable public release version is ([0-9.]+).')"
+          pcre2grep -o1 'The current stable public release version is ([0-9.]+).')"
       update-source-version ${pname} "$new_version"
     '';
   };

--- a/pkgs/by-name/po/poke/package.nix
+++ b/pkgs/by-name/po/poke/package.nix
@@ -80,13 +80,13 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     updateScript = writeScript "update-poke" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -eu -o pipefail
 
       # Expect the text in format of '<a href="...">poke 2.0</a>'
       new_version="$(curl -s https://www.jemarch.net/poke |
-          pcregrep -o1 '>poke ([0-9.]+)</a>')"
+          pcre2grep -o1 '>poke ([0-9.]+)</a>')"
       update-source-version poke "$new_version"
     '';
   };

--- a/pkgs/by-name/po/postfix/update.sh
+++ b/pkgs/by-name/po/postfix/update.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl pcre common-updater-scripts
+#!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
 set -eu -o pipefail
 
 # Expect the text in format of '<a href="official/postfix-3.7.4.tar.gz">Source code</a> |'
 # Stable release goes first.
 new_version="$(curl -s https://postfix-mirror.horus-it.com/postfix-release/index.html |
-    pcregrep -o1 '"official/postfix-([0-9.]+)[.]tar[.]gz">' | head -n1)"
+    pcre2grep -o1 '"official/postfix-([0-9.]+)[.]tar[.]gz">' | head -n1)"
 update-source-version postfix "$new_version"

--- a/pkgs/by-name/se/serd/package.nix
+++ b/pkgs/by-name/se/serd/package.nix
@@ -47,13 +47,13 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     updateScript = writeScript "update-poke" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -eu -o pipefail
 
       # Expect the text in format of 'download.drobilla.net/serd-0.30.16.tar.xz">'
       new_version="$(curl -s https://drobilla.net/category/serd/ |
-          pcregrep -o1 'download.drobilla.net/serd-([0-9.]+).tar.xz' |
+          pcre2grep -o1 'download.drobilla.net/serd-([0-9.]+).tar.xz' |
           head -n1)"
       update-source-version ${finalAttrs.pname} "$new_version"
     '';

--- a/pkgs/by-name/sg/sgt-puzzles/package.nix
+++ b/pkgs/by-name/sg/sgt-puzzles/package.nix
@@ -79,11 +79,11 @@ stdenv.mkDerivation (finalAttrs: {
     tests.sgt-puzzles = nixosTests.sgt-puzzles;
     updateScript = writeScript "update-sgt-puzzles" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -eu -o pipefail
 
-      version="$(curl -sI 'https://www.chiark.greenend.org.uk/~sgtatham/puzzles/puzzles.tar.gz' | grep -Fi Location: | pcregrep -o1 'puzzles-([0-9a-f.]*).tar.gz')"
+      version="$(curl -sI 'https://www.chiark.greenend.org.uk/~sgtatham/puzzles/puzzles.tar.gz' | grep -Fi Location: | pcre2grep -o1 'puzzles-([0-9a-f.]*).tar.gz')"
       update-source-version sgt-puzzles "$version"
     '';
   };

--- a/pkgs/by-name/sl/slang/package.nix
+++ b/pkgs/by-name/sl/slang/package.nix
@@ -67,13 +67,13 @@ stdenv.mkDerivation rec {
   passthru = {
     updateScript = writeScript "update-slang" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -eu -o pipefail
 
       # Expect the text in format of 'Version 2.3.3</td>'
       new_version="$(curl -s https://www.jedsoft.org/slang/ |
-          pcregrep -o1 'Version ([0-9.]+)</td>')"
+          pcre2grep -o1 'Version ([0-9.]+)</td>')"
       update-source-version ${pname} "$new_version"
     '';
   };

--- a/pkgs/by-name/sr/sratom/package.nix
+++ b/pkgs/by-name/sr/sratom/package.nix
@@ -50,13 +50,13 @@ stdenv.mkDerivation rec {
   passthru = {
     updateScript = writeScript "update-sratom" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -eu -o pipefail
 
       # Expect the text in format of 'download.drobilla.net/sratom-0.30.16.tar.xz">'
       new_version="$(curl -s https://drobilla.net/category/sratom/ |
-          pcregrep -o1 'download.drobilla.net/sratom-([0-9.]+).tar.xz' |
+          pcre2grep -o1 'download.drobilla.net/sratom-([0-9.]+).tar.xz' |
           head -n1)"
       update-source-version ${pname} "$new_version"
     '';

--- a/pkgs/by-name/tr/trunk-io/update.sh
+++ b/pkgs/by-name/tr/trunk-io/update.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl pcre common-updater-scripts
+#!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
 set -eu -o pipefail
 
-version="$(curl -fsSL https://trunk.io/releases/trunk | grep -Fi 'readonly TRUNK_LAUNCHER_VERSION=' | pcregrep -o1 '"(\d+(?:\.\d+)+)"')"
+version="$(curl -fsSL https://trunk.io/releases/trunk | grep -Fi 'readonly TRUNK_LAUNCHER_VERSION=' | pcre2grep -o1 '"(\d+(?:\.\d+)+)"')"
 update-source-version trunk-io "$version"

--- a/pkgs/by-name/va/valgrind/package.nix
+++ b/pkgs/by-name/va/valgrind/package.nix
@@ -91,14 +91,14 @@ stdenv.mkDerivation rec {
   passthru = {
     updateScript = writeScript "update-valgrind" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -eu -o pipefail
 
       # Expect the text in format of:
       #  'Current release: <a href="/downloads/current.html#current">valgrind-3.19.0</a>'
       new_version="$(curl -s https://valgrind.org/ |
-          pcregrep -o1 'Current release: .*>valgrind-([0-9.]+)</a>')"
+          pcre2grep -o1 'Current release: .*>valgrind-([0-9.]+)</a>')"
       update-source-version ${pname} "$new_version"
     '';
   };

--- a/pkgs/by-name/xz/xz/package.nix
+++ b/pkgs/by-name/xz/xz/package.nix
@@ -61,14 +61,14 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     updateScript = writeScript "update-xz" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -eu -o pipefail
 
       # Expect the text in format of '>xz-5.2.6.tar.xz</a>'
       # We pick first match where a stable release goes first.
       new_version="$(curl -s https://tukaani.org/xz/ |
-          pcregrep -o1 '>xz-([0-9.]+)[.]tar[.]xz</a>' |
+          pcre2grep -o1 '>xz-([0-9.]+)[.]tar[.]xz</a>' |
           head -n1)"
       update-source-version ${finalAttrs.pname} "$new_version"
     '';

--- a/pkgs/development/interpreters/guile/3.0.nix
+++ b/pkgs/development/interpreters/guile/3.0.nix
@@ -165,13 +165,13 @@ builder rec {
 
     updateScript = writeScript "update-guile-3" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -eu -o pipefail
 
       # Expect the text in format of '"https://ftp.gnu.org/gnu/guile/guile-3.0.8.tar.gz"'
       new_version="$(curl -s https://www.gnu.org/software/guile/download/ |
-          pcregrep -o1 '"https://ftp.gnu.org/gnu/guile/guile-(3[.0-9]+).tar.gz"')"
+          pcre2grep -o1 '"https://ftp.gnu.org/gnu/guile/guile-(3[.0-9]+).tar.gz"')"
       update-source-version guile_3_0 "$new_version"
     '';
   };


### PR DESCRIPTION
## Things done

For #356387 use pcre2grep instead of the old pcregrep.
I tested all greps with the following shity script to ensure that it still does the same thing.
If prefered i can also just create a single commit instead of a commit per package. 

<details>
<summary>Script to test</summary>
```
#!/bin/bash

# argyllcms
echo "argyllcms"
new_version="$(curl -s https://www.argyllcms.com/ |
          pcregrep -o1 '>Current Version ([0-9.]+) ')"

new_version2="$(curl -s https://www.argyllcms.com/ |
          pcre2grep -o1 '>Current Version ([0-9.]+) ')"

echo "old: $new_version new: $new_version2"

# diffoscope
echo "diffoscope"
newVersion="$(curl -s https://diffoscope.org/ | pcregrep -o1 'Latest release: ([0-9]+)')"
newVersion2="$(curl -s https://diffoscope.org/ | pcre2grep -o1 'Latest release: ([0-9]+)')"
echo "old ${newVersion} new: ${newVersion2}"

#GDB
echo "gdb"
new_version="$(curl -s https://www.sourceware.org/gdb/ |
          pcregrep -o1 '<h3>GDB version ([0-9.]+)</h3>')"
new_version2="$(curl -s https://www.sourceware.org/gdb/ |
          pcre2grep -o1 '<h3>GDB version ([0-9.]+)</h3>')"
echo "old: $new_version new: $new_version2"

# mc
echo "mc"
new_version="$(curl -s https://midnight-commander.org/ | pcregrep -o1 'Current version is: (([0-9]+\.?)+);')"
new_version2="$(curl -s https://midnight-commander.org/ | pcre2grep -o1 'Current version is: (([0-9]+\.?)+);')"
echo "old: $new_version new: $new_version2"

# mpfr
echo "mpfr"
new_version="$(curl -s https://www.mpfr.org/mpfr-current/ |
          pcregrep -o1 '<title>GNU MPFR version ([0-9.]+)</title>')"
new_version2="$(curl -s https://www.mpfr.org/mpfr-current/ |
          pcre2grep -o1 '<title>GNU MPFR version ([0-9.]+)</title>')"
echo "old: $new_version new: $new_version2"

# mpg123
echo "mpg123"
new_version="$(curl -s https://mpg123.org/download.shtml |
          pcregrep -o1 '<a href="download/mpg123-([0-9.]+).tar.bz2">')"
new_version2="$(curl -s https://mpg123.org/download.shtml |
          pcre2grep -o1 '<a href="download/mpg123-([0-9.]+).tar.bz2">')"
echo "old: $new_version new: $new_version2"

# mutt
echo "mutt"
new_version="$(curl -s http://www.mutt.org/download.html |
          pcregrep -o1 'The current stable public release version is ([0-9.]+).')"
new_version2="$(curl -s http://www.mutt.org/download.html |
          pcre2grep -o1 'The current stable public release version is ([0-9.]+).')"
echo "old: $new_version new: $new_version2"

# poke
echo "poke"
new_version="$(curl -s https://www.jemarch.net/poke |
          pcregrep -o1 '>poke ([0-9.]+)</a>')"
new_version2="$(curl -s https://www.jemarch.net/poke |
          pcre2grep -o1 '>poke ([0-9.]+)</a>')"
echo "old: $new_version new: $new_version2"

# postfix
echo "postfix"
new_version="$(curl -s https://postfix-mirror.horus-it.com/postfix-release/index.html |
    pcregrep -o1 '"official/postfix-([0-9.]+)[.]tar[.]gz">' | head -n1)"
new_version2="$(curl -s https://postfix-mirror.horus-it.com/postfix-release/index.html |
    pcre2grep -o1 '"official/postfix-([0-9.]+)[.]tar[.]gz">' | head -n1)"
echo "old: $new_version new: $new_version2"

# serd
echo "serd"
new_version="$(curl -s https://drobilla.net/category/serd/ |
          pcregrep -o1 'download.drobilla.net/serd-([0-9.]+).tar.xz' |
          head -n1)"
new_version2="$(curl -s https://drobilla.net/category/serd/ |
          pcre2grep -o1 'download.drobilla.net/serd-([0-9.]+).tar.xz' |
          head -n1)"
echo "old: $new_version new: $new_version2"

# sgt-puzzles
echo "sgt-puzzles"
version="$(curl -sI 'https://www.chiark.greenend.org.uk/~sgtatham/puzzles/puzzles.tar.gz' | grep -Fi Location: | pcregrep -o1 'puzzles-([0-9a-f.]*).tar.gz')"
version2="$(curl -sI 'https://www.chiark.greenend.org.uk/~sgtatham/puzzles/puzzles.tar.gz' | grep -Fi Location: | pcre2grep -o1 'puzzles-([0-9a-f.]*).tar.gz')"
echo "old: $version new: $version2"

# slang
echo "slang"
new_version="$(curl -s https://www.jedsoft.org/slang/ |
          pcregrep -o1 'Version ([0-9.]+)</td>')"
new_version2="$(curl -s https://www.jedsoft.org/slang/ |
          pcre2grep -o1 'Version ([0-9.]+)</td>')"
echo "old: $new_version new: $new_version2"

# sratom
echo "sratom"
new_version="$(curl -s https://drobilla.net/category/sratom/ |
          pcregrep -o1 'download.drobilla.net/sratom-([0-9.]+).tar.xz' |
          head -n1)"
new_version2="$(curl -s https://drobilla.net/category/sratom/ |
          pcre2grep -o1 'download.drobilla.net/sratom-([0-9.]+).tar.xz' |
          head -n1)"
echo "old: $new_version new: $new_version2"

# trunk-io
echo "trunk-io"
version="$(curl -fsSL https://trunk.io/releases/trunk | grep -Fi 'readonly TRUNK_LAUNCHER_VERSION=' | pcregrep -o1 '"(\d+(?:\.\d+)+)"')"
version2="$(curl -fsSL https://trunk.io/releases/trunk | grep -Fi 'readonly TRUNK_LAUNCHER_VERSION=' | pcre2grep -o1 '"(\d+(?:\.\d+)+)"')"
echo "old: $version new: $version2"

# valgrind
echo "valgrind"
new_version="$(curl -s https://valgrind.org/ |
          pcregrep -o1 'Current release: .*>valgrind-([0-9.]+)</a>')"
new_version2="$(curl -s https://valgrind.org/ |
          pcre2grep -o1 'Current release: .*>valgrind-([0-9.]+)</a>')"
echo "old: $new_version new: $new_version2"

#xz
echo "xz"
new_version="$(curl -s https://tukaani.org/xz/ |
          pcregrep -o1 '>xz-([0-9.]+)[.]tar[.]xz</a>' |
          head -n1)"
new_version2="$(curl -s https://tukaani.org/xz/ |
          pcre2grep -o1 '>xz-([0-9.]+)[.]tar[.]xz</a>' |
          head -n1)"
echo "old: $new_version new: $new_version2"

#guile
echo "guile"
new_version="$(curl -s https://www.gnu.org/software/guile/download/ |
          pcregrep -o1 '"https://ftp.gnu.org/gnu/guile/guile-(3[.0-9]+).tar.gz"')"
new_version2="$(curl -s https://www.gnu.org/software/guile/download/ |
          pcre2grep -o1 '"https://ftp.gnu.org/gnu/guile/guile-(3[.0-9]+).tar.gz"')"
echo "old: $new_version new: $new_version2"
```
</details>

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
