### PR TITLE
python3Packages.checksumdir: fix build by switching to poetry-core

### DIFF
--- a/pkgs/development/python-modules/checksumdir/default.nix
+++ b/pkgs/development/python-modules/checksumdir/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  setuptools,
+  poetry-core,
 }:
 
 buildPythonPackage rec {
@@ -17,7 +17,18 @@ buildPythonPackage rec {
     hash = "sha256-rOHRJAK+Or8bwAtzpbINdnEjK3WQcU+4sEZI91tMvAk=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  # pyproject.toml specifies `[tool.poetry]` but doesn't specify `[build-system]`
+  postPatch = ''
+    cat >>pyproject.toml <<EOF
+
+    [build-system]
+    requires = ["poetry-core"]
+    build-backend = "poetry.core.masonry.api"
+
+    EOF
+  '';
+
+  build-system = [ poetry-core ];
 
   doCheck = false; # Package does not contain tests
   pythonImportsCheck = [ "checksumdir" ];


### PR DESCRIPTION
Closes #546110

Forced it to use poetry-core as dotlambda [suggested][3]. The practice of doing this in 'postPatch' is used [once][1]. There is also [one][2] case of doing it inside a patch.

Tried to remove version line too but it didn't help. It is available here:
```
nix run github:attoknot/nixpkgs/1cb7cf3e8b5b#python3Packages.checksumdir
```

[1]: https://github.com/NixOS/nixpkgs/blob/7996eefb4ef44966763e43b579cde389f12a23a4/pkgs/by-name/sp/spoolman/package.nix#L47

[2]: https://github.com/NixOS/nixpkgs/blob/7996eefb4ef44966763e43b579cde389f12a23a4/pkgs/by-name/ki/kitti3/kitti3-fix-build-system.patch#L15

[3]: https://github.com/NixOS/nixpkgs/issues/546110#issuecomment-5092255805
 <!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable: (found no relevant tests)
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
