### PR TITLE
bisq2: make Java classpath deterministic

### DIFF
--- a/pkgs/by-name/bi/bisq2/package.nix
+++ b/pkgs/by-name/bi/bisq2/package.nix
@@ -13,6 +13,8 @@
   zip,
   gnupg,
   coreutils,
+  gnugrep,
+  gnused,
 
   # Used by the bundled webcam-app
   libv4l,
@@ -28,12 +30,18 @@ let
 
   jdk = zulu25.override { enableJavaFX = true; };
 
+  argumentFile = builtins.toFile "app.args" ''
+    -Djpackage.app-version=${version}
+    -classpath
+    @out@/lib/app/desktop-app-launcher.jar:@classpath@
+  '';
+
   bisq-launcher =
     args:
     writeShellScript "bisq-launcher" ''
       rm -fR $HOME/.local/share/Bisq2/tor
 
-      exec "${lib.getExe jdk}" -Djpackage.app-version=@version@ -classpath @out@/lib/app/desktop-app-launcher.jar:@out@/lib/app/* ${args} bisq.desktop_app_launcher.DesktopAppLauncher "$@"
+      exec "${lib.getExe jdk}" @@out@/lib/app.args ${args} bisq.desktop_app_launcher.DesktopAppLauncher "$@"
     '';
 
   # A given release will be signed by either Alejandro Garcia or Henrik Jannsen
@@ -104,6 +112,8 @@ stdenv.mkDerivation (finalAttrs: {
     makeBinaryWrapper
     zip
     gnupg
+    gnugrep
+    gnused
   ];
 
   desktopItems = [
@@ -150,6 +160,10 @@ stdenv.mkDerivation (finalAttrs: {
 
     mkdir -p $out/lib $out/bin
     cp -r opt/bisq2/lib/app $out/lib
+
+    export classpath=$(ls -1 $out/lib/app/ | grep -v desktop-app-launcher.jar | sort | sed -e 's/^/@out@\/lib\/app\//g' | tr '\n' ':')
+    cp -L ${argumentFile} $out/lib/app.args
+    substituteAllInPlace $out/lib/app.args
 
     install -D -m 777 ${bisq-launcher ""} $out/bin/bisq2
     substituteAllInPlace $out/bin/bisq2


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Prior to this change, the JVM classpath was specified using a shell glob. This created the potential for the Java class files to be loaded in a different order on different NixOS systems. See https://github.com/emmanuelrosa/btc-clients-nix/issues/1#issuecomment-5040539566

This change builds the classpath using a sorted list of files, to instruct the JVM the order in which to load the Java class files; It's based on the jlauncher configuration that comes with Bisq2, but which we don't use in the Nix package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
