### PR TITLE
moonshine: 0.13.5 -> 0.15.0

### DIFF
--- a/pkgs/by-name/mo/moonshine/package.nix
+++ b/pkgs/by-name/mo/moonshine/package.nix
@@ -122,7 +122,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/hgaiser/moonshine";
     changelog = "https://github.com/hgaiser/moonshine/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ neobrain ];
+    maintainers = with lib.maintainers; [
+      neobrain
+      anish
+    ];
     mainProgram = "moonshine";
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/mo/moonshine/package.nix
+++ b/pkgs/by-name/mo/moonshine/package.nix
@@ -23,25 +23,25 @@ let
   inputtino-src = fetchFromGitHub {
     owner = "games-on-whales";
     repo = "inputtino";
-    rev = "f4ce2b0df536ef309e9ff318f75b460f7097d7c1";
-    hash = "sha256-mAAXbIK7aNSLyN7OZX9YeesMvT6OZmT9uAx0md6pyRM=";
+    rev = "d28ec79eb63324e68d73a7de22bcb5ff0a6f6bf8";
+    hash = "sha256-xzDsJggQVX5e1twwNvqw5hDXei6OMYA4s5zU4zfp/H0=";
   };
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "moonshine";
-  version = "0.13.5";
+  version = "0.15.0";
 
   src = fetchFromGitHub {
     owner = "hgaiser";
     repo = "moonshine";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-DwRUVMAm4fSqZu6jECeasiRpnwBt7thWkXzztNRIjcs=";
+    hash = "sha256-TvL3s738wooQwZfBKyCqp0V8qcYFtJL98tsxlSX8fLM=";
   };
 
   __structuredAttrs = true;
   strictDeps = true;
 
-  cargoHash = "sha256-M/VNPnccqK3koa0TeMd+tml79O7BKLxHmrGcGPemGhI=";
+  cargoHash = "sha256-PAC8PcGOXxFNN8Eeiik4JrXeH2H+YcqRaBpJVtUoZ44=";
 
   # Build Moonshine binary and Vulkan layer
   cargoBuildFlags = [
@@ -88,6 +88,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
     # udev rules for input
     install -Dm644 dist/60-moonshine.rules "$out/lib/udev/rules.d/60-moonshine.rules"
+
+    # polkit rule for sleep inhibitor
+    install -Dm644 dist/50-moonshine-inhibit-sleep.rules \
+      "$out/share/polkit-1/rules.d/50-moonshine-inhibit-sleep.rules"
   '';
 
   postFixup = ''


### PR DESCRIPTION
[changelog](https://github.com/hgaiser/moonshine/releases/tag/v0.14.5)

* It was flagged in a #544393 review that sleep inhibition via polkit was intended to be optional, but 0.14.1 [adds it unconditionally](https://github.com/hgaiser/moonshine/blob/cf4194ee356487f5900c8247a1794c93343ed0ac/nix/package.nix#L145-L146) and frames this as a bugfix. I'm choosing to match upstream here, since the rule won't do anything until a user is added to the `moonshine` group anyway.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
