### PR TITLE
nixos/tests: fix networking eval outside the test framework

### DIFF
--- a/nixos/tests/nixops/legacy/base-configuration.nix
+++ b/nixos/tests/nixops/legacy/base-configuration.nix
@@ -20,6 +20,7 @@ in
 {
   imports = [
     (modulesPath + "/virtualisation/qemu-vm.nix")
+    (modulesPath + "/virtualisation/guest-networking-options.nix")
     (modulesPath + "/testing/test-instrumentation.nix")
   ];
   virtualisation.writableStore = true;

--- a/nixos/tests/nixos-rebuild-target-host.nix
+++ b/nixos/tests/nixos-rebuild-target-host.nix
@@ -116,6 +116,7 @@
             { lib, modulesPath, ... }: {
               imports = [
                 (modulesPath + "/virtualisation/qemu-vm.nix")
+                (modulesPath + "/virtualisation/guest-networking-options.nix")
                 (modulesPath + "/testing/test-instrumentation.nix")
                 (modulesPath + "/../tests/common/user-account.nix")
                 (lib.modules.importJSON ./target-configuration.json)


### PR DESCRIPTION
68e2e2bde3015a036b0dd09bbd0c20dfe64fe048 ("nixos/test-driver: fix eval with noUserModules")
moved the guest-networking-options.nix import from qemu-vm.nix into the
test framework's baseModules, but the nixos-rebuild-target-host and nixops
tests also depend on it internally. Import it explicitly in these configs.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
