### PR TITLE
nixos-rebuild-ng: use os.statx and stx_btime when available

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from string import Template
 from subprocess import PIPE, CalledProcessError
 from textwrap import dedent
-from typing import Final, Literal
+from typing import Any, Final, Literal
 
 from . import tmpdir
 from .elevate import NO_ELEVATOR, PRESERVE_ENV, Elevator
@@ -432,11 +432,22 @@ def get_generations(profile: Profile) -> list[Generation]:
     if not profile.path.exists():
         raise NixOSRebuildError(f"no profile '{profile.name}' found")
 
+    def btime_or_ctime(path: Path) -> float:
+        # https://github.com/NixOS/nixpkgs/issues/435555
+        statx: Any = getattr(os, "statx", None)
+        statx_btime: int | None = getattr(os, "STATX_BTIME", None)
+
+        if statx and statx_btime:
+            result = statx(path, mask=statx_btime)
+            return float(result.stx_btime)
+
+        return os.stat(path).st_ctime
+
     def parse_path(path: Path, profile: Profile) -> Generation:
         entry_id = path.name.split("-")[1]
         current = path.name == profile.path.readlink().name
         timestamp = datetime.fromtimestamp(
-            timestamp=path.stat().st_ctime,
+            timestamp=btime_or_ctime(path),
             tz=local_tz,
         ).strftime("%Y-%m-%d %H:%M:%S")
 


### PR DESCRIPTION
Python 3.15's has a new `os.statx` call that maps `stx_btime` on Linux. This should fix the issues we are seeing when the user runs `nix-collect-garbage` to delete old generations, since Nix updates the ctime of the generation symlinks but not the btime.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
