### PR TITLE
phpExtensions.relay: fix broken dylib loading on Darwin

### DIFF
--- a/pkgs/development/php-packages/relay/default.nix
+++ b/pkgs/development/php-packages/relay/default.nix
@@ -98,52 +98,28 @@ stdenv.mkDerivation (finalAttrs: {
   ''
   + (
     if stdenv.hostPlatform.isDarwin then
-      let
-        args =
-          lib.concatMapStrings
-            (
-              v:
-              let
-                targetName = if v ? to then v.to else builtins.baseNameOf v.from;
-              in
-              " -change ${v.from} ${lib.strings.makeLibraryPath [ v.pkg ]}/${targetName}"
-            )
-            [
-              {
-                from = "/opt/homebrew/opt/concurrencykit/lib/libck.0.dylib";
-                pkg = libck;
-              }
-              {
-                from = "/opt/homebrew/opt/openssl@3/lib/libssl.3.dylib";
-                pkg = openssl;
-              }
-              {
-                from = "/opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib";
-                pkg = openssl;
-              }
-              {
-                from = "/opt/homebrew/opt/zstd/lib/libzstd.1.dylib";
-                pkg = zstd;
-              }
-              {
-                from = "/opt/homebrew/opt/lz4/lib/liblz4.1.dylib";
-                pkg = lz4;
-              }
-              {
-                from = "/opt/homebrew/opt/hiredis/lib/libhiredis.1.3.0.dylib";
-                pkg = hiredis;
-                to = "libhiredis.1.1.0.dylib";
-              }
-              {
-                from = "/opt/homebrew/opt/hiredis/lib/libhiredis_ssl.1.3.0.dylib";
-                pkg = hiredis;
-                to = "libhiredis_ssl.dylib.1.1.0";
-              }
-            ];
-      in
-      # fixDarwinDylibNames can't be used here because we need to completely remap .dylibs, not just add absolute paths
+      # fixDarwinDylibNames can't be used here because we need to completely remap .dylibs, not just add
+      # absolute paths. Rather than hardcoding the Homebrew paths and versions relay.so happens to be
+      # linked against (which silently goes stale whenever relay or one of these libraries updates),
+      # discover the actual references via otool and remap them by matching their basename.
       ''
-        install_name_tool${args} $out/lib/php/extensions/relay.so
+        for dylib in $(otool -L $out/lib/php/extensions/relay.so | tail -n +2 | awk '{print $1}' | grep '^/opt/homebrew/'); do
+          base=$(basename "$dylib")
+          case "$base" in
+            libhiredis_ssl.*) dir="${lib.makeLibraryPath [ hiredis ]}" ;;
+            libhiredis.*) dir="${lib.makeLibraryPath [ hiredis ]}" ;;
+            libssl.*) dir="${lib.makeLibraryPath [ openssl ]}" ;;
+            libcrypto.*) dir="${lib.makeLibraryPath [ openssl ]}" ;;
+            libzstd.*) dir="${lib.makeLibraryPath [ zstd ]}" ;;
+            liblz4.*) dir="${lib.makeLibraryPath [ lz4 ]}" ;;
+            libck.*) dir="${lib.makeLibraryPath [ libck ]}" ;;
+            *)
+              echo "relay.so references unrecognized Homebrew library $dylib; add a mapping for it" >&2
+              exit 1
+              ;;
+          esac
+          install_name_tool -change "$dylib" "$dir/$base" $out/lib/php/extensions/relay.so
+        done
       ''
     else
       ""


### PR DESCRIPTION
## Description of changes

Fixes `phpExtensions.relay` being broken on Darwin: the Darwin `install_name_tool` remap step hardcoded exact Homebrew library paths/versions that `relay.so` happened to be linked against upstream (hiredis 1.3.0, a `concurrencykit`-prefixed libck path, etc.). These had drifted out of sync with the actual binary (relay bumped to 0.30.0, hiredis bumped to 1.4.0), so the remap silently no-opped and the extension failed to `dlopen` at runtime, referencing missing `/opt/homebrew/...` paths instead of the Nix store.

Reworked the remap to discover the actual `/opt/homebrew/...` references via `otool -L` on the built `relay.so` and remap each by matching its basename to the corresponding Nix package (`hiredis`, `openssl`, `zstd`, `lz4`, `libck`), rather than hardcoding paths and versions. Fails loudly if an unrecognized library shows up instead of silently doing nothing, so this class of bug can't reoccur unnoticed.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true` (my `nix.conf` has `sandbox = false`)
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).