### PR TITLE
nixos/connman: create /run/connman so resolv.conf is not clobbered

### DIFF
--- a/nixos/modules/services/networking/connman.nix
+++ b/nixos/modules/services/networking/connman.nix
@@ -124,6 +124,7 @@ in
         Type = "dbus";
         BusName = "net.connman";
         Restart = "on-failure";
+        RuntimeDirectory = "connman";
         ExecStart = toString (
           [
             "${cfg.package}/sbin/connmand"


### PR DESCRIPTION
## Description of changes

Adds `RuntimeDirectory = "connman"` to `systemd.services.connman` so that `/run/connman` exists before `connmand` starts.

### The problem

Upstream connman ships a tmpfiles snippet, `$out/tmpfiles.d/connman_resolvconf.conf`:

```
d	/var/run/connman	- - - -
L	/etc/resolv.conf	- - - -	/var/run/connman/resolv.conf
```

That `d` line is how upstream guarantees the directory exists — which is why upstream's own shipped unit (`$out/systemd/system/connman.service`) needs no `RuntimeDirectory`.

This module defines its own unit rather than using the packaged one, and never installs that tmpfiles snippet. So on NixOS `/run/connman` never exists, and connman takes its documented fallback. From `connman.conf(5)`, on the `ResolvConf=` option:

> If this option is not set, it tries to write into `/var/run/connman/resolv.conf` and fallbacks to `/etc/resolv.conf` if it fails (`/var/run/connman` does not exist or is not writeable).

The daemon logs exactly that:

```
connmand[614782]: Cannot create /var/run/connman/resolv.conf falling back to /etc/resolv.conf
```

On NixOS `/etc/resolv.conf` is a symlink chain — `/etc/resolv.conf` → `/etc/static/resolv.conf` → `/run/systemd/resolve/stub-resolv.conf` when `services.resolved.enable` is set. connman opens it for writing, follows the chain, and overwrites systemd-resolved's stub file in place with:

```
# Generated by Connection Manager
nameserver ::1
nameserver 127.0.0.1
```

Those addresses are connman's own DNS proxy. connman only has upstream nameservers for interfaces it manages, so on a host where it manages none — e.g. a wired uplink owned by systemd-networkd with no Wi-Fi associated — the proxy has zero upstreams and answers `SERVFAIL` to every query. DNS is dead host-wide, and resolved's stub stays clobbered until the service is restarted.

### Why not `systemd.tmpfiles.packages`

Installing the package's snippet wholesale would also apply its second line, `L /etc/resolv.conf → /var/run/connman/resolv.conf`, which would hand `/etc/resolv.conf` to connman and conflict with systemd-resolved and NixOS' own `/etc/static/resolv.conf` management. Only the directory-creation half is wanted here, and `RuntimeDirectory` is the systemd-native way to express it — with the bonus that systemd cleans it up on stop.

### Testing

Reproduced and verified on a live x86_64-linux NixOS host (connman with `wifi.backend = "iwd"`, wired uplink on systemd-networkd, `services.resolved.enable = true`):

- **Before:** `/run/connman` absent, the fallback log line present, `/run/systemd/resolve/stub-resolv.conf` overwritten by connman, and every query returning `SERVFAIL` (`;; ->>HEADER<<- opcode: QUERY, status: SERVFAIL`) while `dig @127.0.0.53` still resolved normally.
- **After:** with `/run/connman` deliberately deleted first to recreate the original failure condition, connman starts, writes `/run/connman/resolv.conf`, emits no fallback message, and leaves `/etc/resolv.conf` untouched.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`?
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside `nixos/tests`)
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` — n/a, NixOS module change with no package rebuilds; verified by building and activating the affected system closure instead
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)

The module has no entry in `meta.maintainers`, so there is no maintainer to ping.

## AI disclosure

Per the [Automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy), disclosed separately from the commit:

- **This pull request summary** was written by Claude (Anthropic; Opus 5, model id `claude-opus-5`).
- **The commit and its message** were written by Claude (Anthropic; Sonnet 5, model id `claude-sonnet-5`), and carry the corresponding `Assisted-by:` trailer.

The underlying bug was encountered on a real system, and the diagnosis, the reproduction, and the post-fix verification described under "Testing" were all carried out against that live host rather than inferred. A human contributor reviewed the change and this summary before submission and is accountable for them.
