### PR TITLE
erlang: 27.3.4.14 -> 27.3.4.15, 28.5.0.3 -> 28.5.0.4, 29.0.3 -> 29.0.4

### DIFF
--- a/pkgs/development/interpreters/erlang/27.nix
+++ b/pkgs/development/interpreters/erlang/27.nix
@@ -1,6 +1,6 @@
 genericBuilder:
 
 genericBuilder {
-  version = "27.3.4.14";
-  hash = "sha256-vnD6+KAD2Hm21w+/RB9MxrCbxdFTd2YbE79dd4M5t4U=";
+  version = "27.3.4.15";
+  hash = "sha256-viy7cz23K0/8aoZL+lD07j/iIKPv7Cpy0fUR224SrM0=";
 }

--- a/pkgs/development/interpreters/erlang/28.nix
+++ b/pkgs/development/interpreters/erlang/28.nix
@@ -1,6 +1,6 @@
 genericBuilder:
 
 genericBuilder {
-  version = "28.5.0.3";
-  hash = "sha256-OCKR5lryM/jnFFB3hMpud4gQAzPISfK1d0spVXvj358=";
+  version = "28.5.0.4";
+  hash = "sha256-mMzRMGBlv385suCvkrOgMgPLee6/j70DwdqRVrBRP+Y=";
 }

--- a/pkgs/development/interpreters/erlang/29.nix
+++ b/pkgs/development/interpreters/erlang/29.nix
@@ -1,6 +1,6 @@
 genericBuilder:
 
 genericBuilder {
-  version = "29.0.3";
-  hash = "sha256-clRU+zrmp8wgCm3rEVUP9y3MmvLzsJGW4RL8qWDZz8A=";
+  version = "29.0.4";
+  hash = "sha256-Wq1aQ5a8IBJfY/N3f4AnfoSvodgdFo9lYEWpBy5YYTU=";
 }


### PR DESCRIPTION
- **beam27Packages.erlang: 27.3.4.14 -> 27.3.4.15**
- **beam28Packages.erlang: 28.5.0.3 -> 28.5.0.4**
- **beam29Packages.erlang: 29.0.3 -> 29.0.4**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
