### PR TITLE
python3Packages.jupyterlab-git: 0.52.0 -> 0.54.0

### DIFF
--- a/pkgs/development/python-modules/jupyterlab-git-core/default.nix
+++ b/pkgs/development/python-modules/jupyterlab-git-core/default.nix
@@ -1,0 +1,96 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  git,
+  nodejs,
+  writableTmpDirAsHomeHook,
+  yarn-berry_3,
+  anyio,
+  hatch-jupyter-builder,
+  hatch-nodejs-version,
+  hatchling,
+  jupyterlab,
+  nbdime,
+  nbformat,
+  packaging,
+  pexpect,
+  pytest-asyncio,
+  pytestCheckHook,
+  traitlets,
+}:
+
+buildPythonPackage rec {
+  pname = "jupyterlab-git-core";
+  version = "0.54.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jupyterlab";
+    repo = "jupyterlab-git";
+    tag = "v${version}";
+    hash = "sha256-oTXvugfBay2cmRDu4yo6eFm3qGal3wgxc83dFeKs5Gw=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    yarn-berry_3.yarnBerryConfigHook
+  ];
+
+  offlineCache = yarn-berry_3.fetchYarnBerryDeps {
+    inherit src;
+    hash = "sha256-gJvrR/4Ov9jHjhPtlqYe9ZfMYOd2WtGQdbDGv/JikJA=";
+  };
+
+  preBuild = ''
+    cd packages/core
+  '';
+
+  build-system = [
+    hatch-jupyter-builder
+    hatch-nodejs-version
+    hatchling
+    jupyterlab
+  ];
+
+  dependencies = [
+    anyio
+    nbformat
+    packaging
+    pexpect
+    traitlets
+  ];
+
+  propagatedBuildInputs = [ git ];
+
+  nativeCheckInputs = [
+    nbdime
+    pytest-asyncio
+    pytestCheckHook
+    writableTmpDirAsHomeHook
+  ];
+
+  preCheck = ''
+    (
+      cd ../..
+      jlpm test --runInBand \
+        src/__tests__/test-components/NotebookDiff.spec.tsx \
+        src/__tests__/test-components/PlainTextDiff.spec.tsx
+    )
+
+    # Upstream's Core tests import the sibling server package from the workspace.
+    export PYTHONPATH="$PWD/../jupyterlab''${PYTHONPATH:+:$PYTHONPATH}"
+  '';
+
+  pytestFlags = [ "--confcutdir=." ];
+
+  pythonImportsCheck = [ "jupyterlab_git_core" ];
+
+  meta = {
+    description = "Core package for the JupyterLab Git extension";
+    homepage = "https://github.com/jupyterlab/jupyterlab-git";
+    changelog = "https://github.com/jupyterlab/jupyterlab-git/blob/${src.tag}/CHANGELOG.md";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ chiroptical ];
+  };
+}

--- a/pkgs/development/python-modules/jupyterlab-git/default.nix
+++ b/pkgs/development/python-modules/jupyterlab-git/default.nix
@@ -1,21 +1,14 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
-  git,
   gitMinimal,
-  nodejs,
   writableTmpDirAsHomeHook,
-  yarn-berry_3,
-  jupyter-server,
-  hatch-jupyter-builder,
   hatch-nodejs-version,
   hatchling,
-  jupyterlab,
+  jupyterlab-git-core,
+  jupyter-server,
+  jupytext,
   nbdime,
-  nbformat,
-  packaging,
-  pexpect,
   pytest-asyncio,
   pytest-jupyter,
   pytest-tornasync,
@@ -25,60 +18,33 @@
 
 buildPythonPackage rec {
   pname = "jupyterlab-git";
-  version = "0.52.0";
+  inherit (jupyterlab-git-core) src version;
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "jupyterlab";
-    repo = "jupyterlab-git";
-    tag = "v${version}";
-    hash = "sha256-BMzn+134hSYUFrDF+4+Bs81hzSURP9VNX4D9x2UuPMQ=";
-  };
-
-  nativeBuildInputs = [
-    nodejs
-    yarn-berry_3.yarnBerryConfigHook
-  ];
-
-  offlineCache = yarn-berry_3.fetchYarnBerryDeps {
-    inherit src;
-    hash = "sha256-3pVc4xz5ilamCg97wdaLQliBHeSr3mPYwhgnz/lvfj0=";
-  };
+  preBuild = ''
+    cd packages/jupyterlab
+  '';
 
   build-system = [
-    hatch-jupyter-builder
     hatch-nodejs-version
     hatchling
-    jupyterlab
   ];
 
   dependencies = [
+    jupyterlab-git-core
     jupyter-server
     nbdime
-    nbformat
-    packaging
-    pexpect
     traitlets
   ];
 
-  propagatedBuildInputs = [ git ];
-
   nativeCheckInputs = [
     gitMinimal
+    jupytext
     pytest-asyncio
     pytest-jupyter
     pytest-tornasync
     pytestCheckHook
     writableTmpDirAsHomeHook
-  ];
-
-  disabledTestPaths = [
-    "jupyterlab_git/tests/test_handlers.py"
-  ];
-
-  disabledTests = [
-    "test_Git_get_nbdiff_file"
-    "test_Git_get_nbdiff_dict"
   ];
 
   pythonImportsCheck = [ "jupyterlab_git" ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8666,6 +8666,8 @@ self: super: with self; {
 
   jupyterlab-git = callPackage ../development/python-modules/jupyterlab-git { };
 
+  jupyterlab-git-core = callPackage ../development/python-modules/jupyterlab-git-core { };
+
   jupyterlab-lsp = callPackage ../development/python-modules/jupyterlab-lsp { };
 
   jupyterlab-pygments = callPackage ../development/python-modules/jupyterlab-pygments { };


### PR DESCRIPTION
Updates jupyterlab-git to the latest stable release, which fixes CVE-2026-54527 and CVE-2026-54528. Upstream split the project into two Python distributions, so this also packages the new jupyterlab-git-core dependency and builds its JupyterLab frontend from source.

Changelog: https://github.com/jupyterlab/jupyterlab-git/blob/v0.54.0/CHANGELOG.md#0540

The Python test suites pass with Python 3.13 and 3.14: 107 Core tests and 68 server tests per interpreter. The two frontend security-regression suites also pass with six tests, and the composed environments report both extensions as enabled and valid.

Addresses #539881.

This should not be automatically backported to `release-26.05`; stable requires a separately qualified security backport.

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
