### PR TITLE
python3Packages.tomlkit: 0.15.0 -> 0.15.1

### DIFF
--- a/pkgs/development/python-modules/tomlkit/default.nix
+++ b/pkgs/development/python-modules/tomlkit/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
 
   # build-system
   poetry-core,
@@ -9,16 +9,22 @@
   # tests
   pytestCheckHook,
   pyyaml,
+
+  # passthru.tests
+  remarshal,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "tomlkit";
-  version = "0.15.0";
+  version = "0.15.1";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-fRqey6MIZjghGxOBTqeckN1U3RGZNWQ3bzqpInH1x6M=";
+  src = fetchFromGitHub {
+    owner = "python-poetry";
+    repo = "tomlkit";
+    tag = finalAttrs.version;
+    fetchSubmodules = true;
+    hash = "sha256-6zPz07MdVgXIgmsTK7Sic9cHouP/BR8KAR0dN1hUEjU=";
   };
 
   build-system = [ poetry-core ];
@@ -30,11 +36,18 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "tomlkit" ];
 
+  passthru.tests = {
+    inherit remarshal;
+  };
+
   meta = {
-    homepage = "https://github.com/sdispater/tomlkit";
-    changelog = "https://github.com/sdispater/tomlkit/blob/${version}/CHANGELOG.md";
+    homepage = "https://github.com/python-poetry/tomlkit";
+    changelog = "https://github.com/python-poetry/tomlkit/blob/${finalAttrs.version}/CHANGELOG.md";
     description = "Style-preserving TOML library for Python";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ jakewaksbaum ];
+    maintainers = with lib.maintainers; [
+      dotlambda
+      jakewaksbaum
+    ];
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/python-poetry/tomlkit/compare/0.15.0...0.15.1

Changelog: https://github.com/python-poetry/tomlkit/blob/0.15.1/CHANGELOG.md

related: https://github.com/NixOS/nixpkgs/pull/546940
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
