### PR TITLE
amdtop: init at 0.2.6

### DIFF
--- a/pkgs/by-name/am/amdtop/package.nix
+++ b/pkgs/by-name/am/amdtop/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  libdrm,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "amdtop";
+  version = "0.2.6";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "lhl";
+    repo = "amdtop";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-B7/J7jZrJosNot6hnTJ568DxqG+ZRurBPoMDrO4diBk=";
+  };
+
+  cargoHash = "sha256-JXnZ9tYXZywcemN5fQRP8efyhnV+8WVxguk2JEugpj0=";
+
+  buildInputs = [
+    libdrm
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Nvitop-style TUI frontend for amdgpu_top (AMDGPU + Strix Halo XDNA NPU";
+    homepage = "https://github.com/lhl/amdtop";
+    changelog = "https://github.com/lhl/amdtop/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ pborzenkov ];
+    mainProgram = "amdtop";
+  };
+})


### PR DESCRIPTION
https://github.com/lhl/amdtop

Assisted-by: nix-init


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
