### PR TITLE
advcpmv: init at 0.9-9.11

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25405,6 +25405,12 @@
     githubId = 540360;
     name = "Sean Murphy";
   };
+  seanybaggins = {
+    name = "Sean Link";
+    github = "seanybaggins";
+    githubId = 18423154;
+    email = "nixpkgsemail.undecided494@passmail.net";
+  };
   SeanZicari = {
     email = "sean.zicari@gmail.com";
     github = "SeanZicari";

--- a/pkgs/by-name/ad/advcpmv/package.nix
+++ b/pkgs/by-name/ad/advcpmv/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  coreutils,
+  fetchpatch,
+  texinfo,
+  makeWrapper,
+}:
+
+# Build standalone binaries so cp/mv exist as real files, not argv[0] dispatch
+# symlinks into a single coreutils binary.
+(coreutils.override { singleBinary = false; }).overrideAttrs (old: {
+  pname = "advcpmv";
+
+  # advcpmv patch version + the coreutils version it is applied to.
+  # Note: keep `version` unchanged so coreutils' `src` URL (derived from
+  # version) still resolves; expose the combined version via `name` instead.
+  name = "advcpmv-0.9-${old.version}";
+
+  # texinfo: the patch touches doc/coreutils.texi, so the info manual is
+  # regenerated, which requires makeinfo.
+  # makeWrapper: cpg/mvg are cp/mv wrappers that always pass --progress-bar.
+  nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [
+    texinfo
+    makeWrapper
+  ];
+
+  patches = (old.patches or [ ]) ++ [
+    (fetchpatch {
+      name = "advcpmv-0.9-9.11.patch";
+      url = "https://raw.githubusercontent.com/jarun/advcpmv/1a574b81d801ec29a78e0346eeecab0495bba0c8/advcpmv-0.9-9.11.patch";
+      hash = "sha256-VCR7Vy8BXqd1Dc4ayORdoHc2cW1iv8PyZzWRbLHAQm8=";
+    })
+  ];
+
+  # Wrap the patched cp/mv as cpg/mvg with --progress-bar always enabled, then
+  # drop the other coreutils binaries.  cpg/mvg coexist with coreutils' cp/mv.
+  postInstall = (old.postInstall or "") + ''
+    install -Dm755 "$out/bin/cp" "$out/libexec/advcpmv/cp"
+    install -Dm755 "$out/bin/mv" "$out/libexec/advcpmv/mv"
+    find "$out/bin" -mindepth 1 -delete
+    makeWrapper "$out/libexec/advcpmv/cp" "$out/bin/cpg" --add-flags --progress-bar
+    makeWrapper "$out/libexec/advcpmv/mv" "$out/bin/mvg" --add-flags --progress-bar
+  '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = (old.meta or { }) // {
+    description = "GNU cp and mv with an added progress bar (-g/--progress-bar)";
+    homepage = "https://github.com/jarun/advcpmv";
+    mainProgram = "cpg";
+    maintainers = with lib.maintainers; [ seanybaggins ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Adds `advcpmv`, GNU `cp`/`mv` with an added progress bar, exposed as `cpg` and `mvg`.

The package builds coreutils with `singleBinary = false` and applies the upstream advcpmv patch (`advcpmv-0.9-9.11.patch`), then wraps the patched `cp`/`mv` as `cpg`/`mvg` with `--progress-bar` always enabled. The other coreutils binaries are dropped so it coexists with the system coreutils.

The `0.9-9.11` patch (for coreutils 9.11) was authored by me and merged upstream into [jarun/advcpmv](https://github.com/jarun/advcpmv); the derivation pins that upstream patch by commit.

Also adds myself (`seanybaggins`) to the maintainer list as maintainer of this package.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+is%3Aopen+sort%3Areactions-%2B1-desc