### PR TITLE
diopser: fix version

### DIFF
--- a/pkgs/by-name/di/diopser/package.nix
+++ b/pkgs/by-name/di/diopser/package.nix
@@ -29,7 +29,7 @@ let
   };
 
   juce = {
-    version = "unstable-2021-04-07";
+    version = "6.0.8-unstable-2021-04-08";
     src = fetchFromGitHub {
       owner = "juce-framework";
       repo = "JUCE";
@@ -41,7 +41,7 @@ let
 in
 stdenv.mkDerivation {
   pname = "diopser";
-  version = "unstable-2021-5-13";
+  version = "0-unstable-2021-04-13";
 
   src = fetchFromGitHub {
     owner = "robbert-vdh";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- fixed version (#541820)
  - if you want to check my dates, the commit in question is [here](https://github.com/robbert-vdh/diopser/commit/d5fdc92f1caf5a828e071dac99e106e58f06d84d)
 
Note: the upstream repo was archived in 2022.  Removing it seems harsh because a maintained version of the package is still available, but it's through a build system I'm not that familiar with, so I didn't look into it too much.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
