### PR TITLE
knot-*: avoid the legacy download URLs under secure.nic.cz

### DIFF
--- a/pkgs/by-name/kn/knot-dns/package.nix
+++ b/pkgs/by-name/kn/knot-dns/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.5.6";
 
   src = fetchurl {
-    url = "https://secure.nic.cz/files/knot-dns/knot-${finalAttrs.version}.tar.xz";
+    url = "https://knot-dns.nic.cz/release/knot-${finalAttrs.version}.tar.xz";
     sha256 = "8e2dde44c97f8a63ec5e6c11db26099acd5341286af5b6be900b62ccade68898";
   };
 

--- a/pkgs/by-name/kn/knot-resolver_5/package.nix
+++ b/pkgs/by-name/kn/knot-resolver_5/package.nix
@@ -38,7 +38,7 @@ let
     version = "5.7.7";
 
     src = fetchurl {
-      url = "https://secure.nic.cz/files/knot-resolver/knot-resolver-${finalAttrs.version}.tar.xz";
+      url = "https://knot-resolver.nic.cz/release/knot-resolver-${finalAttrs.version}.tar.xz";
       sha256 = "481d2a6eb8690023895d389601e56fffbaeba3cc18cc1de5a5f177df9d0f9530";
     };
 

--- a/pkgs/by-name/kn/knot-resolver_6/package.nix
+++ b/pkgs/by-name/kn/knot-resolver_6/package.nix
@@ -39,7 +39,7 @@ let
     version = "6.4.1";
 
     src = fetchurl {
-      url = "https://secure.nic.cz/files/knot-resolver/knot-resolver-${finalAttrs.version}.tar.xz";
+      url = "https://knot-resolver.nic.cz/release/knot-resolver-${finalAttrs.version}.tar.xz";
       hash = "sha256-GqTClyHAm86amfPVZXIjEQNj1ms1ytSYm5Wyr9qTeag=";
     };
 


### PR DESCRIPTION
They've been HTTP 301 for quite a long time now.
These aliases still work, but let's not rely on that anymore.

Upstream we do this e.g. in https://gitlab.nic.cz/knot/knot-resolver/-/merge_requests/1873 and https://gitlab.nic.cz/websites/knot-resolver.cz/-/merge_requests/159

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (re-checked that these URLs work and give the same hashes)
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable: N/A
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
