### PR TITLE
svelte-check: 4.3.1 -> 4.7.4

### DIFF
--- a/pkgs/by-name/sv/svelte-check/package.nix
+++ b/pkgs/by-name/sv/svelte-check/package.nix
@@ -14,13 +14,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "svelte-check";
-  version = "4.3.1";
+  version = "4.7.4";
 
   src = fetchFromGitHub {
     owner = "sveltejs";
     repo = "language-tools";
-    tag = "svelte-check-${finalAttrs.version}";
-    hash = "sha256-+KDl7tTyXo6QMQpMGA4hSChDaPrfqfVKJXGunTlo9Rg=";
+    tag = "svelte-check@${finalAttrs.version}";
+    hash = "sha256-fjJp+4XAwUPZV8kVvgHnb1LVJbamzrboS3Taax1Vwvs=";
   };
 
   pnpmWorkspaces = [ "svelte-check..." ];
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
       ;
     inherit pnpm;
     fetcherVersion = 3;
-    hash = "sha256-43AIkVzpcq/Y+QO2k7pkr6CN340idXJEpie0gVdxra8=";
+    hash = "sha256-lzphyVC1fpT5EFIuVz7ZMAiSLeyXhjSuOpAqSklh6QU=";
   };
 
   nativeBuildInputs = [
@@ -72,7 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
     extraArgs = [
       "--use-github-releases"
       "--version-regex"
-      "svelte-check-(.*)"
+      "svelte-check@(.*)"
     ];
   };
 


### PR DESCRIPTION
## Things done

Upstream renamed the tags from svelte-check-X.Y.Z to svelte-check@X.Y.Z starting with 4.3.2, which stalled the update script.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].