### PR TITLE
kate-discord-rpc: init at 0-unstable-2026-03-17

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30851,6 +30851,13 @@
     github = "xanderio";
     githubId = 6298052;
   };
+  Xatra1 = {
+    name = "solarfire";
+    github = "Xatra1";
+    githubId = 124910045;
+    email = "xatra169@gmail.com";
+    keys = [ { fingerprint = "D91D 3C69 66B4 437A 519F  3247 1BA5 8E9D 05F4 AC54"; } ];
+  };
   xaverdh = {
     email = "hoe.dom@gmx.de";
     github = "xaverdh";

--- a/pkgs/by-name/ka/kate-discord-rpc/package.nix
+++ b/pkgs/by-name/ka/kate-discord-rpc/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  fetchFromGitHub,
+  kdePackages,
+  qt6,
+  rapidjson,
+  unstableGitUpdater,
+  ...
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "kate-discord-rpc";
+  version = "0-unstable-2026-03-17";
+
+  src = fetchFromGitHub {
+    owner = "leia-uwu";
+    repo = "kate-discord-rpc";
+    rev = "93a14a03887540f819b3b4885fd8c789aee05b19";
+    hash = "sha256-TWMYy6oeFJZ1WTS9tNQLk9RcRBwkvVrZy9kVU2Kr90s=";
+    fetchSubmodules = true;
+  };
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    cmake
+    kdePackages.extra-cmake-modules
+    kdePackages.kcoreaddons
+    kdePackages.kconfig
+    kdePackages.ktexteditor
+    kdePackages.kwidgetsaddons
+    kdePackages.qtbase
+    qt6.wrapQtAppsHook
+    rapidjson
+  ];
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Discord Rich Presence plugin for the KDE Plasma text editor Kate";
+    homepage = "https://github.com/leia-uwu/kate-discord-rpc";
+    license = lib.licenses.gpl2;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ Xatra1 ];
+  };
+})

--- a/pkgs/by-name/ka/kate-discord-rpc/package.nix
+++ b/pkgs/by-name/ka/kate-discord-rpc/package.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   enableParallelBuilding = true;
+  strictDeps = true;
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/ka/kate-discord-rpc/package.nix
+++ b/pkgs/by-name/ka/kate-discord-rpc/package.nix
@@ -25,8 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
   enableParallelBuilding = true;
   strictDeps = true;
 
-  nativeBuildInputs = [
-    cmake
+  buildInputs = [
     kdePackages.extra-cmake-modules
     kdePackages.kcoreaddons
     kdePackages.kconfig
@@ -35,6 +34,10 @@ stdenv.mkDerivation (finalAttrs: {
     kdePackages.qtbase
     qt6.wrapQtAppsHook
     rapidjson
+  ];
+
+  nativeBuildInputs = [
+    cmake
   ];
 
   passthru.updateScript = unstableGitUpdater { };

--- a/pkgs/by-name/ka/kate-discord-rpc/package.nix
+++ b/pkgs/by-name/ka/kate-discord-rpc/package.nix
@@ -10,6 +10,7 @@
   ...
 }:
 stdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
   pname = "kate-discord-rpc";
   version = "0-unstable-2026-03-17";
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/leia-uwu/kate-discord-rpc

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
