### PR TITLE
argocd-vault-plugin: modernize

### DIFF
--- a/pkgs/by-name/ar/argocd-vault-plugin/package.nix
+++ b/pkgs/by-name/ar/argocd-vault-plugin/package.nix
@@ -1,19 +1,20 @@
 {
+  lib,
   buildGoModule,
   fetchFromGitHub,
-  lib,
-  testers,
-  argocd-vault-plugin,
+  versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "argocd-vault-plugin";
   version = "1.18.1";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "argoproj-labs";
     repo = "argocd-vault-plugin";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-rWNR4GVivuEprdX/xhwk/9SReeJ19UWDWx8Bf8z6CTI=";
   };
 
@@ -28,13 +29,9 @@ buildGoModule (finalAttrs: {
   # integration tests require filesystem and network access for credentials
   doCheck = false;
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
   doInstallCheck = true;
-
-  passthru.tests.version = testers.testVersion {
-    package = argocd-vault-plugin;
-    command = "argocd-vault-plugin version";
-    version = "argocd-vault-plugin v${finalAttrs.version} (unknown) BuildDate: 1970-01-01T00:00:00Z";
-  };
 
   meta = {
     homepage = "https://argocd-vault-plugin.readthedocs.io";


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
