### PR TITLE
go-enum: init at 0.9.4

### DIFF
--- a/pkgs/by-name/go/go-enum/package.nix
+++ b/pkgs/by-name/go/go-enum/package.nix
@@ -1,0 +1,47 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "go-enum";
+  version = "0.9.4";
+
+  src = fetchFromGitHub {
+    owner = "abice";
+    repo = "go-enum";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-fFMTnbQ6RUGxvANHveB1YrXlppgUVTJIRB4v1sV3GH8=";
+  };
+
+  vendorHash = "sha256-hGfwb0GZCxc3EQWvxs7/fNVEVGGQE2I0B+MMaH7ecPM=";
+
+  __structuredAttrs = true;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  subPackages = [ "." ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=v${finalAttrs.version}"
+    "-X main.builtBy=nixpkgs"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Enum generator for go";
+    homepage = "https://github.com/abice/go-enum";
+    changelog = "https://github.com/abice/go-enum/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "go-enum";
+    maintainers = with lib.maintainers; [ Nadim147c ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION

## Things done

Adds https://github.com/abice/go-enum. I initially made a PR https://github.com/NixOS/nixpkgs/pull/476140 and closed it because upstream did have any updates for 7 months. But recently it had new release.

Assisted-By: `nix-init`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
