### PR TITLE
gnome-desktop: expose OpenGL driver path to thumbnail sandbox

### DIFF
--- a/pkgs/by-name/gn/gnome-desktop/bubblewrap-paths.patch
+++ b/pkgs/by-name/gn/gnome-desktop/bubblewrap-paths.patch
@@ -2,7 +2,7 @@ diff --git a/libgnome-desktop/gnome-desktop-thumbnail-script.c b/libgnome-deskto
 index ddcc1511..546c2a36 100644
 --- a/libgnome-desktop/gnome-desktop-thumbnail-script.c
 +++ b/libgnome-desktop/gnome-desktop-thumbnail-script.c
-@@ -555,9 +555,9 @@ add_bwrap (GPtrArray   *array,
+@@ -555,9 +555,10 @@ add_bwrap (GPtrArray   *array,
    g_return_val_if_fail (script->s_infile != NULL, FALSE);
  
    add_args (array,
@@ -12,6 +12,7 @@ index ddcc1511..546c2a36 100644
 +	    "@bubblewrap_bin@",
 +	    "--ro-bind", "@storeDir@", "@storeDir@",
 +	    "--ro-bind-try", "/run/current-system", "/run/current-system",
++	    "--ro-bind-try", "/run/opengl-driver", "/run/opengl-driver",
  	    NULL);
  
    /* These directories might be symlinks into /usr/... */


### PR DESCRIPTION
When trying to setup f3d for 3d model thumbnails in GNOME, I noticed that it would segfault. I also saw someone else report this issue in #486336

After reading that issue and some debugging/messing around it turns out that this only happens when f3d is running in the thumbnail sandbox and exposing the opengl driver files fixes the issue. 

Just to be clear: I am not an expert on what f3d does internally or whether this bind is problematic for security reasons. It does resolve the issue though.

I tested this by running a package override on my system with this change and it fixed my f3d thumbnails.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
