### PR TITLE
opensoldat: fix version, switch to finalAttrs

### DIFF
--- a/pkgs/by-name/op/opensoldat/package.nix
+++ b/pkgs/by-name/op/opensoldat/package.nix
@@ -17,9 +17,9 @@
 }:
 
 let
-  base = stdenv.mkDerivation rec {
+  base = stdenv.mkDerivation (finalAttrs: {
     pname = "opensoldat-base";
-    version = "unstable-2025-10-16";
+    version = "0.4-unstable-2025-10-15";
 
     src = fetchFromGitHub {
       name = "base";
@@ -44,15 +44,15 @@ let
       description = "Opensoldat's base game content";
       license = lib.licenses.cc-by-40;
       platforms = lib.platforms.all;
-      inherit (src.meta) homepage;
+      inherit (finalAttrs.src.meta) homepage;
     };
-  };
+  });
 
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "opensoldat";
-  version = "unstable-2025-10-21";
+  version = "1.8-unstable-2025-10-16";
 
   src = fetchFromGitHub {
     name = "opensoldat";
@@ -112,7 +112,7 @@ stdenv.mkDerivation rec {
       lib.licenses.mit
       base.meta.license
     ];
-    inherit (src.meta) homepage;
+    inherit (finalAttrs.src.meta) homepage;
     maintainers = [ lib.maintainers.sternenseemann ];
     platforms = [
       "x86_64-linux"
@@ -123,4 +123,4 @@ stdenv.mkDerivation rec {
     # aarch64 and arm support should be possible:
     # https://github.com/opensoldat/opensoldat/issues/45
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- switched to `finalAttrs` pattern
- fixed version (#541820)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
