### PR TITLE
stb: 0-unstable-2023-01-29 -> 0-unstable-2026-04-15

### DIFF
--- a/pkgs/by-name/_2/_2ship2harkinian/package.nix
+++ b/pkgs/by-name/_2/_2ship2harkinian/package.nix
@@ -19,6 +19,7 @@
   libpulseaudio,
   libzip,
   nlohmann_json,
+  stb,
   SDL2,
   spdlog,
   tinyxml-2,
@@ -80,12 +81,6 @@ let
       #define STB_IMAGE_IMPLEMENTATION
       #include "stb_image.h"
     '';
-  };
-
-  stb' = fetchurl {
-    name = "stb_image.h";
-    url = "https://raw.githubusercontent.com/nothings/stb/0bc88af4de5fb022db643c2d8e549a0927749354/stb_image.h";
-    hash = "sha256-xUsVponmofMsdeLsI6+kQuPg436JS3PBl00IZ5sg3Vw=";
   };
 
   stormlib' = applyPatches {
@@ -213,7 +208,7 @@ stdenv.mkDerivation (finalAttrs: {
   preConfigure = ''
     # mirror 2ship's stb
     mkdir stb
-    cp ${stb'} ./stb/${stb'.name}
+    cp ${stb}/include/stb/stb_image.h ./stb/stb_image.h
     cp ${stb_impl} ./stb/${stb_impl.name}
     substituteInPlace libultraship/cmake/dependencies/common.cmake \
       --replace-fail "\''${STB_DIR}" "$(readlink -f ./stb)"

--- a/pkgs/by-name/no/noctalia-greeter/package.nix
+++ b/pkgs/by-name/no/noctalia-greeter/package.nix
@@ -28,18 +28,6 @@
   nix-update-script,
 }:
 
-let
-  # nixpkgs stb doesn't have stb_image_resize2.h which noctalia-greeter needs
-  stb' = stb.overrideAttrs {
-    version = "0-unstable-2025-10-26";
-    src = fetchFromGitHub {
-      owner = "nothings";
-      repo = "stb";
-      rev = "f1c79c02822848a9bed4315b12c8c8f3761e1296";
-      hash = "sha256-BlyXJtAI7WqXCTT3ylww8zoG0hBxaojJnQDvdQOXJPE=";
-    };
-  };
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "noctalia-greeter";
   version = "1.2.1";
@@ -73,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
     libxkbcommon
     nlohmann_json
     pango
-    stb'
+    stb
     tomlplusplus
     wayland
     wayland-protocols

--- a/pkgs/by-name/no/noctalia/package.nix
+++ b/pkgs/by-name/no/noctalia/package.nix
@@ -49,18 +49,6 @@
   gitMinimal,
 }:
 
-let
-  # nixpkgs stb doesn't have stb_image_resize2.h which noctalia needs
-  stb' = stb.overrideAttrs {
-    version = "0-unstable-2025-10-26";
-    src = fetchFromGitHub {
-      owner = "nothings";
-      repo = "stb";
-      rev = "f1c79c02822848a9bed4315b12c8c8f3761e1296";
-      hash = "sha256-BlyXJtAI7WqXCTT3ylww8zoG0hBxaojJnQDvdQOXJPE=";
-    };
-  };
-in
 stdenv.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
 
@@ -111,7 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
     pipewire
     polkit
     sdbus-cpp_2
-    stb'
+    stb
     systemdLibs
     tomlplusplus
     wayland

--- a/pkgs/by-name/sh/shipwright/package.nix
+++ b/pkgs/by-name/sh/shipwright/package.nix
@@ -25,6 +25,7 @@
   nlohmann_json,
   tinyxml-2,
   spdlog,
+  stb,
   writeTextFile,
   fixDarwinDylibNames,
   applyPatches,
@@ -81,12 +82,6 @@ let
       #define STB_IMAGE_IMPLEMENTATION
       #include "stb_image.h"
     '';
-  };
-
-  stb' = fetchurl {
-    name = "stb_image.h";
-    url = "https://raw.githubusercontent.com/nothings/stb/0bc88af4de5fb022db643c2d8e549a0927749354/stb_image.h";
-    hash = "sha256-xUsVponmofMsdeLsI6+kQuPg436JS3PBl00IZ5sg3Vw=";
   };
 
   stormlib' = applyPatches {
@@ -208,7 +203,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   preConfigure = ''
     mkdir stb
