### PR TITLE
clin: init at 0.9.9

### DIFF
--- a/pkgs/by-name/cl/clin/package.nix
+++ b/pkgs/by-name/cl/clin/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  openssl,
+  zlib,
+  libgit2,
+  libx11,
+  libxcb,
+  installShellFiles,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "clin";
+  version = "0.9.9";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "reekta92";
+    repo = "clin-rs";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-1WrhXeKvxnBcBP8WJHKxLrgQ/FtsLrlBmhuU8McYbmg=";
+  };
+
+  cargoHash = "sha256-Lm5B6rjZy9mgCME+iFQlR62dqpP93+3Ds69LEFirouE=";
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+  ];
+  buildInputs = [
+    openssl
+    zlib
+    libgit2
+    libx11
+    libxcb
+  ];
+
+  postInstall = "install -Dm444 assets/clin.desktop -t $out/share/applications";
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Feature-packed TUI note management app inspired by Obsidian";
+    longDescription = ''
+      clin is a free, open-source terminal note manager inspired by Obsidian.
+      It packs Obsidian's core features — markdown editing and rendering, .canvas
+      files, and a force-directed graph view — into a roughly 2-5 MB Rust binary with
+      minimal resource use, while keeping the UI approachable.
+    '';
+    homepage = "https://github.com/reekta92/clin-rs/tree/main";
+    license = lib.licenses.gpl3;
+    mainProgram = "clin";
+    maintainers = with lib.maintainers; [ louis-thevenet ];
+  };
+})


### PR DESCRIPTION
clin is a free, open-source terminal note manager inspired by Obsidian. It packs Obsidian's core features — markdown editing and rendering, .canvas files, and a force-directed graph view — into a roughly 2-5 MB Rust binary with minimal resource use, while keeping the UI approachable.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
