### PR TITLE
system76-scheduler: 2.0.2-unstable-2025-01-15 -> 2.0.2-unstable-2026-07-22

### DIFF
--- a/pkgs/by-name/sy/system76-scheduler/package.nix
+++ b/pkgs/by-name/sy/system76-scheduler/package.nix
@@ -9,7 +9,7 @@
 }:
 
 let
-  version = "2.0.2-unstable-2025-01-15";
+  version = "2.0.2-unstable-2026-07-22";
 in
 rustPlatform.buildRustPackage {
   pname = "system76-scheduler";
@@ -17,11 +17,11 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "system76-scheduler";
-    rev = "b0b7e98b0dbd2cd05e9fe80829e7083048202da7";
-    hash = "sha256-I+LN7Q5/VQ203Vk0eKM4HZw8oSS0bkcY/wIWbu4hPnI=";
+    rev = "8651bbf74bcfc8a46443b30199b380e12defa97e";
+    hash = "sha256-V8NGJzlWvhnd5LPCjOfaB/eIXGFJDZWYhQYov1RDxkw=";
   };
 
-  cargoHash = "sha256-rTe016jxRdL3xOw6yHz8btyfnecGuPTIashKQustYP0=";
+  cargoHash = "sha256-+heUUihZaETojlyrl+nul3/KuXG88WxRzNXVgsVvaFA=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
Fixes continuous crashing by including pipewire-rs 0.10.0 bump.
See upstream changelog: https://github.com/pop-os/system76-scheduler/commit/8651bbf74bcfc8a46443b30199b380e12defa97e

Closes #546607

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
