### PR TITLE
free42, plus42: add raw2txt and txt2raw bins to output

### DIFF
--- a/pkgs/by-name/fr/free42/package.nix
+++ b/pkgs/by-name/fr/free42/package.nix
@@ -69,6 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     make --jobs=$NIX_BUILD_CORES -C gtk AUDIO_ALSA=1
     make -C gtk clean
     make --jobs=$NIX_BUILD_CORES -C gtk AUDIO_ALSA=1 BCD_MATH=1
+    make --jobs=$NIX_BUILD_CORES -C gtk raw2txt txt2raw
 
     runHook postBuild
   '';
@@ -82,7 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
                         $out/share/icons/hicolor/48x48/apps \
                         $out/share/icons/hicolor/128x128/apps
 
-    install -m755 gtk/free42dec gtk/free42bin $out/bin
+    install -m755 gtk/free42dec gtk/free42bin gtk/raw2txt gtk/txt2raw $out/bin
     install -m644 README $out/share/doc/free42/README
 
     install -m644 gtk/icon-48x48.png $out/share/icons/hicolor/48x48/apps/free42.png

--- a/pkgs/by-name/pl/plus42/package.nix
+++ b/pkgs/by-name/pl/plus42/package.nix
@@ -69,6 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     make --jobs=$NIX_BUILD_CORES -C gtk AUDIO_ALSA=1
     make -C gtk clean
     make --jobs=$NIX_BUILD_CORES -C gtk AUDIO_ALSA=1 BCD_MATH=1
+    make --jobs=$NIX_BUILD_CORES -C gtk raw2txt txt2raw
 
     runHook postBuild
   '';
@@ -82,7 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
                         $out/share/icons/hicolor/48x48/apps \
                         $out/share/icons/hicolor/128x128/apps
 
-    install -m755 gtk/plus42dec gtk/plus42bin $out/bin
+    install -m755 gtk/plus42dec gtk/plus42bin gtk/raw2txt gtk/txt2raw $out/bin
     install -m644 README $out/share/doc/plus42/README
 
     install -m644 gtk/icon-48x48.png $out/share/icons/hicolor/48x48/apps/plus42.png


### PR DESCRIPTION
This PR builds and installs the `raw2txt` and `txt2raw` utilities from source for the `free42` and `plus42` packages.

The upstream project provides prebuilt versions of these tools in the "Additional Downloads" section of the [Free42 website](https://thomasokken.com/free42/). However, these binaries are dynamically linked, which NixOS cannot run without additional work. Building and installing the utilities from source makes them available out of the box.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
