### PR TITLE
python3Packages.emerge: init at 2.8.1

### DIFF
--- a/pkgs/development/python-modules/emerge/default.nix
+++ b/pkgs/development/python-modules/emerge/default.nix
@@ -1,0 +1,157 @@
+{
+  lib,
+  stdenv,
+  config,
+  buildPythonPackage,
+  fetchFromGitHub,
+  writableTmpDirAsHomeHook,
+
+  cudaPackages,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  emsutil,
+  gmsh,
+  joblib,
+  loguru,
+  matplotlib,
+  mkl,
+  msgpack,
+  msgpack-numpy,
+  numba,
+  numpy,
+  psutil,
+  pyvista,
+  scipy,
+
+  # optional-dependencies
+  cupy,
+  nvmath-python,
+  ezdxf,
+  pygerber,
+  #scikit-umfpack,
+
+  # tests
+  callPackage,
+
+  cudaSupport ? config.cudaSupport,
+}:
+
+let
+  # NOTE:
+  # `nvmath.bindings.cudss.AlgType` has been removed in newer versions of
+  # `nvmath-python`, but `emerge` still uses it. See:
+  #   - https://docs.nvidia.com/cuda/nvmath-python/latest/bindings/generated/nvmath.bindings.cudss.AlgType.html
+  #   - https://docs.nvidia.com/cuda/nvmath-python/1.0.0/release-notes.html
+  nvmath-python' = nvmath-python.overrideAttrs rec {
+    version = "0.9.0";
+    src = fetchFromGitHub {
+      owner = "NVIDIA";
+      repo = "nvmath-python";
+      tag = "v${version}";
+      hash = "sha256-sIVvehCmkPvpPbHxhUPbKZ1cHnHTSlrgBHKSsHbUJPg=";
+    };
+    pythonRelaxDeps = [
+      "cuda-core"
+    ];
+  };
+in
+
+buildPythonPackage (finalAttrs: {
+  pname = "emerge";
+  version = "2.8.1";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "FennisRobert";
+    repo = "EMerge";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-TArhxtPAGEmPI4L+/pgy+RhV9atAZ5Ig0TkUDoV+eXQ=";
+  };
+
+  postPatch = ''
+    # TODO: get from pypi?
+    # https://pypi.org/project/mkl
+    sed -i '/mkl!=2024.0;/d' pyproject.toml
+  '';
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    emsutil
+    gmsh
+    joblib
+    loguru
+    matplotlib
+    msgpack
+    msgpack-numpy
+    numba
+    numpy
+    psutil
+    pyvista
+    scipy
+  ]
+  ++ lib.optionals cudaSupport finalAttrs.passthru.optional-dependencies.cudss;
+
+  nativeBuildInputs = [
+    writableTmpDirAsHomeHook
+  ];
+
+  buildInputs =
+    lib.optionals stdenv.hostPlatform.isx86_64 [
+      mkl
+    ]
+    ++ lib.optionals cudaSupport [
+      cudaPackages.libcudss
+    ];
+
+  optional-dependencies = {
+    cudss = [
+      cupy
+      cudaPackages.libcudss
+      nvmath-python'
+    ];
+    dxf = [
+      ezdxf
+    ];
+    gerber = [
+      pygerber
+    ];
+    umfpack = [
+      #scikit-umfpack # TODO: package
+    ];
+  };
+
+  pythonRelaxDeps = [
+    "gmsh"
+    "numpy"
+  ];
+
+  pythonImportsCheck = [
+    "emerge"
+  ];
+
+  # upstream has no tests
+  doCheck = false;
+
+  passthru = {
+    inherit
+      cudaSupport
+      ;
+
+    tests = callPackage ./tests { };
+  };
+
+  meta = {
+    description = "Electromagnetic field computation program";
+    homepage = "https://github.com/FennisRobert/EMerge";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/development/python-modules/emerge/tests/default.nix
+++ b/pkgs/development/python-modules/emerge/tests/default.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  runCommand,
+  python,
+  writableTmpDirAsHomeHook,
+  xvfb-run,
+  pkgs,
+}:
+
+let
+  testRoot = ./.;
+  fs = lib.fileset;
+
+  testFiles = lib.pipe testRoot [
+    (fs.fileFilter (file: file.hasExt "py"))
+    (fs.toList)
+  ];
+
+  brokenTests = [
+    # FIX:
+    # scipy.sparse.linalg._eigen.arpack.arpack.ArpackNoConvergence: ARPACK
+    # error -1: No convergence (20221 iterations, 1/3 eigenvectors converged)
+    ./resonant-cavity.py
+  ];
+
+  # /path/to/foo.py -> "foo"
+  nameOf = file: lib.removeSuffix ".py" (lib.baseNameOf file);
+
+  mkTest =
+    file:
+    runCommand "test-${nameOf file}"
+      {
+        nativeBuildInputs =
+          let
+            pyEnv = python.withPackages (ps: with ps; [ emerge ]);
+
+            # Since we're calling this file using python's `callPackage`, it tries to use
+            # `python3Packages.mesa` rather than the toplevel one. However, the former has
+            # been removed because it's broken.
+            #
+            # As a workaround, we're getting the toplevel `mesa` through `pkgs`.
+            mesa = pkgs.mesa;
+          in
+          [
+            pyEnv
+            writableTmpDirAsHomeHook
+            xvfb-run
+            mesa.llvmpipeHook # OpenGL context
+          ];
+
+        env.EMERGE_MP_SOLVER = lib.optionalString python.pkgs.emerge.cudaSupport "CUDSS";
+        env.NUMBA_DISABLE_JIT = 1; # quite slow and won't be cached anyways
+
+        meta.broken = lib.elem file brokenTests;
+      }
+      ''
+        xvfb-run python ${file}
+        mkdir -p $out
+        cp *.png $out
+      '';
+
+  testAttrs = lib.listToAttrs (
+    map (file: {
+      name = nameOf file;
+      value = mkTest file;
+    }) testFiles
+  );
+in
+testAttrs

