### PR TITLE
ekam: fix version, modernize

### DIFF
--- a/pkgs/by-name/ek/ekam/package.nix
+++ b/pkgs/by-name/ek/ekam/package.nix
@@ -14,13 +14,13 @@ let
 in
 stdenv.mkDerivation {
   pname = "ekam";
-  version = "unstable-2021-09-18";
+  version = "0-unstable-2021-09-18";
 
   src = fetchFromGitHub {
     owner = "capnproto";
     repo = "ekam";
     rev = "77c338f8bd8f4a2ce1e6199b2a52363f1fccf388";
-    sha256 = "0q4bizlb1ykzdp4ca0kld6xm5ml9q866xrj3ijffcnyiyqr51qr8";
+    hash = "sha256-KONQMvbRW+acjEPmbgzCidZSu2l0AsXIbX/6sOiPi2A=";
   };
 
   # The capnproto *source* is required to build ekam.
@@ -50,18 +50,17 @@ stdenv.mkDerivation {
     unset NIX_ENFORCE_PURITY
   '';
 
-  makeFlags = [
-    "PARALLEL=$(NIX_BUILD_CORES)"
-  ];
+  enableParallelBuilding = true;
+
+  postBuild = ''
+    rm bin/{capnp*,ekam-bootstrap}
+  '';
 
   installPhase = ''
+    runHook preInstall
     mkdir $out
     cp -r bin $out
-
-    # Remove capnproto tools; there's a separate nix package for that.
-    rm $out/bin/capnp*
-    # Don't distribute ekam-bootstrap, which is not needed outside this build.
-    rm $out/bin/ekam-bootstrap
+    runHook postInstall
   '';
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- #541820
  - [pinned commit](https://github.com/capnproto/ekam/commit/77c338f8bd8f4a2ce1e6199b2a52363f1fccf388)
  - I didn't find any version references in the repo or the final executable
- various cleanups of older patterns

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
