### PR TITLE
carps-cups: fix version, homepage, license

### DIFF
--- a/pkgs/by-name/ca/carps-cups/package.nix
+++ b/pkgs/by-name/ca/carps-cups/package.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation {
   pname = "carps-cups";
-  version = "unstable-2018-03-05";
+  version = "0-unstable-2018-03-05";
 
   src = fetchFromGitHub {
     owner = "ondrej-zary";
@@ -35,8 +35,8 @@ stdenv.mkDerivation {
 
   meta = {
     description = "CUPS Linux drivers for Canon printers";
-    homepage = "https://www.canon.com/";
-    license = lib.licenses.gpl3Plus;
+    homepage = "https://github.com/ondrej-zary/carps-cups";
+    license = lib.licenses.gpl3Only;
     broken = stdenv.hostPlatform.isDarwin;
     maintainers = with lib.maintainers; [
       ewok


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- fixed version (#541820)
- changed homepage to Github source repo
  - before it linked to https://canon.com, but as far as I can tell, this isn't affiliated with the company in any official way
- changed license to GPLv3
  - AFAIK none of the source files are tagged with license information and the repo only includes a copy of the GPLv3

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
