### PR TITLE
bashunit: update 0.40.0 -> 0.44.0

### DIFF
--- a/pkgs/by-name/ba/bashunit/package.nix
+++ b/pkgs/by-name/ba/bashunit/package.nix
@@ -2,7 +2,7 @@
   stdenvNoCC,
   lib,
   fetchFromGitHub,
-  bash,
+  bashInteractive,
   bc,
   gitMinimal,
   gnugrep,
@@ -17,27 +17,32 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "bashunit";
-  version = "0.40.0";
+  version = "0.44.0";
 
   src = fetchFromGitHub {
     owner = "TypedDevs";
     repo = "bashunit";
     tag = finalAttrs.version;
-    hash = "sha256-7KH0zcoRPbY56h8FtJ0WbCqM2dSn/bklAPIthnktkpI=";
+    hash = "sha256-5GsSJKgMxzy4tAMtecwF1aopDsXOsOT0KTykHuTGHm4=";
     forceFetchGit = true; # needed to include the tests directory for the check phase
   };
 
-  nativeBuildInputs = [ makeBinaryWrapper ];
-
-  postConfigure = ''
-    patchShebangs tests build.sh bashunit
-    substituteInPlace Makefile \
-      --replace-fail "SHELL=/bin/bash" "SHELL=${lib.getExe bash}"
+  postPatch = ''
+    patchShebangs bashunit build.sh tests
+    # Tests emit scripts with #!/usr/bin/env bash at runtime; patch the literals
+    substituteInPlace tests/unit/build_test.sh \
+      --replace-fail "#!/usr/bin/env bash" "#!${lib.getExe bashInteractive}"
   '';
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    bashInteractive # needed for compgen in checkPhase
+  ];
 
   buildPhase = ''
     runHook preBuild
     ./build.sh
+    patchShebangs bin/bashunit
     runHook postBuild
   '';
 
@@ -54,16 +59,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     jq
     which
   ];
+
   checkPhase = ''
     runHook preCheck
-    patchShebangs bin/bashunit
-  ''
-  # Disabling a failing test on Darwin platforms only
-  + lib.optionalString stdenvNoCC.hostPlatform.isDarwin ''
-    rm tests/unit/console_results_test.sh
-  ''
-  + ''
-    make test
+    make test/parallel
     runHook postCheck
   '';
 
@@ -82,9 +81,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     versionCheckHook
     writableTmpDirAsHomeHook
   ];
+
   doInstallCheck = true;
+
   versionCheckKeepEnvironment = [
     "HOME"
+    "PATH"
   ];
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Supersedes https://github.com/NixOS/nixpkgs/pull/543029 and fixes all tests on Darwin in the sandbox thanks to the upstream fixes in https://github.com/TypedDevs/bashunit/pull/913.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
