### PR TITLE
bwa-mem2: unstable-2023-03-18->2.3, add versionCheckHook

### DIFF
--- a/pkgs/by-name/bw/bwa-mem2/package.nix
+++ b/pkgs/by-name/bw/bwa-mem2/package.nix
@@ -3,18 +3,19 @@
   stdenv,
   fetchFromGitHub,
   safestringlib,
+  versionCheckHook,
   zlib,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "bwa-mem2";
-  version = "unstable-2023-03-18";
+  version = "2.3";
 
   src = fetchFromGitHub {
     owner = "bwa-mem2";
     repo = "bwa-mem2";
-    rev = "cf4306a47dac35e7e79a9e75398a35f33900cfd0";
-    hash = "sha256-hY8nLRFWt0GAElhDIcYdUX6cJrzOE3NlYRQr0tC3on4=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DBgAX18YwXbBxUlHHCDeiYJ6fcuVzLZ2ZrEta5zPsAU=";
   };
 
   buildInputs = [ zlib ];
@@ -81,6 +82,13 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  # TODO change this when https://github.com/bwa-mem2/bwa-mem2/issues/283 gets fixed
+  doInstallCheck = false;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  versionCheckProgramArg = "version";
 
   meta = {
     description = "Next version of the bwa-mem algorithm in bwa, a software package for mapping low-divergent sequences against a large reference genome";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- version upgrade (#541820)
- added `versionCheckHook`
  - disabled the install check with a note to re-enable after an issue with versioning gets fixed

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
