### PR TITLE
yet-another-cloudwatch-exporter: init at 0.67.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23988,6 +23988,12 @@
     githubId = 6047658;
     name = "Ryan Horiguchi";
   };
+  rhousand = {
+    email = "rhousand@gmail.com";
+    github = "rhousand";
+    githubId = 6124540;
+    name = "Ryan Housand";
+  };
   rhydianjenkins = {
     name = "Rhydian Jenkins";
     github = "RhydianJenkins";

--- a/pkgs/by-name/ye/yet-another-cloudwatch-exporter/package.nix
+++ b/pkgs/by-name/ye/yet-another-cloudwatch-exporter/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "yet-another-cloudwatch-exporter";
+  version = "0.67.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "prometheus-community";
+    repo = "yet-another-cloudwatch-exporter";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-3VMNLkzzwJX4ZhLihppjyBZDD/W+z5xLsMkZLUYHOF0=";
+  };
+
+  vendorHash = "sha256-0wHvXiYQGYU89SSOEBxiSC0CLGwOfN2Dzn8WeEBLYFk=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/prometheus/common/version.Version=${finalAttrs.version}"
+    "-X github.com/prometheus/common/version.Branch=master"
+    "-X github.com/prometheus/common/version.BuildUser=nixbld@nixpkgs"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Prometheus exporter for AWS CloudWatch metrics";
+    homepage = "https://github.com/prometheus-community/yet-another-cloudwatch-exporter";
+    changelog = "https://github.com/prometheus-community/yet-another-cloudwatch-exporter/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ rhousand ];
+    mainProgram = "yace";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
  Adds `yet-another-cloudwatch-exporter` (YACE), a Prometheus exporter for AWS
  CloudWatch metrics. It discovers AWS resources and exports their CloudWatch
  metrics (e.g. EC2 `CPUCreditBalance`, EBS `BurstBalance`) for scraping by
  Prometheus covering AWS-billed limits that `node_exporter` can't see.

  Homepage: https://github.com/nerdswords/yet-another-cloudwatch-exporter
  Changelog: https://github.com/nerdswords/yet-another-cloudwatch-exporter/releases/tag/v0.67.0

  New package at v0.67.0, `pkgs/by-name`, built with `buildGoModule`.
  `meta.mainProgram = "yace"`, `versionCheckHook` smoke test, `nix-update-script`
  for updates. Requires Go ≥ 1.25 (satisfied by the current default toolchain).

  I intend to maintain this package.

  Derivation drafted with AI assistance (see the `Assisted-by:` commit trailer);
  reviewed, built, and tested by me.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
