### PR TITLE
python3Packages.mapclassify: 2.10.0 -> 2.10.0-unstable-2026-07-20

### DIFF
--- a/pkgs/development/python-modules/mapclassify/default.nix
+++ b/pkgs/development/python-modules/mapclassify/default.nix
@@ -16,19 +16,23 @@
   setuptools-scm,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "mapclassify";
-  version = "2.10.0";
+  version = "2.10.0-unstable-2026-07-20";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pysal";
     repo = "mapclassify";
-    tag = "v${version}";
-    hash = "sha256-OQpDrxa0zRPDAdyS6KP5enb/JZwbYoXTV8kUijV3tNM=";
+    rev = "e8d0550986742de3a4aca6e4e590dfc48d384f0f";
+    # tag = "v${version}";
+    hash = "sha256-UIPMOdDh4sfcFzDqWE70krMywPgXEUOqvPXU73wJQuM=";
   };
 
   build-system = [ setuptools-scm ];
+
+  # Temporary workaround, supply a PEP 440 compliant version
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = "2.10.0.dev20260720";
 
   propagatedBuildInputs = [
     networkx
@@ -91,7 +95,7 @@ buildPythonPackage rec {
   meta = {
     description = "Classification Schemes for Choropleth Maps";
     homepage = "https://pysal.org/mapclassify/";
-    changelog = "https://github.com/pysal/mapclassify/releases/tag/${src.tag}";
+    #changelog = "https://github.com/pysal/mapclassify/releases/tag/${src.tag}";
     license = lib.licenses.bsd3;
     teams = [ lib.teams.geospatial ];
   };


### PR DESCRIPTION
Update package to unstable to fix matplotlib incompatibility. Specific fix is too large to bundle it locally.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
