### PR TITLE
winboat: remove maintainer ppom

### DIFF
--- a/pkgs/by-name/wi/winboat/package.nix
+++ b/pkgs/by-name/wi/winboat/package.nix
@@ -116,7 +116,6 @@ buildNpmPackage (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       rexies
-      ppom
     ];
     platforms = [ "x86_64-linux" ];
   };


### PR DESCRIPTION
I'm removing myself as a maintainer, because I don't use winboat anymore and I don't wish to further maintain this complicated package. Thanks to @Rexcrazy804 for the package :)