### PR TITLE
samrewritten: install desktop file

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14474,6 +14474,12 @@
     githubId = 32649612;
     keys = [ { fingerprint = "65DF D21C 22A9 E4CD FD1A  0804 C3D7 16E7 29B3 C86A"; } ];
   };
+  keksnino = {
+    name = "KeksNino";
+    email = "KeksNino@proton.me";
+    github = "KeksNino";
+    githubId = 87879013;
+  };
   keldu = {
     email = "mail@keldu.de";
     github = "keldu";

--- a/pkgs/by-name/sa/samrewritten/package.nix
+++ b/pkgs/by-name/sa/samrewritten/package.nix
@@ -48,6 +48,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     install -Dm644 assets/org.samrewritten.SamRewritten.gschema.xml \
       $out/share/glib-2.0/schemas/org.samrewritten.SamRewritten.gschema.xml
     glib-compile-schemas $out/share/glib-2.0/schemas
+    substituteInPlace package/samrewritten.desktop \
+      --replace-fail "/usr/bin/samrewritten" "samrewritten"
+    install -Dm644 package/samrewritten.desktop \
+      $out/share/applications/samrewritten.desktop
   '';
 
   env.PKG_CONFIG_PATH = "${openssl.dev}/lib/pkgconfig";

--- a/pkgs/by-name/sa/samrewritten/package.nix
+++ b/pkgs/by-name/sa/samrewritten/package.nix
@@ -64,7 +64,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/PaulCombal/SamRewritten";
     changelog = "https://github.com/PaulCombal/SamRewritten/releases";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ ludovicopiero ];
+    maintainers = with lib.maintainers; [ ludovicopiero keksnino ];
     platforms = [ "x86_64-linux" ];
   };
 })

--- a/pkgs/by-name/sa/samrewritten/package.nix
+++ b/pkgs/by-name/sa/samrewritten/package.nix
@@ -64,7 +64,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/PaulCombal/SamRewritten";
     changelog = "https://github.com/PaulCombal/SamRewritten/releases";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ ludovicopiero keksnino ];
+    maintainers = with lib.maintainers; [
+      ludovicopiero
+      keksnino
+    ];
     platforms = [ "x86_64-linux" ];
   };
 })


### PR DESCRIPTION
Re-added the desktop file since it was missing as of this pr: https://github.com/NixOS/nixpkgs/pull/438243
Write a comment if this should not be re-added, since its unclear to me why it was removed in the first place.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
