### PR TITLE
mihomo-tui: init at 0.4.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22684,6 +22684,11 @@
     github = "potb";
     githubId = 10779093;
   };
+  potoo0 = {
+    name = "potoo0";
+    github = "potoo0";
+    githubId = 34411681;
+  };
   pouya = {
     email = "me@pouyacode.net";
     github = "pouya-abbassi";

--- a/pkgs/by-name/mi/mihomo-tui/package.nix
+++ b/pkgs/by-name/mi/mihomo-tui/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "mihomo-tui";
+  version = "0.4.5";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "potoo0";
+    repo = "mihomo-tui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-tNeH4HnpUL6UipDtSTfQLcT0ruwkUkho5+M6Mlj5E4c=";
+  };
+
+  cargoHash = "sha256-JOa5otMJE1GqpGnsIvY/O4ps0N3N1wpepESigY0+Dic=";
+
+  env = {
+    # nixpkgs adds target-specific rustflags, which take precedence over
+    # the build.rustflags in the upstream .cargo/config.toml.
+    RUSTFLAGS = "--cfg tokio_unstable";
+
+    # build.rs requires Git describe metadata to generate the --version information.
+    VERGEN_GIT_DESCRIBE = "v${finalAttrs.version}";
+    VERGEN_BUILD_DATE = "2026-07-19";
+    VERGEN_DEFAULT_ON_ERROR = "1";
+  };
+
+  nativeInstallCheckInputs = [
+    writableTmpDirAsHomeHook
+    versionCheckHook
+  ];
+  # `--version` initializes the config directory and requires a writable home.
+  versionCheckKeepEnvironment = [ "HOME" ];
+  doInstallCheck = true;
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "A simple TUI dashboard for monitoring and managing Mihomo via its REST API";
+    homepage = "https://github.com/potoo0/mihomo-tui";
+    changelog = "https://github.com/potoo0/mihomo-tui/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ potoo0 ];
+    mainProgram = "mihomo-tui";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})

--- a/pkgs/by-name/mi/mihomo-tui/update.sh
+++ b/pkgs/by-name/mi/mihomo-tui/update.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq nix-update
+
+set -euo pipefail
+
+scriptDir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+release="$(
+  curl -fsSL \
+    https://api.github.com/repos/potoo0/mihomo-tui/releases/latest
+)"
+
+version="$(jq -er '.tag_name | ltrimstr("v")' <<< "$release")"
+buildDate="$(jq -er '.published_at | split("T")[0]' <<< "$release")"
+
+sed -i \
+  's#VERGEN_BUILD_DATE = "[^"]*"#VERGEN_BUILD_DATE = "'"$buildDate"'"#' \
+  "$scriptDir/package.nix"
+
+# Update the package version, source hash, and Cargo dependency hash.
+nix-update mihomo-tui --version "$version"


### PR DESCRIPTION

Supersedes #480592.

#480592 packages the outdated v0.2.2 release. This PR packages the current v0.4.5 release and will be maintained by the upstream author.

## Description of changes

Adds [mihomo-tui](https://github.com/potoo0/mihomo-tui), a TUI dashboard for monitoring and managing Mihomo through its REST API.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [x] Tested basic functionality: `mihomo-tui --version` -> `mihomo-tui 0.4.5 - v0.4.5(2026-07-19)`.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
