### PR TITLE
python3Packages.django-admin-sortable2: include missing files

### DIFF
--- a/pkgs/development/python-modules/django-admin-sortable2/default.nix
+++ b/pkgs/development/python-modules/django-admin-sortable2/default.nix
@@ -30,6 +30,15 @@ let
       runHook postInstall
     '';
   };
+
+  # This is required to get the unminified adminsortable2.js file used when
+  # DEBUG=False
+  assetsDebug = assets.overrideAttrs {
+    npmBuildFlags = [
+      "--"
+      "--debug"
+    ];
+  };
 in
 
 buildPythonPackage rec {
@@ -42,9 +51,26 @@ buildPythonPackage rec {
 
   preBuild = ''
     install -Dm644 ${assets}/*.js -t adminsortable2/static/adminsortable2/js
+    install -Dm644 ${assetsDebug}/*.js -t adminsortable2/static/adminsortable2/js
   '';
 
   pythonImportsCheck = [ "adminsortable2" ];
+
+  # See https://github.com/jrief/django-admin-sortable2/blob/899402aa0aac301d27dc1c16116dc7c067bf4461/.github/workflows/publish.yml#L37-L50
+  configurePhase =
+    let
+      djangoVersion = lib.versions.majorMinor django.version;
+    in
+    ''
+      mkdir -p adminsortable2/static/adminsortable2/js
+      mkdir -p adminsortable2/templates/adminsortable2/edit_inline
+      cp ${django.src}/django/contrib/admin/static/admin/js/actions.js adminsortable2/static/adminsortable2/js/actions-${djangoVersion}.js
+      cp ${django.src}/django/contrib/admin/templates/admin/edit_inline/stacked.html adminsortable2/templates/adminsortable2/edit_inline/stacked-django-${djangoVersion}.html
+      cp ${django.src}/django/contrib/admin/templates/admin/edit_inline/tabular.html adminsortable2/templates/adminsortable2/edit_inline/tabular-django-${djangoVersion}.html
+      patch -p0 adminsortable2/static/adminsortable2/js/actions-${djangoVersion}.js patches/actions-django-5.2.patch
+      patch -p0 adminsortable2/templates/adminsortable2/edit_inline/stacked-django-${djangoVersion}.html patches/stacked-django-4.0.patch
+      patch -p0 adminsortable2/templates/adminsortable2/edit_inline/tabular-django-${djangoVersion}.html patches/tabular-django-4.0.patch
+    '';
 
   # Tests are very slow (end-to-end with playwright)
   doCheck = false;


### PR DESCRIPTION
The django-admin-sortable2 Pypi package includes files that are not present in the source version and that are necessary for it to work with Django 5.2 (eg. actions-5.2.js, adminsortable2.js).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
