### PR TITLE
python3Packages.pythonMetadataCheckHook: improve

### DIFF
--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -368,6 +368,7 @@ in
       substitutions = {
         inherit pythonInterpreter pythonSitePackages;
         pythonWithPackaging = lib.getExe (pythonOnBuildForHost.withPackages (ps: [ ps.packaging ]));
+        retrieveMetadata = ./python-metadata-check-hook-retrieve.py;
       };
       meta = {
         maintainers = [ lib.maintainers.dotlambda ];

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -369,6 +369,7 @@ in
         inherit pythonInterpreter pythonSitePackages;
         pythonWithPackaging = lib.getExe (pythonOnBuildForHost.withPackages (ps: [ ps.packaging ]));
         retrieveMetadata = ./python-metadata-check-hook-retrieve.py;
+        compareMetadata = ./python-metadata-check-hook-compare.py;
       };
       meta = {
         maintainers = [ lib.maintainers.dotlambda ];

--- a/pkgs/development/interpreters/python/hooks/python-metadata-check-hook-compare.py
+++ b/pkgs/development/interpreters/python/hooks/python-metadata-check-hook-compare.py
@@ -6,16 +6,16 @@ derivation_pname = argv[1]
 derivation_version = argv[2]
 metadata_version = argv[3]
 
+if 'unstable-' not in derivation_version:
+    try:
+        parse(derivation_version)
+    except InvalidVersion as e:
+        print(e)
+        print('Make sure you follow https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#versioning.')
+        exit(1)
 
-try:
-    parse(derivation_version)
-except InvalidVersion as e:
-    print(e)
-    print('Make sure you follow https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#versioning.')
-    exit(1)
-
-if Version(derivation_version) != Version(metadata_version):
-    print(f"The '{derivation_pname}' derivation has version '{derivation_version}' but .dist-info/METADATA specifies version '{metadata_version}'.")
-    print('This usually means that the wrong version is hardcoded in pyproject.toml or setup.{py,cfg}.')
-    print("Use the pyprojectVersionPatchHook or patch the version manually so that the project metadata matches the derivation's version.")
-    exit(1)
+    if Version(derivation_version) != Version(metadata_version):
+        print(f"The '{derivation_pname}' derivation has version '{derivation_version}' but .dist-info/METADATA specifies version '{metadata_version}'.")
+        print('This usually means that the wrong version is hardcoded in pyproject.toml or setup.{py,cfg}.')
+        print("Use the pyprojectVersionPatchHook or patch the version manually so that the project metadata matches the derivation's version.")
+        exit(1)

--- a/pkgs/development/interpreters/python/hooks/python-metadata-check-hook-compare.py
+++ b/pkgs/development/interpreters/python/hooks/python-metadata-check-hook-compare.py
@@ -1,0 +1,21 @@
+from packaging.version import InvalidVersion, parse, Version
+from sys import argv, exit
+
+
+derivation_pname = argv[1]
+derivation_version = argv[2]
+metadata_version = argv[3]
+
+
+try:
+    parse(derivation_version)
+except InvalidVersion as e:
+    print(e)
+    print('Make sure you follow https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#versioning.')
+    exit(1)
+
+if Version(derivation_version) != Version(metadata_version):
+    print(f"The '{derivation_pname}' derivation has version '{derivation_version}' but .dist-info/METADATA specifies version '{metadata_version}'.")
+    print('This usually means that the wrong version is hardcoded in pyproject.toml or setup.{py,cfg}.')
+    print("Use the pyprojectVersionPatchHook or patch the version manually so that the project metadata matches the derivation's version.")
+    exit(1)

--- a/pkgs/development/interpreters/python/hooks/python-metadata-check-hook-retrieve.py
+++ b/pkgs/development/interpreters/python/hooks/python-metadata-check-hook-retrieve.py
@@ -1,0 +1,13 @@
+from importlib.metadata import PackageNotFoundError, version
+from sys import argv, exit, stderr
+
+
+pname = argv[1]
+try:
+    print(version(pname))
+except PackageNotFoundError as e:
+    print(e, file=stderr)
+    print("This usually means that the derivation's pname does not correspond to the project name, as found on PyPI, in pyproject.toml, or in setup.{py,cfg}.", file=stderr)
+    print("Use the normalized name for the derivation's pname and its attribute name in python3Packages.", file=stderr)
+    print("See https://packaging.python.org/en/latest/specifications/name-normalization/.", file=stderr)
+    exit(1)

--- a/pkgs/development/interpreters/python/hooks/python-metadata-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-metadata-check-hook.sh
@@ -19,7 +19,7 @@ pythonMetadataCheckPhase() {
   # `python -P` avoids picking up egg-info dirs in $PWD
   local metadataVersion
   metadataVersion="$(PYTHONPATH="$pythonMetadataCheckOutput/@pythonSitePackages@:$PYTHONPATH" \
-    @pythonInterpreter@ -P -c 'from importlib.metadata import version; import sys; print(version(sys.argv[1]))' "$derivationPname")"
+    @pythonInterpreter@ -P @retrieveMetadata@ "$derivationPname")"
 
   # check that both versions can be parsed
   @pythonWithPackaging@ -c "from packaging.version import Version; from sys import argv; Version(argv[1]); Version(argv[2])" "$derivationVersion" "$metadataVersion"

--- a/pkgs/development/interpreters/python/hooks/python-metadata-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-metadata-check-hook.sh
@@ -21,15 +21,7 @@ pythonMetadataCheckPhase() {
   metadataVersion="$(PYTHONPATH="$pythonMetadataCheckOutput/@pythonSitePackages@:$PYTHONPATH" \
     @pythonInterpreter@ -P @retrieveMetadata@ "$derivationPname")"
 
-  # check that both versions can be parsed
-  @pythonWithPackaging@ -c "from packaging.version import Version; from sys import argv; Version(argv[1]); Version(argv[2])" "$derivationVersion" "$metadataVersion"
-
-  if @pythonWithPackaging@ -c "from packaging.version import Version; from sys import argv, exit; exit(Version(argv[1]) == Version(argv[2]))" "$derivationVersion" "$metadataVersion"; then
-    echo "The '$derivationPname' derivation has version '$derivationVersion' but .dist-info/METADATA specifies version '$metadataVersion'."
-    echo "This usually means that the wrong version is hardcoded in pyproject.toml or setup.{py,cfg}."
-    echo "Use the pyprojectVersionPatchHook or patch the version manually so that the project metadata matches the derivation's version."
-    exit 1
-  fi
+  @pythonWithPackaging@ @compareMetadata@ "$derivationPname" "$derivationVersion" "$metadataVersion"
 }
 
 if [ -z "${dontCheckPythonMetadata-}" ]; then

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -370,7 +370,6 @@ lib.extendMkDerivation {
             && isPythonModule finalAttrs.passthru
             # METADATA is unlikely to be correct if pyproject is false or null.
             && pyproject == true
-            && !lib.hasInfix "unstable-" finalAttrs.version
             && !isBootstrapPackage
           )
           [


### PR DESCRIPTION



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
