### PR TITLE
nxv: 0.6.0 -> 0.6.1

### DIFF
--- a/pkgs/by-name/nx/nxv/package.nix
+++ b/pkgs/by-name/nx/nxv/package.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nxv";
-  version = "0.6.0";
+  version = "0.6.1";
 
   src = fetchFromGitHub {
     owner = "utensils";
     repo = "nxv";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Ym30QiImry+3Io933SFQw5q6Lyl5p8nuidQhrXHSv54=";
+    hash = "sha256-2B3J+jrZZUF1CE/chdSXNO6IAuruXfRUd6pG8dyWjpQ=";
   };
 
-  cargoHash = "sha256-syAlYsXPxMUIyPNankujiVD3lXaAgGmr5v585ysxIWI=";
+  cargoHash = "sha256-1WiG2jIVPf0ess3oLbpPvaYSRzvwEJDe9BKaEWWptGE=";
 
   # Tests use mockito which needs to bind to localhost
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
Patch release follow-up to #544893.

Diff: https://github.com/utensils/nxv/compare/v0.6.0...v0.6.1
Changelog: https://github.com/utensils/nxv/blob/v0.6.1/CHANGELOG.md

Supersedes #514996, which diffs against the pre-0.6.0 file (it would reintroduce `fetchSubmodules = true`, dropped in 0.6.0 since the vestigial submodule was removed upstream).

cc @yzhou216 (co-maintainer)

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html#conf-sandbox))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [x] Package tests, including when applicable:
    - [x] Tests exercised by the build (`checkPhase`) and `versionCheckHook`
- [x] Tested basic functionality of all binary files, usually in `./result/bin/` (`nxv --version`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs as applicable.

This PR was made with AI assistance (Claude Code); commits carry `Assisted-by:` trailers and were reviewed by me.