### PR TITLE
clipaste: 2.4.0 -> 2.4.1

### DIFF
--- a/pkgs/by-name/cl/clipaste/package.nix
+++ b/pkgs/by-name/cl/clipaste/package.nix
@@ -2,29 +2,40 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  nix-update-script,
   testers,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "clipaste";
-  version = "2.4.0";
+  version = "2.4.1";
 
   src = fetchFromGitHub {
     owner = "hqhq1025";
     repo = "clipaste";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-MNrhOvdyYs99Z6Wwf2X+xCNRzc6erpLpFB/GHBJRhrg=";
+    hash = "sha256-4I/37f2iEQA9oqEhcXAo4lwZKtZuCt5MaL4v4OYpdc0=";
   };
 
-  cargoHash = "sha256-QrUR3xHZ/1FFkBYt5qxi0mNVTvEaWBcLSjp6OnzR9GY=";
+  cargoHash = "sha256-14EbKpzAUlnP+rzEWk3e8CYkAtw36exDfDFTK1HFsr8=";
 
   strictDeps = true;
   __structuredAttrs = true;
+
+  checkFlags = [
+    # Runs the generated bash script in a simulated remote environment
+    # (PATH=/usr/bin:/bin:...).  In the Nix sandbox standard tools like `grep`
+    # are not available at those paths — syntax check and content assertions
+    # already cover correctness.
+    "--skip"
+    "ssh_setup::tests::remote_script_run_installs_into_empty_home"
+  ];
 
   passthru = {
     tests.version = testers.testVersion {
       package = finalAttrs.finalPackage;
     };
+    updateScript = nix-update-script { };
   };
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
