### PR TITLE
river{-classic}: fix build on aarch64

### DIFF
--- a/pkgs/by-name/ri/river-classic/package.nix
+++ b/pkgs/by-name/ri/river-classic/package.nix
@@ -1,6 +1,7 @@
 {
   callPackage,
   fetchFromCodeberg,
+  fetchpatch,
   lib,
   libGL,
   libevdev,
@@ -38,6 +39,14 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-+Geq3AetoiHB8xkMGf9nsYq8Mse2fZ5Edg1iOZ30f1A=";
     tag = "v${finalAttrs.version}";
   };
+
+  # this fixes aarch64 build, remove on next update
+  patches = [
+    (fetchpatch {
+      url = "https://codeberg.org/river/river-classic/commit/b1af960e1bea8506c25179775c18f902a5cb8c87.diff";
+      hash = "sha256-7X7/ZNLLGlkxr6y3bw/INIRSCXrn3ach7V319nHLIQ8=";
+    })
+  ];
 
   deps = callPackage ./build.zig.zon.nix { };
 
@@ -104,9 +113,5 @@ stdenv.mkDerivation (finalAttrs: {
       rodrgz
     ];
     platforms = lib.platforms.linux;
-    badPlatforms = [
-      # Runs out of memory (using > 100GiB) while building
-      "aarch64-linux"
-    ];
   };
 })

--- a/pkgs/by-name/ri/river/package.nix
+++ b/pkgs/by-name/ri/river/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   callPackage,
   fetchFromCodeberg,
+  fetchpatch,
   libGL,
   libx11,
   libevdev,
@@ -37,6 +38,14 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-q4JAlr9/ex+BEgktBmFwOvZzQEAGvxXPD1QyKqyha4g=";
   };
+
+  # this fixes aarch64 build, remove on next update
+  patches = [
+    (fetchpatch {
+      url = "https://codeberg.org/river/river/commit/8a1afd94ca477045f39bf91ac9ec31da9e9f932a.diff";
+      hash = "sha256-oBbM1meVAFb6j+qIFeG8Ol+FVFllrvFSKtvcY2q3ESs=";
+    })
+  ];
 
   strictDeps = true;
 
@@ -109,9 +118,5 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     mainProgram = "river";
     platforms = lib.platforms.linux;
-    badPlatforms = [
-      # Runs out of memory (using > 100GiB) while building
-      "aarch64-linux"
-    ];
   };
 })


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/543338

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
