### PR TITLE
binutils: add zstdSupport option; perf: read zstd-compressed debug sections

### DIFF
--- a/pkgs/by-name/pe/perf/package.nix
+++ b/pkgs/by-name/pe/perf/package.nix
@@ -36,8 +36,15 @@
   libcap,
   withPython ? true,
   buildPackages,
+  runCommandCC,
 }:
 let
+  binutilsWithZstd = binutils-unwrapped.override {
+    zstdSupport = true;
+    # the bootstrap-built binutils cannot resolve new inputs itself
+    inherit pkg-config zstd;
+  };
+
   d3-flame-graph-templates = stdenv.mkDerivation rec {
     pname = "d3-flame-graph-templates";
     version = "4.1.3";
@@ -162,11 +169,20 @@ stdenv.mkDerivation {
       --prefix PATH : ${
         lib.makeBinPath (
           [
-            binutils-unwrapped
+            binutilsWithZstd
           ]
           ++ lib.optional withPython python3
         )
       }
+  '';
+
+  passthru.tests.zstd-debug-sections = runCommandCC "perf-zstd-debug-sections" { } ''
+    echo 'int main(void) { return 0; }' > test.c
+    $CC -g -o test test.c
+    ${binutilsWithZstd}/bin/objcopy --compress-debug-sections=zstd test
+    main_addr=$(${binutilsWithZstd}/bin/nm test | awk '$3 == "main" { print $1 }')
+    ${binutilsWithZstd}/bin/addr2line -e test "$main_addr" | grep -q test.c
+    touch $out
   '';
 
   meta = {

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -14,8 +14,10 @@ in
   lib,
   noSysDirs,
   perl,
+  pkg-config,
   runCommand,
   zlib,
+  zstd,
 
   enableGold ? withGold stdenv.targetPlatform,
   enableGoldDefault ? false,
@@ -24,6 +26,8 @@ in
   enableShared ? (!stdenv.hostPlatform.isStatic && !stdenv.hostPlatform.isCygwin),
   # WARN: Enabling all targets increases output size to a multiple.
   withAllTargets ? false,
+  # Off by default: the stdenv bootstrap rebuilds binutils and cannot build zstd.
+  zstdSupport ? false,
 }:
 
 # WARN: configure silently disables ld.gold if it's unsupported, so we need to
@@ -146,6 +150,7 @@ stdenv.mkDerivation (finalAttrs: {
     bison
     perl
   ]
+  ++ lib.optionals zstdSupport [ pkg-config ]
   ++ lib.optionals buildPlatform.isDarwin [
     autoconf269
     automake
@@ -156,7 +161,8 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     zlib
     gettext
-  ];
+  ]
+  ++ lib.optionals zstdSupport [ zstd ];
 
   inherit noSysDirs;
 
@@ -251,6 +257,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--enable-gold${lib.optionalString enableGoldDefault "=default"}"
     "--enable-plugins"
   ]
+  ++ lib.optionals zstdSupport [ "--with-zstd" ]
   ++ (
     if enableShared then
       [


### PR DESCRIPTION
This PR fixes support for reading zstd-compressed debug sections in perf. To do so, it needs binutils that supports zstd (`--with-zstd`, added in binutils 2.40, but nixpkgs built it without zstd.),

The first commit adds a `zstdSupport` option to binutils, defaulting to off because binutils is rebuilt during the stdenv bootstrap, whose package set cannot provide zstd, and enabling it by default would be a mass rebuild (ie. sometime later, we should set up an override living in `pkgs/stdenv/linux/default.nix`)

With the default off, the `binutils-unwrapped` derivation is unchanged, verified by comparing `nix-instantiate -A binutils-unwrapped` and `-A stdenv` output before and after (identical `.drv` paths), so this PR causes no rebuilds beyond perf.

The second commit wraps perf with a zstd-enabled binutils. The override passes `pkg-config` and `zstd` explicitly because the native `binutils-unwrapped` is inherited from the stdenv bootstrap, so `.override` re-evaluates its captured arguments in a bootstrap package set where zstd does not evaluate.

It also adds `perf.tests.zstd-debug-sections`: compile a test binary, compress its debug sections with zstd, and check that addr2line resolves a symbol back to its source line. The same script run against stock binutils fails (`objcopy: --compress-debug-sections=zstd: binutils is not built with zstd support`), so the test fails without the fix.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].



[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
