### PR TITLE
spidermonkey: add missing runtime inputs to update script

### DIFF
--- a/pkgs/development/interpreters/spidermonkey/update.nix
+++ b/pkgs/development/interpreters/spidermonkey/update.nix
@@ -1,6 +1,11 @@
 {
   writeShellApplication,
   common-updater-scripts,
+  coreutils,
+  curl,
+  gnugrep,
+  gnupg,
+  gnused,
   xidel,
   baseUrl ? "https://archive.mozilla.org/pub/firefox/releases/",
   version ? "",
@@ -9,6 +14,11 @@ writeShellApplication {
   name = "update-spidermonkey_${version}";
   runtimeInputs = [
     common-updater-scripts
+    coreutils
+    curl
+    gnugrep
+    gnupg
+    gnused
     xidel
   ];
 


### PR DESCRIPTION
we forgot the ambient environment leaked into these in #544248 >.>

https://nixpkgs-update-logs.nix-community.org/spidermonkey_140/2026-07-27.log

we don't think all of these are actually needed for r-ryantm but we might as well assume ≈nothing is available

## Things done

- Built on platform:
  - [x] x86_64-linux (built in the sense that we tested the update script)
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
