### PR TITLE
nixos.acme: fix option descriptions

### DIFF
--- a/nixos/modules/security/acme/default.nix
+++ b/nixos/modules/security/acme/default.nix
@@ -772,7 +772,7 @@ let
           description = ''
             Key type to use for private keys.
             For an up to date list of supported values check the --key-type option
-            at <https://go-acme.github.io/lego/usage/cli/options/>.
+            at <https://go-acme.github.io/lego/references/ref-flags/index.html#options>.
           '';
         };
 
@@ -833,7 +833,7 @@ let
           '';
           example = lib.literalExpression ''
             {
-              "RFC2136_TSIG_SECRET_FILE" = "/run/secrets/tsig-secret-example.org";
+              "DNSUPDATE_TSIG_SECRET_FILE" = "/run/secrets/tsig-secret-example.org";
             }
           '';
         };
@@ -852,8 +852,9 @@ let
           inherit (defaultAndText "ocspMustStaple" false) default defaultText;
           description = ''
             Turns on the OCSP Must-Staple TLS extension.
-            Make sure you know what you're doing! See:
-
+            Make sure you know what you're doing!
+            OCSP Must-Staple can be considered a legacy feature, that is no longer superted by Let's Encrypt. See:
+            - <https://letsencrypt.org/2024/12/05/ending-ocsp>
             - <https://blog.apnic.net/2019/01/15/is-the-web-ready-for-ocsp-must-staple/>
             - <https://blog.hboeck.de/archives/886-The-Problem-with-OCSP-Stapling-and-Must-Staple-and-why-Certificate-Revocation-is-still-broken.html>
           '';


### PR DESCRIPTION
- replace broken links
- replace deprecated value "RFC2136_" in example with "DNSUPDATE_"
- warn against using legacy option "ocspMustStaple"

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
