### PR TITLE
emacs: improve withPackages test

### DIFF
--- a/pkgs/applications/editors/emacs/build-support/wrapper-test/with-packages.el
+++ b/pkgs/applications/editors/emacs/build-support/wrapper-test/with-packages.el
@@ -48,7 +48,7 @@
   (declare (indent 1) (debug (symbolp)))
   (cl-check-type test-name symbol)
   `(defun ,test-name ()
-     (bound-and-true-p ,test-name)))
+     (list (bound-and-true-p ,test-name))))
 
 (defmacro define-with-packages-non-batch-tests-via-bound-and-true-p (&rest test-names)
   "See also `define-with-packages-non-batch-test-via-bound-and-true-p'."
@@ -68,14 +68,14 @@ run non-batch tests on it and collect test results from it.")
 
 (defun with-packages--run-non-batch-test (test-name)
   "Run non-batch test named TEST-NAME, a symbol.
-Return t if the test passes.  Otherwise, return nil."
+Return test result, a list of values.  Each is non-nil if the test passes."
   (cl-check-type test-name symbol)
   (cl-flet ((eval-in-non-batch-emacs (form)
               (server-eval-at with-packages-non-batch-emacs-socket form)))
     (and
      ;; Test test-name is defined in with-packages so we load it in the non-batch Emacs.
      (eval-in-non-batch-emacs '(require 'with-packages))
-     ;; Run the non-batch test.  Return non-nil if it passes.
+     ;; Run the non-batch test and return test result.
      (eval-in-non-batch-emacs `(,test-name)))))
 
 (defmacro define-with-packages-non-batch-ert-test (test-name)
@@ -85,7 +85,12 @@ Return t if the test passes.  Otherwise, return nil."
   `(ert-deftest ,test-name ()
      (should (stringp with-packages-non-batch-emacs-socket))
      (should (file-readable-p with-packages-non-batch-emacs-socket))
-     (should (with-packages--run-non-batch-test (quote ,test-name)))))
+     (let ((test-result (with-packages--run-non-batch-test (quote ,test-name))))
+       (should (consp test-result))
+       ;; Make it easier to find out which condition fails in non-batch tests.
+       (should (equal test-result
+                      (cl-loop for item in test-result
+                               collect (if item item t)))))))
 
 (defmacro define-with-packages-non-batch-ert-tests (&rest test-names)
   "See also `define-with-packages-non-batch-ert-test'."
@@ -102,30 +107,30 @@ Return t if the test passes.  Otherwise, return nil."
   with-packages-early-default-is-loaded-before-default)
 
 (defun with-packages-unwrapped-site-start-is-loaded-quietly ()
-  (and (with-packages-unwrapped-site-start-is-loaded)
-       (not (save-excursion
-              (with-current-buffer "*Messages*"
-                (goto-char (point-min))
-                (save-match-data
-                  (re-search-forward (rx line-start
-                                         "Loading"
-                                         (zero-or-more not-newline)
-                                         "site-start")
-                                     nil
-                                     t)))))))
+  (list (with-packages-unwrapped-site-start-is-loaded)
+        (not (save-excursion
+               (with-current-buffer "*Messages*"
+                 (goto-char (point-min))
+                 (save-match-data
+                   (re-search-forward (rx line-start
+                                          "Loading"
+                                          (zero-or-more not-newline)
+                                          "site-start")
+                                      nil
+                                      t)))))))
 
 (defun with-packages-no-jit-native-comp ()
   "Test no JIT native-comp is triggered during non-batch tests.
 This is a regression test for URL `https://github.com/NixOS/nixpkgs/pull/538964'."
   ;; Give Emacs some time to generate JIT native-comp results.
   (sleep-for 2.5)
-  (and (not (cl-loop for buffer being each buffer
-                     thereis (string= (buffer-name buffer)
-                                      "*Async-native-compile-log*")))
-       (let ((eln-dir (car native-comp-eln-load-path)))
-         (or (directory-empty-p eln-dir)
-             (and (not (file-exists-p eln-dir))
-                  (file-exists-p (file-name-parent-directory eln-dir)))))))
+  (list (not (cl-loop for buffer being each buffer
+                      thereis (string= (buffer-name buffer)
+                                       "*Async-native-compile-log*")))
+        (let ((eln-dir (car native-comp-eln-load-path)))
+          (or (directory-empty-p eln-dir)
+              (and (not (file-exists-p eln-dir))
+                   (file-exists-p (file-name-parent-directory eln-dir)))))))
 
 (define-with-packages-non-batch-ert-tests
   with-packages-early-default-is-loaded

--- a/pkgs/applications/editors/emacs/build-support/wrapper-test/with-packages.el
+++ b/pkgs/applications/editors/emacs/build-support/wrapper-test/with-packages.el
@@ -72,10 +72,11 @@ Return t if the test passes.  Otherwise, return nil."
   (cl-check-type test-name symbol)
   (cl-flet ((eval-in-non-batch-emacs (form)
               (server-eval-at with-packages-non-batch-emacs-socket form)))
-    ;; Test test-name is defined in with-packages so we load it in the non-batch Emacs.
-    (eval-in-non-batch-emacs '(require 'with-packages))
-    ;; Run the non-batch test.  Return non-nil if it passes.
-    (eval-in-non-batch-emacs `(,test-name))))
+    (and
+     ;; Test test-name is defined in with-packages so we load it in the non-batch Emacs.
+     (eval-in-non-batch-emacs '(require 'with-packages))
+     ;; Run the non-batch test.  Return non-nil if it passes.
+     (eval-in-non-batch-emacs `(,test-name)))))
 
 (defmacro define-with-packages-non-batch-ert-test (test-name)
   "See `with-packages--run-non-batch-test' for how the test is run."

--- a/pkgs/applications/editors/emacs/build-support/wrapper-test/with-packages.el
+++ b/pkgs/applications/editors/emacs/build-support/wrapper-test/with-packages.el
@@ -4,6 +4,7 @@
 
 (require 'ert)
 (eval-when-compile (require 'cl-lib))
+(require 'server)
 
 ;; Try to make tests cause no side-effects.
 
@@ -66,22 +67,15 @@ loading of early-default.el and default.el files, we launch a non-batch Emacs,
 run non-batch tests on it and collect test results from it.")
 
 (defun with-packages--run-non-batch-test (test-name)
-  "Run non-batch test named TEST-NAME.
+  "Run non-batch test named TEST-NAME, a symbol.
 Return t if the test passes.  Otherwise, return nil."
-  (cl-flet* ((eval-in-non-batch-emacs (form)
-               (cl-check-type form string)
-               (with-temp-buffer
-                 (call-process "emacsclient" nil t nil
-                               "--socket-name" with-packages-non-batch-emacs-socket
-                               "--eval" form)
-                 (string-trim (buffer-substring-no-properties (point-min) (point-max)))))
-             (funcall-in-non-batch-emacs (function-name)
-               (eval-in-non-batch-emacs (format "(%s)" function-name))))
+  (cl-check-type test-name symbol)
+  (cl-flet ((eval-in-non-batch-emacs (form)
+              (server-eval-at with-packages-non-batch-emacs-socket form)))
     ;; Test test-name is defined in with-packages so we load it in the non-batch Emacs.
-    (eval-in-non-batch-emacs "(require 'with-packages)")
-    (not (string= (format "%s" nil)
-                  ;; Run the non-batch test.  Return non-nil, as string, if it passes.
-                  (funcall-in-non-batch-emacs test-name)))))
+    (eval-in-non-batch-emacs '(require 'with-packages))
+    ;; Run the non-batch test.  Return non-nil if it passes.
+    (eval-in-non-batch-emacs `(,test-name))))
 
 (defmacro define-with-packages-non-batch-ert-test (test-name)
   "See `with-packages--run-non-batch-test' for how the test is run."
@@ -90,7 +84,7 @@ Return t if the test passes.  Otherwise, return nil."
   `(ert-deftest ,test-name ()
      (should (stringp with-packages-non-batch-emacs-socket))
      (should (file-readable-p with-packages-non-batch-emacs-socket))
-     (should (with-packages--run-non-batch-test ,(symbol-name test-name)))))
+     (should (with-packages--run-non-batch-test (quote ,test-name)))))
 
 (defmacro define-with-packages-non-batch-ert-tests (&rest test-names)
   "See also `define-with-packages-non-batch-ert-test'."

--- a/pkgs/applications/editors/emacs/build-support/wrapper-test/with-packages.el
+++ b/pkgs/applications/editors/emacs/build-support/wrapper-test/with-packages.el
@@ -77,7 +77,7 @@ Return t if the test passes.  Otherwise, return nil."
                  (string-trim (buffer-substring-no-properties (point-min) (point-max)))))
              (funcall-in-non-batch-emacs (function-name)
                (eval-in-non-batch-emacs (format "(%s)" function-name))))
-    ;; Load with-packages in the non-batch Emacs in case needed.
+    ;; Test test-name is defined in with-packages so we load it in the non-batch Emacs.
     (eval-in-non-batch-emacs "(require 'with-packages)")
     (not (string= (format "%s" nil)
                   ;; Run the non-batch test.  Return non-nil, as string, if it passes.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- emacs: return a list of values in non-batch withPackages test
- emacs: test non-batch withPackages test can (require 'with-packages)
- emacs: impl eval-in-non-batch-emacs via builtin func in wrapper test


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
