### PR TITLE
frama-c: 32.1 -> 33.0

### DIFF
--- a/pkgs/by-name/fr/frama-c-gui/package.nix
+++ b/pkgs/by-name/fr/frama-c-gui/package.nix
@@ -1,12 +1,11 @@
 {
   lib,
   stdenv,
-  fetchzip,
   fetchYarnDeps,
   yarn,
   fixup-yarn-lock,
   yarnConfigHook,
-  nodejs_22,
+  nodejs_24,
   electron,
   frama-c,
   makeWrapper,
@@ -15,23 +14,16 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  pname = "ivette";
-  version = "32.1";
-  slang = "Germanium";
+  pname = "frama-c-gui";
+  inherit (frama-c) version slang src;
 
   __structuredAttrs = true;
-
-  # Not fetchurl, because we need it unzipped before fetchYarnDeps
-  src = fetchzip {
-    url = "https://frama-c.com/download/frama-c-${finalAttrs.version}-${finalAttrs.slang}.tar.gz";
-    hash = "sha256-D+OJy/pcOqSSexqHVsyCSLSHcMg8zbjKDfmqBZ8xvbk=";
-  };
 
   sourceRoot = "${finalAttrs.src.name}/ivette";
 
   yarnOfflineCache = fetchYarnDeps {
     yarnLock = "${finalAttrs.src}/ivette/yarn.lock";
-    hash = "sha256-1NRSTJkXZ1jvkB/7xI0+u4PmrEzKc3VVBdwM50PtznI=";
+    hash = "sha256-fEwgsoJWQvzeDq3GTp0ngNu+oj1BogH1bwU5rMeRDjQ=";
   };
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
@@ -40,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     yarnConfigHook
-    nodejs_22
+    nodejs_24
     yarn
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
@@ -60,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preBuild
 
     # From api.sh
-    ${lib.getExe frama-c} -server-tsc -server-tsc-out src
+    ${lib.getExe frama-c} -server-tsc src
 
     # Run configure.js and sandboxer.js
     make pkg
@@ -86,35 +78,35 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
   ''
   + lib.optionalString stdenv.hostPlatform.isLinux ''
-    mkdir -p "$out/share/lib/ivette"
-    cp -r dist/*-unpacked/{locales,resources{,.pak}} "$out/share/lib/ivette"
+    mkdir -p "$out/share/lib/frama-c-gui"
+    cp -r dist/*-unpacked/{locales,resources{,.pak}} "$out/share/lib/frama-c-gui"
 
-    install -Dm444 static/icon.png $out/share/icons/hicolor/512x512/apps/ivette.png
+    install -Dm444 static/icon.png $out/share/icons/hicolor/512x512/apps/frama-c-gui.png
 
-    makeWrapper '${electron}/bin/electron' "$out/bin/ivette" \
-      --add-flags "$out/share/lib/ivette/resources/app.asar" \
+    makeWrapper '${electron}/bin/electron' "$out/bin/frama-c-gui" \
+      --add-flags "$out/share/lib/frama-c-gui/resources/app.asar" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --add-flags "--no-sandbox" \
       --inherit-argv0
   ''
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
     mkdir -p $out/Applications
-    cp -r dist/mac*/Ivette.app "$out/Applications/Ivette.app"
-    makeWrapper "$out/Applications/Ivette.app/Contents/MacOS/Ivette" "$out/bin/ivette"
+    cp -r dist/mac*/'Frama-C GUI.app' "$out/Applications/Frama-C GUI.app"
+    makeWrapper "$out/Applications/Frama-C GUI.app/Contents/MacOS/Frama-C GUI" "$out/bin/frama-c-gui"
   ''
   + ''
     runHook postInstall
   '';
 
   desktopItems = lib.optional stdenv.hostPlatform.isLinux (makeDesktopItem {
-    name = "ivette";
-    exec = "ivette";
-    icon = "ivette";
-    desktopName = "Ivette";
+    name = "frama-c-gui";
+    exec = "frama-c-gui";
+    icon = "frama-c-gui";
+    desktopName = "Frama-C GUI";
     genericName = "Frama-C's GUI";
     comment = finalAttrs.meta.description;
     categories = [ "Development" ];
-    startupWMClass = "Ivette";
+    startupWMClass = "Frama-C GUI";
   });
 
   meta = {
@@ -132,6 +124,6 @@ stdenv.mkDerivation (finalAttrs: {
       luc65r
     ];
     platforms = lib.platforms.unix;
-    mainProgram = "ivette";
+    mainProgram = "frama-c-gui";
   };
 })

