### PR TITLE
gnupg, nixos/gnupg: refactor, use upstream units

### DIFF
--- a/nixos/modules/programs/gnupg.nix
+++ b/nixos/modules/programs/gnupg.nix
@@ -111,100 +111,30 @@ in
     environment.etc."gnupg/gpg-agent.conf".source =
       agentSettingsFormat.generate "gpg-agent.conf" cfg.agent.settings;
 
-    # This overrides the systemd user unit shipped with the gnupg package
-    systemd.user.services.gpg-agent = {
-      unitConfig = {
-        Description = "GnuPG cryptographic agent and passphrase cache";
-        Documentation = "man:gpg-agent(1)";
-        Requires = [ "sockets.target" ];
-      };
-      serviceConfig = {
-        ExecStart = "${cfg.package}/bin/gpg-agent --supervised";
-        ExecReload = "${cfg.package}/bin/gpgconf --reload gpg-agent";
-      };
-    };
+    systemd.packages = [ cfg.package ];
+
+    # This overrides the systemd user units shipped with the gnupg package
+    systemd.user.services.gpg-agent = { };
 
     systemd.user.sockets.gpg-agent = {
-      unitConfig = {
-        Description = "GnuPG cryptographic agent and passphrase cache";
-        Documentation = "man:gpg-agent(1)";
-      };
-      socketConfig = {
-        ListenStream = "%t/gnupg/S.gpg-agent";
-        FileDescriptorName = "std";
-        SocketMode = "0600";
-        DirectoryMode = "0700";
-      };
       wantedBy = [ "sockets.target" ];
     };
 
     systemd.user.sockets.gpg-agent-ssh = mkIf cfg.agent.enableSSHSupport {
-      unitConfig = {
-        Description = "GnuPG cryptographic agent (ssh-agent emulation)";
-        Documentation = "man:gpg-agent(1) man:ssh-add(1) man:ssh-agent(1) man:ssh(1)";
-      };
-      socketConfig = {
-        ListenStream = "%t/gnupg/S.gpg-agent.ssh";
-        FileDescriptorName = "ssh";
-        Service = "gpg-agent.service";
-        SocketMode = "0600";
-        DirectoryMode = "0700";
-      };
       wantedBy = [ "sockets.target" ];
     };
 
     systemd.user.sockets.gpg-agent-extra = mkIf cfg.agent.enableExtraSocket {
-      unitConfig = {
-        Description = "GnuPG cryptographic agent and passphrase cache (restricted)";
-        Documentation = "man:gpg-agent(1)";
-      };
-      socketConfig = {
-        ListenStream = "%t/gnupg/S.gpg-agent.extra";
-        FileDescriptorName = "extra";
-        Service = "gpg-agent.service";
-        SocketMode = "0600";
-        DirectoryMode = "0700";
-      };
       wantedBy = [ "sockets.target" ];
     };
 
     systemd.user.sockets.gpg-agent-browser = mkIf cfg.agent.enableBrowserSocket {
-      unitConfig = {
-        Description = "GnuPG cryptographic agent and passphrase cache (access for web browsers)";
-        Documentation = "man:gpg-agent(1)";
-      };
-      socketConfig = {
-        ListenStream = "%t/gnupg/S.gpg-agent.browser";
-        FileDescriptorName = "browser";
-        Service = "gpg-agent.service";
-        SocketMode = "0600";
-        DirectoryMode = "0700";
-      };
       wantedBy = [ "sockets.target" ];
     };
 
-    systemd.user.services.dirmngr = mkIf cfg.dirmngr.enable {
-      unitConfig = {
-        Description = "GnuPG network certificate management daemon";
-        Documentation = "man:dirmngr(8)";
-        Requires = "dirmngr.socket";
-      };
-      serviceConfig = {
-        ExecStart = "${cfg.package}/bin/dirmngr --supervised";
-        ExecReload = "${cfg.package}/bin/gpgconf --reload dirmngr";
-      };
-    };
+    systemd.user.services.dirmngr = mkIf cfg.dirmngr.enable { };
 
     systemd.user.sockets.dirmngr = mkIf cfg.dirmngr.enable {
-      unitConfig = {
-        Description = "GnuPG network certificate management daemon";
-        Documentation = "man:dirmngr(8)";
-      };
-      socketConfig = {
-        ListenStream = "%t/gnupg/S.dirmngr";
-        SocketMode = "0600";
-        DirectoryMode = "0700";
-      };
       wantedBy = [ "sockets.target" ];
     };
 

