### PR TITLE
nixos/uki: allow deviceTree to be excluded from UKI

### DIFF
--- a/nixos/modules/system/boot/uki.nix
+++ b/nixos/modules/system/boot/uki.nix
@@ -12,6 +12,8 @@ let
   inherit (pkgs.stdenv.hostPlatform) efiArch;
 
   format = pkgs.formats.ini { };
+
+  ukiSettings = lib.filterAttrsRecursive (_: v: v != null) cfg.settings;
 in
 
 {
@@ -94,7 +96,7 @@ in
           };
     };
 
-    boot.uki.configFile = lib.mkOptionDefault (format.generate "ukify.conf" cfg.settings);
+    boot.uki.configFile = lib.mkOptionDefault (format.generate "ukify.conf" ukiSettings);
 
     system.boot.loader.ukiFile =
       let


### PR DESCRIPTION
When setting `hardware.deviceTree.name` and `.enable`, a DeviceTree section is added to UKI. This is nice default behavior for arm64 systems. When `hardware.deviceTree.package` plumbs into UEFI firmware (e.g. u-boot), the UKI replaces the UEFI-supplied DTB. Besides bloating the UKI, this has the side-effect of preventing UEFI firmware from making modifications to the devicetree.

Filter out null boot.uki.settings values so that a NixOS configuration can set `boot.uki.settings.UKI.DeviceTree = null;` to remove the default behavior of packing the dtb into the UKI.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
