### PR TITLE
aqua: init at 2.62.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21834,6 +21834,12 @@
     name = "Michael Bergmeister";
     githubId = 53442728;
   };
+  paveg = {
+    email = "pavegy@gmail.com";
+    github = "paveg";
+    githubId = 12677991;
+    name = "Ryota Ikezawa";
+  };
   pawelchcki = {
     email = "pawel.chcki@gmail.com";
     github = "pawelchcki";

--- a/pkgs/by-name/aq/aqua/package.nix
+++ b/pkgs/by-name/aq/aqua/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+let
+  mainProgram = "aqua";
+in
+buildGoModule (finalAttrs: {
+  pname = "aqua";
+  version = "2.62.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "aquaproj";
+    repo = "aqua";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Kwa7u4UvJ4yq0MKQUz/hF+I4GLZhX+Kzx3PMivfdOpI=";
+  };
+
+  vendorHash = "sha256-4m0v1zLgtHq2kMg6Y/a0EytY+jE17A2qbbR1gZ4qTBs=";
+
+  subPackages = [ "cmd/aqua" ];
+
+  env.CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd ${mainProgram} \
+      --bash <("$out/bin/${mainProgram}" completion bash) \
+      --zsh <("$out/bin/${mainProgram}" completion zsh) \
+      --fish <("$out/bin/${mainProgram}" completion fish)
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgramArg = "version";
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex=^v([\\d\\.]+)$" ];
+  };
+
+  meta = {
+    inherit mainProgram;
+    description = "Declarative CLI version manager";
+    homepage = "https://github.com/aquaproj/aqua";
+    changelog = "https://github.com/aquaproj/aqua/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ paveg ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Adds [Aqua](https://github.com/aquaproj/aqua), a declarative CLI version manager, at version 2.62.2.

The package is built from source with Go, installs Bash/Zsh/Fish completions, verifies the installed version via `versionCheckHook`, and includes a stable-release update script. The check phase is scoped to `cmd/aqua` by `subPackages`, so the network-dependent tests elsewhere in the tree are not run.

Note: #514644 also adds `paveg` to the maintainer list. If that PR merges first, this branch will be rebased to drop the duplicate maintainer commit.

Automation disclosure: This package definition and PR draft were prepared with OpenAI Codex (GPT-5); review follow-ups were applied with Claude Code. Source and vendor hashes were determined with Nix tooling, and the package was built and smoke-tested locally. A human reviews all changes before they are pushed.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Assisted-by: OpenAI Codex (GPT-5)
Assisted-by: Claude Code (Claude Fable 5)
