### PR TITLE
python314Packages.iterm2: 2.13 -> 2.20, clean up

### DIFF
--- a/pkgs/development/python-modules/iterm2/default.nix
+++ b/pkgs/development/python-modules/iterm2/default.nix
@@ -3,29 +3,33 @@
   buildPythonPackage,
   fetchPypi,
   protobuf,
+  pytestCheckHook,
+  setuptools,
   websockets,
 }:
 
 buildPythonPackage rec {
   pname = "iterm2";
-  version = "2.13";
-  format = "setuptools";
+  version = "2.20";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-vslDklETWNlOfD+E4xvMOAJXyyYYVs9/CKHk5WPXI34=";
+    hash = "sha256-Fo04B81Ys+Z4R2hSviu0pc2J8AjZXjfSd32YEHMc/wg=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
     protobuf
     websockets
   ];
 
-  # The tests require pyobjc. We can't use pyobjc because at
-  # time of writing the pyobjc derivation is disabled on python 3.
-  # iterm2 won't build on python 2 because it depends on websockets
-  # which is disabled below python 3.3.
-  doCheck = false;
+  nativeBuildInputs = [
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [ "iterm2" ];
 


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
