### PR TITLE
python3Packages.tmodbus: 0.4.1 -> 0.5.0; python3Packages.modbus-connection: 3.8.1 -> 3.9.0

### DIFF
--- a/pkgs/development/python-modules/modbus-connection/default.nix
+++ b/pkgs/development/python-modules/modbus-connection/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "modbus-connection";
-  version = "3.8.1";
+  version = "3.9.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -20,7 +20,7 @@ buildPythonPackage (finalAttrs: {
     owner = "home-assistant-libs";
     repo = "modbus-connection";
     tag = finalAttrs.version;
-    hash = "sha256-2XuOrouOnK6MyhX8Pf7RSma49/V8/5ZlHRqYZl0JY90=";
+    hash = "sha256-WmPjIAxC9e6tYxPJSQpvdhUNj2tbYim5e1RP5MIiL9M=";
   };
 
   nativeBuildInputs = [
@@ -39,8 +39,7 @@ buildPythonPackage (finalAttrs: {
     tmodbus = [
       tmodbus
     ]
-    ++ tmodbus.optional-dependencies.async-serial
-    ++ tmodbus.optional-dependencies.smart;
+    ++ tmodbus.optional-dependencies.async-serial;
   };
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/tmodbus/default.nix
+++ b/pkgs/development/python-modules/tmodbus/default.nix
@@ -1,5 +1,6 @@
 {
   buildPythonPackage,
+  cryptography,
   fetchFromGitHub,
   hatchling,
   hatch-vcs,
@@ -9,17 +10,18 @@
   rustPlatform,
   serialx,
   socat,
+  sybil,
   tenacity,
 }:
 
 let
-  version = "0.4.1";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "wlcrs";
     repo = "tmodbus";
     tag = "v${version}";
-    hash = "sha256-pVP2QaCYkeeKhlEha7qIyNhbN1DfVyRxTSZBloEMXxc=";
+    hash = "sha256-NbDa6AEhk28qGg2URqdfySXN6JIu/CMEQt8raNWv+A4=";
   };
 
   rmodbus-server = rustPlatform.buildRustPackage (finalAttrs: {
@@ -30,7 +32,7 @@ let
 
     sourceRoot = "${src.name}/integration_tests/rmodbus";
 
-    cargoHash = "sha256-t7lJ7zC5+z1E/EDWTPR6cbGhcy/RmtXQXon+FiXRZlI=";
+    cargoHash = "sha256-wJ6HVtl7X+1M3By06q02K2naBFEvZNWh42StOhJbYt0=";
 
     meta = {
       description = "Rust Modbus server";
@@ -47,7 +49,7 @@ let
 
     sourceRoot = "${src.name}/integration_tests/tokio";
 
-    cargoHash = "sha256-grYnQxf0CH7hkFq1zTMxw6brtHfCheh/O2EtPPPpVqA=";
+    cargoHash = "sha256-/V10uVQPgiqp05557OvhVgo/jDyWopRUUAkf4Ibfh/E=";
 
     meta = {
       description = "Rust Tokio Modbus server";
@@ -65,9 +67,7 @@ buildPythonPackage (finalAttrs: {
   __structuredAttrs = true;
 
   postPatch = ''
-    substituteInPlace \
-      integration_tests/tokio/test_tokio_client.py \
-      integration_tests/rmodbus/test_rmodbus_client.py \
+    substituteInPlace integration_tests/helpers.py \
       --replace-fail "/usr/bin/socat" "${lib.getExe socat}"
 
     mkdir -p integration_tests/{rmodbus,tokio}/target/release
@@ -81,18 +81,21 @@ buildPythonPackage (finalAttrs: {
     hatchling
   ];
 
+  dependencies = [ tenacity ];
+
   optional-dependencies = {
     async-serial = [
       serialx
     ];
-    smart = [
-      tenacity
+    security = [
+      cryptography
     ];
   };
 
   nativeCheckInputs = [
     pytest-asyncio
     pytestCheckHook
+    sybil
   ]
   ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
 


### PR DESCRIPTION
https://github.com/wlcrs/tmodbus/releases/tag/v0.5.0
https://github.com/home-assistant-libs/modbus-connection/releases/tag/3.9.0

Closes: #546332 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
