### PR TITLE
disk_indicator: fix version, license

### DIFF
--- a/pkgs/by-name/di/disk_indicator/package.nix
+++ b/pkgs/by-name/di/disk_indicator/package.nix
@@ -3,11 +3,15 @@
   stdenv,
   fetchFromGitHub,
   libx11,
+  installShellFiles,
 }:
 
 stdenv.mkDerivation {
   pname = "disk-indicator";
-  version = "unstable-2018-12-18";
+  version = "0.2.1-unstable-2018-12-18";
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "MeanEYE";
@@ -18,30 +22,27 @@ stdenv.mkDerivation {
 
   buildInputs = [ libx11 ];
 
+  nativeBuildInputs = [ installShellFiles ];
+
   postPatch = ''
     # avoid -Werror
-    substituteInPlace Makefile --replace "-Werror" ""
+    substituteInPlace Makefile --replace-fail "-Werror" ""
     # avoid host-specific options
-    substituteInPlace Makefile --replace "-march=native" ""
+    substituteInPlace Makefile --replace-fail "-march=native" ""
     # fix signal handler signature
     substituteInPlace src/main.c --replace-fail "void handle_signal()" "void handle_signal(int sig)"
   '';
 
-  postConfigure = ''
-    patchShebangs ./configure.sh
-    ./configure.sh --all
-  '';
+  configureScript = "./configure.sh";
 
   makeFlags = [
-    "COMPILER=${stdenv.cc.targetPrefix}cc"
+    "COMPILER=${lib.getExe stdenv.cc}"
   ];
 
   installPhase = ''
     runHook preInstall
-
-    mkdir -p "$out/bin"
-    cp ./disk_indicator "$out/bin/"
-
+    mkdir -p $out/bin
+    installBin disk_indicator
     runHook postInstall
   '';
 
@@ -53,7 +54,7 @@ stdenv.mkDerivation {
       Small program for Linux that will turn your Scroll, Caps or Num Lock LED
       or LED on your ThinkPad laptop into a hard disk activity indicator.
     '';
-    license = lib.licenses.gpl3;
+    license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- #541820
- [source for license change](https://github.com/MeanEYE/Disk-Indicator/blob/ec2d2f6833f038f07a72d15e2d52625c23e10b12/src/main.c#L12-L15)
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
