### PR TITLE
go-mockery: 3.5.5 -> 3.7.2

### DIFF
--- a/pkgs/by-name/go/go-mockery/package.nix
+++ b/pkgs/by-name/go/go-mockery/package.nix
@@ -10,17 +10,17 @@
 
 buildGoModule (finalAttrs: {
   pname = "go-mockery";
-  version = "3.5.5";
+  version = "3.7.2";
 
   src = fetchFromGitHub {
     owner = "vektra";
     repo = "mockery";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-paoI7KkpLbpQyEwS/oW8Ck9KiJRTUxzFzihsnFyhrCw=";
+    hash = "sha256-lPyoWjLaRhE4SpVahJd8T3LsCyfdFMIsuxmWODRoLL0=";
   };
 
   proxyVendor = true;
-  vendorHash = "sha256-YOhlytIMgMHwj2BM/6vOeheyQd4nUuDWpkwLdCqru8c=";
+  vendorHash = "sha256-izMi4MqbfKX1PmNMWyCwBOWqiPZfth/ZSzsuEcTN6Pg=";
 
   ldflags = [
     "-s"
@@ -41,8 +41,11 @@ buildGoModule (finalAttrs: {
   prePatch = ''
     # remove test.ci's dependency on lint since we don't need it and
     # it tries to use remote golangci-lint
+    # remove test.ci's git-state check, which runs `git diff --exit-code`;
+    # the source has no .git directory, so the check cannot work here
     substituteInPlace Taskfile.yml \
       --replace-fail "deps: [lint]" "" \
+      --replace-fail "      - task: git-state" "" \
       --replace-fail "go run gotest.tools/gotestsum" "gotestsum"
 
     # patch scripts used in e2e testing

--- a/pkgs/by-name/op/opencloud/package.nix
+++ b/pkgs/by-name/op/opencloud/package.nix
@@ -6,7 +6,6 @@
   ncurses,
   gettext,
   pigeon,
-  go-mockery,
   protoc-go-inject-tag,
   libxcrypt,
   vips,
@@ -20,7 +19,8 @@ let
   bingoBinsMakefile = builtins.concatStringsSep "\n" (
     lib.mapAttrsToList (n: v: "${n} := ${v}\n\\$(${n}):") {
       GO_XGETTEXT = "xgettext";
-      MOCKERY = "mockery";
+      # no need to generate mocks, as they are in-repo already
+      MOCKERY = "true";
       PIGEON = "pigeon";
       PROTOC_GO_INJECT_TAG = "protoc-go-inject-tag";
     }
@@ -76,7 +76,6 @@ buildGoModule (finalAttrs: {
     ncurses
     gettext
     pigeon
-    go-mockery
     protoc-go-inject-tag
     pkg-config
   ];


### PR DESCRIPTION
Auto-update mockery from 3.5.5 to 3.72 using [nixpkgs-update](https://github.com/nix-community/nixpkgs-update).

Changelog: https://github.com/vektra/mockery/releases

This is intended to supersede #461036.

Note that in #461036, a blocking issue was opencloud failing to build. This PR removes the mockery dependency from opencloud as the mocks are already committed upstream and don't need to be regeneraed.

AI Disclaimer: While nixpkgs-update did generate the update, I used Claude to help identify a fix for the opencloud blocker.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
