### PR TITLE
sqlgg: init at 20260721

### DIFF
--- a/pkgs/by-name/sq/sqlgg/package.nix
+++ b/pkgs/by-name/sq/sqlgg/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  ocamlPackages,
+  fetchFromGitHub,
+}:
+
+ocamlPackages.buildDunePackage (finalAttrs: {
+  pname = "sqlgg";
+  version = "20260721";
+
+  src = fetchFromGitHub {
+    owner = "ygrek";
+    repo = "sqlgg";
+    tag = finalAttrs.version;
+    sha256 = "sha256-I0a+wZ8aWWLjxv6fBCKA/ijFOwTkALsOcVenG4Ykzxg=";
+  };
+
+  nativeBuildInputs = with ocamlPackages; [
+    menhir
+  ];
+
+  buildInputs = with ocamlPackages; [
+    mybuild
+    extlib
+    integers
+    odoc
+    ounit
+    ppx_deriving
+    yojson
+  ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "SQL query parser and binding code generator for C#, C++, Java, OCaml";
+    homepage = "https://ygrek.org/p/sqlgg/";
+    license = lib.licenses.gpl2;
+    maintainers = [ lib.maintainers.niols ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/development/ocaml-modules/mybuild/default.nix
+++ b/pkgs/development/ocaml-modules/mybuild/default.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  buildDunePackage,
+  fetchFromGitHub,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "mybuild";
+  version = "7";
+
+  src = fetchFromGitHub {
+    owner = "ygrek";
+    repo = "mybuild";
+    tag = "v${finalAttrs.version}";
+    sha256 = "sha256-3NBu+8orypL7I8PBU7trI5DA4kbtg8wA/qzyCLUUWYM=";
+  };
+
+  meta = {
+    description = "Small library and utility to generate version from VCS (git)";
+    homepage = "https://github.com/ygrek/mybuild";
+    license = lib.licenses.unlicense;
+    maintainers = [ lib.maintainers.niols ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1437,6 +1437,8 @@ let
 
         mustache = callPackage ../development/ocaml-modules/mustache { };
 
+        mybuild = callPackage ../development/ocaml-modules/mybuild { };
+
         ### N ###
 
         name_matcher_parser = callPackage ../development/ocaml-modules/name_matcher_parser { };


### PR DESCRIPTION
Introduce package `sqlgg`, an SQL query parser and code generator:

> sqlgg is an SQL query parser and binding code generator for C#, C++, Java, OCaml. It starts off with SQL schema and queries, and generates code (or XML, allowing further code generation for various purposes). Generated code only defines a mapping of output columns and query parameters to the host language, trying to be as unobtrusive as possible and leaving the choice of SQL database (and API to access it) to the developer.

- https://ygrek.org/p/sqlgg/
- https://github.com/ygrek/sqlgg
- https://github.com/ygrek/sqlgg/releases/tag/20260721

Also introduce one necessary OCaml dependency, `mybuild`:

> Small library to generate OCaml file with the project version extracted from git + command-line utility to do the same.

- https://github.com/ygrek/mybuild

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
