### PR TITLE
cider-2: capture hotfix increment in update script

### DIFF
--- a/pkgs/by-name/ci/cider-2/updater.sh
+++ b/pkgs/by-name/ci/cider-2/updater.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 LATEST_DEB=$(curl -s https://repo.cider.sh/apt/pool/main/ | \
-    grep -oP 'cider-v(\d+\.\d+\.\d+)-linux-x64\.deb' | \
+    grep -oP 'cider-v(\d+\.\d+\.\d+(?:\.\d+)?)-linux-x64\.deb' | \
     sort -rV | head -n 1)
 
 if [[ -z "$LATEST_DEB" ]]; then


### PR DESCRIPTION
Cider has so far been following a semantic versioning, but the latest hotfix release (v4.0.9.1) obliges us to consider a fourth segment in the version to prevent the update bot from returning the package to its non hotfixed version.

Ref. #543478 #546808

```console
$ pkgs/by-name/ci/cider-2/updater.sh
comparing versions 4.0.9.1 -> 4.0.9.1
Already up to date!
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
