### PR TITLE
edac-utils: fix version, add __structuredAttrs

### DIFF
--- a/pkgs/by-name/ed/edac-utils/package.nix
+++ b/pkgs/by-name/ed/edac-utils/package.nix
@@ -10,7 +10,7 @@
 
 stdenv.mkDerivation {
   pname = "edac-utils";
-  version = "unstable-2023-01-30";
+  version = "0.18-unstable-2023-01-30";
 
   src = fetchFromGitHub {
     owner = "grondo";
@@ -36,6 +36,7 @@ stdenv.mkDerivation {
   # a Perl script. Perl from buildInputs is used by patchShebangsAuto in
   # fixupPhase to update the hash bang line.
   strictDeps = true;
+  __structuredAttrs = true;
   nativeBuildInputs = [ perl ];
   buildInputs = [
     perl


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- #541820
  - [pinned commit](https://github.com/grondo/edac-utils/commit/8fdc1d40e30f65737fef6c3ddcd1d2cd769f6277)
  - [versions](https://github.com/grondo/edac-utils/tags)
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
