### PR TITLE
circt: 1.147.0 -> 1.157.0

### DIFF
--- a/pkgs/by-name/ci/circt/package.nix
+++ b/pkgs/by-name/ci/circt/package.nix
@@ -9,11 +9,9 @@
   ninja,
   lit,
   z3,
-  sv-lang_10, # update sv-lang version here according to upstream requirements
   fmt,
   boost,
   mimalloc,
-  gitUpdater,
   callPackage,
   versionCheckHook,
 
@@ -24,15 +22,16 @@
 let
   pythonEnv = python3.withPackages (ps: [ ps.psutil ]);
   circt-llvm = callPackage ./circt-llvm.nix { };
+  circt-sv-lang = callPackage ./sv-lang.nix { };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "circt";
-  version = "1.147.0";
+  version = "1.157.0";
   src = fetchFromGitHub {
     owner = "llvm";
     repo = "circt";
     tag = "firtool-${finalAttrs.version}";
-    hash = "sha256-rtnvahI7EzUJXE80X3XPWjjDD/6f9BPmZ7S97Lstuhw=";
+    hash = "sha256-WPwmUVaOhRUKMorutlBFbgZjOpGOOxvJTkNIjY8qo6E=";
     fetchSubmodules = true;
   };
 
@@ -55,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     boost
     fmt
     mimalloc
