### PR TITLE
supersonic: 0.21.1 -> 0.22.0

### DIFF
--- a/pkgs/by-name/su/supersonic/package.nix
+++ b/pkgs/by-name/su/supersonic/package.nix
@@ -19,21 +19,24 @@
   libxkbcommon,
   libglvnd,
   mpv-unwrapped,
-  waylandSupport ? false,
 }:
 
 buildGoModule (finalAttrs: {
-  pname = "supersonic" + lib.optionalString waylandSupport "-wayland";
-  version = "0.21.1";
+  pname = "supersonic";
+  version = "0.22.0";
 
   src = fetchFromGitHub {
     owner = "dweymouth";
     repo = "supersonic";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-jKmkj7Y3D2Af7XNOkLY3sknOelvId649NZXpu/fU7ko=";
+    hash = "sha256-Ynw/NLDk2AVmn30llFtt/A9hEheUZ+/VZqXOIdiUSxQ=";
   };
 
-  vendorHash = "sha256-Qg5OWg+iFcGuD8E3/7YwmmciiRGdUFNSHLrEAaqRmnQ=";
+  vendorHash = "sha256-W5Uwma72lqJB+QHkSasi7WArsYlfXLVPph9TlDSxFEk=";
+
+  # "go mod vendor" fails to build; go-gl/glfw fails with an error like:
+  # xdg-shell-client-protocol.h: No such file or directory
+  proxyVendor = true;
 
   nativeBuildInputs = [
     copyDesktopItems
@@ -43,8 +46,7 @@ buildGoModule (finalAttrs: {
     desktopToDarwinBundle
   ];
 
-  # go-glfw doesn't support both X11 and Wayland in single build
-  tags = [ "migrated_fynedo" ] ++ lib.optionals waylandSupport [ "wayland" ];
+  tags = [ "migrated_fynedo" ];
 
   buildInputs = [
     libglvnd
@@ -53,15 +55,11 @@ buildGoModule (finalAttrs: {
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     libxxf86vm
     libx11
-  ]
-  ++ lib.optionals (stdenv.hostPlatform.isLinux && !waylandSupport) [
     libxrandr
     libxinerama
     libxcursor
     libxi
     libxext
-  ]
-  ++ lib.optionals (stdenv.hostPlatform.isLinux && waylandSupport) [
     wayland
     wayland-protocols
     libxkbcommon
@@ -73,9 +71,6 @@ buildGoModule (finalAttrs: {
         mkdir -p $out/share/icons/hicolor/$dimensions/apps
         cp res/appicon-$dimension.png $out/share/icons/hicolor/$dimensions/apps/${finalAttrs.meta.mainProgram}.png
     done
-  ''
-  + lib.optionalString waylandSupport ''
-    mv $out/bin/supersonic $out/bin/${finalAttrs.meta.mainProgram}
   '';
 
   desktopItems = [
@@ -83,7 +78,7 @@ buildGoModule (finalAttrs: {
       name = finalAttrs.meta.mainProgram;
       exec = finalAttrs.meta.mainProgram;
       icon = finalAttrs.meta.mainProgram;
-      desktopName = "Supersonic" + lib.optionalString waylandSupport " (Wayland)";
+      desktopName = "Supersonic";
       genericName = "Subsonic Client";
       comment = finalAttrs.meta.description;
       type = "Application";
@@ -95,11 +90,11 @@ buildGoModule (finalAttrs: {
   ];
 
   meta = {
-    mainProgram = "supersonic" + lib.optionalString waylandSupport "-wayland";
+    mainProgram = "supersonic";
     description = "Lightweight cross-platform desktop client for Subsonic music servers";
     homepage = "https://github.com/dweymouth/supersonic";
     changelog = "https://github.com/dweymouth/supersonic/releases/tag/${finalAttrs.src.tag}";
-    platforms = lib.platforms.linux ++ lib.optionals (!waylandSupport) lib.platforms.darwin;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       zane

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -2274,6 +2274,7 @@ mapAliases {
   sumalibs = throw "'sumalibs' has been removed as it was archived upstream and broken with GCC 14"; # Added 2025-06-14
   sumatra = throw "'sumatra' has been removed as it was archived upstream and broken with GCC 14"; # Added 2025-06-14
   sumneko-lua-language-server = throw "'sumneko-lua-language-server' has been renamed to/replaced by 'lua-language-server'"; # Converted to throw 2025-10-27
+  supersonic-wayland = throw "'supersonic-wayland' has been removed as its functionality has been incorporated into 'supersonic'"; # Added 2026-07-25
   superTux = warnAlias "'superTux' has been renamed to 'supertux'" supertux; # Added 2026-02-12
   superTuxKart = warnAlias "'superTuxKart' has been renamed to 'supertuxkart'" supertuxkart; # Added 2026-02-12
   surge-XT = warnAlias "'surge-XT' has been renamed to 'surge-xt'" surge-xt; # Added 2026-02-12

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9386,10 +9386,6 @@ with pkgs;
     pythonBindings = true;
   };
 
-  supersonic-wayland = supersonic.override {
-    waylandSupport = true;
-  };
-
   synergyWithoutGUI = synergy.override { withGUI = false; };
 
   tabbed = callPackage ../applications/window-managers/tabbed {


### PR DESCRIPTION
Combined X11/Wayland build, throw on supersonic-wayland.

Alternative to https://github.com/NixOS/nixpkgs/pull/547129 that merges the separate x11/wayland binaries.

Set `XDG_SESSION_TYPE=wayland` or `XDG_SESSION_TYPE=x11` to choose the backend.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
