### PR TITLE
 amethyst-mod-manager: init at 2.5.0; python3Packages.libloot: init at 0.29.6

### DIFF
--- a/pkgs/development/python-modules/libloot/default.nix
+++ b/pkgs/development/python-modules/libloot/default.nix
@@ -1,0 +1,55 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  git,
+  lib,
+  rustPlatform,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "libloot";
+  version = "0.29.6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "loot";
+    repo = "libloot";
+    tag = finalAttrs.version;
+    hash = "sha256-Pz13z0uQfTeo47NJORfZ8n8ucqZdoLVGNIsrf2+OOGA=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/python";
+  cargoRoot = "..";
+
+  nativeBuildInputs = [
+    git
+  ]
+  ++ (with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+  ]);
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) src;
+    hash = "sha256-IQowGdrol/JFoh+hGfhwoJ2FumkvbuZsp8Xx/V2hFdw=";
+  };
+
+  env = {
+    CARGO_TARGET_DIR = "./target";
+  };
+
+  # no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "loot" ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Experimental Python wrapper around libloot";
+    homepage = "https://github.com/loot/libloot/tree/master/python";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ RoGreat ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9279,6 +9279,8 @@ self: super: with self; {
 
   liblistenbrainz = callPackage ../development/python-modules/liblistenbrainz { };
 
+  libloot = callPackage ../development/python-modules/libloot { };
+
   liblp = callPackage ../development/python-modules/liblp { };
 
   liblzfse = callPackage ../development/python-modules/liblzfse { inherit (pkgs) lzfse; };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

"A Linux native mod manager for a variety of games"

Homepage: https://github.com/ChrisDKN/Amethyst-Mod-Manager

Package request here: https://github.com/ChrisDKN/Amethyst-Mod-Manager/issues/224

This also requires the libloot python package. Looks like the main program needs an update as well in a separate PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
