### PR TITLE
systemd: add `doc` output

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -97,7 +97,7 @@
   withCoredump ? true,
   withCryptsetup ? true,
   withRepart ? true,
-  withDocumentation ? true,
+  withDocumentation ? null,
   withEfi ? stdenv.hostPlatform.isEfi,
   withFido2 ? true,
   withFirstboot ? true,
@@ -191,6 +191,11 @@ assert withUkify -> (withEfi && withBootloader);
 assert withRepart -> withCryptsetup;
 assert withBootloader -> withEfi;
 
+# `warn` shoved into an `assert true` to prevent the entire file from being reformatted.
+assert lib.warnIf (withDocumentation != null) ''
+  systemd: withDocumentation has been deprecated as documentation is now unconditionally installed in the `doc` output
+'' true;
+
 let
   wantCurl = withRemote || withImportd || withImds;
 
@@ -272,7 +277,10 @@ stdenv.mkDerivation (finalAttrs: {
     "out"
     "dev"
   ]
-  ++ (lib.optional (!buildLibsOnly) "man");
+  ++ (lib.optionals (!buildLibsOnly) [
+    "man"
+    "doc"
+  ]);
   separateDebugInfo = true;
   __structuredAttrs = true;
 
@@ -634,9 +642,6 @@ stdenv.mkDerivation (finalAttrs: {
       # For compatibility with dependents that use sbin instead of bin.
       ln -s bin "$out/sbin"
     ''
-    + lib.optionalString (!withDocumentation) ''
-      rm -rf $out/share/doc
-    ''
     + lib.optionalString (withKmod && !buildLibsOnly) ''
       mv $out/lib/modules-load.d $out/example
     ''
@@ -646,15 +651,20 @@ stdenv.mkDerivation (finalAttrs: {
 
   doInstallCheck = true;
 
-  # check udev rules exposed by systemd
-  # can't use `udevCheckHook` here as that would introduce infinite recursion
   installCheckPhase = ''
     runHook preInstallCheck
 
-    ${lib.optionalString (
-      !buildLibsOnly
-    ) "$out/bin/udevadm verify --resolve-names=late --no-style $out/lib/udev/rules.d"}
-
+    if [ -e $out/share/doc ] ; then
+      echo "error: share/doc found in 'out' output (should be in 'doc')"
+      false
+    fi
+  ''
+  # check udev rules exposed by systemd
+  # can't use `udevCheckHook` here as that would introduce infinite recursion
+  + lib.optionalString (!buildLibsOnly) ''
+    $out/bin/udevadm verify --resolve-names=late --no-style $out/lib/udev/rules.d
+  ''
+  + ''
     runHook postInstallCheck
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8005,7 +8005,6 @@ with pkgs;
     withCoredump = false;
     withCryptsetup = false;
     withRepart = false;
-    withDocumentation = false;
     withEfi = false;
     withFido2 = false;
     withGcrypt = false;


### PR DESCRIPTION
Before this PR:
- `buildLibsOnly = true`: no docs
- `buildLibsOnly = false; withDocumentation = true`: docs in `out`
- `buildLibsOnly = false; withDocumentation = false`: docs installed into `out`, then removed

After this PR:
- `buildLibsOnly = true`: no docs
- `buildLibsOnly = false`: docs in `doc`

cc:
- https://github.com/NixOS/nixpkgs/issues/515268
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
