### PR TITLE
gromacs: select more specific SIMD instruction sets

### DIFF
--- a/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
@@ -34,22 +34,24 @@ let
   # The possible values are defined in CMakeLists.txt:
   # AUTO None SSE2 SSE4.1 AVX_128_FMA AVX_256 AVX2_256
   # AVX2_128 AVX_512 AVX_512_KNL MIC ARM_NEON ARM_NEON_ASIMD
-  SIMD =
-    x:
-    if (cpuAcceleration != null) then
-      x
-    else if hostPlatform.system == "i686-linux" then
+  defaultSIMD =
+    if hostPlatform.system == "i686-linux" then
       "SSE2"
-    else if hostPlatform.system == "x86_64-linux" then
-      "SSE4.1"
-    else if hostPlatform.system == "x86_64-darwin" then
-      "SSE4.1"
-    else if hostPlatform.system == "aarch64-darwin" then
-      "ARM_NEON_ASIMD"
-    else if hostPlatform.system == "aarch64-linux" then
+    else if hostPlatform.isx86_64 then
+      if hostPlatform.avx512Support then
+        "AVX_512"
+      else if hostPlatform.avx2Support then
+        "AVX2_256"
+      else if hostPlatform.avxSupport then
+        "AVX_256"
+      else
+        "SSE4.1"
+    else if hostPlatform.isAarch64 then
       "ARM_NEON_ASIMD"
     else
       "None";
+
+  SIMD = if cpuAcceleration != null then cpuAcceleration else defaultSIMD;
 
   source =
     if enablePlumed then
@@ -122,7 +124,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "GMX_HWLOC" true)
-    (lib.cmakeFeature "GMX_SIMD" (SIMD cpuAcceleration))
+    (lib.cmakeFeature "GMX_SIMD" SIMD)
     (lib.cmakeBool "GMX_OPENMP" true)
     (lib.cmakeBool "BUILD_SHARED_LIBS" true)
 


### PR DESCRIPTION
Gromacs was always defaulting to SSE4.1 SIMD on x86_64 architectures. Added the detection of systems supporting AVX_512, AVX2_256 and AVX_256 using hostplatform.avx512Support, etc.
This pattern is already present in ELPA:
https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/el/elpa/package.nix


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
