### PR TITLE
octomap: fix for gcc16, clean, adopt

### DIFF
--- a/pkgs/by-name/oc/octomap/package.nix
+++ b/pkgs/by-name/oc/octomap/package.nix
@@ -49,6 +49,9 @@ stdenv.mkDerivation (finalAttrs: {
     "-Wno-error=deprecated-declarations"
   ];
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   meta = {
     description = "Probabilistic, flexible, and compact 3D mapping library for robotic systems";
     homepage = "https://octomap.github.io/";

--- a/pkgs/by-name/oc/octomap/package.nix
+++ b/pkgs/by-name/oc/octomap/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   cmake,
 }:
 
@@ -15,6 +16,29 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "v${finalAttrs.version}";
     hash = "sha256-QxQHxxFciR6cvB/b8i0mr1hqGxOXhXmB4zgdsD977Mw=";
   };
+
+  patches = [
+    (fetchpatch2 {
+      name = "prepare-for-next-patch.patch";
+      url = "https://github.com/OctoMap/octomap/commit/c5c714139a82969915b84cd5548dedcd257ebf1e.patch?full_index=1";
+      stripLen = 1;
+      excludes = [ ".gitignore" ];
+      hash = "sha256-p/qvBiqeZt93aI7p7MYG6SUwcRlchHV9AnXKVTzBhRs=";
+    })
+    # fix for gcc16, merged upstream
+    (fetchpatch2 {
+      name = "fix-gcc16.patch";
+      url = "https://github.com/OctoMap/octomap/commit/d7e54ca1c4074f88381c07bfdd685bd4fced0636.patch?full_index=1";
+      stripLen = 1;
+      hash = "sha256-8ZwX1CJFykMduEEXIqTRH9VHn7ItvO/ZfdNNDIDmtss=";
+    })
+  ];
+
+  # ref. https://github.com/OctoMap/octomap/pull/448 not merged yet
+  postPatch = ''
+    substituteInPlace include/octomap/OcTreeKey.h --replace-fail \
+      "#include <ciso646>" ""
+  '';
 
   sourceRoot = "${finalAttrs.src.name}/octomap";
 

--- a/pkgs/by-name/oc/octomap/package.nix
+++ b/pkgs/by-name/oc/octomap/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "OctoMap";
     repo = "octomap";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-QxQHxxFciR6cvB/b8i0mr1hqGxOXhXmB4zgdsD977Mw=";
   };
 
@@ -53,10 +53,14 @@ stdenv.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
 
   meta = {
+    changelog = "https://github.com/OctoMap/octomap/releases/tag/${finalAttrs.src.tag}";
     description = "Probabilistic, flexible, and compact 3D mapping library for robotic systems";
     homepage = "https://octomap.github.io/";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ lopsided98 ];
-    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
+      lopsided98
+      nim65s
+    ];
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
   };
 })


### PR DESCRIPTION
Hi,

This fix: https://hydra.nixos.org/build/339241756/nixlog/2
```cpp
In file included from /build/source/octomap/include/octomap/OcTreeKey.h:40,
                 from /build/source/octomap/include/octomap/OcTreeBaseImpl.h:45,
                 from /build/source/octomap/include/octomap/OccupancyOcTreeBase.h:44,
                 from /build/source/octomap/include/octomap/OcTree.h:38,
                 from /build/source/octomap/src/AbstractOcTree.cpp:36:
/nix/store/lp6jmy0pivyi2kafijwaryk0dp04hafp-gcc-16.1.0/include/c++/16.1.0/ciso646:49:6: error: #warning "<ciso646> is not a standard header since C++20, use <version> to detect implementation-specific macros" [[-Werror=cpp](https://gcc.gnu.org/onlinedocs/gcc-16.1.0/gcc/Warning-Options.html#index-Wcpp)]
   49 | #    warning "<ciso646> is not a standard header since C++20, use <version> to detect implementation-specific macros"
      |      ^~~~~~~
```

ref #537781

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
