### PR TITLE
proxysql: 3.0.2 -> 3.0.9

### DIFF
--- a/pkgs/by-name/pr/proxysql/makefiles.patch
+++ b/pkgs/by-name/pr/proxysql/makefiles.patch
@@ -1,8 +1,17 @@
 diff --git a/Makefile b/Makefile
-index 01aa5730..6c71b3a5 100644
+index 06f5fd4..aafa66d 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -81,10 +81,7 @@ endif
+@@ -9,7 +9,7 @@
+ ### export GIT_VERSION=3.x.y-dev
+ ### ```
+ 
+-GIT_VERSION_BASE := $(shell git describe --long --abbrev=7 2>/dev/null || git describe --long --abbrev=7 --always)
++GIT_VERSION_BASE ?= $(shell git describe --long --abbrev=7 2>/dev/null || git describe --long --abbrev=7 --always)
+ ifndef GIT_VERSION_BASE
+     $(error GIT_VERSION_BASE is not set)
+ endif
+@@ -175,10 +175,7 @@ endif
  export MAKEOPT := -j${NPROCS}
  
  ### systemd
@@ -13,20 +22,32 @@ index 01aa5730..6c71b3a5 100644
 +SYSTEMD := 1
  
  ### check user/group
- USERCHECK := $(shell getent passwd proxysql)
-@@ -415,16 +412,10 @@ cleanbuild:
+ USERCHECK :=
+@@ -552,24 +549,18 @@ cleanbuild:
  
  .PHONY: install
  install: src/proxysql
 -	install -m 0755 src/proxysql /usr/bin
 -	install -m 0600 etc/proxysql.cnf /etc
 -	if [ ! -d /var/lib/proxysql ]; then mkdir /var/lib/proxysql ; fi
++	install -m 0755 src/proxysql $(out)/bin
++	install -m 0600 etc/proxysql.cnf $(out)/etc
+ 	if [ -f plugins/mysqlx/ProxySQL_MySQLX_Plugin.so ]; then \
+-		install -d /usr/lib/proxysql/plugins ; \
+-		install -m 0755 plugins/mysqlx/ProxySQL_MySQLX_Plugin.so /usr/lib/proxysql/plugins/ ; \
++		install -d $(out)/lib/proxysql/plugins ; \
++		install -m 0755 plugins/mysqlx/ProxySQL_MySQLX_Plugin.so $(out)/lib/proxysql/plugins/ ; \
+ 	fi
+ 	if [ -f plugins/genai/ProxySQL_GenAI_Plugin.so ]; then \
+-		install -d /usr/lib/proxysql/plugins ; \
+-		install -m 0755 plugins/genai/ProxySQL_GenAI_Plugin.so /usr/lib/proxysql/plugins/ ; \
++		install -d $(out)/lib/proxysql/plugins ; \
++		install -m 0755 plugins/genai/ProxySQL_GenAI_Plugin.so $(out)/lib/proxysql/plugins/ ; \
+ 	fi
 -ifeq ($(findstring proxysql,$(USERCHECK)),)
 -	@echo "Creating proxysql user and group"
 -	useradd -r -U -s /bin/false proxysql
 -endif
-+	install -m 0755 src/proxysql $(out)/bin
-+	install -m 0600 etc/proxysql.cnf $(out)/etc
  ifeq ($(SYSTEMD), 1)
 -	install -m 0644 systemd/system/proxysql.service /usr/lib/systemd/system/
 -	systemctl enable proxysql.service
@@ -35,11 +56,11 @@ index 01aa5730..6c71b3a5 100644
  	install -m 0755 etc/init.d/proxysql /etc/init.d
  ifeq ($(DISTRO),"CentOS Linux")
 diff --git a/deps/Makefile b/deps/Makefile
-index 87d2a20e..505e069a 100644
+index 7acd359..d481cd2 100644
 --- a/deps/Makefile
 +++ b/deps/Makefile
-@@ -61,27 +61,22 @@ default: $(targets)
- ### deps targets
+@@ -69,10 +69,7 @@ include $(PROXYSQL_PATH)/common_mk/openssl_version_check.mk
+ 
  
  libinjection/libinjection/src/libinjection.a:
 -	cd libinjection && rm -rf libinjection-*/ || true
@@ -49,16 +70,8 @@ index 87d2a20e..505e069a 100644
  	cd libinjection/libinjection && patch -p1 < ../libinjection_sqli.c.patch
  endif
  ifeq ($(UNAME_S),Darwin)
- 	sed -i '' 's/CC=/CC?=/' libinjection/libinjection/src/Makefile
- else
- 	sed -i -e 's/CC=/CC?=/' libinjection/libinjection/src/Makefile
- endif
- 	cd libinjection/libinjection && CC=${CC} CXX=${CXX} ${MAKE}
+@@ -86,8 +83,6 @@ libinjection: libinjection/libinjection/src/libinjection.a
  
