### PR TITLE
iravoice: init at 0.7.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12050,6 +12050,12 @@
     githubId = 31273774;
     name = "Inigo Querejeta-Azurmendi";
   };
+  iravoiceFounder = {
+    email = "hello@iravoice.com";
+    github = "deepmehta11";
+    githubId = 83613089;
+    name = "IraVoice Founder";
+  };
   irenes = {
     name = "Irene Knapp";
     email = "ireneista@gmail.com";

--- a/pkgs/by-name/ir/iravoice/package.nix
+++ b/pkgs/by-name/ir/iravoice/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  undmg,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "iravoice";
+  version = "0.7.2";
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchurl {
+    url = "https://iravoice.com/downloads/IraVoice-${finalAttrs.version}.dmg";
+    hash = "sha256-ZOT+T6mix1NgUwbe8O9uts0bbRL1MMk77MGvPcKSNN0=";
+  };
+
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
+
+  nativeBuildInputs = [ undmg ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications"
+    cp -R IraVoice.app "$out/Applications/"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Private on-device dictation app for Apple-silicon Macs";
+    homepage = "https://iravoice.com/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ iravoiceFounder ];
+    platforms = [ "aarch64-darwin" ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/ir/iravoice/package.nix
+++ b/pkgs/by-name/ir/iravoice/package.nix
@@ -12,7 +12,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
 
   src = fetchurl {
-    url = "https://iravoice.com/downloads/IraVoice-${finalAttrs.version}.dmg";
+    url = "https://iravoice.com/downloads/distribution/IraVoice-${finalAttrs.version}.dmg";
     hash = "sha256-ZOT+T6mix1NgUwbe8O9uts0bbRL1MMk77MGvPcKSNN0=";
   };
 


### PR DESCRIPTION
## Description

Adds IraVoice 0.7.2, a proprietary Apple-silicon macOS dictation app, as an `aarch64-darwin` package.

The package fetches the stable signed and notarized DMG, extracts the unchanged `IraVoice.app`, and installs it under `$out/Applications`. It disables fixups to preserve the Developer ID signature. The package is intentionally marked `unfree`, not `unfreeRedistributable`, because the publisher permits mirroring the original DMG but does not grant redistribution rights for a repackaged derivation output.

I am submitting this as the product's maintainer representative. The public distribution permission and product terms are documented at:

- https://iravoice.com/pad/iravoice.xml
- https://iravoice.com/terms

## Verification

- `nixfmt-rfc-style` completed successfully on both changed files.
- `nix-build lib/tests/maintainers.nix --no-out-link` returned `checked-maintainers-success`.
- Evaluation for `aarch64-darwin` produced an `iravoice-0.7.2.drv` with the expected unfree license, platform, and maintainer.
- Nix source prefetch returned `sha256-ZOT+T6mix1NgUwbe8O9uts0bbRL1MMk77MGvPcKSNN0=`.
- The downloaded DMG has SHA-256 `64e4fe4fa9a2c753605306def0ef6eb6cd1b6d12f530c93becc1af3dc29234dd`.
- Copying the app bundle with `cp -R` preserved its signature; `codesign --verify --deep --strict` passed and Gatekeeper reported `Notarized Developer ID`.

## Remaining validation

A full Nix build was not available locally because there was no `aarch64-darwin` Nix builder. This is a draft so Darwin CI or a reviewer with a Darwin builder can provide that final proof before the PR is marked ready.
