### PR TITLE
[staging-next] nixos/systemd: patch to avoid update-utmp failure with audit 4.2

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -259,7 +259,27 @@ in
 
   options.systemd = {
 
-    package = mkPackageOption pkgs "systemd" { };
+    package = mkPackageOption pkgs "systemd" { } // {
+      # audit 4.2 rejects overlong values (max 15 bytes) for the kernel comm.
+      # systemd attempts to send the full 19 bytes of "systemd-update-utmp",
+      # and the systemd-update-utmp service fails to start. this patch shortens
+      # the kernel comm entry to "update-utmp".
+      # TODO: revert on staging when updating to audit 4.2.1
+      # original commit: https://github.com/linux-audit/audit-userspace/commit/d7ea98263ebdb974b383a4057856a5ec339776fc
+      # switch to truncate: https://github.com/linux-audit/audit-userspace/commit/d7ea98263ebdb974b383a4057856a5ec339776fc
+      # systemd pr: https://github.com/systemd/systemd/pull/43144
+      apply =
+        pkg:
+        pkg.overrideAttrs (prevAttrs: {
+          patches = prevAttrs.patches or [ ] ++ [
+            (pkgs.fetchpatch {
+              name = "systemd-update-utmp-shorten-comm.patch";
+              url = "https://github.com/systemd/systemd/commit/b8968c492108506952ab2748c4a44ce32fc9477c.patch";
+              hash = "sha256-d0rMssj1+cDw3+KOk8ecjqIIuBhjDixIH+7MJfC+I+M=";
+            })
+          ];
+        });
+    };
 
     enableStrictShellChecks = mkEnableOption "" // {
       description = ''


### PR DESCRIPTION
see discussion in #staging:nixos.org starting at https://matrix.to/#/!UNVBThoJtlIiVwiDjU:nixos.org/$nUMH0ULEV7kMmSOMrOiCZI3rb2yGvXDGn_yY-wNYmDU?via=nixos.org&via=matrix.org&via=tchncs.de for much more context.

audit 4.2 rejects overlong values (max 15 bytes) for the kernel comm. systemd attempts to send the full 19 bytes of "systemd-update-utmp", and the systemd-update-utmp service fails to start. this was changed to truncate instead of reject in audit 4.2.1, but until we can take the mass rebuild on staging, we fetch the systemd patch which shortens "systemd-update-utmp" to "update-utmp". this is in the nixos module as `apply` instead of part of the systemd package as that would be a larger rebuild and would delay other fixes making their way to master.

original commit: https://github.com/linux-audit/audit-userspace/commit/d7ea98263ebdb974b383a4057856a5ec339776fc
switch to truncate: https://github.com/linux-audit/audit-userspace/commit/d7ea98263ebdb974b383a4057856a5ec339776fc
systemd pr: https://github.com/systemd/systemd/pull/43144

tested: `nixosTests.login` had logs of utmp failing to start before, and no longer does with this. also tested on my laptop running staging-next.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
