### PR TITLE
nixos/tests/paperless: remove snarky comment

### DIFF
--- a/nixos/tests/paperless.nix
+++ b/nixos/tests/paperless.nix
@@ -36,7 +36,7 @@
               };
             };
 
-            # OOMs randomly otherwise. ✨️AI✨️ or something idk.
+            # OOMs randomly otherwise
             virtualisation.memorySize = 2048;
           };
         postgres = {


### PR DESCRIPTION
Paperless is a complex software and does many things including local AI. It surely did not reduce the memory usage, but the feature is not activated in the test, so python only loads the dependencies. Probably lazy imports will help here in the future.

But why do I remove that again? For many people managing documents sucks and is a task they try to avoid and postpone, including me. Doing applications to get the money you are entitled to sucks and I personally know and can understand why some do not hand in applications and leave money on the table. I have some hopes that paperless can be a support for them, to not leave money on the table and lets be real: most of those applications are only checked for plausibility and a theater dance. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