-    sv-lang_10
+    circt-sv-lang
   ];
 
   cmakeFlags = [
@@ -111,6 +110,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     patchShebangs tools/circt-test
+
+    # Keep the self-contained TableGen tests compatible with nixpkgs' lit.
+    substituteInPlace test/Tools/circt-tblgen/self-contained/self_contained_td_format.py \
+      --replace-fail \
+        'timeout = test.config.maxIndividualTestTime or None' \
+        'timeout = getattr(test.config, "maxIndividualTestTime", None)'
 
     # Replace slang references to match the package in nixpkgs
     substituteInPlace \
@@ -169,10 +174,9 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    updateScript = gitUpdater {
-      rev-prefix = "firtool-";
-    };
+    updateScript = ./update.sh;
     llvm = circt-llvm;
+    sv-lang = circt-sv-lang;
   };
 
   meta = {

--- a/pkgs/by-name/ci/circt/sv-lang.nix
+++ b/pkgs/by-name/ci/circt/sv-lang.nix
@@ -1,0 +1,23 @@
+# CIRCT depends on a specific sv-lang revision, so pin it separately from nixpkgs' sv-lang.
+{
+  sv-lang,
+  fetchFromGitHub,
+  tomlplusplus,
+}:
+
+sv-lang.overrideAttrs (old: {
+  src = fetchFromGitHub {
+    owner = "MikePopoloski";
+    repo = "slang";
+    rev = "44dc55f99b9c64971893013e7931e643fbedcf23";
+    hash = "sha256-tKse5rV5kHZmCOb8Zb8k4bOw4wN3pDfY5exdpva57bU=";
+  };
+
+  cmakeFlags = old.cmakeFlags ++ [
+    "-DSLANG_USE_SYSTEM_TOMLPLUSPLUS=ON"
+  ];
+
+  propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [
+    tomlplusplus
+  ];
+})

--- a/pkgs/by-name/ci/circt/update.sh
+++ b/pkgs/by-name/ci/circt/update.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=. -i bash -p bash coreutils gnugrep jq gnused nix nix-prefetch-git nix-prefetch-github common-updater-scripts
+# shellcheck shell=bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(realpath "$ROOT/../../../..")"
+cd "$REPO_ROOT"
+
+# Make the checkout available to the nested Nix invocations as well.
+export NIX_PATH="nixpkgs=$REPO_ROOT${NIX_PATH:+:$NIX_PATH}"
+
+attrPath="${UPDATE_NIX_ATTR_PATH:-circt}"
+
+# CIRCT publishes firtool releases as firtool-<version> Git tags. Find the
+# highest version rather than relying on the ordering returned by GitHub.
+latestVersion=$(
+  list-git-tags --url=https://github.com/llvm/circt.git |
+    sed -n 's/^firtool-//p' |
+    sort --version-sort |
+    tail -n1
+)
+currentVersion="${UPDATE_NIX_OLD_VERSION:-$(nix eval --raw -f . "$attrPath.version")}"
+
+if [[ "$currentVersion" == "$latestVersion" ]]; then
+  echo "CIRCT is up to date: $currentVersion"
+  exit 0
+fi
+
+# Prefetch the release with its LLVM submodule, matching fetchFromGitHub in
+# package.nix.
+currentHash=$(nix eval --raw -f . "$attrPath.src.outputHash")
+circtHash=$(
+  nix-prefetch-github llvm circt \
+    --rev "firtool-$latestVersion" \
+    --fetch-submodules |
+    jq --raw-output .hash
+)
+
+echo "updating CIRCT from $currentVersion to $latestVersion"
+sed -i \
+  -e "s|$currentVersion|$latestVersion|" \
+  -e "s|$currentHash|$circtHash|" \
+  "$ROOT/package.nix"
+
+# Build only the updated source derivation so its CMakeLists.txt can tell us
+# which exact slang revision this CIRCT release expects. CIRCT_UPDATE_SRC_DIR is
+# useful when developing the script against an already checked-out source tree.
+src="${CIRCT_UPDATE_SRC_DIR:-}"
+if [[ -z "$src" ]]; then
+  src=$(nix-build --no-out-link -A "$attrPath.src")
+fi
+
+# CMakeLists.txt contains several FetchContent declarations and therefore
+# several GIT_TAG lines. First isolate the declaration for the slang repository,
+# then extract its nearby GIT_TAG. The tag may be followed by a comment or end
+# immediately after the revision.
+slangRev=$(
+  grep -A5 "https://github.com/MikePopoloski/slang" "$src/CMakeLists.txt" |
+  sed -nE 's/.*GIT_TAG[[:space:]]+([0-9a-f]{40}).*/\1/p' |
+  head -n1
+)
+if [[ -z "$slangRev" ]]; then
+  echo "failed to find slang GIT_TAG in $src/CMakeLists.txt" >&2
+  exit 1
+fi
+
+# Prefetch slang independently because CIRCT's source hash does not cover
+# FetchContent dependencies when CIRCT uses a system-provided slang package.
+slangUrl="https://github.com/MikePopoloski/slang/archive/${slangRev}.tar.gz"
+slangHash=$(nix-prefetch-url --unpack "$slangUrl")
+slangHash=$(nix hash convert --hash-algo sha256 --to sri "$slangHash")
+currentSlangRev=$(nix eval --raw -f . "$attrPath.passthru.sv-lang.src.rev")
+currentSlangHash=$(nix eval --raw -f . "$attrPath.passthru.sv-lang.src.outputHash")
+
+# Keep the private sv-lang override synchronized with the revision declared by
+# CIRCT without changing the version of nixpkgs' general sv-lang package.
+if [[ "$currentSlangRev" != "$slangRev" || "$currentSlangHash" != "$slangHash" ]]; then
+  echo "updating slang from $currentSlangRev to $slangRev"
+  sed -i \
+    -e "s|$currentSlangRev|$slangRev|" \
+    -e "s|$currentSlangHash|$slangHash|" \
+    "$ROOT/sv-lang.nix"
+else
+  echo "slang is up to date: $slangRev"
+fi


### PR DESCRIPTION
This PR updates circt.
I have pinned sv-lang to a specific version because circt seems to depend on a specific version, and the version provided by nixpkgs was incompatible.
I have also added a custom update script to set the sv-lang version to match the upstream version.

closes #530181

Assisted-by: pi (OpenAI gpt-5.6-sol)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
