### PR TITLE
Backport 547227 to staging 26.05

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1780,6 +1780,7 @@ in
   userborn-static = runTest ./userborn-static.nix;
   ustreamer = runTest ./ustreamer.nix;
   utils = import ./utils { inherit runTest; };
+  utmp = runTest ./utmp.nix;
   uwsgi = runTest ./uwsgi.nix;
   v2ray = runTest ./v2ray.nix;
   varnish60 = runTest {

--- a/nixos/tests/utmp.nix
+++ b/nixos/tests/utmp.nix
@@ -1,0 +1,65 @@
+{ lib, ... }:
+{
+
+  name = "utmp";
+
+  meta = {
+    maintainers = with lib.maintainers; [ grimmauld ];
+  };
+
+  nodes = {
+    machine = {
+      imports = [ ./common/user-account.nix ];
+      security.audit.enable = true;
+      security.auditd.enable = true;
+    };
+  };
+
+  testScript = ''
+    import re
+
+    def extract_utmp_fields(line: str) -> tuple[str, str] | None:
+      m = re.match(r"^\[\d*\]\s*\[\d*\]\s*\[([^\]\s]*)\s*]\s*\[([^\]\s]*)\s*]", line)
+      if not m:
+          return None
+      return m.group(1), m.group(2)
+
+    machine.wait_for_unit("auditd.service")
+    machine.wait_for_unit("systemd-update-utmp.service")
+    machine.wait_for_file("/run/utmp")
+
+    with subtest("systemd updated utmp"):
+      utmp = machine.succeed("utmpdump /run/utmp").strip().split("\n")
+      print(utmp)
+      assert extract_utmp_fields(utmp[0]) == ("~~", "reboot") # first entry is the reboot
+
+    with subtest("Test utmp entries are created by logins"):
+      machine.wait_for_unit("multi-user.target")
+      machine.wait_until_tty_matches("1", "login: ")
+      machine.send_chars("alice\n")
+      machine.wait_until_tty_matches("1", "Password: ")
+      machine.send_chars("foobar\n")
+      machine.wait_until_succeeds("pgrep -u alice bash")
+      utmp = machine.succeed("utmpdump /run/utmp").strip().split("\n")
+      print(utmp)
+      assert extract_utmp_fields(utmp[1]) == ("tty1", "alice") # second entry is alice login
+      machine.send_chars("exit\n")
+      machine.wait_until_fails("pgrep -u alice bash")
+
+    with subtest("Test utmp entries are cleaned after logout"):
+      utmp = machine.succeed("utmpdump /run/utmp").strip().split("\n")
+      print(utmp)
+      assert extract_utmp_fields(utmp[1]) in [("tty1", ""), ("tty1", "LOGIN")] # tty1 previously in use by alice is now clear
+
+    with subtest("audit logs utmp system boot"):
+      audit_log = machine.succeed("ausearch -m SYSTEM_BOOT")
+      print(audit_log)
+      # audit 4.2.1 truncates too long comm entries, while systemd shortened the entry from `systemd-update-utmp` (truncated) to `update-utmp`
+      # see also:
+      # - systemd: https://github.com/systemd/systemd/pull/43144
+      # - audit: https://github.com/linux-audit/audit-userspace/commit/d7ea98263ebdb974b383a4057856a5ec339776fc
+      # accept either fix in this test
+      assert 'comm="update-utmp"' in audit_log or f'comm="{"systemd-update-utmp"[:15]}"' in audit_log
+  '';
+
+}

--- a/pkgs/by-name/au/audit/package.nix
+++ b/pkgs/by-name/au/audit/package.nix
@@ -30,13 +30,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "audit";
-  version = "4.2";
+  version = "4.2.1";
 
   src = fetchFromGitHub {
     owner = "linux-audit";
     repo = "audit-userspace";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-poldhsF+ccutCxK7KE/gYpxa1x3wUQJWoCwU6pGFj6A=";
+    hash = "sha256-W8VyeOYQGPAvvmQUe3F22u5ldWwIuxrVJ/sXyu0Qrl4=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/au/audit/package.nix
+++ b/pkgs/by-name/au/audit/package.nix
@@ -153,7 +153,7 @@ stdenv.mkDerivation (finalAttrs: {
       musl = pkgsMusl.audit or null;
       static = pkgsStatic.audit or null;
       pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      inherit (nixosTests) audit audit-testsuite;
+      inherit (nixosTests) audit audit-testsuite utmp;
       # Broken on a hardened kernel
       package = finalAttrs.finalPackage.overrideAttrs (previousAttrs: {
         pname = previousAttrs.pname + "-test";


### PR DESCRIPTION
backports #547227

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