- libinjection: libinjection/libinjection/src/libinjection.a
- 
- include ../common_mk/openssl_flags.mk
- include ../common_mk/openssl_version_check.mk
  
  libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a: libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a re2/re2/obj/libre2.a
 -	cd libhttpserver && rm -rf libhttpserver-*/ || true
@@ -66,7 +79,7 @@ index 87d2a20e..505e069a 100644
  	cd libhttpserver/libhttpserver && patch -p1 < ../noexcept.patch
  	cd libhttpserver/libhttpserver && patch -p1 < ../re2_regex.patch
  	cd libhttpserver/libhttpserver && patch -p1 < ../final_val_post_process.patch
-@@ -99,77 +94,66 @@ libhttpserver: libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a
+@@ -105,8 +100,6 @@ libhttpserver: libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a
  
  
  libev/libev/.libs/libev.a:
@@ -75,49 +88,25 @@ index 87d2a20e..505e069a 100644
  	cd libev/libev && patch ev.c < ../ev.c-multiplication-overflow.patch
  	cd libev/libev && ./configure
  	cd libev/libev && CC=${CC} CXX=${CXX} ${MAKE}
+@@ -124,8 +117,6 @@ coredumper: coredumper/coredumper/src/libcoredumper.a
  
- ev: libev/libev/.libs/libev.a
- 
- 
- coredumper/coredumper/src/libcoredumper.a:
- 	cd coredumper && rm -rf coredumper-*/ || true
- 	cd coredumper && tar -zxf coredumper-*.tar.gz
- 	cd coredumper/coredumper && patch -p1 < ../includes.patch
--	cd coredumper/coredumper && cmake . -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Debug
-+	cd coredumper/coredumper && cmake . -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Debug -DCMAKE_POLICY_VERSION_MINIMUM=3.5
- 	cd coredumper/coredumper && CC=${CC} CXX=${CXX} ${MAKE}
- coredumper: coredumper/coredumper/src/libcoredumper.a
  
  curl/curl/lib/.libs/libcurl.a:
 -	cd curl && rm -rf curl-*/ || true
 -	cd curl && tar -zxf curl-*.tar.gz
- #	cd curl/curl && ./configure --disable-debug --disable-ftp --disable-ldap --disable-ldaps --disable-rtsp --disable-proxy --disable-dict --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smb --disable-smtp --disable-gopher --disable-manual --disable-ipv6 --disable-sspi --disable-crypto-auth --disable-ntlm-wb --disable-tls-srp --without-nghttp2 --without-libidn2 --without-libssh2 --without-brotli --with-ssl=$(shell pwd)/../../libssl/openssl/ && CC=${CC} CXX=${CXX} ${MAKE}
  	cd curl/curl && autoreconf -fi
  ifeq ($(UNAME_S),Darwin)
- 	cd curl/curl && patch configure < ../configure.patch
- endif
- 	cd curl/curl && CPPFLAGS="-I$(SSL_IDIR)" LDFLAGS="$(LIB_SSL_PATH) $(LIB_CRYPTO_PATH)" ./configure --disable-debug --disable-ftp --disable-ldap --disable-ldaps --disable-rtsp --disable-proxy --disable-dict --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smb --disable-smtp --disable-gopher --disable-manual --disable-ipv6 --disable-sspi --disable-ntlm-wb --disable-tls-srp --without-nghttp2 --without-libidn2 --without-libssh2 --without-brotli --without-librtmp --without-libpsl --without-zstd --with-ssl --enable-shared=yes
- 	cd curl/curl && CFLAGS=-fPIC CC=${CC} CXX=${CXX} ${MAKE}
- 
- curl: curl/curl/lib/.libs/libcurl.a
+ 	cd curl/curl && sed -i '' 's/as_fn_error \$$? "one or more libs available at link-time are not available run-time/echo "Skipped check: one or more libs available at link-time are not available run-time/' configure
+@@ -139,8 +130,6 @@ curl: curl/curl/lib/.libs/libcurl.a
  
  
  libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a:
 -	cd libmicrohttpd && rm -rf libmicrohttpd-*/ || true
 -	cd libmicrohttpd && tar -zxf libmicrohttpd-*.tar.gz
--#	cd libmicrohttpd/libmicrohttpd && patch src/microhttpd/connection.c < ../connection.c-snprintf-overflow.patch
  	cd libmicrohttpd/libmicrohttpd && ./configure --enable-https && CC=${CC} CXX=${CXX} ${MAKE}
  
  microhttpd: libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a
