### PR TITLE
qemu: fix minimal build

### DIFF
--- a/pkgs/by-name/qe/qemu/fix-tls-tests-without-tasn1.patch
+++ b/pkgs/by-name/qe/qemu/fix-tls-tests-without-tasn1.patch
@@ -1,0 +1,31 @@
+diff --git a/tests/qtest/migration/tls-tests.c b/tests/qtest/migration/tls-tests.c
+index 827cc7bcf8..9bdb1165af 100644
+--- a/tests/qtest/migration/tls-tests.c
++++ b/tests/qtest/migration/tls-tests.c
+@@ -492,6 +492,7 @@ static void test_precopy_tcp_no_tls(char *name, MigrateCommon *args)
+     test_precopy_common(args);
+ }
+ 
++#ifdef CONFIG_TASN1
+ static void *
+ migrate_hook_start_tls_x509_no_host(QTestState *from, QTestState *to)
+ {
+@@ -519,7 +520,6 @@ static void test_precopy_tcp_tls_no_hostname(char *name, MigrateCommon *args)
+     test_precopy_common(args);
+ }
+ 
+-#ifdef CONFIG_TASN1
+ static void test_precopy_tcp_tls_x509_default_host(char *name,
+                                                    MigrateCommon *args)
+ {
+@@ -719,8 +719,10 @@ void migration_test_add_tls(MigrationTestEnv *env)
+ 
+     migration_test_add("/migration/precopy/tcp/no-tls",
+                        test_precopy_tcp_no_tls);
++#ifdef CONFIG_TASN1
+     migration_test_add("/migration/precopy/tcp/tls/no-hostname",
+                        test_precopy_tcp_tls_no_hostname);
++#endif /* CONFIG_TASN1 */
+ 
+     migration_test_add("/migration/precopy/unix/tls/psk",
+                        test_precopy_unix_tls_psk);

--- a/pkgs/by-name/qe/qemu/package.nix
+++ b/pkgs/by-name/qe/qemu/package.nix
@@ -280,6 +280,12 @@ stdenv.mkDerivation (finalAttrs: {
       sha256 = "sha256-oC+bRjEHixv1QEFO9XAm4HHOwoiT+NkhknKGPydnZ5E=";
       revert = true;
     })
+
+    # Fix compilation of the TLS migration tests when gnutls is available
+    # but libtasn1 is not, as in the minimal build, see #547163.
+    # Submitted upstream, remove when included in a release:
+    # https://lists.gnu.org/archive/html/qemu-devel/2026-07/msg08469.html
+    ./fix-tls-tests-without-tasn1.patch
   ]
   ++ lib.optional nixosTestRunner ./force-uid0-on-9p.patch;
 


### PR DESCRIPTION
Resolves #547163 

this PR fixes the build failure for minimal qemu by moving `libtasn1` into the minimal build inputs

the relevant test file from the build failure `tls-tests.c` [runs when qemu is compiled with `gnuutils`](https://github.com/qemu/qemu/blob/e1705a25aff35635c360bbaba4c2731d019a422a/tests/qtest/meson.build#L378). `tls-tests.c` defines [the helpers](https://github.com/qemu/qemu/blob/e1705a25aff35635c360bbaba4c2731d019a422a/tests/qtest/migration/tls-tests.c#L138) that show in the error within a `#ifdef CONFIG_TASN1` check, but there's [a test](https://github.com/qemu/qemu/blob/e1705a25aff35635c360bbaba4c2731d019a422a/tests/qtest/migration/tls-tests.c#L503) that calls the helper outwith any `CONFIG_TASN1` check, meaning if `gnuutils` is included but `libtasn1` isn't then the build fails.

this should probably also be fixed upstream but submitting changes to qemu is kind of a pain.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
