### PR TITLE
profile-sync-daemon: 6.50 -> 7.04

### DIFF
--- a/nixos/modules/services/desktops/profile-sync-daemon.nix
+++ b/nixos/modules/services/desktops/profile-sync-daemon.nix
@@ -31,66 +31,18 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    systemd = {
-      user = {
-        services = {
-          psd = {
-            enable = true;
-            description = "Profile Sync daemon";
-            wants = [ "psd-resync.service" ];
-            wantedBy = [ "default.target" ];
-            path = with pkgs; [
-              rsync
-              kmod
-              gawk
-              net-tools
-              util-linux
-              profile-sync-daemon
-            ];
-            unitConfig = {
-              RequiresMountsFor = [ "/home/" ];
-            };
-            serviceConfig = {
-              Type = "oneshot";
-              RemainAfterExit = "yes";
-              ExecStart = "${pkgs.profile-sync-daemon}/bin/profile-sync-daemon sync";
-              ExecStop = "${pkgs.profile-sync-daemon}/bin/profile-sync-daemon unsync";
-            };
-          };
+    environment.systemPackages = [ pkgs.profile-sync-daemon ];
 
-          psd-resync = {
-            enable = true;
-            description = "Timed profile resync";
-            after = [ "psd.service" ];
-            wants = [ "psd-resync.timer" ];
-            partOf = [ "psd.service" ];
-            wantedBy = [ "default.target" ];
-            path = with pkgs; [
-              rsync
-              kmod
-              gawk
-              net-tools
-              util-linux
-              profile-sync-daemon
-            ];
-            serviceConfig = {
-              Type = "oneshot";
-              ExecStart = "${pkgs.profile-sync-daemon}/bin/profile-sync-daemon resync";
-            };
-          };
-        };
+    systemd.packages = [ pkgs.profile-sync-daemon ];
 
-        timers.psd-resync = {
-          description = "Timer for profile sync daemon - ${cfg.resyncTimer}";
-          partOf = [
-            "psd-resync.service"
-            "psd.service"
-          ];
-
-          timerConfig = {
-            OnUnitActiveSec = "${cfg.resyncTimer}";
-          };
-        };
+    systemd.user = {
+      services.psd = {
+        wantedBy = [ "default.target" ];
+        enableDefaultPath = false;
+      };
+      timers.psd-resync.timerConfig = {
+        OnCalendar = "";
+        OnUnitActiveSec = cfg.resyncTimer;
       };
     };
   };

--- a/pkgs/by-name/pr/profile-sync-daemon/package.nix
+++ b/pkgs/by-name/pr/profile-sync-daemon/package.nix
@@ -1,32 +1,54 @@
 {
   lib,
-  stdenv,
+  stdenvNoCC,
   fetchFromGitHub,
-  util-linux,
-  coreutils,
+  makeWrapper,
+  rsync,
+  kmod,
+  gawk,
+  glib,
+  fuse-overlayfs,
+  fuse3,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "profile-sync-daemon";
-  version = "6.50";
+  version = "7.04";
 
   src = fetchFromGitHub {
     owner = "graysky2";
     repo = "profile-sync-daemon";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-Wb9YLxuu9i9s/Y6trz5NZDU9WRywe3138cp5Q2gWbxM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-G2w5V9Eq19Jjx7PZcKH8bBZ3tOoghYaPQyMjlwFkARY=";
   };
 
-  installPhase = ''
-    PREFIX=\"\" DESTDIR=$out make install
-    substituteInPlace $out/bin/profile-sync-daemon \
-      --replace "/usr/" "$out/" \
-      --replace "sudo " "/run/wrappers/bin/sudo "
-    # $HOME detection fails (and is unnecessary)
-    sed -i '/^HOME/d' $out/bin/profile-sync-daemon
-    substituteInPlace $out/bin/psd-overlay-helper \
-      --replace "PATH=/usr/bin:/bin" "PATH=${util-linux.bin}/bin:${coreutils}/bin" \
-      --replace "sudo " "/run/wrappers/bin/sudo "
+  nativeBuildInputs = [ makeWrapper ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "INITDIR_SYSTEMD=$(out)/lib/systemd/user"
+  ];
+
+  postInstall = ''
+    substituteInPlace \
+      $out/bin/{profile-sync-daemon,psd-suspend-sync} \
+      $out/lib/systemd/user/psd{.service,-resync.service} \
+      --replace-fail /usr $out
+
+    for f in $out/bin/*; do
+      if [ ! -L "$f" ]; then
+        wrapProgram $f --prefix PATH : ${
+          lib.makeBinPath [
+            rsync
+            kmod
+            gawk
+            glib
+            fuse-overlayfs
+            fuse3
+          ]
+        }
+      fi
+    done
   '';
 
   meta = {


### PR DESCRIPTION
Closes #500548
Closes #482135

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
