### PR TITLE
python3Packages.pylance: 8.0.0 -> 9.0.0

### DIFF
--- a/pkgs/development/python-modules/cel-python/default.nix
+++ b/pkgs/development/python-modules/cel-python/default.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  google-re2,
+  jmespath,
+  lark,
+  pendulum,
+  pyyaml,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "cel-python";
+  version = "0.5.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "cloud-custodian";
+    repo = "cel-python";
+    tag = "v${lib.versions.majorMinor finalAttrs.version}";
+    hash = "sha256-DPHgHRvzQnBzjl2y9yNWt330xF535dO0iBObuqlr+PI=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    google-re2
+    jmespath
+    lark
+    pendulum
+    pyyaml
+  ];
+
+  pythonImportsCheck = [ "celpy" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  enabledTestPaths = [
+    "tests"
+  ];
+
+  disabledTestPaths = [
+    # Require cloud-custodian (c7n)
+    "tests/test_c7n_to_cel.py"
+    "tests/test_c7nlib.py"
+  ];
+
+  meta = {
+    description = "Pure Python implementation of the Common Expression Language";
+    homepage = "https://github.com/cloud-custodian/cel-python";
+    changelog = "https://github.com/cloud-custodian/cel-python/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/development/python-modules/crewai-cli/default.nix
+++ b/pkgs/development/python-modules/crewai-cli/default.nix
@@ -1,0 +1,139 @@
+{
+  lib,
+  buildPythonPackage,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  appdirs,
+  certifi,
+  click,
+  crewai-core,
+  cryptography,
+  httpx,
+  packaging,
+  pydantic,
+  pydantic-settings,
+  pyjwt,
+  python-dotenv,
+  rich,
+  textual,
+  tomli,
+  tomli-w,
+  uv,
+
+  # tests
+  versionCheckHook,
+
+  # passthru
+  aiohttp,
+  crewai,
+  pytest-asyncio,
+  pytest-recording,
+  pytest-subprocess,
+  pytest-timeout,
+  pytest-xdist,
+  pytestCheckHook,
+  vcrpy,
+  writableTmpDirAsHomeHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "crewai-cli";
+  version = "1.15.10";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  inherit (crewai-core) src;
+
+  sourceRoot = "${finalAttrs.src.name}/lib/cli";
+
+  build-system = [
+    hatchling
+  ];
+
+  pythonRelaxDeps = [
+    "click"
+    "crewai-core"
+    "pydantic"
+    "pydantic-settings"
+    "pyjwt"
+    "python-dotenv"
+    "textual"
+    "tomli"
+    "tomli-w"
+    "uv"
+  ];
+  dependencies = [
+    appdirs
+    certifi
+    click
+    crewai-core
+    cryptography
+    httpx
+    packaging
+    pydantic
+    pydantic-settings
+    pyjwt
+    python-dotenv
+    rich
+    textual
+    tomli
+    tomli-w
+    uv
+  ];
+
+  pythonImportsCheck = [ "crewai_cli" ];
+
+  nativeCheckInputs = [
+    versionCheckHook
+  ];
+
+  disabledTests = [
+    # error: Failed to discover managed Python installations
+    # Caused by: Could not read ELF interpreter from any of the following paths: /bin/sh, /usr/bin/env, /bin/dash, /bin/ls
+    "test_create_crew"
+    "test_deploy_with_project_name"
+    "test_deploy_with_remote_keeps_remote_path_when_fetch_fails"
+    "test_deploy_with_remote_keeps_remote_path_when_initial_commit_fails"
+    "test_deploy_with_uuid"
+    "test_json_runner_code_loads_current_cli_package_over_project_env"
+    "test_json_runner_imports_with_older_project_env_crewai_core"
+    "test_missing_crewai_package_shows_full_install_hint"
+    "test_publish_calls_api"
+    "test_publish_metadata_extraction_failure_continues_with_warning"
+
+    # ValueError: Git fetch failed with exit code
+    "test_publish_api_error"
+    "test_publish_failure"
+
+    # AssertionError: assert '"crewai[tools]>=1.15.0,<2.0.0"' in content
+    "test_create_success"
+  ];
+
+  # Circular dependency with crewai
+  passthru.tests = finalAttrs.finalPackage.overrideAttrs (old: {
+    nativeInstallCheckInputs = [
+      aiohttp
+      crewai
+      pytest-asyncio
+      pytest-recording
+      pytest-subprocess
+      pytest-timeout
+      pytest-xdist
+      pytestCheckHook
+      vcrpy
+      writableTmpDirAsHomeHook
+    ];
+  });
+
+  meta = {
+    description = "CLI for CrewAI: scaffold, run, deploy and manage AI agent crews";
+    homepage = "https://github.com/crewAIInc/crewAI/tree/main/lib/cli";
+    changelog = "https://github.com/crewAIInc/crewAI/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    mainProgram = "crewai";
+  };
+})

--- a/pkgs/development/python-modules/crewai-core/default.nix
+++ b/pkgs/development/python-modules/crewai-core/default.nix
@@ -1,0 +1,92 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  appdirs,
+  cryptography,
+  httpx,
+  opentelemetry-api,
+  opentelemetry-exporter-otlp-proto-http,
+  opentelemetry-sdk,
+  packaging,
+  portalocker,
+  pydantic,
+  pyjwt,
+  rich,
+  tomli,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "crewai-core";
+  version = "1.15.10";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "crewAIInc";
+    repo = "crewAI";
+    tag = finalAttrs.version;
+    hash = "sha256-O59F1TqQsTW2TBkuUTiNu4f35UeajRVSVc2HomxHK3Q=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/lib/crewai-core";
+
+  build-system = [ hatchling ];
+
+  pythonRelaxDeps = [
+    "opentelemetry-api"
+    "opentelemetry-exporter-otlp-proto-http"
+    "opentelemetry-sdk"
+    "portalocker"
+    "pydantic"
+    "tomli"
+  ];
+
+  dependencies = [
+    appdirs
+    cryptography
+    httpx
+    opentelemetry-api
+    opentelemetry-exporter-otlp-proto-http
+    opentelemetry-sdk
+    packaging
+    portalocker
+    pydantic
+    pyjwt
+    rich
+    tomli
+  ];
+
+  pythonImportsCheck = [ "crewai_core" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  enabledTestPaths = [
+    "tests"
+  ];
+
+  pytestFlags = [
+    # Avoid loading the repository-wide conftest.py (needs many optional test deps)
+    "--confcutdir=tests"
+    # Drop addopts from the repository-wide pyproject.toml (xdist, socket, timeout)
+    "--override-ini=addopts="
+  ];
+
+  meta = {
+    description = "Shared utilities for CrewAI (version, paths, user-data, telemetry, printer)";
+    homepage = "https://github.com/crewAIInc/crewAI/tree/main/lib/crewai-core";
+    changelog = "https://github.com/crewAIInc/crewAI/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/development/python-modules/crewai/default.nix
+++ b/pkgs/development/python-modules/crewai/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
   nix-update-script,
 
   # build-system
@@ -11,14 +10,17 @@
   aiofiles,
   aiosqlite,
   appdirs,
+  cel-python,
   chromadb,
   click,
+  crewai-cli,
+  crewai-core,
+  httpx,
   instructor,
   json-repair,
   json5,
   jsonref,
   lancedb,
-  litellm,
   mcp,
   openai,
   opentelemetry-api,
@@ -31,12 +33,14 @@
   pydantic-settings,
   pyjwt,
   python-dotenv,
+  pyyaml,
   regex,
-  textual,
   tokenizers,
   tomli,
   tomli-w,
-  uv,
+
+  # optional-dependencies
+  litellm,
 
   # tests
   a2a-sdk,
@@ -50,34 +54,24 @@
   pytestCheckHook,
   qdrant-client,
   vcrpy,
-  versionCheckHook,
   writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "crewai";
-  version = "1.14.4";
+  version = "1.15.10";
   pyproject = true;
+  __structuredAttrs = true;
 
-  src = fetchFromGitHub {
-    owner = "crewAIInc";
-    repo = "crewAI";
-    tag = finalAttrs.version;
-    hash = "sha256-QrJM2oVoqos8GMhrn9E6i1m1O1guP/q+51b8NYtJA5Q=";
-  };
+  inherit (crewai-core) src;
 
-  postPatch = ''
-    substituteInPlace ../../conftest.py \
-      --replace-fail \
-        "import vcr.stubs.httpx_stubs as httpx_stubs" \
-        "import vcr.stubs.httpcore_stubs as httpx_stubs" \
-      --replace-fail \
-        "def _patched_make_vcr_request(httpx_request: Any, **kwargs: Any) -> Any:" \
-        "def _patched_make_vcr_request(httpx_request: Any, request_body: Any = None, **kwargs: Any) -> Any:" \
-      --replace-fail \
-        "raw_body = httpx_request.read()" \
-        "raw_body = request_body if request_body is not None else httpx_request.read()"
-  '';
+  postPatch =
+    # The crewai executable is provided by the crewai-cli package (a dependency);
+    # drop the duplicate entry point to avoid a file collision in shared environments.
+    ''
+      substituteInPlace pyproject.toml \
+        --replace-fail 'crewai = "crewai_cli.cli:crewai"' ""
+    '';
 
   sourceRoot = "${finalAttrs.src.name}/lib/crewai";
 
@@ -90,7 +84,6 @@ buildPythonPackage (finalAttrs: {
     "json-repair"
     "json5"
     "lancedb"
-    "litellm"
     "mcp"
     "openai"
     "opentelemetry-api"
@@ -106,21 +99,23 @@ buildPythonPackage (finalAttrs: {
     "tokenizers"
     "tomli"
     "tomli-w"
-    "uv"
   ];
 
   dependencies = [
     aiofiles
     aiosqlite
     appdirs
+    cel-python
     chromadb
     click
+    crewai-cli
+    crewai-core
+    httpx
     instructor
     json-repair
     json5
     jsonref
     lancedb
-    litellm
     mcp
     openai
     opentelemetry-api
@@ -133,19 +128,21 @@ buildPythonPackage (finalAttrs: {
     pydantic-settings
     pyjwt
     python-dotenv
+    pyyaml
     regex
-    textual
     tokenizers
     tomli
     tomli-w
-    uv
   ];
+
+  optional-dependencies = {
+    litellm = [ litellm ];
+  };
 
   pythonImportsCheck = [ "crewai" ];
 
   disabledTestPaths = [
     # Ignore tests that require {chromadb, telemetry, security, test_agent}
-    "tests/cli/test_git.py" # require git
     "tests/test_crew.py" # require require API keys
     "tests/rag/chromadb/test_client.py" # issue with chromadb
     "tests/telemetry/test_telemetry.py" # telemetry need network access
@@ -180,6 +177,7 @@ buildPythonPackage (finalAttrs: {
     "tests/agents/test_lite_agent.py"
 
     # Tests requiring crewai-files
+    "tests/agents/test_agent_executor.py"
     "tests/llms/test_multimodal.py"
     "tests/llms/test_multimodal_integration.py"
     "tests/test_agent_multimodal.py"
@@ -476,16 +474,9 @@ buildPythonPackage (finalAttrs: {
     "test_areset_wrong_client_type"
     "test_adelete_collection"
 
-    # Tests requiring litellm
-    "test_litellm_anthropic_error_handling"
-    "test_litellm_auth_error_handling"
-    "test_crew_agent_executor_litellm_auth_error"
-    "test_agent_with_callbacks"
-    "test_crew_memoization"
-    "test_task_guardrail"
-    "test_crew_name"
-    "test_get_conversion_instructions_non_gpt"
-    "test_supports_function_calling_false"
+    # Tests requiring crewai-tools
+    "test_non_ok_response_becomes_a_tool_failure"
+    "test_ok_response_still_returns_json"
 
     # Tests requiring network
     "test_agent_events_have_event_ids"
@@ -546,13 +537,14 @@ buildPythonPackage (finalAttrs: {
     anthropic
     boto3
     google-genai
-    pytestCheckHook
+    # litellm is an optional dependency upstream, but the test suite requires it
+    litellm
     pytest-asyncio
     pytest-recording
     pytest-xdist
+    pytestCheckHook
     qdrant-client
     vcrpy
-    versionCheckHook
     writableTmpDirAsHomeHook
   ];
 
@@ -574,6 +566,5 @@ buildPythonPackage (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ liberodark ];
     platforms = lib.platforms.linux;
-    mainProgram = "crewai";
   };
 })

--- a/pkgs/development/python-modules/lance-namespace-urllib3-client/default.nix
+++ b/pkgs/development/python-modules/lance-namespace-urllib3-client/default.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "lance-namespace-urllib3-client";
-  version = "0.8.6";
+  version = "0.9.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -26,7 +26,7 @@ buildPythonPackage (finalAttrs: {
     owner = "lancedb";
     repo = "lance-namespace";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-QYzVsarjTg2arNNuCFbVgtA7rfLTm6AJD3liNr3QuSU=";
+    hash = "sha256-8BfKK7k7NDptFYjaJ312QID/tIr24y3oGTmxHz/b2w0=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/python/lance_namespace_urllib3_client";

--- a/pkgs/development/python-modules/lance-namespace/default.nix
+++ b/pkgs/development/python-modules/lance-namespace/default.nix
@@ -30,7 +30,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "lance-namespace";
-  version = "0.8.6";
+  version = "0.9.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -38,7 +38,7 @@ buildPythonPackage (finalAttrs: {
     owner = "lancedb";
     repo = "lance-namespace";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-QYzVsarjTg2arNNuCFbVgtA7rfLTm6AJD3liNr3QuSU=";
+    hash = "sha256-8BfKK7k7NDptFYjaJ312QID/tIr24y3oGTmxHz/b2w0=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/python/lance_namespace";

--- a/pkgs/development/python-modules/lancedb/default.nix
+++ b/pkgs/development/python-modules/lancedb/default.nix
@@ -60,6 +60,26 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-rfAhvC6byg134NF21CR5n0A0DL42CLGy7VvHi9aZUrw=";
   };
 
+  # `lance-linalg`'s AVX-512 VNNI u8-distance kernels call `_mm512_dpbusd_epi32` /
+  # `_mm512_dpwssd_epi32`. With the current toolchain, stdarch's signature for these intrinsics
+  # mismatches LLVM's `llvm.x86.avx512.vpdpbusd.512`, so the crate fails to compile.
+  # Drop the AVX-512 VNNI dispatch branch: the kernels then become dead code (their module is
+  # crate-private and otherwise only used from `#[cfg(test)]`, which is not built for
+  # dependencies), so they are never codegen'd and runtime dispatch falls back to the equivalent
+  # AVX2 / scalar kernels.
+  postPatch = ''
+    lanceDistance="$cargoDepsCopy/source-registry-0/lance-linalg-9.0.0/src/distance"
+
+    substituteInPlace "$lanceDistance/dot_u8.rs" \
+      --replace-fail "return |a, b| unsafe { x86::dot_u8_avx512_vnni(a, b) };" ""
+
+    substituteInPlace "$lanceDistance/l2_u8.rs" \
+      --replace-fail "return |a, b| unsafe { x86::l2_u8_avx512_vnni(a, b) };" ""
+
+    substituteInPlace "$lanceDistance/cosine_u8.rs" \
+      --replace-fail "return |a, b| unsafe { x86::cosine_u8_accum_avx512_vnni(a, b) };" ""
+  '';
+
   build-system = [ rustPlatform.maturinBuildHook ];
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/lancedb/default.nix
+++ b/pkgs/development/python-modules/lancedb/default.nix
@@ -42,7 +42,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "lancedb";
-  version = "0.32.0";
+  version = "0.36.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -50,14 +50,14 @@ buildPythonPackage (finalAttrs: {
     owner = "lancedb";
     repo = "lancedb";
     tag = "python-v${finalAttrs.version}";
-    hash = "sha256-OIoQCk0YlWpaaau4AiWxarvH4oy1rAjaS9yvs3mIzzo=";
+    hash = "sha256-JOUrLHoVBZs4B8UGYFZIs00kzBnxFFAkTXFIz2bOZ7w=";
   };
 
   buildAndTestSubdir = "python";
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-rfAhvC6byg134NF21CR5n0A0DL42CLGy7VvHi9aZUrw=";
+    hash = "sha256-KEczUf/e3+Eb53pouOzajp+yVjWctDUNbdVEgQVoCZE=";
   };
 
   # `lance-linalg`'s AVX-512 VNNI u8-distance kernels call `_mm512_dpbusd_epi32` /
@@ -130,7 +130,7 @@ buildPythonPackage (finalAttrs: {
   disabledTests = [
     # Requires internet access
     # RuntimeError: lance error: LanceError(IO): Generic S3 error
-    "test_bucket_without_dots_passes"
+    "test_bucket_without_dots_is_not_rejected"
 
     # lance_namespace.errors.UnsupportedOperationError: Not supported: create_empty_table
     "TestAsyncNamespaceConnection"

--- a/pkgs/development/python-modules/pylance/default.nix
+++ b/pkgs/development/python-modules/pylance/default.nix
@@ -58,6 +58,26 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-VSy1cOshPLAic+1HkTGiavdNRffiEVAlWThNeebJSyg=";
   };
 
+  # `lance-linalg`'s AVX-512 VNNI u8-distance kernels call `_mm512_dpbusd_epi32` /
+  # `_mm512_dpwssd_epi32`. With the current toolchain, stdarch's signature for these intrinsics
+  # mismatches LLVM's `llvm.x86.avx512.vpdpbusd.512`, so the crate fails to compile.
+  # Drop the AVX-512 VNNI dispatch branch: the kernels then become dead code (their module is
+  # crate-private and otherwise only used from `#[cfg(test)]`, which is not built for
+  # dependencies), so they are never codegen'd and runtime dispatch falls back to the equivalent
+  # AVX2 / scalar kernels.
+  postPatch = ''
+    lanceDistance="../rust/lance-linalg/src/distance"
+
+    substituteInPlace "$lanceDistance/dot_u8.rs" \
+      --replace-fail "return |a, b| unsafe { x86::dot_u8_avx512_vnni(a, b) };" ""
+
+    substituteInPlace "$lanceDistance/l2_u8.rs" \
+      --replace-fail "return |a, b| unsafe { x86::l2_u8_avx512_vnni(a, b) };" ""
+
+    substituteInPlace "$lanceDistance/cosine_u8.rs" \
+      --replace-fail "return |a, b| unsafe { x86::cosine_u8_accum_avx512_vnni(a, b) };" ""
+  '';
+
   nativeBuildInputs = [
     pkg-config
     protobuf # for protoc

--- a/pkgs/development/python-modules/pylance/default.nix
+++ b/pkgs/development/python-modules/pylance/default.nix
@@ -35,7 +35,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pylance";
-  version = "8.0.0";
+  version = "9.0.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -43,7 +43,7 @@ buildPythonPackage (finalAttrs: {
     owner = "lancedb";
     repo = "lance";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-pxggvF23u3Wfm6YdaHwbDUZDUwtJ4tOaTLViUfGZ0B8=";
+    hash = "sha256-G4BcK/con6a1MOlA9pB3+uI8YULLNg71G8bFLKhUedg=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/python";
@@ -55,7 +55,7 @@ buildPythonPackage (finalAttrs: {
       src
       sourceRoot
       ;
-    hash = "sha256-VSy1cOshPLAic+1HkTGiavdNRffiEVAlWThNeebJSyg=";
+    hash = "sha256-IzB+kzjAEWQpA0gCyKAXI+5XAJK00AV3alFRgastbPM=";
   };
 
   # `lance-linalg`'s AVX-512 VNNI u8-distance kernels call `_mm512_dpbusd_epi32` /
@@ -94,8 +94,10 @@ buildPythonPackage (finalAttrs: {
     protobuf
   ];
 
-  pythonRelaxDeps = [ "pyarrow" ];
-
+  pythonRelaxDeps = [
+    "lance-namespace"
+    "pyarrow"
+  ];
   dependencies = [
     lance-namespace
     numpy

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3677,6 +3677,8 @@ self: super: with self; {
 
   crewai = callPackage ../development/python-modules/crewai { };
 
+  crewai-cli = callPackage ../development/python-modules/crewai-cli { };
+
   crewai-core = callPackage ../development/python-modules/crewai-core { };
 
   crispy-bootstrap3 = callPackage ../development/python-modules/crispy-bootstrap3 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2930,6 +2930,8 @@ self: super: with self; {
 
   cdxj-indexer = callPackage ../development/python-modules/cdxj-indexer { };
 
+  cel-python = callPackage ../development/python-modules/cel-python { };
+
   celery = callPackage ../development/python-modules/celery { };
 
   celery-batches = callPackage ../development/python-modules/celery-batches { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3677,6 +3677,8 @@ self: super: with self; {
 
   crewai = callPackage ../development/python-modules/crewai { };
 
+  crewai-core = callPackage ../development/python-modules/crewai-core { };
+
   crispy-bootstrap3 = callPackage ../development/python-modules/crispy-bootstrap3 { };
 
   crispy-bootstrap4 = callPackage ../development/python-modules/crispy-bootstrap4 { };


### PR DESCRIPTION
- **python3Packages.lance-namespace-urllib3-client: 0.8.6 -> 0.9.0** ([Diff](https://github.com/lancedb/lance-namespace/compare/v0.8.6...v0.9.0), [Changelog](https://github.com/lancedb/lance-namespace/releases/tag/v0.9.0))
- **python3Packages.lance-namespace: 0.8.6 -> 0.9.0** ([Diff](https://github.com/lancedb/lance-namespace/compare/v0.8.6...v0.9.0), [Changelog](https://github.com/lancedb/lance-namespace/releases/tag/v0.9.0))
- **python3Packages.pylance: fix build**
- **python3Packages.lancedb: fix build**
- **python3Packages.pylance: 8.0.0 -> 9.0.0** ([Diff](https://github.com/lancedb/lance/compare/v8.0.0...v9.0.0), [Changelog](https://github.com/lancedb/lance/releases/tag/v9.0.0))
- **python3Packages.lancedb: 0.32.0 -> 0.36.0** ([Diff](https://github.com/lancedb/lancedb/compare/python-v0.32.0...python-v0.36.0), [Changelog](https://github.com/lancedb/lancedb/releases/tag/python-v0.36.0))
- **python3Packages.cel-python: init at 0.5.0**
- **python3Packages.crewai-core: init at 1.15.10**
- **python3Packages.crewai-cli: init at 1.15.10**
- **python3Packages.crewai: 1.14.4 -> 1.15.10** ([Diff](https://github.com/crewAIInc/crewAI/compare/1.14.4...1.15.10), [Changelog](https://github.com/crewAIInc/crewAI/releases/tag/1.15.10))

cc @natsukium

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
