### PR TITLE
creek: 0.4.3 -> 0.4.4

### DIFF
--- a/pkgs/by-name/cr/creek/build.zig.zon.nix
+++ b/pkgs/by-name/cr/creek/build.zig.zon.nix
@@ -8,10 +8,10 @@
 
 linkFarm "zig-packages" [
   {
-    name = "fcft-2.0.0-zcx6C5EaAADIEaQzDg5D4UvFFMjSEwDE38vdE9xObeN9";
+    name = "fcft-3.0.0-zcx6CxQfAAAOlHFehXv7HwRPcuo7StCjZAtapZbSB6fq";
     path = fetchzip {
-      url = "https://git.sr.ht/~novakane/zig-fcft/archive/v2.0.0.tar.gz";
-      hash = "sha256-qDEtiZNSkzN8jUSnZP/itqh8rMf+lakJy4xMB0I8sxQ=";
+      url = "https://git.sr.ht/~novakane/zig-fcft/archive/v3.0.0.tar.gz";
+      hash = "sha256-/sd+lUK/M48Vfqth1z9BJp/dJ/SMahoCfPqhMJD3lgQ=";
     };
   }
   {
@@ -22,10 +22,10 @@ linkFarm "zig-packages" [
     };
   }
   {
-    name = "wayland-0.3.0-lQa1kjPIAQDmhGYpY-zxiRzQJFHQ2VqhJkQLbKKdt5wl";
+    name = "wayland-0.6.0-dev-lQa1krD8AQBlMqwuhAMJjPQKXvpRByZBxxqMVAZ7yzbG";
     path = fetchzip {
-      url = "https://codeberg.org/ifreund/zig-wayland/archive/v0.3.0.tar.gz";
-      hash = "sha256-ydEavD9z20wRwn9ZVX56ZI2T5i1tnm3LupVxfa30o84=";
+      url = "https://codeberg.org/ifreund/zig-wayland/archive/4a150a04f76f7329e80280661355c04328369d1f.tar.gz";
+      hash = "sha256-B5nA05xYm6iRDDRFC2KUbhBCtjwmApka+BcDCZRssfw=";
     };
   }
 ]

--- a/pkgs/by-name/cr/creek/package.nix
+++ b/pkgs/by-name/cr/creek/package.nix
@@ -1,9 +1,10 @@
 {
   callPackage,
   lib,
-  zig_0_14,
+  zig_0_16,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   fcft,
   pixman,
   pkg-config,
@@ -12,18 +13,26 @@
   wayland-protocols,
 }:
 let
-  zig = zig_0_14;
+  zig = zig_0_16;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "creek";
-  version = "0.4.3";
+  version = "0.4.4";
 
   src = fetchFromGitHub {
     owner = "nmeum";
     repo = "creek";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-5TANQt/VWafm6Lj4dYViiK0IMy/chGr/Gzq0S66HZqI=";
+    hash = "sha256-573tuXZLbn/A/IQGbu26Tw3jShpahNeeFz5UMz72+WE=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "0000-consume-status-line-delimiter-and-reset-the-status-buffer.patch";
+      url = "https://github.com/nmeum/creek/commit/037d2d0a3b382743e5fd0a1a913b9c7df0921b81.patch";
+      hash = "sha256-eJ30s1QS/v+g8VjxXkrCGaXkOEyw3EfpBngIHoGfML0=";
+    })
+  ];
 
   depsBuildBuild = [ pkg-config ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: https://github.com/nmeum/creek/releases/tag/v0.4.4
Diff: https://github.com/nmeum/creek/compare/v0.4.3...v0.4.4
Patch: https://github.com/nmeum/creek/commit/037d2d0a3b382743e5fd0a1a913b9c7df0921b81


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
