### PR TITLE
xen: patch with XSAs 495, 497, 499-508

### DIFF
--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -372,6 +372,12 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-cQc/wkaP1wK7dzbdFHmvghK6BcokWrTAtxk0gtIDQ1E=";
     })
 
+    # XSA #501
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa501.patch";
+      hash = "sha256-RvdzD/ZCpC7VT0/zzksse/dN5FBl8W/Gul04XQ5EyRg=";
+    })
+
     # patch `libxl` to search for `qemu-system-i386` properly. (Before 4.21)
     (fetchpatch {
       url = "https://github.com/xen-project/xen/commit/f6281291704aa356489f4bd927cc7348a920bd01.diff?full_index=1";

--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -396,6 +396,12 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-uMygMaI824GW0L4obYXfaRIiohiBZpwAvoEO6slOZCE=";
     })
 
+    # XSA #505
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa505.patch";
+      hash = "sha256-eZ8CdfzU5Ylyi6BpB4fOJh0VHfHeWa2JsRyhH+sh400=";
+    })
+
     # patch `libxl` to search for `qemu-system-i386` properly. (Before 4.21)
     (fetchpatch {
       url = "https://github.com/xen-project/xen/commit/f6281291704aa356489f4bd927cc7348a920bd01.diff?full_index=1";

--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -336,6 +336,36 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-xftChrVcwMJYgkH22HUlUQXSTPee0ghPRnPVymWJr3o=";
     })
 
+    # XSA #499
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa499/xsa499-4.20-1.patch";
+      hash = "sha256-Xk8+g/mEAtf3HIWqHL2+0iYSihtWy/tohaP6DcLo1+s=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa499/xsa499-4.20-2.patch";
+      hash = "sha256-YiDERwBeOvXtgsKjLbpCoLrfYQ1aw/QnXv9i4lKMrDs=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa499/xsa499-4.20-3.patch";
+      hash = "sha256-wyEc7GW83Vf++J10s/pqJTghXgqQhwUymPjpryuq8Wg=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa499/xsa499-4.20-4.patch";
+      hash = "sha256-bK6VYiMorwGHi25q9tPu5r/YQCMPc6NWBirLAx6oCPg=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa499/xsa499-4.20-5.patch";
+      hash = "sha256-Vj5vcpVvuuExK2NvDBP6vrIRjTPsgx8Yv4zVt0ftUnk=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa499/xsa499-4.20-6.patch";
+      hash = "sha256-uTBGP6WMfE5FipQ7rzOKY7FxCztQUV6jqbROtHZozoY=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa499/xsa499-4.20-7.patch";
+      hash = "sha256-UsAx2ouUB/BNpCQCObvcjj+DLPuRBqyxlI6QQsPXtWM=";
+    })
+
     # patch `libxl` to search for `qemu-system-i386` properly. (Before 4.21)
     (fetchpatch {
       url = "https://github.com/xen-project/xen/commit/f6281291704aa356489f4bd927cc7348a920bd01.diff?full_index=1";

--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -414,6 +414,12 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-3d5h0evLsFzTAyEDYstvPFcqYLirIZxMWPSY5L868ng=";
     })
 
+    # XSA #508
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa508.patch";
+      hash = "sha256-KhNGfEsVxlxFbnlO+yeeIj8Eo75NE9QOPmg0xlt8U6U=";
+    })
+
     # patch `libxl` to search for `qemu-system-i386` properly. (Before 4.21)
     (fetchpatch {
       url = "https://github.com/xen-project/xen/commit/f6281291704aa356489f4bd927cc7348a920bd01.diff?full_index=1";

--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -324,6 +324,12 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-ns0s++J2adUD/HWuMiYad/g3MITs+twlMnkpFnP7T0w=";
     })
 
+    # XSA #495
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa495-4.20.patch";
+      hash = "sha256-SAMu8r0yyPvD3zLCaQL53oNs+ZhV3puKUq4cCofkut8=";
+    })
+
     # patch `libxl` to search for `qemu-system-i386` properly. (Before 4.21)
     (fetchpatch {
       url = "https://github.com/xen-project/xen/commit/f6281291704aa356489f4bd927cc7348a920bd01.diff?full_index=1";

--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -390,6 +390,12 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-l64K1LetmngV1V8Vy9fH4dEvUdlAH6ukXwuEMetg83A=";
     })
 
