### PR TITLE
python3Packages.patchright: fix build by correcting pyproject.toml

### DIFF
--- a/pkgs/development/python-modules/patchright/default.nix
+++ b/pkgs/development/python-modules/patchright/default.nix
@@ -9,7 +9,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "patchright";
-  version = "1.58.0";
+  version = "1.61.0";
   pyproject = true;
 
   __structuredAttrs = true;
@@ -18,15 +18,15 @@ buildPythonPackage (finalAttrs: {
     owner = "Kaliiiiiiiiii-Vinyzu";
     repo = "patchright-python";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-msV0CbVbTDSAB1BgxkUOpuzQDr8vMK2/wxJy1SSUU80=";
+    hash = "sha256-2CiN1yxX0Bn+codnzb5DOVR4Dq4ZCICiUItXJjSP4n0=";
   };
+
+  # https://github.com/Kaliiiiiiiiii-Vinyzu/patchright-python/pull/120
+  patches = [ ./match-pyproject-to-package.patch ];
 
   build-system = [ setuptools ];
 
-  dependencies = [
-    playwright
-    toml
-  ];
+  # No external dependencies.
 
   # Module has no tests
   doCheck = false;

--- a/pkgs/development/python-modules/patchright/match-pyproject-to-package.patch
+++ b/pkgs/development/python-modules/patchright/match-pyproject-to-package.patch
@@ -1,0 +1,88 @@
+diff --git a/examples/pyproject.toml b/examples/pyproject.toml
+new file mode 100644
+index 0000000..8da1024
+--- /dev/null
++++ b/examples/pyproject.toml
+@@ -0,0 +1,35 @@
++# Only for test Runs, does not relate to actual Patchright package
++[project]
++name = "patchright-tests"
++version = "1.0.0"
++requires-python = ">=3.11"
++dependencies = [
++    "patchright>=1.59.1",
++]
++
++[tool.pytest.ini_options]
++addopts = "-Wall -rsx" #  -s
++markers = [
++    "skip_browser",
++    "only_browser",
++    "skip_platform",
++    "only_platform"
++]
++junit_family = "xunit2"
++asyncio_mode = "auto"
++asyncio_default_fixture_loop_scope = "session"
++asyncio_default_test_loop_scope = "session"
++
++[dependency-groups]
++dev = [
++    "autobahn>=25.12.2",
++    "pillow>=12.0.0",
++    "pixelmatch>=0.3.0",
++    "pyopenssl>=25.3.0",
++    "pytest>=9.0.2",
++    "pytest-asyncio>=1.3.0",
++    "pytest-timeout>=2.4.0",
++    "requests>=2.32.5",
++    "twisted>=25.5.0",
++    "toml>=0.10.0"
++]
+diff --git a/pyproject.toml b/pyproject.toml
+index 8da1024..ccddf76 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,35 +1,8 @@
+-# Only for test Runs, does not relate to actual Patchright package
+-[project]
+-name = "patchright-tests"
+-version = "1.0.0"
+-requires-python = ">=3.11"
+-dependencies = [
+-    "patchright>=1.59.1",
+-]
+-
+-[tool.pytest.ini_options]
+-addopts = "-Wall -rsx" #  -s
+-markers = [
+-    "skip_browser",
+-    "only_browser",
+-    "skip_platform",
+-    "only_platform"
+-]
+-junit_family = "xunit2"
+-asyncio_mode = "auto"
+-asyncio_default_fixture_loop_scope = "session"
+-asyncio_default_test_loop_scope = "session"
++[build-system]
++requires = ["setuptools>=61.0"]
++build-backend = "setuptools.build_meta"
+ 
+-[dependency-groups]
+-dev = [
+-    "autobahn>=25.12.2",
+-    "pillow>=12.0.0",
+-    "pixelmatch>=0.3.0",
+-    "pyopenssl>=25.3.0",
+-    "pytest>=9.0.2",
+-    "pytest-asyncio>=1.3.0",
+-    "pytest-timeout>=2.4.0",
+-    "requests>=2.32.5",
+-    "twisted>=25.5.0",
+-    "toml>=0.10.0"
+-]
++[project]
++name = "patchright"
++version = "1.61.0"
++description = "A patched drop-in replacement for Playwright"


### PR DESCRIPTION
Upstream supplies a `pyproject.toml` for a hypothetical `patchright_test` without specifying one for the actual package. This causes the `pythonMetadataCheckHook` to fail as it's looking for the hypothetical package.

Fixed by archiving the old `pyproject.toml` to `examples` and generating a new one.

Filed: https://github.com/Kaliiiiiiiiii-Vinyzu/patchright-python/issues/119
Upstream fix: https://github.com/Kaliiiiiiiiii-Vinyzu/patchright-python/issues/120

Supersedes #545878

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
