### PR TITLE
gomuks-{web,desktop}: synchronize updating gomuks-desktop with gomuks-web

### DIFF
--- a/pkgs/by-name/go/gomuks-web/package.nix
+++ b/pkgs/by-name/go/gomuks-web/package.nix
@@ -7,6 +7,12 @@
   npmHooks,
   pkg-config,
   libheif,
+
+  writeShellApplication,
+  _experimental-update-script-combinators,
+  nix-update-script,
+  nix,
+  jq,
 }:
 
 buildGoModule (finalAttrs: {
@@ -76,14 +82,51 @@ buildGoModule (finalAttrs: {
     mv $out/bin/gomuks $out/bin/gomuks-web
   '';
 
-  passthru.updateScript = ./update.sh;
+  passthru.updateScript = _experimental-update-script-combinators.sequence [
+    ./update.sh
+
+    # Update gomuks-desktop
+    (lib.getExe (writeShellApplication {
+      name = "gomuks-desktop-electron-updater";
+      runtimeInputs = [
+        nix
+        jq
+      ];
+      runtimeEnv = {
+        PNAME = finalAttrs.pname; # we actually don't care as `-desktop` inherits the source
+        PKG_DIR = toString ./.; # nixpkgs-vet complains if we refer to a file outside this dir
+      };
+      text = ''
+        set -euo pipefail
+
+        new_src="$(nix-build --attr "pkgs.$PNAME.src" --no-out-link)/desktop"
+        new_electron_major="$(jq -r '.devDependencies.electron' "$new_src/package.json" | cut -d. -f1)"
+
+        sed -i -E "s/electron_[0-9]+/electron_$new_electron_major/g" "$PKG_DIR/../gomuks-desktop/package.nix"
+      '';
+    }))
+    (nix-update-script {
+      # Updates npmDepsHash
+      attrPath = "gomuks-desktop";
+      extraArgs = [
+        "--no-src"
+        "--version=skip"
+      ];
+    })
+  ];
 
   meta = {
     mainProgram = "gomuks-web";
     description = "Matrix client written in Go";
     homepage = "https://github.com/tulir/gomuks";
     license = lib.licenses.agpl3Only;
-    maintainers = [ lib.maintainers.zaphyra ];
+    maintainers = with lib.maintainers; [
+      zaphyra
+
+      # For the gomuks-desktop update script
+      logn
+      xaltsc
+    ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/go/gomuks-web/update.sh
+++ b/pkgs/by-name/go/gomuks-web/update.sh
@@ -17,4 +17,4 @@ VERSION="${RELEASE#v}"
 # Debug
 echo "Release ${RELEASE} -> Version ${VERSION}"
 
-nix-update --build --commit --version "${VERSION}" gomuks-web
+nix-update --build --version "${VERSION}" gomuks-web


### PR DESCRIPTION
This PR synchronizes updating two sister packages: `gomuks-web` and `gomuks-desktop`.

Both packages share the same source and repository, `src` and `version` (along with a few other attributes) are actually inherited in `gomuks-desktop` from `gomuks-web`, from which it depends anyways.

I have been told this was the better way to do it. The goal is that, whenever @r-ryantm  updates `gomuks-web`, it does the necessary things **IN THE SAME PR** to ensure that `gomuks-desktop` stays a valid package.

One quirk worth noting: I had to remove the `--commit` argument from the (original) `gomuks-web` update script as the update wouldn't progress further since it couldn't notice any diff, and would just assume that everything was up to date.

> [!IMPORTANT]
> This is rather urgent, as `gomuks` seems to release a new version each month. Next update of `gomuks-web` will break `gomuks-desktop` likely next week (that of 10/08/2026). 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [X] Tested it with `nix-update -u gomuks-web`
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
