### PR TITLE
lemon: fix version, add commit date comments

### DIFF
--- a/pkgs/by-name/le/lemon/package.nix
+++ b/pkgs/by-name/le/lemon/package.nix
@@ -9,11 +9,13 @@ let
   srcs = {
     lemon = fetchurl {
       hash = "sha256-TXVOEtRpOhLCyi4C3RMt0lHmMp/y2K5YdL8ND6WPrOY=";
+      # from 2026-01-04
       url = "https://www.sqlite.org/src/raw/3fdc16b23f1ea0c91c049b518fc3f75c71843dbfe2b447fcb3cd92d9e4f219f8?at=lemon.c";
       name = "lemon.c";
     };
     lempar = fetchurl {
       hash = "sha256-TYKrUJHtpoljeRWZq4Y1rYLlu7LeM/HuUhe3LJZZkVo=";
+      # from 2025-11-18
       url = "https://www.sqlite.org/src/raw/b57e1780bf8098dd4a9a5bba537f994276ea825a420f6165153e5894dc2dfb07?at=lempar.c";
       name = "lempar.c";
     };
@@ -22,7 +24,7 @@ let
 in
 stdenv.mkDerivation {
   pname = "lemon";
-  version = "1.0-unstable";
+  version = "1.0-unstable-2026-01-04";
 
   dontUnpack = true;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Fixes unstable version (#541820).  I also added comments on the sources to save future contributors the time of finding the dates manually.  Here are my sources for those dates:
https://www.sqlite.org/src/artifact/3fdc16b23f1ea0c9
https://www.sqlite.org/src/artifact/b57e1780bf8098dd 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
