### PR TITLE
gersemi: 0.23.2 -> 0.28.0

### DIFF
--- a/pkgs/by-name/ge/gersemi/package.nix
+++ b/pkgs/by-name/ge/gersemi/package.nix
@@ -2,22 +2,39 @@
   lib,
   python3Packages,
   fetchFromGitHub,
+  cargo,
+  rustPlatform,
+  rustc,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "gersemi";
-  version = "0.23.2";
+  version = "0.28.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "BlankSpruce";
     repo = "gersemi";
     tag = finalAttrs.version;
-    hash = "sha256-sXgu3KscRi/3Myg/4jarMZ4W7/CaQTmyxxbcu8/0o6Y=";
+    hash = "sha256-92R+jSsE9icZgeNXcPyagZtL4jZNLh2EMCMofM5FFsU=";
   };
 
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) src pname version;
+    sourceRoot = "${finalAttrs.src.name}/gersemi/rust-backend";
+    hash = "sha256-2ukdpS5oNDE9kf0zFrPXyh+6zA/l0ByUhb71xhJJ8nA=";
+  };
+
+  cargoRoot = "gersemi/rust-backend";
+
+  nativeBuildInputs = [
+    cargo
+    rustPlatform.cargoSetupHook
+    rustc
+  ];
+
   build-system = with python3Packages; [
-    setuptools
+    setuptools-rust
   ];
 
   dependencies = with python3Packages; [
@@ -30,6 +47,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   meta = {
     description = "Formatter to make your CMake code the real treasure";
     homepage = "https://github.com/BlankSpruce/gersemi";
+    changelog = "https://github.com/BlankSpruce/gersemi/blob/${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [ xeals ];
     mainProgram = "gersemi";


### PR DESCRIPTION
Version bump from `0.23.2` to `0.28.0`. 

Upstream has added a Rust extension module (`setuptools-rust`) since. Added relevant rust dependencies. Added `changelog` to `meta` attributes.

- Changelog: https://github.com/BlankSpruce/gersemi/blob/0.28.0/CHANGELOG.md

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
