### PR TITLE
email: fix version, modernize

### DIFF
--- a/pkgs/by-name/em/email/package.nix
+++ b/pkgs/by-name/em/email/package.nix
@@ -6,37 +6,28 @@
   openssl,
 }:
 
-let
-  eMailSrc = fetchFromGitHub {
+stdenv.mkDerivation {
+  pname = "email";
+  version = "0-unstable-2016-08-08";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
     owner = "deanproxy";
     repo = "eMail";
     rev = "7d23c8f508a52bd8809e2af4290417829b6bb5ae";
-    sha256 = "1cxxzhm36civ6vjdgrk7mfmlzkih44kdii6l2xgy4r434s8rzcpn";
+    fetchSubmodules = true;
+    hash = "sha256-bSTfyRhSWNw4/M3xgX590q34LpiX5rftB3uXkEWgJr0=";
   };
-
-  srcRoot = eMailSrc.name;
-
-  dlibSrc = fetchFromGitHub {
-    owner = "deanproxy";
-    repo = "dlib";
-    rev = "f62f29e918748b7cea476220f7492672be81c9de";
-    sha256 = "0h34cikch98sb7nsqjnb9wl384c8ndln3m6yb1172l4y89qjg9rr";
-  };
-
-in
-
-stdenv.mkDerivation {
-  pname = "email-git";
-  version = "unstable-2016-01-31";
-  src = eMailSrc;
 
   patches = [
-    # Pul patch pending upstream inclusion for -fno-common toolchain support:
+    # Pull patch pending upstream inclusion for -fno-common toolchain support:
     #   https://github.com/deanproxy/eMail/pull/61
     (fetchpatch {
       name = "fno-common.patch";
       url = "https://github.com/deanproxy/eMail/commit/c3c1e52132832be0e51daa6e0037d5bb79a17751.patch";
-      sha256 = "17ndrb65g0v4y521333h4244419s8nncm0yx2jwv12sf0dl6gy8i";
+      hash = "sha256-EflnaANOi7C5FN2DyqxFOgVCiCBwjBFE8WSDV8zKzZ4=";
     })
   ];
 
@@ -45,12 +36,6 @@ stdenv.mkDerivation {
   env.NIX_CFLAGS_COMPILE = toString [ "-std=gnu17" ];
 
   buildInputs = [ openssl ];
-
-  unpackPhase = ''
-    unpackPhase;
-    cp -Rp ${dlibSrc}/* ${srcRoot}/dlib;
-    chmod -R +w ${srcRoot}/dlib;
-  '';
 
   meta = {
     description = "Command line SMTP client";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- #541820
  - [pinned commit](https://github.com/deanproxy/email/commit/7d23c8f508a52bd8809e2af4290417829b6bb5ae)
  - [version](https://github.com/deanproxy/eMail/blob/fe8acf4789d1d60bec6b200ff87e4f589767e41f/VERSION)
- cleaned up some old code
  - enabled fetching submodules, so the second dependency isn't needed
  - added `strictDeps`, `__structuredAttrs`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
