### PR TITLE
nushellPlugins.polars: fix build

### DIFF
--- a/pkgs/by-name/nu/nushell/plugins/polars/package.nix
+++ b/pkgs/by-name/nu/nushell/plugins/polars/package.nix
@@ -10,7 +10,11 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nu_plugin_polars";
-  inherit (nushell) version src cargoHash;
+  inherit (nushell) version src;
+
+  # https://github.com/nushell/nushell/commit/1139611e188d5fc2b0264b8b24d7d38da160f05b
+  cargoPatches = [ ./update-ethnum.patch ];
+  cargoHash = "sha256-Cpv58bqpx1o0Dz2AykqzFY+PQE/Updr5MusQflpEF74=";
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
   buildInputs = [ openssl ];

--- a/pkgs/by-name/nu/nushell/plugins/polars/update-ethnum.patch
+++ b/pkgs/by-name/nu/nushell/plugins/polars/update-ethnum.patch
@@ -1,0 +1,10 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index dffde283d..61121dd60 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -2082 +2082 @@ name = "ethnum"
+-version = "1.5.2"
++version = "1.5.3"
+@@ -2084 +2084 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
++checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"


### PR DESCRIPTION
`nu_plugin_polars` 0.114.1 pins `ethnum` 1.5.2, which constructs a
`TryFromIntError` by transmuting from `()`. That no longer compiles with
Rust 1.97 because the two types have different sizes.

Carry the [lockfile update already merged in Nushell] to use
[`ethnum` 1.5.3]. That release replaces the unsound transmute with a safe
integer conversion.
This patch can be dropped when the next Nushell release containing the
lockfile update reaches Nixpkgs.

Resolves #546250.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Validation:

- `nix-build -A nushellPlugins.polars --no-out-link`
- 212 package tests passed, 0 failed, 1 pre-existing test filtered
- `nu_plugin_polars --help`
- `nixfmt` and `git diff --check`

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
[lockfile update already merged in Nushell]: https://github.com/nushell/nushell/commit/1139611e188d5fc2b0264b8b24d7d38da160f05b
[`ethnum` 1.5.3]: https://github.com/nlordell/ethnum-rs/releases/tag/v1.5.3

Assisted-by: OpenAI Codex (GPT-5)
