### PR TITLE
vicinae: add darwin support

### DIFF
--- a/pkgs/by-name/vi/vicinae/package.nix
+++ b/pkgs/by-name/vi/vicinae/package.nix
@@ -1,4 +1,5 @@
 {
+  apple-sdk,
   cmake,
   cmark-gfm,
   coreutils,
@@ -15,10 +16,12 @@
   pkg-config,
   qt6,
   stdenv,
+  swift,
   wayland,
   libxml2,
   udevCheckHook,
 }:
+
 stdenv.mkDerivation (finalAttrs: {
   pname = "vicinae";
   version = "0.23.2";
@@ -45,7 +48,11 @@ stdenv.mkDerivation (finalAttrs: {
     "VICINAE_PROVENANCE" = "nix";
     "INSTALL_NODE_MODULES" = "OFF";
     "INSTALL_BROWSER_NATIVE_HOST" = "OFF";
+    "USE_SYSTEM_CMARK_GFM" = "ON";
     "USE_SYSTEM_GLAZE" = "ON";
+    "USE_SYSTEM_KF6" = "ON";
+    "USE_SYSTEM_QT_KEYCHAIN" = "ON";
+    "BUNDLE_SOULVER_CORE" = "OFF";
     "CMAKE_INSTALL_PREFIX" = placeholder "out";
     "CMAKE_INSTALL_DATAROOTDIR" = "share";
     "CMAKE_INSTALL_BINDIR" = "bin";
@@ -60,22 +67,34 @@ stdenv.mkDerivation (finalAttrs: {
     nodejs
     pkg-config
     qt6.wrapQtAppsHook
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    qt6.qttools
+    swift
   ];
 
   buildInputs = [
     cmark-gfm
     glaze
-    kdePackages.layer-shell-qt
     kdePackages.qtkeychain
     kdePackages.syntax-highlighting
     libqalculate
     minizip
     nodejs
     qt6.qtbase
+    qt6.qtdeclarative
+    qt6.qtimageformats
     qt6.qtsvg
+    qt6.qtshadertools
+    libxml2
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    kdePackages.layer-shell-qt
     qt6.qtwayland
     wayland
-    libxml2
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    apple-sdk
   ];
 
   postPatch = ''
@@ -98,14 +117,28 @@ stdenv.mkDerivation (finalAttrs: {
     }"
   ];
 
-  postFixup = ''
-    substituteInPlace $out/share/systemd/user/vicinae.service \
-      --replace-fail "/bin/kill" "${lib.getExe' coreutils "kill"}"\
-      --replace-fail "ExecStart=vicinae" "ExecStart=$out/bin/vicinae"
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    app=$out/Applications/Vicinae.app
+    install -Dm755 bin/vicinae-server "$app/Contents/MacOS/Vicinae"
+    install -Dm755 bin/vicinae "$app/Contents/MacOS/vicinae-cli"
+    install -Dm644 Info.plist "$app/Contents/Info.plist"
+    install -Dm644 ../extra/vicinae.icns "$app/Contents/Resources/vicinae.icns"
+    cp -r ../extra/themes "$app/Contents/Resources/themes"
+    rm -f "$out/bin/vicinae"
   '';
 
-  doInstallCheck = true;
-  nativeInstallCheckInputs = [ udevCheckHook ];
+  postFixup =
+    lib.optionalString stdenv.hostPlatform.isLinux ''
+      substituteInPlace $out/share/systemd/user/vicinae.service \
+        --replace-fail "/bin/kill" "${lib.getExe' coreutils "kill"}"\
+        --replace-fail "ExecStart=vicinae" "ExecStart=$out/bin/vicinae"
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      ln -s ../Applications/Vicinae.app/Contents/MacOS/vicinae-cli "$out/bin/vicinae"
+    '';
+
+  doInstallCheck = stdenv.hostPlatform.isLinux;
+  nativeInstallCheckInputs = lib.optionals stdenv.hostPlatform.isLinux [ udevCheckHook ];
 
   passthru.updateScript = ./update.sh;
 
@@ -114,7 +147,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/vicinaehq/vicinae";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ zstg ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
     mainProgram = "vicinae";
   };
 })


### PR DESCRIPTION
Add Apple Silicon (`aarch64-darwin`) support to `vicinae` while keeping the Linux build unchanged.          
                                                                                                               
   Upstream already supports macOS and provides a `flake.nix` that builds on Darwin. This change brings that   
 support into Nixpkgs:                                                                                         
                                                                                                               
   - Add `aarch64-darwin` to `meta.platforms`                                                                  
   - Conditionally include Darwin-only build inputs (`apple-sdk`, `swift`, `qt6.qtdeclarative`,                
 `qt6.qtimageformats`, `qt6.qtshadertools`)                                                                    
   - Conditionally include Linux-only build inputs (`layer-shell-qt`, `qtwayland`, `wayland`)                  
   - Add missing CMake flags (`USE_SYSTEM_CMARK_GFM`, `USE_SYSTEM_KF6`, `USE_SYSTEM_QT_KEYCHAIN`,              
 `BUNDLE_SOULVER_CORE`) to prevent the build from trying to fetch dependencies over the network                
   - Assemble `.app` bundle on Darwin and symlink CLI back to `$out/bin/vicinae`                               
   - Guard Linux-specific `postFixup`, `doInstallCheck`, and `udevCheckHook`      
   
   References:
 - https://docs.vicinae.com/build-macos
 - https://github.com/vicinaehq/vicinae/blob/main/flake.nix

Closes #545492

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
