### PR TITLE
haskell-modules: remove usage of `with`

### DIFF
--- a/pkgs/development/haskell-modules/configuration-arm.nix
+++ b/pkgs/development/haskell-modules/configuration-arm.nix
@@ -23,9 +23,13 @@
 
 let
   inherit (pkgs) lib;
+  inherit (haskellLib)
+    dontCheck
+    dontHaddock
+    overrideCabal
+    unmarkBroken
+    ;
 in
-
-with haskellLib;
 
 self: super:
 {

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -15,7 +15,34 @@ self: super:
 
 let
   inherit (pkgs) fetchpatch lib;
-  inherit (lib) throwIfNot versionOlder;
+  inherit (lib) versionOlder;
+
+  inherit (haskellLib)
+    addBuildDepend
+    addBuildDepends
+    addBuildTool
+    addBuildTools
+    addExtraLibrary
+    addTestToolDepends
+    appendConfigureFlag
+    appendConfigureFlags
+    appendPatch
+    appendPatches
+    disableCabalFlag
+    disableHardening
+    disableLibraryProfiling
+    disableParallelBuilding
+    doDistribute
+    doJailbreak
+    dontCheck
+    dontCheckIf
+    dontDistribute
+    enableCabalFlag
+    markBroken
+    overrideCabal
+    overrideSrc
+    unmarkBroken
+    ;
 
   warnAfterVersion =
     ver: pkg:
@@ -24,8 +51,6 @@ let
     ) "override for haskellPackages.${pkg.pname} may no longer be needed" pkg;
 
 in
