### PR TITLE
python3Packages.dynaconf: 3.2.13 -> 3.3.5

### DIFF
--- a/pkgs/by-name/an/ansible-doctor/package.nix
+++ b/pkgs/by-name/an/ansible-doctor/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   python3Packages,
   fetchFromGitHub,
+  fetchpatch,
   versionCheckHook,
   writableTmpDirAsHomeHook,
 }:
@@ -41,6 +42,21 @@ python3Packages.buildPythonApplication (finalAttrs: {
   ];
 
   pythonRelaxDeps = true;
+
+  # dynaconf >= 3.3 honours fresh_vars: those keys are re-read from the
+  # loaders on every get(), discarding the default written by the validator.
+  # Commit 70df7a0add (the dynaconf 3.3.2 bump) dropped fresh_vars; v8.3.3
+  # predates that commit, so this patch backports the change.
+  patches = lib.optionals (lib.versionOlder finalAttrs.version "8.3.4") [
+    (fetchpatch {
+      url = "https://github.com/thegeeklab/ansible-doctor/commit/70df7a0add.patch";
+      hash = "sha256-OmTKFFOgB3kaVvEowm+5/K2k/8CxLZPilQ9nmEKtEmw=";
+      excludes = [
+        "poetry.lock"
+        "pyproject.toml"
+      ];
+    })
+  ];
 
   doCheck = true;
 

--- a/pkgs/development/python-modules/dynaconf/default.nix
+++ b/pkgs/development/python-modules/dynaconf/default.nix
@@ -25,14 +25,14 @@
 
 buildPythonPackage rec {
   pname = "dynaconf";
-  version = "3.2.13";
+  version = "3.3.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "dynaconf";
     repo = "dynaconf";
     tag = version;
-    hash = "sha256-3qUGLEQ0x/WTF/M/SEts6v9w1yGYSB6LYEcxKQcbqSk=";
+    hash = "sha256-Tdz6LDDoXf6SUYZP63yanMc5uLQYa8pnZruZx9hs3fc=";
   };
 
   build-system = [ setuptools ];
@@ -60,32 +60,41 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
-    # AssertionError: assert 42.1 == 'From development env'
-    "test_envless_load_file"
+    # These tests share global state and fail when pytest-xdist runs the
+    # suite in parallel.
+    "test_extracted_validators_from_annotated"
+    "test_validator_from_types"
+    "test_default_value_from_types"
   ];
 
   disabledTestPaths = [
-    # import file mismatch
-    # imported module 'app_test' has this __file__ attribute:
-    # /build/source/tests_functional/issues/1005-key-type-error/app_test.py
-    # which is not the same as the test file we want to collect:
-    # /build/source/tests_functional/issues/994_validate_on_update_fix/app_test.py
-    "tests_functional/django_pytest_pure/app/tests"
+    # Under the full suite (pytest-xdist) the flask CLI raises NoAppException
+    # for 'dynaconf write', and a few subprocess tests fail.
+    "tests/test_cli.py"
+    # All these files are named app_test.py; pytest imports the one under
+    # 1005-key-type-error first, then rejects the others with
+    # ImportPathMismatchError.
     "tests_functional/issues/575_603_666_690__envvar_with_template_substitution/app_test.py"
     "tests_functional/issues/658_nested_envvar_override/app_test.py"
     "tests_functional/issues/835_926_enable-merge-equal-false/app_test.py"
     "tests_functional/issues/994_validate_on_update_fix/app_test.py"
-    "tests_functional/pytest_example/app/tests"
-    "tests_functional/pytest_example/flask/tests"
-    # flask.cli.NoAppException: Failed to find Flask application or factory in module 'app'
-    # Use 'app:name' to specify one
-    "tests/test_cli.py"
-    # sqlite3.OperationalError: no such table: auth_user
-    "tests_functional/django_pytest/app/tests/test_app.py::test_admin_user"
-    # unable connect port
+    # Its conftest.py shares the module name app.tests.conftest with
+    # tests_functional/legacy/django_pytest/app/tests/conftest.py, so pytest
+    # rejects it with ImportPathMismatchError.
+    "tests_functional/legacy/django_pytest_pure/app/tests"
+    # Needs pytest-django to create the auth_user table; without it the test
+    # fails with sqlite3.OperationalError: no such table: auth_user.
+    "tests_functional/legacy/django_pytest/app/tests/test_app.py::test_admin_user"
+    # Integration tests that need a running redis container.
     "tests/test_redis.py"
-    # need docker
+    # Integration tests that need a running vault container.
     "tests/test_vault.py"
+    # ImportError while importing the test module.
+    "tests/test_release_utility.py"
+    # Their conftest.py is also named tests.conftest, which clashes with
+    # tests/conftest.py.
+    "tests_functional/legacy/pytest_example_app/flask/tests"
+    "tests_functional/legacy/pytest_example_app/tests"
   ];
 
   # django.core.exceptions.ImproperlyConfigured: Requested setting LOGGING_CONFIG