- 
- 
- cityhash/cityhash/src/.libs/libcityhash.a:
- 	cd cityhash && rm -rf cityhash-*/ || true
- 	cd cityhash && tar -zxf cityhash-*.tar.gz
- 	cd cityhash/cityhash && cp ../config.guess . && chmod +x config.guess && cp ../config.sub . && chmod +x config.sub
- 	cd cityhash/cityhash && ./configure && CC=${CC} CXX=${CXX} ${MAKE}
- 
- cityhash: cityhash/cityhash/src/.libs/libcityhash.a
+@@ -156,8 +145,6 @@ cityhash: cityhash/cityhash/src/.libs/libcityhash.a
  
  
  lz4/lz4/lib/liblz4.a:
@@ -126,18 +115,15 @@ index 87d2a20e..505e069a 100644
  	cd lz4/lz4 && CC=${CC} CXX=${CXX} ${MAKE}
  
  lz4: lz4/lz4/lib/liblz4.a
- 
- 
- clickhouse-cpp/clickhouse-cpp/clickhouse/libclickhouse-cpp-lib-static.a:
+@@ -201,15 +188,13 @@ protobuf: $(PROTOBUF_LIB)
+ clickhouse-cpp/clickhouse-cpp/clickhouse/libclickhouse-cpp-lib.a:
  	cd clickhouse-cpp && rm -rf clickhouse-cpp-*/ || true
- 	cd clickhouse-cpp && tar -zxf v2.3.0.tar.gz
- 	cd clickhouse-cpp && ln -fs clickhouse-cpp-*/ clickhouse-cpp
- 	cd clickhouse-cpp/clickhouse-cpp && patch clickhouse/base/wire_format.h < ../wire_format.patch
+ 	cd clickhouse-cpp && tar -zxf clickhouse-cpp-*.tar.gz
 -	cd clickhouse-cpp/clickhouse-cpp && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo .
 +	cd clickhouse-cpp/clickhouse-cpp && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_POLICY_VERSION_MINIMUM=3.5 .
  	cd clickhouse-cpp/clickhouse-cpp && CC=${CC} CXX=${CXX} ${MAKE}
  
- clickhouse-cpp: clickhouse-cpp/clickhouse-cpp/clickhouse/libclickhouse-cpp-lib-static.a
+ clickhouse-cpp: clickhouse-cpp/clickhouse-cpp/clickhouse/libclickhouse-cpp-lib.a
  
  
  libdaemon/libdaemon/libdaemon/.libs/libdaemon.a:
@@ -146,25 +132,16 @@ index 87d2a20e..505e069a 100644
  	cd libdaemon/libdaemon && patch -p0 < ../daemon_fork_umask.patch
  	cd libdaemon/libdaemon && cp ../config.guess . && chmod +x config.guess && cp ../config.sub . && chmod +x config.sub && ./configure --disable-examples
  	cd libdaemon/libdaemon && CC=${CC} CXX=${CXX} ${MAKE}
-@@ -194,7 +178,7 @@ mariadb-client-library/mariadb_client/libmariadb/libmariadbclient.a:
- 	cd mariadb-client-library && rm -rf mariadb-connector-c-*/ || true
- 	cd mariadb-client-library && tar -zxf mariadb-connector-c-3.3.8-src.tar.gz
- 	cd mariadb-client-library/mariadb_client && patch -p0 < ../plugin_auth_CMakeLists.txt.patch
--	cd mariadb-client-library/mariadb_client && cmake . -Wno-dev -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOPENSSL_ROOT_DIR=$(SSL_IDIR) -DOPENSSL_LIBRARIES=$(SSL_LDIR) -DICONV_LIBRARIES=$(brew --prefix libiconv)/lib -DICONV_INCLUDE=$(brew --prefix libiconv)/include .
-+	cd mariadb-client-library/mariadb_client && cmake . -Wno-dev -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOPENSSL_ROOT_DIR=$(SSL_IDIR) -DOPENSSL_LIBRARIES=$(SSL_LDIR) -DICONV_LIBRARIES=$(brew --prefix libiconv)/lib -DICONV_INCLUDE=$(brew --prefix libiconv)/include .
- ifeq ($(PROXYDEBUG),1)
- 	cd mariadb-client-library/mariadb_client && patch -p0 < ../ma_context.h.patch
- else ifeq ($(USEVALGRIND),1)
-@@ -253,18 +237,13 @@ sqlite3/sqlite3/sqlite3.o:
- sqlite3: sqlite3/sqlite3/sqlite3.o
+@@ -322,8 +307,6 @@ sqlite-vec: sqlite3/sqlite3/vec.o
  
- libconfig/libconfig/lib/.libs/libconfig++.a:
+ 
+ libconfig/libconfig/out/libconfig++.a:
 -	cd libconfig && rm -rf libconfig-*/ || true
 -	cd libconfig && tar -zxf libconfig-*.tar.gz
