### PR TITLE
navidromePlugins: Clean-up builder, to extendMkDerivation, use patched manifest

### DIFF
--- a/pkgs/by-name/na/navidrome/plugins/build-plugin.nix
+++ b/pkgs/by-name/na/navidrome/plugins/build-plugin.nix
@@ -25,6 +25,12 @@ lib.extendMkDerivation {
       ...
     }@args:
     {
+      __structuredAttrs = true;
+
+      nativeBuildInputs = [
+        zip
+      ];
+
       env = {
         CGO_ENABLED = "0";
       }
@@ -35,20 +41,21 @@ lib.extendMkDerivation {
         GOARCH=wasm \
         go build \
           -buildmode=c-shared \
-          -o "$GOPATH/bin/plugin.wasm" .
+          -o "./plugin.wasm" .
       '';
 
       installPhase = ''
         runHook preInstall
 
         mkdir -p "$out/share"
+        buildDir="$(mktemp -d)"
 
-        pushd $(mktemp -d)
-        cp "$GOPATH/bin/plugin.wasm" .
-        cp ${finalAttrs.src}/manifest.json .
+        cp "./plugin.wasm" "$buildDir"
+        cp manifest.json "$buildDir"
 
-        ${lib.getExe zip} \
-          "$out/share/${finalAttrs.pname}.ndp" \
+        pushd "$buildDir"
+
+        zip "$out/share/${finalAttrs.pname}.ndp" \
           plugin.wasm \
           manifest.json
 

--- a/pkgs/by-name/na/navidrome/plugins/build-plugin.nix
+++ b/pkgs/by-name/na/navidrome/plugins/build-plugin.nix
@@ -35,20 +35,26 @@ lib.extendMkDerivation {
         GOARCH=wasm \
         go build \
           -buildmode=c-shared \
-          -o $GOPATH/bin/plugin.wasm .
+          -o "$GOPATH/bin/plugin.wasm" .
       '';
 
-      postInstall = ''
-        mkdir $out/share
+      installPhase = ''
+        runHook preInstall
+
+        mkdir -p "$out/share"
+
         pushd $(mktemp -d)
-        cp $GOPATH/bin/plugin.wasm .
+        cp "$GOPATH/bin/plugin.wasm" .
         cp ${finalAttrs.src}/manifest.json .
+
         ${lib.getExe zip} \
-          $out/share/${finalAttrs.pname}.ndp \
+          "$out/share/${finalAttrs.pname}.ndp" \
           plugin.wasm \
           manifest.json
+
         popd
-        rm -r $out/bin
+
+        runHook postInstall
       '';
 
       passthru = {

--- a/pkgs/by-name/na/navidrome/plugins/build-plugin.nix
+++ b/pkgs/by-name/na/navidrome/plugins/build-plugin.nix
@@ -4,64 +4,61 @@
   navidrome,
   zip,
 }:
+lib.extendMkDerivation {
+  constructDrv = buildGoModule;
 
-{
-  pname,
-  src,
-  version,
-  vendorHash,
-  meta,
-  ...
-}@args:
-
-buildGoModule (
-  finalAttrs:
-  {
-    inherit
-      pname
-      version
-      src
-      vendorHash
-      ;
-
-    env = {
-      CGO_ENABLED = "0";
-    }
-    // (args.env or { });
-
-    postBuild = ''
-      GOOS=wasip1 \
-      GOARCH=wasm \
-      go build \
-        -buildmode=c-shared \
-        -o $GOPATH/bin/plugin.wasm .
-    '';
-
-    postInstall = ''
-      mkdir $out/share
-      pushd $(mktemp -d)
-      cp $GOPATH/bin/plugin.wasm .
-      cp ${finalAttrs.src}/manifest.json .
-      ${lib.getExe zip} \
-        $out/share/${finalAttrs.pname}.ndp \
-        plugin.wasm \
-        manifest.json
-      popd
-      rm -r $out/bin
-    '';
-
-    passthru = {
-      isNavidromePlugin = true;
-    }
-    // args.passthru or { };
-
-    meta = {
-      inherit (navidrome.meta) platforms maintainers;
-    }
-    // args.meta or { };
-  }
-  // removeAttrs args [
+  excludeDrvArgNames = [
     "meta"
     "passthru"
-  ]
-)
+  ];
+
+  extendDrvArgs =
+    finalAttrs:
+    {
+      pname,
+      version,
+      src,
+      vendorHash,
+      meta,
+      env ? { },
+      passthru ? { },
+      ...
+    }@args:
+    {
+      env = {
+        CGO_ENABLED = "0";
+      }
+      // env;
+
+      postBuild = ''
+        GOOS=wasip1 \
+        GOARCH=wasm \
+        go build \
+          -buildmode=c-shared \
+          -o $GOPATH/bin/plugin.wasm .
+      '';
+
+      postInstall = ''
+        mkdir $out/share
+        pushd $(mktemp -d)
+        cp $GOPATH/bin/plugin.wasm .
+        cp ${finalAttrs.src}/manifest.json .
+        ${lib.getExe zip} \
+          $out/share/${finalAttrs.pname}.ndp \
+          plugin.wasm \
+          manifest.json
+        popd
+        rm -r $out/bin
+      '';
+
+      passthru = {
+        isNavidromePlugin = true;
+      }
+      // passthru;
+
+      meta = meta // {
+        platforms = navidrome.meta.platforms;
+        maintainers = navidrome.meta.maintainers ++ meta.maintainers or [ ];
+      };
+    };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
This is the first in a series of 3 patches I have. The end goal is using a non-Go plugin. But in the process of that I think some maintenance should be done first. Since GH doesn't support stacked PRs (yet...) I'll put do them in series.

This first patch cleans up the builder. It uses the now commonplace `lib.extendMkDerivation` rather than ad-hoc extension. Other changes:

1. Entirely set the `installPhase` because the base installPhase is mostly useless with the plugins.
2. Do not name `finalAttrs.src` as this will not propagate any patches that downstream users may apply.
3. Allow plugins to have their own authors and platforms.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
