### PR TITLE
irrd: 4.5.2 -> 4.5.3

### DIFF
--- a/pkgs/by-name/ir/irrd/package.nix
+++ b/pkgs/by-name/ir/irrd/package.nix
@@ -47,36 +47,20 @@ let
         doCheck = false;
       });
 
-      # ariadne 0.29+ is missing 'convert_kwargs_to_snake_case'
-      ariadne = prev.ariadne.overridePythonAttrs (oldAttrs: rec {
-        version = "0.28.0";
-        src =
-          fetchPypi {
-            inherit (oldAttrs) pname;
-            inherit version;
-            hash = "sha256-gW66L7djPo4nHjd/UN18IPYFo956wzSqM+p1AZF/qnw=";
-          }
-          // {
-            tag = version;
-          };
-        patches = [ ];
-        doCheck = false;
-      });
-
     };
   };
 in
 
 py.pkgs.buildPythonPackage (finalAttrs: {
   pname = "irrd";
-  version = "4.5.2";
+  version = "4.5.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "irrdnet";
     repo = "irrd";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Lr2+3pG22l479mNrn1JFiea+zp+n9qWVX1yTp0Cj4Ds=";
+    hash = "sha256-XXqG/ygW5EbhKs4T5r9w/6URlv7y37+sjhWagI4n2pg=";
   };
 
   pythonRelaxDeps = true;


### PR DESCRIPTION
Changelog: https://irrd.readthedocs.io/en/stable/releases/4.5.3/
Diff: https://github.com/irrdnet/irrd/compare/v4.5.2...v4.5.3

This also brings the build one step closer to working. The tests are still broken, but backporting this change to 26.05 at least fixes the build there.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
