### PR TITLE
python3Packages.torchaudio: fix gpuCheck metadata check

### DIFF
--- a/pkgs/development/python-modules/torchaudio/default.nix
+++ b/pkgs/development/python-modules/torchaudio/default.nix
@@ -154,6 +154,8 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
 
   passthru.gpuCheck = torchaudio.overridePythonAttrs (old: {
     pname = "${finalAttrs.pname}-gpuCheck";
+    # This is only a test derivation; its metadata still identifies the package as "torchaudio".
+    dontCheckPythonMetadata = true;
     requiredSystemFeatures = [ "cuda" ];
 
     env = (old.env or { }) // {


### PR DESCRIPTION
Keep the original `pname` when creating `passthru.gpuCheck`.

Overriding `pname` caused Python's metadata check to compare `torchaudio-gpuCheck` against the installed distribution metadata for `torchaudio`. Set `name` explicitly instead, preserving a distinct derivation name without changing the Python package name.

Verified that evaluation produces:

```text
python3.14-torchaudio-gpuCheck-2.11.0
```

This fixes the corresponding nixos-cuda task and helps move the channel-unstable jobset (https://hydra.nixos-cuda.org/jobset/nixos-cuda/channel-unstable) forward.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/tree/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/tree/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/tree/master/pkgs/test