### PR TITLE
clash-rs: 0.10.7 -> 0.10.8

### DIFF
--- a/pkgs/by-name/cl/clash-rs/package.nix
+++ b/pkgs/by-name/cl/clash-rs/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  fetchpatch,
   fetchFromGitHub,
   rustPlatform,
   protobuf,
@@ -13,27 +14,43 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "clash-rs";
-  version = "0.10.7";
+  version = "0.10.8";
 
   src = fetchFromGitHub {
     owner = "Watfaq";
     repo = "clash-rs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-tY/GB6J8kr6Ni9ScOpKkDYLaLffvtaIxH8tXK24LHt8=";
+    hash = "sha256-dnM8lHObjgYF/Wm0uD7LlYosZ+mSPNbaTDKyWU2sNvo=";
   };
 
   patches = [
     # Remove the `npm ci` call in build.rs as it fails.
     ./skip-npm-ci.patch
+
+    # The shadowquic git patch in [patch.crates-io] is marked [[patch.unused]]
+    # in Cargo.lock because registry 0.3.12 already carries the fix. In
+    # offline/vendor mode cargo still tries to resolve the git source and
+    # fails because only shadowquic-macros was vendored from that repo.
+    # Also fixes watfaq-netstack version mismatch and release workflow.
+    (fetchpatch {
+      url = "https://github.com/Watfaq/clash-rs/commit/227255546187e509795b00c68d8cead738f1db7d.patch";
+      hash = "sha256-WMu/mBL0Gcz4OJW6/16MwkxDPbt/ERu4+Mt+iJvagXo=";
+    })
   ];
 
-  cargoHash = "sha256-SlkqNu6Vk1D9aU4GgyNDW9Or3z8KSbEjwCUK9w3Jyx0=";
+  # Keep the vendored Cargo.lock in sync with the patched source one.
+  postPatch = ''
+    sed -i '/^$/N;/^\n\[\[patch\.unused\]\]$/,$d' "$cargoDepsCopy/Cargo.lock"
+    sed -i '/name = "watfaq-netstack"/{n;s/version = "0.1.1"/version = "0.1.0"/;}' "$cargoDepsCopy/Cargo.lock"
+  '';
+
+  cargoHash = "sha256-Gu4NkpU9GVGEsMVoGReiBYf9TEkEsznSsJTlZMK/1TY=";
 
   npmDeps = fetchNpmDeps {
     name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
     inherit (finalAttrs) src;
     sourceRoot = "${finalAttrs.src.name}/clash-dashboard";
-    hash = "sha256-H8G3GuEh4JXZV1zxTfo89tl6D6WA5hWGOF9i8qP0njw=";
+    hash = "sha256-fL0PTkAtopysqXr1D8JmtQ7C77SGOBnpweRe02bn7jE=";
   };
 
   npmRoot = "clash-dashboard";


### PR DESCRIPTION
AI assistance: I directed Pi coding agent (DeepSeek V4 Flash) to implement this update and reviewed and tested the final diff myself.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