--- a/pkgs/development/python-modules/dynaconf/default.nix
+++ b/pkgs/development/python-modules/dynaconf/default.nix
@@ -25,14 +25,14 @@
 
 buildPythonPackage rec {
   pname = "dynaconf";
-  version = "3.2.13";
+  version = "3.3.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "dynaconf";
     repo = "dynaconf";
     tag = version;
-    hash = "sha256-3qUGLEQ0x/WTF/M/SEts6v9w1yGYSB6LYEcxKQcbqSk=";
+    hash = "sha256-rIATIZLcvb8UtUFGjOSdNd0Wlb4CceDp9B1OdlnIlYc=";
   };
 
   build-system = [ setuptools ];
@@ -60,32 +60,41 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
-    # AssertionError: assert 42.1 == 'From development env'
-    "test_envless_load_file"
+    # These tests share global state and fail when pytest-xdist runs the
+    # suite in parallel.
+    "test_extracted_validators_from_annotated"
+    "test_validator_from_types"
+    "test_default_value_from_types"
   ];
 
   disabledTestPaths = [
-    # import file mismatch
-    # imported module 'app_test' has this __file__ attribute:
-    # /build/source/tests_functional/issues/1005-key-type-error/app_test.py
-    # which is not the same as the test file we want to collect:
-    # /build/source/tests_functional/issues/994_validate_on_update_fix/app_test.py
-    "tests_functional/django_pytest_pure/app/tests"
+    # Under the full suite (pytest-xdist) the flask CLI raises NoAppException
+    # for 'dynaconf write', and a few subprocess tests fail.
+    "tests/test_cli.py"
+    # All these files are named app_test.py; pytest imports the one under
+    # 1005-key-type-error first, then rejects the others with
+    # ImportPathMismatchError.
     "tests_functional/issues/575_603_666_690__envvar_with_template_substitution/app_test.py"
     "tests_functional/issues/658_nested_envvar_override/app_test.py"
     "tests_functional/issues/835_926_enable-merge-equal-false/app_test.py"
     "tests_functional/issues/994_validate_on_update_fix/app_test.py"
-    "tests_functional/pytest_example/app/tests"
-    "tests_functional/pytest_example/flask/tests"
-    # flask.cli.NoAppException: Failed to find Flask application or factory in module 'app'
-    # Use 'app:name' to specify one
-    "tests/test_cli.py"
-    # sqlite3.OperationalError: no such table: auth_user
-    "tests_functional/django_pytest/app/tests/test_app.py::test_admin_user"
-    # unable connect port
+    # Its conftest.py shares the module name app.tests.conftest with
+    # tests_functional/legacy/django_pytest/app/tests/conftest.py, so pytest
+    # rejects it with ImportPathMismatchError.
+    "tests_functional/legacy/django_pytest_pure/app/tests"
+    # Needs pytest-django to create the auth_user table; without it the test
+    # fails with sqlite3.OperationalError: no such table: auth_user.
+    "tests_functional/legacy/django_pytest/app/tests/test_app.py::test_admin_user"
+    # Integration tests that need a running redis container.
     "tests/test_redis.py"
-    # need docker
+    # Integration tests that need a running vault container.
     "tests/test_vault.py"
+    # ImportError while importing the test module.
+    "tests/test_release_utility.py"
+    # Their conftest.py is also named tests.conftest, which clashes with
+    # tests/conftest.py.
+    "tests_functional/legacy/pytest_example_app/flask/tests"
+    "tests_functional/legacy/pytest_example_app/tests"
   ];
 
   # django.core.exceptions.ImproperlyConfigured: Requested setting LOGGING_CONFIG


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/dynaconf/dynaconf/releases/tag/3.3.5

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
