### PR TITLE
zennotes-desktop: 2.14.0 -> 2.19.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26050,6 +26050,13 @@
     githubId = 819413;
     name = "Benedict Aas";
   };
+  showhyt = {
+    email = "mirantuten@yandex.com";
+    github = "ShowhyT";
+    githubId = 109768004;
+    keys = [ { fingerprint = "94AD E7C4 73B5 3DC7 7615  D946 3E76 7D8C 58D4 8C78"; } ];
+    name = "Miran Tuten";
+  };
   shunueda = {
     name = "Shun Ueda";
     github = "shunueda";

--- a/pkgs/by-name/ze/zennotes-desktop/package.nix
+++ b/pkgs/by-name/ze/zennotes-desktop/package.nix
@@ -13,14 +13,14 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "zennotes-desktop";
-  version = "2.14.0";
-  npmDepsHash = "sha256-7dchbcGAZm+PlVsES76sYD9NOqeCulEKC7S0zLERvvY=";
+  version = "2.19.0";
+  npmDepsHash = "sha256-z1njt74VvEpxO75bprGD3/eUsv1gH2GPIz6Svye+WYg=";
 
   src = fetchFromGitHub {
     owner = "ZenNotes";
     repo = "zennotes";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-C+doF20/PoCyCtueH9VI3Pb9CA6jOeQP1mGA1Lwd2mQ=";
+    hash = "sha256-pf90wkUMIJ9wGM8JzkTWv/CipJc0cBzeSozhKdGPCGw=";
   };
 
   npmWorkspace = "apps/desktop";
@@ -90,6 +90,7 @@ buildNpmPackage (finalAttrs: {
       justkrysteq
       Br1ght0ne
       ad030
+      showhyt
     ];
     mainProgram = "zennotes-desktop";
     platforms = lib.platforms.darwin ++ lib.platforms.linux;


### PR DESCRIPTION
## Things done

zennotes-desktop: 2.14.0 -> 2.19.0

Updates the package to the latest upstream release. The app was tested
manually and launches/works correctly.
Changelog: https://github.com/ZenNotes/zennotes/releases/tag/v2.19.0
(cumulative since 2.14.0: v2.15.0 through v2.19.0)
Also adds myself (@ShowhyT) as a maintainer of this package.

Tested on NixOS-WSL (x86_64-linux).

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].