### PR TITLE
keepass: 2.60 -> 2.61.1; remove gtk2

### DIFF
--- a/pkgs/by-name/ke/keepass/package.nix
+++ b/pkgs/by-name/ke/keepass/package.nix
@@ -52,11 +52,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "keepass";
-  version = "2.60";
+  version = "2.61.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/keepass/KeePass-${finalAttrs.version}-Source.zip";
-    hash = "sha256-AraAdneAkLTS1wZ7pWC0Mm51m50s2hCy6wN74nlUtxo=";
+    hash = "sha256-cRvZ7HB2ZhZ4Rp5Ruuh23rrAegjDLxscazuP5edhwTo=";
   };
 
   sourceRoot = ".";

--- a/pkgs/by-name/ke/keepass/package.nix
+++ b/pkgs/by-name/ke/keepass/package.nix
@@ -14,7 +14,6 @@
   coreutils,
   unixtools,
   glib,
-  gtk2,
   makeDesktopItem,
   plugins ? [ ],
 }:
@@ -60,6 +59,8 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   sourceRoot = ".";
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     unzip
@@ -119,8 +120,6 @@ stdenv.mkDerivation (finalAttrs: {
   # buildEnv in the plugin derivation. Wrapper below makes sure it
   # is found and does not pollute output path.
   binPaths = lib.concatStringsSep ":" (map (x: x + "/bin") plugins);
-
-  dynlibPath = lib.makeLibraryPath [ gtk2 ];
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
Changelog: https://keepass.info/news/n260304_2.61.html#v1

Remove gtk2 dependency, part of #410814.

~~Switch to GTK3 as GTK2 is being deprecated.~~
~~In the FAQ (here: https://keepass.info/help/base/faq_tech.html#guifont) I saw that Keepass apparently uses the systems default GUI and mentioned Gnome 3 so I just tried to replace GTK2 with GTK3 and it seems to work fine as of brief testing.~~

Supersedes: #496740

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
