### PR TITLE
coqPackages: small cleaning

### DIFF
--- a/pkgs/development/coq-modules/QuickChick/default.nix
+++ b/pkgs/development/coq-modules/QuickChick/default.nix
@@ -25,8 +25,8 @@
     lib.switch
       [ coq.coq-version mathcomp-boot.version ]
       [
-        (case (lib.versions.range "8.15" "9.1") lib.pred.true "2.1.1")
-        (case (lib.versions.range "8.13" "8.17") lib.pred.true "1.6.5")
+        (case (lib.versions.range "8.20" "9.1") lib.pred.true "2.1.1")
+        (case (lib.versions.range "8.13" "8.16") lib.pred.true "1.6.5")
         (case "8.13" lib.pred.true "1.5.0")
         (case "8.12" lib.pred.true "1.4.0")
         (case "8.11" lib.pred.true "1.3.2")

--- a/pkgs/development/coq-modules/simple-io/default.nix
+++ b/pkgs/development/coq-modules/simple-io/default.nix
@@ -1,56 +1,62 @@
 {
   lib,
   callPackage,
-  mkCoqDerivation,
+  mkRocqDerivation,
   coq,
+  dune,
   ExtLib,
   version ? null,
 }:
 
-(mkCoqDerivation {
-  pname = "simple-io";
-  owner = "Lysxia";
-  repo = "coq-simple-io";
-  inherit version;
-  defaultVersion =
-    let
-      case = case: out: { inherit case out; };
-    in
-    with lib.versions;
-    lib.switch coq.coq-version [
-      (case (range "8.17" "9.1") "1.11.0")
-      (case (range "8.11" "8.19") "1.8.0")
-      (case (range "8.7" "8.13") "1.3.0")
-    ] null;
-  release."1.11.0".hash = "sha256-sgbH7eI4TPHOQ5qBvM6x7G3j8B40HSEMEzFaN1G9VEw=";
-  release."1.10.0".hash = "sha256-67cBhLvRMWLWBL7NXK1zZTQC4PtSKu9qtesU4SqKkOw=";
-  release."1.8.0".hash = "sha256-3ADNeXrBIpYRlfUW+LkLHUWV1w1HFrVc/TZISMuwvRY=";
-  release."1.7.0".hash = "sha256:1a1q9x2abx71hqvjdai3n12jxzd49mhf3nqqh3ya2ssl2lj609ci";
-  release."1.3.0".hash = "sha256:1yp7ca36jyl9kz35ghxig45x6cd0bny2bpmy058359p94wc617ax";
-  mlPlugin = true;
-  nativeBuildInputs = [ coq.ocamlPackages.cppo ];
-  propagatedBuildInputs = [
-    ExtLib
-  ]
-  ++ (with coq.ocamlPackages; [
-    ocaml
-    findlib
-    ocamlbuild
-  ]);
+(mkRocqDerivation.override
+  (lib.optionalAttrs (coq.coq-version == "8.20") { dune = dune.override { version = "3.21.1"; }; })
+  {
+    useCoq = true;
+    namePrefix = [ "coq" ];
+    pname = "simple-io";
+    owner = "Lysxia";
+    repo = "coq-simple-io";
+    inherit version;
+    defaultVersion =
+      let
+        case = case: out: { inherit case out; };
+      in
+      with lib.versions;
+      lib.switch coq.coq-version [
+        (case (range "8.20" "9.1") "1.11.0")
+        (case (range "8.11" "8.16") "1.8.0")
+        (case (range "8.10" "8.13") "1.3.0")
+      ] null;
+    release."1.11.0".hash = "sha256-sgbH7eI4TPHOQ5qBvM6x7G3j8B40HSEMEzFaN1G9VEw=";
+    release."1.10.0".hash = "sha256-67cBhLvRMWLWBL7NXK1zZTQC4PtSKu9qtesU4SqKkOw=";
+    release."1.8.0".hash = "sha256-3ADNeXrBIpYRlfUW+LkLHUWV1w1HFrVc/TZISMuwvRY=";
+    release."1.7.0".hash = "sha256:1a1q9x2abx71hqvjdai3n12jxzd49mhf3nqqh3ya2ssl2lj609ci";
+    release."1.3.0".hash = "sha256:1yp7ca36jyl9kz35ghxig45x6cd0bny2bpmy058359p94wc617ax";
+    mlPlugin = true;
+    nativeBuildInputs = [ coq.ocamlPackages.cppo ];
+    propagatedBuildInputs = [
+      ExtLib
+    ]
+    ++ (with coq.ocamlPackages; [
+      ocaml
+      findlib
+      ocamlbuild
+    ]);
 
-  doCheck = true;
-  checkTarget = "test";
+    doCheck = true;
+    checkTarget = "test";
 
-  useDuneifVersion = v: (lib.versionAtLeast v "1.10.0" || v == "dev");
+    useDuneifVersion = v: (lib.versionAtLeast v "1.10.0" || v == "dev");
 
-  passthru.tests.HelloWorld = callPackage ./test.nix { };
+    passthru.tests.HelloWorld = callPackage ./test.nix { };
 
-  meta = {
-    description = "Purely functional IO for Coq";
-    license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.vbgl ];
-  };
-}).overrideAttrs
+    meta = {
+      description = "Purely functional IO for Coq";
+      license = lib.licenses.mit;
+      maintainers = [ lib.maintainers.vbgl ];
+    };
+  }
+).overrideAttrs
   (
     o:
     lib.optionalAttrs (lib.versionAtLeast o.version "1.8.0" || o.version == "dev") {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -589,7 +589,7 @@ let
               };
           in
           {
-            ppx_deriving_0_15 = ppx_deriving_ "0.15";
+            ppx_deriving_0_15 = ppx_deriving_ "0.15.0";
             ppx_deriving_0_33 = ppx_deriving_ "0.33.0";
           }
         );


### PR DESCRIPTION
Fix an evaluation issue in `coq-elpi`, remove some versions of `tsimple-io` and `QuickChick` that fail to build and fix them for Coq 8.20 by using a compatible version of dune.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
