### PR TITLE
proxysql: fix build by adjusting for gcc 15

### DIFF
--- a/pkgs/by-name/pr/proxysql/btree-cstdint.patch
+++ b/pkgs/by-name/pr/proxysql/btree-cstdint.patch
@@ -1,0 +1,16 @@
+The vendored copy of Google's cpp-btree relies on <cstdint> being pulled in
+transitively.  libstdc++ 15 no longer does so, which makes uint8_t/uint16_t
+undeclared, and the resulting fallback to int trips the kNodeValues
+COMPILE_ASSERT with a "1 << 32" shift.
+
+diff --git a/include/btree.h b/include/btree.h
+--- a/include/btree.h
++++ b/include/btree.h
+@@ -104,6 +104,7 @@
+ #include <stddef.h>
+ #include <string.h>
+ #include <sys/types.h>
++#include <cstdint>
+ #include <algorithm>
+ #include <functional>
+ #include <iostream>

--- a/pkgs/by-name/pr/proxysql/makefiles.patch
+++ b/pkgs/by-name/pr/proxysql/makefiles.patch
@@ -151,7 +151,7 @@ index 87d2a20e..505e069a 100644
  	cd mariadb-client-library && tar -zxf mariadb-connector-c-3.3.8-src.tar.gz
  	cd mariadb-client-library/mariadb_client && patch -p0 < ../plugin_auth_CMakeLists.txt.patch
 -	cd mariadb-client-library/mariadb_client && cmake . -Wno-dev -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOPENSSL_ROOT_DIR=$(SSL_IDIR) -DOPENSSL_LIBRARIES=$(SSL_LDIR) -DICONV_LIBRARIES=$(brew --prefix libiconv)/lib -DICONV_INCLUDE=$(brew --prefix libiconv)/include .
-+	cd mariadb-client-library/mariadb_client && cmake . -Wno-dev -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOPENSSL_ROOT_DIR=$(SSL_IDIR) -DOPENSSL_LIBRARIES=$(SSL_LDIR) -DICONV_LIBRARIES=$(brew --prefix libiconv)/lib -DICONV_INCLUDE=$(brew --prefix libiconv)/include .
++	cd mariadb-client-library/mariadb_client && cmake . -Wno-dev -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_C_FLAGS=-std=gnu17 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOPENSSL_ROOT_DIR=$(SSL_IDIR) -DOPENSSL_LIBRARIES=$(SSL_LDIR) -DICONV_LIBRARIES=$(brew --prefix libiconv)/lib -DICONV_INCLUDE=$(brew --prefix libiconv)/include .
  ifeq ($(PROXYDEBUG),1)
  	cd mariadb-client-library/mariadb_client && patch -p0 < ../ma_context.h.patch
  else ifeq ($(USEVALGRIND),1)

--- a/pkgs/by-name/pr/proxysql/package.nix
+++ b/pkgs/by-name/pr/proxysql/package.nix
@@ -49,6 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     ./makefiles.patch
     ./dont-phone-home.patch
+    ./btree-cstdint.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
I'm currently working on service module for proxysql and just found out that it is currently broken again :/

close https://github.com/NixOS/nixpkgs/issues/546381

I then pointed out Claude Opus 5 to find the actual cause why it builds in `release-25.11` but not later.
The cause is gcc15, and it just fixed things to make it work with it.

this is already upstream: https://github.com/sysown/proxysql/commit/5e7ab935ac3cfff6f32a177ffbaaaf86ff8f4b0f

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Assisted-by: Claude Opus 5