### PR TITLE
python3Packages.countryinfo: fix build

### DIFF
--- a/pkgs/development/python-modules/countryinfo/default.nix
+++ b/pkgs/development/python-modules/countryinfo/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   poetry-core,
   pydantic,
+  pyprojectVersionPatchHook,
   pytestCheckHook,
   typer,
 }:
@@ -28,6 +29,8 @@ buildPythonPackage (finalAttrs: {
     pydantic
     typer
   ];
+
+  nativeBuildInputs = [ pyprojectVersionPatchHook ];
 
   pythonImportsCheck = [ "countryinfo" ];
 


### PR DESCRIPTION
## Things done

Patches the `pyproject.toml` version [that is not properly set upstream](https://github.com/porimol/countryinfo/blob/32168b1de5f047c06031bb8b5d275ca4a17d2aef/pyproject.toml#L3). Fix the build failure introduced by the new metadata check phase.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
