### PR TITLE
boost: backport regression fixes for boost.context

### DIFF
--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -194,6 +194,35 @@ stdenv.mkDerivation {
       extraPrefix = "libs/context/";
       sha256 = "sha256-bCfLL7bD1Rn4Ie/P3X+nIcgTkbXdCX6FW7B9lHsmVW8=";
     })
+    # Backports https://github.com/boostorg/context/pull/331, which prevents
+    # an optimisation that breaks coroutine migration between threads.
+    # (mostly needed to avoid conflicts when applying the patch below,
+    # but it's a meaningful standalone fix too).
+    ++
+      lib.optional (lib.versionAtLeast version "1.88.0" && lib.versionOlder version "1.92.0")
+        (fetchpatch {
+          url = "https://github.com/boostorg/context/commit/0921b9fd5c776aec7748475c6c10807e0d51bc6d.patch";
+          relative = "include";
+          hash = "sha256-nQYMd3HFsDLxijnGdyas0ZHs3ylQVMGQL14K7F6MkF0=";
+        })
+    # Backports https://github.com/boostorg/context/pull/337 which fixes a regression that breaks
+    # std::uncaught_exceptions for abandoned coroutines under libstdc++ and fcontext implementation.
+    # This bug also caused subtle breakage in Nix. See https://github.com/NixOS/nix/issues/16174.
+    ++
+      lib.optional (lib.versionAtLeast version "1.88.0" && lib.versionOlder version "1.93.0")
+        (fetchpatch {
+          url = "https://github.com/boostorg/context/commit/5883212311535a0046031d74d1568ae173c1e35b.patch";
+          relative = "include";
+          hash = "sha256-CytNLi2d0wjI/lY5lDv98mwwQaEt7qeIs4UkE6QgCBU=";
+        })
+    ++
+      # This also broke Nix https://github.com/NixOS/nix/issues/13145 and probably much more dependants too.
+      lib.optional (lib.versionAtLeast version "1.88.0" && lib.versionOlder version "1.89.0")
+        (fetchpatch {
+          url = "https://github.com/boostorg/context/commit/c79564d0de69422ed33f2fbc892908ad510e6a19.patch";
+          relative = "include";
+          hash = "sha256-5iZ+rSdtyOupBUYws6U8whd43XMkTlQlApW5xvE0ZB4=";
+        })
     # This fixes another issue regarding ill-formed constant expressions, which is a default error
     # in clang 16 and will be a hard error in clang 17.
     ++ lib.optional (lib.versionOlder version "1.80") (fetchpatch {


### PR DESCRIPTION
Applies the fixes for 1.88 regressions that have caused widespread breakage in Nix. Currently we are building with 1.89, so only 2 fixes are relevant [1,2], with the second patch being backported to avoid conflicts - the issue it addresses doesn't blow up in nix - but it does in userver and other stuff too probably. The third one is 1.88-only and is included in upstream >= 1.89.

The third patch was authored by NaN-git to unbreak nix with 1.89, so we apply it to 1.88 (the initial version that had the fiber-specific exception state changes with fcontext and libstdc++). This is mostly for consistency and unbreak boost.context on that version.

Even though we have only observed this breakage in Nix, I'm pretty sure any serious consumer of boost.context and downstream boost libraries (like asio/coroutine2 e.t.c.) is similarly broken currently so I'd prefer that we fix the root cause here instead of rolling a gazillion workarounds everywhere.

[1]: https://github.com/boostorg/context/pull/337
[2]: https://github.com/boostorg/context/pull/331

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
