### PR TITLE
python313Packages.tree-sitter-grammars.*: fix pname

### DIFF
--- a/pkgs/development/python-modules/tree-sitter-grammars/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-grammars/default.nix
@@ -27,7 +27,6 @@ let
     )
   ];
   snakeCaseName = lib.replaceStrings [ "-" ] [ "_" ] name;
-  drvPrefix = "python-${name}";
   # If the name of the grammar attribute differs from the grammar's symbol name,
   # it could cause a symbol mismatch at load time. This manually curated collection
   # of overrides ensures the binding can find the correct symbol
@@ -39,12 +38,12 @@ let
 in
 buildPythonPackage {
   inherit version;
-  pname = drvPrefix;
+  pname = name;
   pyproject = true;
   build-system = [ setuptools ];
 
   src = symlinkJoin {
-    name = "${drvPrefix}-source";
+    name = "${name}-source";
     paths = [
       (writeTextDir "${snakeCaseName}/__init__.py" /* python */ ''
         # AUTO-GENERATED DO NOT EDIT


### PR DESCRIPTION
The new python metadata check enforces that the pname is the same as in the actual python metadata the name of the package.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