-
-with haskellLib;
 
 # To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead.
 {

--- a/pkgs/development/haskell-modules/configuration-darwin.nix
+++ b/pkgs/development/haskell-modules/configuration-darwin.nix
@@ -3,11 +3,18 @@
 { pkgs, haskellLib }:
 
 let
-  inherit (pkgs) lib darwin;
+  inherit (pkgs) lib;
+  inherit (haskellLib)
+    addBuildDepend
+    addExtraLibrary
+    addTestToolDepends
+    appendConfigureFlag
+    appendPatch
+    disableCabalFlag
+    dontCheck
+    overrideCabal
+    ;
 in
-
-with haskellLib;
-
 self: super:
 (
   {

--- a/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
@@ -2,19 +2,20 @@
 
 self: super:
 
-with haskellLib;
-
 let
   inherit (pkgs) lib;
 
-  warnAfterVersion =
-    ver: pkg:
-    lib.warnIf (lib.versionOlder ver
-      super.${pkg.pname}.version
-    ) "override for haskell.packages.ghc910.${pkg.pname} may no longer be needed" pkg;
-
+  inherit (haskellLib)
+    addBuildDepends
+    appendConfigureFlags
+    doDistribute
+    doJailbreak
+    dontCheck
+    dontDistribute
+    markBroken
+    overrideCabal
+    ;
 in
-
 {
   # Disable GHC core libraries
   array = null;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
@@ -5,6 +5,15 @@ self: super:
 let
   inherit (pkgs) lib;
 
+  inherit (haskellLib)
+    addBuildDepends
+    doDistribute
+    doJailbreak
+    dontCheck
+    dontCheckIf
+    overrideCabal
+    ;
+
   warnAfterVersion =
     ver: pkg:
     lib.warnIf (lib.versionOlder ver
@@ -12,9 +21,6 @@ let
     ) "override for haskell.packages.ghc912.${pkg.pname} may no longer be needed" pkg;
 
 in
-
-with haskellLib;
-
 {
   # Disable GHC core libraries
   array = null;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
@@ -5,6 +5,15 @@ self: super:
 let
   inherit (pkgs) lib;
 
+  inherit (haskellLib)
+    addBuildDepends
+    appendPatches
+    doDistribute
+    doJailbreak
+    dontCheck
+    unmarkBroken
+    ;
+
   warnAfterVersion =
     ver: pkg:
     lib.warnIf (lib.versionOlder ver
@@ -12,9 +21,6 @@ let
     ) "override for haskell.packages.ghc912.${pkg.pname} may no longer be needed" pkg;
 
 in
-
-with haskellLib;
-
 {
   # Disable GHC core libraries
   array = null;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.16.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.16.x.nix
@@ -1,10 +1,5 @@
 { pkgs, haskellLib }:
 
-let
-  inherit (pkgs) lib;
-
-in
-
 self: super: {
   # Disable GHC core libraries
   array = null;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -1,10 +1,21 @@
 { pkgs, haskellLib }:
 
 let
-  inherit (pkgs) fetchpatch lib;
+  inherit (pkgs) lib;
+
+  inherit (haskellLib)
+    addBuildDepend
+    addBuildDepends
+    doDistribute
+    doJailbreak
+    dontCheck
+    dontHaddock
+    markBroken
+    overrideCabal
+    unmarkBroken
+    ;
 in
 
-with haskellLib;
 self: super: {
   # Disable GHC core libraries.
   array = null;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -2,10 +2,22 @@
 
 self: super:
 
-with haskellLib;
-
 let
   inherit (pkgs) lib;
+
+  inherit (haskellLib)
+    addBuildDepend
+    addBuildDepends
+    appendConfigureFlag
+    appendPatch
+    appendPatches
+    doDistribute
+    doJailbreak
+    dontCheck
+    markUnbroken
+    overrideCabal
+    unmarkBroken
+    ;
 
   warnAfterVersion =
     ver: pkg:

--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -2,22 +2,21 @@
 
 self: super:
 
-with haskellLib;
-
 let
-  inherit (pkgs.stdenv.hostPlatform) isDarwin;
   inherit (pkgs) lib;
 
-  warnAfterVersion =
-    ver: pkg:
-    lib.warnIf (lib.versionOlder ver
-      super.${pkg.pname}.version
-    ) "override for haskell.packages.ghc98.${pkg.pname} may no longer be needed" pkg;
-
+  inherit (haskellLib)
+    addBuildDepend
+    addBuildDepends
+    appendConfigureFlag
+    appendPatch
+    doDistribute
+    doJailbreak
+    dontCheck
+    unmarkBroken
+    ;
 in
-
 {
-
   # Disable GHC core libraries.
   array = null;
   base = null;

--- a/pkgs/development/haskell-modules/configuration-ghcjs-9.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs-9.x.nix
@@ -1,10 +1,14 @@
 { pkgs, haskellLib }:
 
 let
-  inherit (pkgs) lib;
+  inherit (haskellLib)
+    addBuildDepend
+    addBuildDepends
+    appendPatch
+    doDistribute
+    overrideCabal
+    ;
 in
-
-with haskellLib;
 
 # cabal2nix doesn't properly add dependencies conditional on arch(javascript)
 

--- a/pkgs/development/haskell-modules/configuration-microhs.nix
+++ b/pkgs/development/haskell-modules/configuration-microhs.nix
@@ -1,7 +1,13 @@
 { pkgs, haskellLib }:
 
-with haskellLib;
-
+let
+  inherit (haskellLib)
+    addBuildDepends
+    markUnbroken
+    doDistribute
+    markBroken
+    ;
+in
 self: super: {
   # Disable MicroHs core libraries
   base = null;

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -30,10 +30,36 @@
 let
   inherit (pkgs) lib;
   canExecute = pkgs.stdenv.buildPlatform.canExecute pkgs.stdenv.hostPlatform;
+
+  inherit (haskellLib)
+    addBuildDepend
+    addBuildDepends
+    addBuildTool
+    addBuildTools
+    addExtraLibraries
+    addExtraLibrary
+    addPkgconfigDepend
+    addPkgconfigDepends
+    addTestToolDepend
+    addTestToolDepends
+    appendConfigureFlag
+    appendConfigureFlags
+    appendPatch
+    disableCabalFlag
+    disableHardening
+    doDistribute
+    doJailbreak
+    dontCheck
+    dontCheckIf
+    dontDistribute
+    enableCabalFlag
+    enableSeparateBinOutput
+    justStaticExecutables
+    overrideCabal
+    overrideSrc
+    unmarkBroken
+    ;
 in
-
-with haskellLib;
-
 # All of the overrides in this set should look like:
 #
 #   foo = ... something involving super.foo ...

--- a/pkgs/development/haskell-modules/configuration-tensorflow.nix
+++ b/pkgs/development/haskell-modules/configuration-tensorflow.nix
@@ -1,7 +1,8 @@
 { pkgs, haskellLib }:
 
-with haskellLib;
-
+let
+  inherit (haskellLib) overrideCabal;
+in
 self: super:
 let
   # This contains updates to the dependencies, without which it would

--- a/pkgs/development/haskell-modules/configuration-windows.nix
+++ b/pkgs/development/haskell-modules/configuration-windows.nix
@@ -2,9 +2,13 @@
 
 let
   inherit (pkgs) fetchpatch lib;
-in
 
-with haskellLib;
+  inherit (haskellLib)
+    addBuildDepends
+    appendConfigureFlag
+    appendPatch
+    ;
+in
 
 (self: super: {
   # cabal2nix doesn't properly add dependencies conditional on os(windows)


### PR DESCRIPTION
Inheriting from lib instead.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
