### PR TITLE
nixos/proxmox: exclude diskSize from QEMU config

### DIFF
--- a/nixos/modules/virtualisation/proxmox-image.nix
+++ b/nixos/modules/virtualisation/proxmox-image.nix
@@ -279,7 +279,7 @@ with lib;
         ''
           ${vma}/bin/vma create "${config.image.baseName}.vma" \
             -c ${
-              cfgFile "qemu-server.conf" (cfg.qemuConf // cfg.qemuExtraConf)
+              cfgFile "qemu-server.conf" (removeAttrs cfg.qemuConf [ "diskSize" ] // cfg.qemuExtraConf)
             }/qemu-server.conf drive-virtio0=$diskImage
           rm $diskImage
           ${pkgs.zstd}/bin/zstd "${config.image.baseName}.vma"


### PR DESCRIPTION
`proxmox.qemuConf.diskSize` is a compatibility alias for `virtualisation.diskSize`. Serializing all of `qemuConf` evaluates the alias and emits a deprecation warning even when users did not configure the old option.

This warning was previously fixed in [ae027401](https://github.com/NixOS/nixpkgs/commit/ae0274015624d3fff799b622a5a56bd24681c247). The later Proxmox cloud-image refactor in [#429178](https://github.com/NixOS/nixpkgs/pull/429178) reintroduced serialization of the full `qemuConf` set.

Exclude only the compatibility alias from the generated `qemu-server.conf`. Image sizing continues to use `virtualisation.diskSize`. Explicit use of the deprecated option still warns and maps to the new option, and an explicit `qemuExtraConf.diskSize` value remains supported.

## Testing

Native Proxmox image evaluations verified that:

- the default configuration evaluates without the deprecation warning
- `proxmox.qemuConf.diskSize = 2048` still warns and produces `virtualisation.diskSize = 2048`
- `proxmox.qemuExtraConf.diskSize = 4096` remains present in the generated QEMU configuration
- the changed file passes `nixfmt`

Automation disclosure: OpenCode (OpenAI GPT-5.6 Sol) assisted with tracing the regression, preparing the patch and PR text, running the evaluation checks, and a second-pass review. I reviewed the patch and test results.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/tree/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/tree/master/pkgs/test