### PR TITLE
kikit: fix for zone duplication

### DIFF
--- a/pkgs/by-name/ki/kikit/default.nix
+++ b/pkgs/by-name/ki/kikit/default.nix
@@ -4,8 +4,7 @@
   lib,
   bats,
   fetchFromGitHub,
-  fetchpatch,
-  python,
+  fetchpatch2,
   buildPythonApplication,
   callPackage,
   kicad,
@@ -49,10 +48,16 @@ buildPythonApplication (finalAttrs: {
   };
 
   patches = [
-    (fetchpatch {
-      name = "fix-stencil-arc-numpy2.patch";
-      url = "https://github.com/yaqwsx/KiKit/commit/036ca08fc380dd2c5b8b3ba2adc4215f4114e975.patch?full_index=1";
-      hash = "sha256-AmvH822nAubqVhl1PEKvE0Ij/K0NrBsSvnMUJXgxmfI=";
+    # Remove when new release is tagged
+    # NOTE: not bumping the above with a `rev = latest git commit`
+    # because versioneer doesn't handle non-semver versions
+    # packaging.version.InvalidVersion: Invalid version: '1.8.0-unstable-2026-07-23'
+    # https://github.com/yaqwsx/KiKit/issues/925
+    # NOTE: .patch doesn't apply so using diff
+    (fetchpatch2 {
+      name = "fix-zone-duplication-on-kicad-10.0.5-and-numpy2-stencil-arc.diff";
+      url = "https://github.com/yaqwsx/KiKit/compare/6eb4e7aed72165c0179af485a1a1de2d98abfe95..054ac1a5be281e8d74052d3195ad5fb0a701a2ec.diff";
+      hash = "sha256-uN6FjhqCLgfZnyGLGg7j1FxHo/nUWYQ6rYVx7kUXh7g=";
     })
   ];
 


### PR DESCRIPTION
closes https://github.com/NixOS/nixpkgs/issues/545160
closes https://github.com/NixOS/nixpkgs/issues/547062

https://hydra.nixos.org/build/339915577

kicad 10.0.5 broke kikit. It is not backported to stable yet and kikit builds on stable.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
