### PR TITLE
binaryen: omit binaryen-unittests in non-cross too

### DIFF
--- a/pkgs/development/compilers/binaryen/default.nix
+++ b/pkgs/development/compilers/binaryen/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   strictDeps = true;
 
   preConfigure = ''
-    if [ $doCheck -eq 1 ]; then
+    if [ -n "$doCheck" ]; then
       sed -i '/gtest/d' third_party/CMakeLists.txt
       rmdir test/spec/testsuite
       ln -s ${testsuite} test/spec/testsuite

--- a/pkgs/development/compilers/binaryen/default.nix
+++ b/pkgs/development/compilers/binaryen/default.nix
@@ -62,6 +62,14 @@ stdenv.mkDerivation rec {
     LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/lib python3 ../check.py $tests
   '';
 
+  # bin/binaryen-unittests is absent on cross builds which don't have doCheck,
+  # so delete it on non-cross builds too (thus removing gtest from the closure).
+  postInstall = ''
+    if [ -n "$doCheck" ]; then
+      rm "$out/bin/binaryen-unittests"
+    fi
+  '';
+
   tests = [
     "version"
     "wasm-opt"


### PR DESCRIPTION
A cross build of this package has `doCheck = false`, which causes there to be no `bin/binaryen-unittests` file. But in a non-cross build, `bin/binaryen-unittests` is left in the final output. This PR removes it for consistency, which also has the added benefit of removing GTest from the closure and overall saving a few megabytes in the closure size.

On `x86_64-linux`:

```diff
 $ nix path-info --recursive --size --closure-size --human-readable .#binaryen
 /nix/store/kw26hfd5b653cn2lm6yfh0q7y18d6d9l-gcc-15.3.0-libgcc    193.1 KiB       193.1 KiB
 /nix/store/47wlgfansg09j38cg44dh7rfh0smq8ym-libunistring-1.4.2     2.0 MiB         2.0 MiB
 /nix/store/1zpz45w7k0i1j6b4m2z1cc12kbnv1m6y-libidn2-2.3.8        359.5 KiB         2.3 MiB
 /nix/store/i9hdf87r1r8xkc26gj3h9cp08hx0iqbs-xgcc-15.3.0-libgcc   193.0 KiB       193.0 KiB
 /nix/store/l8si8gnvvq93yzms1jsgh5aixyf9rl5x-glibc-2.42-67         33.4 MiB        36.0 MiB
 /nix/store/0iv8glcslgfcgn371lbjr5jjw5a6cqir-gcc-15.3.0-lib         9.8 MiB        46.0 MiB
-/nix/store/jp8aa66xzb31cdcrdxra2nnjjn1lnsna-gtest-1.17.0         842.0 KiB        46.8 MiB
-/nix/store/da14h11bs0khjzkziaylknfd05jaa9hv-binaryen-130          38.0 MiB        84.8 MiB
+/nix/store/y1nxqv9psbj0hrpci1r74irwmbynnsz3-binaryen-130          34.3 MiB        80.3 MiB
```

On `aarch64-linux`:

```diff
 $ nix path-info --recursive --size --closure-size --human-readable .#binaryen
 /nix/store/4mkfd0wwj77317npdgkcgw8j4hkgqgaa-gcc-15.3.0-libgcc    150.2 KiB       150.2 KiB
 /nix/store/84i6rp3qvbrm0vl88w5fm9h37yka5mzb-xgcc-15.3.0-libgcc   150.1 KiB       150.1 KiB
 /nix/store/qr7qvicd9q4lnq6lznx223z5sakp9jrx-libunistring-1.4.2     2.0 MiB         2.0 MiB
 /nix/store/qlmazqi9rqlg4b1gbw5qj2v8pwd9bl39-libidn2-2.3.8        366.1 KiB         2.4 MiB
 /nix/store/cj4jysawj8cc6yv2cwdgzxhdhq7dnf05-glibc-2.42-67         44.4 MiB        47.0 MiB
 /nix/store/acydkjgciry45a32qfsl1fi2vnpbhn1x-gcc-15.3.0-lib         9.4 MiB        56.5 MiB
-/nix/store/7zg7yyv6cn7vps6pkrzip8gd89i97ysn-gtest-1.17.0         925.6 KiB        57.4 MiB
-/nix/store/xs256qfmx4ab9m6fvcmzys3i6agg3wwk-binaryen-130          36.5 MiB        94.0 MiB
+/nix/store/p6jfw5rsh79v2mfwy8dwcydcb4ikbbjd-binaryen-130          33.1 MiB        89.6 MiB
```

On `aarch64-darwin`:

```diff
 $ nix path-info --recursive --size --closure-size --human-readable .#binaryen
-/nix/store/bvi50spjgvnwnk7ixxi225cdziqsbvk7-gtest-1.17.0         743.4 KiB       743.4 KiB
-/nix/store/jk80gd5gq2ijqxfdrxdwmqafwzrxd2bi-binaryen-130          27.1 MiB        27.9 MiB
+/nix/store/ix9ak7bk6sxj1kpa7h3425sr4r1k3dfg-binaryen-130          24.4 MiB        24.4 MiB
```

For consistency, this PR also modifies this file's other existing usage of `$doCheck` to match. Both ways of writing it are equivalent when `doCheck = true`:

```diff
 $ nix-shell -E 'with import ./. { }; binaryen' --run 'cd "$(mktemp -d)"; unpackPhase >/dev/null; cd "$sourceRoot"; echo "doCheck=$doCheck"; eval "$preConfigure"; echo "cmakeFlagsArray=${cmakeFlagsArray[*]}"'
 doCheck=1
 cmakeFlagsArray=
```

But the reason to prefer writing it in this modified way is because, when `doCheck = false`, it's [passed as an empty string](https://nix.dev/manual/nix/2.35/language/derivations), which is not a valid argument for the binary operator `-eq` that only accepts integers:

```diff
 $ nix-shell -E 'with import ./. { }; binaryen.overrideAttrs { doCheck = false; }' --run 'cd "$(mktemp -d)"; unpackPhase >/dev/null; cd "$sourceRoot"; echo "doCheck=$doCheck"; eval "$preConfigure"; echo "cmakeFlagsArray=${cmakeFlagsArray[*]}"'
 doCheck=
-/tmp/nix-shell-2960674-95520795/rc: line 3: [: -eq: unary operator expected
 cmakeFlagsArray=-DBUILD_TESTS=0
```

This also matches how `$doCheck` is used elsewhere in Nixpkgs:

https://github.com/NixOS/nixpkgs/blob/ea3ed88478f937cc7a9873b3b8825034b911635c/pkgs/by-name/un/unbound/package.nix#L202

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test