### PR TITLE
openshadinglanguage: remove libclang as shared lib

### DIFF
--- a/pkgs/by-name/op/openshadinglanguage/libclang-no-shared.patch
+++ b/pkgs/by-name/op/openshadinglanguage/libclang-no-shared.patch
@@ -1,0 +1,24 @@
+diff --git a/src/cmake/modules/FindLLVM.cmake b/src/cmake/modules/FindLLVM.cmake
+index 56809dc3..b1a1ec1e 100644
+--- a/src/cmake/modules/FindLLVM.cmake
++++ b/src/cmake/modules/FindLLVM.cmake
+@@ -103,19 +103,6 @@ if (NOT LLVM_LIBRARY)
+     set (LLVM_LIBRARY "${LLVM_LIBRARIES}")
+ endif ()
+ 
+-execute_process (COMMAND ${LLVM_CONFIG} --shared-mode
+-       OUTPUT_VARIABLE LLVM_SHARED_MODE
+-       OUTPUT_STRIP_TRAILING_WHITESPACE)
+-if (LLVM_SHARED_MODE STREQUAL "shared")
+-    find_library ( _CLANG_CPP_LIBRARY
+-                   NAMES "clang-cpp"
+-                   PATHS ${LLVM_LIB_DIR}
+-                   NO_DEFAULT_PATH)
+-    if (_CLANG_CPP_LIBRARY)
+-        list (APPEND CLANG_LIBRARIES ${_CLANG_CPP_LIBRARY})
+-    endif ()
+-endif ()
+-
+ foreach (COMPONENT clangFrontend clangDriver clangSerialization
+                    clangParse clangSema clangAnalysis clangAST
+                    clangASTMatchers clangEdit clangLex

--- a/pkgs/by-name/op/openshadinglanguage/package.nix
+++ b/pkgs/by-name/op/openshadinglanguage/package.nix
@@ -31,6 +31,8 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-edtYKN2obQexQtclrIUflm3upc14MhHQ7eLvit5Hqq0=";
   };
 
+  patches = [ ./libclang-no-shared.patch ];
+
   cmakeFlags = [
     (lib.cmakeBool "LLVM_STATIC" true)
     (lib.cmakeBool "USE_QT" false)

--- a/pkgs/by-name/op/openshadinglanguage/package.nix
+++ b/pkgs/by-name/op/openshadinglanguage/package.nix
@@ -38,7 +38,6 @@ stdenv.mkDerivation (finalAttrs: {
     # Build system implies llvm-config and llvm-as are in the same directory.
     # Override defaults.
     (lib.cmakeFeature "LLVM_BC_GENERATOR" "${clang}/bin/clang++")
-    (lib.cmakeFeature "LLVM_CONFIG" "${llvm.dev}/bin/llvm-config")
     (lib.cmakeFeature "LLVM_DIRECTORY" "${llvm}")
   ];
 
@@ -53,7 +52,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     bison
-    clang
     cmake
     flex
   ];


### PR DESCRIPTION
See commit msgs for details.

Fixes https://github.com/NixOS/nixpkgs/issues/530702

## Things done

Built `pkgsRocm.blender` and tested HIP GPU render and OSL CPU render.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
