### PR TITLE
zennotes-desktop: 2.19.0 -> 2.20.2

### DIFF
--- a/pkgs/by-name/ze/zennotes-desktop/package.nix
+++ b/pkgs/by-name/ze/zennotes-desktop/package.nix
@@ -13,14 +13,14 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "zennotes-desktop";
-  version = "2.19.0";
-  npmDepsHash = "sha256-z1njt74VvEpxO75bprGD3/eUsv1gH2GPIz6Svye+WYg=";
+  version = "2.20.2";
+  npmDepsHash = "sha256-xm9VdnjAxeCi/wyD/otqlv0ioqb53eORcELoyPY7PK8=";
 
   src = fetchFromGitHub {
     owner = "ZenNotes";
     repo = "zennotes";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-pf90wkUMIJ9wGM8JzkTWv/CipJc0cBzeSozhKdGPCGw=";
+    hash = "sha256-t2VCOSpdpfRIEuck3kiJ9SWcnQzYEHbPDDRhnX2l0+k=";
   };
 
   npmWorkspace = "apps/desktop";


### PR DESCRIPTION
Update zennotes-desktop 2.19.0 -> 2.20.2. I'm the upstream author of ZenNotes.

Retargeted from 2.20.1 to 2.20.2 while this PR awaited review, and rebased
onto current master (@ShowhyT's 2.19.0 bump landed there in the meantime,
thanks!), so it now carries only the 2.19.0 -> 2.20.2 delta with the
maintainers addition preserved.

2.20.2 is a fix release: databases on a self-hosted server could fail to
open against a server older than 2.20, because the client could not tell a
missing file apart from a failed request on servers that answer 500 for
both. 2.20.0 and 2.20.1 are skipped here (2.20.0 had a launch bug fixed
within hours by 2.20.1).

Hash provenance: `npmDepsHash` is the value our repo's own Nix packaging CI
computed and build-verified on a Nix runner (the in-repo flake builds the
same workspace from the same lockfile, and that build passed on this
release). The `src` hash matches the fetchzip hash our CI computed for the
v2.20.2 tag, and an independent NAR-serialization computation of the tag
tarball reproduces it exactly, as it does the 2.19.0 hash now on master.

Changelog: https://github.com/ZenNotes/zennotes/releases/tag/v2.20.2

## Things done

- Built on platform(s)
  - [x] x86_64-linux (equivalent derivation with these hashes build-verified
        in upstream repo CI on x86_64-linux)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
