### PR TITLE
gladtex: unstable-2023-01-22->4.0

### DIFF
--- a/pkgs/by-name/gl/gladtex/package.nix
+++ b/pkgs/by-name/gl/gladtex/package.nix
@@ -4,16 +4,16 @@
   python3Packages,
 }:
 
-python3Packages.buildPythonPackage {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "gladtex";
-  version = "unstable-2023-01-22";
+  version = "4.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "humenda";
     repo = "GladTeX";
-    rev = "f84e63836622ff1325dfddc7c5649f11a795afa0";
-    sha256 = "sha256-B5sNEmLO4iIJRDgcPhr9LFKV77dPJws8ITNz4R+FE08=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-z8DZxQRLibEHdMAR8S4Gz1rwBqXXwkd25scUNbBHs2g=";
   };
 
   build-system = with python3Packages; [
@@ -28,4 +28,4 @@ python3Packages.buildPythonPackage {
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ pentane ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- version update (cc #541820)
  - This was attempted in #436254, but didn't work out there (I assume) because `src` was pinned to a specific commit

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