--- a/pkgs/development/python-modules/emerge/tests/first-simulation.py
+++ b/pkgs/development/python-modules/emerge/tests/first-simulation.py
@@ -1,0 +1,40 @@
+import emerge as em
+
+mm = 0.001  # Define a millimeter
+wg_width = 22.86 * mm  # Width of WR90 waveguide
+wg_height = 10.16 * mm  # Height of WR90 waveguide
+wg_length = 50 * mm  # Arbitrary length
+
+model = em.Simulation("MyFirstModel")
+
+box = em.geo.Box(wg_width, wg_length, wg_height)
+
+model.commit_geometry()
+
+model.view(screenshot="001-01.png", off_screen=True)
+
+model.mw.set_frequency_range(8e9, 10e9, 21)
+
+model.generate_mesh()
+
+model.view(plot_mesh=True, screenshot="001-02.png", off_screen=True)
+
+port1 = model.mw.bc.RectangularWaveguide(box.front, 1)
+port2 = model.mw.bc.RectangularWaveguide(box.back, 2)
+
+fdata = model.mw.run_sweep()
+
+freqs = fdata.scalar.grid.freq
+S11 = fdata.scalar.grid.S(1, 1)
+S21 = fdata.scalar.grid.S(2, 1)
+
+from emerge.plot import plot_sp
+
+plot_sp(
+    freqs,
+    [S11, S21],
+    labels=["S11", "S21"],
+    dblim=[-60, 3],
+    show_plot=False,
+    filename="001-03.png",
+)

--- a/pkgs/development/python-modules/emerge/tests/resonant-cavity.py
+++ b/pkgs/development/python-modules/emerge/tests/resonant-cavity.py
@@ -1,0 +1,36 @@
+import emerge as em
+import numpy as np
+
+model = em.Simulation("ResonanceCavity")
+cm = 0.01
+width = 6 * cm
+height = 2 * cm
+length = 10 * cm
+Nmodes = 3  # Amount of modes to solve for
+f = 2e9  # First eigenfreq at around 21GHz
+
+box = em.geo.Box(width, length, height, alignment=em.CENTER)
+model.commit_geometry()
+
+model.mw.set_frequency(f)
+model.mw.set_resolution(0.1)
+model.generate_mesh()
+model.view(plot_mesh=True, screenshot="002-01.png", off_screen=True)
+
+data = model.mw.eigenmode(f, nmodes=Nmodes)
+# Example: Access the eigenfrequency of the first solution
+field = data.field[0]
+print(f"Frequency = {field.freq / 1e9:.2f} GHz")
+# 2.91GHz
+
+model.display.add_field(
+    field.cutplane(ds=0.05 * cm, z=0).scalar("Ez", "real"), cmap="rainbow"
+)
+model.display.add_field(
+    field.cutplane(ds=0.05 * cm, z=height / 3).scalar("Ez", "real"), cmap="rainbow"
+)
+model.display.add_field(
+    field.cutplane(ds=0.05 * cm, z=-height / 3).scalar("Ez", "real"), cmap="rainbow"
+)
+model.display.populate()
+model.display.show(screenshot="002-02.png", off_screen=True)

