### PR TITLE
mullvad-vpn: add desktop icons, minor improvements

### DIFF
--- a/pkgs/by-name/mu/mullvad-vpn/package.nix
+++ b/pkgs/by-name/mu/mullvad-vpn/package.nix
@@ -7,6 +7,7 @@
   electron,
   copyDesktopItems,
   grpc-tools,
+  librsvg,
   makeBinaryWrapper,
   versionCheckHook,
   makeDesktopItem,
@@ -33,6 +34,7 @@ buildNpmPackage (finalAttrs: {
   nativeBuildInputs = [
     copyDesktopItems
     grpc-tools
+    librsvg
     makeBinaryWrapper
   ];
 
@@ -63,14 +65,18 @@ buildNpmPackage (finalAttrs: {
   npmWorkspace = "mullvad-vpn";
   npmBuildScript = "pack:linux";
 
-  # Mullvad currently depends on iproute2 being available at runtime to
-  # set the userspace routing for certain obfuscation types.
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/share/mullvad-vpn/
     cp -r ../dist/*-unpacked/{locales,resources{,.pak}} $out/share/mullvad-vpn/
-    cp ../graphics/icon{-square.svg,.svg} $out/share/mullvad-vpn/resources/
+    cp ../graphics/icon{-square,}.svg $out/share/mullvad-vpn/resources/
+
+    install -D ../graphics/icon.svg $out/share/icons/hicolor/scalable/apps/mullvad-vpn.svg
+    for size in 16 32 48 64 128 256 512 1024; do
+      mkdir -p $out/share/icons/hicolor/''${size}x''${size}/apps
+      rsvg-convert -o $out/share/icons/hicolor/''${size}x''${size}/apps/mullvad-vpn.png -w $size -h $size ../graphics/icon.svg
+    done
 
     makeWrapper ${lib.getExe electron} $out/bin/mullvad-vpn \
         --add-flags $out/share/mullvad-vpn/resources/app.asar \
@@ -95,18 +101,16 @@ buildNpmPackage (finalAttrs: {
 
   nativeInstallCheckInputs = [ versionCheckHook ];
 
-  desktopItems = [
-    (makeDesktopItem {
-      name = "mullvad-vpn";
-      categories = [ "Network" ];
-      comment = "Mullvad VPN client";
-      desktopName = "Mullvad VPN";
-      exec = "mullvad-vpn";
-      icon = "mullvad-vpn";
-      startupWMClass = "Mullvad VPN";
-      terminal = false;
-    })
-  ];
+  desktopItems = lib.singleton (makeDesktopItem {
+    name = "mullvad-vpn";
+    categories = [ "Network" ];
+    comment = "Mullvad VPN client";
+    desktopName = "Mullvad VPN";
+    exec = "mullvad-vpn";
+    icon = "mullvad-vpn";
+    startupWMClass = "Mullvad VPN";
+    terminal = false;
+  });
 
   passthru.hasMullvadGUI = true;
 


### PR DESCRIPTION
I assumed that Electron would magically setup the icons, since they worked when I had both the old and the new `mullvad-vpn` installed, but I guess you still need to package them individually on `$out/share/icons`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
