### PR TITLE
lazyrsync: init at 0.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14771,6 +14771,11 @@
     githubId = 12160;
     name = "Kirill Radzikhovskyy";
   };
+  kiryuulight = {
+    github = "KiryuuLight";
+    githubId = 70501251;
+    name = "Luis Ortiz";
+  };
   kiskae = {
     github = "Kiskae";
     githubId = 546681;

--- a/pkgs/by-name/la/lazyrsync/package.nix
+++ b/pkgs/by-name/la/lazyrsync/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  rsync,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "lazyrsync";
+  version = "0.1.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "westpoint-io";
+    repo = "lazyrsync";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JBELPmNSaiwxHq9iZHvvrCX/YLSBsOO3OrzXJ0mPrNw=";
+  };
+
+  cargoHash = "sha256-/L6N08TFqwW6yeNFiIUtmz6SxdEuxa6SHMxDoZ4Myl8=";
+
+  nativeCheckInputs = [ rsync ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Terminal UI for rsync with profiles, dry-run preview and live progress";
+    homepage = "https://lazyrsync.westpoint.io";
+    changelog = "https://github.com/westpoint-io/lazyrsync/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    mainProgram = "lazyrsync";
+    maintainers = with lib.maintainers; [ kiryuulight ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Terminal UI for rsync: reusable transfer profiles, a dry-run diff before transferring, live progress. Shells out to the system `rsync`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable: upstream's test suite runs in `checkPhase` (49 passing), plus `versionCheckHook`.
- [ ] Tested compilation of all packages that depend on this change — new package, no reverse dependencies.
- [x] Tested basic functionality: `lazyrsync --version` → `lazyrsync 0.1.1`.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
