### PR TITLE
nocturne: 1.4.2 -> 1.5.1

### DIFF
--- a/pkgs/by-name/no/nocturne/package.nix
+++ b/pkgs/by-name/no/nocturne/package.nix
@@ -16,6 +16,8 @@
   python3,
   python3Packages,
   libadwaita,
+  libportal,
+  libportal-gtk4,
   gobject-introspection,
   libsecret,
   gst_all_1,
@@ -31,13 +33,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nocturne";
-  version = "1.4.2";
+  version = "1.5.1";
 
   src = fetchFromGitHub {
     owner = "Jeffser";
     repo = "Nocturne";
     tag = finalAttrs.version;
-    hash = "sha256-q2jN1X/2Iayzqf+2d1roQ9dbZKGqWy3sXC78lKXLzPM=";
+    hash = "sha256-83RvrMFUmBUmeObz2u+ScNrT8hb9y02xxWiFqYGnAEU=";
   };
 
   __structuredAttrs = true;
@@ -63,6 +65,8 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     gtk4
     libadwaita
+    libportal
+    libportal-gtk4
     libsecret
     python3
     glib-networking


### PR DESCRIPTION
Diff: https://github.com/Jeffser/Nocturne/compare/1.4.2...1.5.1

Changelog: https://github.com/Jeffser/Nocturne/releases


<img width="2118" height="1876" alt="image" src="https://github.com/user-attachments/assets/2193109b-5437-42a2-a3f2-23456b8c95d4" />


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
