### PR TITLE
hk: add git to nativeCheckInputs, add sshine to maintainers

### DIFF
--- a/pkgs/by-name/hk/hk/package.nix
+++ b/pkgs/by-name/hk/hk/package.nix
@@ -10,6 +10,7 @@
   libgit2,
   openssl,
   usage,
+  gitMinimal,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -37,6 +38,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     libgit2
     openssl
   ];
+
+  # Some tests build fixture repositories by shelling out to git.
+  nativeCheckInputs = [ gitMinimal ];
 
   # These tests require external dependencies and are fragile -- skipping.
   checkFlags = [
@@ -77,6 +81,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     maintainers = with lib.maintainers; [
       typedrat
       Br1ght0ne
+      sshine
     ];
     mainProgram = "hk";
   };


### PR DESCRIPTION
The r-ryantm auto-updater breaks because some tests build fixture repositories by shelling out to git, so `hk` hasn't been updating (relevant excerpt from [nixpkgs-update-logs for 2026-07-26](https://nixpkgs-update-logs.nix-community.org/hk/2026-07-26.log)):

```
Received ExitFailure 1 when running
Raw command: nix-build --option sandbox true --arg config "{ allowUnfree = true; allowAliases = false; }" --arg overlays "[ ]" -A hk
nix build failed.
test tera::tests::for_display_truncates_raw_file_lists ... ok
test tera::tests::split_quoted_tokens_handles_escaped_quote_in_double ... ok
test tera::tests::split_quoted_tokens_handles_unquoted ... ok
test step::types::tests::structured_argv_with_blank_executable_is_empty ... ok
test step::types::tests::test_script_all_none_produces_empty ... ok
test step::types::tests::structured_argv_rejects_unavailable_workspace_files ... ok
test tera::tests::split_quoted_tokens_preserves_single_quoted_spaces ... ok
test tera::tests::truncate_quoted_list_preserves_quoted_first_token ... ok
test tera::tests::truncate_quoted_list_returns_none_for_empty_or_missing ... ok
test tera::tests::truncate_quoted_list_returns_none_for_single_token ... ok
test step::filtering::tests::match_any_preserves_input_order ... ok
test step_group::tests::init_inherits_group_fields_without_merging_child_overrides ... ok
test config::tests::discover_subprojects_literal_and_glob ... ok
test tera::tests::truncate_quoted_list_truncates_multiple_tokens ... ok

failures:

---- cli::util::no_commit_to_branch::tests::test_get_current_branch_attached_and_detached stdout ----

thread 'cli::util::no_commit_to_branch::tests::test_get_current_branch_attached_and_detached' (8614) panicked at src/cli/util/no_commit_to_branch.rs:67:18:
called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    cli::util::no_commit_to_branch::tests::test_get_current_branch_attached_and_detached

test result: FAILED. 191 passed; 1 failed; 0 ignored; 0 measured; 8 filtered out; finished in 0.06s

[1m[91merror[0m: test failed, to rerun pass `--bin hk`
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
