### PR TITLE
borgbackup: fix build failure

### DIFF
--- a/pkgs/by-name/bo/borgbackup/package.nix
+++ b/pkgs/by-name/bo/borgbackup/package.nix
@@ -4,7 +4,6 @@
   acl,
   e2fsprogs,
   fetchFromGitHub,
-  fetchpatch,
   libb2,
   lz4,
   openssh,
@@ -32,26 +31,6 @@ python.pkgs.buildPythonApplication (finalAttrs: {
     tag = finalAttrs.version;
     hash = "sha256-jkFF+nNZL8lEXgworFLNoEKTr2LgCat1fOFlTh7AWs4=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "msgspec-1.2.0-compat.patch";
-      url = "https://github.com/borgbackup/borg/commit/364438f58c86aebd157b55bd2202afaf5945e008.patch";
-      excludes = [ "docs/changes.rst" ];
-      hash = "sha256-YhZDD6i2cn7p00Dgmpqi8uGJzFZzixMZmHPcZroB1sE=";
-    })
-    (fetchpatch {
-      name = "msgspec-1.2.1-compat.patch";
-      url = "https://github.com/borgbackup/borg/commit/8abdd3b8bf065dceecd52d2b22d92b3c407a7c1d.patch";
-      excludes = [ "docs/changes.rst" ];
-      hash = "sha256-bvSRxEzNvejG6PQFkeNDuQB7Zd4/EYPEZkrgjpgQ9Ss=";
-    })
-    (fetchpatch {
-      name = "msgspec-1.2.1-unpacker-compat.patch";
-      url = "https://github.com/borgbackup/borg/commit/b09bbed3de095d6ac9d69a42a486ec18523046dc.patch";
-      hash = "sha256-F8CIqOcQOLdYn7srsev2op0pgkgt8zdkc5DQUH1c6xg=";
-    })
-  ];
 
   postPatch = ''
     # sandbox does not support setuid/setgid/sticky bits


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fix compilation of borgbackup. Resolves #546777

## Things done

(ps: I do not know how to use borgbackup. My test was just seeing the binary show help message when ran. In addition to the automated tests)
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
