### PR TITLE
sara: init at 0.9.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -31255,6 +31255,11 @@
     githubId = 33605526;
     name = "Yash Garg";
   };
+  yasunori0418 = {
+    github = "yasunori0418";
+    githubId = 74786563;
+    name = "yasunori0418";
+  };
   yavko = {
     name = "Yavor Kolev";
     email = "yavornkolev@gmail.com";

--- a/pkgs/by-name/sa/sara/package.nix
+++ b/pkgs/by-name/sa/sara/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  git,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "sara";
+  version = "0.9.4";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "cledouarec";
+    repo = "sara";
+    tag = "sara-cli-v${finalAttrs.version}";
+    hash = "sha256-jt7/DDwmOHs60xCnsdlxVRIsQueoHoWrtTEm67Igalc=";
+  };
+
+  cargoHash = "sha256-3kvRmzsyKF7N8L/MPTu9B8AHIyaZ9rODpINkaFhB7Tg=";
+
+  # The CLI integration tests shell out to `git` to build fixture repositories.
+  nativeCheckInputs = [ git ];
+
+  checkFlags = [
+    # Asserts that the working directory is a git repository, which only holds
+    # when running from an upstream checkout rather than an unpacked tarball.
+    "--skip=repository::git::tests::test_is_git_repo"
+  ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      # Both sara-cli and sara-core are tagged in this repository, only follow
+      # the CLI which provides the `sara` binary.
+      "--version-regex"
+      "sara-cli-v([0-9.]+)"
+    ];
+  };
+
+  meta = {
+    description = "Manage architecture documents and requirements as a knowledge graph";
+    homepage = "https://embedded-leadership.com/projects/sara/";
+    changelog = "https://github.com/cledouarec/sara/blob/sara-cli-v${finalAttrs.version}/sara-cli/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ yasunori0418 ];
+    mainProgram = "sara";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Adds [SARA](https://github.com/cledouarec/sara) (Solution Architecture Requirement for Alignment), a CLI that manages architecture documents and requirements as an interconnected knowledge graph. It uses plain Markdown files with YAML frontmatter as the single source of truth, providing traceability between requirements, design and implementation without a database or a proprietary format.

Homepage: https://embedded-leadership.com/projects/sara/
Changelog: https://github.com/cledouarec/sara/blob/sara-cli-v0.9.4/sara-cli/CHANGELOG.md

Packaging notes:

- Upstream is a Cargo workspace that tags `sara-cli` and `sara-core` separately. This packages the CLI, which provides the `sara` binary, so `src` follows the `sara-cli-v*` tags and `passthru.updateScript` is constrained with `--version-regex` to avoid picking up `sara-core-v*` tags.
- The CLI integration tests shell out to `git` to build fixture repositories, so `git` is added to `nativeCheckInputs`.
- One unit test (`repository::git::tests::test_is_git_repo`) asserts that the working directory is a git repository. Upstream notes this in a comment (`// This test assumes we're running from within the sara repo`), and it only holds when running from an upstream checkout rather than an unpacked tarball, so it is skipped via `checkFlags`. The remaining 283 tests pass.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

`nixpkgs-review` was run on x86_64-linux and built `sara` successfully. Being a new package, it has no reverse dependencies.

Beyond `--version` and `--help`, basic functionality was exercised end to end in a scratch git repository: `sara init swreq` generated valid frontmatter with an auto-assigned ID, `sara check` parsed the documents and reported the resulting graph, and `sara schema` exported the active model.

Upstream CI builds and tests on Linux, macOS and Windows, and the dependency tree is pure Rust with no platform-specific native dependencies, so `meta.platforms` is set to `unix`. Only x86_64-linux was tested locally; feedback from ofborg on darwin is welcome.

Automation disclosure, per the [automation/AI policy]: Claude Code (Opus 5) was used to research upstream packaging details and draft the package definition, this pull request summary, and the commit messages. All output was reviewed and the build, test suite and binary were verified locally before submission. The commits carry `Assisted-by: Claude Code (Opus 5)` trailers.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

