### PR TITLE
superfile: 1.3.3 -> 1.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23322,6 +23322,12 @@
     githubId = 20760527;
     name = "Madelyn";
   };
+  r4nmaru314 = {
+    email = "niklas.lehmann314@gmail.com";
+    github = "R4nmaru314";
+    githubId = 64467664;
+    name = "Niklas Lehmann";
+  };
   r4v3n6101 = {
     name = "r4v3n6101";
     email = "raven6107@gmail.com";

--- a/pkgs/by-name/su/superfile/package.nix
+++ b/pkgs/by-name/su/superfile/package.nix
@@ -6,23 +6,22 @@
   nix-update-script,
   writableTmpDirAsHomeHook,
   exiftool,
+  zoxide,
 }:
-let
-  version = "1.3.3";
-  tag = "v${version}";
-in
-buildGoModule {
+buildGoModule (finalAttrs: {
   pname = "superfile";
-  inherit version;
+  version = "1.6.0";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "yorukot";
     repo = "superfile";
-    inherit tag;
-    hash = "sha256-A1SWsBcPtGNbSReslp5L3Gg4hy3lDSccqGxFpLfVPrk=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JETdQ42vGPnpviCAR29BSdBTG+huWRr5syN5NysnAlo=";
   };
 
-  vendorHash = "sha256-sqt0BzJW1nu6gYAhscrXlTAbwIoUY7JAOuzsenHpKEI=";
+  vendorHash = "sha256-d2Yo8fWJ2fj7RJrnktljY6TkEPq6Tnbdh2BM4DIAr0E=";
 
   ldflags = [
     "-s"
@@ -31,7 +30,20 @@ buildGoModule {
 
   nativeBuildInputs = [ exiftool ];
 
-  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+    # Upstream's TestZoxide initializes a go-zoxide client, which looks up the
+    # zoxide binary on PATH (exec.LookPath). Without it, the test fails with
+    # "zoxide initialization failed" on Linux.
+    zoxide
+  ];
+
+  # New file panels open in $HOME; layout validation rejects empty directories
+  # (cursor 0 with element count 0). Dotfiles are hidden by default, so use a
+  # visible file to keep $HOME non-empty for TestLayout.
+  preCheck = ''
+    touch "$HOME/keep"
+  '';
 
   # Upstream notes that this could be flaky, and it consistently fails for me.
   checkFlags = [
@@ -48,11 +60,12 @@ buildGoModule {
   meta = {
     description = "Pretty fancy and modern terminal file manager";
     homepage = "https://github.com/yorukot/superfile";
-    changelog = "https://github.com/yorukot/superfile/blob/${tag}/changelog.md";
+    changelog = "https://github.com/yorukot/superfile/blob/${finalAttrs.src.tag}/changelog.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
+      r4nmaru314
       redyf
     ];
     mainProgram = "superfile";
   };
-}
+})


### PR DESCRIPTION
Last version update is over a year ago so this is a huge bump.

Things i did:
```
- Add zoxide to nativeCheckInputs: TestZoxide uses go-zoxide, which requires
  the zoxide CLI on PATH; without it the check phase fails on Linux with
  "zoxide initialization failed".
- Seed $HOME with a visible file in preCheck: new panels open in $HOME and
  layout validation rejects empty directories (dotfiles are hidden by default)
```

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
