### PR TITLE
pokemonsay: 1.0.0 -> 2.0.0

### DIFF
--- a/pkgs/by-name/po/pokemonsay/package.nix
+++ b/pkgs/by-name/po/pokemonsay/package.nix
@@ -2,31 +2,21 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
-  fetchpatch,
   cowsay,
   coreutils,
   findutils,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "pokemonsay";
-  version = "1.0.0";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "HRKings";
     repo = "pokemonsay-newgenerations";
-    rev = "v${version}";
-    hash = "sha256-IDTAZmOzkUg0kLUM0oWuVbi8EwE4sEpLWrNAtq/he+g=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MHR9rr/dIQF0POLHAXgd2JaIPu+QqwFbDpwSWbSsWQA=";
   };
-
-  patches = [
-    (fetchpatch {
-      # https://github.com/HRKings/pokemonsay-newgenerations/pull/5
-      name = "word-wrap-fix.patch";
-      url = "https://github.com/pbsds/pokemonsay-newgenerations/commit/7056d7ba689479a8e6c14ec000be1dfcd83afeb0.patch";
-      hash = "sha256-aqUJkyJDWArLjChxLZ4BbC6XAB53LAqARzTvEAxrFCI=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace pokemonsay.sh \
@@ -65,15 +55,17 @@ stdenvNoCC.mkDerivation rec {
   doInstallCheck = true;
   installCheckPhase = ''
     (set -x
-      test "$($out/bin/pokemonsay --list | wc -l)" -ge 891
+      test "$($out/bin/pokemonsay --list | wc -l)" -ge 992
     )
   '';
 
   meta = {
     description = "Print pokemon in the CLI! An adaptation of the classic cowsay";
+    changelog = "https://github.com/HRKings/pokemonsay-newgenerations/releases/tag/v${finalAttrs.version}";
     homepage = "https://github.com/HRKings/pokemonsay-newgenerations";
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ pbsds ];
+    mainProgram = "pokemonsay";
   };
-}
+})


### PR DESCRIPTION
Bumps pokemonsay from 1.0.0 to 2.0.0

Refactor to finalAttrs pattern. Switch `rev` for `tag`. Update `installCheckPhase` test to current number of pokemon included. `mainProgram` added.

(Note: `Patches` removed as it has since been merged in. [https://github.com/HRKings/pokemonsay-newgenerations/pull/5](https://github.com/HRKings/pokemonsay-newgenerations/pull/5))

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
