### PR TITLE
hm: apply upstream patch for gcc 16

### DIFF
--- a/pkgs/by-name/hm/hm/package.nix
+++ b/pkgs/by-name/hm/hm/package.nix
@@ -20,6 +20,18 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-zWBwrnCNKi2sIopdu2XQj/7IoTsJQzlcIFNNKM0glDQ=";
   };
 
+  patches = [
+    # GCC 16 has better analysis of unused variables than previous versions.
+    # Since HM builds with -Werror by default, this causes a build failure, so
+    # we fetch the commit that fixed this issue upstream until it makes it into
+    # a release.
+    (fetchpatch {
+      name = "gcc16-unused-variable.patch";
+      url = "https://vcgit.hhi.fraunhofer.de/jvet/HM/-/commit/884d704b9d04ac1728b2c6049174e47eb04987d2.patch";
+      hash = "sha256-UqZf7XFTEOpfE0Uyyrq+ydScR9GzMgR+JQVeZGFjc1c=";
+    })
+  ];
+
   postPatch = ''
     substituteInPlace CMakeLists.txt \
       --replace-fail "-msse4.1" ""


### PR DESCRIPTION
GCC 16 has better analysis of unused variables than previous versions. Since HM builds with -Werror by default, this causes a build failure, so we fetch the commit that fixed this issue upstream until it makes it into a release. (Disclaimer: We authored that commit and sent it via email to one of the maintainers, and they MRed, reviewed, and merged it for us: https://vcgit.hhi.fraunhofer.de/jvet/HM/-/merge_requests/116).

We elected to take a patch instead of suppressing the error (with -Wno-error=…) since patches will be removed on the next update while flags often sit untouched and unnoticed long after they're necessary.

example failing build logs: https://hydra.nixos.org/build/339181152/log
working towards #537781

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
