### PR TITLE
netcat-openbsd: refactor, enable checks, 1.234-2 -> 1.238-1

### DIFF
--- a/pkgs/by-name/ne/netcat-openbsd/package.nix
+++ b/pkgs/by-name/ne/netcat-openbsd/package.nix
@@ -2,14 +2,21 @@
   lib,
   stdenv,
   fetchFromGitLab,
+  quilt,
   pkg-config,
   libbsd,
   installShellFiles,
+  strace,
+  iproute2,
+  procps,
+  util-linux,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "netcat-openbsd";
   version = "1.234-2";
+  __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchFromGitLab {
     domain = "salsa.debian.org";
@@ -19,41 +26,74 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-kA9QzEI4nutQrKonHw+SxWYbuBLtn91edMAk8JBdAhU=";
   };
 
-  strictDeps = true;
+  postPatch = ''
+    QUILT_PATCHES=debian/patches quilt push -a
+  '';
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
+  doCheck = true;
+
   nativeBuildInputs = [
+    quilt
     pkg-config
     installShellFiles
   ];
-  buildInputs = [ libbsd ];
 
-  postPatch = ''
-    for file in $(cat debian/patches/series); do
-      patch -p1 < debian/patches/$file
-    done
-  '';
+  buildInputs = [
+    libbsd
+  ];
+
+  nativeCheckInputs = [
+    strace
+    iproute2
+    procps
+    util-linux
+  ];
 
   installPhase = ''
     runHook preInstall
 
-    install -Dm755 -t $out/bin nc
+    installBin nc
     installManPage nc.1
 
     runHook postInstall
   '';
 
-  doInstallCheck = true;
-  installCheckPhase = ''
-    $out/bin/nc -h 2> /dev/null
+  checkPhase = ''
+    runHook preCheck
+
+    substituteInPlace debian/tests/client-server debian/checks/netcat \
+      --replace-fail 'PATH="/usr/bin:/bin"' ""
+    patchShebangs debian/tests/client-server debian/checks/netcat
+
+    # normally built by debian/rules
+    $CC -shared -o debian/checks/readpassphrase.so debian/checks/readpassphrase.c
+    $CC -o debian/checks/sun_path-size debian/checks/sun_path-size.c
+
+    # name resolution does not really exists in sandbox
+    rm debian/checks/07-name-resolution
+
+    debian/tests/client-server
+    debian/checks/netcat
+
+    runHook postCheck
   '';
 
   meta = {
     description = "TCP/IP swiss army knife. OpenBSD variant";
     homepage = "https://salsa.debian.org/debian/netcat-openbsd";
     maintainers = with lib.maintainers; [ artturin ];
-    license = lib.licenses.bsd3;
+    license = with lib.licenses; [
+      bsd2
+      bsd3
+    ];
     platforms = lib.platforms.unix;
     mainProgram = "nc";
-    # never built on aarch64-darwin, x86_64-darwin since first introduction in nixpkgs
-    broken = stdenv.hostPlatform.isDarwin;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    badPlatforms = lib.platforms.darwin;
   };
 })

--- a/pkgs/by-name/ne/netcat-openbsd/package.nix
+++ b/pkgs/by-name/ne/netcat-openbsd/package.nix
@@ -14,7 +14,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "netcat-openbsd";
-  version = "1.234-2";
+  version = "1.238-1";
   __structuredAttrs = true;
   strictDeps = true;
 
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "debian";
     repo = "netcat-openbsd";
     tag = "debian/${finalAttrs.version}";
-    hash = "sha256-kA9QzEI4nutQrKonHw+SxWYbuBLtn91edMAk8JBdAhU=";
+    hash = "sha256-CCxPZmZlTRNcQ985zf1RVYE4m3OHTM8FFWol1g8Osjc=";
   };
 
   postPatch = ''
@@ -71,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs debian/tests/client-server debian/checks/netcat
 
     # normally built by debian/rules
-    $CC -shared -o debian/checks/readpassphrase.so debian/checks/readpassphrase.c
+    $CC -shared -o debian/checks/readpassphrase${stdenv.hostPlatform.extensions.sharedLibrary} debian/checks/readpassphrase.c
     $CC -o debian/checks/sun_path-size debian/checks/sun_path-size.c
 
     # name resolution does not really exists in sandbox


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
