### PR TITLE
python3Packages.svg2tikz: 3.3.4 -> 3.3.6

### DIFF
--- a/pkgs/development/python-modules/svg2tikz/default.nix
+++ b/pkgs/development/python-modules/svg2tikz/default.nix
@@ -9,7 +9,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "svg2tikz";
   version = "3.3.6";
 
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "xyz2tex";
     repo = "svg2tikz";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-0Bp+nr/jlu9eJqMQOlBwsmr468qUgxJqgLK2VDNT9yY=";
   };
 
@@ -43,7 +43,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "svg2tikz" ];
 
   meta = {
-    changelog = "https://github.com/xyz2tex/svg2tikz/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/xyz2tex/svg2tikz/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     homepage = "https://github.com/xyz2tex/svg2tikz";
     description = "Set of tools for converting SVG graphics to TikZ/PGF code";
     license = lib.licenses.gpl2Plus;
@@ -52,4 +52,4 @@ buildPythonPackage rec {
       gal_bolle
     ];
   };
-}
+})

--- a/pkgs/development/python-modules/svg2tikz/default.nix
+++ b/pkgs/development/python-modules/svg2tikz/default.nix
@@ -5,12 +5,13 @@
   poetry-core,
   inkex,
   lxml,
+  pygobject3,
   pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "svg2tikz";
-  version = "3.3.4";
+  version = "3.3.6";
 
   pyproject = true;
 
@@ -18,7 +19,7 @@ buildPythonPackage rec {
     owner = "xyz2tex";
     repo = "svg2tikz";
     tag = "v${version}";
-    hash = "sha256-hIVxrUqT9g3e8eKdz1xPqRBiN62BPLav+xPHm6WCAqw=";
+    hash = "sha256-0Bp+nr/jlu9eJqMQOlBwsmr468qUgxJqgLK2VDNT9yY=";
   };
 
   build-system = [
@@ -28,11 +29,13 @@ buildPythonPackage rec {
   dependencies = [
     inkex
     lxml
+    pygobject3
   ];
 
   pythonRelaxDeps = [
     "inkex"
     "lxml"
+    "pygobject"
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];


### PR DESCRIPTION
Diff: https://github.com/xyz2tex/svg2tikz/compare/v3.3.4...v3.3.6

Changelog: https://github.com/xyz2tex/svg2tikz/blob/v3.3.6/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
