### PR TITLE
blasfeo: 0.1.4.2 -> 0.1.4.3, hpipm: 0.1.3-unstable-2025-07-25 -> 0.1.4, casadi: 3.7.2 -> 3.8.0

### DIFF
--- a/pkgs/by-name/bl/blasfeo/package.nix
+++ b/pkgs/by-name/bl/blasfeo/package.nix
@@ -1,7 +1,6 @@
 {
   cmake,
   fetchFromGitHub,
-  fetchpatch,
   lib,
   stdenv,
   withTarget ? "GENERIC",
@@ -9,26 +8,21 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "blasfeo";
-  version = "0.1.4.2";
+  version = "0.1.4.3";
 
   src = fetchFromGitHub {
     owner = "giaf";
     repo = "blasfeo";
     tag = finalAttrs.version;
-    hash = "sha256-p1pxqJ38h6RKXMg1t+2RHlfmRKPuM18pbUarUx/w9lw=";
+    hash = "sha256-+hdS/HGw49pSKOOL4jzAhScVGIFTsEqYwXSpQi3GBm0=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "blasfeo-fix-cmake-4.patch";
-      url = "https://github.com/giaf/blasfeo/commit/75078e2b6153d1c8bc5329e83a82d4d4d3eefd76.patch";
-      hash = "sha256-bH5xUKAjNFCO9rRc655BcMiUesNFFln+iEPC5JHcQAU=";
-    })
-  ];
 
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [ "-DTARGET=${withTarget}" ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   meta = {
     description = "Basic linear algebra subroutines for embedded optimization";

--- a/pkgs/by-name/ca/casadi/package.nix
+++ b/pkgs/by-name/ca/casadi/package.nix
@@ -10,7 +10,6 @@
   cplex,
   fatrop,
   fetchFromGitHub,
-  fetchpatch,
   gurobi,
   highs,
   hpipm,
@@ -38,34 +37,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "casadi";
-  version = "3.7.2";
+  version = "3.8.0";
 
   src = fetchFromGitHub {
     owner = "casadi";
     repo = "casadi";
     tag = finalAttrs.version;
-    hash = "sha256-I6CYtKVvE67NSYH/JGJFP5wHhm1xACctz7uTwOFFihA=";
+    hash = "sha256-kSuNOn55eSaF4admtw4aHmPpdxUS/JDF1yBMrRbPv04=";
   };
-
-  patches = [
-    # Add missing include
-    # ref. https://github.com/casadi/casadi/pull/4192
-    (fetchpatch {
-      url = "https://github.com/casadi/casadi/pull/4192/commits/fc1a83e8db37f328657eabff41f00a9a34d3cc74.patch";
-      hash = "sha256-9GXOtYa/BFq5vp6tE8HxO8xW3ep3my6TPD3FvkDhUUA=";
-    })
-
-    # Fix build with osqp v1
-    # ref. https://github.com/casadi/casadi/pull/4105
-    (fetchpatch {
-      url = "https://github.com/casadi/casadi/pull/4105/commits/cca4eb5d423c9d034f0666f71338063d3f8c9c43.patch";
-      hash = "sha256-pDI9x4yzPj+rjtzZpFKwfSsyE52Jt20izfqo5blkUOA=";
-    })
-    (fetchpatch {
-      url = "https://github.com/casadi/casadi/pull/4105/commits/6035a95e48088928134c3827ab90a2a3a82b1389.patch";
-      hash = "sha256-1nOcCLXVwFBRH/abAhTly28+1oNjDumJCjT0NyRAgz0=";
-    })
-  ];
 
   postPatch = ''
     # fix case of hpipmConfig.cmake
@@ -105,6 +84,10 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     ninja
     pkg-config
+  ]
+  ++ lib.optionals pythonSupport [
+    python3Packages.python
+    swig
   ];
 
   buildInputs = [
@@ -140,13 +123,13 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals pythonSupport [
     python3Packages.numpy
-    python3Packages.python
   ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [ llvmPackages.openmp ];
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    llvmPackages.openmp
+  ];
 
   cmakeFlags = [
     (lib.cmakeBool "WITH_PYTHON" pythonSupport)
-    (lib.cmakeBool "WITH_PYTHON3" pythonSupport)
     # We don't mind always setting this cmake variable, it will be read only if
     # pythonSupport is enabled.
     "-DPYTHON_PREFIX=${placeholder "out"}/${python3Packages.python.sitePackages}"
@@ -199,6 +182,9 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   doCheck = true;
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   meta = {
     description = "Symbolic framework for numeric optimization";

--- a/pkgs/by-name/hp/hpipm/package.nix
+++ b/pkgs/by-name/hp/hpipm/package.nix
@@ -9,14 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hpipm";
-  #version = "0.1.3";  not building, use master instead
-  version = "0.1.3-unstable-2025-07-25";
+  version = "0.1.4";
 
   src = fetchFromGitHub {
     owner = "giaf";
     repo = "hpipm";
-    rev = "00c2a084e059e2e1b79877f668e282d0c4282110";
-    hash = "sha256-Lg7po7xTs9jc8FiYFMbNFJooTjOpzBFiyd5f+TPMWQA=";
+    tag = finalAttrs.version;
+    hash = "sha256-URsO+QZwD+f5DgwWvknBNQGjDrhP0hUYJwynPQrg/BE=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -30,6 +29,9 @@ stdenv.mkDerivation (finalAttrs: {
     "-DBUILD_SHARED_LIBS=ON"
   ]
   ++ lib.optionals (!stdenv.hostPlatform.isx86_64) [ "-DTARGET=GENERIC" ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   meta = {
     description = "High-performance interior-point-method QP and QCQP solvers";


### PR DESCRIPTION
Diff: https://github.com/giaf/blasfeo/compare/0.1.4.2...0.1.4.3

Changelog: https://github.com/giaf/blasfeo/blob/0.1.4.3/Changelog.txt

Diff: https://github.com/giaf/hpipm/compare/0.1.3...0.1.4

Changelog: https://github.com/giaf/hpipm/blob/refs/tags/0.1.4/Changelog.txt

Diff: https://github.com/casadi/casadi/compare/3.7.2...3.8.0
    
Changelog: https://github.com/casadi/casadi/releases/tag/3.8.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
