### PR TITLE
graphify: 0.4.23 -> 0.9.28

### DIFF
--- a/pkgs/by-name/gr/graphify/package.nix
+++ b/pkgs/by-name/gr/graphify/package.nix
@@ -8,34 +8,49 @@
 python3Packages.buildPythonApplication rec {
   __structuredAttrs = true;
   pname = "graphify";
-  version = "0.4.23";
+  version = "0.9.28";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Graphify-Labs";
     repo = "graphify";
     tag = "v${version}";
-    hash = "sha256-QEzB1tFBqGhpmI7oudMRC1Ia0CDcm+GYt6AgxMA5zDo=";
+    hash = "sha256-iu/ARF1ylyrDUWke70kLpji4azfIeBSDSQ6uS+CKYiw=";
   };
 
   build-system = [
     python3.pkgs.setuptools
   ];
 
+  # The bindings in python3Packages.tree-sitter-grammars track the grammar
+  # repos, whose versions drift from the pins upstream declares.
+  pythonRelaxDeps = [
+    "tree-sitter-fortran"
+    "tree-sitter-groovy"
+    "tree-sitter-julia"
+    "tree-sitter-kotlin"
+  ];
+
   dependencies =
     with python3.pkgs;
     [
       networkx
+      numpy
+      rapidfuzz
       tree-sitter
     ]
     ++ (with python3.pkgs.tree-sitter-grammars; [
+      tree-sitter-bash
       tree-sitter-c
       tree-sitter-c-sharp
       tree-sitter-cpp
       tree-sitter-elixir
+      tree-sitter-fortran
       tree-sitter-go
+      tree-sitter-groovy
       tree-sitter-java
       tree-sitter-javascript
+      tree-sitter-json
       tree-sitter-julia
       tree-sitter-kotlin
       tree-sitter-lua
@@ -53,11 +68,21 @@ python3Packages.buildPythonApplication rec {
     ]);
 
   optional-dependencies = with python3.pkgs; {
+    anthropic = [
+      anthropic
+    ];
+    bedrock = [
+      boto3
+    ];
+    chinese = [
+      jieba
+    ];
     leiden = [
       graspologic
     ];
     mcp = [
       mcp
+      starlette
     ];
     neo4j = [
       neo4j
@@ -66,9 +91,16 @@ python3Packages.buildPythonApplication rec {
       openpyxl
       python-docx
     ];
+    openai = [
+      openai
+      tiktoken
+    ];
     pdf = [
-      html2text
+      markdownify
       pypdf
+    ];
+    postgres = [
+      psycopg
     ];
     svg = [
       matplotlib
@@ -82,11 +114,24 @@ python3Packages.buildPythonApplication rec {
     ];
   };
 
+  pythonImportsCheck = [ "graphify" ];
+
+  # The attribute and the command are `graphify`, but upstream publishes the
+  # distribution as `graphifyy`. pythonMetadataCheckPhase resolves the
+  # distribution by `pname`, so it cannot find it:
+  #   nix-build -E 'with import ./. {};
+  #     python3.withPackages (_: [ (python3.pkgs.toPythonModule graphify) ])'
+  #   => PackageNotFoundError: No package metadata was found for graphify
+  dontCheckPythonMetadata = true;
+
   meta = {
     description = "AI coding assistant skill. Turn any folder of code, docs, papers, images, or videos into a queryable knowledge graph.";
     homepage = "https://github.com/Graphify-Labs/graphify";
-    changelog = "https://github.com/Graphify-Labs/graphify/blob/${src.rev}/CHANGELOG.md";
-    license = lib.licenses.mit;
+    changelog = "https://github.com/Graphify-Labs/graphify/blob/${src.tag}/CHANGELOG.md";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
     maintainers = with lib.maintainers; [ stunkymonkey ];
     mainProgram = "graphify";
   };


### PR DESCRIPTION
## Things done

Two commits. The first is a prerequisite for the second: every
`python3Packages.tree-sitter-grammars.*` binding currently fails to build, and
those bindings are `graphify`'s entire dependency set, so the bump is not
testable without the fix. Happy to split if maintainers prefer.

### 1. `python3Packages.tree-sitter-grammars: fix build`

The whole set has been broken since `pythonMetadataCheckHook` was introduced in
006c7936a2e9.

The derivations are named `python-tree-sitter-<lang>` to follow the nixpkgs
naming convention, but the distribution each builds is named
`tree_sitter_<lang>` to match upstream PyPI. That distribution name has to stay
as it is, or consumers declaring a `tree-sitter-<lang>` dependency cannot
resolve it. `pythonMetadataCheckPhase` looks the distribution up by `pname`, so
it trips on the intentional mismatch every time:

```
importlib.metadata.PackageNotFoundError: No package metadata was found for python-tree-sitter-bash
```

Fixed with `dontCheckPythonMetadata`, as several other packages with a
deliberate pname/distribution mismatch already do.

### 2. `graphify: 0.4.23 -> 0.9.28`

- The project moved from `safishamsi/graphify` to `Graphify-Labs/graphify`; src
  and homepage repointed.
- License corrected to `asl20` — the repo is Apache-2.0 (with an accompanying
  `LICENSE-MIT` and `NOTICE`), not MIT.
- 0.9.x adds `numpy` and `rapidfuzz`, plus four more grammars (bash, fortran,
  groovy, json).
- Four grammars need `pythonRelaxDeps`: `tree-sitter-grammars` tracks the
  grammar repos, whose versions drift from upstream's pins.
- The `pdf` extra swapped `html2text` for `markdownify`; `anthropic`, `bedrock`,
  `chinese`, `openai` and `postgres` extras are new and all resolvable here.
  `falkordb` has no nixpkgs package, so that extra is omitted.

## Testing

- `nix-build -A graphify` succeeds on x86_64-linux.
- Sampled 22 grammar bindings individually (`bash json fortran groovy swift
  python c cpp typescript go java php scala verilog zig powershell objc elixir
  lua ruby kotlin julia`) — all build.
- End-to-end smoke test on a small mixed Python/Rust tree:
  `graphify extract . --code-only` produced a graph (24 nodes, 37 edges, 5
  communities — so Leiden/graspologic works on python 3.14), and
  `graphify explain` returned correct `inherits` / `method` / `contains` edges
  with the expected `EXTRACTED` provenance tags.

## Things done (checklist)

- [x] Built on platform(s): x86_64-linux
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? N/A
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`: see note below
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)

Note on `nixpkgs-review`: the grammar fix touches ~250 derivations in the
`tree-sitter-grammars` set. I verified a 22-grammar sample rather than the full
set; all of them are generated from the same template, and none of them could
have had a working reverse dependency before this fix, so the regression risk is
limited to the set itself.

cc @stunkymonkey (graphify maintainer), @stepbrobd @mightyiam @adfaure @a-jay98
(tree-sitter-grammars maintainers)