### PR TITLE
plezy: 2.9.1 -> 2.10.0

### DIFF
--- a/pkgs/by-name/pl/plezy/package.nix
+++ b/pkgs/by-name/pl/plezy/package.nix
@@ -27,13 +27,13 @@
 
 let
   pname = "plezy";
-  version = "2.9.1";
+  version = "2.10.0";
 
   src = fetchFromGitHub {
     owner = "edde746";
     repo = "plezy";
     tag = version;
-    hash = "sha256-Fc2KWx4byfrulWzOGm0WW6EUXMvV8uwmvVjoSgzQmuA=";
+    hash = "sha256-82OPOad3ti+5Eec8U3vEJaAE12+ViQb+P7ZhMhEplL8=";
   };
 
   simdutf = fetchurl {
@@ -146,7 +146,7 @@ let
 
     src = fetchurl {
       url = "https://github.com/edde746/plezy/releases/download/${version}/plezy-macos.dmg";
-      hash = "sha256-jNwMukPYLTWBk1daanHtxYdJpZCB5I/hiKvFx4tL4sY=";
+      hash = "sha256-lwO34G2w4hAju06z3/HwI3Tq7dHhgWZD4HxShby8OYg=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/by-name/pl/plezy/pubspec.lock.json
+++ b/pkgs/by-name/pl/plezy/pubspec.lock.json
@@ -4,41 +4,41 @@
       "dependency": "transitive",
       "description": {
         "name": "_fe_analyzer_shared",
-        "sha256": "8d7ff3948166b8ec5da0fbb5962000926b8e02f2ed9b3e51d1738905fbd4c98d",
+        "sha256": "3b19a47f6ea7c2632760777c78174f47f6aec1e05f0cd611380d4593b8af1dbc",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "93.0.0"
+      "version": "96.0.0"
     },
     "analysis_server_plugin": {
       "dependency": "transitive",
       "description": {
         "name": "analysis_server_plugin",
-        "sha256": "5f3920acbd5765764ec9ef6c5bbdd102015424281232ee4fb4f5431c87abb4eb",
+        "sha256": "c9611c4b053f868434400e734c594a7e8464f307f8eaf7ff266d903cd2d615c0",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.3.7"
+      "version": "0.3.10"
     },
     "analyzer": {
-      "dependency": "transitive",
+      "dependency": "direct dev",
       "description": {
         "name": "analyzer",
-        "sha256": "de7148ed2fcec579b19f122c1800933dfa028f6d9fd38a152b04b1516cec120b",
+        "sha256": "0c516bc4ad36a1a75759e54d5047cb9d15cded4459df01aa35a0b5ec7db2c2a0",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "10.0.1"
+      "version": "10.2.0"
     },
     "analyzer_plugin": {
       "dependency": "transitive",
       "description": {
         "name": "analyzer_plugin",
-        "sha256": "7df504f0c9d6891bacc9f73a5a8c5f6fe4fc49c90ec8e3379916372906ba0b32",
+        "sha256": "a886aaa94fb128ffe9cf5ee2495d9ef42ef129fe2e265b84b8820987ca15f4cd",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.14.1"
+      "version": "0.14.4"
     },
     "ansicolor": {
       "dependency": "transitive",
@@ -64,11 +64,11 @@
       "dependency": "transitive",
       "description": {
         "name": "async",
-        "sha256": "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb",
+        "sha256": "e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.13.0"
+      "version": "2.13.1"
     },
     "auto_updater": {
       "dependency": "direct main",
@@ -139,41 +139,41 @@
       "dependency": "transitive",
       "description": {
         "name": "build",
-        "sha256": "275bf6bb2a00a9852c28d4e0b410da1d833a734d57d39d44f94bfc895a484ec3",
+        "sha256": "45d14a0fb23e018d8287c32fc98d726ce466b231928ed9b9200f29bd3ccd39ae",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.0.4"
+      "version": "4.0.7"
     },
     "build_config": {
       "dependency": "transitive",
       "description": {
         "name": "build_config",
-        "sha256": "4070d2a59f8eec34c97c86ceb44403834899075f66e8a9d59706f8e7834f6f71",
+        "sha256": "f2c223156a26eea323e6244b85141d76413a80aeee9fe0b380773789fabaf8ae",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.3.0"
+      "version": "1.3.1"
     },
     "build_daemon": {
       "dependency": "transitive",
       "description": {
         "name": "build_daemon",
-        "sha256": "bf05f6e12cfea92d3c09308d7bcdab1906cd8a179b023269eed00c071004b957",
+        "sha256": "fd754058c342243718d5171a95f352cfc9fcf0cba8cfa26df67cb13a5836db78",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.1.1"
+      "version": "4.1.2"
     },
     "build_runner": {
       "dependency": "direct dev",
       "description": {
         "name": "build_runner",
-        "sha256": "3552e5c2874ed47cf9ed9d6813ac71b2276ee07622f48530468b8013f1767e3f",
+        "sha256": "5367e521935b102bdf1e735d2aab461e36b2edca6517662d088dd04cc39f8d16",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.13.0"
+      "version": "2.15.1"
     },
     "built_collection": {
       "dependency": "transitive",
@@ -189,21 +189,21 @@
       "dependency": "transitive",
       "description": {
         "name": "built_value",
-        "sha256": "6ae8a6435a8c6520c7077b107e77f1fb4ba7009633259a4d49a8afd8e7efc5e9",
+        "sha256": "34e4067d30ce212937df995f03b69992eea683539ceeac7f679a1f1eba055b56",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "8.12.4"
+      "version": "8.12.6"
     },
     "cached_network_image_ce": {
       "dependency": "direct main",
       "description": {
         "name": "cached_network_image_ce",
-        "sha256": "d4701fbbdf508de831e847fd1d49c644ffa6191c6018c416ab6f66bbe1ad5fff",
+        "sha256": "9c61372fecd5f6ac6aaa66fa6808b4c303b8574875e853a0916116bf2fae6840",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.6.4"
+      "version": "4.9.0"
     },
     "cached_network_image_platform_interface_ce": {
       "dependency": "transitive",
@@ -279,21 +279,11 @@
       "dependency": "transitive",
       "description": {
         "name": "code_assets",
-        "sha256": "83ccdaa064c980b5596c35dd64a8d3ecc68620174ab9b90b6343b753aa721687",
+        "sha256": "bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.0.0"
-    },
-    "code_builder": {
-      "dependency": "transitive",
-      "description": {
-        "name": "code_builder",
-        "sha256": "6a6cab2ba4680d6423f34a9b972a4c9a94ebe1b62ecec4e1a1f2cba91fd1319d",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "4.11.1"
+      "version": "1.2.1"
     },
     "collection": {
       "dependency": "direct main",
@@ -350,11 +340,11 @@
       "dependency": "transitive",
       "description": {
         "name": "cross_file",
-        "sha256": "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937",
+        "sha256": "92c9c43c383bfa1c32079d3bc492d55d6d4318044b7b47edaff8971cbb555c51",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.3.5+2"
+      "version": "0.3.5+4"
     },
     "crypto": {
       "dependency": "direct main",
@@ -390,21 +380,21 @@
       "dependency": "direct main",
       "description": {
         "name": "cupertino_http",
-        "sha256": "82cbec60c90bf785a047a9525688b6dacac444e177e1d5a5876963d3c50369e8",
+        "sha256": "3c8c69cc1b94b9c7570d9454bf1e11fa7010b248547a0760843adc71f0c08fbe",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.4.0"
+      "version": "3.0.2"
     },
     "dart_code_linter": {
       "dependency": "direct dev",
       "description": {
         "name": "dart_code_linter",
-        "sha256": "44cce8527a2094201067b50aed97778930638cc43e8bb3cb0b40a90c36fb9c84",
+        "sha256": "5079aaacdf9e3c0c3a539143966ab0ad549aa58d1bf31fe73c18b8cf8f1db19e",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.1.6"
+      "version": "4.1.8"
     },
     "dart_discord_presence": {
       "dependency": "direct main",
@@ -430,21 +420,21 @@
       "dependency": "transitive",
       "description": {
         "name": "dbus",
-        "sha256": "d0c98dcd4f5169878b6cf8f6e0a52403a9dff371a3e2f019697accbf6f44a270",
+        "sha256": "792974a4007974fbc5c1b5433eb2330a9db3e368c3f906253af4c007d0f49a91",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.7.12"
+      "version": "0.7.13"
     },
     "device_info_plus": {
       "dependency": "direct main",
       "description": {
         "name": "device_info_plus",
-        "sha256": "4df8babf73058181227e18b08e6ea3520cf5fc5d796888d33b7cb0f33f984b7c",
+        "sha256": "b4fed1b2835da9d670d7bed7db79ae2a94b0f5ad6312268158a9b5479abbacdd",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "12.3.0"
+      "version": "12.4.0"
     },
     "device_info_plus_platform_interface": {
       "dependency": "transitive",
@@ -460,21 +450,21 @@
       "dependency": "direct main",
       "description": {
         "name": "drift",
-        "sha256": "970cd188fddb111b26ea6a9b07a62bf5c2432d74147b8122c67044ae3b97e99e",
+        "sha256": "84688491040b0ceb26575709a84d701c84ad4df4d8aff020adf6d85f155fb0dd",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.31.0"
+      "version": "2.34.2"
     },
     "drift_dev": {
       "dependency": "direct dev",
       "description": {
         "name": "drift_dev",
-        "sha256": "917184b2fb867b70a548a83bf0d36268423b38d39968c06cce4905683da49587",
+        "sha256": "9cfff1576b49725da0d32c040651a41ae195e8c4af8d8da301593e41d7abc2f7",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.31.0"
+      "version": "2.34.0"
     },
     "duration": {
       "dependency": "direct main",
@@ -520,11 +510,11 @@
       "dependency": "direct main",
       "description": {
         "name": "file_picker",
-        "sha256": "57d9a1dd5063f85fa3107fb42d1faffda52fdc948cefd5fe5ea85267a5fc7343",
+        "sha256": "f13a03000d942e476bc1ff0a736d2e9de711d2f89a95cd4c1d88f861c3348387",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "10.3.10"
+      "version": "11.0.2"
     },
     "fixnum": {
       "dependency": "transitive",
@@ -582,21 +572,21 @@
       "dependency": "transitive",
       "description": {
         "name": "flutter_plugin_android_lifecycle",
-        "sha256": "ee8068e0e1cd16c4a82714119918efdeed33b3ba7772c54b5d094ab53f9b7fd1",
+        "sha256": "3854fe5e3bff0b113c658f260b90c95dea17c92db0f2addeac2e343dd9969785",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.0.33"
+      "version": "2.0.35"
     },
     "flutter_svg": {
       "dependency": "direct main",
       "description": {
         "name": "flutter_svg",
-        "sha256": "1ded017b39c8e15c8948ea855070a5ff8ff8b3d5e83f3446e02d6bb12add7ad9",
+        "sha256": "35882981abcbfb8c15b286f0cd690ff25bac12d95eff3e25ee207f37d4c42e7f",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.2.4"
+      "version": "2.3.0"
     },
     "flutter_test": {
       "dependency": "direct dev",
@@ -674,11 +664,11 @@
       "dependency": "transitive",
       "description": {
         "name": "hooks",
-        "sha256": "e79ed1e8e1929bc6ecb6ec85f0cb519c887aa5b423705ded0d0f2d9226def388",
+        "sha256": "9a62a50b50b769a737bc0a8ff381f333529df3ab746b2f6b02e83760231455ba",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.0.2"
+      "version": "2.0.2"
     },
     "html": {
       "dependency": "transitive",
@@ -784,21 +774,21 @@
       "dependency": "direct main",
       "description": {
         "name": "json_annotation",
-        "sha256": "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1",
+        "sha256": "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.9.0"
+      "version": "4.12.0"
     },
     "json_serializable": {
       "dependency": "direct dev",
       "description": {
         "name": "json_serializable",
-        "sha256": "5b89c1e32ae3840bb20a1b3434e3a590173ad3cb605896fb0f60487ce2f8104e",
+        "sha256": "ffcd10cde35a93b2abbbcc26bd9971f4ca93763e8abe78d855e3c4177797e501",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.11.4"
+      "version": "6.14.0"
     },
     "leak_tracker": {
       "dependency": "transitive",
@@ -884,11 +874,11 @@
       "dependency": "direct main",
       "description": {
         "name": "material_symbols_icons",
-        "sha256": "49c532dd0b74544e9d8d93ec0f821d52ec532e7c9263c889ebe71b1be4f34ba7",
+        "sha256": "bd513edc2bc9b034108d5518c48cf5cebbb67d0653728cc452368cb27ca80bb0",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.2951.0"
+      "version": "4.2960.0"
     },
     "meta": {
       "dependency": "transitive",
@@ -899,6 +889,16 @@
       },
       "source": "hosted",
       "version": "1.18.0"
+    },
+    "mgenware_dart_lints": {
+      "dependency": "direct dev",
+      "description": {
+        "name": "mgenware_dart_lints",
+        "sha256": "14f47c0ba0073c1980298ee10f602c19fa244151c68ec75fde602642c3de3a4e",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "8.1.0"
     },
     "mime": {
       "dependency": "transitive",
@@ -914,11 +914,11 @@
       "dependency": "transitive",
       "description": {
         "name": "native_toolchain_c",
-        "sha256": "6ba77bb18063eebe9de401f5e6437e95e1438af0a87a3a39084fbd37c90df572",
+        "sha256": "f9c168717100ae6d9fee9ffb0be379bf1f8b26b0f6bcbd4fdddcd931993a6a72",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.17.6"
+      "version": "0.19.2"
     },
     "nested": {
       "dependency": "transitive",
@@ -944,11 +944,11 @@
       "dependency": "transitive",
       "description": {
         "name": "objective_c",
-        "sha256": "100a1c87616ab6ed41ec263b083c0ef3261ee6cd1dc3b0f35f8ddfa4f996fe52",
+        "sha256": "6cb691c686fa2838c6deb34980d426145c2a5d537491cb83d463c33cdbc726ed",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "9.3.0"
+      "version": "9.4.1"
     },
     "octo_image": {
       "dependency": "transitive",
@@ -985,11 +985,11 @@
       "dependency": "direct main",
       "description": {
         "name": "package_info_plus",
-        "sha256": "f69da0d3189a4b4ceaeb1a3defb0f329b3b352517f52bed4290f83d4f06bc08d",
+        "sha256": "468c26b4254ab01979fa5e4a98cb343ea3631b9acee6f21028997419a80e1a20",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "9.0.0"
+      "version": "9.0.1"
     },
     "package_info_plus_platform_interface": {
       "dependency": "transitive",
@@ -1025,21 +1025,21 @@
       "dependency": "direct main",
       "description": {
         "name": "path_provider",
-        "sha256": "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd",
+        "sha256": "a7f4874f987173da295a61c181b8ee71dab59b332a486b391babf26a1b884825",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.5"
+      "version": "2.1.6"
     },
     "path_provider_android": {
       "dependency": "transitive",
       "description": {
         "name": "path_provider_android",
-        "sha256": "f2c65e21139ce2c3dad46922be8272bb5963516045659e71bb16e151c93b580e",
+        "sha256": "149441ca6e4f38193b2e004c0ca6376a3d11f51fa5a77552d8bd4d2b0c0912ba",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.2.22"
+      "version": "2.2.23"
     },
     "path_provider_foundation": {
       "dependency": "transitive",
@@ -1055,21 +1055,21 @@
       "dependency": "transitive",
       "description": {
         "name": "path_provider_linux",
-        "sha256": "f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279",
+        "sha256": "58c2005f147315b11e9b4a7bc889cd5203e250cba8e3f012dae259b4972b5c16",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.2.1"
+      "version": "2.2.2"
     },
     "path_provider_platform_interface": {
       "dependency": "direct dev",
       "description": {
         "name": "path_provider_platform_interface",
-        "sha256": "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334",
+        "sha256": "484838772624c3a4b94f1e44a3e19897fee738f2d5c4ce448443b0417f7c9dda",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.2"
+      "version": "2.1.3"
     },
     "path_provider_windows": {
       "dependency": "transitive",
@@ -1221,15 +1221,25 @@
       "source": "hosted",
       "version": "4.1.0"
     },
+    "record_use": {
+      "dependency": "transitive",
+      "description": {
+        "name": "record_use",
+        "sha256": "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.6.0"
+    },
     "saf_stream": {
       "dependency": "direct main",
       "description": {
         "name": "saf_stream",
-        "sha256": "6fa5179bf5c8f5f99b183286df6236b23de33c1e874d69ce1fe565a63f95f62b",
+        "sha256": "0be813853004e4c3d2aca2dae1f3089cef8769059af4528e2e137471b8e3367e",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.0.0"
+      "version": "3.1.0"
     },
     "saf_util": {
       "dependency": "direct main",
@@ -1244,81 +1254,81 @@
       "dependency": "transitive",
       "description": {
         "name": "screen_retriever",
-        "sha256": "570dbc8e4f70bac451e0efc9c9bb19fa2d6799a11e6ef04f946d7886d2e23d0c",
+        "sha256": "ace919117a7520c13a50a6259e60c4a0d4cbe98809468792a91b5c5adada2aa6",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.2.0"
+      "version": "0.2.2"
     },
     "screen_retriever_linux": {
       "dependency": "transitive",
       "description": {
         "name": "screen_retriever_linux",
-        "sha256": "f7f8120c92ef0784e58491ab664d01efda79a922b025ff286e29aa123ea3dd18",
+        "sha256": "7b52006a5ceae1f3d5af7f77188c3290d6e7d8ded16d99809bea84967c65c257",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.2.0"
+      "version": "0.2.2"
     },
     "screen_retriever_macos": {
       "dependency": "transitive",
       "description": {
         "name": "screen_retriever_macos",
-        "sha256": "71f956e65c97315dd661d71f828708bd97b6d358e776f1a30d5aa7d22d78a149",
+        "sha256": "a1489b99cce597c45a54b9aae1cd94c8d4705353b7e0bb2457a6e4de44e0ad8a",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.2.0"
+      "version": "0.2.2"
     },
     "screen_retriever_platform_interface": {
       "dependency": "transitive",
       "description": {
         "name": "screen_retriever_platform_interface",
-        "sha256": "ee197f4581ff0d5608587819af40490748e1e39e648d7680ecf95c05197240c0",
+        "sha256": "94a5535277510a63184ca178ce12a1449bc0b38618879aa1c18bf57369c5064a",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.2.0"
+      "version": "0.2.2"
     },
     "screen_retriever_windows": {
       "dependency": "transitive",
       "description": {
         "name": "screen_retriever_windows",
-        "sha256": "449ee257f03ca98a57288ee526a301a430a344a161f9202b4fcc38576716fe13",
+        "sha256": "dafc6922b0bfbf1d48cf3ccbf519b4fff47bdcb820da1728ea6db675fecc9324",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.2.0"
+      "version": "0.2.2"
     },
     "sentry": {
       "dependency": "transitive",
       "description": {
         "name": "sentry",
-        "sha256": "09c573f98ff6c5e98d527f351f037eb8ea9ff684a6e9e84b2e91357144016254",
+        "sha256": "a84bf3a83b3ce1c89fce28b9f97659e3826df14a73a256952465aac2c5efdf5a",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "9.24.0"
+      "version": "9.25.0"
     },
     "sentry_dart_plugin": {
       "dependency": "direct dev",
       "description": {
         "name": "sentry_dart_plugin",
-        "sha256": "2c5f263f8d5aea3cf387a7e03f77e355d35c71bd9a429474d633fbc085b86ceb",
+        "sha256": "da9c1d0b3c87a251bfc36301f16af090a88c2d59128fe9a6f908f5ac20340c97",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.3.0"
+      "version": "3.4.0"
     },
     "sentry_flutter": {
       "dependency": "direct main",
       "description": {
         "name": "sentry_flutter",
-        "sha256": "4a04b7e1901b8128df783b6d36d48706b07b0cd055e621517c998de87f5dafb9",
+        "sha256": "c85575266d91f57364e9b4cb522835156ec3c5581c78339dc7fae491cd0c6f76",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "9.24.0"
+      "version": "9.25.0"
     },
     "serial_csv": {
       "dependency": "transitive",
@@ -1334,21 +1344,21 @@
       "dependency": "direct main",
       "description": {
         "name": "shared_preferences",
-        "sha256": "2939ae520c9024cb197fc20dee269cd8cdbf564c8b5746374ec6cacdc5169e64",
+        "sha256": "c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.5.4"
+      "version": "2.5.5"
     },
     "shared_preferences_android": {
       "dependency": "transitive",
       "description": {
         "name": "shared_preferences_android",
-        "sha256": "8374d6200ab33ac99031a852eba4c8eb2170c4bf20778b3e2c9eccb45384fb41",
+        "sha256": "0634e64bd719f89c012f392938e173521f535d3ecaf66558fa94a056d22b5cc7",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.4.21"
+      "version": "2.4.27"
     },
     "shared_preferences_foundation": {
       "dependency": "transitive",
@@ -1374,11 +1384,11 @@
       "dependency": "direct dev",
       "description": {
         "name": "shared_preferences_platform_interface",
-        "sha256": "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80",
+        "sha256": "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.4.1"
+      "version": "2.4.2"
     },
     "shared_preferences_web": {
       "dependency": "transitive",
@@ -1430,51 +1440,51 @@
       "dependency": "direct main",
       "description": {
         "name": "slang",
-        "sha256": "ea6702ed6b1c82065fb2de906fe34ac9298117342e3c2ea2567132efdc81bd17",
+        "sha256": "76dbf1f8e87ed1c417026e93a57512f6b6b597104ce72eed99b24a3ed08f0ba2",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.14.0"
+      "version": "4.18.0"
     },
     "slang_build_runner": {
       "dependency": "direct dev",
       "description": {
         "name": "slang_build_runner",
-        "sha256": "1db59254041026aec97df5aca30a602e09e9d1546c3d16b55c3c7cf4c16cdb6c",
+        "sha256": "e24f5ab540c2078db20a1e3292b9bae11ef4ed07bef1c235ae000b0a6113267e",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.14.0"
+      "version": "4.18.0"
     },
     "slang_flutter": {
       "dependency": "direct main",
       "description": {
         "name": "slang_flutter",
-        "sha256": "dcc4e77527c91b12348fc8bdd43d3eb92d8cea37c12a23a1f9719cdc12c804c6",
+        "sha256": "7523a9389b44210eabcfd58412d9131f284b9b3c22d731614f0016e9582ee996",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.14.0"
+      "version": "4.18.0"
     },
     "source_gen": {
       "dependency": "transitive",
       "description": {
         "name": "source_gen",
-        "sha256": "adc962c96fffb2de1728ef396a995aaedcafbe635abdca13d2a987ce17e57751",
+        "sha256": "a603f1fb984a7391ae5978d1b92bfaaa08b350dca5c825256f925818f7943bf5",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.2.1"
+      "version": "4.2.4"
     },
     "source_helper": {
       "dependency": "transitive",
       "description": {
         "name": "source_helper",
-        "sha256": "1d3b229b2934034fb2e691fbb3d53e0f75a4af7b1407f88425ed8f209bcb1b8f",
+        "sha256": "4227d54ceefd0bb8ca4c8fcb96e1719dc53f1ee1b6e2ca9d7a6069da160e4eae",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.3.11"
+      "version": "1.3.12"
     },
     "source_span": {
       "dependency": "transitive",
@@ -1490,31 +1500,21 @@
       "dependency": "transitive",
       "description": {
         "name": "sqlite3",
-        "sha256": "3145bd74dcdb4fd6f5c6dda4d4e4490a8087d7f286a14dee5d37087290f0f8a2",
+        "sha256": "c73fd75df1332d76a6257f4823ae4df9c791f522b97e4a60cbcad214de1becf4",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.9.4"
-    },
-    "sqlite3_flutter_libs": {
-      "dependency": "direct main",
-      "description": {
-        "name": "sqlite3_flutter_libs",
-        "sha256": "eeb9e3a45207649076b808f8a5a74d68770d0b7f26ccef6d5f43106eee5375ad",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "0.5.42"
+      "version": "3.5.0"
     },
     "sqlparser": {
       "dependency": "transitive",
       "description": {
         "name": "sqlparser",
-        "sha256": "337e9997f7141ffdd054259128553c348635fa318f7ca492f07a4ab76f850d19",
+        "sha256": "40bdddb306a727be9ce510bd2d2b9a6c9db6c586d846ef7b22e3990a2b24f02d",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.43.1"
+      "version": "0.44.5"
     },
     "stack_trace": {
       "dependency": "transitive",
@@ -1527,7 +1527,7 @@
       "version": "1.12.1"
     },
     "stream_channel": {
-      "dependency": "transitive",
+      "dependency": "direct dev",
       "description": {
         "name": "stream_channel",
         "sha256": "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d",
@@ -1610,11 +1610,21 @@
       "dependency": "direct main",
       "description": {
         "name": "universal_gamepad",
-        "sha256": "eec9726c9e03b4ce54c0c613628ee3998c33f6d5e98ef4a99af3d5d7a79d341b",
+        "sha256": "8570c1c2d354c0959592839f45683599fd7d6a3b8b438b5b634388c6a5724798",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.5.7"
+      "version": "1.5.8"
+    },
+    "unorm_dart": {
+      "dependency": "direct main",
+      "description": {
+        "name": "unorm_dart",
+        "sha256": "0c69186b03ca6addab0774bcc0f4f17b88d4ce78d9d4d8f0619e30a99ead58e7",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.3.2"
     },
     "url_launcher": {
       "dependency": "direct main",
@@ -1630,11 +1640,11 @@
       "dependency": "transitive",
       "description": {
         "name": "url_launcher_android",
-        "sha256": "767344bf3063897b5cf0db830e94f904528e6dd50a6dfaf839f0abf509009611",
+        "sha256": "b413d49b73867ac08dd2f9890efd3cc11f2a0e577618d50843440a1fb3776c32",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.3.28"
+      "version": "6.3.32"
     },
     "url_launcher_ios": {
       "dependency": "transitive",
@@ -1680,11 +1690,11 @@
       "dependency": "transitive",
       "description": {
         "name": "url_launcher_web",
-        "sha256": "d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f",
+        "sha256": "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.4.2"
+      "version": "2.4.3"
     },
     "url_launcher_windows": {
       "dependency": "transitive",
@@ -1700,21 +1710,21 @@
       "dependency": "direct main",
       "description": {
         "name": "uuid",
-        "sha256": "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489",
+        "sha256": "9b129329f58692f6e6578329498a8fe9fbe98f090beb764ffbb8ee2eadd01dcd",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.5.3"
+      "version": "4.6.0"
     },
     "vector_graphics": {
       "dependency": "transitive",
       "description": {
         "name": "vector_graphics",
-        "sha256": "7076216a10d5c390315fbe536a30f1254c341e7543e6c4c8a815e591307772b1",
+        "sha256": "2306c03da2ba81724afeb589c351ebbc0aa7d86005925be8f8735856dbe5e42d",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.1.20"
+      "version": "1.2.2"
     },
     "vector_graphics_codec": {
       "dependency": "transitive",
@@ -1730,11 +1740,11 @@
       "dependency": "transitive",
       "description": {
         "name": "vector_graphics_compiler",
-        "sha256": "5a88dd14c0954a5398af544651c7fb51b457a2a556949bfb25369b210ef73a74",
+        "sha256": "142a9146f447d15b10bdc00e21d5f4d83e5b32bb5f8f8f5a04c75311344923a3",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.2.0"
+      "version": "1.2.6"
     },
     "vector_math": {
       "dependency": "transitive",
@@ -1750,11 +1760,11 @@
       "dependency": "transitive",
       "description": {
         "name": "vm_service",
-        "sha256": "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60",
+        "sha256": "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "15.0.2"
+      "version": "15.2.0"
     },
     "wakelock_plus": {
       "dependency": "direct main",
@@ -1849,11 +1859,11 @@
       "dependency": "direct main",
       "description": {
         "name": "window_manager",
-        "sha256": "7eb6d6c4164ec08e1bf978d6e733f3cebe792e2a23fb07cbca25c2872bfdbdcd",
+        "sha256": "05c231fd7b23d2380f14c5cc10b7b93d60d4fa4a2fb4e0f032de27e44b5560e9",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.5.1"
+      "version": "0.5.2"
     },
     "xdg_directories": {
       "dependency": "transitive",
@@ -1869,11 +1879,11 @@
       "dependency": "direct main",
       "description": {
         "name": "xml",
-        "sha256": "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025",
+        "sha256": "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.6.1"
+      "version": "7.0.1"
     },
     "yaml": {
       "dependency": "transitive",

--- a/pkgs/development/compilers/dart/package-source-builders/sqlite3/default.nix
+++ b/pkgs/development/compilers/dart/package-source-builders/sqlite3/default.nix
@@ -20,10 +20,17 @@ stdenv.mkDerivation (finalAttrs: {
     preFixupHooks+=(sqliteFixupHook)
   '';
 
-  postPatch = lib.optionalString (lib.versionAtLeast version "3.2.0") ''
-    substituteInPlace lib/src/hook/description.dart \
-      --replace-fail "return PrecompiledFromGithubAssets(LibraryType.sqlite3);" "return LookupSystem('sqlite3');"
-  '';
+  postPatch =
+    if lib.versionAtLeast version "3.5.0" then
+      ''
+        substituteInPlace lib/src/hook/compile/description.dart \
+          --replace-fail "return fromGitHub(LibraryType.sqlite3);" "return LookupSystem('sqlite3');"
+      ''
+    else
+      lib.optionalString (lib.versionAtLeast version "3.2.0") ''
+        substituteInPlace lib/src/hook/description.dart \
+          --replace-fail "return PrecompiledFromGithubAssets(LibraryType.sqlite3);" "return LookupSystem('sqlite3');"
+      '';
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
https://github.com/edde746/plezy/releases/tag/2.10.0
https://github.com/edde746/plezy/compare/2.9.1...2.10.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
