### PR TITLE
shogihome: improve version source

### DIFF
--- a/pkgs/by-name/sh/shogihome/package.nix
+++ b/pkgs/by-name/sh/shogihome/package.nix
@@ -13,6 +13,8 @@
   _experimental-update-script-combinators,
   writeShellApplication,
   nix,
+  curl,
+  common-updater-scripts,
   jq,
   gnugrep,
 }:
@@ -130,9 +132,26 @@ buildNpmPackage (finalAttrs: {
 
   passthru = {
     updateScript = _experimental-update-script-combinators.sequence [
+      (lib.getExe (writeShellApplication {
+        name = "${finalAttrs.pname}-version-updater";
+
+        runtimeInputs = [
+          curl
+          jq
+          common-updater-scripts
+        ];
+
+        # Use release.json as the primary source rather than git tags or GitHub releases:
+        # https://github.com/sunfish-shogi/shogihome/issues/1704#issuecomment-5105936699
+        text = ''
+          version="$(curl -s 'https://sunfish-shogi.github.io/shogihome/release.json' | jq -r '.latest.version')"
+          update-source-version '${finalAttrs.pname}' "$version"
+        '';
+      }))
+      # Update src.hash and npmDepsHash
       (nix-update-script {
         extraArgs = [
-          "--version-regex=^v([\\d\\.]+)$"
+          "--version=skip"
         ];
       })
       (lib.getExe (writeShellApplication {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I've checked the [release flow](https://github.com/sunfish-shogi/shogihome/issues/1704#issuecomment-5105936699) and learned that using [release.json](https://sunfish-shogi.github.io/shogihome/release.json) is the most accurate method to track new versions for this package.

I tested this update script with the following patterns.

`release.json`

```json
{
 "stable": {
  "version": "1.27.4",
  "tag": "v1.27.4",
  "link": "https://github.com/sunfish-shogi/shogihome/releases/tag/v1.27.4"
 },
 "latest": {
  "version": "1.28.0",
  "tag": "v1.28.0",
  "link": "https://github.com/sunfish-shogi/shogihome/releases/tag/v1.28.0"
 }
}
```

* Normal update: 1.28.0 -> 1.28.0
* Switch to stable: 1.28.0 -> 1.27.4
* Manually specify 1.27.3:  1.28.0 -> 1.27.3 (produces the same hash as https://github.com/NixOS/nixpkgs/blob/26.05/pkgs/by-name/sh/shogihome/package.nix#L24-L33)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
