### PR TITLE
supersonic, supersonic-wayland: 0.21.1 -> 0.22.0

### DIFF
--- a/pkgs/by-name/su/supersonic/package.nix
+++ b/pkgs/by-name/su/supersonic/package.nix
@@ -24,16 +24,20 @@
 
 buildGoModule (finalAttrs: {
   pname = "supersonic" + lib.optionalString waylandSupport "-wayland";
-  version = "0.21.1";
+  version = "0.22.0";
 
   src = fetchFromGitHub {
     owner = "dweymouth";
     repo = "supersonic";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-jKmkj7Y3D2Af7XNOkLY3sknOelvId649NZXpu/fU7ko=";
+    hash = "sha256-Ynw/NLDk2AVmn30llFtt/A9hEheUZ+/VZqXOIdiUSxQ=";
   };
 
-  vendorHash = "sha256-Qg5OWg+iFcGuD8E3/7YwmmciiRGdUFNSHLrEAaqRmnQ=";
+  vendorHash = "sha256-W5Uwma72lqJB+QHkSasi7WArsYlfXLVPph9TlDSxFEk=";
+
+  # "go mod vendor" fails to build; go-gl/glfw fails with an error like:
+  # xdg-shell-client-protocol.h: No such file or directory
+  proxyVendor = true;
 
   nativeBuildInputs = [
     copyDesktopItems
@@ -43,8 +47,8 @@ buildGoModule (finalAttrs: {
     desktopToDarwinBundle
   ];
 
-  # go-glfw doesn't support both X11 and Wayland in single build
-  tags = [ "migrated_fynedo" ] ++ lib.optionals waylandSupport [ "wayland" ];
+  # we could omit the "wayland" and "x11" tags if we wanted to support both X11 and Wayland in single build.
+  tags = [ "migrated_fynedo" ] ++ (if waylandSupport then [ "wayland" ] else [ "x11" ]);
 
   buildInputs = [
     libglvnd


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: https://github.com/dweymouth/supersonic/releases/tag/v0.22.0

Switched to `proxyVendor = true`. The default approach doesn't work - `go mod vendor` forgets to include some C headers that are part of `go-gl/glfw`.

Explicitly add the `x11` tag when we're building with `waylandSupport = false` - otherwise the build expects Wayland dependencies to be present.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
