### PR TITLE
ankiAddons.ajt-card-management: 25.10.14.0 -> 26.2.21.0

### DIFF
--- a/pkgs/by-name/an/anki/addons/ajt-card-management/default.nix
+++ b/pkgs/by-name/an/anki/addons/ajt-card-management/default.nix
@@ -6,24 +6,14 @@
 
 anki-utils.buildAnkiAddon (finalAttrs: {
   pname = "ajt-card-management";
-  version = "25.10.14.0";
-  src =
-    (fetchFromGitHub {
-      owner = "Ajatt-Tools";
-      repo = "learn-now-button";
-      rev = "v${finalAttrs.version}";
-      hash = "sha256-ebGMrEfDV9ZWtrV2AjiaNd7WMeNBHlaOBE2xL1x0nWs=";
-      fetchSubmodules = true;
-    })
-    # HACK: remove when https://github.com/Ajatt-Tools/learn-now-button/pull/9 is released
-    .overrideAttrs
-      (oldAttrs: {
-        env = oldAttrs.env or { } // {
-          GIT_CONFIG_COUNT = 1;
-          GIT_CONFIG_KEY_0 = "url.https://github.com/.insteadOf";
-          GIT_CONFIG_VALUE_0 = "git@github.com:";
-        };
-      });
+  version = "26.2.21.0";
+  src = fetchFromGitHub {
+    owner = "Ajatt-Tools";
+    repo = "learn-now-button";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-9PLEEE9M+4LQX5xI7R/xORvykq9qf0k+Eo2UG71e1iM=";
+    fetchSubmodules = true;
+  };
   sourceRoot = "${finalAttrs.src.name}/card_management";
   meta = {
     description = "Reset, Learn, and Grade cards from the card browser";


### PR DESCRIPTION

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
