### PR TITLE
dart-source: apply upstream patches for gcc 16 

### DIFF
--- a/pkgs/development/compilers/dart/source/default.nix
+++ b/pkgs/development/compilers/dart/source/default.nix
@@ -7,6 +7,7 @@
   dart-bin,
   debug ? false,
   fetchurl,
+  fetchpatch,
   gn,
   gitMinimal,
   gitSetupHook,
@@ -144,6 +145,28 @@ dart-bin.overrideAttrs (oldAttrs: {
     ./gcc13.patch
     ./zlib-not-found.patch
     ./custom-flags.patch
+
+    # GCC 16 triggers various build warnings (made errors by -Werror) in the
+    # Dart SDK. These have been fixed upstream, either by correcting the
+    # problematic code or silencing the relevant warnings. Until they have
+    # been released, we fetch the patches here.
+    # Remove when upgrading to Dart 3.13:
+    (fetchpatch {
+      name = "dart-fix-gcc-build.patch";
+      url = "https://github.com/dart-lang/sdk/commit/b2911c0bf1dab671ee4008e05b0d71441a522d84.patch";
+      hash = "sha256-RuS4NuOofg0VjhkwN2oFE1iYjMnCdFtoNZnZLzCDJaU=";
+    })
+    (fetchpatch {
+      name = "dart-fix-gcc16-build.patch";
+      url = "https://github.com/dart-lang/sdk/commit/2f2a523818bf64e23657d1bf9da901d7f58c67aa.patch";
+      hash = "sha256-NQd9YcaFKUXDcG2IdBSTnkJAIqs+3/ahN82gWPnOeQo=";
+    })
+    # Remove when upgrading to Dart 3.14:
+    (fetchpatch {
+      name = "dart-ignore-binaryen-warnings.patch";
+      url = "https://github.com/dart-lang/sdk/commit/963b46dfebad01cab9e063fc8b508df227154a31.patch";
+      hash = "sha256-+JY97WFq+UWNoGikXfHIPxBwPdCWV1HYHjhi9pzqVCo=";
+    })
   ]
   ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [
     ./unbundle.patch


### PR DESCRIPTION
~~This is stacked on #546005, as the patches don't apply to 3.11.4 and it doesn't make sense to rebase them if we're updating soon anyway. Only the second commit here is new.~~ Rebased and unstacked.

GCC 16 triggers various build warnings (made errors by -Werror) in the Dart SDK. These have been fixed upstream, either by correcting the problematic code or silencing the relevant warnings. Until they have been released, we fetch the patches here. Two of the patches will be included in Dart 3.13, and another is in Dart 3.14.

example failing build logs, though there are more issues that come up after: https://hydra.nixos.org/build/339167126/log

working towards #537781.

## Things done

- Built on platform:
  - [x] x86_64-linux (on this commit and on top of the `wip-gcc-16` branch in Nixpkgs)
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
