### PR TITLE
 nixos/tests/utmp: init,  audit: 4.2 -> 4.2.1 

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -259,27 +259,7 @@ in
 
   options.systemd = {
 
-    package = mkPackageOption pkgs "systemd" { } // {
-      # audit 4.2 rejects overlong values (max 15 bytes) for the kernel comm.
-      # systemd attempts to send the full 19 bytes of "systemd-update-utmp",
-      # and the systemd-update-utmp service fails to start. this patch shortens
-      # the kernel comm entry to "update-utmp".
-      # TODO: revert on staging when updating to audit 4.2.1
-      # original commit: https://github.com/linux-audit/audit-userspace/commit/d7ea98263ebdb974b383a4057856a5ec339776fc
-      # switch to truncate: https://github.com/linux-audit/audit-userspace/commit/d7ea98263ebdb974b383a4057856a5ec339776fc
-      # systemd pr: https://github.com/systemd/systemd/pull/43144
-      apply =
-        pkg:
-        pkg.overrideAttrs (prevAttrs: {
-          patches = prevAttrs.patches or [ ] ++ [
-            (pkgs.fetchpatch {
-              name = "systemd-update-utmp-shorten-comm.patch";
-              url = "https://github.com/systemd/systemd/commit/b8968c492108506952ab2748c4a44ce32fc9477c.patch";
-              hash = "sha256-d0rMssj1+cDw3+KOk8ecjqIIuBhjDixIH+7MJfC+I+M=";
-            })
-          ];
-        });
-    };
+    package = mkPackageOption pkgs "systemd" { };
 
     enableStrictShellChecks = mkEnableOption "" // {
       description = ''

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1833,6 +1833,7 @@ in
   userborn-static = runTest ./userborn-static.nix;
   ustreamer = runTest ./ustreamer.nix;
   utils = import ./utils { inherit runTest; };
+  utmp = runTest ./utmp.nix;
   uwsgi = runTest ./uwsgi.nix;
   v2ray = runTest ./v2ray.nix;
   varnish80 = runTest {

--- a/nixos/tests/utmp.nix
+++ b/nixos/tests/utmp.nix
@@ -1,0 +1,65 @@
+{ lib, ... }:
+{
+
+  name = "utmp";
+
+  meta = {
+    maintainers = with lib.maintainers; [ grimmauld ];
+  };
+
+  nodes = {
+    machine = {
+      imports = [ ./common/user-account.nix ];
+      security.audit.enable = true;
+      security.auditd.enable = true;
+    };
+  };
+
+  testScript = ''
+    import re
+
+    def extract_utmp_fields(line: str) -> tuple[str, str] | None:
+      m = re.match(r"^\[\d*\]\s*\[\d*\]\s*\[([^\]\s]*)\s*]\s*\[([^\]\s]*)\s*]", line)
+      if not m:
+          return None
+      return m.group(1), m.group(2)
+
+    machine.wait_for_unit("auditd.service")
+    machine.wait_for_unit("systemd-update-utmp.service")
+    machine.wait_for_file("/run/utmp")
+
+    with subtest("systemd updated utmp"):
+      utmp = machine.succeed("utmpdump /run/utmp").strip().split("\n")
+      print(utmp)
+      assert extract_utmp_fields(utmp[0]) == ("~~", "reboot") # first entry is the reboot
+
+    with subtest("Test utmp entries are created by logins"):
+      machine.wait_for_unit("multi-user.target")
+      machine.wait_until_tty_matches("1", "login: ")
+      machine.send_chars("alice\n")
+      machine.wait_until_tty_matches("1", "Password: ")
+      machine.send_chars("foobar\n")
+      machine.wait_until_succeeds("pgrep -u alice bash")
+      utmp = machine.succeed("utmpdump /run/utmp").strip().split("\n")
+      print(utmp)
+      assert extract_utmp_fields(utmp[1]) == ("tty1", "alice") # second entry is alice login
+      machine.send_chars("exit\n")
+      machine.wait_until_fails("pgrep -u alice bash")
+
+    with subtest("Test utmp entries are cleaned after logout"):
+      utmp = machine.succeed("utmpdump /run/utmp").strip().split("\n")
+      print(utmp)
+      assert extract_utmp_fields(utmp[1]) in [("tty1", ""), ("tty1", "LOGIN")] # tty1 previously in use by alice is now clear
+
+    with subtest("audit logs utmp system boot"):
+      audit_log = machine.succeed("ausearch -m SYSTEM_BOOT")
+      print(audit_log)
+      # audit 4.2.1 truncates too long comm entries, while systemd shortened the entry from `systemd-update-utmp` (truncated) to `update-utmp`
+      # see also:
+      # - systemd: https://github.com/systemd/systemd/pull/43144
+      # - audit: https://github.com/linux-audit/audit-userspace/commit/d7ea98263ebdb974b383a4057856a5ec339776fc
+      # accept either fix in this test
+      assert 'comm="update-utmp"' in audit_log or f'comm="{"systemd-update-utmp"[:15]}"' in audit_log
+  '';
+
+}

--- a/pkgs/by-name/au/audit/package.nix
+++ b/pkgs/by-name/au/audit/package.nix
@@ -30,13 +30,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "audit";
-  version = "4.2";
+  version = "4.2.1";
 
   src = fetchFromGitHub {
     owner = "linux-audit";
     repo = "audit-userspace";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-poldhsF+ccutCxK7KE/gYpxa1x3wUQJWoCwU6pGFj6A=";
+    hash = "sha256-W8VyeOYQGPAvvmQUe3F22u5ldWwIuxrVJ/sXyu0Qrl4=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/au/audit/package.nix
+++ b/pkgs/by-name/au/audit/package.nix
@@ -153,7 +153,7 @@ stdenv.mkDerivation (finalAttrs: {
       musl = pkgsMusl.audit or null;
       static = pkgsStatic.audit or null;
       pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      inherit (nixosTests) audit audit-testsuite;
+      inherit (nixosTests) audit audit-testsuite utmp;
       # Broken on a hardened kernel
       package = finalAttrs.finalPackage.overrideAttrs (previousAttrs: {
         pname = previousAttrs.pname + "-test";


### PR DESCRIPTION
Release notes: https://github.com/linux-audit/audit-userspace/releases/tag/v4.2.1
This is the upstream fix in audit for the hotfix in https://github.com/NixOS/nixpkgs/pull/547195.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
