### PR TITLE
cpufetch: Fix build on POWER

### DIFF
--- a/pkgs/by-name/cp/cpufetch/package.nix
+++ b/pkgs/by-name/cp/cpufetch/package.nix
@@ -16,6 +16,14 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-qmT7WBWKtSWGIK/dEd3/bF1bBjqSjfkP99htfnlFLCw=";
   };
 
+  postPatch =
+    # Copy-pasting typo
+    # https://github.com/Dr-Noob/cpufetch/issues/350
+    ''
+      substituteInPlace src/ppc/udev.c \
+        --replace-fail 'memset(name, 0, sizeof(char) * 128)' 'memset(path, 0, sizeof(char) * 128)'
+    '';
+
   nativeBuildInputs = [
     installShellFiles
   ];


### PR DESCRIPTION
https://github.com/Dr-Noob/cpufetch/issues/350

Repo doesn't accept pull requests. :(

<img width="1271" height="349" alt="image" src="https://github.com/user-attachments/assets/76da5cad-0004-445e-8cb6-e77dc2879e92" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] powerpc64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
