### PR TITLE
jailer: 16.11 -> 17.2

### DIFF
--- a/pkgs/by-name/ja/jailer/package.nix
+++ b/pkgs/by-name/ja/jailer/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "jailer";
-  version = "16.11";
+  version = "17.2";
 
   src = fetchFromGitHub {
     owner = "Wisser";
     repo = "Jailer";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-bSwLxO7UtKv82WoF/OcFROtbLfkdeupLtoR2/ELzO1U=";
+    hash = "sha256-5vNa+jV3a0bkTPw1gCaVvB3VCVmhmeMKIORaAKcbo3g=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Things done

Update jailer from 16.11 to 17.2.

Changelog: https://github.com/Wisser/Jailer/releases/tag/v17.2

- Built on the platform(s):
  - [x] x86_64-linux