### PR TITLE
nixos/dbus: add check for invalid configuration

### DIFF
--- a/nixos/modules/services/system/dbus.nix
+++ b/nixos/modules/services/system/dbus.nix
@@ -59,6 +59,10 @@ in
         '';
       };
 
+      enableConfigCheck = lib.mkEnableOption "checking the config during build time" // {
+        default = true;
+      };
+
       dbusPackage = lib.mkPackageOption pkgs "dbus" { };
 
       brokerPackage = lib.mkPackageOption pkgs "dbus-broker" { };
@@ -153,6 +157,34 @@ in
       systemd.user.sockets.dbus.wantedBy = [
         "sockets.target"
       ];
+
+      # ensure that all the imported dbus configurations are at least valid XML
+      system.checks =
+        let
+          dbusConfigCheck =
+            path:
+            pkgs.runCommand "check-dbus-config-${path.name}" { } ''
+              shopt -s nullglob
+
+              check_path () {
+                for path in $1/*.conf; do
+                  ${lib.getExe' pkgs.libxml2 "xmllint"} -noout "$path" \
+                    || (echo "d-bus check failed due to invalid XML" && exit 1)
+                done
+              }
+
+              pkg="${path}"
+              check_path "$pkg/etc/dbus-1/system.d"
+              check_path "$pkg/share/dbus-1/system.d"
+              check_path "$pkg/share/dbus-1/system-services"
+              check_path "$pkg/etc/dbus-1/session.d"
+              check_path "$pkg/share/dbus-1/session.d"
+              check_path "$pkg/share/dbus-1/services"
+
+              touch $out
+            '';
+        in
+        lib.mkIf cfg.enableConfigCheck (builtins.map dbusConfigCheck cfg.packages);
     }
 
     (mkIf config.boot.initrd.systemd.dbus.enable {


### PR DESCRIPTION
Creating this PR as a result of #545966. 

While that turned out to be a case of local store corruption it seems like a good idea to guard against invalid configuration since dbus does not handle it gracefully.

This adds a build-time check to ensure all the `*.conf` files included through `makeDBusConf` are actually valid XML. While dbus-broker appears to define a DTD it is explicitly not meant for validation.

Validated that this will reject the following configuration:

```nix
  services.dbus.packages = [(
    pkgs.runCommand "broken-config" {} ''
      mkdir -p $out/share/dbus-1/system.d

      touch $out/share/dbus-1/system.d/other.conf
    ''
  )];
```

Result:
```console
check-dbus-config-broken-config> /nix/store/a9rivcggvdgg2wq2mfgskxf5l5c8vsw1-broken-config/share/dbus-1/system.d/other.conf:1: parser error : Document is empty
check-dbus-config-broken-config> ^
check-dbus-config-broken-config> d-bus check failed due to invalid XML
error: builder for '/nix/store/fawqz5y9g7vz3mk740j4wv9p44xr3k3r-check-dbus-config-broken-config.drv' failed with exit code 1;
       last 4 log lines:
       > /nix/store/a9rivcggvdgg2wq2mfgskxf5l5c8vsw1-broken-config/share/dbus-1/system.d/other.conf:1: parser error : Document is empty
       >
       > ^
       > d-bus check failed due to invalid XML
       For full logs, run:
           nix log /nix/store/fawqz5y9g7vz3mk740j4wv9p44xr3k3r-check-dbus-config-broken-config.drv
error: 1 dependencies of derivation '/nix/store/mrb618d5g7qv2qhqalv3b4gl45kh8y07-nixos-system-cetoddle-26.05.20260724.597283a.drv' failed to build
```

Also ran the `nixosTests.power-profiles-daemon` test since it appears to go through dbus.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
