### PR TITLE
python3Packages.licomp-oslc-handbook: fix darwin build

### DIFF
--- a/pkgs/development/python-modules/licomp-oslc-handbook/default.nix
+++ b/pkgs/development/python-modules/licomp-oslc-handbook/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -24,12 +25,13 @@ buildPythonPackage (finalAttrs: {
     owner = "hesa";
     repo = "licomp-oslc-handbook";
     tag = finalAttrs.version;
-    hash = "sha256-cE3X7oT5Xg1W9lAMLJCYE6qRqrrXpVGLfBp18ynUYLE=";
-    postFetch = ''
-      # conflicts with `licenses` on Darwin, thus producing a different source
-      # hash.
-      mv $out/LICENSES $out/LICENSES_
-    '';
+    hash =
+      # Darwin's case-insensitive filesystem produces a different source hash,
+      # given a conflict with `licenses` and `LICENSES`
+      if stdenv.hostPlatform.isDarwin then
+        "sha256-Y01AHnaXWIwqWVS1/QTrGrOqy0ejYC1wwJZ+q2+y0yc="
+      else
+        "sha256-cgvwFwKlClEPfj9DWvxdBFpnYpdhdXBPsM+qPXxb+SE=";
   };
 
   build-system = [
@@ -60,8 +62,5 @@ buildPythonPackage (finalAttrs: {
     ];
     maintainers = with lib.maintainers; [ eljamm ];
     teams = with lib.teams; [ ngi ];
-    # TODO: remove when this is resolved:
-    # https://github.com/hesa/licomp-oslc-handbook/issues/4
-    badPlatforms = lib.platforms.darwin;
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [Built on platform](https://github.com/eljamm/nixpkgs-review-gha/actions/runs/30372625521):
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
