### PR TITLE
steamtinkerlaunch: yad 15 compat patch

### DIFF
--- a/pkgs/by-name/st/steamtinkerlaunch/package.nix
+++ b/pkgs/by-name/st/steamtinkerlaunch/package.nix
@@ -1,6 +1,7 @@
 {
   bash,
   fetchFromGitHub,
+  fetchpatch2,
   gawk,
   git,
   lib,
@@ -14,9 +15,9 @@
   wget,
   writeShellApplication,
   xdotool,
-  xwininfo,
-  xrandr,
   xprop,
+  xrandr,
+  xwininfo,
   yad,
 }:
 
@@ -30,6 +31,14 @@ stdenvNoCC.mkDerivation {
     rev = "8550ab26a712b7f5f6d0947070181446b9de61fd";
     hash = "sha256-mCcxdm8odHvTt4aP58RHY6NkaUMmMbQesUtY6dvIvOc=";
   };
+
+  patches = [
+    (fetchpatch2 {
+      name = "yad-15-compat.patch";
+      url = "https://github.com/sonic2kk/steamtinkerlaunch/commit/7b5d45e64e2d98e6cbc09cac95140a411f48de53.patch?full_index=1";
+      hash = "sha256-BRtdcjZ1+NLe2aKRyd/VSQrHEg6x4qe63OFUShjT5go=";
+    })
+  ];
 
   passthru.updateScript = unstableGitUpdater {
     tagPrefix = "v";
@@ -115,6 +124,7 @@ stdenvNoCC.mkDerivation {
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [
       surfaceflinger
+      RoGreat
     ];
     platforms = lib.platforms.linux;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Everything did build with yad 15. I thought I tested this package at the time when upgrading to yad 15, but it requires a patch for it to work: https://github.com/sonic2kk/steamtinkerlaunch/pull/1314. 

Must've built it wrong or did not go into the settings, sorry if this affects anyone. All other packages that built did run though in `nixpkgs-review`, so I think it's just this one.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
