### PR TITLE
pinentry-egui: init at 0-unstable-2026-07-10

### DIFF
--- a/pkgs/by-name/pi/pinentry-egui/package.nix
+++ b/pkgs/by-name/pi/pinentry-egui/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  expat,
+  fontconfig,
+  freetype,
+  libGL,
+  libxkbcommon,
+  wayland,
+  libx11,
+  libxcursor,
+  libxi,
+  libxrandr,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "pinentry-egui";
+  version = "0-unstable-2026-07-10";
+
+  src = fetchFromGitHub {
+    owner = "dsociative";
+    repo = "pinentry-egui";
+    rev = "c81bf237048f5b296488751467bb2975982d05af";
+    hash = "sha256-xUhPaXiysXbOctM3FO6WgafVPUOQ+9lP2d4U9PBxCvk=";
+  };
+
+  __structuredAttrs = true;
+
+  cargoHash = "sha256-81W3NOQ6EOV3bMt7SYtg3AjAgmdHZ81gEtQkaOYVFIk=";
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    expat
+    fontconfig
+    freetype
+    libGL
+    libxkbcommon
+    wayland
+    libx11
+    libxcursor
+    libxi
+    libxrandr
+  ];
+
+  postFixup = ''
+    patchelf $out/bin/pinentry-egui \
+      --add-rpath ${
+        lib.makeLibraryPath [
+          libGL
+          libxkbcommon
+          wayland
+        ]
+      }
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Modern, native Wayland pinentry implementation for GPG using egui";
+    homepage = "https://github.com/dsociative/pinentry-egui";
+    license =
+      with lib.licenses;
+      OR [
+        mit
+        asl20
+      ];
+    maintainers = with lib.maintainers; [ colemickens ];
+    mainProgram = "pinentry-egui";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Packages `pinentry-egui`.

I'm doing this in response to: https://github.com/NixOS/nixpkgs/issues/545176 so I can replace `wayprompt` with `pinentry-egui`.

I've deployed this to a NixOS laptop (running COSMIC) and it works fine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
