### PR TITLE
luvus: init at 0.11.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24165,6 +24165,12 @@
     githubId = 7221768;
     name = "Andika Demas Riyandi";
   };
+  rizriyz = {
+    email = "rizflagz@gmail.com";
+    github = "RizRiyz";
+    githubId = 2667489;
+    name = "Riz";
+  };
   rjpcasalino = {
     email = "ryan@rjpc.net";
     github = "rjpcasalino";

--- a/pkgs/by-name/lu/luvus/package.nix
+++ b/pkgs/by-name/lu/luvus/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  makeWrapper,
+  versionCheckHook,
+  git,
+  gh,
+  openssh,
+  bashInteractive,
+  coreutils,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "luvus";
+  version = "0.11.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "RizRiyz";
+    repo = "luvus";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-aKL/5N0E91IVIG7drMwKozNQy/bzy/78VdNCl67Dunc=";
+  };
+
+  cargoHash = "sha256-CqRDKuHC5kwIdGXLdpehBRoV1kE+Vj2Mj7xix3anz9k=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # The test suite spawns real PTYs, `ps`, and child processes and reads $HOME,
+  # all awkward inside the Nix sandbox; upstream CI runs the full suite on every
+  # push, so the package build just compiles the release binary.
+  doCheck = false;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  postFixup = ''
+    wrapProgram $out/bin/luvus \
+      --suffix PATH : ${
+        lib.makeBinPath [
+          git
+          gh
+          openssh
+        ]
+      } \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          bashInteractive
+          coreutils
+        ]
+      }
+  '';
+
+  meta = {
+    description = "Mission control for your AI coding agents";
+    homepage = "https://luvus.dev";
+    changelog = "https://github.com/RizRiyz/luvus/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.agpl3Plus;
+    mainProgram = "luvus";
+    maintainers = with lib.maintainers; [ rizriyz ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
#### Description of changes

Adds **Luvus** ([luvus.dev](https://luvus.dev)), mission control for AI coding agents. Luvus provides persistent panes, tabs, and workspaces that survive detach, a live sidebar of agent states, zero-config session resume, a built-in Git tab, first-class Git worktrees, and remote attach over SSH. It ships as a static Rust binary.

This replaces the earlier Bohay submission with Luvus v0.11.0. The upstream project, repository, package path, and installed binary are now all named `luvus`.

Upstream: https://github.com/RizRiyz/luvus

Notes for reviewers:

- `doCheck = false` because the upstream test suite spawns real PTYs and child processes and reads `$HOME`, which the Nix sandbox does not provide. Upstream CI runs the full suite on every push.
- The runtime tools Luvus invokes, `git`, `gh`, and `openssh`, are wrapped into `PATH` with `makeWrapper`. The user PATH remains appended, so user-installed newer tools take precedence.
- License: `agpl3Plus`.

#### AI assistance disclosure

Per the [Automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy), the packaging commit was prepared with assistance from Claude Code and OpenAI Codex and carries the appropriate trailers. The `maintainers: add rizriyz` commit was written by me without agent assistance. I am the upstream author and listed maintainer, have reviewed the derivation, built it locally on aarch64-darwin, and stand behind this submission.

#### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`?
- [x] Tested basic functionality: `nix-build -A luvus --no-out-link` succeeds and `luvus --version` prints `luvus 0.11.0`.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)
