### PR TITLE
iay: 0.4.3 -> 0.5.0

### DIFF
--- a/pkgs/by-name/ia/iay/package.nix
+++ b/pkgs/by-name/ia/iay/package.nix
@@ -5,26 +5,29 @@
   rustPlatform,
   openssl,
   pkg-config,
+  gitMinimal,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "iay";
-  version = "0.4.3";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "aaqaishtyaq";
     repo = "iay";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-oNUK2ROcocKoIlAuNZcJczDYtSchzpB1qaYbSYsjN50=";
+    hash = "sha256-H0h3ChS+B8+Pnet8rNQIkpr4k/t7P2hYrS06dademUU=";
   };
 
-  cargoHash = "sha256-QO9gzJKSBMs5s1fCfpBuyHDK9uE1B148bMjp8RjH4nY=";
+  cargoHash = "sha256-66bhmIk/YCweL9GquPpObkkl2Sn45IlU2HqnKn43294=";
 
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [
     openssl
   ];
+
+  nativeCheckInputs = [ gitMinimal ];
 
   env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
     NIX_LDFLAGS = toString [


### PR DESCRIPTION
## Description of changes

Update `iay` from 0.4.3 to 0.5.0.

- Release: https://github.com/aaqaishtyaq/iay/releases/tag/v0.5.0
- Diff: https://github.com/aaqaishtyaq/iay/compare/v0.4.3...v0.5.0

Also add `gitMinimal` to `nativeCheckInputs` so the new VCS regression integration tests can run in the check phase.

## Things done

- Built on macOS (aarch64-darwin): `iay` package builds and all tests pass (including `vcs_regression`)
- Tested using sandboxing (nix sandbox)

- [x] Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] Tested, as applicable:
  - [ ] NixOS test(s)
  - [x] package tests (as defined in package.nix / cargo tests)
- [ ] Tested basic functionality of all binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)