### PR TITLE
ldc: 1.41.0 -> 1.42.0

### DIFF
--- a/pkgs/by-name/ld/ldc/bootstrap.nix
+++ b/pkgs/by-name/ld/ldc/bootstrap.nix
@@ -14,13 +14,12 @@ let
   OS = if hostPlatform.isDarwin then "osx" else hostPlatform.parsed.kernel.name;
   ARCH =
     if hostPlatform.isDarwin && hostPlatform.isAarch64 then "arm64" else hostPlatform.parsed.cpu.name;
-  version = "1.41.0";
+  version = "1.42.0";
   hashes = {
     # Get these from `nix store prefetch-file https://github.com/ldc-developers/ldc/releases/download/v1.19.0/ldc2-1.19.0-osx-x86_64.tar.xz` etc..
-    osx-x86_64 = "sha256-W8/0i2PFakXbqs2wxb3cjqa+htSgx7LHyDGOBH9yEYE=";
-    linux-x86_64 = "sha256-SkOUV/D+WeadAv1rV1Sfw8h60PVa2fueQlB7b44yfI8=";
-    linux-aarch64 = "sha256-HEuVChPVM3ntT1ZDZsJ+xW1iYeIWhogNcMdIaz6Me6g=";
-    osx-arm64 = "sha256-FXJnBC8QsEchBhkxSqcZtPC/iHYB6TscY0qh7LPFRuQ=";
+    linux-x86_64 = "sha256-p7yclWE49VjK35yWI1L1nUHIDfbrOuP4A58lvhSmkwM=";
+    linux-aarch64 = "sha256-aHcHw+IP+RBSjrLZLyepjLCWAoTeOwJua/IChKwchRE=";
+    osx-arm64 = "sha256-emjiHFMFdmp09HNsyJGnlC23hCqSJmIyCVBLyFxwE4I=";
   };
 in
 stdenv.mkDerivation {

--- a/pkgs/by-name/ld/ldc/package.nix
+++ b/pkgs/by-name/ld/ldc/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   callPackage,
   makeWrapper,
   removeReferencesTo,
@@ -11,7 +10,7 @@
   targetPackages,
   cmake,
   ninja,
-  llvm_18,
+  llvm_21,
   curl,
   tzdata,
   lit,
@@ -32,13 +31,13 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ldc";
-  version = "1.41.0";
+  version = "1.42.0";
 
   src = fetchFromGitHub {
     owner = "ldc-developers";
     repo = "ldc";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-6LcpY3LSFK4KgEiGrFp/LONu5Vr+/+vI04wEEpF3s+s=";
+    hash = "sha256-adA14tx/bruGvHVoODz13f8h/U2ol1lK0ytxnypsLv8=";
     fetchSubmodules = true;
   };
 
@@ -70,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     ldcBootstrap
     lit
     lit.python
-    llvm_18.dev
+    llvm_21.dev
     makeWrapper
     ninja
     unzip

--- a/pkgs/by-name/tu/tumiki-fighters/ldc-1.42.0-dangling-else.patch
+++ b/pkgs/by-name/tu/tumiki-fighters/ldc-1.42.0-dangling-else.patch
@@ -1,0 +1,23 @@
+diff --git a/src/abagames/tf/stuckenemy.d b/src/abagames/tf/stuckenemy.d
+index a90d1f1003..cd20d291e6 100644
+--- a/src/abagames/tf/stuckenemy.d
++++ b/src/abagames/tf/stuckenemy.d
+@@ -217,11 +217,13 @@
+     cnt++;
+     int mp = 1;
+     int sen = SoundManager.Se.STUCK_BONUS;
+-    if (manager.mode == GameManager.Mode.EXTRA)
+-      if (stuckEnemies.pullInRatio >= 1)
+-	mp = 5;
+-      else
+-	sen = SoundManager.Se.STUCK_BONUS_PUSHIN;
++    if (manager.mode == GameManager.Mode.EXTRA) {
++      if (stuckEnemies.pullInRatio >= 1) {
++	mp = 5;
++      } else {
++	sen = SoundManager.Se.STUCK_BONUS_PUSHIN;
++      }
++    }
+     if (tumikiSet.fireScoreInterval > 0 &&
+ 	(cnt % tumikiSet.fireScoreInterval) == 0 &&
+ 	!field.checkHit(pos)) {

--- a/pkgs/by-name/tu/tumiki-fighters/package.nix
+++ b/pkgs/by-name/tu/tumiki-fighters/package.nix
@@ -43,6 +43,10 @@ stdenv.mkDerivation (finalAttrs: {
     (debianPatch "dlang_v2" "1isnvbl3bjnpyphji8k3fl0yd1z4869h0lai143vpwgj6518lpg4")
     (debianPatch "gdc-8" "1md0zwmv50jnak5g9d93bglv9v4z41blinjii6kv3vmgjnajapzj")
     (debianPatch "gcc12" "sha256-3ZFsI2Q4zCT591qCOu2iT2edE52DfO2pUySnMMBhNIQ=")
+
+    # ldc 1.42.0 gains stricter checking of ambiguous "else" clauses for if
+    # statements, so we add braces in order to disambiguate.
+    ./ldc-1.42.0-dangling-else.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
release notes: https://github.com/ldc-developers/ldc/releases/tag/v1.42.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (tested `ldc2` against various examples from the website)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 546711`
Commit: `759525454cb2f92bc5cb27a35d032378811a32ad`

---
### `x86_64-linux`
<details>
  <summary>:x: 2 packages failed to build:</summary>
  <ul>
    <li>inochi-creator</li>
    <li>tumiki-fighters</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 24 packages built:</summary>
  <ul>
    <li>btdu</li>
    <li>cheesecutter</li>
    <li>ddhx</li>
    <li>dformat</li>
    <li>dplusplus</li>
    <li>dscanner</li>
    <li>dstep</li>
    <li>dtools</li>
    <li>dub</li>
    <li>dubBuildHook</li>
    <li>dubCheckHook</li>
    <li>gtkd</li>
    <li>inochi-session</li>
    <li>ldc</li>
    <li>literate</li>
    <li>luneta</li>
    <li>onedrive</li>
    <li>onedrivegui</li>
    <li>rund</li>
    <li>sambamba</li>
    <li>serve-d</li>
    <li>tilix</li>
    <li>titanion</li>
    <li>torus-trooper</li>
  </ul>
</details>


---
<details>
<summary>inochi-creator</summary>
<pre>                       ^
source/creator/windows/flipconfig.d(111,38):        instantiated from here: `serializeValue!(JsonSerializer!(&quot;&quot;, void delegate(const(char)[]) pure nothrow @safe), FlipPair)`
            serializer.serializeValue(pair);
                                     ^
source/creator/windows/flipconfig.d(52,9): Deprecation: alias `fghj.serialization.JsonSerializer!(&quot;&quot;, void delegate(const(char)[]) pure nothrow @safe).JsonSerializer.objectEnd` is deprecated - Use structEnd instead
        serializer.objectEnd(state);
        ^
../.dub/packages/fghj/1.0.2/fghj/source/fghj/serialization.d(1776,24):        instantiated from here: `serialize!(JsonSerializer!(&quot;&quot;, void delegate(const(char)[]) pure nothrow @safe))`
        value.serialize(serializer);
                       ^
source/creator/windows/flipconfig.d(111,38):        instantiated from here: `serializeValue!(JsonSerializer!(&quot;&quot;, void delegate(const(char)[]) pure nothrow @safe), FlipPair)`
            serializer.serializeValue(pair);
                                     ^
source/creator/windows/flipconfig.d(113,9): Deprecation: alias `fghj.serialization.JsonSerializer!(&quot;&quot;, void delegate(const(char)[]) pure nothrow @safe).JsonSerializer.arrayEnd` is deprecated - Use listEnd instead
        serializer.arrayEnd(i);
        ^
source/creator/viewport/common/mesheditor/tools/point.d(484,101): Error: Runtime function `objc_opt_isKindOfClass` was not found
            auto pointTool = cast(PointTool)(editors.length == 0 ? null: editors.values()[0].getTool());
                                                                                                    ^
Error /nix/store/qz1fmnm67imgpn7nz42h6qrpijpjpyk6-ldc-1.42.0/bin/ldc2 failed with exit code 1.</pre>
</details>
<details>
<summary>tumiki-fighters</summary>
<pre>patching file src/abagames/util/csv.d
patching file src/abagames/util/logger.d
patching file src/abagames/util/rand.d
applying patch /nix/store/28vd689qzz4xqk9x32b81sm78lrq6aay-gcc12.patch
patching file import/SDL_cdrom.d
patching file import/SDL_mouse.d
substituteStream() in derivation tumiki-fighters-0.21: WARNING: &#x27;--replace&#x27; is deprecated, use --replace-{fail,warn,quiet}. (file &#x27;src/abagames/tf/barragemanager.d&#x27;)
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { &quot;action&quot;: &quot;setPhase&quot;, &quot;phase&quot;: &quot;updateAutotoolsGnuConfigScriptsPhase&quot; }
Running phase: configurePhase
@nix { &quot;action&quot;: &quot;setPhase&quot;, &quot;phase&quot;: &quot;configurePhase&quot; }
no configure script, doing nothing
Running phase: buildPhase
@nix { &quot;action&quot;: &quot;setPhase&quot;, &quot;phase&quot;: &quot;buildPhase&quot; }
build flags: SHELL=/nix/store/c9mv5v53f7vy3wd00ah0f77k509mzmn7-bash-5.3p15/bin/bash GDC=ldc2
ldc2 -of=tumiki-fighters  -Iimport -Isrc     import/SDL.d import/SDL_active.d import/SDL_audio.d import/SDL_byteorder.d import/SDL_cdrom.d import/SDL_copying.d import/SDL_endian.d import/SDL_error.d import/SDL_events.d import/SDL_getenv.d import/SDL_joystick.d import/SDL_keyboard.d import/SDL_keysym_.d import/SDL_mixer.d import/SDL_mouse.d import/SDL_mutex.d import/SDL_quit.d import/SDL_rwops.d import/SDL_syswm.d import/SDL_thread.d import/SDL_timer.d import/SDL_types.d import/SDL_version_.d import/SDL_video.d import/bulletml.d import/opengl.d import/openglu.d src/abagames/tf/attractmanager.d src/abagames/tf/barragemanager.d src/abagames/tf/boot.d src/abagames/tf/bulletactor.d src/abagames/tf/bulletactorpool.d src/abagames/tf/bulletinst.d src/abagames/tf/bullettarget.d src/abagames/tf/damagegauge.d src/abagames/tf/enemy.d src/abagames/tf/enemyspec.d src/abagames/tf/field.d src/abagames/tf/fragment.d src/abagames/tf/gamemanager.d src/abagames/tf/letterrender.d src/abagames/tf/mobileletter.d src/abagames/tf/morphbullet.d src/abagames/tf/particle.d src/abagames/tf/prefmanager.d src/abagames/tf/scoresign.d src/abagames/tf/screen.d src/abagames/tf/ship.d src/abagames/tf/soundmanager.d src/abagames/tf/splinter.d src/abagames/tf/stagemanager.d src/abagames/tf/stuckenemy.d src/abagames/tf/tumiki.d src/abagames/tf/tumikiset.d src/abagames/util/actor.d src/abagames/util/actorpool.d src/abagames/util/bulletml/bullet.d src/abagames/util/bulletml/bulletsmanager.d src/abagames/util/csv.d src/abagames/util/iterator.d src/abagames/util/logger.d src/abagames/util/prefmanager.d src/abagames/util/rand.d src/abagames/util/sdl/gamemanager.d src/abagames/util/sdl/input.d src/abagames/util/sdl/mainloop.d src/abagames/util/sdl/pad.d src/abagames/util/sdl/screen.d src/abagames/util/sdl/screen3d.d src/abagames/util/sdl/sdlexception.d src/abagames/util/sdl/sound.d src/abagames/util/sdl/texture.d src/abagames/util/vector.d -L-lSDL -L-lGL -L-lSDL_mixer -L-lbulletml
src/abagames/tf/stuckenemy.d(223): Error: else is dangling, add { } after condition at src/abagames/tf/stuckenemy.d(220)
      else
      ^
make: *** [Makefile:8: tumiki-fighters] Error 1</pre>
</details>