### PR TITLE
nixos/pam: make lastlog optional by default

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -606,6 +606,18 @@ let
             description = "Whether to update {file}`/var/log/wtmp`.";
           };
 
+          require = lib.mkOption {
+            default = false;
+            example = true;
+            type = lib.types.bool;
+            description = ''
+              Whether to require login auditing. By default this is false,
+              because a full disk or other scenario in which writing to the
+              database fails will cause the system to deny all logins. If this
+              behaviour is instead desired, set this option to true.
+            '';
+          };
+
           silent = lib.mkOption {
             default = true;
             example = false;
@@ -1560,7 +1572,7 @@ let
               {
                 name = "lastlog";
                 enable = cfg.lastlog.enable;
-                control = "required";
+                control = if cfg.lastlog.require then "required" else "optional";
                 modulePath = "${pkgs.util-linux.lastlog}/lib/security/pam_lastlog2.so";
                 settings = {
                   inherit (cfg.lastlog) silent;

--- a/nixos/tests/pam/pam-lastlog.nix
+++ b/nixos/tests/pam/pam-lastlog.nix
@@ -3,30 +3,59 @@
 {
   name = "pam-lastlog";
 
-  nodes.machine =
-    { ... }:
-    {
-      imports = [ ../common/user-account.nix ];
-    };
+  nodes = {
+    machine1 =
+      { ... }:
+      {
+        imports = [ ../common/user-account.nix ];
+      };
+
+    machine2 =
+      { ... }:
+      {
+        imports = [ ../common/user-account.nix ];
+        security.pam.services.login.lastlog.require = true;
+      };
+  };
 
   testScript = ''
-    with subtest("Test legacy lastlog import"):
-      # create old lastlog file to test import
-      # empty = nothing will actually be imported, but the service will run
-      machine.succeed("touch /var/log/lastlog")
-      machine.wait_for_unit("lastlog2-import.service")
-      machine.succeed("journalctl -b --grep 'Starting Import lastlog data into lastlog2 database'")
-      machine.succeed("stat /var/log/lastlog.migrated")
+    start_all()
 
-    with subtest("Test lastlog entries are created by logins"):
+    def login(machine, succeed=True):
       machine.wait_for_unit("multi-user.target")
       machine.wait_until_tty_matches("1", "login: ")
       machine.send_chars("alice\n")
       machine.wait_until_tty_matches("1", "Password: ")
       machine.send_chars("foobar\n")
-      machine.wait_until_succeeds("pgrep -u alice bash")
-      print(machine.succeed("lastlog2 --active --user alice"))
-      machine.succeed("stat /var/lib/lastlog/lastlog2.db")
-      machine.send_chars("exit\n")
+      if succeed:
+        machine.wait_until_succeeds("pgrep -u alice bash")
+        print(machine.succeed("lastlog2 --active --user alice"))
+        machine.succeed("stat /var/lib/lastlog/lastlog2.db")
+        machine.send_chars("exit\n")
+      else:
+        machine.wait_until_tty_matches("1", "login: ")
+
+    with subtest("Test legacy lastlog import"):
+      # create old lastlog file to test import
+      # empty = nothing will actually be imported, but the service will run
+      machine1.succeed("touch /var/log/lastlog")
+      machine1.wait_for_unit("lastlog2-import.service")
+      machine1.succeed("journalctl -b --grep 'Starting Import lastlog data into lastlog2 database'")
+      machine1.succeed("stat /var/log/lastlog.migrated")
+
+    with subtest("Test lastlog entries are created by logins"):
+      login(machine1)
+
+    with subtest("Test login succeeds with read-only disk by default"):
+      machine1.succeed("mount -o bind,ro /var /var")
+      login(machine1)
+      machine1.succeed("umount /var")
+
+    with subtest("Test login fails with read-only disk when disallowed"):
+      machine2.succeed("mount -o bind,ro /var /var")
+      login(machine2, succeed=False)
+      machine2.wait_until_succeeds("journalctl --grep='SQL error: attempt to write a readonly database'")
+      machine2.fail("pgrep -u alice bash")
+      machine2.succeed("umount /var")
   '';
 }


### PR DESCRIPTION
If the disk is full, it will block *all* logins including root. So make it optional by default, so a disk failure doesn't soft brick the system.

Setting required to true makes it required again.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
