### PR TITLE
martian-mono: use installFonts, build from source

### DIFF
--- a/pkgs/by-name/ma/martian-mono/package.nix
+++ b/pkgs/by-name/ma/martian-mono/package.nix
@@ -46,7 +46,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://github.com/evilmartians/mono";
     changelog = "https://github.com/evilmartians/mono/raw/${finalAttrs.src.tag}/Changelog.md";
     license = lib.licenses.ofl;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ pancaek ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/ma/martian-mono/package.nix
+++ b/pkgs/by-name/ma/martian-mono/package.nix
@@ -15,6 +15,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     "webfont"
   ];
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "evilmartians";
     repo = "mono";

--- a/pkgs/by-name/ma/martian-mono/package.nix
+++ b/pkgs/by-name/ma/martian-mono/package.nix
@@ -1,39 +1,52 @@
 {
   lib,
   stdenvNoCC,
-  fetchzip,
+  fetchFromGitHub,
+  installFonts,
+  python3Packages,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "martian-mono";
   version = "1.1.0";
 
-  src = fetchzip {
-    url = "https://github.com/evilmartians/mono/releases/download/v${version}/martian-mono-${version}-otf.zip";
-    sha256 = "sha256-W6ewNtFDS1O1fwoAe27tIgNZn7AAKo965dWkZYzsg+o=";
-    stripRoot = false;
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "evilmartians";
+    repo = "mono";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-qm1Ljz344BTesQXIjKwuE4XwXwskZQlNkCgaVyst54o=";
   };
 
-  dontPatch = true;
-  dontConfigure = true;
-  dontBuild = true;
-  doCheck = false;
-  dontFixup = true;
+  env.PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION = "python";
 
-  installPhase = ''
-    runHook preInstall
+  nativeBuildInputs = [
+    python3Packages.gftools
+    python3Packages.fontmake
+    installFonts
+  ];
 
-    install -Dm644 -t $out/share/fonts/opentype/ *.otf
-
-    runHook postInstall
+  buildPhase = ''
+    runHook preBuild
+    # clean out the prebuilt files
+    rm -r fonts
+    gftools builder sources/config.yaml
+    runHook postBuild
   '';
+
+  dontUseNinjaBuild = true;
+  dontUseNinjaInstall = true;
 
   meta = {
     description = "Free and open-source monospaced font from Evil Martians";
     homepage = "https://github.com/evilmartians/mono";
-    changelog = "https://github.com/evilmartians/mono/raw/v${version}/Changelog.md";
+    changelog = "https://github.com/evilmartians/mono/raw/${finalAttrs.src.tag}/Changelog.md";
     license = lib.licenses.ofl;
     maintainers = [ ];
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
Part of #495640 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
