### PR TITLE
nixos/nginx: add missing types from the referenced compression configs

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -48,8 +48,11 @@ let
     "application/ld+json"
     "application/manifest+json"
     "application/rdf+xml"
+    "application/rss+xml" # What the default (mailcap) mime.types maps ".rss" to
+    "application/vnd.api+json"
     "application/vnd.ms-fontobject"
     "application/wasm"
+    "application/x-javascript" # Legacy alias of "application/javascript", still emitted by some upstreams
     "application/x-rss+xml"
     "application/x-web-app-manifest+json"
     "application/xhtml+xml"
@@ -61,6 +64,8 @@ let
     "image/bmp"
     "image/svg+xml"
     "image/vnd.microsoft.icon"
+    "image/x-icon" # What nginx's own mime.types maps ".ico" to, see services.nginx.defaultMimeTypes
+    "image/x-ms-bmp" # What nginx's own mime.types maps ".bmp" to, see services.nginx.defaultMimeTypes
     "text/cache-manifest"
     "text/calendar"
     "text/css"
@@ -72,6 +77,7 @@ let
     "text/vnd.rim.location.xloc"
     "text/vtt"
     "text/x-component"
+    "text/x-cross-domain-policy"
     "text/xml"
   ];
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1183,6 +1183,7 @@ in
   nghttpx = runTest ./nghttpx.nix;
   nginx = runTest ./nginx.nix;
   nginx-auth = runTest ./nginx-auth.nix;
+  nginx-compression = runTest ./nginx-compression.nix;
   nginx-etag = runTest ./nginx-etag.nix;
   nginx-etag-compression = runTest ./nginx-etag-compression.nix;
   nginx-globalredirect = runTest ./nginx-globalredirect.nix;

--- a/nixos/tests/nginx-compression.nix
+++ b/nixos/tests/nginx-compression.nix
@@ -1,0 +1,80 @@
+{ lib, ... }:
+let
+  # defaultMimeTypes holds file extensions, selected by the property that nginx's mime.types maps
+  # each one to a MIME type that gzip ought to cover. The test doesn't assert a specific
+  # Content-Type but the actual file extension, so that if requesting test.rss, nginx already knows
+  # this will have Content-Type: application/rss+xml and the test will check it is gzipped, without
+  # hardcoding the content type.
+  compressible = [
+    "atom"
+    "bmp"
+    "css"
+    "eot"
+    "html"
+    "ico"
+    "js"
+    "json"
+    "rss"
+    "svg"
+    "txt"
+    "wasm"
+    "xhtml"
+    "xml"
+  ];
+
+  # Formats that are already compressed and must be served verbatim.
+  incompressible = [
+    "jpg"
+    "png"
+    "zip"
+  ];
+in
+{
+  name = "nginx-compression";
+
+  containers.machine =
+    { pkgs, ... }:
+    {
+      services.nginx = {
+        enable = true;
+        recommendedGzipSettings = true;
+        virtualHosts.default.root = pkgs.runCommandLocal "nginx-compression-testdir" { } ''
+          mkdir "$out"
+          for ext in ${lib.concatStringsSep " " (compressible ++ incompressible)}; do
+            # Well past gzip_min_length, and trivially compressible.
+            printf 'the quick brown fox jumps over the lazy dog\n%.0s' {1..32} > "$out/test.$ext"
+          done
+        '';
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("nginx")
+    machine.wait_for_open_port(80)
+
+    def probe(ext):
+        out = machine.succeed(
+            "curl -sSf -o /dev/null -H 'Accept-Encoding: gzip' "
+            "-w '%{content_type}|%header{content-encoding}' "
+            f"http://127.0.0.1/test.{ext}"
+        )
+        content_type, _, encoding = out.partition("|")
+        return content_type.strip(), encoding.strip()
+
+    with subtest("compressible types are gzipped"):
+        for ext in ${builtins.toJSON compressible}:
+            content_type, encoding = probe(ext)
+            assert encoding == "gzip", (
+                f".{ext} is served as {content_type} but came back uncompressed "
+                f"(content-encoding: {encoding}); is that type in compressMimeTypes?"
+            )
+
+    with subtest("already compressed types are served verbatim"):
+        for ext in ${builtins.toJSON incompressible}:
+            content_type, encoding = probe(ext)
+            assert encoding == "", (
+                f".{ext} is served as {content_type} and should not be recompressed, "
+                f"but content-encoding was {encoding}"
+            )
+  '';
+}


### PR DESCRIPTION
compressMimeTypes documents itself as being taken from the ngx_brotli sample configuration and h5bp/server-configs-nginx, but had drifted from both.

What had bitten me was `application/rss+xml`, which was missing while "application/x-rss+xml" (the older, non-standard spelling) was present. Also add the remaining types those references recommend and were not actually included.

Claude helped produce tests for it.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
