### PR TITLE
buildNpmPackage,fetchNpmDeps: customization/override improvements

### DIFF
--- a/pkgs/build-support/node/build-npm-package/default.nix
+++ b/pkgs/build-support/node/build-npm-package/default.nix
@@ -12,15 +12,10 @@ lib.extendMkDerivation {
 
   extendDrvArgs =
     finalAttrs:
+    let
+      name = finalAttrs.name or "${finalAttrs.pname}-${finalAttrs.version}";
+    in
     {
-      name ? "${args.pname}-${args.version}",
-      src ? null,
-      srcs ? null,
-      sourceRoot ? null,
-      prePatch ? "",
-      patches ? [ ],
-      postPatch ? "",
-      patchFlags ? [ ],
       nativeBuildInputs ? [ ],
       buildInputs ? [ ],
       # The output hash of the dependencies for this project.
@@ -55,22 +50,6 @@ lib.extendMkDerivation {
       # Value for npm `--workspace` flag and directory in which the files to be installed are found.
       npmWorkspace ? null,
       nodejs ? topLevelArgs.nodejs,
-      npmDeps ? fetchNpmDeps {
-        inherit
-          forceGitDeps
-          forceEmptyCache
-          src
-          srcs
-          sourceRoot
-          prePatch
-          patches
-          postPatch
-          patchFlags
-          ;
-        name = "${name}-npm-deps";
-        hash = npmDepsHash;
-        fetcherVersion = npmDepsFetcherVersion;
-      },
       # Custom npmConfigHook
       npmConfigHook ? null,
       # Custom npmBuildHook
@@ -87,7 +66,29 @@ lib.extendMkDerivation {
       };
     in
     {
-      inherit npmDeps npmBuildScript;
+      inherit npmBuildScript;
+
+      npmDeps =
+        args.npmDeps or (fetchNpmDeps {
+          name = "${name}-npm-deps";
+
+          src = finalAttrs.src or null;
+          srcs = finalAttrs.srcs or null;
+          sourceRoot = finalAttrs.sourceRoot or null;
+          prePatch = finalAttrs.prePatch or "";
+          patches = finalAttrs.patches or [ ];
+          postPatch = finalAttrs.postPatch or "";
+          patchFlags = finalAttrs.patchFlags or [ ];
+
+          inherit
+            forceGitDeps
+            forceEmptyCache
+            ;
+
+          fetcherVersion = npmDepsFetcherVersion;
+
+          hash = npmDepsHash;
+        });
 
       env = (args.env or { }) // {
         NIX_NPM_FETCHER_VERSION = npmDepsFetcherVersion;

--- a/pkgs/build-support/node/prefetch-npm-deps/default.nix
+++ b/pkgs/build-support/node/prefetch-npm-deps/default.nix
@@ -227,111 +227,115 @@
     };
   };
 
-  fetchNpmDeps =
-    {
-      name ? "npm-deps",
-      hash ? "",
-      forceGitDeps ? false,
-      forceEmptyCache ? false,
-      nativeBuildInputs ? [ ],
-      # A string with a JSON attrset specifying registry mirrors, for example
-      #   {"registry.example.org": "my-mirror.local/registry.example.org"}
-      npmRegistryOverridesString ? config.npmRegistryOverridesString,
-      # Fetcher format version. Bump this to invalidate all existing hashes.
-      # Version 1: original format (tarballs only)
-      # Version 2: includes packuments for workspace support
-      fetcherVersion ? 1,
-      ...
-    }@args:
-    let
-      hash_ =
-        if hash != "" then
-          {
-            outputHash = hash;
-          }
-        else
-          {
-            outputHash = "";
-            outputHashAlgo = "sha256";
-          };
+  fetchNpmDeps = lib.makeOverridable (
+    lib.extendMkDerivation {
+      constructDrv = stdenvNoCC.mkDerivation;
 
-      forceGitDeps_ = lib.optionalAttrs forceGitDeps { FORCE_GIT_DEPS = true; };
-      forceEmptyCache_ = lib.optionalAttrs forceEmptyCache { FORCE_EMPTY_CACHE = true; };
-    in
-    stdenvNoCC.mkDerivation (
-      args
-      // {
-        inherit name;
-
-        nativeBuildInputs = nativeBuildInputs ++ [ prefetch-npm-deps ];
-
-        buildPhase = ''
-          runHook preBuild
-
-          if [[ -f npm-shrinkwrap.json ]]; then
-            local -r srcLockfile="npm-shrinkwrap.json"
-          elif [[ -f package-lock.json ]]; then
-            local -r srcLockfile="package-lock.json"
-          else
-            echo
-            echo "ERROR: No lock file!"
-            echo
-            echo "package-lock.json or npm-shrinkwrap.json is required to make sure"
-            echo "that npmDepsHash doesn't change when packages are updated on npm."
-            echo
-            echo "Hint: You can copy a vendored package-lock.json file via postPatch."
-            echo
-
-            exit 1
-          fi
-
-          outputHash="${hash_.outputHash}" prefetch-npm-deps $srcLockfile $out
-
-          runHook postBuild
-        '';
-
-        dontInstall = true;
-
-        # NIX_NPM_TOKENS environment variable should be a JSON mapping in the shape of:
-        # `{ "registry.example.com": "example-registry-bearer-token", ... }`
-        impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [ "NIX_NPM_TOKENS" ];
-
-        env = {
-          NIX_NPM_REGISTRY_OVERRIDES = npmRegistryOverridesString;
-
-          # Fetcher version controls which features are enabled in prefetch-npm-deps
-          NPM_FETCHER_VERSION =
-            let
-              # Increment when we introduce a new version.
-              validFetcherVersions = [
-                1 # Initial version
-                2 # enables packument fetching for workspace support
-              ];
-            in
-            assert lib.assertMsg (lib.elem fetcherVersion validFetcherVersions)
-              "fetchNpmDeps: fetcher version must be one of: ${
-                lib.concatMapStringsSep ", " toString validFetcherVersions
-              }.";
-            (toString fetcherVersion);
-
-          SSL_CERT_FILE =
-            if
-              (
-                hash_.outputHash == ""
-                || hash_.outputHash == lib.fakeSha256
-                || hash_.outputHash == lib.fakeSha512
-                || hash_.outputHash == lib.fakeHash
-              )
-            then
-              "${cacert}/etc/ssl/certs/ca-bundle.crt"
+      extendDrvArgs =
+        finalAttrs:
+        {
+          name ? "npm-deps",
+          hash ? "",
+          forceGitDeps ? false,
+          forceEmptyCache ? false,
+          nativeBuildInputs ? [ ],
+          # A string with a JSON attrset specifying registry mirrors, for example
+          #   {"registry.example.org": "my-mirror.local/registry.example.org"}
+          npmRegistryOverridesString ? config.npmRegistryOverridesString,
+          # Fetcher format version. Bump this to invalidate all existing hashes.
+          # Version 1: original format (tarballs only)
+          # Version 2: includes packuments for workspace support
+          fetcherVersion ? 1,
+          ...
+        }:
+        let
+          hash_ =
+            if hash != "" then
+              {
+                outputHash = hash;
+              }
             else
-              "/no-cert-file.crt";
-        }
-        // forceGitDeps_
-        // forceEmptyCache_;
+              {
+                outputHash = "";
+                outputHashAlgo = "sha256";
+              };
 
-        outputHashMode = "recursive";
-      }
-      // hash_
-    );
+          forceGitDeps_ = lib.optionalAttrs forceGitDeps { FORCE_GIT_DEPS = true; };
+          forceEmptyCache_ = lib.optionalAttrs forceEmptyCache { FORCE_EMPTY_CACHE = true; };
+        in
+        {
+          inherit name;
+
+          nativeBuildInputs = nativeBuildInputs ++ [ prefetch-npm-deps ];
+
+          buildPhase = ''
+            runHook preBuild
+
+            if [[ -f npm-shrinkwrap.json ]]; then
+              local -r srcLockfile="npm-shrinkwrap.json"
+            elif [[ -f package-lock.json ]]; then
+              local -r srcLockfile="package-lock.json"
+            else
+              echo
+              echo "ERROR: No lock file!"
+              echo
+              echo "package-lock.json or npm-shrinkwrap.json is required to make sure"
+              echo "that npmDepsHash doesn't change when packages are updated on npm."
+              echo
+              echo "Hint: You can copy a vendored package-lock.json file via postPatch."
+              echo
+
+              exit 1
+            fi
+
+            outputHash="${hash_.outputHash}" prefetch-npm-deps $srcLockfile $out
+
+            runHook postBuild
+          '';
+
+          dontInstall = true;
+
+          # NIX_NPM_TOKENS environment variable should be a JSON mapping in the shape of:
+          # `{ "registry.example.com": "example-registry-bearer-token", ... }`
+          impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [ "NIX_NPM_TOKENS" ];
+
+          env = {
+            NIX_NPM_REGISTRY_OVERRIDES = npmRegistryOverridesString;
+
+            # Fetcher version controls which features are enabled in prefetch-npm-deps
+            NPM_FETCHER_VERSION =
+              let
+                # Increment when we introduce a new version.
+                validFetcherVersions = [
+                  1 # Initial version
+                  2 # enables packument fetching for workspace support
+                ];
+              in
+              assert lib.assertMsg (lib.elem fetcherVersion validFetcherVersions)
+                "fetchNpmDeps: fetcher version must be one of: ${
+                  lib.concatMapStringsSep ", " toString validFetcherVersions
+                }.";
+              (toString fetcherVersion);
+
+            SSL_CERT_FILE =
+              if
+                (
+                  hash_.outputHash == ""
+                  || hash_.outputHash == lib.fakeSha256
+                  || hash_.outputHash == lib.fakeSha512
+                  || hash_.outputHash == lib.fakeHash
+                )
+              then
+                "${cacert}/etc/ssl/certs/ca-bundle.crt"
+              else
+                "/no-cert-file.crt";
+          }
+          // forceGitDeps_
+          // forceEmptyCache_;
+
+          outputHashMode = "recursive";
+        }
+        // hash_;
+    }
+  );
 }


### PR DESCRIPTION
These changes allow overriding npmDeps using the common prevAttrs/finalAttrs pattern.

Example:

```nix
html-minifier.overrideAttrs (prevAttrs: {
  version = "3.5.20";
  src = prevAttrs.src.override {
    hash = "sha256-OAykAqBxgr7tbeXXfSH23DALf7Eoh3VjDKNKWGAL3+A=";
  };
  npmDeps = prevAttrs.npmDeps.override {
    hash = "sha256-VWXc/nBXgvSE/DoLHR4XTFQ5kuwWC1m0/cj1CndfPH8=";
  };
})
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
