### PR TITLE
nixos/dawarich: add environmentSecrets option; other misc env changes

### DIFF
--- a/nixos/modules/services/web-apps/dawarich.nix
+++ b/nixos/modules/services/web-apps/dawarich.nix
@@ -131,15 +131,7 @@ let
 
   defaultSecretKeyBaseFile = "${dataDir}/secrets/secret-key-base";
   needsGenCredentialsUnit = cfg.secretKeyBaseFile == null;
-  credentials = {
-    SECRET_KEY_BASE = lib.defaultTo defaultSecretKeyBaseFile cfg.secretKeyBaseFile;
-  }
-  // lib.optionalAttrs (cfg.database.passwordFile != null) {
-    DATABASE_PASSWORD = cfg.database.passwordFile;
-  }
-  // lib.optionalAttrs (cfg.smtp.passwordFile != null) {
-    SMTP_PASSWORD = cfg.smtp.passwordFile;
-  };
+  credentials = cfg.environmentSecrets;
   loadCredentialsIntoEnv = lib.concatMapAttrsStringSep "\n" (
     name: _: ''export ${name}="$(systemd-creds cat ${name})"''
   ) credentials;
@@ -497,6 +489,17 @@ in
         '';
       };
 
+      environmentSecrets = lib.mkOption {
+        type = with lib.types; attrsOf path;
+        default = { };
+        description = ''
+          Extra environment variables to pass to all dawarich services, loaded from the given file via systemd credentials.
+        '';
+        example = {
+          OIDC_CLIENT_SECRET = "/run/keys/dawarich-oidc-client-secret";
+        };
+      };
+
       extraEnvFiles = lib.mkOption {
         type = with lib.types; listOf path;
         default = [ ];
@@ -525,6 +528,18 @@ in
             '';
           }
         ];
