### PR TITLE
{lixPackageSets.*.,}npb: init at 0-unstable-2026-07-27

### DIFF
--- a/pkgs/by-name/np/npb-unwrapped/package.nix
+++ b/pkgs/by-name/np/npb-unwrapped/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  testers,
+
+  sqlite,
+  zstd,
+
+  git,
+  perl,
+  pkg-config,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "npb-unwrapped";
+  version = "0-unstable-2026-07-27";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "samestep";
+    repo = "npb";
+    rev = "72ff3daa65418c74e953b26b7dd54e783961d721";
+    hash = "sha256-c4AVr/JczA+Q6C0PUT/iLl6jg+/ksPvjxAIYZyCGSrM=";
+  };
+
+  cargoHash = "sha256-ZFxkuhHLhZVmW6HJW6uzOFwm/VTLADJ5O/W9V2z634A=";
+
+  nativeBuildInputs = [
+    perl
+    pkg-config
+  ];
+
+  nativeCheckInputs = [ git ];
+
+  buildInputs = [
+    sqlite
+    zstd
+  ];
+
+  env = {
+    LIBSQLITE3_SYS_USE_PKG_CONFIG = true;
+    ZSTD_SYS_USE_PKG_CONFIG = true;
+    NPB_REV =
+      if finalAttrs.src.tag != null then
+        finalAttrs.src.tag
+      else if finalAttrs.src.rev != null then
+        finalAttrs.src.rev
+      else
+        "main";
+  };
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      version = "https://github.com/samestep/npb/tree/${finalAttrs.env.NPB_REV}";
+    };
+  };
+
+  meta = {
+    description = "Nixpkgs build outcome diff CLI";
+    homepage = "https://github.com/samestep/npb";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      samestep
+      dtomvan
+    ];
+    mainProgram = "npb";
+  };
+})

--- a/pkgs/by-name/np/npb/package.nix
+++ b/pkgs/by-name/np/npb/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  symlinkJoin,
+  makeWrapper,
+  npb-unwrapped,
+
+  git,
+  nix,
+  nix-eval-jobs,
+  nix-output-monitor,
+}:
+symlinkJoin (finalAttrs: {
+  pname = "npb";
+  inherit (npb-unwrapped) version;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  paths = [ npb-unwrapped ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postBuild = ''
+    wrapProgram $out/bin/npb \
+      --prefix PATH : "${lib.makeBinPath finalAttrs.passthru.runtimeDeps}"
+  '';
+
+  passthru = {
+    runtimeDeps = [
+      nix
+      nix-eval-jobs
+      nix-output-monitor
+      git
+    ];
+  };
+
+  meta = {
+    inherit (npb-unwrapped.meta)
+      description
+      homepage
+      license
+      maintainers
+      mainProgram
+      ;
+  };
+})

--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -29,6 +29,7 @@
   colmena,
   nix-update,
   nix-init,
+  npb,
   nurl,
 
   storeDir ? "/nix/store",
@@ -162,6 +163,11 @@ let
           nix-init = nix-init.override {
             nix = self.lix;
             inherit (self) nurl;
+          };
+
+          npb = npb.override {
+            nix = self.lix;
+            inherit (self) nix-eval-jobs;
           };
 
           nurl = nurl.override {


### PR DESCRIPTION
https://github.com/samestep/npb (cc @samestep)

Split into wrapped and unwrapped to prevent a full rust rebuild for any of the lix variants

Assisted-by: nix-init

TODOing because I don't know if the upstream project is ready enough yet. Just `--intent-to-add` :)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
