### PR TITLE
jetbrains.*: Make libraries for jcef plugin available

### DIFF
--- a/pkgs/applications/editors/jetbrains/builder/linux.nix
+++ b/pkgs/applications/editors/jetbrains/builder/linux.nix
@@ -23,6 +23,26 @@
   libGL,
   libx11,
 
+  # bundled jcef-plugin
+  alsa-lib,
+  at-spi2-atk,
+  at-spi2-core,
+  atk,
+  cairo,
+  cups,
+  dbus,
+  libgbm,
+  libxcb,
+  libxcomposite,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxkbcommon,
+  libxrandr,
+  nspr,
+  nss,
+  pango,
+
   jdk,
   vmopts ? null,
   forceWayland ? null,
@@ -88,6 +108,24 @@ lib.extendMkDerivation {
         libx11
         # required for the bundled jcef-plugin
         udev
+        alsa-lib
+        at-spi2-atk
+        at-spi2-core
+        atk
+        cairo
+        cups
+        dbus
+        libgbm
+        libxcb
+        libxcomposite
+        libxdamage
+        libxext
+        libxfixes
+        libxkbcommon
+        libxrandr
+        nspr
+        nss
+        pango
       ];
 
       nativeBuildInputs = nativeBuildInputs ++ [
@@ -104,6 +142,19 @@ lib.extendMkDerivation {
 
         if [ -d "plugins/remote-dev-server" ]; then
           patch -F3 -p1 < ${../patches/jetbrains-remote-dev.patch}
+        fi
+
+        # The bundled libraries of the remote dev server are not used (see the patch above),
+        # so drop them. This has to happen before autoPatchelfHook runs, otherwise their
+        # directory ends up in the RPATH of unrelated binaries, see below.
+        rm -rf plugins/remote-dev-server/selfcontained
+
+        # libjcef.so has "." in its RPATH. autoPatchelfHook follows the RPATHs of the
+        # libraries it indexes and resolves that "." against the build directory, which
+        # makes it prefer bundled copies of libraries over the ones from nixpkgs and
+        # bake build-time-only paths into the RPATHs it writes.
+        if [ -e plugins/jcef-plugin/jcef/libjcef.so ]; then
+          patchelf --set-rpath '$ORIGIN' plugins/jcef-plugin/jcef/libjcef.so
         fi
 
         vmopts_file=bin/linux/${vmoptsName}
@@ -179,7 +230,6 @@ lib.extendMkDerivation {
         fi
 
         ln -s "$launcher" $out/bin/$pname
-        rm -rf $out/$pname/plugins/remote-dev-server/selfcontained/
         echo -e '#!/usr/bin/env bash\n'"$out/$pname/bin/remote-dev-server.sh"' "$@"' > $out/$pname/bin/remote-dev-server-wrapped.sh
         chmod +x $out/$pname/bin/remote-dev-server-wrapped.sh
         ln -s "$out/$pname/bin/remote-dev-server-wrapped.sh" $out/bin/$pname-remote-dev-server

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -5,18 +5,28 @@
   callPackage,
 
   python3,
+  jetbrains,
 
-  jdk,
   vmopts ? null,
   forceWayland ? false,
 }:
 
 let
-  mkJetBrainsProduct = callPackage ./builder/default.nix { inherit jdk forceWayland vmopts; };
-  mkJetBrainsSource = callPackage ./source/build.nix { };
+  jetbrainsBuilder =
+    jdk:
+    callPackage ./builder/default.nix {
+      inherit jdk forceWayland vmopts;
+    };
 
   mkSrcIde =
-    path: extras: callPackage path ({ inherit mkJetBrainsProduct mkJetBrainsSource; } // extras);
+    path: extras:
+    callPackage path (
+      {
+        mkJetBrainsProduct = jetbrainsBuilder jetbrains.jdk;
+        mkJetBrainsSource = callPackage ./source/build.nix { };
+      }
+      // extras
+    );
 
   _idea-oss = mkSrcIde ./ides/idea-oss.nix { };
 
@@ -25,7 +35,7 @@ let
     path: extras:
     callPackage path (
       {
-        inherit mkJetBrainsProduct;
+        mkJetBrainsProduct = jetbrainsBuilder jetbrains.jdk-no-jcef;
         libdbm = _idea-oss.libdbm;
         fsnotifier = _idea-oss.fsnotifier;
       }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8756,7 +8756,6 @@ with pkgs;
     recurseIntoAttrs (
       callPackages ../applications/editors/jetbrains {
         vmopts = config.jetbrains.vmopts or null;
-        jdk = jetbrains.jdk;
       }
     )
     // {


### PR DESCRIPTION
Currenly fails with `Rider.Backend: error while loading
  shared libraries: libstdc++.so.6: cannot open shared object file: No
such file or directory`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
