### PR TITLE
shadow: 4.19.4 -> 4.20.0

### DIFF
--- a/nixos/tests/shadow/system.nix
+++ b/nixos/tests/shadow/system.nix
@@ -4,6 +4,7 @@ let
   controllerPython = pkgs.python3.withPackages (ps: [
     ps.flaky
     ps.jc
+    ps.passlib
     ps.pytest
     ps.pytest-mh
     ps.pytest-ticket
@@ -35,6 +36,7 @@ in
         environment.systemPackages = with pkgs; [
           shadow
           expect
+          vim
         ];
 
         users.defaultUserShell = "/bin/sh";

--- a/pkgs/by-name/sh/shadow/package.nix
+++ b/pkgs/by-name/sh/shadow/package.nix
@@ -20,7 +20,6 @@
   withTcb ? lib.meta.availableOn stdenv.hostPlatform tcb,
   tcb,
   cmocka,
-  fetchpatch,
 }:
 let
   glibc' =
@@ -34,13 +33,13 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "shadow";
-  version = "4.19.4";
+  version = "4.20.0";
 
   src = fetchFromGitHub {
     owner = "shadow-maint";
     repo = "shadow";
     tag = finalAttrs.version;
-    hash = "sha256-vR6dwB3EttGY2DgQ20nOr9kNhF+nsAaBEyklcJAZ20Y=";
+    hash = "sha256-UafTyfK+pmW2wyAQnvHov9KIorf1HSc6haskfv7auHs=";
   };
 
   outputs = [
@@ -150,36 +149,6 @@ stdenv.mkDerivation (finalAttrs: {
         cp -r . $out/
       '';
       dontBuild = true;
-      patches = [
-        # tests: update useradd tests to expect ID 1001
-        (fetchpatch {
-          name = "update-useradd-tests.patch";
-          url = "https://github.com/shadow-maint/shadow/commit/59fbe8415dab17f1e702fbdee96956886c86c737.patch";
-          hash = "sha256-U0+NSCd4AfTuHMddTx9+wNtpdJt9t8+D5ApW0OCNgsY=";
-          stripLen = 2;
-        })
-        # tests: update usermod tests to expect ID 1001
-        (fetchpatch {
-          name = "update-usermod-tests.patch";
-          url = "https://github.com/shadow-maint/shadow/commit/91c2ad44ababca2e32cdb71152b0f7f2a7c546be.patch";
-          hash = "sha256-v1EEvMfUYoE/ZnBM0k/+kUBK3W1dXr588OQzvFmnXLI=";
-          stripLen = 2;
-        })
-        # tests: update groupadd tests to expect GID 1001
-        (fetchpatch {
-          name = "update-groupadd-tests.patch";
-          url = "https://github.com/shadow-maint/shadow/commit/60568eaec13d1e417f56f0e59ac9573c0e3b9a83.patch";
-          hash = "sha256-tLmGeW4Y7UcZqMhW3IXgygKPhCmbZkkW5XTJ7CFz9vg=";
-          stripLen = 2;
-        })
-        # tests: update newgrp tests to expect GID 1002
-        (fetchpatch {
-          name = "update-newgrp-tests.patch";
-          url = "https://github.com/shadow-maint/shadow/commit/49ff9bf33a7b6af57cb26688c3139f014302c9d9.patch";
-          hash = "sha256-1760t4Ezd5Ke4PFZ70Njb+k+1kp17aT/7uqu1PswVss=";
-          stripLen = 2;
-        })
-      ];
       postPatch = ''
         # Replace the gshadow existence check in the test framework with a more NixOS-friendly one, since NixOS does not have /etc/gshadow as a regular file
         substituteInPlace framework/hosts/shadow.py \


### PR DESCRIPTION
Changes: https://github.com/shadow-maint/shadow/releases/tag/4.20.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
