### PR TITLE
img2key: init at 2.0.0x

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14619,6 +14619,12 @@
     githubId = 59027018;
     name = "Andrey Khorokhorin";
   };
+  khitboksy = {
+    email = "khitboksy@proton.me";
+    github = "khitboksy";
+    githubId = 58287028;
+    name = "Taylor Hendrix";
+  };
   khumba = {
     email = "bog@khumba.net";
     github = "khumba";

--- a/pkgs/by-name/im/img2key/package.nix
+++ b/pkgs/by-name/im/img2key/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  bun,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+  writableTmpDirAsHomeHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "img2key";
+  version = "2.0.0x";
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Khitboksy";
+    repo = "img2key";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-D00eDU32/W3uE7SU3ASowZvtm52jS14+Rjd46GwyLHk=";
+  };
+
+  nativeBuildInputs = [
+    bun
+    writableTmpDirAsHomeHook
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    bun build --compile --target=bun --outfile=img2key ./src/main.ts
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 img2key $out/bin/img2key
+    runHook postInstall
+  '';
+
+  dontFixup = true;
+  dontStrip = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Derive deterministic passwords from images";
+    homepage = "https://github.com/Khitboksy/img2key";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "img2key";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ khitboksy ];
+  };
+})


### PR DESCRIPTION
img2key: init at 2.0.0x

Derive deterministic passwords from images using HKDF-SHA512.
https://github.com/Khitboksy/img2key

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [-] [NixOS tests] in [nixos/tests].
  - [-] [Package tests] at `passthru.tests`.
  - [-] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [-] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [-] Module addition: when adding a new NixOS module.
  - [-] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
