### PR TITLE
openbangla-keyboard: fix build caused by cmake update

### DIFF
--- a/pkgs/by-name/op/openbangla-keyboard/0001-skip-enable-language-rust.patch
+++ b/pkgs/by-name/op/openbangla-keyboard/0001-skip-enable-language-rust.patch
@@ -1,0 +1,14 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -12,8 +12,9 @@ add_definitions(-DPROJECT_VERSION="${PROJECT_VERSION}")
+ set(CMAKE_CXX_STANDARD 17)
+
+ if(NOT WIN32)
+-    enable_language(Rust)
+-    include(CMakeCargo)
++    find_program(CARGO_EXECUTABLE cargo REQUIRED)
++    find_program(RUSTC_EXECUTABLE rustc REQUIRED)
++    include(CMakeCargo)
+ endif()
+
+ find_package(Qt5 COMPONENTS Widgets Network REQUIRED)

--- a/pkgs/by-name/op/openbangla-keyboard/package.nix
+++ b/pkgs/by-name/op/openbangla-keyboard/package.nix
@@ -64,6 +64,10 @@ stdenv.mkDerivation (finalAttrs: {
       "-DENABLE_IBUS=YES"
     ];
 
+  patches = [
+    ./0001-skip-enable-language-rust.patch
+  ];
+
   cargoRoot = "src/engine/riti";
   postPatch = ''
     cp ${./Cargo.lock} ${finalAttrs.cargoRoot}/Cargo.lock


### PR DESCRIPTION
CMake introduced experimental rust support, but that caused `enable_language()` to fail, as now `CMAKE_Rust_EXPERIMENTAL="hash"` must be set, which is dynamic. This fixes it by removing that `enable_language()` call and uses REQUIRED instead.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
