### PR TITLE
dvdisaster: fix build

### DIFF
--- a/pkgs/by-name/dv/dvdisaster/package.nix
+++ b/pkgs/by-name/dv/dvdisaster/package.nix
@@ -5,6 +5,7 @@
   gettext,
   pkg-config,
   which,
+  util-linux,
   glib,
   gtk3,
   wrapGAppsHook3,
@@ -27,6 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
     gettext
     pkg-config
     which
+    util-linux
     wrapGAppsHook3
   ];
 
@@ -69,7 +71,9 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail /dev/shm "$TMP/log" \
       --replace-fail /var/tmp "$TMP"
 
-    ./runtests.sh
+    # Cap parallelism: upstream defaults MAX_JOBS to nproc (16 on Hydra),
+    # which piles too many large test images into $TMP and exhausts disk.
+    MAX_JOBS=4 ./runtests.sh
 
     popd
     runHook postCheck


### PR DESCRIPTION
Add `util-linux` to `nativeBuildInputs` so `flock`, used by the pl6 regression test suite, is available - tests were failing because of this.

Also capped the test suite's `MAX_JOBS` to `4` in `checkPhase`. Upstream defaults it to `nproc`, which piles too many large test images into `$TMP` and exhausts disk, causing spurious test failures.

Fixes #542317


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
