### PR TITLE
flatcc: 0.6.1 -> 0.6.3

### DIFF
--- a/pkgs/by-name/fl/flatcc/package.nix
+++ b/pkgs/by-name/fl/flatcc/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   versionCheckHook,
   nix-update-script,
@@ -10,68 +9,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "flatcc";
-  version = "0.6.1";
+  version = "0.6.3";
 
+  __structuredAttrs = true;
   strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "dvidelabs";
     repo = "flatcc";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-0/IZ7eX6b4PTnlSSdoOH0FsORGK9hrLr1zlr/IHsJFQ=";
+    hash = "sha256-kDZ05r/k15peBLGG2jzyeKwrdTn3+1PWrrDUmC3SV50=";
   };
-
-  patches = [
-    # Fix builds on clang15. Remove post-0.6.1.
-    (fetchpatch {
-      name = "clang15fixes.patch";
-      url = "https://github.com/dvidelabs/flatcc/commit/5885e50f88248bc7ed398880c887ab23db89f05a.patch";
-      hash = "sha256-z2HSxNXerDFKtMGu6/vnzGRlqfz476bFMjg4DVfbObQ";
-    })
-    # Bump cmake to 2.8.12, required fox 3.16 patch
-    (fetchpatch {
-      name = "bump-cmake-version.patch";
-      url = "https://github.com/dvidelabs/flatcc/commit/5f07eda43caabd81a2bfa2857af0e3f26dc6d4ee.patch?full_index=1";
-      hash = "sha256-eRlkQw+YGRgCUjrlYB3I8w+/cPuJhgEfNUW/+TZhHlI=";
-    })
-    # Bump min. CMake to 3.16 and fix custom build rules
-    (fetchpatch {
-      name = "fix-cmake-version.patch";
-      url = "https://github.com/dvidelabs/flatcc/commit/385c27b23236dff7ad4fa35c59fd4f9143dcaae6.patch?full_index=1";
-      hash = "sha256-ORDby2LRRQdFrNc1owHKxo0TfMIxISj5SuD5oqvDFFo=";
-      excludes = [
-        "README.md"
-        "CHANGELOG.md"
-        "test/doublevec_test/CMakeLists.txt"
-        "test/monster_test_cpp/CMakeLists.txt"
-      ];
-    })
-  ]
-  ++ lib.optionals stdenv.cc.isClang [
-    # Fix clang compilation
-    # https://github.com/dvidelabs/flatcc/pull/273
-    (fetchpatch {
-      name = "fix-c23-fallthrough.patch";
-      url = "https://github.com/dvidelabs/flatcc/commit/7c199e3b191a6f714694035f1eba40112e71675c.patch";
-      hash = "sha256-kGupiMVa2r+hsQnknatRK+EfscNjJD0T75NY1ELkJ5U=";
-    })
-
-    # Fix implicit int conversion on negation for int8/int16
-    # https://github.com/dvidelabs/flatcc/commit/5df663837c93eb7516890c27574dcc4b042890cb
-    (fetchpatch {
-      name = "fix-pprintint-implicit-int-conversion.patch";
-      url = "https://github.com/dvidelabs/flatcc/commit/5df663837c93eb7516890c27574dcc4b042890cb.patch";
-      hash = "sha256-pntpatUDkZbj5pEViA8jDvXP+9KNdfhUDQCUd598Lxg=";
-      excludes = [ "CHANGELOG.md" ];
-    })
-  ];
-
-  postPatch = ''
-    substituteInPlace include/flatcc/portable/grisu3_print.h \
-      --replace-fail \
-        'static char hexdigits[16] = "0123456789ABCDEF";' \
-        "static char hexdigits[16] = {'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F'};"
-  '';
 
   nativeBuildInputs = [ cmake ];
 


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/dvidelabs/flatcc/compare/v0.6.1...v0.6.3
Changelog: https://github.com/dvidelabs/flatcc/blob/v0.6.3/CHANGELOG.md

cc @onny

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test