### PR TITLE
microsoft-rush: init at 5.178.0

### DIFF
--- a/pkgs/by-name/mi/microsoft-rush/package.nix
+++ b/pkgs/by-name/mi/microsoft-rush/package.nix
@@ -1,0 +1,121 @@
+{
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  lib,
+  makeWrapper,
+  nodejs,
+  pnpm_10,
+  pnpmConfigHook,
+  stdenv,
+  testers,
+  yq,
+}:
+
+let
+  pnpm = pnpm_10;
+  rushWorkspace = "@microsoft/rush...";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "microsoft-rush";
+  version = "5.178.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "rushstack";
+    tag = "@microsoft/rush_v${finalAttrs.version}";
+    hash = "sha256-e3M/wbdstVUZR0ShEHO7Bemz2BYHZn7tIIZP33UrRu8=";
+  };
+
+  # We have to patch some files to build rush with pnpm,
+  # as the repo is designed to be built with rush itself
+  postPatch = ''
+    # Rush usually places the pnpm lock file in a subdirectory (common/temp/default),
+    # but we need it at the root of the workspace
+    #
+    # But for this to work, we need to patch a few things:
+    # - We remove rush-specific overrides and checksums
+    # - We set injectWorkspacePackages to true to avoid ERR_PNPM_LOCKFILE_CONFIG_MISMATCH
+    # - We adjust the importer paths be relative to the root of the workspace instead of the common/temp/default subdirectory
+    ${lib.getExe yq} -y '
+      del(.overrides, .packageExtensionsChecksum, .pnpmfileChecksum)
+      | .settings.injectWorkspacePackages = true
+      | .importers |= with_entries(.key |= sub("^\\.\\./\\.\\./\\.\\./"; ""))
+    ' common/config/subspaces/default/pnpm-lock.yaml > pnpm-lock.yaml
+
+    # Since rush doesn't provide a committed pnpm workspace file, we synthesize one from the pnpm lock file
+    ${lib.getExe yq} -y \
+      '{ packages: (.importers | keys | map(select(. != "."))) }' \
+      pnpm-lock.yaml > pnpm-workspace.yaml
+  '';
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      postPatch
+      env
+      pnpmWorkspaces
+      ;
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = "sha256-3zRdVvJQTT7jBaOm4SdM76LmikjaTjVCkZXZK+MFf7A=";
+  };
+
+  pnpmWorkspaces = [ rushWorkspace ];
+
+  env = {
+    npm_config_auto_install_peers = "false";
+    npm_config_inject_workspace_packages = "true";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    nodejs
+    pnpm
+    pnpmConfigHook
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm --filter '${rushWorkspace}' --recursive --if-present run _phase:lite-build
+    pnpm --filter '${rushWorkspace}' --recursive --if-present run _phase:build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    pnpm --filter @microsoft/rush deploy --prod --offline "$out/libexec/microsoft-rush"
+
+    for command in rush rush-pnpm rushx; do
+      makeWrapper ${nodejs}/bin/node "$out/bin/$command" \
+        --add-flags "$out/libexec/microsoft-rush/bin/$command"
+    done
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      inherit (finalAttrs) version;
+      command = "HOME=$TMPDIR rush --help";
+    };
+    updateScript = ./update.sh;
+  };
+
+  meta = {
+    description = "Scalable monorepo manager for the web";
+    homepage = "https://rushjs.io";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nilathedragon ];
+    inherit (nodejs.meta) platforms;
+    mainProgram = "rush";
+  };
+})

--- a/pkgs/by-name/mi/microsoft-rush/update.sh
+++ b/pkgs/by-name/mi/microsoft-rush/update.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix-update nodejs
+# shellcheck shell=bash
+
+set -euo pipefail
+
+version="$(npm view @microsoft/rush version)"
+nix-update "$UPDATE_NIX_ATTR_PATH" --version "$version" --build --test


### PR DESCRIPTION
Rush(JS) is a monorepo package manager capable of handling hundreds of packages in one repo. 

https://rushjs.io/

I chose microsoft-rush as the package name since the package is distributed as @microsoft/rush and the "rush" package already exists.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
