### PR TITLE
lifeograph: 3.0.4 -> 3.1.4

### DIFF
--- a/pkgs/by-name/li/lifeograph/package.nix
+++ b/pkgs/by-name/li/lifeograph/package.nix
@@ -1,47 +1,51 @@
 {
   lib,
   stdenv,
-  fetchgit,
+  fetchFromGitLab,
   pkg-config,
   meson,
   ninja,
   wrapGAppsHook4,
   enchant,
   gtkmm4,
-  libchamplain_libsoup3,
   libgcrypt,
+  gtk3,
   shared-mime-info,
   libshumate,
-  gitUpdater,
+  nix-update-script,
+  python3,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lifeograph";
-  version = "3.0.4";
+  version = "3.1.3";
 
-  src = fetchgit {
-    url = "https://git.launchpad.net/lifeograph";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-Zo3bMIAao055YhhIFR8AH43lMi6T82PrcYR3Cis/yK0=";
+  src = fetchFromGitLab {
+    owner = "bilheps";
+    repo = "lifeograph";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-EliJ77EoPDE78UNtfsyeQRMB1VlBuh70KblZYgcz1mU=";
   };
 
   nativeBuildInputs = [
     meson
     ninja
     pkg-config
+    gtk3 # for gtk-update-icon-cache (meson post-install script)
     shared-mime-info # for update-mime-database
     wrapGAppsHook4
+    python3.pkgs.pybind11
   ];
 
   buildInputs = [
     libgcrypt
     enchant
     gtkmm4
-    libchamplain_libsoup3
     libshumate
+    python3
   ];
 
-  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://lifeograph.sourceforge.net/doku.php?id=start";

--- a/pkgs/by-name/li/lifeograph/package.nix
+++ b/pkgs/by-name/li/lifeograph/package.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lifeograph";
-  version = "3.1.3";
+  version = "3.1.4";
 
   src = fetchFromGitLab {
     owner = "bilheps";
     repo = "lifeograph";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-EliJ77EoPDE78UNtfsyeQRMB1VlBuh70KblZYgcz1mU=";
+    hash = "sha256-Tsvuc6s8D45WKCTWSqRBIVu1zOjx43edBlAw/TLOGV0=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
