### PR TITLE
nixos-rebuild-ng: fix ruff linter warns

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -86,7 +86,7 @@ def get_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.ArgumentPa
 
     main_parser = argparse.ArgumentParser(
         prog="nixos-rebuild",
-        parents=list(sub_parsers.values()),
+        parents=sub_parsers.values(),
         description="Reconfigure a NixOS machine",
         add_help=False,
         allow_abbrev=False,
@@ -260,7 +260,6 @@ def parse_args(
     if args.v or args.debug:
         logger.setLevel(logging.DEBUG)
 
-    # https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh#L56
     if args.action == Action.DRY_RUN.value:
         args.action = Action.DRY_BUILD.value
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -30,6 +30,8 @@ from .models import (
 from .process import run_wrapper, ssh_default_opts
 from .utils import Args, dict_to_flags
 
+local_tz: Final = datetime.now().astimezone().tzinfo
+
 FLAKE_FLAGS: Final = ["--extra-experimental-features", "nix-command flakes"]
 FLAKE_REPL_TEMPLATE: Final = "repl.nix.template"
 SWITCH_TO_CONFIGURATION_CMD_PREFIX: Final = [
@@ -433,9 +435,10 @@ def get_generations(profile: Profile) -> list[Generation]:
     def parse_path(path: Path, profile: Profile) -> Generation:
         entry_id = path.name.split("-")[1]
         current = path.name == profile.path.readlink().name
-        timestamp = datetime.fromtimestamp(path.stat().st_ctime).strftime(
-            "%Y-%m-%d %H:%M:%S"
-        )
+        timestamp = datetime.fromtimestamp(
+            timestamp=path.stat().st_ctime,
+            tz=local_tz,
+        ).strftime("%Y-%m-%d %H:%M:%S")
 
         return Generation(
             id=int(entry_id),

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/utils.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/utils.py
@@ -46,8 +46,7 @@ def dict_to_flags(d: Args | None) -> list[str]:
                 for vs in value:
                     flags.append(flag)
                     if isinstance(vs, list):
-                        for v in vs:
-                            flags.append(v)
+                        flags.extend(vs)
                     else:
                         flags.append(vs)
             case _:

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/pyproject.toml
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/pyproject.toml
@@ -82,6 +82,10 @@ extend-select = [
     # allow Any type
     "ANN401"
 ]
+"nixos_rebuild/constants.py" = [
+    # allow constant comparison since the values are replaced at build-time
+    "PLR0133"
+]
 
 [tool.pytest.ini_options]
 pythonpath = ["."]

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -993,9 +993,9 @@ def test_execute_nix_switch_flake_build_host(
     config_path.touch()
 
     def run_side_effect(args: list[str], **kwargs: Any) -> CompletedProcess[str]:
-        if args[0] == "nix" and "eval" in args:
-            return CompletedProcess([], 0, str(config_path))
-        elif args[0] == "ssh" and "nix" in args:
+        if (args[0] == "nix" and "eval" in args) or (
+            args[0] == "ssh" and "nix" in args
+        ):
             return CompletedProcess([], 0, str(config_path))
         elif args[0] == "nix-instantiate":
             return CompletedProcess([], 1)
@@ -1316,9 +1316,7 @@ def test_execute_test_flake(mock_run: Mock, tmp_path: Path) -> None:
     def run_side_effect(args: list[str], **kwargs: Any) -> CompletedProcess[str]:
         if args[0] == "nix":
             return CompletedProcess([], 0, str(config_path))
-        elif args[0] == "nix-instantiate":
-            return CompletedProcess([], 1)
-        elif args[0] == "test":
+        elif args[0] == "nix-instantiate" or args[0] == "test":
             return CompletedProcess([], 1)
         else:
             return CompletedProcess([], 0)
@@ -1386,9 +1384,9 @@ def test_execute_test_rollback(
                 2084   2024-11-07 23:54:17   (current)
                 """),
             )
-        elif args[0] == "nix-instantiate" and "nixos-system" in args:
-            return CompletedProcess([], 1)
-        elif args[0] == "test":
+        elif (args[0] == "nix-instantiate" and "nixos-system" in args) or args[
+            0
+        ] == "test":
             return CompletedProcess([], 1)
         else:
             return CompletedProcess([], 0)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
@@ -29,8 +29,10 @@ def test_remote_env_shell_argv() -> None:
         "sudo",
         "/bin/sh",
         "-c",
-        """exec /usr/bin/env -i PATH="${PATH-}" LOCALE_ARCHIVE="${LOCALE_ARCHIVE-}" """
-        '''NIXOS_NO_CHECK="${NIXOS_NO_CHECK-}" NIXOS_INSTALL_BOOTLOADER=0 "$@"''',
+        (
+            """exec /usr/bin/env -i PATH="${PATH-}" LOCALE_ARCHIVE="${LOCALE_ARCHIVE-}" """
+            '''NIXOS_NO_CHECK="${NIXOS_NO_CHECK-}" NIXOS_INSTALL_BOOTLOADER=0 "$@"'''
+        ),
         "sh",
         "cmd",
         "arg",


### PR DESCRIPTION
A recent ruff update triggered new warns, let's fix them.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
