### PR TITLE
waterfurnace_aurora: patch ccutrer-serialport for glibc 2.42

### DIFF
--- a/pkgs/by-name/wa/waterfurnace_aurora/package.nix
+++ b/pkgs/by-name/wa/waterfurnace_aurora/package.nix
@@ -1,7 +1,9 @@
 {
   lib,
+  fetchpatch2,
   bundlerApp,
   bundlerUpdateScript,
+  defaultGemConfig,
 }:
 
 bundlerApp {
@@ -15,6 +17,19 @@ bundlerApp {
     "aurora_mqtt_bridge"
     "web_aid_tool"
   ];
+
+  gemConfig = defaultGemConfig // {
+    ccutrer-serialport = attrs: {
+      dontBuild = false;
+      patches = [
+        (fetchpatch2 {
+          name = "use-numeric-baud-rates.patch";
+          url = "https://github.com/ccutrer/ccutrer-serialport/commit/52f5c1cba94fe9453444baa79dd7c08b2efab8bf.patch?full_index=1";
+          hash = "sha256-KKH/RXhql/3jl3/xheZmQ16Rv1w0/AWV7WfCZQb1Xlk=";
+        })
+      ];
+    };
+  };
 
   passthru.updateScript = bundlerUpdateScript "waterfurnace_aurora";
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`waterfurnace_aurora` broke when nixpkgs upgraded `glibc` to 2.42 because of a bug in its dependency `ccutrer-serialport`. I submitted an upstream patch in https://github.com/ccutrer/ccutrer-serialport/pull/1, and this pulls in the upstream patch to fix `waterfurnace_aurora` in the meantime.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
