### PR TITLE
appimageTools: warn on deprecated type-specific aliases

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -135,6 +135,8 @@
 
 - `vimacs` has been removed, as it has not been maintained in 10 years and was built for an old version of vim (6.0).
 
+- The deprecated `appimageTools.extractType1`, `appimageTools.extractType2`, and `appimageTools.wrapType1` aliases now emit warnings. Use `appimageTools.extract` and `appimageTools.wrapType2` instead.
+
 ## Other Notable Changes {#sec-nixpkgs-release-26.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/pkgs/applications/office/mendeley/default.nix
+++ b/pkgs/applications/office/mendeley/default.nix
@@ -16,7 +16,7 @@ let
     hash = "sha256-yuoNGAV6JuPfm5GagzD4R2ojBRpKo9aZ8K92jC63MQE=";
   };
 
-  appimageContents = appimageTools.extractType2 {
+  appimageContents = appimageTools.extract {
     inherit pname version src;
   };
 in

--- a/pkgs/build-support/appimage/default.nix
+++ b/pkgs/build-support/appimage/default.nix
@@ -55,9 +55,9 @@ rec {
       '';
 
   # for compatibility, deprecated
-  extractType1 = extract;
-  extractType2 = extract;
-  wrapType1 = wrapType2;
+  extractType1 = lib.warn "'appimageTools.extractType1' is deprecated, use 'appimageTools.extract' instead" extract;
+  extractType2 = lib.warn "'appimageTools.extractType2' is deprecated, use 'appimageTools.extract' instead" extract;
+  wrapType1 = lib.warn "'appimageTools.wrapType1' is deprecated, use 'appimageTools.wrapType2' instead" wrapType2;
 
   wrapAppImage = lib.extendMkDerivation {
     constructDrv = buildFHSEnv;

--- a/pkgs/by-name/al/altus/package.nix
+++ b/pkgs/by-name/al/altus/package.nix
@@ -15,7 +15,7 @@ let
     hash = "sha256-FSyXs9thTQ5T5bvCfg/+QXBZMIOyoijAw0dUsvLRGH8=";
   };
 
-  appimageContents = appimageTools.extractType2 {
+  appimageContents = appimageTools.extract {
     inherit pname version src;
   };
 in

--- a/pkgs/by-name/ar/archipelago/package.nix
+++ b/pkgs/by-name/ar/archipelago/package.nix
@@ -50,7 +50,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     zenity
   ];
 
-  appimageContents = appimageTools.extractType2 { inherit (finalAttrs) pname version src; };
+  appimageContents = appimageTools.extract { inherit (finalAttrs) pname version src; };
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/ar/arduino-ide/package.nix
+++ b/pkgs/by-name/ar/arduino-ide/package.nix
@@ -13,7 +13,7 @@ let
     hash = "sha256-m4RYtjJMZ01M1qwKc70Gkey9QLQ4Gk59rwpunm4TY2g=";
   };
 
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 in
 appimageTools.wrapType2 {
   inherit pname version src;

--- a/pkgs/by-name/aw/awakened-poe-trade/package.nix
+++ b/pkgs/by-name/aw/awakened-poe-trade/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   passthru = {
-    appImageContents = appimageTools.extractType2 {
+    appImageContents = appimageTools.extract {
       inherit (finalAttrs) pname src version;
     };
 

--- a/pkgs/by-name/ba/badlion-client/package.nix
+++ b/pkgs/by-name/ba/badlion-client/package.nix
@@ -9,7 +9,7 @@ appimageTools.wrapAppImage rec {
   pname = "badlion-client";
   version = "4.5.4";
 
-  src = appimageTools.extractType2 {
+  src = appimageTools.extract {
     inherit pname version;
     src = fetchurl {
       name = "badlion-client-linux";

--- a/pkgs/by-name/bl/bloomrpc/package.nix
+++ b/pkgs/by-name/bl/bloomrpc/package.nix
@@ -14,7 +14,7 @@ let
     hash = "sha512-PebdYDpcplPN5y3mRu1mG6CXenYfYvBXNLgIGEr7ZgKnR5pIaOfJNORSNYSdagdGDb/B1sxuKfX4+4f2cqgb6Q==";
   };
 
-  appimageContents = appimageTools.extractType2 {
+  appimageContents = appimageTools.extract {
     inherit pname src version;
   };
 in

--- a/pkgs/by-name/bo/bootstrap-studio/package.nix
+++ b/pkgs/by-name/bo/bootstrap-studio/package.nix
@@ -11,7 +11,7 @@ let
     url = "https://releases.bootstrapstudio.io/${version}/Bootstrap%20Studio.AppImage";
     sha256 = "sha256-tn5MkRSS2SLqVU5SQOH0WYN15wll7nREFA9rkXTPAtQ=";
   };
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 in
 appimageTools.wrapType2 {
   inherit pname version src;

--- a/pkgs/by-name/bu/buckets/package.nix
+++ b/pkgs/by-name/bu/buckets/package.nix
@@ -32,7 +32,7 @@ let
     url = "https://github.com/buckets/application/releases/download/v${version}/Buckets-linux-latest-${platform}-${version}.AppImage";
     inherit hash;
   };
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 in
 appimageTools.wrapType2 {
   inherit pname version src;

--- a/pkgs/by-name/bu/buttercup-desktop/package.nix
+++ b/pkgs/by-name/bu/buttercup-desktop/package.nix
@@ -11,7 +11,7 @@ let
     url = "https://github.com/buttercup/buttercup-desktop/releases/download/v${version}/Buttercup-linux-x86_64.AppImage";
     sha256 = "sha256-iCuvs+FisYPvCmPVg1dhYMX+Lw3WmrMSRytdy6TLrxg=";
   };
-  appimageContents = appimageTools.extractType2 { inherit pname src version; };
+  appimageContents = appimageTools.extract { inherit pname src version; };
 
 in
 appimageTools.wrapType2 {

--- a/pkgs/by-name/ca/caido-desktop/package.nix
+++ b/pkgs/by-name/ca/caido-desktop/package.nix
@@ -50,7 +50,7 @@ let
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
 
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 
   linux = appimageTools.wrapType2 {
     inherit

--- a/pkgs/by-name/ca/capacities/package.nix
+++ b/pkgs/by-name/ca/capacities/package.nix
@@ -14,7 +14,7 @@ let
     hash = "sha256-ATiX1h9hXmKMFtY6OEyZEoJ/SxJGgbj5/QZwFF1sfFQ=";
   };
 
-  appimageContents = appimageTools.extractType2 {
+  appimageContents = appimageTools.extract {
     inherit
       pname
       src

--- a/pkgs/by-name/ca/caprine-bin/build-from-appimage.nix
+++ b/pkgs/by-name/ca/caprine-bin/build-from-appimage.nix
@@ -14,7 +14,7 @@ let
     name = "Caprine-${version}.AppImage";
     inherit sha256;
   };
-  extracted = appimageTools.extractType2 { inherit pname version src; };
+  extracted = appimageTools.extract { inherit pname version src; };
 in
 (appimageTools.wrapType2 {
   inherit pname version src;

--- a/pkgs/by-name/cl/clash-nyanpasu/package.nix
+++ b/pkgs/by-name/cl/clash-nyanpasu/package.nix
@@ -15,7 +15,7 @@ appimageTools.wrapType2 rec {
 
   extraInstallCommands =
     let
-      appimageContents = appimageTools.extractType2 { inherit pname version src; };
+      appimageContents = appimageTools.extract { inherit pname version src; };
     in
     ''
       install -Dm444 ${appimageContents}/clash-nyanpasu.desktop -t $out/share/applications

--- a/pkgs/by-name/cl/clickup/package.nix
+++ b/pkgs/by-name/cl/clickup/package.nix
@@ -23,7 +23,7 @@ let
     extraPkgs = pkgs: [ pkgs.libxkbfile ];
   };
 
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 in
 stdenvNoCC.mkDerivation {
   inherit pname version;

--- a/pkgs/by-name/co/codux/package.nix
+++ b/pkgs/by-name/co/codux/package.nix
@@ -13,7 +13,7 @@ let
     hash = "sha256-rD0yXZAEUcPtxWlWuZD77gjw6JlcUvBsaDYGj+NgLss=";
   };
 
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 in
 
 appimageTools.wrapType2 {

--- a/pkgs/by-name/cr/crypto-org-wallet/package.nix
+++ b/pkgs/by-name/cr/crypto-org-wallet/package.nix
@@ -9,7 +9,7 @@ appimageTools.wrapAppImage rec {
   pname = "chain-desktop-wallet";
   version = "1.5.1";
 
-  src = appimageTools.extractType2 {
+  src = appimageTools.extract {
     inherit pname version;
     src = fetchurl {
       url = "https://github.com/crypto-com/chain-desktop-wallet/releases/download/v${version}/Crypto.com-DeFi-Desktop-Wallet-${version}.AppImage";

--- a/pkgs/by-name/de/deskreen/package.nix
+++ b/pkgs/by-name/de/deskreen/package.nix
@@ -28,7 +28,7 @@ appimageTools.wrapType2 rec {
     };
   extraInstallCommands =
     let
-      contents = appimageTools.extractType2 { inherit pname version src; };
+      contents = appimageTools.extract { inherit pname version src; };
     in
     ''
       install -m 444 -D ${contents}/deskreen-ce.desktop $out/share/applications/deskreen-ce.desktop

--- a/pkgs/by-name/ev/everdo/package.nix
+++ b/pkgs/by-name/ev/everdo/package.nix
@@ -12,7 +12,7 @@ let
     hash = "sha256-67b0gSoVcCIfkFRUL3afgB6eYj5YEuvDTtQgTIwV9S0=";
   };
 
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 in
 appimageTools.wrapType2 {
   inherit pname version src;

--- a/pkgs/by-name/fi/firefly-desktop/package.nix
+++ b/pkgs/by-name/fi/firefly-desktop/package.nix
@@ -11,7 +11,7 @@ let
     url = "https://github.com/iotaledger/firefly/releases/download/desktop-${version}/firefly-desktop-${version}.AppImage";
     sha256 = "sha256-MATMl5eEIauDQpz8/wqIzD7IugPVZ2HJAWCbDM4n+hA=";
   };
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 
 in
 appimageTools.wrapType2 {

--- a/pkgs/by-name/fl/fluent-reader/package.nix
+++ b/pkgs/by-name/fl/fluent-reader/package.nix
@@ -13,7 +13,7 @@ let
     hash = "sha256-AJxE1X6X/KJg/6xWZQJyvgHj9TabFBk2TQdotDs4iWQ=";
   };
 
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 in
 appimageTools.wrapType2 {
   inherit pname version src;

--- a/pkgs/by-name/fr/framesh/package.nix
+++ b/pkgs/by-name/fr/framesh/package.nix
@@ -13,7 +13,7 @@ let
     hash = "sha256-t60jsA4ojXF805OUrqIOdk8eP9PlwA/g0XxEBCahmb4=";
   };
 
-  appimageContents = appimageTools.extractType2 {
+  appimageContents = appimageTools.extract {
     inherit pname version src;
   };
 in

--- a/pkgs/by-name/fr/freelens-bin/linux.nix
+++ b/pkgs/by-name/fr/freelens-bin/linux.nix
@@ -8,7 +8,7 @@
   makeWrapper,
 }:
 let
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 
 in
 appimageTools.wrapType2 {

--- a/pkgs/by-name/ft/ftb-app/package.nix
+++ b/pkgs/by-name/ft/ftb-app/package.nix
@@ -39,7 +39,7 @@ let
   };
 in
 let
-  appimageContents = appimageTools.extractType2 { inherit pname src version; };
+  appimageContents = appimageTools.extract { inherit pname src version; };
 in
 appimageTools.wrapType2 {
   inherit

--- a/pkgs/by-name/gd/gdevelop/linux.nix
+++ b/pkgs/by-name/gd/gdevelop/linux.nix
@@ -17,7 +17,7 @@ let
       }
     else
       throw "${pname}-${version} is not supported on ${stdenv.hostPlatform.system}";
-  appimageContents = appimageTools.extractType2 {
+  appimageContents = appimageTools.extract {
     inherit pname version src;
     postExtract = ''
       substituteInPlace $out/gdevelop.desktop --replace-fail 'Exec=AppRun --no-sandbox %U' 'Exec=gdevelop'

--- a/pkgs/by-name/gs/gsender/package.nix
+++ b/pkgs/by-name/gs/gsender/package.nix
@@ -13,7 +13,7 @@ let
     hash = "sha256-xWsRSzJm5aA13qCBI2MRzauvPqoOBtxqtGb3gLAa3sI=";
   };
 
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 
 in
 appimageTools.wrapType2 rec {

--- a/pkgs/by-name/ha/handheld-daemon-ui/package.nix
+++ b/pkgs/by-name/ha/handheld-daemon-ui/package.nix
@@ -11,7 +11,7 @@ let
     url = "https://github.com/hhd-dev/hhd-ui/releases/download/v${version}/hhd-ui.Appimage";
     hash = "sha256-91Wa50dJAW6Re1MBperHFoftAPagihUP4fv5cMb+pxI=";
   };
-  extractedFiles = appimageTools.extractType2 { inherit pname version src; };
+  extractedFiles = appimageTools.extract { inherit pname version src; };
 in
 appimageTools.wrapType2 {
   inherit pname version src;

--- a/pkgs/by-name/he/heynote/package.nix
+++ b/pkgs/by-name/he/heynote/package.nix
@@ -14,7 +14,7 @@ let
     sha256 = "sha256-37as29Jh5Xz3nEW5aryD52puqaCiAxlMBs+aRIZbbU8=";
   };
 
-  appimageContents = appimageTools.extractType2 {
+  appimageContents = appimageTools.extract {
     inherit version pname src;
   };
 

--- a/pkgs/by-name/hi/hifile/package.nix
+++ b/pkgs/by-name/hi/hifile/package.nix
@@ -14,7 +14,7 @@ let
     inherit hash;
   };
 
-  appimageContents = appimageTools.extractType2 {
+  appimageContents = appimageTools.extract {
     inherit pname version src;
   };
 

--- a/pkgs/by-name/ho/hoppscotch/package.nix
+++ b/pkgs/by-name/ho/hoppscotch/package.nix
@@ -82,7 +82,7 @@ else
 
     extraInstallCommands =
       let
-        appimageContents = appimageTools.extractType2 { inherit pname version src; };
+        appimageContents = appimageTools.extract { inherit pname version src; };
       in
       ''
         # Install .desktop files

--- a/pkgs/by-name/ht/httpie-desktop/package.nix
+++ b/pkgs/by-name/ht/httpie-desktop/package.nix
@@ -22,7 +22,7 @@ appimageTools.wrapType2 rec {
 
   extraInstallCommands =
     let
-      contents = appimageTools.extractType2 { inherit pname version src; };
+      contents = appimageTools.extract { inherit pname version src; };
     in
     ''
       install -Dm644 ${contents}/httpie.desktop $out/share/applications/httpie.desktop

--- a/pkgs/by-name/hy/hydralauncher/package.nix
+++ b/pkgs/by-name/hy/hydralauncher/package.nix
@@ -12,7 +12,7 @@ let
     hash = "sha256-LQ2z8yUUhKLs98YvHHLnhqqtcJFGIvEQ19kB5l0Ti9E=";
   };
 
-  appimageContents = appimageTools.extractType2 { inherit pname src version; };
+  appimageContents = appimageTools.extract { inherit pname src version; };
 in
 appimageTools.wrapType2 {
   inherit pname src version;

--- a/pkgs/by-name/ir/irccloud/package.nix
+++ b/pkgs/by-name/ir/irccloud/package.nix
@@ -13,7 +13,7 @@ let
     sha256 = "sha256-/hMPvYdnVB1XjKgU2v47HnVvW4+uC3rhRjbucqin4iI=";
   };
 
-  appimageContents = appimageTools.extractType2 {
+  appimageContents = appimageTools.extract {
     inherit pname version src;
   };
 

--- a/pkgs/by-name/ja/jan/package.nix
+++ b/pkgs/by-name/ja/jan/package.nix
@@ -24,7 +24,7 @@ let
     hash = "sha256-NNTIq02kisIjINS2TCh0Rb2UyRMSlJLR2+uzZmWxSVo=";
   };
 
-  appimageContents = appimageTools.extractType2 {
+  appimageContents = appimageTools.extract {
     inherit pname version;
     src = linux-src;
   };

--- a/pkgs/by-name/jb/jbrowse/package.nix
+++ b/pkgs/by-name/jb/jbrowse/package.nix
@@ -13,7 +13,7 @@ let
     sha256 = "sha256-aCmNpZX8TBZm7nbS13GBUG4a/X4kvwWRHvwWWykoLwU=";
   };
 
-  appimageContents = appimageTools.extractType2 {
+  appimageContents = appimageTools.extract {
     inherit pname version src;
   };
 

--- a/pkgs/by-name/je/jet-pilot/package.nix
+++ b/pkgs/by-name/je/jet-pilot/package.nix
@@ -13,7 +13,7 @@ appimageTools.wrapType2 rec {
     hash = "sha256-W1VRV29ZV8nD3wAcSNAsWguN8s+zio0lsVaZwAnCOwE=";
   };
 
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 
   meta = {
     description = "Open-source Kubernetes desktop client that focuses on less clutter, speed and good looks";

--- a/pkgs/by-name/kc/kchat/package.nix
+++ b/pkgs/by-name/kc/kchat/package.nix
@@ -16,7 +16,7 @@ appimageTools.wrapType2 rec {
 
   extraInstallCommands =
     let
-      contents = appimageTools.extractType2 { inherit pname version src; };
+      contents = appimageTools.extract { inherit pname version src; };
     in
     ''
       mkdir -p "$out/share/applications"

--- a/pkgs/by-name/ki/kirimoto/package.nix
+++ b/pkgs/by-name/ki/kirimoto/package.nix
@@ -13,7 +13,7 @@ let
     hash = "sha256-kf0dy/VelirxBHq0e593c/PM0hurvJqOh1VkDndzNFA=";
   };
 
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 
 in
 appimageTools.wrapType2 rec {

--- a/pkgs/by-name/km/kmeet/package.nix
+++ b/pkgs/by-name/km/kmeet/package.nix
@@ -16,7 +16,7 @@ appimageTools.wrapType2 rec {
 
   extraInstallCommands =
     let
-      contents = appimageTools.extractType2 { inherit pname version src; };
+      contents = appimageTools.extract { inherit pname version src; };
     in
     ''
       mkdir -p "$out/share/applications"

--- a/pkgs/by-name/kr/krunker/linux.nix
+++ b/pkgs/by-name/kr/krunker/linux.nix
@@ -11,7 +11,7 @@ let
     hash = "sha512-a8E5heLsKXOtv/wRKlrnV0GD48cY1mOiSSDW93c7YZ+HoeuBQDxtRaHKg5EqU51Yi+d4tPF5nOh10jZW36c7WQ==";
   };
 
-  appimageContents = appimageTools.extractType2 {
+  appimageContents = appimageTools.extract {
     inherit pname version src;
   };
 in

--- a/pkgs/by-name/le/ledger-live-desktop/package.nix
+++ b/pkgs/by-name/le/ledger-live-desktop/package.nix
@@ -15,7 +15,7 @@ let
     hash = "sha256-XjJBywTscKNNVLTvcVfJPNfKPBBcKoeeSSmDSqz8ePk=";
   };
 
-  appimageContents = appimageTools.extractType2 {
+  appimageContents = appimageTools.extract {
     inherit pname version src;
   };
 in

--- a/pkgs/by-name/le/lens/linux.nix
+++ b/pkgs/by-name/le/lens/linux.nix
@@ -8,7 +8,7 @@
   makeWrapper,
 }:
 let
-  appimageContents = appimageTools.extractType2 {
+  appimageContents = appimageTools.extract {
     inherit pname version src;
   };
 

--- a/pkgs/by-name/li/listen1/package.nix
+++ b/pkgs/by-name/li/listen1/package.nix
@@ -11,7 +11,7 @@ let
     url = "https://github.com/listen1/listen1_desktop/releases/download/v${version}/listen1_${version}_linux_x86_64.AppImage";
     hash = "sha256-RMpusz9bNrHpN23HrncjteiIGkLJgsP7FS2t7zD1Ud0=";
   };
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 in
 appimageTools.wrapType2 {
   inherit pname version src;

--- a/pkgs/by-name/lm/lmath/package.nix
+++ b/pkgs/by-name/lm/lmath/package.nix
@@ -13,7 +13,7 @@ let
     hash = "sha256-JOV+g7izjctCkHl5q/9T2PSUZzPzVPisHppbPofVYy0=";
   };
 
-  appimageContents = appimageTools.extractType2 {
+  appimageContents = appimageTools.extract {
     inherit pname version src;
   };
 in

--- a/pkgs/by-name/lm/lmstudio/linux.nix
+++ b/pkgs/by-name/lm/lmstudio/linux.nix
@@ -14,7 +14,7 @@
 let
   src = fetchurl { inherit url hash; };
 
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 in
 appimageTools.wrapType2 {
   inherit

--- a/pkgs/by-name/lo/losslesscut-bin/build-from-appimage.nix
+++ b/pkgs/by-name/lo/losslesscut-bin/build-from-appimage.nix
@@ -14,7 +14,7 @@ let
     inherit hash;
   };
 
-  extracted = appimageTools.extractType2 {
+  extracted = appimageTools.extract {
     inherit pname version src;
   };
 in

--- a/pkgs/by-name/mo/mobilecoin-wallet/package.nix
+++ b/pkgs/by-name/mo/mobilecoin-wallet/package.nix
@@ -11,7 +11,7 @@ let
     url = "https://github.com/mobilecoinofficial/desktop-wallet/releases/download/v${version}/MobileCoin.Wallet-${version}.AppImage";
     hash = "sha256-JfG+eHsPFXZKi9Vjbw7CPvhmeMvfPWSDS65Ey4Lb8iQ=";
   };
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 
 in
 appimageTools.wrapType2 {

--- a/pkgs/by-name/mo/mochi/package.nix
+++ b/pkgs/by-name/mo/mochi/package.nix
@@ -22,7 +22,7 @@ let
       hash = "sha256-QYBh9ZvmJse3ZimvpU+9ky6ml0pCSZ3mVrYtWtMQGA0=";
     };
 
-    appimageContents = appimageTools.extractType2 { inherit pname version src; };
+    appimageContents = appimageTools.extract { inherit pname version src; };
 
     extraPkgs = pkgs: [ libxshmfence ];
 

--- a/pkgs/by-name/mo/mockoon/package.nix
+++ b/pkgs/by-name/mo/mockoon/package.nix
@@ -13,7 +13,7 @@ let
     hash = "sha256-Y6DmoWGvNp0cvRYgDDMHul5K6CzhiWxMxVTR+W9PE5E=";
   };
 
-  appimageContents = appimageTools.extractType2 {
+  appimageContents = appimageTools.extract {
     inherit pname version src;
   };
 in

--- a/pkgs/by-name/mo/molotov/package.nix
+++ b/pkgs/by-name/mo/molotov/package.nix
@@ -11,7 +11,7 @@ let
     url = "https://desktop-auto-upgrade.molotov.tv/linux/${version}/molotov.AppImage";
     sha256 = "sha256-l4Il6i8uXSeJqH3ITC8ZUpKXPQb0qcW7SpKx1R46XDc=";
   };
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 in
 appimageTools.wrapType2 {
   inherit pname version src;

--- a/pkgs/by-name/mo/motrix/package.nix
+++ b/pkgs/by-name/mo/motrix/package.nix
@@ -12,7 +12,7 @@ let
     hash = "sha256-oSO+VH3bZcjnXjECqZgOmsvlOONbfgOq50qVLvHdKfo=";
   };
 
-  appimageContents = appimageTools.extractType2 {
+  appimageContents = appimageTools.extract {
     inherit pname version src;
   };
 in

--- a/pkgs/by-name/mq/mqttx/package.nix
+++ b/pkgs/by-name/mq/mqttx/package.nix
@@ -28,7 +28,7 @@ let
     sources.${stdenv.hostPlatform.system}
       or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
-  appimageContents = appimageTools.extractType2 {
+  appimageContents = appimageTools.extract {
     inherit pname version src;
   };
 in

--- a/pkgs/by-name/mu/muffon/package.nix
+++ b/pkgs/by-name/mu/muffon/package.nix
@@ -12,7 +12,7 @@ let
     url = "https://github.com/staniel359/muffon/releases/download/v${version}/muffon-${version}-linux-x86_64.AppImage";
     hash = "sha256-C9oaRXS4w89i4tq/hWh5n5uHUETzaoEid49OII/+5dg=";
   };
-  appimageContents = appimageTools.extractType2 { inherit pname src version; };
+  appimageContents = appimageTools.extract { inherit pname src version; };
 in
 appimageTools.wrapType2 {
   inherit pname src version;

--- a/pkgs/by-name/my/mycrypto/package.nix
+++ b/pkgs/by-name/my/mycrypto/package.nix
@@ -15,7 +15,7 @@ let
     inherit sha256;
   };
 
-  appimageContents = appimageTools.extractType2 {
+  appimageContents = appimageTools.extract {
     inherit pname version src;
   };
 

--- a/pkgs/by-name/na/navicat-premium/package.nix
+++ b/pkgs/by-name/na/navicat-premium/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "navicat-premium";
   version = "17.3.7";
 
-  src = appimageTools.extractType2 {
+  src = appimageTools.extract {
     inherit (finalAttrs) pname version;
     src =
       {

--- a/pkgs/by-name/no/notesnook/package.nix
+++ b/pkgs/by-name/no/notesnook/package.nix
@@ -37,7 +37,7 @@ let
     updateScript = ./update.sh;
   };
 
-  appimageContents = appimageTools.extractType2 {
+  appimageContents = appimageTools.extract {
     inherit pname version src;
   };
 

--- a/pkgs/by-name/nr/nrfconnect-bluetooth-low-energy/package.nix
+++ b/pkgs/by-name/nr/nrfconnect-bluetooth-low-energy/package.nix
@@ -16,7 +16,7 @@ let
     name = "${pname}-${version}.AppImage";
   };
 
-  appimageContents = appimageTools.extractType2 {
+  appimageContents = appimageTools.extract {
     inherit pname version src;
   };
 

--- a/pkgs/by-name/nr/nrfconnect/package.nix
+++ b/pkgs/by-name/nr/nrfconnect/package.nix
@@ -16,7 +16,7 @@ let
     name = "${pname}-${version}.AppImage";
   };
 
-  appimageContents = appimageTools.extractType2 {
+  appimageContents = appimageTools.extract {
     inherit pname version src;
   };
 

--- a/pkgs/by-name/p3/p3x-onenote/package.nix
+++ b/pkgs/by-name/p3/p3x-onenote/package.nix
@@ -26,7 +26,7 @@ let
     inherit hash;
   };
 
-  appimageContents = appimageTools.extractType2 {
+  appimageContents = appimageTools.extract {
     inherit pname version src;
   };
 in

--- a/pkgs/by-name/pc/pcloud/package.nix
+++ b/pkgs/by-name/pc/pcloud/package.nix
@@ -54,7 +54,7 @@ in
 stdenv.mkDerivation {
   inherit pname version;
 
-  src = appimageTools.extractType2 {
+  src = appimageTools.extract {
     inherit pname version;
 
     src = "${src}/pCloud.AppImage";

--- a/pkgs/by-name/pi/pinokio/package.nix
+++ b/pkgs/by-name/pi/pinokio/package.nix
@@ -18,7 +18,7 @@ let
       }
       .${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");
 
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 
   meta = {
     homepage = "https://pinokio.computer";

--- a/pkgs/by-name/pl/plexamp/package.nix
+++ b/pkgs/by-name/pl/plexamp/package.nix
@@ -15,7 +15,7 @@ let
     hash = "sha512-Ww/QfMgmeghthfuGfc4Plv7vUKLikLf4R+SImG6TuYg0pDJ5psuHtXQezV0BurVRm6eQ+Ori+YGK2A52tCkcfw==";
   };
 
-  appimageContents = appimageTools.extractType2 {
+  appimageContents = appimageTools.extract {
     inherit pname version src;
   };
 in

--- a/pkgs/by-name/pu/pureref/package.nix
+++ b/pkgs/by-name/pu/pureref/package.nix
@@ -29,7 +29,7 @@ let
         chmod 755 $out
       '';
 in
-appimageTools.wrapType1 {
+appimageTools.wrapType2 {
   pname = "pureref";
   inherit version;
 

--- a/pkgs/by-name/qu/quba/package.nix
+++ b/pkgs/by-name/qu/quba/package.nix
@@ -34,7 +34,7 @@ let
     hash = "sha256-xB1r8DNFOFQQx+MeGC1mWhf7PuMavM7DyYRBlEjAZ8k=";
   };
 
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 
   linux = appimageTools.wrapType2 {
     inherit

--- a/pkgs/by-name/ra/raven-reader/package.nix
+++ b/pkgs/by-name/ra/raven-reader/package.nix
@@ -11,7 +11,7 @@ let
     url = "https://github.com/hello-efficiency-inc/raven-reader/releases/download/v${version}/Raven-Reader-${version}.AppImage";
     sha256 = "sha256-RkpUWM1hAH73ePpQPj2C3SOukLpcPXbaXmb1VbcHaSU=";
   };
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 
 in
 appimageTools.wrapType2 {

--- a/pkgs/by-name/re/redact/package.nix
+++ b/pkgs/by-name/re/redact/package.nix
@@ -12,7 +12,7 @@ let
     url = "https://update-desktop.redact.dev/build/Redact-${version}.AppImage";
     hash = "sha256-NnOQIVv/Y4C+qR5TsXh7rQq/WOYd7Vdtfru4x78djZA=";
   };
-  appimageContents = appimageTools.extractType2 { inherit pname src version; };
+  appimageContents = appimageTools.extract { inherit pname src version; };
 in
 appimageTools.wrapType2 {
   inherit pname version src;

--- a/pkgs/by-name/re/requestly/package.nix
+++ b/pkgs/by-name/re/requestly/package.nix
@@ -13,7 +13,7 @@ let
     hash = "sha256-aUhgn6QeCHcs3yi1KKzw+yOUucbTOeNqObTYZTkKqrs=";
   };
 
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 in
 appimageTools.wrapType2 {
   inherit pname version src;

--- a/pkgs/by-name/re/revolt-desktop/package.nix
+++ b/pkgs/by-name/re/revolt-desktop/package.nix
@@ -52,7 +52,7 @@
           .${stdenvNoCC.hostPlatform.system}
             or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
 
-        appimageContents = appimageTools.extractType2 { inherit (final) src pname version; };
+        appimageContents = appimageTools.extract { inherit (final) src pname version; };
 
         dontUnpack = true;
 

--- a/pkgs/by-name/sa/saleae-logic-2/package.nix
+++ b/pkgs/by-name/sa/saleae-logic-2/package.nix
@@ -26,7 +26,7 @@ appimageTools.wrapType2 {
 
   extraInstallCommands =
     let
-      appimageContents = appimageTools.extractType2 { inherit pname version src; };
+      appimageContents = appimageTools.extract { inherit pname version src; };
     in
     ''
       mkdir -p $out/etc/udev/rules.d

--- a/pkgs/by-name/so/sonixd/package.nix
+++ b/pkgs/by-name/so/sonixd/package.nix
@@ -11,7 +11,7 @@ let
     url = "https://github.com/jeffvli/sonixd/releases/download/v${version}/Sonixd-${version}-linux-x86_64.AppImage";
     sha256 = "sha256-j8B+o/CJ5SsZPMNbugyP3T9Kb+xuxlVxH02loxlwwDg=";
   };
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 in
 appimageTools.wrapType2 rec {
   inherit pname version src;

--- a/pkgs/by-name/ss/ssb-patchwork/package.nix
+++ b/pkgs/by-name/ss/ssb-patchwork/package.nix
@@ -20,7 +20,7 @@ let
     inherit pname version src;
   };
   # we only use this to extract the icon
-  appimage-contents = appimageTools.extractType2 {
+  appimage-contents = appimageTools.extract {
     inherit pname version src;
   };
 

--- a/pkgs/by-name/su/sunsama/package.nix
+++ b/pkgs/by-name/su/sunsama/package.nix
@@ -11,7 +11,7 @@ let
     url = "https://download.todesktop.com/2003096gmmnl0g1/sunsama-${version}-build-260521zej1bgvs1-x86_64.AppImage";
     hash = "sha512-Stb0Mcap4KmRkj/s5jf1uZLm8sR5KNKGpZKXa2VtBIFxKofS1CxQJDWiJiPSNGsqtezLxmvsC4VSI45isYQSpQ==";
   };
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 in
 
 appimageTools.wrapType2 {

--- a/pkgs/by-name/ti/timeular/package.nix
+++ b/pkgs/by-name/ti/timeular/package.nix
@@ -13,7 +13,7 @@ let
     hash = "sha256-oXdalYfysZ4Jb46eHABSkiWThMuc2JGCmP/mk0vCjkE=";
   };
 
-  appimageContents = appimageTools.extractType2 {
+  appimageContents = appimageTools.extract {
     inherit pname version src;
   };
 in

--- a/pkgs/by-name/up/upscayl/linux.nix
+++ b/pkgs/by-name/up/upscayl/linux.nix
@@ -9,7 +9,7 @@
 }:
 
 let
-  appimageContents = appimageTools.extractType2 {
+  appimageContents = appimageTools.extract {
     inherit pname version src;
   };
 in

--- a/pkgs/by-name/vi/via/package.nix
+++ b/pkgs/by-name/vi/via/package.nix
@@ -12,7 +12,7 @@ let
     name = "via-${version}-linux.AppImage";
     sha256 = "sha256-+uTvmrqHK7L5VA/lUHCZZeRYPUrcVA+vjG7venxuHhs=";
   };
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 in
 appimageTools.wrapType2 {
   inherit pname version src;

--- a/pkgs/by-name/vi/vial/package.nix
+++ b/pkgs/by-name/vi/vial/package.nix
@@ -12,7 +12,7 @@ let
     hash = "sha256-sN8i/MOPhaLZ4iJNKz/MdpRIGTZVV/G5qD7o+ID8dAM=";
   };
 
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 in
 appimageTools.wrapType2 {
   inherit pname version src;

--- a/pkgs/by-name/wo/wowup-cf/package.nix
+++ b/pkgs/by-name/wo/wowup-cf/package.nix
@@ -13,9 +13,9 @@ let
     hash = "sha256-596j+i2TTbzpGfdWwzzoQKpB6AD2rqT0hvF4nvbD32A=";
   };
 
-  appimageContents = appimageTools.extractType1 { inherit pname version src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 in
-appimageTools.wrapType1 {
+appimageTools.wrapType2 {
   inherit pname version src;
 
   extraInstallCommands = ''

--- a/pkgs/by-name/ze/zettlr/package.nix
+++ b/pkgs/by-name/ze/zettlr/package.nix
@@ -15,7 +15,7 @@ let
     url = "https://github.com/Zettlr/Zettlr/releases/download/v${version}/Zettlr-${version}-x86_64.appimage";
     hash = "sha256-l1jpZZ6vAlmTlu0m106waeVQaM1mZb5wC1Tcv2IS0Ec=";
   };
-  appimageContents = appimageTools.extractType2 {
+  appimageContents = appimageTools.extract {
     inherit pname version src;
   };
 in


### PR DESCRIPTION
Also migrates away from them with these commands, using ast-grep 0.43.0 with these commands in bash (assisted by ChatGPT):
```bash
for old in extractType1 extractType2; do
  ast-grep \
    --lang nix \
    --pattern "\$TOOLS.$old" \
    --rewrite '$TOOLS.extract' \
    --update-all \
    pkgs
done

ast-grep \
  --lang nix \
  --pattern '$TOOLS.wrapType1' \
  --rewrite '$TOOLS.wrapType2' \
  --update-all \
  pkgs
```

Assisted-by: GPT-5.6-Sol Medium via ChatGPT


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
