### PR TITLE
nix-output-monitor: 2.1.8 -> 2.2.0

### DIFF
--- a/pkgs/by-name/ni/nix-output-monitor/generated-package.nix
+++ b/pkgs/by-name/ni/nix-output-monitor/generated-package.nix
@@ -10,14 +10,15 @@
   cassava,
   containers,
   directory,
+  doctest-parallel,
   extra,
   fetchzip,
   filelock,
   filepath,
+  fsnotify,
   hermes-json,
   HUnit,
   lib,
-  MemoTrie,
   nix-derivation,
   optics,
   random,
@@ -27,7 +28,6 @@
   stm,
   streamly-core,
   strict,
-  strict-types,
   terminal-size,
   text,
   time,
@@ -38,11 +38,12 @@
 }:
 mkDerivation {
   pname = "nix-output-monitor";
-  version = "2.1.8";
+  version = "2.2.0";
   src = fetchzip {
-    url = "https://code.maralorn.de/maralorn/nix-output-monitor/archive/v2.1.8.tar.gz";
-    sha256 = "09zpz9dbllaqngkg6hz0vl4sx3kbvlp4cdk6lqa0kgszrwsdwl9r";
+    url = "https://code.maralorn.de/maralorn/nix-output-monitor/archive/v2.2.0.tar.gz";
+    sha256 = "14qlawcwi4zq586rq75msxh19nkwh3zigzl41g7gdj7fzg030rnl";
   };
+  postUnpack = "sourceRoot+=/nix-output-monitor; echo source root reset to $sourceRoot";
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
@@ -57,8 +58,8 @@ mkDerivation {
     extra
     filelock
     filepath
+    fsnotify
     hermes-json
-    MemoTrie
     nix-derivation
     optics
     relude
@@ -67,7 +68,6 @@ mkDerivation {
     stm
     streamly-core
     strict
-    strict-types
     terminal-size
     text
     time
@@ -86,8 +86,8 @@ mkDerivation {
     extra
     filelock
     filepath
+    fsnotify
     hermes-json
-    MemoTrie
     nix-derivation
     optics
     relude
@@ -96,7 +96,6 @@ mkDerivation {
     stm
     streamly-core
     strict
-    strict-types
     terminal-size
     text
     time
@@ -114,12 +113,13 @@ mkDerivation {
     cassava
     containers
     directory
+    doctest-parallel
     extra
     filelock
     filepath
+    fsnotify
     hermes-json
     HUnit
-    MemoTrie
     nix-derivation
     optics
     random
@@ -129,7 +129,6 @@ mkDerivation {
     stm
     streamly-core
     strict
-    strict-types
     terminal-size
     text
     time
@@ -139,7 +138,7 @@ mkDerivation {
   ];
   homepage = "https://code.maralorn.de/maralorn/nix-output-monitor";
   description = "Processes output of Nix commands to show helpful and pretty information";
-  license = lib.licenses.agpl3Plus;
+  license = lib.meta.getLicenseFromSpdxId "EUPL-1.2";
   mainProgram = "nom";
   maintainers = [ lib.maintainers.maralorn ];
 }

--- a/pkgs/by-name/ni/nix-output-monitor/package.nix
+++ b/pkgs/by-name/ni/nix-output-monitor/package.nix
@@ -12,7 +12,10 @@ let
 
     # nom has unit-tests and golden-tests
     # golden-tests call nix and thus can’t be run in a nix build.
-    testTargets = [ "unit-tests" ];
+    testTargets = [
+      "unit-tests"
+      "doc-tests"
+    ];
 
     buildTools = [ installShellFiles ];
     postInstall = ''

--- a/pkgs/by-name/ni/nix-output-monitor/update.sh
+++ b/pkgs/by-name/ni/nix-output-monitor/update.sh
@@ -25,6 +25,7 @@ EOF
 cabal2nix \
   --maintainer maralorn \
   "https://code.maralorn.de/maralorn/nix-output-monitor/archive/${new_version}.tar.gz" \
+  --subpath nix-output-monitor \
   >> "$derivation_file"
 
 nixfmt "$derivation_file"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Changes
https://code.maralorn.de/maralorn/nix-output-monitor/releases/tag/v2.2.0


## Things done



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
