### PR TITLE
tlp: 1.9.1 -> 1.10.2

### DIFF
--- a/pkgs/tools/misc/tlp/default.nix
+++ b/pkgs/tools/misc/tlp/default.nix
@@ -30,13 +30,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "tlp";
-  version = "1.9.1";
+  version = "1.10.2";
 
   src = fetchFromGitHub {
     owner = "linrunner";
     repo = "TLP";
     rev = version;
-    hash = "sha256-23B+KV0VrvfSneKIFB9sm9iZZm8uZRk+r60W13++J4g=";
+    hash = "sha256-/xTg53eJ+AKrlG++nQGLsosaWzg1JrwGIGB2+h0MZDI=";
   };
 
   # XXX: See patch files for relevant explanations.

--- a/pkgs/tools/misc/tlp/patches/0001-makefile-correctly-sed-paths.patch
+++ b/pkgs/tools/misc/tlp/patches/0001-makefile-correctly-sed-paths.patch
@@ -1,7 +1,7 @@
-From 6500d02a70572f94e7b7df4d70b391ac27ac8bcb Mon Sep 17 00:00:00 2001
+From e2954dbd55a72a3c946ba09fd5dc41d1d2ee079c Mon Sep 17 00:00:00 2001
 From: Bernardo Meurer <bernardo@meurer.org>
 Date: Fri, 15 Oct 2021 23:22:50 -0700
-Subject: [PATCH 1/2] makefile: correctly sed paths
+Subject: [PATCH] makefile: correctly sed paths
 
 The default Makefile for tlp makes a mess with catenating `DESTDIR` to
 everything, but then not actualy using the catenated (_ prefixed)
@@ -14,15 +14,22 @@ not where it doesn't (/etc/tlp.conf should be just that).
 The reason DESTDIR is used at all, as opposed to the more appropriate
 PREFIX, is covered in the nix formula, and is (also) due to the Makefile
 being a bit "different."
+
+===
+IogaMaster <iogamastercode+nixpkgs@gmail.com>
+This patch was not applying correctly, so I applied to the base repo and
+fixed merge conflicts.
+That is the new patch that is below!
+
 ---
- Makefile | 18 +++++++++---------
- 1 file changed, 9 insertions(+), 9 deletions(-)
+ Makefile | 17 +++++++++--------
+ 1 file changed, 9 insertions(+), 8 deletions(-)
 
 diff --git a/Makefile b/Makefile
-index 41eb38d..df3abb7 100644
+index fd1844d..1e005e2 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -57,17 +57,17 @@ _VAR     = $(DESTDIR)$(TLP_VAR)
+@@ -72,16 +72,17 @@ _VAR     = $(DESTDIR)$(TLP_VAR)
  
  SED = sed \
  	-e "s|@TLPVER@|$(TLPVER)|g" \
@@ -41,14 +48,12 @@ index 41eb38d..df3abb7 100644
 -	-e "s|@TLP_CONFDEF@|$(TLP_CONFDEF)|g" \
 -	-e "s|@TLP_CONFREN@|$(TLP_CONFREN)|g" \
 -	-e "s|@TLP_CONFDPR@|$(TLP_CONFDPR)|g" \
--	-e "s|@TLP_CONF@|$(TLP_CONF)|g" \
 +	-e "s|@TLP_CONFDEF@|$(_CONFDEF)|g" \
 +	-e "s|@TLP_CONFREN@|$(_CONFREN)|g" \
 +	-e "s|@TLP_CONFDPR@|$(_CONFDPR)|g" \
 +	-e "s|@TLP_CONF@|$(_CONF)|g" \
+ 	-e "s|@TLP_SDSL@|$(TLP_SDSL)|g" \
  	-e "s|@TLP_RUN@|$(TLP_RUN)|g"   \
  	-e "s|@TLP_VAR@|$(TLP_VAR)|g"
- 
 -- 
-2.44.1
-
+2.54.0


### PR DESCRIPTION
Diff: https://github.com/linrunner/TLP/compare/1.9.1...1.10.2

Changelog: https://github.com/linrunner/TLP/releases/tag/1.10.2

Fixes #547184


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
