### PR TITLE
nixos/virtualbox-guest: Prefix udev rules with number < 72

### DIFF
--- a/nixos/modules/virtualisation/virtualbox-guest.nix
+++ b/nixos/modules/virtualisation/virtualbox-guest.nix
@@ -133,14 +133,19 @@ in
 
         users.groups.vboxuserdev = { };
 
-        services.udev.extraRules = ''
-          # /dev/vboxuser is necessary for VBoxClient to work.  Maybe we
-          # should restrict this to logged-in users.
-          KERNEL=="vboxuser",  OWNER="root", GROUP="vboxuserdev", MODE="0660", TAG+="uaccess"
+        services.udev.packages = lib.singleton (
+          pkgs.writeTextFile {
+            name = "virtualboxGuestAdditions";
+            text = ''
+              # /dev/vboxuser is necessary for VBoxClient to work
+              KERNEL=="vboxuser", OWNER="root", GROUP="vboxuserdev", MODE="0660", TAG+="uaccess"
 
-          # Allow systemd dependencies on vboxguest.
-          SUBSYSTEM=="misc", KERNEL=="vboxguest", TAG+="systemd"
-        '';
+              # Allow systemd dependencies on vboxguest.
+              SUBSYSTEM=="misc", KERNEL=="vboxguest", TAG+="systemd"
+            '';
+            destination = "/etc/udev/rules.d/70-virtualboxGuestAdditions.rules";
+          }
+        );
 
         systemd.user.services.virtualboxClientVmsvga = mkVirtualBoxUserService "--vmsvga-session" cfg.verbose;
       }


### PR DESCRIPTION
uaccess does not work for the current udev rule for /dev/vboxuser because the udev filename does not start with a number less than 72. Therefore, the udev rules from virtualboxGuestAdditions have been moved to the dev package with the correct filename convention.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
