### PR TITLE
pulumi: 3.253.0 → 3.255.0

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -653,6 +653,16 @@ with lib.maintainers;
     enableFeatureFreezePing = true;
   };
 
+  pulumi = {
+    scope = "Maintains the Pulumi IaC tool and its language-specific SDKs";
+    shortName = "Pulumi";
+    members = [
+      nicoo
+      tie
+      untio11
+    ];
+  };
+
   python = {
     members = [
       hexa

--- a/pkgs/by-name/pu/pulumi/package.nix
+++ b/pkgs/by-name/pu/pulumi/package.nix
@@ -17,18 +17,18 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "pulumi";
-  version = "3.253.0";
+  version = "3.255.0";
 
   src = fetchFromGitHub {
     owner = "pulumi";
     repo = "pulumi";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ZwK9IXuKD583MJ+6VG9CsrEIwh4aJGBlCXys/TYfrmg=";
+    hash = "sha256-G1AC+vPxCJRt6Iv82Y37rONgeE9E3eiEZdrqRBc4Gcs=";
     # Some tests rely on checkout directory name
     name = "pulumi";
   };
 
-  vendorHash = "sha256-5HYYesdKfZqCqDNrD2LZc25hxrczxRV/jsMXWeFT6fc=";
+  vendorHash = "sha256-aUnqpnf1Svy8hbp6s+sZvQ5sA3FSt59VnhuVyoggi2s=";
 
   sourceRoot = "${finalAttrs.src.name}/pkg";
 
@@ -86,6 +86,10 @@ buildGoModule (finalAttrs: {
         "TestNewCmdYesWritesMinimalPulumiYAMLWithExplicitName"
         "TestNewCmdYesSanitizesDefaultDirectoryName"
         "TestNewCmdYesUsesCurrentDirectoryNameByDefault"
+        "TestRetrieveStandardTemplate"
+        "TestRetrieveHttpsTemplate"
+        "TestRetrieveNonExistingTemplate"
+        "TestRetrieveNonExistingTemplateSimilar"
 
         # Connects to https://api.pulumi.com/…
         "TestGetLatestPluginIncludedVersion"
@@ -153,6 +157,8 @@ buildGoModule (finalAttrs: {
         # Requires invoking pulumi binary.
         "TestDecryptEncryptedLog"
         "TestDecryptGzipLog"
+        "TestShareEncryptedLogIntegration"
+        "TestShareGzipLogIntegration"
 
         # Requires unavailable access token.
         "TestRunNewYesWithAILanguage"

--- a/pkgs/by-name/pu/pulumi/package.nix
+++ b/pkgs/by-name/pu/pulumi/package.nix
@@ -240,11 +240,6 @@ buildGoModule (finalAttrs: {
     sourceProvenance = [ lib.sourceTypes.fromSource ];
     license = lib.licenses.asl20;
     mainProgram = "pulumi";
-    maintainers = with lib.maintainers; [
-      nicoo
-      tie
-      untio11
-      veehaitch
-    ];
+    maintainers = lib.teams.pulumi.members;
   };
 })

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-bun/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-bun/package.nix
@@ -39,8 +39,11 @@ symlinkJoin (finalAttrs: {
     description = "Language host for Pulumi programs written in TypeScript & JavaScript (Bun)";
     license = lib.licenses.asl20;
     mainProgram = "pulumi-language-bun";
-    maintainers = with lib.maintainers; [
-      niklasravnsborg
-    ];
+    maintainers =
+      with lib.maintainers;
+      lib.teams.pulumi.members
+      ++ [
+        niklasravnsborg
+      ];
   };
 })

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-go/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-go/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/sdk/go/pulumi-language-go";
 
-  vendorHash = "sha256-NTIOTy6pLJgnxI6AP87Nfljr551fvih/b9c59VYg3PA=";
+  vendorHash = "sha256-rDrxbojnaywJ9JDjQi2GrHw33wYHnP2vWXNfJIay5rs=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-nodejs/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-nodejs/package.nix
@@ -12,7 +12,7 @@ buildGoModule (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/sdk/nodejs/cmd/pulumi-language-nodejs";
 
-  vendorHash = "sha256-q+7Qm3HL2avVtx29Cz066BOD7tgyukEwj1FinzmEdw8=";
+  vendorHash = "sha256-41+98hPcHS6AkTpr0hhof6+2t9+2EmSRXW9zbKCTUlI=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-nodejs/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-nodejs/package.nix
@@ -51,9 +51,6 @@ buildGoModule (finalAttrs: {
     description = "Language host for Pulumi programs written in TypeScript & JavaScript (Node.js)";
     license = lib.licenses.asl20;
     mainProgram = "pulumi-language-nodejs";
-    maintainers = with lib.maintainers; [
-      tie
-      untio11
-    ];
+    maintainers = lib.teams.pulumi.members;
   };
 })

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-python/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-python/package.nix
@@ -12,7 +12,7 @@ buildGoModule (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/sdk/python/cmd/pulumi-language-python";
 
-  vendorHash = "sha256-JlfRmBrowYYcKG+lkG6DCxWIibb0V1NVbpgPT86iRFU=";
+  vendorHash = "sha256-p5H9y9FtyV2McUiM1naobuXRogjLwlwARmzB5nWWj0g=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-python/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-python/package.nix
@@ -54,10 +54,6 @@ buildGoModule (finalAttrs: {
     description = "Language host for Pulumi programs written in Python";
     license = lib.licenses.asl20;
     mainProgram = "pulumi-language-python";
-    maintainers = with lib.maintainers; [
-      nicoo
-      tie
-      untio11
-    ];
+    maintainers = lib.teams.pulumi.members;
   };
 })

--- a/pkgs/development/python-modules/pulumi/default.nix
+++ b/pkgs/development/python-modules/pulumi/default.nix
@@ -76,16 +76,6 @@ buildPythonPackage {
     pulumi-python
   ];
 
-  disabledTestPaths = [
-    # To be removed in v3.255.0; see https://github.com/pulumi/pulumi/issues/24048#issuecomment-5077378071
-    "lib/test/test_deprecated.py::DeprecatedTests::test_non_deprecated_can_be_called"
-    "lib/test/test_deprecated.py::DeprecatedTests::test_deprecated_can_be_called"
-    "lib/test/test_deprecated.py::DeprecatedTests::test_deprecated_can_passthrough"
-    "lib/test/test_deprecated.py::DeprecatedTests::test_deprecated_prints_warnings"
-    "lib/test/runtime/test_resource_dep_cycle.py"
-    "lib/test/test_broken_dynamic_provider.py"
-  ];
-
   # CheckPhase script based on:
   # https://github.com/pulumi/pulumi/blob/0acaf8060640fdd892abccf1ce7435cd6aae69fe/sdk/python/scripts/test_fast.sh#L10-L11
   # https://github.com/pulumi/pulumi/blob/0acaf8060640fdd892abccf1ce7435cd6aae69fe/sdk/python/scripts/test_fast.sh#L16


### PR DESCRIPTION
Update `pulumi`, as well as all derivations which reuse its `src` and `version`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [Package tests] at `passthru.tests`.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
