### PR TITLE
netcoredbg: expose only executables to bin, add update script

### DIFF
--- a/pkgs/by-name/ne/netcoredbg/package.nix
+++ b/pkgs/by-name/ne/netcoredbg/package.nix
@@ -7,6 +7,7 @@
   fetchFromGitHub,
   dotnetCorePackages,
   buildDotnetModule,
+  makeWrapper,
   netcoredbg,
   testers,
 }:
@@ -18,11 +19,12 @@ let
   hash = "sha256-Ci4GwHYTCn7BoEG73WsjxyplCCThSF5uVi39lLVZDXY=";
 
   coreclr-version = "v10.0.1";
+  coreclr-hash = "sha256-pVcLvew3THRqXgKMVO6jTZyPP06R46KZPMpYdiM3yXU=";
   coreclr-src = fetchFromGitHub {
     owner = "dotnet";
     repo = "runtime";
     rev = coreclr-version;
-    hash = "sha256-pVcLvew3THRqXgKMVO6jTZyPP06R46KZPMpYdiM3yXU=";
+    hash = coreclr-hash;
     name = "coreclr";
   };
 
@@ -92,18 +94,29 @@ stdenv.mkDerivation {
   # include source here so that autoPatchelfHook can do it's job
   src = managed;
 
-  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+  nativeBuildInputs = [
+    makeWrapper
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ (lib.getLib stdenv.cc.cc) ];
   installPhase = ''
-    mkdir -p $out/share/netcoredbg $out/bin
-    cp ${unmanaged}/* $out/share/netcoredbg
-    cp ./lib/netcoredbg/* $out/share/netcoredbg
-    # darwin won't work unless we link all files
-    ln -s $out/share/netcoredbg/* "$out/bin/"
+    runHook preInstall
+
+    mkdir -p $out/libexec/netcoredbg
+    cp ${unmanaged}/* $out/libexec/netcoredbg
+    cp ./lib/netcoredbg/* $out/libexec/netcoredbg
+
+    # netcoredbg loads libdbgshim and ManagedPart.dll from the directory of its own
+    # executable. Use a wrapper: exec'ing the real path keeps the lookup inside
+    # $out/libexec/netcoredbg on both platforms.
+    makeWrapper $out/libexec/netcoredbg/netcoredbg $out/bin/netcoredbg
+
+    runHook postInstall
   '';
 
   passthru = {
     inherit (managed) fetch-deps;
+    updateScript = ./update.sh;
     tests.version = testers.testVersion {
       package = netcoredbg;
       command = "netcoredbg --version";

--- a/pkgs/by-name/ne/netcoredbg/update.sh
+++ b/pkgs/by-name/ne/netcoredbg/update.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=./. -i bash -p nix git gnused coreutils
+
+set -euo pipefail
+
+dir=$(dirname "$(readlink -f "$0")")
+pkg=$dir/package.nix
+nixpkgs=$(readlink -f "$dir/../../../..")
+
+# Reads `  <name> = "<value>";` from package.nix.
+getVar() {
+  sed -n "s/^  $1 = \"\(.*\)\";\$/\1/p" "$pkg"
+}
+
+setVar() {
+  sed -i "s|^  $1 = \".*\";\$|  $1 = \"$2\";|" "$pkg"
+}
+
+prefetchSri() {
+  nix hash convert --hash-algo sha256 --to sri \
+    "$(nix-prefetch-url --unpack --type sha256 "$1" 2>/dev/null)"
+}
+
+# latestTag <owner/repo> <ref glob> <regex>
+latestTag() {
+  local tag
+  tag=$(git ls-remote --tags --refs "https://github.com/$1" "refs/tags/$2" |
+    sed 's|.*refs/tags/||' |
+    grep -E "$3" |
+    sort -V |
+    tail -1)
+
+  if [[ -z $tag ]]; then
+    echo "netcoredbg: no release tag matching '$2' in $1" >&2
+    return 1
+  fi
+  printf '%s\n' "$tag"
+}
+
+oldRelease=$(getVar release)
+oldBuild=$(getVar build)
+oldCoreclr=$(getVar coreclr-version)
+
+# netcoredbg tags its releases `<release>-<build>`, e.g. `3.2.0-1092`.
+latest=$(latestTag Samsung/netcoredbg '*' '^[0-9]+\.[0-9]+\.[0-9]+-[0-9]+$')
+newRelease=${latest%-*}
+newBuild=${latest##*-}
+
+series=${oldCoreclr%.*}
+newCoreclr=$(latestTag dotnet/runtime "$series.*" '^v[0-9]+\.[0-9]+\.[0-9]+$')
+
+changed=0
+
+if [[ $latest != "$oldRelease-$oldBuild" ]]; then
+  echo "netcoredbg: $oldRelease-$oldBuild -> $latest"
+  setVar release "$newRelease"
+  setVar build "$newBuild"
+  setVar hash "$(prefetchSri "https://github.com/Samsung/netcoredbg/archive/refs/tags/$latest.tar.gz")"
+  changed=1
+else
+  echo "netcoredbg: already at $oldRelease-$oldBuild"
+fi
+
+if [[ $newCoreclr != "$oldCoreclr" ]]; then
+  echo "netcoredbg: coreclr $oldCoreclr -> $newCoreclr"
+  setVar coreclr-version "$newCoreclr"
+  setVar coreclr-hash "$(prefetchSri "https://github.com/dotnet/runtime/archive/refs/tags/$newCoreclr.tar.gz")"
+  changed=1
+else
+  echo "netcoredbg: coreclr already at $oldCoreclr"
+fi
+
+if ((changed == 0)); then
+  exit 0
+fi
+
+echo "netcoredbg: regenerating deps.json"
+"$(nix-build "$nixpkgs" --attr netcoredbg.fetch-deps --no-out-link)"


### PR DESCRIPTION
Fixes the problem mentioned in https://github.com/NixOS/nixpkgs/pull/546493 for all platforms.

Enables automatic updates.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
