### PR TITLE
emscripten: 6.0.2 -> 6.0.5

### DIFF
--- a/pkgs/development/compilers/emscripten/default.nix
+++ b/pkgs/development/compilers/emscripten/default.nix
@@ -22,7 +22,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "emscripten";
-  version = "6.0.2";
+  version = "6.0.5";
 
   llvmEnv = symlinkJoin {
     name = "emscripten-llvm-${version}";
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     name = "emscripten-node-modules-${version}";
     inherit pname version src;
 
-    npmDepsHash = "sha256-uZSDPdMNT50JBg4e16cHDoon0cunxB/JyWWkj67X5ls=";
+    npmDepsHash = "sha256-iVK19noxfVIduglYPyqWcTN1DABgZKzhU63BuGj5kMM=";
 
     dontBuild = true;
 
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "emscripten-core";
     repo = "emscripten";
-    hash = "sha256-tFJ699cOOmv1uEsl5RzsIV5gosOgTvMX2UQYTb0x7Gk=";
+    hash = "sha256-OhLNKqlWGseAN6Qqes5Iu6B7pQ9w9bJmLhMBFb/Rr68=";
     rev = version;
   };
 
@@ -79,8 +79,14 @@ stdenv.mkDerivation rec {
 
         patchShebangs .
 
-        # emscripten 5.0.0 expects LLVM tip-of-tree instead of LLVM 22
-        sed -i -e "s/EXPECTED_LLVM_VERSION = 23/EXPECTED_LLVM_VERSION = 22/g" tools/shared.py
+        # Emscripten requires an unreleased LLVM version. Set the check to the
+        # LLVM version that this package supplies. The --replace-fail flag stops
+        # the build if Emscripten changes this constant. A sed command for a
+        # fixed version does not give an error. It leaves the check at an LLVM
+        # version that this package does not have.
+        substituteInPlace tools/shared.py \
+          --replace-fail "EXPECTED_LLVM_VERSION = 24" \
+            "EXPECTED_LLVM_VERSION = ${lib.versions.major llvmPackages.llvm.version}"
 
         # fixes cmake support
         sed -i -e "s/print \('emcc (Emscript.*\)/sys.stderr.write(\1); sys.stderr.flush()/g" emcc.py


### PR DESCRIPTION
https://github.com/emscripten-core/emscripten/blob/6.0.5/ChangeLog.md

Upstream moved EXPECTED_LLVM_VERSION from 23 to 24 in this range, so the hardcoded sed matched nothing and left the check set to 24 while this package supplies LLVM 22. Replace the sed with substituteInPlace --replace-fail and take the value from llvmPackages, so a future upstream change to this constant stops the build instead of passing silently.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