+
+        services.dawarich = {
+          environmentSecrets = {
+            SECRET_KEY_BASE = lib.defaultTo defaultSecretKeyBaseFile cfg.secretKeyBaseFile;
+          }
+          // lib.optionalAttrs (cfg.database.passwordFile != null) {
+            DATABASE_PASSWORD = cfg.database.passwordFile;
+          }
+          // lib.optionalAttrs (cfg.smtp.passwordFile != null) {
+            SMTP_PASSWORD = cfg.smtp.passwordFile;
+          };
+        };
 
         environment.systemPackages = [
           dawarichConsole

--- a/nixos/modules/services/web-apps/dawarich.nix
+++ b/nixos/modules/services/web-apps/dawarich.nix
@@ -14,47 +14,6 @@ let
 
   isRedisUnixSocket = lib.hasPrefix "/" cfg.redis.host;
 
-  redisEnv =
-    if isRedisUnixSocket then
-      {
-        REDIS_URL = "unix://${config.services.redis.servers.dawarich.unixSocket}";
-      }
-    else
-      {
-        # Does not support passwords, but upstream does not provide an adequate env variable
-        # Perhaps patch or make a PR upstream in the future
-        REDIS_URL = "redis://${cfg.redis.host}:${toString cfg.redis.port}";
-      };
-
-  env = {
-    RAILS_ENV = "production";
-    NODE_ENV = "production";
-    BUNDLE_USER_HOME = "/tmp/bundle"; # will use private tmp inside systemd unit
-
-    SELF_HOSTED = "true";
-    STORE_GEODATA = "true";
-    APPLICATION_PROTOCOL = "http";
-    TIME_ZONE = config.time.timeZone; # otherwise upstream forces it to Europe/London
-    DOMAIN = cfg.localDomain;
-    APPLICATION_HOSTS = "127.0.0.1,::1,${cfg.localDomain}";
-
-    BOOTSNAP_CACHE_DIR = "/var/cache/dawarich/precompile";
-    LD_PRELOAD = "${lib.getLib pkgs.jemalloc}/lib/libjemalloc.so";
-
-    DATABASE_USER = cfg.database.user;
-    DATABASE_HOST = cfg.database.host;
-    DATABASE_NAME = cfg.database.name;
-    DATABASE_PORT = toString cfg.database.port;
-
-    SMTP_SERVER = cfg.smtp.host;
-    SMTP_PORT = toString cfg.smtp.port;
-    SMTP_FROM = cfg.smtp.fromAddress;
-    SMTP_USERNAME = cfg.smtp.user;
-    PORT = toString cfg.webPort;
-  }
-  // redisEnv
-  // cfg.environment;
-
   systemCallFilter =
     let
       allowedSystemCalls = [
@@ -147,7 +106,7 @@ let
           export RAILS_ROOT="${cfg.package}"
           exec ${lib.getExe' cfg.package "rails"} "$@"
         '';
-        env' = lib.filterAttrs (_: value: value != null) env;
+        env' = lib.filterAttrs (_: value: value != null) cfg.environment;
         supplementaryGroups = lib.optionalString (cfg.redis.createLocally && isRedisUnixSocket) (
           lib.escapeShellArg "--property=SupplementaryGroups=${config.services.redis.servers.dawarich.group}"
         );
@@ -198,7 +157,7 @@ let
         requires = lib.optional needsGenCredentialsUnit "dawarich-init-credentials.service" ++ commonUnits;
         description = "Dawarich sidekiq${jobClassLabel}";
         wantedBy = [ "dawarich.target" ];
-        environment = env // {
+        environment = cfg.environment // {
           RAILS_MAX_THREADS = threads;
         };
         script = ''
@@ -529,6 +488,42 @@ in
         ];
 
         services.dawarich = {
+          environment = {
+            RAILS_ENV = "production";
+            NODE_ENV = "production";
+            BUNDLE_USER_HOME = "/tmp/bundle"; # will use private tmp inside systemd unit
+
+            SELF_HOSTED = "true";
+            STORE_GEODATA = "true";
+            APPLICATION_PROTOCOL = "http";
+            TIME_ZONE = config.time.timeZone; # otherwise upstream forces it to Europe/London
+            DOMAIN = cfg.localDomain;
+            APPLICATION_HOSTS = "127.0.0.1,::1,${cfg.localDomain}";
+
+            BOOTSNAP_CACHE_DIR = "/var/cache/dawarich/precompile";
+            LD_PRELOAD = "${lib.getLib pkgs.jemalloc}/lib/libjemalloc.so";
+
+            DATABASE_USER = cfg.database.user;
+            DATABASE_HOST = cfg.database.host;
+            DATABASE_NAME = cfg.database.name;
+            DATABASE_PORT = toString cfg.database.port;
+
+            SMTP_SERVER = cfg.smtp.host;
+            SMTP_PORT = toString cfg.smtp.port;
+            SMTP_FROM = cfg.smtp.fromAddress;
+            SMTP_USERNAME = cfg.smtp.user;
+
+            PORT = toString cfg.webPort;
+
+            REDIS_URL =
+              if isRedisUnixSocket then
+                "unix://${config.services.redis.servers.dawarich.unixSocket}"
+              else
+                # Does not support passwords, but upstream does not provide an adequate env variable
+                # Perhaps patch or make a PR upstream in the future
+                "redis://${cfg.redis.host}:${toString cfg.redis.port}";
+          };
+
           environmentSecrets = {
             SECRET_KEY_BASE = lib.defaultTo defaultSecretKeyBaseFile cfg.secretKeyBaseFile;
           }
@@ -562,7 +557,7 @@ in
             fi
           '';
 
-          environment = env;
+          environment = cfg.environment;
           serviceConfig = {
             Type = "oneshot";
             SyslogIdentifier = "dawarich-init-dirs";
@@ -590,7 +585,7 @@ in
             rails db:seed
           '';
           path = [ cfg.package ];
-          environment = env;
+          environment = cfg.environment;
           serviceConfig = {
             Type = "oneshot";
             LoadCredential = loadCredentials;
@@ -622,7 +617,7 @@ in
           requires = lib.optional needsGenCredentialsUnit "dawarich-init-credentials.service" ++ commonUnits;
           wantedBy = [ "dawarich.target" ];
           description = "Dawarich web";
-          environment = env;
+          environment = cfg.environment;
           script = ''
             ${loadCredentialsIntoEnv}
 

--- a/nixos/modules/services/web-apps/dawarich.nix
+++ b/nixos/modules/services/web-apps/dawarich.nix
@@ -142,9 +142,7 @@ let
 
     text =
       let
-        sourceExtraEnv = lib.concatMapStrings (p: "source ${p}\n") cfg.extraEnvFiles;
         command = pkgs.writeShellScript "dawarich-rails-unwrapped" ''
-          ${sourceExtraEnv}
           ${loadCredentialsIntoEnv}
           export RAILS_ROOT="${cfg.package}"
           exec ${lib.getExe' cfg.package "rails"} "$@"
@@ -159,6 +157,7 @@ let
           ${
             lib.escapeShellArgs (map (credential: "--property=LoadCredential=${credential}") loadCredentials)
           } \
+          ${lib.escapeShellArgs (map (file: "--property=EnvironmentFile=${file}") cfg.extraEnvFiles)} \
           ${
             lib.escapeShellArgs (lib.mapAttrsToList (name: value: "--setenv=${name}=${toString value}") env')
           } \


### PR DESCRIPTION
Closes #545545

See commit descriptions for reasoning.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
