### PR TITLE
noctalia: fix nvidia gpu support

### DIFF
--- a/pkgs/by-name/no/noctalia/package.nix
+++ b/pkgs/by-name/no/noctalia/package.nix
@@ -10,6 +10,7 @@
   pkg-config,
   wayland-scanner,
   makeBinaryWrapper,
+  autoAddDriverRunpath,
 
   # libraries
   cairo,
@@ -78,6 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     wayland-scanner
     makeBinaryWrapper
+    autoAddDriverRunpath
   ];
 
   buildInputs = [


### PR DESCRIPTION
Adds `autoAddDriverRunpath` so noctalia can dlopen libnvidia-ml.so.1 via DT_RUNPATH, allowing it to get gpu data via nvml.

It doesn't need to be gated behind an option (like in the noctalia repo package) because `autoAddDriverRunpath` just prepends the driver path to DT_RUNPATH. If it's not there it just gets skipped and there's no build cost to including it.

Current package:
```
13:13:00.540 [INF] [sysmon] detected GPU temperature source: unavailable; NVML-only mode active; NVML unavailable
13:13:00.540 [INF] [sysmon] detected GPU usage source: unavailable
13:13:00.540 [INF] [sysmon] detected GPU VRAM source: unavailable
```

With this change:
```
13:13:33.085 [INF] [sysmon] detected GPU temperature source: nvml (47C); NVML-only mode active
13:13:33.087 [INF] [sysmon] detected GPU usage source: nvml (18%)
13:13:33.087 [INF] [sysmon] detected GPU VRAM source: nvml (4.3 GiB / 24.0 GiB)
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
