### PR TITLE
warpgate: 0.23.4 -> 0.26.1

### DIFF
--- a/pkgs/by-name/wa/warpgate/hardcode-version.patch
+++ b/pkgs/by-name/wa/warpgate/hardcode-version.patch
@@ -2,12 +2,18 @@ diff --git a/warpgate-common/src/version.rs b/warpgate-common/src/version.rs
 index 0e7985a..62c2b67 100644
 --- a/warpgate-common/src/version.rs
 +++ b/warpgate-common/src/version.rs
-@@ -1,8 +1,3 @@
+@@ -1,14 +1,3 @@
 -use git_version::git_version;
 -
  pub const fn warpgate_version() -> &'static str {
 -    git_version!(
--        args = ["--tags", "--always", "--dirty=-modified"],
+-        args = [
+-            "--tags",
+-            "--always",
+-            "--dirty=-modified",
+-            "--match",
+-            "v[0-9]*"
+-        ],
 -        fallback = "unknown"
 -    )
 +    "v@version@"

--- a/pkgs/by-name/wa/warpgate/package.nix
+++ b/pkgs/by-name/wa/warpgate/package.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage (
 
       patches = [ ./web-ui-package-json.patch ];
 
-      npmDepsHash = "sha256-JW3nibMIETj5PQcaNRS5UVZgguSvGd9Bw8uGD3kb5uM=";
+      npmDepsHash = "sha256-McQI5EmTfrbdcWnYRsoRHjhZphrZVaV/fN9i9MX8XF0=";
 
       nativeBuildInputs = [ openapi-generator-cli ];
 
@@ -36,16 +36,16 @@ rustPlatform.buildRustPackage (
   in
   {
     pname = "warpgate";
-    version = "0.23.4";
+    version = "0.26.1";
 
     src = fetchFromGitHub {
       owner = "warp-tech";
       repo = "warpgate";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-/IhnDBQq7Ed5vaGiCHNTcE7Uu9b9VrBN1ipCd2Tai1o=";
+      hash = "sha256-1Dg7bzhBQNe+u90Tw+kcmVaxV5IK0/t505HZr18qP5I=";
     };
 
-    cargoHash = "sha256-PRR+bzvmWcWUVdV1HqDqD08SwvDCvGXMvkIVoFEnaQI=";
+    cargoHash = "sha256-A5rRLrqlAZV/3ID8F+wUO8OP3Ocivg7vYrNDiMqRKik=";
 
     patches = [
       (replaceVars ./hardcode-version.patch { inherit (finalAttrs) version; })

--- a/pkgs/by-name/wa/warpgate/package.nix
+++ b/pkgs/by-name/wa/warpgate/package.nix
@@ -81,6 +81,7 @@ rustPlatform.buildRustPackage (
     meta = {
       description = "Smart SSH, HTTPS, MySQL and Postgres bastion that requires no additional client-side software";
       homepage = "https://warpgate.null.page";
+      changelog = "https://github.com/warp-tech/warpgate/releases/tag/v${finalAttrs.version}";
       license = lib.licenses.asl20;
       platforms = lib.platforms.linux ++ lib.platforms.darwin;
       mainProgram = "warpgate";

--- a/pkgs/by-name/wa/warpgate/package.nix
+++ b/pkgs/by-name/wa/warpgate/package.nix
@@ -7,6 +7,7 @@
   buildNpmPackage,
   openapi-generator-cli,
   nixosTests,
+  nix-update-script,
 }:
 rustPlatform.buildRustPackage (
   finalAttrs:
@@ -67,8 +68,14 @@ rustPlatform.buildRustPackage (
     # skip check, project included tests require python stuff and docker
     doCheck = false;
 
-    passthru.tests = {
-      inherit (nixosTests) warpgate;
+    passthru = {
+      inherit warpgate-web;
+      tests = {
+        inherit (nixosTests) warpgate;
+      };
+      updateScript = nix-update-script {
+        extraArgs = [ "--subpackage=warpgate-web" ];
+      };
     };
 
     meta = {

--- a/pkgs/by-name/wa/warpgate/package.nix
+++ b/pkgs/by-name/wa/warpgate/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   replaceVars,
-  fetchurl,
   fetchFromGitHub,
   rustPlatform,
   buildNpmPackage,

--- a/pkgs/by-name/wa/warpgate/remove-nightly-rustflags.patch
+++ b/pkgs/by-name/wa/warpgate/remove-nightly-rustflags.patch
@@ -2,25 +2,30 @@ diff --git a/Cargo.toml b/Cargo.toml
 index 0e92acb..d187ebc 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -100,21 +100,3 @@ strip = "debuginfo"
+@@ -1,5 +1,3 @@
+-cargo-features = ["profile-rustflags"]
+-
+ [workspace]
+ members = [
+     "warpgate",
+@@ -160,20 +158,2 @@
  [profile.coverage]
  inherits = "dev"
- # rustflags = ["-Cinstrument-coverage"]
 -
 -[profile.dev.package.aws-sdk-ec2]
--rustflags = ["-Zhint-mostly-unused"]
+-hint-mostly-unused = true
 -
 -[profile.release.package.aws-sdk-ec2]
--rustflags = ["-Zhint-mostly-unused"]
+-hint-mostly-unused = true
 -
 -[profile.dev.package.aws-sdk-rds]
--rustflags = ["-Zhint-mostly-unused"]
+-hint-mostly-unused = true
 -
 -[profile.release.package.aws-sdk-rds]
--rustflags = ["-Zhint-mostly-unused"]
+-hint-mostly-unused = true
 -
 -[profile.dev.package.aws-sdk-eks]
--rustflags = ["-Zhint-mostly-unused"]
+-hint-mostly-unused = true
 -
 -[profile.release.package.aws-sdk-eks]
--rustflags = ["-Zhint-mostly-unused"]
+-hint-mostly-unused = true


### PR DESCRIPTION
- **warpgate: add updateScript**
- **warpgate: 0.23.4 -> 0.26.1**
- **warpgate: add changelog**
- **warpgate: cleanup**

I don't have a real deployment of warpgate. Tested with NixOS test only.

This release contains a few high severity security fixes and will need to be
backported for this reason.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
