### PR TITLE
nixos/black-magic-debug: init module

### DIFF
--- a/nixos/modules/hardware/black-magic-debug.nix
+++ b/nixos/modules/hardware/black-magic-debug.nix
@@ -1,0 +1,23 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.hardware.blackMagicDebug;
+in
+{
+  options.hardware.blackMagicDebug.enable = lib.mkEnableOption ''
+    Enables Black Magic Debug udev rules, installs the utilities and ensures 'plugdev' group exists.
+    This is a prerequisite to using Black Magic debug devices without being root.
+    Ensure your user is a member of the 'plugdev' group after enabling.
+  '';
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.bmputil ];
+    services.udev.packages = [ pkgs.bmputil ];
+
+    users.groups.plugdev = { };
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -53,6 +53,7 @@
   ./hardware/all-firmware.nix
   ./hardware/all-hardware.nix
   ./hardware/apple-touchbar.nix
+  ./hardware/black-magic-debug.nix
   ./hardware/bladeRF.nix
   ./hardware/brillo.nix
   ./hardware/ckb-next.nix


### PR DESCRIPTION
This module allows the [Black Magic debug probe](https://black-magic.org/) to be used as a non-root user, it will install udev rules, ensure the plugdev group exists (required for the rules) and install the utilities for the hardware.

I've followed the hackrf module as it is similar

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

I've run this on my machine, plugging in my device has the udev rules run as expected. I don't know if/how I should add release notes 

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