-    cp ${stb'} ./stb/${stb'.name}
+    cp ${stb}/include/stb/stb_image.h ./stb/stb_image.h
     cp ${stb_impl} ./stb/${stb_impl.name}
     substituteInPlace libultraship/cmake/dependencies/common.cmake \
       --replace-fail "\''${STB_DIR}" "$(readlink -f ./stb)"

--- a/pkgs/by-name/sp/spaghettikart/package.nix
+++ b/pkgs/by-name/sp/spaghettikart/package.nix
@@ -24,6 +24,7 @@
   SDL2,
   SDL2_net,
   spdlog,
+  stb,
   tinyxml-2,
   tomlplusplus,
   zenity,
@@ -81,12 +82,6 @@ let
       #define STB_IMAGE_IMPLEMENTATION
       #include "stb_image.h"
     '';
-  };
-
-  stb' = fetchurl {
-    name = "stb_image.h";
-    url = "https://raw.githubusercontent.com/nothings/stb/0bc88af4de5fb022db643c2d8e549a0927749354/stb_image.h";
-    hash = "sha256-xUsVponmofMsdeLsI6+kQuPg436JS3PBl00IZ5sg3Vw=";
   };
 
   stormlib' = applyPatches {
@@ -219,7 +214,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   preConfigure = ''
     mkdir stb
-    cp ${stb'} ./stb/${stb'.name}
+    cp ${stb}/include/stb/stb_image.h ./stb/stb_image.h
     cp ${stb_impl} ./stb/${stb_impl.name}
     substituteInPlace libultraship/cmake/dependencies/common.cmake \
       --replace-fail "\''${STB_DIR}" "$(readlink -f ./stb)"

--- a/pkgs/by-name/st/starship-sf64/package.nix
+++ b/pkgs/by-name/st/starship-sf64/package.nix
@@ -24,6 +24,7 @@
   nlohmann_json,
   SDL2,
   spdlog,
+  stb,
   tinyxml-2,
   zenity,
   sdl_gamecontrollerdb,
@@ -74,12 +75,6 @@ let
       #define STB_IMAGE_IMPLEMENTATION
       #include "stb_image.h"
     '';
-  };
-
-  stb' = fetchurl {
-    name = "stb_image.h";
-    url = "https://raw.githubusercontent.com/nothings/stb/0bc88af4de5fb022db643c2d8e549a0927749354/stb_image.h";
-    hash = "sha256-xUsVponmofMsdeLsI6+kQuPg436JS3PBl00IZ5sg3Vw=";
   };
 
   stormlib' = applyPatches {
@@ -195,7 +190,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   preConfigure = ''
     mkdir stb
-    cp ${stb'} ./stb/${stb'.name}
+    cp ${stb}/include/stb/stb_image.h ./stb/stb_image.h
     cp ${stb_impl} ./stb/${stb_impl.name}
     substituteInPlace libultraship/cmake/dependencies/common.cmake \
       --replace-fail "\''${STB_DIR}" "$(readlink -f ./stb)"

--- a/pkgs/by-name/st/stb/package.nix
+++ b/pkgs/by-name/st/stb/package.nix
@@ -4,17 +4,18 @@
   fetchFromGitHub,
   copyPkgconfigItems,
   makePkgconfigItem,
+  unstableGitUpdater,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "stb";
-  version = "0-unstable-2023-01-29";
+  version = "0-unstable-2026-04-15";
 
   src = fetchFromGitHub {
     owner = "nothings";
     repo = "stb";
-    rev = "5736b15f7ea0ffb08dd38af21067c314d6a3aae9";
-    hash = "sha256-s2ASdlT3bBNrqvwfhhN6skjbmyEnUgvNOrvhgUSRj98=";
+    rev = "31c1ad37456438565541f4919958214b6e762fb4";
+    hash = "sha256-m2yNUlA37hDkKQVrQ+R8nufHfW/cXLnMo+n1X1Cyun0=";
   };
 
   nativeBuildInputs = [ copyPkgconfigItems ];
@@ -41,6 +42,8 @@ stdenv.mkDerivation (finalAttrs: {
     cp *.c $out/include/stb/
     runHook postInstall
   '';
+
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = {
     description = "Single-file public domain libraries for C/C++";


### PR DESCRIPTION
Nothing major, just some updates and adding an updateScript. many packages rely on a later version since it ships with a new image resizing header that the current version does not have. Let's get this updated to reduce the amount of duplicated packages in nixpkgs. I've run nixpkgs-review but aborted it a while through since it was taking way too long.

Tentatively overrides #491159 unless that one starts moving again.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
