### PR TITLE
init tbs agent desktop at 4.5.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5166,6 +5166,11 @@
     name = "Christian Kruse";
     keys = [ { fingerprint = "BC5D 9F4E F7FB 4382 6056  E834 B8E0 F342 A99A 9D73"; } ];
   };
+  cl0vr = {
+    name = "Clover";
+    github = "cl0vrfi3ld";
+    githubId = 47996003;
+  };
   clacke = {
     email = "claes.wallin@greatsinodevelopment.com";
     github = "clacke";

--- a/pkgs/by-name/tb/tbs-agent-desktop/package.nix
+++ b/pkgs/by-name/tb/tbs-agent-desktop/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  appimageTools,
+  fetchzip,
+}:
+let
+  pname = "tbs-agent-desktop";
+  version = "4.5.1";
+
+  src = fetchzip {
+    # upstream only publishes this mutable "latest" URL and the pinned version is
+    # taken from the AppImage filename inside the zip.
+    # we could snapshot this using the wayback machine.
+    url = "https://agent.team-blacksheep.com/agent/TBS-Agent-v4-latest-linux.zip";
+    hash = "sha256-XHdk9rqe34WX+ajPEC3yHrwCWD9eX3dusfjwgGXb3qM=";
+    stripRoot = false;
+    # The AppImage filename contains a space, which appimageTools cannot handle.
+    postFetch = ''
+      mv "$out/TBS Agent-${version}.AppImage" $out/tbs-agent-desktop.AppImage
+    '';
+  };
+
+  appimageContents = appimageTools.extract {
+    inherit pname version;
+    src = "${src}/tbs-agent-desktop.AppImage";
+  };
+in
+appimageTools.wrapType2 {
+  inherit pname version;
+  src = "${src}/tbs-agent-desktop.AppImage";
+
+  extraInstallCommands = ''
+    install -Dm444 ${appimageContents}/@tbsagent.desktop \
+      $out/share/applications/tbs-agent-desktop.desktop
+    install -Dm444 ${appimageContents}/usr/share/icons/hicolor/512x512/apps/@tbsagent.png \
+      $out/share/icons/hicolor/512x512/apps/tbs-agent-desktop.png
+    substituteInPlace $out/share/applications/tbs-agent-desktop.desktop \
+      --replace-fail 'Exec=AppRun --no-sandbox %U' 'Exec=tbs-agent-desktop %U' \
+      --replace-fail 'Icon=@tbsagent' 'Icon=tbs-agent-desktop'
+  '';
+
+  meta = {
+    description = "The one-stop Software for updating and configuring your TBS gear";
+    homepage = "https://www.team-blacksheep.com/products/prod:agentx";
+    downloadPage = "https://www.team-blacksheep.com/download";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "tbs-agent-desktop";
+    maintainers = with lib.maintainers; [ cl0vr ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I've added the TBS Agent Desktop package to Nixpkgs starting at version 4.5.1.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

AI usage note: the package was authored by Claude Code and tested/reviewed by me.