### PR TITLE
gaffer: init at 1.6.21.1

### DIFF
--- a/pkgs/by-name/ga/gaffer/package.nix
+++ b/pkgs/by-name/ga/gaffer/package.nix
@@ -1,0 +1,105 @@
+{
+  autoPatchelfHook,
+  bash,
+  bzip2,
+  fetchzip,
+  fontconfig,
+  glib,
+  krb5,
+  lcms2,
+  lib,
+  libGL,
+  libGLU,
+  libice,
+  libsm,
+  libtinfo,
+  libx11,
+  libxcb-image,
+  libxcb-cursor,
+  libxcb-wm,
+  libxcb-keysyms,
+  libxcb-render-util,
+  libxkbcommon,
+  libxt,
+  stdenv,
+  xz,
+  zlib,
+
+  withArnold ? false,
+  withRenderman ? false,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gaffer";
+  version = "1.6.21.1";
+  src = fetchzip {
+    url = "https://github.com/GafferHQ/gaffer/releases/download/${finalAttrs.version}/gaffer-${finalAttrs.version}-linux-gcc11.tar.gz";
+    hash = "sha256-5F/LTCwRm/zzJfpn21cN6aYl56MJkWGDmVSdMRP99Ec=";
+  };
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r * $out/.
+
+    ${lib.optionalString (!withArnold) "rm -r $out/arnold"}
+    ${lib.optionalString (!withRenderman) "rm -r $out/renderMan"}
+
+    runHook postInstall
+  '';
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  autoPatchelfIgnoreMissingDeps = [
+    "*"
+  ];
+
+  buildInputs = [
+    bash
+    bzip2
+    fontconfig
+    glib
+    krb5
+    lcms2
+    libGL
+    libGLU
+    libice
+    libsm
+    libtinfo
+    libx11
+    libxcb-image
+    libxcb-cursor
+    libxcb-wm
+    libxcb-keysyms
+    libxcb-render-util
+    libxkbcommon
+    libxt
+    xz
+    zlib
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  meta = {
+    description = "Gaffer is a free, open-source, node-based VFX application.";
+    longDescription = ''
+      Gaffer is a free, open-source, node-based VFX application that enables look developers, lighters, and compositors to easily build, tweak, iterate, and render scenes.
+      Built with flexibility in mind, Gaffer supports in-application scripting in Python and OSL, so VFX artists and technical directors can design shaders,
+      automate processes, and build production workflows.
+
+      With hooks in both C++ and Python, Gaffer's readily extensible API provides both professional studios and enthusiasts with the tools to add their own custom modules,
+      nodes, and UI.
+
+      The workhorse of the production pipeline at Image Engine Design Inc., Gaffer has been used to build award-winning VFX for shows such as
+      Jurassic World: Fallen Kingdom, Lost in Space, Logan, and Game of Thrones.
+    '';
+    homepage = "https://www.gafferhq.org/";
+    changelog = "https://github.com/GafferHQ/gaffer/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.bsd3;
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "gaffer";
+    maintainers = with lib.maintainers; [ permahorse ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Add Gaffer package
nixpkgs already have blender and houdini, why not adding another VFX software, maybe not one as widely known.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
