### PR TITLE
courier-prime: fix version, switch to finalAttrs, use fetchFromGitHub

### DIFF
--- a/pkgs/by-name/co/courier-prime/package.nix
+++ b/pkgs/by-name/co/courier-prime/package.nix
@@ -9,6 +9,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "courier-prime";
   version = "0-unstable-2019-11-20";
 
+  __structuredAttrs = true;
+  strictDeps = true;
   src = fetchFromGitHub {
     owner = "quotunquoteapps";
     repo = "CourierPrime";

--- a/pkgs/by-name/co/courier-prime/package.nix
+++ b/pkgs/by-name/co/courier-prime/package.nix
@@ -1,24 +1,25 @@
 {
   lib,
   stdenvNoCC,
-  fetchzip,
+  fetchFromGitHub,
+  installFonts,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "courier-prime";
-  version = "unstable-2019-12-05";
+  version = "0-unstable-2019-11-20";
 
-  src = fetchzip {
-    url = "https://github.com/quoteunquoteapps/CourierPrime/archive/7f6d46a766acd9391d899090de467c53fd9c9cb0/courier-prime-${version}.zip";
+  src = fetchFromGitHub {
+    owner = "quotunquoteapps";
+    repo = "CourierPrime";
+    rev = "7f6d46a766acd9391d899090de467c53fd9c9cb0";
     hash = "sha256-pMFZpytNtgoZrBj2Gj8SgJ0Lab8uVY5aQtcO2lFbHj4=";
   };
 
-  installPhase = ''
-    runHook preInstall
+  nativeBuildInputs = [ installFonts ];
 
-    install -m444 -Dt $out/share/fonts/truetype fonts/ttf/*.ttf
-
-    runHook postInstall
+  postInstall = ''
+    installFonts ttf $out/share/fonts/truetype
   '';
 
   meta = {
@@ -28,4 +29,4 @@ stdenvNoCC.mkDerivation rec {
     maintainers = [ lib.maintainers.austinbutler ];
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- fixed version (#541820)
- switched to `finalAttrs` pattern
- switched to `fetchFromGitHub`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test