### PR TITLE
nixos/nextcloud: improve `Cache-Control` headers

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -1640,6 +1640,20 @@ in
 
         services.nginx.enable = lib.mkDefault true;
 
+        services.nginx.appendHttpConfig = ''
+          map $arg_v $nextcloud_v_immutable {
+            "" "";
+            default ", immutable";
+          }
+          map $uri $nextcloud_chunk_immutable {
+            "~\.chunk\.(?:css|js|mjs)$" ", immutable";
+            default "";
+          }
+        '';
+
+        # The checker does not understand add_header_inherit.
+        services.nginx.validateConfigFile = false;
+
         services.nginx.virtualHosts.${cfg.hostName} = {
           root = webroot;
           locations = {
@@ -1709,8 +1723,11 @@ in
             "~ \\.(?:css|js|mjs|svg|gif|ico|jpg|jpeg|png|webp|wasm|tflite|map|html|ttf|bcmap|mp4|webm|ogg|flac)$".extraConfig =
               ''
                 try_files $uri /index.php$request_uri;
-                expires 6M;
                 access_log off;
+
+                add_header Cache-Control "public, max-age=31536000$nextcloud_v_immutable$nextcloud_chunk_immutable";
+                add_header_inherit merge;
+
                 location ~ \.mjs$ {
                   default_type text/javascript;
                 }


### PR DESCRIPTION
The [admin manual](https://docs.nextcloud.com/server/stable/admin_manual/installation/nginx.html) recommends adding `Cache-Control: public` to all assets, and `Cache-Control: immutable` when there is a cache busting parameter.

I deviated from their example slightly by

- Adding `Cache-Control: immutable` to `.chunk.mjs` files as well, as these appear to have cache busting in the file name.
- Increasing `max-age` to a value from the [QPACK](https://datatracker.ietf.org/doc/html/rfc9204) table.

I don't like disabling the config validator here, but see #546462. The alternative would be to copy all previously defined headers into the block.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
