### PR TITLE
[26.05] chiri: 0.8.1 -> 0.9.2

### DIFF
--- a/pkgs/by-name/ch/chiri/package.nix
+++ b/pkgs/by-name/ch/chiri/package.nix
@@ -7,9 +7,9 @@
 
   # build tools
   cargo-tauri,
-  nodejs_22,
+  nodejs_26,
   pnpmConfigHook,
-  pnpm_10,
+  pnpm_11,
   fetchPnpmDeps,
   pkg-config,
   makeBinaryWrapper,
@@ -24,29 +24,29 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "chiri";
-  version = "0.8.1";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
-    owner = "SapphoSys";
+    owner = "chiriapp";
     repo = "chiri";
     tag = "app-v${finalAttrs.version}";
-    hash = "sha256-45a1mmh8dxrWw+UQzJcbPAujFjCYC4ovsGhdAn39LkI=";
+    hash = "sha256-xlB7VqHXBljOjOOK96hK3HYENsuICMqRqfgJdtEnlUI=";
   };
 
-  cargoHash = "sha256-TLYiCdkF/uX3uIVwplI7L1b7Ta5LTRdKqFlmnvCxFFc=";
+  cargoHash = "sha256-MTPd8HqbU35wmYVCv8HtfAuooBPsZk+p5J2Y5HjHTsA=";
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_10;
-    hash = "sha256-jDSljbGzEGDl0PsnjdmyhIGXX4fUPVeCndv5pUm/utE=";
+    pnpm = pnpm_11;
+    hash = "sha256-dxfoo5Ajjt7zUsdQojXhePHp0K2itpdjequvGqqnZ7k=";
     fetcherVersion = 3;
   };
 
   nativeBuildInputs = [
     cargo-tauri.hook
-    nodejs_22
+    nodejs_26
     pnpmConfigHook
-    pnpm_10
+    pnpm_11
     pkg-config
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
@@ -98,8 +98,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
     else
       ''
         mv $out/bin/Chiri $out/bin/chiri
-        substituteInPlace $out/share/applications/Chiri.desktop \
-          --replace-fail "Exec=Chiri" "Exec=chiri"
+        for desktopFile in \
+          $out/share/applications/Chiri.desktop \
+          $out/share/applications/garden.chiri.Chiri.desktop
+        do
+          if [ -f "$desktopFile" ]; then
+            substituteInPlace "$desktopFile" \
+              --replace-fail "Exec=Chiri" "Exec=chiri"
+          fi
+        done
       '';
 
   doCheck = false;
@@ -108,8 +115,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Cross-platform CalDAV task management app";
-    homepage = "https://github.com/SapphoSys/chiri";
-    changelog = "https://github.com/SapphoSys/chiri/releases/tag/app-v${finalAttrs.version}";
+    homepage = "https://github.com/chiriapp/chiri";
+    changelog = "https://github.com/chiriapp/chiri/releases/tag/app-v${finalAttrs.version}";
     license = lib.licenses.zlib;
     maintainers = with lib.maintainers; [ SapphoSys ];
     mainProgram = "chiri";

--- a/pkgs/by-name/ch/chiri/package.nix
+++ b/pkgs/by-name/ch/chiri/package.nix
@@ -22,104 +22,122 @@
   webkitgtk_4_1,
 }:
 
-rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "chiri";
-  version = "0.9.0";
+rustPlatform.buildRustPackage (
+  finalAttrs:
+  let
+    # on macOS, Node.js worker threads default to `trackUnmanagedFds: true`
+    # when used with pnpm's graceful-fs EAGAIN retry loop, this causes file descriptor
+    # churn that leads to a crash during cleanup (presenting as `Killed: 9` / SIGKILL)
+    # within the Nix sandbox. so we just disable `trackUnmanagedFds` to prevent this
+    # see: https://github.com/NixOS/nixpkgs/issues/525627
+    pnpm-patched = pnpm_11.overrideAttrs (old: {
+      postPatch = (old.postPatch or "") + ''
+        substituteInPlace dist/pnpm.mjs \
+          --replace-fail \
+            'resourceLimits: this._workerResourceLimits' \
+            'resourceLimits: this._workerResourceLimits, trackUnmanagedFds: false'
+      '';
+    });
+  in
+  {
+    pname = "chiri";
+    version = "0.9.1";
 
-  src = fetchFromGitHub {
-    owner = "chiriapp";
-    repo = "chiri";
-    tag = "app-v${finalAttrs.version}";
-    hash = "sha256-xlB7VqHXBljOjOOK96hK3HYENsuICMqRqfgJdtEnlUI=";
-  };
+    src = fetchFromGitHub {
+      owner = "chiriapp";
+      repo = "chiri";
+      tag = "app-v${finalAttrs.version}";
+      hash = "sha256-rkkyp36EIfvD0DXq0Tn+uLS/cBtgGk4x4sVkppTDaLg=";
+    };
 
-  cargoHash = "sha256-MTPd8HqbU35wmYVCv8HtfAuooBPsZk+p5J2Y5HjHTsA=";
+    cargoHash = "sha256-nSK4oyaW+chFHKrCI80d9785UsqBlX8YAdU26b/aa0s=";
 
-  pnpmDeps = fetchPnpmDeps {
-    inherit (finalAttrs) pname version src;
-    pnpm = pnpm_11;
-    hash = "sha256-dxfoo5Ajjt7zUsdQojXhePHp0K2itpdjequvGqqnZ7k=";
-    fetcherVersion = 3;
-  };
+    pnpmDeps = fetchPnpmDeps {
+      inherit (finalAttrs) pname version src;
+      pnpm = pnpm-patched;
+      hash = "sha256-dxfoo5Ajjt7zUsdQojXhePHp0K2itpdjequvGqqnZ7k=";
+      fetcherVersion = 3;
+    };
 
-  nativeBuildInputs = [
-    cargo-tauri.hook
-    nodejs_26
-    pnpmConfigHook
-    pnpm_11
-    pkg-config
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
-    wrapGAppsHook4
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    makeBinaryWrapper
-  ];
+    nativeBuildInputs = [
+      cargo-tauri.hook
+      nodejs_26
+      pnpmConfigHook
+      pnpm-patched
+      pkg-config
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      wrapGAppsHook4
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      makeBinaryWrapper
+    ];
 
-  buildInputs = [
-    openssl
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
-    glib-networking
-    libayatana-appindicator
-    webkitgtk_4_1
-  ];
+    buildInputs = [
+      openssl
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      glib-networking
+      libayatana-appindicator
+      webkitgtk_4_1
+    ];
 
-  cargoRoot = "src-tauri";
-  buildAndTestSubdir = "src-tauri";
+    cargoRoot = "src-tauri";
+    buildAndTestSubdir = "src-tauri";
 
-  postPatch =
-    lib.optionalString stdenv.hostPlatform.isLinux ''
-      for libappindicatorRs in $cargoDepsCopy/*/libappindicator-sys-*/src/lib.rs; do
-        if [[ -f "$libappindicatorRs" ]]; then
-          substituteInPlace "$libappindicatorRs" \
-            --replace-fail "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
-        fi
-      done
-    ''
-    + ''
-      substituteInPlace src-tauri/tauri.conf.json \
-        --replace-fail '"createUpdaterArtifacts": true' '"createUpdaterArtifacts": false'
-    '';
-
-  # This is needed since the signing keys are private, and are only used in CI during releases anyways. Regular users won't need this.
-  preBuild = ''
-    unset TAURI_SIGNING_PRIVATE_KEY
-    unset TAURI_SIGNING_PUBLIC_KEY
-    pnpm build
-  '';
-
-  postInstall =
-    if stdenv.hostPlatform.isDarwin then
-      ''
-        mkdir -p $out/bin
-        makeWrapper "$out/Applications/Chiri.app/Contents/MacOS/chiri" "$out/bin/chiri"
-      ''
-    else
-      ''
-        mv $out/bin/Chiri $out/bin/chiri
-        for desktopFile in \
-          $out/share/applications/Chiri.desktop \
-          $out/share/applications/garden.chiri.Chiri.desktop
-        do
-          if [ -f "$desktopFile" ]; then
-            substituteInPlace "$desktopFile" \
-              --replace-fail "Exec=Chiri" "Exec=chiri"
+    postPatch =
+      lib.optionalString stdenv.hostPlatform.isLinux ''
+        for libappindicatorRs in $cargoDepsCopy/*/libappindicator-sys-*/src/lib.rs; do
+          if [[ -f "$libappindicatorRs" ]]; then
+            substituteInPlace "$libappindicatorRs" \
+              --replace-fail "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
           fi
         done
+      ''
+      + ''
+        substituteInPlace src-tauri/tauri.conf.json \
+          --replace-fail '"createUpdaterArtifacts": true' '"createUpdaterArtifacts": false'
       '';
 
-  doCheck = false;
+    # This is needed since the signing keys are private, and are only used in CI during releases anyways. Regular users won't need this.
+    preBuild = ''
+      unset TAURI_SIGNING_PRIVATE_KEY
+      unset TAURI_SIGNING_PUBLIC_KEY
+      pnpm build
+    '';
 
-  passthru.updateScript = nix-update-script;
+    postInstall =
+      if stdenv.hostPlatform.isDarwin then
+        ''
+          mkdir -p $out/bin
+          makeWrapper "$out/Applications/Chiri.app/Contents/MacOS/chiri" "$out/bin/chiri"
+        ''
+      else
+        ''
+          mv $out/bin/Chiri $out/bin/chiri
+          for desktopFile in \
+            $out/share/applications/Chiri.desktop \
+            $out/share/applications/garden.chiri.Chiri.desktop
+          do
+            if [ -f "$desktopFile" ]; then
+              substituteInPlace "$desktopFile" \
+                --replace-fail "Exec=Chiri" "Exec=chiri"
+            fi
+          done
+        '';
 
-  meta = {
-    description = "Cross-platform CalDAV task management app";
-    homepage = "https://github.com/chiriapp/chiri";
-    changelog = "https://github.com/chiriapp/chiri/releases/tag/app-v${finalAttrs.version}";
-    license = lib.licenses.zlib;
-    maintainers = with lib.maintainers; [ SapphoSys ];
-    mainProgram = "chiri";
-    platforms = lib.platforms.linux ++ lib.platforms.darwin;
-  };
-})
+    doCheck = false;
+
+    passthru.updateScript = nix-update-script;
+
+    meta = {
+      description = "Cross-platform CalDAV task management app";
+      homepage = "https://github.com/chiriapp/chiri";
+      changelog = "https://github.com/chiriapp/chiri/releases/tag/app-v${finalAttrs.version}";
+      license = lib.licenses.zlib;
+      maintainers = with lib.maintainers; [ SapphoSys ];
+      mainProgram = "chiri";
+      platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    };
+  }
+)

