### PR TITLE
netcoredbg: only put the main binary in bin on linux

### DIFF
--- a/pkgs/by-name/ne/netcoredbg/package.nix
+++ b/pkgs/by-name/ne/netcoredbg/package.nix
@@ -98,9 +98,13 @@ stdenv.mkDerivation {
     mkdir -p $out/share/netcoredbg $out/bin
     cp ${unmanaged}/* $out/share/netcoredbg
     cp ./lib/netcoredbg/* $out/share/netcoredbg
+    ln -s $out/share/netcoredbg/netcoredbg "$out/bin/"
+  ''
+  +
     # darwin won't work unless we link all files
-    ln -s $out/share/netcoredbg/* "$out/bin/"
-  '';
+    lib.optionalString stdenv.hostPlatform.isDarwin ''
+      ln -s $out/share/netcoredbg/* "$out/bin/"
+    '';
 
   passthru = {
     inherit (managed) fetch-deps;


### PR DESCRIPTION
I noticed there are many DLL files (and an .so file) in my ~/.nix-profile coming from this package which doesn't seem necessary.
According to the comment it is needed on darwin, so I made it darwin only instead of removing it.
I tested this on linux, a debug session starts and basic functionality work.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
