### PR TITLE
python3Packages.{cached-property,py-evm,web3}: fix Python 3.14 build

### DIFF
--- a/pkgs/development/python-modules/cached-property/default.nix
+++ b/pkgs/development/python-modules/cached-property/default.nix
@@ -19,6 +19,13 @@ buildPythonPackage rec {
     hash = "sha256-sOThFJs18DR9aBgIpqkORU4iRmhCVKehyM3DLYUt/Wc=";
   };
 
+  patches = [
+    # fix Python 3.14, replace deprecated asyncio.iscoroutinefunction
+    # https://github.com/pydanny/cached-property/pull/359
+    # vendoring because the PR is not yet merged
+    ./python-3.14-compat.patch
+  ];
+
   build-system = [ setuptools ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/cached-property/python-3.14-compat.patch
+++ b/pkgs/development/python-modules/cached-property/python-3.14-compat.patch
@@ -1,0 +1,60 @@
+From cb1f82b160e053819f41c87fcb41a48d4d44b0ea Mon Sep 17 00:00:00 2001
+From: Petr Viktorin <encukou@gmail.com>
+Date: Thu, 2 Dec 2021 11:26:20 +0100
+Subject: [PATCH] Use iscoroutinefunction from inspect not asyncio
+
+Python 3.14 will deprecate asyncio.iscoroutinefunction:
+https://github.com/python/cpython/pull/122875
+
+inspect.iscoroutinefunction exists since 3.5 and our baseline
+is 3.8, so we can just use it unconditionally.
+
+Using a wrapper with @asyncio.coroutine in __get__ wasn't
+necessary (the future from asyncio.ensure_future is awaitable,
+and the wrapper doesn't do anything asynchronous), so the
+logic can be simplified to just call asyncio.ensure_future
+(to schedule the task and store the result when it's
+available).
+---
+ cached_property.py | 18 ++++++------------
+ 1 file changed, 6 insertions(+), 12 deletions(-)
+
+diff --git a/cached_property.py b/cached_property.py
+index e83ecca..fe06b34 100644
+--- a/cached_property.py
++++ b/cached_property.py
+@@ -4,6 +4,7 @@
+ __license__ = "BSD"
+ 
+ from functools import wraps
++from inspect import iscoroutinefunction
+ from time import time
+ import threading
+ import asyncio
+@@ -24,21 +25,14 @@ def __get__(self, obj, cls):
+         if obj is None:
+             return self
+ 
+-        if asyncio.iscoroutinefunction(self.func):
+-            return self._wrap_in_coroutine(obj)
++        if iscoroutinefunction(self.func):
++            value = asyncio.ensure_future(self.func(obj))
++        else:
++            value = self.func(obj)
+ 
+-        value = obj.__dict__[self.func.__name__] = self.func(obj)
++        obj.__dict__[self.func.__name__] = value
+         return value
+ 
+-    def _wrap_in_coroutine(self, obj):
+-        @wraps(obj)
+-        def wrapper():
+-            future = asyncio.ensure_future(self.func(obj))
+-            obj.__dict__[self.func.__name__] = future
+-            return future
+-
+-        return wrapper()
+-
+ 
+ class threaded_cached_property:
+     """

--- a/pkgs/development/python-modules/py-evm/default.nix
+++ b/pkgs/development/python-modules/py-evm/default.nix
@@ -3,7 +3,6 @@
   fetchFromGitHub,
   # python module stuff
   buildPythonPackage,
-  pythonAtLeast,
   setuptools,
   # dependencies
   cached-property,
@@ -29,9 +28,6 @@ buildPythonPackage (finalAttrs: {
   pname = "py-evm";
   version = "0.12.1-beta.1";
   pyproject = true;
-
-  # py-evm project has been archived by upstream; its support should be deprecated from "3.14".
-  disabled = pythonAtLeast "3.14";
 
   src = fetchFromGitHub {
     owner = "ethereum";

--- a/pkgs/development/python-modules/web3/default.nix
+++ b/pkgs/development/python-modules/web3/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
 
   # build-system
   setuptools,
@@ -39,15 +40,25 @@
 
 buildPythonPackage rec {
   pname = "web3";
-  version = "7.15.0";
+  version = "7.16.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ethereum";
     repo = "web3.py";
     tag = "v${version}";
-    hash = "sha256-BStkLH7lCnhVs2Fc3c0EBXzyZtEgI8ywA01OEBYLUeQ=";
+    hash = "sha256-Dgkmmx4gmVJa4P26X1waaQaKc75COC17OSeJz43EZZ0=";
   };
+
+  patches = [
+    # fix Python 3.14, avoid copying itertools.count, which is no longer supported
+    # https://github.com/ethereum/web3.py/pull/3779
+    (fetchpatch {
+      url = "https://github.com/ethereum/web3.py/commit/9923ee46cab6a49af4d7bdb3f922c4f8d9670633.patch";
+      includes = [ "web3/_utils/module_testing/utils.py" ];
+      hash = "sha256-N6v3QVDN0fCEWqs34uZ+B18+WXOPoY+Lyk9rIM+btjk=";
+    })
+  ];
 
   build-system = [ setuptools ];
 


### PR DESCRIPTION
- python3Packages.cached-property: fix Python 3.14 build
- python3Packages.py-evm: enable Python 3.14 build
- python3Packages.web3: fix Python 3.14 build

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
