### PR TITLE
[backport staging-26.05] libssh2: patch CVE-2026-58050 and CVE-2026-58051

### DIFF
--- a/pkgs/by-name/li/libssh2/package.nix
+++ b/pkgs/by-name/li/libssh2/package.nix
@@ -51,6 +51,18 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://salsa.debian.org/debian/libssh2/-/raw/1d4906e6ebe85a9da2931ba33677ead96a61f07f/debian/patches/libssh-unconst-backport.patch";
       hash = "sha256-jc01Fb70GbaD9+RYeSjRaLFBtKLiMPTMuXas21aC0Ag=";
     })
+
+    # https://github.com/libssh2/libssh2/issues/1925#issuecomment-4938515829
+    (fetchurl {
+      name = "CVE-2026-58050.patch";
+      url = "https://raw.githubusercontent.com/JuliaPackaging/Yggdrasil/9404aa5dd96c945a790c425a5f49af19ed2a93b0/L/LibSSH2/LibSSH2%401.11/bundled/patches/CVE-2026-58050-3449752.patch";
+      hash = "sha256-BZ1ewZgrroev2gkJwdoHCMFJK4wiRmA/Y4tzwaQqBd8=";
+    })
+    (fetchurl {
+      name = "CVE-2026-58051.patch";
+      url = "https://github.com/JuliaPackaging/Yggdrasil/raw/9404aa5dd96c945a790c425a5f49af19ed2a93b0/L/LibSSH2/LibSSH2%401.11/bundled/patches/CVE-2026-58051-a9758da.patch";
+      hash = "sha256-fduXIH02uwzqWV2RDidZmaDBy51V8yuC4XKlGYacjxg=";
+    })
   ];
 
   # this could be accomplished by updateAutotoolsGnuConfigScriptsHook, but that causes infinite recursion

--- a/pkgs/by-name/li/libssh2/package.nix
+++ b/pkgs/by-name/li/libssh2/package.nix
@@ -95,6 +95,5 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.libssh2.org";
     platforms = lib.platforms.all;
     license = with lib.licenses; [ bsd3 ];
-    maintainers = with lib.maintainers; [ SuperSandro2000 ];
   };
 })


### PR DESCRIPTION
backport of #543937

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
