### PR TITLE
shiki: init at 0.8.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25256,6 +25256,12 @@
     githubId = 11632726;
     name = "Arijit Basu";
   };
+  sazardev = {
+    email = "cerberusprogrammer@gmail.com";
+    github = "sazardev";
+    githubId = 66286300;
+    name = "Omar Flores Salazar";
+  };
   sb0 = {
     email = "sb@m-labs.hk";
     github = "sbourdeauducq";

--- a/pkgs/by-name/sh/shiki/package.nix
+++ b/pkgs/by-name/sh/shiki/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  cmake,
+  perl,
+  nasm,
+  stdenv,
+  openssl,
+  oniguruma,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "shiki";
+  version = "0.8.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "sazardev";
+    repo = "shiki";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-A78tDlq6FdWD3KhfWWlTJHhTg4dW0/FKDLQq6Kec1pU=";
+  };
+
+  cargoHash = "sha256-SRWB+DY/TWKk8NhG1aiARBooHuR5LD71brzvPkgNs14=";
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    perl
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isx86_64 [ nasm ];
+
+  buildInputs = [
+    openssl
+    oniguruma
+  ];
+
+  env = {
+    # git2 hardcodes the vendored-openssl feature
+    OPENSSL_NO_VENDOR = 1;
+    # syntect's default features pull in onig_sys
+    RUSTONIG_SYSTEM_LIBONIG = true;
+  };
+
+  meta = {
+    description = "TUI note-taking app with a Yazi-style three-pane layout and modal navigation, notes as plain Markdown + YAML frontmatter, each notebook its own git repo";
+    homepage = "https://github.com/sazardev/shiki";
+    changelog = "https://github.com/sazardev/shiki/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sazardev ];
+    mainProgram = "shiki";
+  };
+})


### PR DESCRIPTION
## Summary

Adds `shiki`, a TUI note-taking app written in Rust (inspired by Yazi's
three-pane layout and modal navigation). Notes are plain Markdown files
with YAML frontmatter, organized into "notebooks" — each its own git
repo, with built-in sync/push/pull.

- Homepage: https://github.com/sazardev/shiki
- License: MIT
- `pkgs/by-name/sh/shiki/package.nix`, `rustPlatform.buildRustPackage`,
  `cargoHash` (no git dependencies in `Cargo.lock`, so no aggregate
  `outputHashes` needed; `cargoLock.lockFile` can't be used here since it
  reads the lockfile out of `src` at evaluation time, which needs
  import-from-derivation — nixpkgs' PR eval CI runs with
  `allow-import-from-derivation=false` and fails on that).
- `git2`'s `Cargo.toml` hardcodes the `vendored-openssl` feature (needed
  for the project's own cross-platform release binaries); this package
  overrides that via `OPENSSL_NO_VENDOR = 1` to link nixpkgs' own
  `openssl` instead, same as nixpkgs' `gitui` package for the identical
  situation. `syntect`'s default features similarly pull in `onig_sys`;
  `RUSTONIG_SYSTEM_LIBONIG = true` links nixpkgs' `oniguruma` instead of
  building its own copy, same as nixpkgs' `atac` package.
- `libgit2-sys`'s vendored build (hardcoded via `git2`'s
  `vendored-libgit2` feature) still compiles from source, hence `cmake`
  in `nativeBuildInputs`; `perl`/`nasm` cover `openssl-sys`/`aws-lc-sys`'s
  own build scripts.

I'm the upstream author of `shiki` (added myself as a maintainer in a
separate commit).

Some of the code and commit message text in this PR was produced with
help from Claude Code (Claude Sonnet 5); see the `Assisted-by:` trailer
on the `shiki: init at 0.8.2` commit. I reviewed and understand the
change and take responsibility for it.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
