### PR TITLE
[Backport release-26.05] papra: 26.4.0 -> 26.6.1

### DIFF
--- a/nixos/modules/services/web-apps/papra.nix
+++ b/nixos/modules/services/web-apps/papra.nix
@@ -80,8 +80,8 @@ in
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
         Restart = "on-failure";
-        ExecStartPre = "${lib.getExe pkgs.tsx} ${cfg.package}/lib/src/scripts/migrate-up.script.ts";
-        ExecStart = "${cfg.package}/bin/papra";
+        ExecStartPre = "${lib.getExe' cfg.package "papra-migrate-up"}";
+        ExecStart = "${lib.getExe' cfg.package "papra"}";
         User = cfg.user;
         Group = cfg.group;
         StateDirectory = "papra";

--- a/pkgs/by-name/pa/papra/package.nix
+++ b/pkgs/by-name/pa/papra/package.nix
@@ -22,20 +22,20 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "papra";
-  version = "26.5.0";
+  version = "26.6.1";
 
   src = fetchFromGitHub {
     owner = "papra-hq";
     repo = "papra";
     tag = "@papra/app@${finalAttrs.version}";
-    hash = "sha256-BOeApLfB1NR07izBM3ChHqzgGx3xf1NkAXqKVeMzqx4=";
+    hash = "sha256-4Kcfv6bcKM7SXTmKn0cjXjhUXEZSypSFWyr7jIP/4+E=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm;
     fetcherVersion = 4;
-    hash = "sha256-J1syB5X+sI40iPlqDVABqeWDiBjKGP3qQRIh5w3GRUU=";
+    hash = "sha256-1Iv8vvGFQuxBFM8YB8sYulmU4SxE4G9Yyh67BBzEoZo=";
     pnpmWorkspaces = [
       "@papra/app-client..."
       "@papra/app-server..."

--- a/pkgs/by-name/pa/papra/package.nix
+++ b/pkgs/by-name/pa/papra/package.nix
@@ -1,10 +1,11 @@
 {
   makeBinaryWrapper,
-  nodejs,
+  nodejs_26,
+  nodejs-slim_26,
   node-gyp,
   fetchPnpmDeps,
   fetchFromGitHub,
-  pnpm_10,
+  pnpm_11,
   pnpmConfigHook,
   stdenv,
   lib,
@@ -12,26 +13,29 @@
   pkg-config,
   python3,
   nix-update-script,
+  tsx,
 }:
 let
-  pnpm = pnpm_10;
+  pnpm = pnpm_11.override { nodejs-slim = nodejs-slim_26; };
+  nodejs = nodejs_26;
+  tsx' = tsx.override { nodejs-slim_22 = nodejs-slim_26; };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "papra";
-  version = "26.4.0";
+  version = "26.5.0";
 
   src = fetchFromGitHub {
     owner = "papra-hq";
     repo = "papra";
     tag = "@papra/app@${finalAttrs.version}";
-    hash = "sha256-wQdDBS+QRarZhEIRmLQ4VRtq73I5YFIN2P3ZtAZWvxw=";
+    hash = "sha256-BOeApLfB1NR07izBM3ChHqzgGx3xf1NkAXqKVeMzqx4=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm;
-    fetcherVersion = 3;
-    hash = "sha256-8k8hzpyOQuHAPF+zzIhW+5vo6lHSyZeKAY+tYIf6jKU=";
+    fetcherVersion = 4;
+    hash = "sha256-J1syB5X+sI40iPlqDVABqeWDiBjKGP3qQRIh5w3GRUU=";
     pnpmWorkspaces = [
       "@papra/app-client..."
       "@papra/app-server..."
@@ -64,12 +68,6 @@ stdenv.mkDerivation (finalAttrs: {
   buildPhase = ''
     runHook preBuild
 
-    pnpm config set inject-workspace-packages true
-
-    pushd node_modules/sharp
-    pnpm run install
-    popd
-
     pnpm --filter "@papra/app-client..." run build
     pnpm --filter "@papra/app-server..." run build
 
@@ -81,7 +79,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     mkdir -p $out/{bin,lib}
 
-    pnpm deploy --filter=@papra/app-server --prod $out/lib/
+    pnpm config set --location=project injectWorkspacePackages true
+    pnpm deploy --ignore-script --filter=@papra/app-server --prod $out/lib/
 
     mkdir -p $out/lib/public
     cp -r apps/papra-client/dist/* $out/lib/public/
@@ -89,6 +88,9 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper "${lib.getExe nodejs}" $out/bin/papra \
       --add-flags "$out/lib/dist/index.js" \
       --set "NODE_PATH" $out/lib/node_modules
+
+    makeWrapper "${lib.getExe tsx'}" $out/bin/papra-migrate-up \
+      --add-flags "$out/lib/src/scripts/migrate-up.script.ts"
 
     runHook postInstall
   '';


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/531079 and https://github.com/NixOS/nixpkgs/pull/539053 to address https://github.com/NixOS/nixpkgs/issues/546677 and https://github.com/NixOS/nixpkgs/issues/546669
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
