### PR TITLE
poetry: fix tests broken due to virtualenv update

### DIFF
--- a/pkgs/by-name/po/poetry/plugins/poetry-plugin-export.nix
+++ b/pkgs/by-name/po/poetry/plugins/poetry-plugin-export.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     owner = "python-poetry";
     repo = "poetry-plugin-export";
     tag = version;
-    hash = "sha256-KsvkM4hjG+jrdPVauXYdc6E87Gp7srMg/mJHpWRjaEs=";
+    hash = "sha256-JFP44lMmJyS55dvMtxKvqctJ2Dt1NUJ+V4un/FHkIWw=";
   };
 
   build-system = [

--- a/pkgs/by-name/po/poetry/unwrapped.nix
+++ b/pkgs/by-name/po/poetry/unwrapped.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   findpython,
   installShellFiles,
   build,
@@ -44,6 +45,17 @@ buildPythonPackage rec {
     tag = version;
     hash = "sha256-Mb1etVmBm542q7FrcMU6pzXdMUDQSpI8DFg/gbOiG4U=";
   };
+
+  patches = [
+    # since virtualenv update to 21.6.1 the poetry tests do not pass.
+    # This should be removed once the upstream PR is merged and released.
+    # See : https://github.com/python-poetry/poetry/pull/10994
+    (fetchpatch {
+      url = "https://github.com/python-poetry/poetry/commit/aedda8577cd6e7c2d2b983130933a640b1b6545a.patch";
+      hash = "sha256-n1etA9em5+kvCN4yiLwBensUb7n6asW+xrIEhA9fNaE=";
+      excludes = [ "poetry.lock" ];
+    })
+  ];
 
   build-system = [
     poetry-core


### PR DESCRIPTION
Resolves #544083

See https://github.com/python-poetry/poetry/pull/10997 for more details.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
