### PR TITLE
node-re2: init at 1.26.1

### DIFF
--- a/pkgs/by-name/no/node-re2/package.nix
+++ b/pkgs/by-name/no/node-re2/package.nix
@@ -1,0 +1,49 @@
+{
+  buildNpmPackage,
+  fetchFromGitHub,
+  lib,
+  stdenv,
+}:
+buildNpmPackage (finalAttrs: {
+  pname = "node-re2";
+  version = "1.26.1";
+
+  src = fetchFromGitHub {
+    owner = "uhop";
+    repo = "node-re2";
+    tag = finalAttrs.version;
+    fetchSubmodules = true;
+    hash = "sha256-076Zm5c9uCJ/OQeLTZnYgUubIL2ron+wKA1gTe3x41U=";
+  };
+
+  npmDepsHash = "sha256-QLzoOO5Mb13U1NfShuohJrqP+s1wRemwb8XRrqhKYkE=";
+
+  env.NODE_PLATFORM = with stdenv.hostPlatform.node; "${platform}-${arch}";
+
+  installPhase = ''
+    runHook preInstall
+
+    # NOTE: this uses build platform's node. Let's hope that the node ABI version is identical between platforms
+    nodeApi=$(node -e 'console.log(process.versions.modules)')
+
+    # Taken from https://github.com/uhop/install-artifact-from-github/wiki/install%E2%80%90from%E2%80%90cache#command-line-parameters
+    targetName="$NODE_PLATFORM-$nodeApi"
+
+    install -Dm755 build/Release/re2.node "$out/$targetName"
+
+    runHook postInstall
+  '';
+
+  setupHook = ./setup-hook.sh;
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  meta = {
+    description = "Node.js bindings for RE2 (binary only)";
+    homepage = "https://github.com/uhop/node-re2";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ Scrumplex ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/no/node-re2/setup-hook.sh
+++ b/pkgs/by-name/no/node-re2/setup-hook.sh
@@ -1,0 +1,4 @@
+echo "Setting up RE2 download mirror to @out@"
+export RE2_DOWNLOAD_MIRROR=@out@
+export RE2_DOWNLOAD_SKIP_PATH="1"
+export RE2_DOWNLOAD_SKIP_VER="1"


### PR DESCRIPTION
This adds a a package that builds re2's native counterpart for use during
sandboxed builds. The included setup hook sets the necessary environment vars
to skip downloading binaries and skip building from source.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
