### PR TITLE
tomato-c: 0-unstable-2025-11-11 -> 1.0.3

### DIFF
--- a/pkgs/by-name/to/tomato-c/package.nix
+++ b/pkgs/by-name/to/tomato-c/package.nix
@@ -4,59 +4,71 @@
   fetchFromGitHub,
   libnotify,
   makeWrapper,
-  mpv,
+  makeDesktopItem,
+  copyDesktopItems,
   ncurses,
   pkg-config,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tomato-c";
-  version = "0-unstable-2025-11-11";
+  version = "1.0.3";
 
   src = fetchFromGitHub {
     owner = "gabrielzschmitz";
     repo = "Tomato.C";
-    rev = "590224cbbf0f53f09d33080c4e83797a11ad02d1";
-    hash = "sha256-TVvCqWWjfFHcFOMEO9frfrs9638cOjkV8yvqavdzdmI=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-YdFwHCeYRgzCizO8G+f/9jjMDgp2CiJTH7PR2T6mRD8=";
   };
 
   nativeBuildInputs = [
     makeWrapper
     pkg-config
+    copyDesktopItems
   ];
 
   buildInputs = [
     libnotify
-    mpv
     ncurses
   ];
 
+  enableParallelBuilding = true;
   makeFlags = [
+    "-C build"
+    "DATAPREFIX=${placeholder "out"}/share/tomato"
     "PREFIX=${placeholder "out"}"
   ];
 
-  installFlags = [
-    "CPPFLAGS=$NIX_CFLAGS_COMPILE"
-    "LDFLAGS=$NIX_LDFLAGS"
-  ];
-
-  postFixup = ''
-    for file in $out/bin/*; do
-      wrapProgram $file \
-        --prefix PATH : ${
-          lib.makeBinPath [
-            libnotify
-            mpv
-          ]
-        }
-    done
+  installPhase = ''
+    install -Dm755 build/${finalAttrs.meta.mainProgram} $out/bin/${finalAttrs.meta.mainProgram}
+    mkdir -p $out/share/tomato/{sprites,sounds,icons}
+    cp resources/sprites/*.asc $out/share/tomato/sprites/
+    cp resources/sounds/*.mp3 $out/share/tomato/sounds/
+    cp resources/icons/* $out/share/tomato/icons/
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Tomato.c";
+      desktopName = "Pomodoro timer";
+      comment = finalAttrs.meta.description;
+      icon = "tomato";
+      exec = finalAttrs.meta.mainProgram;
+      terminal = true;
+      categories = [ "Utility" ];
+      keywords = [
+        "pomodoro"
+        "productivity"
+        "timer"
+      ];
+    })
+  ];
 
   strictDeps = true;
 
   meta = {
     homepage = "https://github.com/gabrielzschmitz/Tomato.C";
-    description = "Pomodoro timer written in pure C";
+    description = "Terminal-based pomodoro timer written in pure C";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ _3JlOy-PYCCKUi ];
     mainProgram = "tomato";


### PR DESCRIPTION
This new version (1.x.x) is a complete rewrite.
Old source code is located in the “legacy” branch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
