### PR TITLE
emacs: eval emacsPackages in CI without building them on hydra

### DIFF
--- a/pkgs/applications/editors/emacs/build-support/generic.nix
+++ b/pkgs/applications/editors/emacs/build-support/generic.nix
@@ -69,6 +69,9 @@ lib.extendMkDerivation {
       meta = {
         broken = false;
         platforms = emacs.meta.platforms;
+        # Do not build on hydra to avoid going through staging cycles.
+        # In the future, we may consider selectively building a few of them on hydra.
+        hydraPlatforms = [ ];
       }
       // optionalAttrs ((args.src.meta.homepage or "") != "") {
         homepage = args.src.meta.homepage;

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -416,7 +416,11 @@ let
             '';
           });
 
-          magit = buildWithGit super.magit;
+          magit = (buildWithGit super.magit).overrideAttrs (old: {
+            meta = old.meta // {
+              hydraPlatforms = [ "x86_64-linux" ];
+            };
+          });
 
           magit-find-file = buildWithGit super.magit-find-file;
 

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -419,6 +419,7 @@ let
           magit = (buildWithGit super.magit).overrideAttrs (old: {
             meta = old.meta // {
               hydraPlatforms = [ "x86_64-linux" ];
+              maintainers = [ lib.maintainers.linj ];
             };
           });
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8553,11 +8553,9 @@ with pkgs;
       pkgs' = pkgs; # default pkgs used for bootstrapping the emacs package set
     };
 
-  # We want emacsPackages to be visible in search but not be build on hydra
-  emacsPackages = recurseIntoAttrsWith {
-    hydra = false;
-    eval = false;
-  } emacs.pkgs;
+  # We want emacsPackages to be visible in search.
+  # They are not built on hydra because we set their meta.hydraPlatforms to [ ].
+  emacsPackages = recurseIntoAttrs emacs.pkgs;
 
   espeak = espeak-ng;
 


### PR DESCRIPTION



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
