### PR TITLE
awscli: 1.44.21 -> 1.45.56

### DIFF
--- a/pkgs/by-name/aw/awscli/package.nix
+++ b/pkgs/by-name/aw/awscli/package.nix
@@ -15,14 +15,14 @@ let
     pname = "awscli";
     # N.B: if you change this, change botocore and boto3 to a matching version too
     # check e.g. https://github.com/aws/aws-cli/blob/1.33.21/setup.py
-    version = "1.44.21";
+    version = "1.45.56";
     pyproject = true;
 
     src = fetchFromGitHub {
       owner = "aws";
       repo = "aws-cli";
       tag = finalAttrs.version;
-      hash = "sha256-yQFK1YjehmACZGMXfMQLc5OiiIGDO08OtwFSpaRyi58=";
+      hash = "sha256-ut4VbXw3CeM7idHfM5+ENhoBzhTT62Y4kaWvX9WSnYg=";
     };
 
     pythonRelaxDeps = [

--- a/pkgs/development/python-modules/aiobotocore/default.nix
+++ b/pkgs/development/python-modules/aiobotocore/default.nix
@@ -24,14 +24,14 @@
 
 buildPythonPackage rec {
   pname = "aiobotocore";
-  version = "3.1.1";
+  version = "3.9.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "aio-libs";
     repo = "aiobotocore";
     tag = version;
-    hash = "sha256-/Yf2rt/5FH1WiD2VV2hEksM1XleEl4YRBqGQI4GVa8Q=";
+    hash = "sha256-hF/xJGjDu6435hnusIc4L45tDmA1E2G/Yk3PCyXAxjM=";
   };
 
   # Relax version constraints: aiobotocore works with newer botocore versions

--- a/pkgs/development/python-modules/boto3/default.nix
+++ b/pkgs/development/python-modules/boto3/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage (finalAttrs: {
     owner = "boto";
     repo = "boto3";
     tag = finalAttrs.version;
-    hash = "sha256-fzwVxbn4+5zkcAKQ9+bEbNSdwcPKZqsNIJZPqhV+n8w=";
+    hash = "sha256-S5ukVIBdOckaCN3qIr9vABMl2g7LMq4WyoiG8h4qwws=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/botocore/default.nix
+++ b/pkgs/development/python-modules/botocore/default.nix
@@ -18,16 +18,16 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "botocore";
-  version = "1.42.31"; # N.B: if you change this, change boto3 and awscli to a matching version
+  version = "1.43.56"; # N.B: if you change this, change boto3 and awscli to a matching version
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "boto";
     repo = "botocore";
-    tag = version;
-    hash = "sha256-avuv1uXKMeSr3SL+BI9XW8tDCQM/dlXFn590di3S03k=";
+    tag = finalAttrs.version;
+    hash = "sha256-Z0KbNZ9Kyl70vyKVLWT46bHaE5e/k0LKDvGQRLf+pXY=";
   };
 
   postPatch = ''
@@ -66,8 +66,8 @@ buildPythonPackage rec {
   meta = {
     description = "Low-level interface to a growing number of Amazon Web Services";
     homepage = "https://github.com/boto/botocore";
-    changelog = "https://github.com/boto/botocore/blob/${src.tag}/CHANGELOG.rst";
+    changelog = "https://github.com/boto/botocore/blob/${finalAttrs.src.tag}/CHANGELOG.rst";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ anthonyroussel ];
   };
-}
+})

--- a/pkgs/development/python-modules/s3transfer/default.nix
+++ b/pkgs/development/python-modules/s3transfer/default.nix
@@ -8,16 +8,16 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "s3transfer";
-  version = "0.16.0";
+  version = "0.19.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "boto";
     repo = "s3transfer";
-    tag = version;
-    hash = "sha256-dpDlsZtLjd6r4kLkIDPG6ZPFFs6/4elYiHk2HDpa9+4=";
+    tag = finalAttrs.version;
+    hash = "sha256-BOK8kfTdxM6CInouXrBsQf4/zgL3l/A+VElh1VJj4mA=";
   };
 
   build-system = [
@@ -51,8 +51,8 @@ buildPythonPackage rec {
   meta = {
     description = "Library for managing Amazon S3 transfers";
     homepage = "https://github.com/boto/s3transfer";
-    changelog = "https://github.com/boto/s3transfer/blob/${src.tag}/CHANGELOG.rst";
+    changelog = "https://github.com/boto/s3transfer/blob/${finalAttrs.src.tag}/CHANGELOG.rst";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ nickcao ];
   };
-}
+})


### PR DESCRIPTION
Bumped awscli, boto3, botocore, as stated in the comments,
and s3transfer as awscli requires s3transfer to have a version >=0.19.0 <0.20.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