--- a/pkgs/development/python-modules/emsutil/default.nix
+++ b/pkgs/development/python-modules/emsutil/default.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  loguru,
+  matplotlib,
+  msgpack,
+  msgpack-numpy,
+  numpy,
+  pyvista,
+  scipy,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "emsutil";
+  version = "0.8.3";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "FennisRobert";
+    repo = "emsutil";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Ca+nhaa9pMMsNy5p9Yg17bVJgFPPTnBFgz8vTFLCjVU=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    loguru
+    matplotlib
+    msgpack
+    msgpack-numpy
+    numpy
+    pyvista
+    scipy
+  ];
+
+  pythonRelaxDeps = [
+    "numpy"
+  ];
+
+  pythonImportsCheck = [
+    "emsutil"
+  ];
+
+  meta = {
+    description = "Utilities for the EMerge software suite";
+    homepage = "https://github.com/FennisRobert/emsutil";
+    license =
+      with lib.licenses;
+      AND [
+        cc0 # src/emsutil/lib.py
+        unfree # FIXME: https://github.com/FennisRobert/emsutil/issues/1
+      ];
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/development/python-modules/nvmath-python/default.nix
+++ b/pkgs/development/python-modules/nvmath-python/default.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  config,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  cudaPackages_13_1,
+  cython,
+  setuptools,
+  tomli,
+
+  # dependencies
+  cuda-bindings,
+  cuda-core,
+  cuda-pathfinder,
+  numpy,
+
+  cudaSupport ? config.cudaSupport,
+}:
+
+buildPythonPackage.override { stdenv = cudaPackages_13_1.backendStdenv; } (finalAttrs: {
+  pname = "nvmath-python";
+  version = "1.0.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = "nvmath-python";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-RpgEX6IFBw35TED3mb8ibLc0o15ciMNwX+LuIrlClqg=";
+  };
+
+  postPatch = ''
+    # FIX:
+    # > ERROR Unmet dependencies (checked against /nix/store/XXX-python3-3.14.6/bin/python3.14):
+    # >       cuda-toolkit[cudart,nvcc]<14,>=13.1
+    # >             wanted: <14,>=13.1
+    # >              found: not installed
+    sed -i '/cuda-toolkit/d' pyproject.toml
+  '';
+
+  build-system = [
+    cudaPackages_13_1.cudatoolkit
+    cython
+    setuptools
+    tomli
+  ];
+
+  dependencies = [
+    cuda-bindings
+    cuda-core
+    cuda-pathfinder
+    numpy
+  ];
+
+  nativeBuildInputs = [
+    cudaPackages_13_1.cudatoolkit
+  ];
+
+  buildInputs = [
+    cudaPackages_13_1.cudatoolkit
+  ];
+
+  pythonImportsCheck = [
+    "nvmath"
+  ];
+
+  meta = {
+    description = "NVIDIA Math Libraries for the Python Ecosystem";
+    homepage = "https://pypi.org/project/nvmath-python";
+    license = with lib.licenses; [ asl20 ];
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+    broken = !cudaSupport;
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5405,6 +5405,8 @@ self: super: with self; {
 
   emcee = callPackage ../development/python-modules/emcee { };
 
+  emerge = callPackage ../development/python-modules/emerge { };
+
   emmiai-noether = callPackage ../development/python-modules/emmiai-noether { };
 
   emoji = callPackage ../development/python-modules/emoji { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11954,6 +11954,8 @@ self: super: with self; {
 
   nvidia-ml-py = callPackage ../development/python-modules/nvidia-ml-py { };
 
+  nvmath-python = callPackage ../development/python-modules/nvmath-python { };
+
   nwdiag = callPackage ../development/python-modules/nwdiag { };
 
   nxt-python = callPackage ../development/python-modules/nxt-python { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5417,6 +5417,8 @@ self: super: with self; {
 
   empy = callPackage ../development/python-modules/empy { };
 
+  emsutil = callPackage ../development/python-modules/emsutil { };
+
   emulated-roku = callPackage ../development/python-modules/emulated-roku { };
 
   emv = callPackage ../development/python-modules/emv { };


### PR DESCRIPTION
[EMerge](https://github.com/FennisRobert/EMerge) is an open source Python based all-in-one finite element simulator for high frequency electromagnetic simulations.

> [!NOTE]
> Work done as part of the [Nix@NGI](https://nixos.org/community/teams/ngi) packaging effort 


Closes: https://github.com/ngi-nix/projects/issues/1329
Assisted-by: nix-init

<img width="1074" height="1090" alt="image" src="https://github.com/user-attachments/assets/2b5306e8-4bbe-4e68-af54-b1d48e555a57" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
