### PR TITLE
deluge: use standard-pkg-resources

### DIFF
--- a/pkgs/applications/networking/p2p/deluge/default.nix
+++ b/pkgs/applications/networking/p2p/deluge/default.nix
@@ -41,7 +41,10 @@ let
           service-identity
           libtorrent-rasterbar.dev
           libtorrent-rasterbar.python
-          setuptools
+          # pkg_resources was removed in setuptools>=82; deluge 2.2.0 still uses it
+          # standard-pkg-resources is an independent PyPI redistribution providing it
+          # TODO: remove once deluge migrates off pkg_resources
+          standard-pkg-resources
           setproctitle
           pillow
           rencode

--- a/pkgs/development/python-modules/standard-pkg-resources/default.nix
+++ b/pkgs/development/python-modules/standard-pkg-resources/default.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  setuptools-scm,
+  jaraco-text,
+  packaging,
+  platformdirs,
+  jaraco-envs,
+  jaraco-path,
+  pytestCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+
+buildPythonPackage rec {
+  pname = "standard-pkg-resources";
+  version = "1.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "stephenfin";
+    repo = "standard-pkg_resources";
+    tag = "v${version}";
+    hash = "sha256-MdibVeBssPa/kiNAw7f4jTl4Y6JKFnDLshvrc/cFWXw=";
+  };
+
+  # This filter references the coverage module directly; drop it instead of pulling in coverage/pytest-cov as a dependency.
+  postPatch = ''
+    substituteInPlace pytest.ini \
+      --replace-fail "	ignore:Couldn't import C tracer:coverage.exceptions.CoverageWarning" ""
+  '';
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    jaraco-text
+    packaging
+    platformdirs
+  ];
+
+  nativeCheckInputs = [
+    jaraco-envs
+    jaraco-path
+    pytestCheckHook
+    writableTmpDirAsHomeHook
+  ];
+
+  disabledTests = [
+    # Fails against current setuptools_scm: it warns when a distribution's version is already set before it tries to infer one, which this test doesn't expect.
+    "test_version_resolved_from_egg_info"
+    # Requires internet access, unavailable in the Nix build sandbox.
+    "test_interop_pkg_resources_iter_entry_points"
+  ];
+
+  pythonImportsCheck = [ "pkg_resources" ];
+
+  meta = {
+    description = "Standalone redistribution of pkg_resources, extracted from setuptools";
+    homepage = "https://github.com/stephenfin/standard-pkg_resources";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ a-peirogon ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19476,6 +19476,8 @@ self: super: with self; {
   standard-pipes =
     if pythonAtLeast "3.13" then callPackage ../development/python-modules/standard-pipes { } else null;
 
+  standard-pkg-resources = callPackage ../development/python-modules/standard-pkg-resources { };
+
   standard-sndhdr =
     if pythonAtLeast "3.13" then
       callPackage ../development/python-modules/standard-sndhdr { }


### PR DESCRIPTION
Fixes #540545

deluge 2.2.0 still imports `pkg_resources` in `pluginmanagerbase.py`, which setuptools>=82 removed. No direct `importlib.metadata` equivalent exists for this API. Adding `setuptools_80` alongside `setuptools` instead of pinning was tried, but nixpkgs' duplicate-package check rejects it.

Temporary workaround until upstream migrates (deluge-torrent/deluge#485) and cuts a new release. Tested: `deluged`/`deluge-gtk` start without the error; only one `setuptools` version in the closure.