### PR TITLE
swtpm: fix cross-compilation

### DIFF
--- a/pkgs/by-name/sw/swtpm/package.nix
+++ b/pkgs/by-name/sw/swtpm/package.nix
@@ -46,6 +46,11 @@ stdenv.mkDerivation (finalAttrs: {
     python3
     autoreconfHook
     makeWrapper
+    # configure.ac does AC_CHECK_PROG([OPENSSL_CLITOOL], [openssl], ...) and
+    # errors out when the tool is not on PATH. openssl is in buildInputs for
+    # the library, which puts its bin dir on PATH only when build == host, so
+    # the check fails when cross-compiling.
+    openssl
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
configure.ac probes for the openssl CLI:

    AC_CHECK_PROG([OPENSSL_CLITOOL], [openssl], [yes], [no])
    AS_IF([test "$OPENSSL_CLITOOL" != "yes"],
        [AC_MSG_ERROR("Could not find openssl tool. Is openssl installed?")])

swtpm gained this check when it switched its local CA from the gnutls certtool to the openssl CLI in 0.10.1-unstable-2026-05-21.

openssl is currently only in buildInputs, for the library. Natively that happens to satisfy the probe as well, since build == host means the buildInputs bin dirs land on PATH anyway, but when cross-compiling they go to HOST_PATH instead and configure aborts:

    configure: error: "Could not find openssl tool. Is openssl installed?"

Add openssl to nativeBuildInputs so the build-platform CLI is on PATH. The probe is only a presence test -- the path baked into swtpm_localca is already substituted to the host openssl via lib.getExe -- so this does not change what the built package runs.

Tested with `nix build -f . pkgsCross.aarch64-multiplatform.swtpm`, which fails on master and succeeds with this change.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
