### PR TITLE
programs/zoxide: ensure shell init is always added last

### DIFF
--- a/nixos/modules/programs/zoxide.nix
+++ b/nixos/modules/programs/zoxide.nix
@@ -6,7 +6,7 @@
 }:
 let
   inherit (lib.options) mkEnableOption mkPackageOption mkOption;
-  inherit (lib.modules) mkIf;
+  inherit (lib.modules) mkIf mkAfter;
   inherit (lib.meta) getExe;
   inherit (lib.types) listOf str;
   inherit (lib.strings) concatStringsSep;
@@ -52,15 +52,15 @@ in
     environment.systemPackages = [ cfg.package ];
 
     programs = {
-      zsh.interactiveShellInit = mkIf cfg.enableZshIntegration ''
+      zsh.interactiveShellInit = mkIf cfg.enableZshIntegration (mkAfter ''
         eval "$(${getExe cfg.package} init zsh ${cfgFlags} )"
-      '';
-      bash.interactiveShellInit = mkIf cfg.enableBashIntegration ''
+      '');
+      bash.interactiveShellInit = mkIf cfg.enableBashIntegration (mkAfter ''
         eval "$(${getExe cfg.package} init bash ${cfgFlags} )"
-      '';
-      fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
+      '');
+      fish.interactiveShellInit = mkIf cfg.enableFishIntegration (mkAfter ''
         ${getExe cfg.package} init fish ${cfgFlags} | source
-      '';
+      '');
       xonsh.config = ''
         execx($(${getExe cfg.package} init xonsh ${cfgFlags}), 'exec', __xonsh__.ctx, filename='zoxide')
       '';


### PR DESCRIPTION
Fixes #528653


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