+    # XSA #504
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa504.patch";
+      hash = "sha256-uMygMaI824GW0L4obYXfaRIiohiBZpwAvoEO6slOZCE=";
+    })
+
     # patch `libxl` to search for `qemu-system-i386` properly. (Before 4.21)
     (fetchpatch {
       url = "https://github.com/xen-project/xen/commit/f6281291704aa356489f4bd927cc7348a920bd01.diff?full_index=1";

--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -384,6 +384,12 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-hSmNtFwYValGoTwYgoz0uXhQiQV/pZ4rsYRNLAY5Ak8=";
     })
 
+    # XSA #503
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa503.patch";
+      hash = "sha256-l64K1LetmngV1V8Vy9fH4dEvUdlAH6ukXwuEMetg83A=";
+    })
+
     # patch `libxl` to search for `qemu-system-i386` properly. (Before 4.21)
     (fetchpatch {
       url = "https://github.com/xen-project/xen/commit/f6281291704aa356489f4bd927cc7348a920bd01.diff?full_index=1";

--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -408,6 +408,12 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-8unTCZE3Kh2JfqDSG5KrgRx9zL9J9pcVzeXnO5vUM0Y=";
     })
 
+    # XSA #507
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa507.patch";
+      hash = "sha256-3d5h0evLsFzTAyEDYstvPFcqYLirIZxMWPSY5L868ng=";
+    })
+
     # patch `libxl` to search for `qemu-system-i386` properly. (Before 4.21)
     (fetchpatch {
       url = "https://github.com/xen-project/xen/commit/f6281291704aa356489f4bd927cc7348a920bd01.diff?full_index=1";

--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -330,6 +330,12 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-SAMu8r0yyPvD3zLCaQL53oNs+ZhV3puKUq4cCofkut8=";
     })
 
+    # XSA #497
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa497.patch";
+      hash = "sha256-xftChrVcwMJYgkH22HUlUQXSTPee0ghPRnPVymWJr3o=";
+    })
+
     # patch `libxl` to search for `qemu-system-i386` properly. (Before 4.21)
     (fetchpatch {
       url = "https://github.com/xen-project/xen/commit/f6281291704aa356489f4bd927cc7348a920bd01.diff?full_index=1";

--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -378,6 +378,12 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-RvdzD/ZCpC7VT0/zzksse/dN5FBl8W/Gul04XQ5EyRg=";
     })
 
+    # XSA #502
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa502-4.21.patch";
+      hash = "sha256-hSmNtFwYValGoTwYgoz0uXhQiQV/pZ4rsYRNLAY5Ak8=";
+    })
+
     # patch `libxl` to search for `qemu-system-i386` properly. (Before 4.21)
     (fetchpatch {
       url = "https://github.com/xen-project/xen/commit/f6281291704aa356489f4bd927cc7348a920bd01.diff?full_index=1";

--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -402,6 +402,12 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-eZ8CdfzU5Ylyi6BpB4fOJh0VHfHeWa2JsRyhH+sh400=";
     })
 
+    # XSA #506
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa506.patch";
+      hash = "sha256-8unTCZE3Kh2JfqDSG5KrgRx9zL9J9pcVzeXnO5vUM0Y=";
+    })
+
     # patch `libxl` to search for `qemu-system-i386` properly. (Before 4.21)
     (fetchpatch {
       url = "https://github.com/xen-project/xen/commit/f6281291704aa356489f4bd927cc7348a920bd01.diff?full_index=1";

--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -366,6 +366,12 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-UsAx2ouUB/BNpCQCObvcjj+DLPuRBqyxlI6QQsPXtWM=";
     })
 
+    # XSA #500
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa500.patch";
+      hash = "sha256-cQc/wkaP1wK7dzbdFHmvghK6BcokWrTAtxk0gtIDQ1E=";
+    })
+
     # patch `libxl` to search for `qemu-system-i386` properly. (Before 4.21)
     (fetchpatch {
       url = "https://github.com/xen-project/xen/commit/f6281291704aa356489f4bd927cc7348a920bd01.diff?full_index=1";


### PR DESCRIPTION
Skipped 496 as that only affects 4.21, and 498 as that's for XAPI, not Xen.

https://xenbits.xen.org/xsa/advisory-495.html
https://xenbits.xen.org/xsa/advisory-497.html
https://xenbits.xen.org/xsa/advisory-499.html
https://xenbits.xen.org/xsa/advisory-500.html
https://xenbits.xen.org/xsa/advisory-501.html
https://xenbits.xen.org/xsa/advisory-502.html
https://xenbits.xen.org/xsa/advisory-503.html
https://xenbits.xen.org/xsa/advisory-504.html
https://xenbits.xen.org/xsa/advisory-505.html
https://xenbits.xen.org/xsa/advisory-506.html
https://xenbits.xen.org/xsa/advisory-507.html
https://xenbits.xen.org/xsa/advisory-508.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
