### PR TITLE
emu2: fix version, license; modernize

### DIFF
--- a/pkgs/by-name/em/emu2/package.nix
+++ b/pkgs/by-name/em/emu2/package.nix
@@ -6,7 +6,10 @@
 
 stdenv.mkDerivation {
   pname = "emu2";
-  version = "0.pre+unstable=2021-09-22";
+  version = "2021.01-unstable-2021-09-22";
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "dmsc";
@@ -22,7 +25,7 @@ stdenv.mkDerivation {
     description = "Simple text-mode x86 + DOS emulator";
     platforms = lib.platforms.linux;
     maintainers = [ ];
-    license = lib.licenses.gpl2Plus;
+    license = lib.licenses.gpl2Only;
     mainProgram = "emu2";
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- #541820
  - [pinned commit](github.com/dmsc/emu2/commit/8d01b53f154d6bfc9561a44b9c281b46e00a4e87)
  - [version](https://github.com/dmsc/emu2/releases/tag/v2021.01)
- changed to GPLv2 (only)
  - I couldn't find any notes in any of the source permitting the use of later GPL's
- added `strictDeps`, `__structuredAttrs`
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
