### PR TITLE
nixos-rebuild-ng: flake repl: resolve flake url with `nix flake metadata`

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -166,6 +166,10 @@ class GenerationJson(TypedDict):
     current: bool
 
 
+class FlakeMetadataJson(TypedDict):
+    resolvedUrl: str
+
+
 @dataclass(frozen=True)
 class GroupedNixArgs:
     build_flags: Args

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -601,9 +601,8 @@ def repl_flake(flake: Flake, flake_flags: Args | None = None) -> None:
         files(__package__).joinpath(FLAKE_REPL_TEMPLATE).read_text()
     ).substitute(
         flake=flake,
-        flake_path=flake.resolve_path_if_exists(),
         # Normalize flake url to respect VSC if present:
-        flake_resolved=get_flake_metadata(flake, flake_flags)["resolvedUrl"],
+        flake_path=get_flake_metadata(flake, flake_flags)["resolvedUrl"],
         flake_attr=flake.attr,
         bold="\033[1m",
         blue="\033[34;1m",

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -19,6 +19,7 @@ from .models import (
     Action,
     BuildAttr,
     Flake,
+    FlakeMetadataJson,
     Generation,
     GenerationJson,
     ImageVariants,
@@ -576,12 +577,33 @@ def repl(build_attr: BuildAttr, nix_flags: Args | None = None) -> None:
     run_wrapper([*run_args, *dict_to_flags(nix_flags)])
 
 
+def get_flake_metadata(
+    flake: Flake, flake_flags: Args | None = None
+) -> FlakeMetadataJson:
+    r = run_wrapper(
+        [
+            "nix",
+            *FLAKE_FLAGS,
+            "flake",
+            "metadata",
+            "--json",
+            flake.resolve_path_if_exists(),
+            *dict_to_flags(flake_flags),
+        ],
+        stdout=PIPE,
+    )
+    j: FlakeMetadataJson = json.loads(r.stdout.strip())
+    return j
+
+
 def repl_flake(flake: Flake, flake_flags: Args | None = None) -> None:
     expr = Template(
         files(__package__).joinpath(FLAKE_REPL_TEMPLATE).read_text()
     ).substitute(
         flake=flake,
         flake_path=flake.resolve_path_if_exists(),
+        # Normalize flake url to respect VSC if present:
+        flake_resolved=get_flake_metadata(flake, flake_flags)["resolvedUrl"],
         flake_attr=flake.attr,
         bold="\033[1m",
         blue="\033[34;1m",

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/repl.nix.template
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/repl.nix.template
@@ -1,6 +1,6 @@
 # vim: set syntax=nix:
 let
-  flake = builtins.getFlake ''${flake_resolved}'';
+  flake = builtins.getFlake ''${flake_path}'';
   configuration = flake.${flake_attr};
   motd = ''
     $${"\n"}

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/repl.nix.template
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/repl.nix.template
@@ -1,6 +1,6 @@
 # vim: set syntax=nix:
 let
-  flake = builtins.getFlake ''${flake_path}'';
+  flake = builtins.getFlake ''${flake_resolved}'';
   configuration = flake.${flake_attr};
   motd = ''
     $${"\n"}

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -1,3 +1,4 @@
+import json
 import sys
 import textwrap
 import uuid
@@ -639,12 +640,18 @@ def test_repl(mock_run: Mock) -> None:
     mock_run.assert_called_with(["nix", "repl", "--file", Path("file.nix"), "myAttr"])
 
 
-@patch(get_qualified_name(n.run_wrapper, n), autospec=True)
+@patch(
+    get_qualified_name(n.run_wrapper, n),
+    autospec=True,
+    return_value=CompletedProcess(
+        [], 0, stdout=json.dumps({"resolvedUrl": "path:/flake.nix"})
+    ),
+)
 def test_repl_flake(mock_run: Mock) -> None:
     n.repl_flake(m.Flake("flake.nix", "myAttr"), {"nix_flag": True})
     # See nixos-rebuild-ng.tests.repl for a better test,
     # this is mostly for sanity check
-    assert mock_run.call_count == 1
+    assert mock_run.call_count == 2
 
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/545430

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`. (only `.repl` and `.linters`)
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