--- a/pkgs/by-name/fr/frama-c/package.nix
+++ b/pkgs/by-name/fr/frama-c/package.nix
@@ -2,16 +2,14 @@
   lib,
   stdenv,
   darwin,
-  fetchurl,
+  fetchzip,
+  makeBinaryWrapper,
   graphviz,
   doxygen,
   ocamlPackages,
   coq,
   dune,
   why3,
-  gdk-pixbuf,
-  wrapGAppsHook3,
-  withGui ? true,
   withWP ? true,
   withMarkdown ? true,
   withApron ? true,
@@ -20,14 +18,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "frama-c";
-  version = "32.1";
-  slang = "Germanium";
+  version = "33.0";
+  slang = "Arsenic";
 
   __structuredAttrs = true;
 
-  src = fetchurl {
+  src = fetchzip {
     url = "https://frama-c.com/download/frama-c-${finalAttrs.version}-${finalAttrs.slang}.tar.gz";
-    hash = "sha256-3V1uid9d3mpAs4vq0wLQpbmGCxw7ZbzYU2CneAh8E+I=";
+    hash = "sha256-QGqEwwyNFEVrUoE179Yz2AR2s5wWbkUrP3EsnQw9Cjo=";
   };
 
   preConfigure = ''
@@ -38,8 +36,8 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   nativeBuildInputs = [
-    wrapGAppsHook3
     dune
+    makeBinaryWrapper
   ]
   ++ (with ocamlPackages; [
     ocaml
@@ -64,10 +62,6 @@ stdenv.mkDerivation (finalAttrs: {
       unionFind
       yojson
       zarith
-    ]
-    ++ lib.optionals withGui [
-      lablgtk3
-      lablgtk3-sourceview3
     ]
     ++ lib.optionals withWP [
       why3
@@ -113,7 +107,8 @@ stdenv.mkDerivation (finalAttrs: {
       ocamlPath = lib.makeSearchPath "/lib/ocaml/${ocamlPackages.ocaml.version}/site-lib" runtimeDeps;
     in
     ''
-      gappsWrapperArgs+=(--prefix OCAMLPATH ':' ${ocamlPath}:$out/lib/)
+      wrapProgram $out/bin/frama-c \
+        --prefix OCAMLPATH : ${ocamlPath}:$out/lib/
     '';
 
   meta = {
@@ -133,8 +128,6 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     platforms = lib.platforms.unix;
     mainProgram = "frama-c";
-    broken =
-      !lib.versionAtLeast ocamlPackages.ocaml.version "4.14"
-      || lib.versionAtLeast ocamlPackages.ocaml.version "5.5";
+    broken = !lib.versionAtLeast ocamlPackages.ocaml.version "4.14";
   };
 })

--- a/pkgs/development/ocaml-modules/frama-c-lannotate/default.nix
+++ b/pkgs/development/ocaml-modules/frama-c-lannotate/default.nix
@@ -2,17 +2,21 @@
   lib,
   buildDunePackage,
   dune-site,
-  fetchzip,
+  fetchFromGitLab,
   frama-c,
 }:
 
 buildDunePackage (finalAttrs: {
   pname = "frama-c-lannotate";
-  version = "0.2.5";
+  version = "0.2.6";
 
-  src = fetchzip {
-    url = "https://git.frama-c.com/pub/ltest/lannotate/-/archive/${finalAttrs.version}/lannotate-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-S7/So+1HBdkeq4k7BisEe2gpzW4vHFi6x8J8evaPgRw=";
+  src = fetchFromGitLab {
+    domain = "git.frama-c.com";
+    group = "pub";
+    owner = "ltest";
+    repo = "lannotate";
+    rev = finalAttrs.version;
+    hash = "sha256-F08YrRtRdRZXNfGqdIc0ATOfWN8Kw0RXYY579da9Xuw=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/frama-c-luncov/default.nix
+++ b/pkgs/development/ocaml-modules/frama-c-luncov/default.nix
@@ -11,15 +11,15 @@
 
 buildDunePackage (finalAttrs: {
   pname = "frama-c-luncov";
-  version = "0.2.4-unstable-2025-11-24";
+  version = "0.2.6";
 
   src = fetchFromGitLab {
+    domain = "git.frama-c.com";
     group = "pub";
     owner = "ltest";
     repo = "luncov";
-    domain = "git.frama-c.com";
-    rev = "76b14a41ae9e5eacb90649cb1401a75e37a61d52"; # latest commit from stable/germanium branch
-    hash = "sha256-dp693isevR4N4V/3FZ1lnbw0xjR+CuAK8BD/Bwvny0E";
+    rev = finalAttrs.version;
+    hash = "sha256-rj/JGGr368UlEdtb1yXn9PpkU6fQCdxB8wQ2gIlYmrY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -871,7 +871,7 @@ mapAliases {
   forgejo-actions-runner = throw "'forgejo-actions-runner' has been renamed to/replaced by 'forgejo-runner'"; # Converted to throw 2025-10-27
   fped = throw "'fped' has been removed, as it is unmaintained upstream and depends on GTK 2. Consider using 'kicad' instead."; # Added 2026-05-22
   fractal-next = throw "'fractal-next' has been renamed to/replaced by 'fractal'"; # Converted to throw 2025-10-27
-  framac = frama-c; # Added 2026-04-24
+  framac = warnAlias "'framac' has been renamed to 'frama-c'" frama-c; # Added 2026-04-24
   framework-system-tools = throw "'framework-system-tools' has been renamed to/replaced by 'framework-tool'"; # Converted to throw 2025-10-27
   francis = throw "'francis' has been renamed to/replaced by 'kdePackages.francis'"; # Converted to throw 2025-10-27
   freebsdCross = throw "'freebsdCross' has been renamed to/replaced by 'freebsd'"; # Converted to throw 2025-10-27

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1104,6 +1104,7 @@ mapAliases {
   itktcl = throw "'itktcl' has been renamed to/replaced by 'tclPackages.itktcl'"; # Converted to throw 2025-10-27
   itm-tools = throw "'itm-tools' has been removed because it was deprecated and archived upstream."; # Added 2026-01-15
   itpp = throw "itpp has been removed, as it was broken"; # Added 2025-08-25
+  ivette = warnAlias "'ivette' has been renamed to 'frama-c-gui'" frama-c-gui; # Added 2026-07-28
   jack_rack = throw "'jack_rack' has been removed due to lack of maintenance upstream."; # Added 2025-06-10
   jami-client = throw "'jami-client' has been renamed to/replaced by 'jami'"; # Converted to throw 2025-10-27
   jami-client-qt = throw "'jami-client-qt' has been renamed to/replaced by 'jami-client'"; # Converted to throw 2025-10-27


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
I updated frama-c to version 33.0, and renamed ivette to frama-c-gui. I also tested frama-c on OCaml 5.5.

As frama-c-gui should stay in sync with frama-c, should I move it to frama-c.gui using passthru?

Also, I'd like to add a withProvers version, using why3.withProvers. Should I also add it using passthru?


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
