### PR TITLE
mark: 16.6.0 -> 16.8.9

### DIFF
--- a/pkgs/by-name/ma/mark/package.nix
+++ b/pkgs/by-name/ma/mark/package.nix
@@ -1,23 +1,24 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
+  iana-etc,
+  libredirect,
 }:
 
-# Tests with go 1.24 do not work. For now
-# https://github.com/kovetskiy/mark/pull/581#issuecomment-2797872996
 buildGoModule (finalAttrs: {
   pname = "mark";
-  version = "16.6.0";
+  version = "16.8.9";
 
   src = fetchFromGitHub {
     owner = "kovetskiy";
     repo = "mark";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-kpWY+8r6ILHmZr1VWO+4rj8tLqzyucsDNPnoPaF1IkU=";
+    sha256 = "sha256-tIixIAgMooDONu1ZcU0tTFM0DR+j2R4gcO9s1tA0x9I=";
   };
 
-  vendorHash = "sha256-vJn/bFhbnDY0OfuD9swvt/X5Pb0nWpaoHc1iwWCVwpg=";
+  vendorHash = "sha256-DR3ma5pliR7C1gJ+b2gbWEIEEb+QaH7hSSc9mroA5Tc=";
 
   ldflags = [
     "-s"
@@ -25,17 +26,34 @@ buildGoModule (finalAttrs: {
     "-X main.version=${finalAttrs.version}"
   ];
 
+  nativeCheckInputs = lib.optionals stdenv.hostPlatform.isDarwin [ libredirect.hook ];
+
+  # goldmark-katex pulls in modernc.org/libc, whose vendored netdb package reads
+  # /etc/protocols and /etc/services during package init. It falls back to a
+  # built-in table when they do not exist, but panics when they exist and are
+  # unreadable, which is what the Darwin sandbox produces.
+  preCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    export NIX_REDIRECTS=/etc/protocols=${iana-etc}/etc/protocols:/etc/services=${iana-etc}/etc/services
+  '';
+
   checkFlags =
     let
       skippedTests = [
         # Expects to be able to launch google-chrome
         "TestExtractMermaidImage"
         "TestExtractD2Image/example"
+        "TestAttachmentFilenameAttributeIsEscaped"
+        "TestDiagramWithoutTitleHasNoCaption"
+        "TestDiagramWithTitleKeepsCaption"
       ];
     in
     [
       "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$"
     ];
+
+  # confluence/api_test.go serves a mock Confluence API over httptest, which
+  # binds a localhost listener.
+  __darwinAllowLocalNetworking = true;
 
   meta = {
     description = "Tool for syncing your markdown documentation with Atlassian Confluence pages";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
mark [v16.8.9](https://github.com/kovetskiy/mark/releases/tag/v16.8.9) update

Full changelog: https://github.com/kovetskiy/mark/compare/v16.6.0...v16.8.9

There are new tests I had to skip.
Some tests now requre a local web server, so there is a local network permission for darwin sandbox.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
