### PR TITLE
readium: init at 0.9.1

### DIFF
--- a/pkgs/by-name/re/readium/package.nix
+++ b/pkgs/by-name/re/readium/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+buildGoModule (finalAttrs: {
+  pname = "readium";
+  version = "0.9.1";
+  __structuredAttrs = true;
+  __darwinAllowLocalNetworking = true;
+
+  src = fetchFromGitHub {
+    owner = "readium";
+    repo = "cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-D7Qpf+6qMdXWQ35zdIBZTVpT6zJEK7TVpjpLDPg+/n0=";
+  };
+
+  vendorHash = "sha256-Jph5NafR7PSrH2ub+85Cd/QxHPi6UyvyDJdlfsJrQNw=";
+
+  ldflags = [ "-X=github.com/readium/cli/internal/version.Version=v${finalAttrs.version}" ];
+
+  postInstall = ''
+    mv $out/bin/cmd $out/bin/readium
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    description = "CLI utility with support for a wide range of commands for ebooks, comics and audiobooks";
+    homepage = "https://github.com/readium/cli/";
+    changelog = "https://github.com/readium/cli/blob/develop/CHANGELOG.MD";
+    license = lib.licenses.bsd3;
+    mainProgram = "readium";
+    maintainers = with lib.maintainers; [ CodeF53 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[readium](https://github.com/readium/cli) is a utility for easily interacting with publication files.

No AI was used writing/testing this derivation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
