### PR TITLE
zabbix: 6.0.47 -> 6.0.48; 7.0.28 -> 7.0.29; 7.4.12 -> 7.4.13

### DIFF
--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -1,7 +1,7 @@
 generic: {
   v74 = generic {
-    version = "7.4.12";
-    hash = "sha256-LGBinl3OYfUDAmyZ2KksL2at4y7v2Ji6XZAA/enrndA=";
+    version = "7.4.13";
+    hash = "sha256-68T7BUr5GbEjYi/uqdTDmXEc8FB+8ZPi3tdnE6gO48Y=";
   };
   v70 = generic {
     version = "7.0.28";

--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -8,7 +8,7 @@ generic: {
     hash = "sha256-GE0DRU1/8tSfodKSCCrTNbzpB7oi4w1UA10FMpcIzjI=";
   };
   v60 = generic {
-    version = "6.0.47";
-    hash = "sha256-OxmVVCablDeDLogGq9dnNYHHfWhl3XZgoDa7oKgUuQ0=";
+    version = "6.0.48";
+    hash = "sha256-cIibBi7O1e5YKjznoyli/lq7gX/UhoPEc8K8a1kDZJw=";
   };
 }

--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -4,8 +4,8 @@ generic: {
     hash = "sha256-68T7BUr5GbEjYi/uqdTDmXEc8FB+8ZPi3tdnE6gO48Y=";
   };
   v70 = generic {
-    version = "7.0.28";
-    hash = "sha256-AgomSaRQpkLD10V361g+wXX0vYXr4sPTnt45lIfh2jM=";
+    version = "7.0.29";
+    hash = "sha256-GE0DRU1/8tSfodKSCCrTNbzpB7oi4w1UA10FMpcIzjI=";
   };
   v60 = generic {
     version = "6.0.47";


### PR DESCRIPTION
https://www.zabbix.com/rn/rn7.4.13
https://www.zabbix.com/rn/rn7.0.29
https://www.zabbix.com/rn/rn6.0.48

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
