### PR TITLE
qt6.qtwebengine: skip Metal toolchain check on Darwin

### DIFF
--- a/pkgs/development/libraries/qt-6/modules/qtwebengine/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwebengine/default.nix
@@ -160,6 +160,15 @@ qtModule {
       --replace-fail "/usr/bin/xcrun" "${xcbuild}/bin/xcrun"
     substituteInPlace cmake/QtToolchainHelpers.cmake \
       --replace-fail 'clang_base_path="''${QWELibClang_BASE_PATH}"' 'clang_base_path="${stdenv.cc}"'
+
+    # xcbuild's xcrun doesn't implement the real (proprietary) Metal shader
+    # compiler, so this check always fails. The one build step that actually
+    # invokes it (ANGLE's internal shader precompilation) is already disabled
+    # below, so it's safe to report the toolchain as present.
+    substituteInPlace cmake/QtConfigureHelpers.cmake \
+      --replace-fail 'message(STATUS "Checking for Metal Toolchain")' 'message(STATUS "Checking for Metal Toolchain")
+    set(TEST_metal_toolchain TRUE PARENT_SCOPE)
+    return()'
   '';
 
   cmakeFlags = [


### PR DESCRIPTION
xcbuild's `xcrun` doesn't implement the real (proprietary) Metal
shader compiler, so QtWebEngine's Metal toolchain check always fails
at configure time. The one build step that actually invokes it
(ANGLE's internal shader precompilation) is already disabled
elsewhere in `postPatch`, so it's safe to report the toolchain as
present and let configure proceed.

This is one of several fixes needed for a fully clean
`qt6.qtwebengine` build on Darwin, alongside:
- #515997 (relative `-isysroot` stripped from chromium-emitted lflags)
- #520445 (`clang_base_path` / `CMAKE_CXX_COMPILER` fix)

Stacked with those two, `qt6.qtwebengine` builds successfully on
aarch64-darwin. Opening this separately since it's an independent,
orthogonal issue from the other two.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

`jellyfin-desktop` built and its basic functionality was tested successfully.

<details>
<summary><code>nixpkgs-review</code> results (72 built, 22 pre-existing failures, 4 pre-existing broken)</summary>

```
4 packages marked as broken and skipped:
cutterPlugins.rz-ghidra frescobaldi novelwriter stellarium

22 packages failed to build:
anki electrum golden-cheetah hydrus ki manim-slides mnemosyne previewqt python313Packages.glueviz python313Packages.pvextractor python313Packages.qasync python313Packages.qscintilla-qt6 python313Packages.stytra python314Packages.glueviz python314Packages.pvextractor python314Packages.qasync python314Packages.qscintilla-qt6 python314Packages.stytra qgis sasview trunk-recorder vtk_9_6

72 packages built:
aab ankiAddons.review-heatmap beeref corrscope cutter datalab f3d git-cola git-credential-email git-protonmail gnuradio gnuradioPackages.lora_sdr gnuradioPackages.osmosdr hifiscan inkcut inkscape-extensions.inkcut jellyfin-desktop kdePackages.qtwebengine kitsas leo-editor lsd2dsl merkaartor nanovna-saver openmotor openusd optiland pageedit phantom python313Packages.datalab-platform python313Packages.echo python313Packages.enamlx python313Packages.f3d python313Packages.guidata python313Packages.napari-console python313Packages.pglive python313Packages.plotpy python313Packages.pyqt6 python313Packages.pyqt6-charts python313Packages.pyqt6-webengine python313Packages.pyqtgraph python313Packages.pythonqwt python313Packages.qpageview python313Packages.qreactor python313Packages.qtconsole python313Packages.sigima python314Packages.datalab-platform python314Packages.echo python314Packages.enamlx python314Packages.f3d python314Packages.guidata python314Packages.napari-console python314Packages.pglive python314Packages.plotpy python314Packages.pyqt6 python314Packages.pyqt6-charts python314Packages.pyqt6-webengine python314Packages.pyqtgraph python314Packages.pythonqwt python314Packages.qpageview python314Packages.qreactor python314Packages.qtconsole python314Packages.sigima qlog qolibri qutebrowser retext sigil syncthingtray tageditor time-decode uchmviewer zeal
```

</details>

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
