### PR TITLE
mistral-vibe: 2.19.0 -> 2.23.1

### DIFF
--- a/pkgs/by-name/mi/mistral-vibe/package.nix
+++ b/pkgs/by-name/mi/mistral-vibe/package.nix
@@ -13,7 +13,7 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "mistral-vibe";
-  version = "2.19.0";
+  version = "2.23.1";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -21,7 +21,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     owner = "mistralai";
     repo = "mistral-vibe";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-PODG/SQsZsixBz/j+k8ALBhXS1fPg3v/o6TXkTyzSIQ=";
+    hash = "sha256-WEyzBhkqh/B4NZD8tKoRkQGrw/85xVCftFyRamlMaYg=";
   };
 
   build-system = with python3Packages; [
@@ -163,6 +163,9 @@ python3Packages.buildPythonApplication (finalAttrs: {
     # AssertionError: assert 0 == 1
     "test_preserves_accents_when_matching_latin1_encoded_file"
 
+    # TypeError: cannot pickle 'itertools.count' object (Python 3.14 compatibility)
+    "test_orchestrator_deepcopies_and_stays_functional"
+
     # Fail in the sandbox
     # vibe.core.audio_recorder.audio_recorder_port.NoAudioInputDeviceError: No audio input device available
     "test_audio_stream_yields_chunks"
@@ -226,7 +229,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "tests/e2e/"
 
     # ACP tests require network access
-    "tests/acp/test_acp.py"
     "tests/acp/test_acp_entrypoint_smoke.py"
   ];
 

--- a/pkgs/development/python-modules/agent-client-protocol/default.nix
+++ b/pkgs/development/python-modules/agent-client-protocol/default.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "agent-client-protocol";
-  version = "0.10.1";
+  version = "0.11.1";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -27,7 +27,7 @@ buildPythonPackage (finalAttrs: {
     owner = "agentclientprotocol";
     repo = "python-sdk";
     tag = finalAttrs.version;
-    hash = "sha256-iVmNzAx/YlvFXXVPjS1SmjDqGAr9aRDdSW93Nw2ayAY=";
+    hash = "sha256-R4DYTUuy7vs4c+8k4nF7IjOWVjICGe/Zf9/QlyXu94U=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/mistralai/default.nix
+++ b/pkgs/development/python-modules/mistralai/default.nix
@@ -33,7 +33,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "mistralai";
-  version = "2.6.0";
+  version = "2.8.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -41,7 +41,7 @@ buildPythonPackage (finalAttrs: {
     owner = "mistralai";
     repo = "client-python";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ddQOi7jZiV3affmbsDI36n3wpbkLup5MuJ+9iDPZbro=";
+    hash = "sha256-3RMev6XdxIU1PVWIoZsGzHEqzmd+VZPR1baL39q1CLE=";
   };
 
   preBuild = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: [mistralai/mistral-vibe@v2.19.0...v2.23.1](https://github.com/mistralai/mistral-vibe/compare/v2.19.0...v2.23.1)
Changelog: [https://github.com/mistralai/mistral-vibe/blob/v2.23.1/CHANGELOG.md](https://github.com/mistralai/mistral-vibe/blob/v2.23.1/CHANGELOG.md)

Diff: [mistralai/client-python@v2.6.0...v2.8.0](https://github.com/mistralai/client-python/compare/v2.6.0...v2.8.0)
Changelog: [https://github.com/mistralai/client-python/blob/v2.8.0/RELEASES.md](https://github.com/mistralai/client-python/blob/v2.8.0/RELEASES.md)

Diff: [agentclientprotocol/python-sdk@v0.10.1...v0.11.1](https://github.com/agentclientprotocol/python-sdk/compare/v0.10.1...v0.11.1)
Changelog: [https://github.com/agentclientprotocol/python-sdk/releases/tag/0.11.1](https://github.com/agentclientprotocol/python-sdk/releases/tag/0.11.1)

cc @GaetanLepage @shikanime @mana-byte

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at passthru.tests.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and core functionality.
- [x] Ran [nixpkgs-review](https://github.com/Mic92/nixpkgs-review#usage) on this PR. See [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage).
- [x] Tested basic functionality of all binary files, usually in ./result/bin/.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.
- [ ] Follows the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy).