### PR TITLE
python3Packages.pydub: don't warn on calls to ffmpeg

### DIFF
--- a/pkgs/development/python-modules/pydub/ffmpeg-fix-path.patch
+++ b/pkgs/development/python-modules/pydub/ffmpeg-fix-path.patch
@@ -1,28 +1,28 @@
 diff --git a/pydub/utils.py b/pydub/utils.py
-index 2694f90..7764b3f 100644
+index 740c500..e741100 100644
 --- a/pydub/utils.py
 +++ b/pydub/utils.py
-@@ -172,7 +172,7 @@ def get_encoder_name():
-     else:
-         # should raise exception
-         warn("Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work", RuntimeWarning)
+@@ -164,5 +164,5 @@ def get_encoder_name():
+     if which("avconv"):
+         return "avconv"
+-    elif which("ffmpeg"):
 -        return "ffmpeg"
++    elif which("@ffmpeg@"):
 +        return "@ffmpeg@"
-
-
- def get_player_name():
-@@ -186,7 +186,7 @@ def get_player_name():
      else:
-         # should raise exception
-         warn("Couldn't find ffplay or avplay - defaulting to ffplay, but may not work", RuntimeWarning)
+@@ -178,5 +178,5 @@ def get_player_name():
+     if which("avplay"):
+         return "avplay"
+-    elif which("ffplay"):
 -        return "ffplay"
++    elif which("@ffplay@"):
 +        return "@ffplay@"
-
-
- def get_prober_name():
-@@ -200,7 +200,7 @@ def get_prober_name():
      else:
-         # should raise exception
-         warn("Couldn't find ffprobe or avprobe - defaulting to ffprobe, but may not work", RuntimeWarning)
+@@ -192,5 +192,5 @@ def get_prober_name():
+     if which("avprobe"):
+         return "avprobe"
+-    elif which("ffprobe"):
 -        return "ffprobe"
++    elif which("@ffprobe@"):
 +        return "@ffprobe@"
+     else:


### PR DESCRIPTION
The replacement was done in the codepath that is a fallback that
triggers a warning. So even though the library was ultimately calling to
the right nixpkgs binaries for ffmpeg tools, each call resulted in a
confusing warning like:

Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
