### PR TITLE
warp-terminal: 0.2026.07.15.08.55.stable_01 -> 0.2026.07.22.09.01.stable_01

### DIFF
--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-zxI3pyzqk9mnfCe0maFY2poA/egvKmbVdyO2wwMpfuI=",
-    "version": "0.2026.07.15.08.55.stable_01"
+    "hash": "sha256-wKXwL2frlyE7UVMVMzscrHfXJ6b4LIzGMTK53jAG4c4=",
+    "version": "0.2026.07.22.09.01.stable_01"
   },
   "linux_x86_64": {
-    "hash": "sha256-S8mcscl9I9AnKIPHrTNJQYNVYtRACc7jrPDQ0UOB8hY=",
-    "version": "0.2026.07.15.08.55.stable_01"
+    "hash": "sha256-afV/GSoaL4bdn0rdlVtdy6Z3S1EImRknNIODddYNhpg=",
+    "version": "0.2026.07.22.09.01.stable_01"
   },
   "linux_aarch64": {
-    "hash": "sha256-EznnYYZGhxxCZEtUpC+Bq1xAMY/AWfVEI30O1YdzlT8=",
-    "version": "0.2026.07.15.08.55.stable_01"
+    "hash": "sha256-nqRt4OLzpy9BW/3GRtOsvdSxJoZRNwso44WxVZuT6sE=",
+    "version": "0.2026.07.22.09.01.stable_01"
   }
 }


### PR DESCRIPTION
Updates Warp Terminal to the [2026.07.23 release](https://docs.warp.dev/changelog/2026/#20260723-v0202607220901).

Verification performed:

- Ran the package update script and confirmed it is idempotent.
- Evaluated the package version for aarch64-darwin, x86_64-linux, and aarch64-linux.
- Built the package on aarch64-darwin.
- Ran the packaged executable with `--version`.
- Ran `git diff --check`.

Automation disclosure: OpenCode using openai/gpt-5.6-sol assisted with the package update, verification, and this PR description.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of the primary packaged executable.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test