--- a/pkgs/by-name/ch/chiri/package.nix
+++ b/pkgs/by-name/ch/chiri/package.nix
@@ -41,16 +41,16 @@ rustPlatform.buildRustPackage (
   in
   {
     pname = "chiri";
-    version = "0.9.1";
+    version = "0.9.2";
 
     src = fetchFromGitHub {
       owner = "chiriapp";
       repo = "chiri";
       tag = "app-v${finalAttrs.version}";
-      hash = "sha256-rkkyp36EIfvD0DXq0Tn+uLS/cBtgGk4x4sVkppTDaLg=";
+      hash = "sha256-zBv/egEvmsZXklhKtN5fd2DOKH+UWcaGUUkFxz0G+JI=";
     };
 
-    cargoHash = "sha256-nSK4oyaW+chFHKrCI80d9785UsqBlX8YAdU26b/aa0s=";
+    cargoHash = "sha256-69r9ILhSov7A9zdWcPphGMXur/8lYyZYo7qSGPW9IzM=";
 
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname version src;

--- a/pkgs/by-name/ch/chiri/package.nix
+++ b/pkgs/by-name/ch/chiri/package.nix
@@ -55,8 +55,8 @@ rustPlatform.buildRustPackage (
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname version src;
       pnpm = pnpm-patched;
-      hash = "sha256-dxfoo5Ajjt7zUsdQojXhePHp0K2itpdjequvGqqnZ7k=";
-      fetcherVersion = 3;
+      hash = "sha256-1S1XR/E611LGivXpIK0kvkvXWPNqDzvFKPT7a1Qu1zg=";
+      fetcherVersion = 4;
     };
 
     nativeBuildInputs = [


### PR DESCRIPTION
Backport Chiri from 0.8.1 to 0.9.2 on the `release-26.05` branch.

This cherry-picks the already-merged master updates in order:

- https://github.com/NixOS/nixpkgs/pull/528885
- https://github.com/NixOS/nixpkgs/pull/529598
- https://github.com/NixOS/nixpkgs/pull/531408

Changelog: https://github.com/chiriapp/chiri/compare/app-v0.8.1...app-v0.9.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
