### PR TITLE
pystalk: init at 0.9.1

### DIFF
--- a/pkgs/development/python-modules/pystalk/default.nix
+++ b/pkgs/development/python-modules/pystalk/default.nix
@@ -9,12 +9,12 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pystalk";
-  version = "0.9.0";
+  version = "0.9.1";
   pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
-    hash = "sha256-cX5P0KAjbyjJU6EcL0gvifNNlCGHTc89jacGWhVgFH0=";
+    hash = "sha256-s6mPn5+DI1b8l746+mEtZDzAHhqM3MaEhZAjJbfW/q8=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/pystalk/default.nix
+++ b/pkgs/development/python-modules/pystalk/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  attrs,
+  buildPythonPackage,
+  fetchPypi,
+  pyyaml,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "pystalk";
+  version = "0.8.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "NUCCllxw4egR4OLUDv+c8D1ie67YnB8RjqZ2bXzepYE=";
+  };
+
+  build-system = [ setuptools ];
+
+  doCheck = false; # no tests
+
+  dependencies = [
+    attrs
+    pyyaml
+  ];
+
+  meta = {
+    description = "Simple Python Beanstalkd client";
+    homepage = "https://github.com/easypost/pystalk";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ jbcrail ];
+  };
+}

--- a/pkgs/development/python-modules/pystalk/default.nix
+++ b/pkgs/development/python-modules/pystalk/default.nix
@@ -7,7 +7,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pystalk";
   version = "0.8.1";
   pyproject = true;
@@ -32,4 +32,4 @@ buildPythonPackage rec {
     license = lib.licenses.isc;
     maintainers = with lib.maintainers; [ jbcrail ];
   };
-}
+})

--- a/pkgs/development/python-modules/pystalk/default.nix
+++ b/pkgs/development/python-modules/pystalk/default.nix
@@ -9,12 +9,12 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pystalk";
-  version = "0.8.1";
+  version = "0.9.0";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "NUCCllxw4egR4OLUDv+c8D1ie67YnB8RjqZ2bXzepYE=";
+    inherit (finalAttrs) pname version;
+    hash = "sha256-cX5P0KAjbyjJU6EcL0gvifNNlCGHTc89jacGWhVgFH0=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15939,6 +15939,8 @@ self: super: with self; {
 
   pystache = callPackage ../development/python-modules/pystache { };
 
+  pystalk = callPackage ../development/python-modules/pystalk { };
+
   pystardict = callPackage ../development/python-modules/pystardict { };
 
   pystatgrab = callPackage ../development/python-modules/pystatgrab { };


### PR DESCRIPTION
I added a new package, pystalk 0.9.1, which is a simple Python beanstalkd client.

The pystalk homepage is https://github.com/EasyPost/pystalk.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
