### PR TITLE
emacsPackages.kitty-graphics: init at 1.0.0

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/kitty-graphics/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/kitty-graphics/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  melpaBuild,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+melpaBuild {
+  pname = "kitty-graphics";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "cashmeredev";
+    repo = "kitty-graphics.el";
+    rev = "v1.0.0";
+    hash = "sha256-wctqnbM7vdQndXl6uArLdfMHYdU6tdN7MWp2Rxdz668=";
+  };
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Display images in terminal Emacs (emacs -nw) via the Kitty graphics protocol or Sixel";
+    homepage = "https://github.com/cashmeredev/kitty-graphics.el";
+    license = lib.licenses.gpl2Plus;
+    maintainers = [ lib.maintainers.shunueda ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adding [kitty-graphics.el](https://github.com/cashmeredev/kitty-graphics.el). 

The author [does not plan to publish to ELPAs](https://github.com/cashmeredev/kitty-graphics.el/issues/44) anytime soon so adding as a manual package.

It's been actively developed for about 6 months (according to the link above), and has gained a decent attention (100+ stars). It is LLM-assisted but I believe this is a very cool project that's worth adding to Nixpkgs. Open to discussion.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
