### PR TITLE
python3Packages.home-assistant-chip-wheels: fix cross compilation

### DIFF
--- a/pkgs/development/python-modules/home-assistant-chip-wheels/default.nix
+++ b/pkgs/development/python-modules/home-assistant-chip-wheels/default.nix
@@ -1,65 +1,24 @@
 {
-  aiohttp,
-  alive-progress,
-  ast-serialize,
   build,
   clang-tools,
   click,
-  colorama,
-  coloredlogs,
-  cryptography,
-  debugpy,
-  diskcache,
   fetchFromGitHub,
   fetchpatch,
   glib,
   gn,
-  googleapis-common-protos,
-  ipython,
   jinja2,
-  json5,
-  jsonschema,
   lark,
   lib,
   libnl,
-  mobly,
-  mypy,
-  mypy-protobuf,
   ninja,
   openssl,
-  packaging,
-  parameterized,
   pip-tools,
   pkg-config,
   pkgconfig,
-  prompt-toolkit,
-  protobuf,
-  psutil,
-  ptpython,
-  pyelftools,
-  pyfakefs,
-  pygments,
-  pykwalify,
-  pyperclip,
-  pyserial,
   python,
-  python-daemon,
   python-path,
-  pyyaml,
-  requests,
   setuptools,
-  six,
-  sphinx,
-  sphinx-argparse,
-  sphinx-design,
   stdenv,
-  tabulate,
-  tomli,
-  tornado,
-  types-pyyaml,
-  types-requests,
-  watchdog,
-  websockets,
   zap-chip,
 }:
 
@@ -194,54 +153,57 @@ stdenv.mkDerivation rec {
   env.PIP_NO_INDEX = "1";
   env.PIP_FIND_LINKS =
     let
-      dependencies = [
-        aiohttp
-        alive-progress
-        ast-serialize
-        colorama
-        coloredlogs
-        click
-        cryptography
-        debugpy
-        diskcache
-        googleapis-common-protos
-        ipython
-        jinja2
-        json5
-        jsonschema
-        lark
-        mobly
-        mypy
-        mypy-protobuf
-        packaging
-        parameterized
-        pkgconfig
-        prompt-toolkit
-        protobuf
-        psutil
-        ptpython
-        pyfakefs
-        pyelftools
-        pygments
-        pykwalify
-        pyperclip
-        pyserial
-        python-daemon
-        python-path
-        pyyaml
-        requests
-        six
-        sphinx
-        sphinx-argparse
-        sphinx-design
-        tabulate
-        tomli
-        tornado
-        types-pyyaml
-        types-requests
-        watchdog
-        websockets
-      ];
+      # these packages are needed at build-time, so we need to pull them from pythonOnBuildForHost
+      dependencies = lib.attrValues {
+        inherit (python.pythonOnBuildForHost.pkgs)
+          aiohttp
+          alive-progress
+          ast-serialize
+          colorama
+          coloredlogs
+          click
+          cryptography
+          debugpy
+          diskcache
+          googleapis-common-protos
+          ipython
+          jinja2
+          json5
+          jsonschema
+          lark
+          mobly
+          mypy
+          mypy-protobuf
+          packaging
+          parameterized
+          pkgconfig
+          prompt-toolkit
+          protobuf
+          psutil
+          ptpython
+          pyfakefs
+          pyelftools
+          pygments
+          pykwalify
+          pyperclip
+          pyserial
+          python-daemon
+          python-path
+          pyyaml
+          requests
+          six
+          sphinx
+          sphinx-argparse
+          sphinx-design
+          tabulate
+          tomli
+          tornado
+          types-pyyaml
+          types-requests
+          watchdog
+          websockets
+          ;
+      };
       filterNull = list: lib.filter (dep: dep != null) list;
       toItem = dep: {
         inherit dep;
@@ -272,6 +234,8 @@ stdenv.mkDerivation rec {
     ''target_cc="${stdenv.cc.targetPrefix}cc"''
     ''target_cxx="${stdenv.cc.targetPrefix}c++"''
     ''target_ar="${stdenv.cc.targetPrefix}ar"''
+    # Needed for cross-compilation
+    ''pkg_config="${stdenv.cc.targetPrefix}pkg-config"''
   ];
 
   preBuild = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixed cross compilation for home-assistant-chip-wheels
Two changes in this patch:
- Added pkg config path in gnFlags because it wasnt found automatically in cross compilation environment
- Use packages from the pythonOnBuildForHost set for the build-time venv

I'm not really familiar with python nor with hacw build process so that might not be the best way to do it, but hey it works :) 

Also not sure if it qualifies as proper testing but my cross-compiled home-assistant installation works pretty well!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
  - [x] cross x86_64-linux -> aarch64-multiplatform
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
