### PR TITLE
kdePackages.syntax-highlighting: add darwin support

### DIFF
--- a/pkgs/kde/frameworks/syntax-highlighting/default.nix
+++ b/pkgs/kde/frameworks/syntax-highlighting/default.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   mkKdeDerivation,
   qtdeclarative,
   qttools,
@@ -12,5 +13,8 @@ mkKdeDerivation {
     qttools
     perl
   ];
-  meta.mainProgram = "ksyntaxhighlighter6";
+  meta = {
+    mainProgram = "ksyntaxhighlighter6";
+    platforms = lib.platforms.linux ++ lib.platforms.freebsd ++ lib.platforms.darwin;
+  };
 }


### PR DESCRIPTION
`syntax-highlighting` is currently limited to `linux` and `freebsd` via `mkKdeDerivation`'s default         
 `meta.platforms`. However, the package builds and works fine on macOS.                                        
                                                                                                               
   This is needed for downstream packages like `vicinae` (https://github.com/NixOS/nixpkgs/pull/546651) that depend on `kdePackages.syntax-highlighting` and  
 want to support Darwin without having to override `meta.platforms` locally.                                   
                                                                                                               
   Extend `meta.platforms` to include `lib.platforms.darwin`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test