### PR TITLE
mg: switch to troglobit's mg version

### DIFF
--- a/pkgs/by-name/mg/mg/package.nix
+++ b/pkgs/by-name/mg/mg/package.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Micro (GNU) Emacs-like text editor";
     homepage = "https://github.com/troglobit/mg";
+    maintainers = with lib.maintainers; [ cve ];
     license = lib.licenses.publicDomain;
     mainProgram = "mg";
     platforms = lib.platforms.all;

--- a/pkgs/by-name/mg/mg/package.nix
+++ b/pkgs/by-name/mg/mg/package.nix
@@ -2,45 +2,34 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  pkg-config,
-  ncurses,
-  buildPackages,
+  autoreconfHook,
+  nix-update-script,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "mg";
-  version = "7.3-unstable-2024-06-04";
+  version = "4.0";
 
   src = fetchFromGitHub {
-    owner = "ibara";
+    owner = "troglobit";
     repo = "mg";
-    rev = "4d4abcfc793554dbd4effdba8a3cc28ce2654c33";
-    hash = "sha256-+sp8Edu5UWv73TCNVZTeH5rl2Q5XarYrlTYHuQsroVs=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Ja6z/aFdsdlqAoWsevCOUySIE8At4yS3wsmDbjbU0dk=";
   };
 
-  postPatch = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
-    substituteInPlace configure --replace "./conftest" "echo"
-  '';
+  nativeBuildInputs = [ autoreconfHook ];
 
   enableParallelBuilding = true;
+  strictDeps = true;
+  __structuredAttrs = true;
 
-  makeFlags = [
-    "PKG_CONFIG=${buildPackages.pkg-config}/bin/${buildPackages.pkg-config.targetPrefix}pkg-config"
-  ];
-
-  installPhase = ''
-    install -m 555 -Dt $out/bin mg
-    install -m 444 -Dt $out/share/man/man1 mg.1
-  '';
-  nativeBuildInputs = [ pkg-config ];
-
-  buildInputs = [ ncurses ];
+  passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "Micro GNU/emacs, a portable version of the mg maintained by the OpenBSD team";
-    homepage = "https://man.openbsd.org/OpenBSD-current/man1/mg.1";
+    description = "Micro (GNU) Emacs-like text editor";
+    homepage = "https://github.com/troglobit/mg";
     license = lib.licenses.publicDomain;
     mainProgram = "mg";
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
This commit modifies the mg package to now use the version maintained by
@troglobit, as the OpenBSD-portable version from ibara has not received
any updates in the past 2 years.

Besides, this version actually contains very cool improvements, such as
syntax highlighting and UTF-8 support.

It also adds myself as the maintainer, as there is currently none.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
