### PR TITLE
gs1200-exporter: add updateScript

### DIFF
--- a/pkgs/by-name/gs/gs1200-exporter/package.nix
+++ b/pkgs/by-name/gs/gs1200-exporter/package.nix
@@ -3,24 +3,29 @@
   buildGoModule,
   fetchFromGitHub,
   nixosTests,
+  nix-update-script,
 }:
 buildGoModule rec {
   pname = "gs1200-exporter";
   version = "2.11.13";
   __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "robinelfrink";
     repo = "gs1200-exporter";
     tag = "v${version}";
     hash = "sha256-s+CdJBa9k4DBYBiwEAtWJz1r6DvDQtZR+dEB3FBSu3g=";
   };
+
   vendorHash = "sha256-R8is2TM2npCY1eOTRsL1spTJWf/KiBqHpjr4EjraLeU=";
-  postPatch = ''
-    substituteInPlace go.mod --replace-fail "go 1.26.4" "go 1.26.3"
-  '';
-  passthru.tests = {
-    inherit (nixosTests) gs1200-exporter;
+
+  passthru = {
+    tests = {
+      inherit (nixosTests) gs1200-exporter;
+    };
+    updateScript = nix-update-script { };
   };
+
   meta = {
     description = "Prometheus exporter for Zyxel GS1200 switches";
     homepage = "https://github.com/robinelfrink/gs1200-exporter";


### PR DESCRIPTION
## Things done
- Added `passthru.updateScript = nix-update-script { }` so the package can be auto-updated
- Removed the `postPatch` pinning `go.mod`'s `go` directive to 1.26.3 — nixpkgs' `go` is now 1.26.5, newer than upstream's declared 1.26.4, so the patch is no longer necessary
- Verified `nix build .#gs1200-exporter` succeeds and `nix-update gs1200-exporter --version=skip` runs cleanly

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- [x] Follows the [automation/AI policy].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

Assisted-by: Claude Sonnet 5 (Anthropic), used to help draft and verify the `passthru.updateScript` addition and confirm the `postPatch` was no longer needed.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test