--- a/pkgs/tools/security/gnupg/24.nix
+++ b/pkgs/tools/security/gnupg/24.nix
@@ -35,7 +35,7 @@
 assert guiSupport -> !enableMinimal;
 
 stdenv.mkDerivation (finalAttrs: {
-  pname = "gnupg";
+  pname = "gnupg" + lib.optionalString enableMinimal "-minimal";
   version = "2.4.9";
 
   src = fetchurl {

--- a/pkgs/tools/security/gnupg/24.nix
+++ b/pkgs/tools/security/gnupg/24.nix
@@ -34,12 +34,12 @@
 
 assert guiSupport -> !enableMinimal;
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gnupg";
   version = "2.4.9";
 
   src = fetchurl {
-    url = "mirror://gnupg/gnupg/gnupg-${version}.tar.bz2";
+    url = "mirror://gnupg/gnupg/gnupg-${finalAttrs.version}.tar.bz2";
     hash = "sha256-3RerLpoE/XnTnYU/WZy8hSBi3bmrUqTd60F2/YswKWQ=";
   };
 
@@ -103,7 +103,7 @@ stdenv.mkDerivation rec {
     # in the patch file.
     ./static.patch
   ]
-  ++ lib.map (v: "${freepgPatches}/STABLE-BRANCH-2-4-freepg/" + v) [
+  ++ lib.map (v: "${finalAttrs.freepgPatches}/STABLE-BRANCH-2-4-freepg/" + v) [
     "0002-gpg-accept-subkeys-with-a-good-revocation-but-no-sel.patch"
     "0003-gpg-allow-import-of-previously-known-keys-even-witho.patch"
     "0004-tests-add-test-cases-for-import-without-uid.patch"
@@ -206,7 +206,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "https://gnupg.org";
-    changelog = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob;f=NEWS;hb=refs/tags/gnupg-${version}";
+    changelog = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob;f=NEWS;hb=refs/tags/gnupg-${finalAttrs.version}";
     description = "Modern release of the GNU Privacy Guard, a GPL OpenPGP implementation";
     license = lib.licenses.gpl3Plus;
     longDescription = ''
@@ -227,6 +227,6 @@ stdenv.mkDerivation rec {
     teams = [ lib.teams.security-review ];
     platforms = lib.platforms.all;
     mainProgram = "gpg";
-    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnupg" version;
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnupg" finalAttrs.version;
   };
-}
+})

--- a/pkgs/tools/security/gnupg/24.nix
+++ b/pkgs/tools/security/gnupg/24.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
   version = "2.4.9";
 
   src = fetchurl {
-    url = "mirror://gnupg/gnupg/${pname}-${version}.tar.bz2";
+    url = "mirror://gnupg/gnupg/gnupg-${version}.tar.bz2";
     hash = "sha256-3RerLpoE/XnTnYU/WZy8hSBi3bmrUqTd60F2/YswKWQ=";
   };
 
@@ -206,7 +206,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "https://gnupg.org";
-    changelog = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=${pname}.git;a=blob;f=NEWS;hb=refs/tags/${pname}-${version}";
+    changelog = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob;f=NEWS;hb=refs/tags/gnupg-${version}";
     description = "Modern release of the GNU Privacy Guard, a GPL OpenPGP implementation";
     license = lib.licenses.gpl3Plus;
     longDescription = ''

--- a/pkgs/tools/security/gnupg/24.nix
+++ b/pkgs/tools/security/gnupg/24.nix
@@ -30,6 +30,8 @@
   withTpm2Tss ? !stdenv.hostPlatform.isDarwin && !enableMinimal,
   tpm2-tss,
   nixosTests,
+  runtimeShell,
+  gawk,
 }:
 
 assert guiSupport -> !enableMinimal;
@@ -143,6 +145,17 @@ stdenv.mkDerivation (finalAttrs: {
         --replace-fail "hkps://keyserver.ubuntu.com"  "hkps://keys.openpgp.org"
       substituteInPlace doc/gnupg.info-1 doc/dirmngr.texi \
         --replace-fail "https://keyserver.ubuntu.com" "https://keys.openpgp.org"
+      # Patch executables' paths in services
+      substituteInPlace doc/examples/systemd-user/*.service \
+        --replace-fail "/usr/bin" "$out/bin"
+      substituteInPlace doc/examples/systemd-user/keyboxd.service \
+        --replace-fail "/usr/lib/gnupg" "$out/libexec"
+      substituteInPlace doc/examples/systemd-user/gpg-agent-ssh.socket \
+        --replace-fail "=sh" "=${runtimeShell}" \
+        --replace-fail "gpgconf" "$out/bin/gpgconf" \
+        --replace-fail "awk" "${lib.getExe gawk}"
+      substituteInPlace doc/examples/systemd-user/gpg-agent.service \
+        --replace-fail "gpg-agent.socket" "sockets.target"
     ''
     + lib.optionalString (stdenv.hostPlatform.isLinux && withPcsc) ''
       sed -i 's,"libpcsclite\.so[^"]*","${lib.getLib pcsclite}/lib/libpcsclite.so",g' scd/scdaemon.c
@@ -192,6 +205,8 @@ stdenv.mkDerivation (finalAttrs: {
           if [[ "$(basename $f)" == "gpg-wks-client" ]]; then continue; fi
           ln -s $f $out/bin/$(basename $f)
         done
+
+        install -Dm644 -t $out/lib/systemd/user doc/examples/systemd-user/*.{service,socket}
       '';
 
   enableParallelBuilding = true;

--- a/pkgs/tools/security/gnupg/24.nix
+++ b/pkgs/tools/security/gnupg/24.nix
@@ -36,7 +36,7 @@
 assert guiSupport -> !enableMinimal;
 
 stdenv.mkDerivation (finalAttrs: {
-  pname = "gnupg";
+  pname = "gnupg" + lib.optionalString enableMinimal "-minimal";
   version = "2.4.9";
 
   src = fetchurl {

--- a/pkgs/tools/security/gnupg/24.nix
+++ b/pkgs/tools/security/gnupg/24.nix
@@ -31,6 +31,8 @@
   withTpm2Tss ? !stdenv.hostPlatform.isDarwin && !enableMinimal,
   tpm2-tss,
   nixosTests,
+  runtimeShell,
+  gawk,
 }:
 
 assert guiSupport -> !enableMinimal;
@@ -147,6 +149,17 @@ stdenv.mkDerivation (finalAttrs: {
         --replace-fail "hkps://keyserver.ubuntu.com"  "hkps://keys.openpgp.org"
       substituteInPlace doc/gnupg.info-1 doc/dirmngr.texi \
         --replace-fail "https://keyserver.ubuntu.com" "https://keys.openpgp.org"
+      # Patch executables' paths in services
+      substituteInPlace doc/examples/systemd-user/*.service \
+        --replace-fail "/usr/bin" "$out/bin"
+      substituteInPlace doc/examples/systemd-user/keyboxd.service \
+        --replace-fail "/usr/lib/gnupg" "$out/libexec"
+      substituteInPlace doc/examples/systemd-user/gpg-agent-ssh.socket \
+        --replace-fail "=sh" "=${runtimeShell}" \
+        --replace-fail "gpgconf" "$out/bin/gpgconf" \
+        --replace-fail "awk" "${lib.getExe gawk}"
+      substituteInPlace doc/examples/systemd-user/gpg-agent.service \
+        --replace-fail "gpg-agent.socket" "sockets.target"
     ''
     + lib.optionalString (stdenv.hostPlatform.isLinux && withPcsc) ''
       sed -i 's,"libpcsclite\.so[^"]*","${lib.getLib pcsclite}/lib/libpcsclite.so",g' scd/scdaemon.c
@@ -196,6 +209,8 @@ stdenv.mkDerivation (finalAttrs: {
           if [[ "$(basename $f)" == "gpg-wks-client" ]]; then continue; fi
           ln -s $f $out/bin/$(basename $f)
         done
+
+        install -Dm644 -t $out/lib/systemd/user doc/examples/systemd-user/*.{service,socket}
       '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Since the units were removed in https://github.com/gpg/gnupg/commit/eae28f1bd4a5632e8f8e85b7248d1c4d4a10a5ed, they've been reintroduced by FreePG patches ([1](https://gitlab.com/freepg/gnupg/-/blob/main/STABLE-BRANCH-2-4-freepg/0010-Ship-sample-systemd-unit-files.patch) and [2](https://gitlab.com/freepg/gnupg/-/blob/main/STABLE-BRANCH-2-4-freepg/0029-Add-keyboxd-systemd-support.patch)), but haven't been used in Nixpkgs in any sense.

Module is tested, functions well

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
