### PR TITLE
kronosnet: 1.33 -> 1.35

### DIFF
--- a/pkgs/by-name/kr/kronosnet/package.nix
+++ b/pkgs/by-name/kr/kronosnet/package.nix
@@ -17,17 +17,20 @@
   zlib,
   zstd,
   doxygen,
+  withWiresharkDissector ? false,
+  wireshark,
+  glib,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "kronosnet";
-  version = "1.33";
+  version = "1.35";
 
   src = fetchFromGitHub {
     owner = "kronosnet";
     repo = "kronosnet";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-mLpHV54BqYmWNjkoNt2v/lu/QfMwkHeMgMUCDEGeUPI=";
+    hash = "sha256-dlokVXqm1U9tt7/X07TQ7076yYXVjarHq01+R3sqCJM=";
   };
 
   nativeBuildInputs = [
@@ -49,6 +52,14 @@ stdenv.mkDerivation (finalAttrs: {
     xz
     zlib
     zstd
+  ]
+  ++ lib.optionals withWiresharkDissector [
+    wireshark
+    glib
+  ];
+
+  configureFlags = [
+    (lib.enableFeature withWiresharkDissector "wireshark-dissector")
   ];
 
   meta = {


### PR DESCRIPTION
Fixes #544623 and fixes #544133

Wireshark added as a dependency in upstream kronosnet repository in v1.34 which defaults to "true" by default.
Owing to this, wireshark (and subsequently glib) added as optional dependencies using withWiresharkDissector (default: "false" to keep the closure small) argument for kronosnet v1.35

Release Notes:
  https://github.com/kronosnet/kronosnet/releases/tag/v1.35
  https://github.com/kronosnet/kronosnet/releases/tag/v1.34

Affected maintainers:
  cc @ryantm

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. (ran nixosTests/pacemaker as that was the only Test found between kronosnet and its dependent corosync)
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