- 	cd libconfig/libconfig && ./configure --disable-examples
+ 	cd libconfig/libconfig && patch -p1 < ../restore_unknown_escape_passthrough.patch
+ 	cd libconfig/libconfig && cmake -DBUILD_SHARED_LIBS=0 -DBUILD_EXAMPLES=0 -DBUILD_TESTS=0 -DBUILD_FUZZERS=0 .
  	cd libconfig/libconfig && CC=${CC} CXX=${CXX} ${MAKE}
- 
- libconfig: libconfig/libconfig/lib/.libs/libconfig++.a
+@@ -332,9 +315,6 @@ libconfig: libconfig/libconfig/out/libconfig++.a
  
  
  prometheus-cpp/prometheus-cpp/lib/libprometheus-cpp-core.a:
@@ -174,7 +151,7 @@ index 87d2a20e..505e069a 100644
  	cd prometheus-cpp/prometheus-cpp && patch -p1 < ../serial_exposer.patch
  	cd prometheus-cpp/prometheus-cpp && patch -p1 < ../registry_counters_reset.patch
  	cd prometheus-cpp/prometheus-cpp && patch -p1 < ../fix_old_distros.patch
-@@ -293,17 +272,13 @@ re2: re2/re2/obj/libre2.a
+@@ -363,16 +343,12 @@ re2: re2/re2/obj/libre2.a
  
  
  pcre/pcre/.libs/libpcre.a:
@@ -185,15 +162,9 @@ index 87d2a20e..505e069a 100644
  	cd pcre/pcre && CC=${CC} CXX=${CXX} ${MAKE}
  
  pcre: pcre/pcre/.libs/libpcre.a
- 
  postgresql/postgresql/src/interfaces/libpq/libpq.a:
 -	cd postgresql && rm -rf postgresql-*/ || true
 -	cd postgresql && tar -zxf postgresql-*.tar.gz
  	cd postgresql/postgresql && patch -p0 < ../get_result_from_pgconn.patch
  	cd postgresql/postgresql && patch -p0 < ../handle_row_data.patch
  	cd postgresql/postgresql && patch -p0 < ../fmt_err_msg.patch
-@@ -361,4 +336,3 @@ cleanall:
- 	cd libusual && rm -rf libusual-*/ || true
- 	cd libscram && rm -rf lib/* obj/* || true
- .PHONY: cleanall
--

--- a/pkgs/by-name/pr/proxysql/package.nix
+++ b/pkgs/by-name/pr/proxysql/package.nix
@@ -37,13 +37,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "proxysql";
-  version = "3.0.2";
+  version = "3.0.9";
 
   src = fetchFromGitHub {
     owner = "sysown";
     repo = "proxysql";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-kbfuUulEDPx/5tpp7uOkIXQuyaFYzos3crCvkWHSmHg=";
+    hash = "sha256-QDS4T0e0HZS3aTjpp/6RVdAor4UbI4yvXlx7UxkMfhE=";
   };
 
   patches = [
@@ -77,7 +77,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  env.GIT_VERSION = finalAttrs.version;
+  env = {
+    GIT_VERSION = finalAttrs.version;
+    # the makefile derives GIT_VERSION from GIT_VERSION_BASE and errors out
+    # when that is unset; there is no git in the build sandbox
+    GIT_VERSION_BASE = finalAttrs.version;
+  };
 
   dontConfigure = true;
 
@@ -197,8 +202,11 @@ stdenv.mkDerivation (finalAttrs: {
       autoreconf
       popd
 
+      # libconfig is built with cmake, so it needs no autoreconf, but its
+      # release tarball does not ship the lib/win32 directory that
+      # lib/CMakeLists.txt unconditionally lists as a source.
       pushd libconfig/libconfig
-      autoreconf
+      sed -i '\_^ *win32/stdint\.h$_d' lib/CMakeLists.txt
       popd
 
       pushd libdaemon/libdaemon


### PR DESCRIPTION
Upstream reworked both makefiles, so makefiles.patch was regenerated from scratch; 7 of its 8 hunks no longer applied.

Version is now derived from GIT_VERSION_BASE, which is assigned with `:=` and therefore cannot be overridden from the environment. Relax it to `?=` and set it alongside GIT_VERSION, as there is no git in the sandbox.

libconfig moved from autotools to cmake upstream, so its autoreconf step is gone. Its release tarball does not ship the lib/win32 directory that lib/CMakeLists.txt lists as a source, so drop that entry.

coredumper and the mariadb client now carry CMAKE_POLICY_VERSION_MINIMUM upstream; keep it only for clickhouse-cpp. The new mysqlx and genai plugins install into $(out) rather than /usr/lib.

Assisted-by: Claude Opus 5

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
