### PR TITLE
nwchem: 7.2.3 -> 7.3.1

### DIFF
--- a/pkgs/by-name/nw/nwchem/package.nix
+++ b/pkgs/by-name/nw/nwchem/package.nix
@@ -26,13 +26,13 @@ assert blas-ilp64.isILP64 == lapack-ilp64.isILP64;
 assert blas-ilp64.isILP64 == scalapack-ilp64.isILP64;
 
 let
-  versionGA = "5.8.2"; # Fixed by nwchem
+  versionGA = "5.9.2"; # Fixed by nwchem
 
   gaSrc = fetchFromGitHub {
     owner = "GlobalArrays";
     repo = "ga";
     rev = "v${versionGA}";
-    hash = "sha256-2ffQIg9topqKX7ygnWaa/UunL9d0Lj9qr9xucsjLuoY=";
+    hash = "sha256-leCvbWteOp7z7ORwtljA+KslHUptY2vdupZTmAjsArg=";
   };
 
   dftd3Src = fetchurl {
@@ -43,20 +43,20 @@ let
   plumedSrc = fetchFromGitHub {
     owner = "edoapra";
     repo = "plumed2";
-    rev = "88f06db71173e7893713a582e5ada7193e8ae1c9";
-    hash = "sha256-p5XNxHcE/QkJ5WdQH/xPp2EyrqCNjA/w/e1R2fkwYts=";
+    rev = "e7c908da50bde1c6399c9f0e445d6ea3330ddd9b";
+    hash = "sha256-CNlb6MTEkD977hj3xonYqZH1/WlQ1EdVD7cvL//heRM=";
   };
 
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "nwchem";
-  version = "7.2.3";
+  version = "7.3.1";
 
   src = fetchFromGitHub {
     owner = "nwchemgit";
     repo = "nwchem";
     tag = "v${finalAttrs.version}-release";
-    hash = "sha256-2qc4kLb/WmUJuJGonIyS7pgCfyt8yXdcpDAKU0RMY58=";
+    hash = "sha256-B/P7F5dV+Uy+im6t6FoO6DVAELKb7QwHyW2BFEYtYRE=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/nw/nwchem/package.nix
+++ b/pkgs/by-name/nw/nwchem/package.nix
@@ -20,7 +20,6 @@
   autoconf,
   libtool,
   makeWrapper,
-  mpich,
 }:
 
 assert blas-ilp64.isILP64 == lapack-ilp64.isILP64;
@@ -76,9 +75,9 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper
     gfortran
     which
-    mpich
     python3
     openssh
+    mpi
   ];
   buildInputs = [
     tcsh


### PR DESCRIPTION
This updates NWChem to the latest version, see

* [7.3.1](https://github.com/nwchemgit/nwchem/blob/master/release.notes.7.3.1.md)
* [7.3.0](https://github.com/nwchemgit/nwchem/blob/master/release.notes.7.3.0.md)

Also removes the erroneous introduction of mpich of #539409 to fix compiler issues, which would corrupt runtime (other MPI runtime than compilers).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
