### PR TITLE
ocamlPackages.ppx_import: make compatible with OCaml 5.5

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_import/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_import/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchurl,
+  fetchpatch,
   ocaml,
   buildDunePackage,
   ounit,
@@ -38,6 +39,14 @@ buildDunePackage {
       ."${version}";
   };
 
+  patches =
+    # Compatibility with OCaml 5.5
+    # See https://github.com/ocaml-ppx/ppx_import/pull/107
+    lib.optional (lib.versionAtLeast ocaml.version "5.5") (fetchpatch {
+      url = "https://github.com/ocaml-ppx/ppx_import/commit/ddff918dc86f3d336af60ea67de4a0b5373b7409.patch";
+      hash = "sha256-PenEGKPltvzJY//YoU5iNqZIYGz3vBGXZONBcwgQgjY=";
+    });
+
   propagatedBuildInputs = [
     ppxlib
   ];
@@ -54,6 +63,5 @@ buildDunePackage {
     description = "Syntax extension for importing declarations from interface files";
     license = lib.licenses.mit;
     homepage = "https://github.com/ocaml-ppx/ppx_import";
-    broken = lib.versionAtLeast ocaml.version "5.5";
   };
 }


### PR DESCRIPTION
The package `ocaml-ng.ocamlPackages_latest.ppx_import` is currently broken. This applies a patch that has been submitted upstream.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
