### PR TITLE
acados: init at 0.6.0

### DIFF
--- a/pkgs/by-name/ac/acados/package.nix
+++ b/pkgs/by-name/ac/acados/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  nix-update-script,
+
+  eigen,
+  llvmPackages,
+
+  withShared ? (!stdenv.hostPlatform.isStatic),
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "acados";
+  version = "0.6.0";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "acados";
+    repo = "acados";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-NGwiANC50eqLZgmwzP85vse0Q+gjncFNdJOVvVfi41k=";
+    fetchSubmodules = true; # TODO they fork every dependency :(
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    eigen
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    llvmPackages.openmp
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" withShared)
+    (lib.cmakeBool "ACADOS_UNIT_TESTS" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeBool "ACADOS_WITH_OPENMP" true)
+
+    # everything that works out of the box here has been enabled
+    (lib.cmakeBool "ACADOS_WITH_QPOASES" false)
+    (lib.cmakeBool "ACADOS_WITH_DAQP" true)
+    (lib.cmakeBool "ACADOS_WITH_HPMPC" false)
+    (lib.cmakeBool "ACADOS_WITH_QORE" false)
+    (lib.cmakeBool "ACADOS_WITH_OOQP" false)
+    (lib.cmakeBool "ACADOS_WITH_QPDUNES" true)
+    (lib.cmakeBool "ACADOS_WITH_OSQP" true)
+    (lib.cmakeBool "ACADOS_WITH_CLARABEL" false)
+    (lib.cmakeBool "ACADOS_OCTAVE" false)
+
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5" # for their fork of qpdunes
+  ];
+
+  doCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Fast and embedded solvers for nonlinear optimal control and nonlinear model predictive control";
+    homepage = "https://github.com/acados/acados";
+    changelog = "https://github.com/acados/acados/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ nim65s ];
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
+  };
+})


### PR DESCRIPTION
Hi,

This add https://github.com/acados/acados, an optimal control solver from University of Freiburg.

Upstream heavily fork all their dependencies. I tried to untangle that a bit, but clearly this would require way more work.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
