### PR TITLE
paperless-ngx: unpin Python

### DIFF
--- a/nixos/tests/paperless.nix
+++ b/nixos/tests/paperless.nix
@@ -35,6 +35,9 @@
                 };
               };
             };
+
+            # OOMs randomly otherwise. ✨️AI✨️ or something idk.
+            virtualisation.memorySize = 2048;
           };
         postgres = {
           imports = [ self.simple ];

--- a/pkgs/by-name/pa/paperless-ngx/package.nix
+++ b/pkgs/by-name/pa/paperless-ngx/package.nix
@@ -7,8 +7,7 @@
   callPackage,
   nixosTests,
   gettext,
-  # tests fail and eventually lock up on 3.14
-  python313Packages,
+  python3Packages,
   ghostscript_headless,
   imagemagickBig,
   jbig2enc,
@@ -32,7 +31,7 @@ let
     ocrmypdf = prev.ocrmypdf.override { tesseract = tesseract5; };
   };
 
-  pythonPackages = python313Packages.overrideScope (
+  pythonPackages = python3Packages.overrideScope (
     final: prev:
     lib.composeManyExtensions [ defaultPythonPackageOverrides extraPythonPackageOverrides ] final prev
   );


### PR DESCRIPTION
It seems to build fine on 3.14 now.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
