### PR TITLE
nixos/ec2-metadata-fetcher: fail instead of fetch with invalid token

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -139,6 +139,8 @@
 
 - `slskd` has been updated to v0.25.0, which renames the `global` option to `transfers`. Please review the [changelog](https://github.com/slskd/slskd/releases#release-0.25.0).
 
+- On the `amazon-image` profile, `fetch-ec2-metadata.service` now fails when the EC2 instance metadata service cannot be reached or rejects the IMDSv2 token, and is retried up to 5 times before it stays failed. It previously fetched nothing and reported success, so a transient IMDS failure at first boot left `/etc/ec2-metadata/user-data` missing and `amazon-init` silently skipped the instance's user data. Machines using this profile without a reachable metadata service will now show this unit as failed.
+
 ## Other Notable Changes {#sec-release-26.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/virtualisation/amazon-image.nix
+++ b/nixos/modules/virtualisation/amazon-image.nix
@@ -108,6 +108,15 @@ in
       script = builtins.readFile ./ec2-metadata-fetcher.sh;
       serviceConfig.Type = "oneshot";
       serviceConfig.StandardOutput = "journal+console";
+      # The fetcher now exits non-zero when IMDS is unreachable or rejects our
+      # token. That is frequently transient at first boot, and an instance that
+      # loses this race never gets its user data, so retry a bounded number of
+      # times before giving up and staying failed.
+      serviceConfig.RemainAfterExit = true;
+      serviceConfig.Restart = "on-failure";
+      serviceConfig.RestartSec = 10;
+      startLimitIntervalSec = 300;
+      startLimitBurst = 5;
     };
 
     # Amazon-issued AMIs include the SSM Agent by default, so we do the same.

--- a/nixos/modules/virtualisation/ec2-metadata-fetcher.sh
+++ b/nixos/modules/virtualisation/ec2-metadata-fetcher.sh
@@ -57,12 +57,31 @@ if [ "$IMDS_TOKEN" == "" ]; then
 fi
 
 try=1
+imds_validated=""
 while [ $try -le 10 ]; do
   echo "(attempt $try/10) validating the EC2 instance metadata service v2 token..."
-  preflight_imds_token "$IMDS_BASE_URL" && break
+  if preflight_imds_token "$IMDS_BASE_URL"; then
+    imds_validated=1
+    break
+  fi
   try=$((try + 1))
   sleep 1
+  # The token we already hold can itself be the problem: IMDS may hand out a
+  # token that then only yields 401s. Get a fresh one before trying again.
+  # Skipped when we never obtained a token, since we are then validating the
+  # token-less (IMDSv1) path, which the loop above already gave up on.
+  if [ -n "$IMDS_TOKEN" ] && token=$(get_imds_token "$IMDS_BASE_URL"); then
+    IMDS_TOKEN="$token"
+  fi
 done
+
+if [ "$imds_validated" == "" ]; then
+  # Do not fall through to fetching metadata we know we cannot read: every
+  # request would fail, nothing would be written to $metaDir, and the unit
+  # would still report success, silently dropping the instance's user data.
+  echo "failed to access the EC2 instance metadata service at $IMDS_BASE_URL; giving up." >&2
+  exit 1
+fi
 
 echo "getting EC2 instance metadata..."
 

--- a/nixos/tests/common/imds-server.py
+++ b/nixos/tests/common/imds-server.py
@@ -7,7 +7,11 @@ guestfwd and socat contexts.
 Usage: imds-server <metadata-directory>
 
 The metadata directory should contain:
-  latest/api/token                        - Token value (returned on PUT)
+  latest/api/token                        - Token value accepted on GET
+  latest/api/token-issued                 - Optional. Token handed out on PUT
+                                            when it differs from the accepted
+                                            one, to simulate an IMDS that
+                                            rejects the token it just issued.
   1.0/meta-data/hostname                  - Instance hostname
   1.0/meta-data/ami-manifest-path         - AMI manifest path
   1.0/meta-data/instance-id               - Instance ID
@@ -70,13 +74,24 @@ def main():
     else:
         expected_token = None
 
+    # An optional second token to hand out on PUT. When it is present and
+    # differs from the accepted one, every authenticated GET 401s even though
+    # token acquisition looked healthy -- the failure mode that used to leave
+    # the fetcher reporting success with no metadata written.
+    issued_path = os.path.join(base_dir, "latest", "api", "token-issued")
+    if os.path.isfile(issued_path):
+        with open(issued_path) as f:
+            issued_token = f.read().strip()
+    else:
+        issued_token = expected_token
+
     method, path, headers = read_request()
     rel_path = path.lstrip("/")
 
     # PUT /latest/api/token — IMDSv2 token acquisition
     if method == "PUT" and rel_path == "latest/api/token":
         if expected_token is not None:
-            respond("200 OK", expected_token)
+            respond("200 OK", issued_token)
         else:
             respond("404 Not Found", "IMDSv2 token endpoint not configured\n")
         return

--- a/nixos/tests/ec2-image.nix
+++ b/nixos/tests/ec2-image.nix
@@ -328,6 +328,47 @@ in
               )
               test_userdata_decompression(machine, user_data_path, proc.stdout, "lzip")
 
+          with subtest("IMDS rejecting the token it issued fails the unit"):
+              # Hand out a token the metadata service will not accept: token
+              # acquisition keeps looking healthy while every authenticated
+              # request 401s.
+              issued_token_path = os.path.join(metadata_dir, "latest", "api", "token-issued")
+              with open(issued_token_path, "w") as f:
+                  f.write("rejected-token-99999")
+
+              # Pin the unit for the duration of the subtest; the auto-restart
+              # added for transient IMDS failures would otherwise race the
+              # assertions below.
+              machine.succeed(
+                  "mkdir -p /run/systemd/system/fetch-ec2-metadata.service.d",
+                  "printf '[Service]\\nRestart=no\\n'"
+                  " > /run/systemd/system/fetch-ec2-metadata.service.d/99-no-restart.conf",
+                  "systemctl daemon-reload",
+              )
+
+              machine.succeed("rm -f /etc/ec2-metadata/user-data")
+              machine.succeed("systemctl reset-failed fetch-ec2-metadata")
+              machine.fail("systemctl restart fetch-ec2-metadata")
+              machine.succeed("systemctl is-failed --quiet fetch-ec2-metadata")
+
+              # The point of the exercise: no user-data means amazon-init must
+              # not be told the instance simply has none.
+              machine.fail("test -e /etc/ec2-metadata/user-data")
+
+              journal = machine.succeed("journalctl -u fetch-ec2-metadata --no-pager -b")
+              assert "failed to access the EC2 instance metadata service" in journal, \
+                  f"Expected the fetcher to report giving up, got: {journal}"
+
+              # Restore a working IMDS and confirm the unit recovers.
+              os.remove(issued_token_path)
+              machine.succeed(
+                  "rm -f /run/systemd/system/fetch-ec2-metadata.service.d/99-no-restart.conf",
+                  "systemctl daemon-reload",
+                  "systemctl reset-failed fetch-ec2-metadata",
+                  "systemctl restart fetch-ec2-metadata",
+                  "test -e /etc/ec2-metadata/user-data",
+              )
+
           with subtest("IPv6 IMDS fallback"):
               # Save hostname fetched via IPv4 for later comparison
               original_hostname = machine.succeed("cat /etc/ec2-metadata/hostname").strip()


### PR DESCRIPTION
`fetch-ec2-metadata` could report success having fetched nothing. If all 10 IMDSv2 token-validation attempts 401'd, the script fell out of the loop, fetched every metadata path anyway behind `get_imds`' `|| true`, wrote nothing and exited 0. `/etc/ec2-metadata/user-data` never appeared and `amazon-init` silently skipped the instance's user data on first boot, with every unit green.

- Re-acquire the token before each validation retry. The 401s follow a PUT that looked healthy, so the token we hold is itself suspect. Skipped when we never got one, so the token-less IMDSv1 path costs no extra requests.
- Exit non-zero if validation never succeeds, instead of issuing requests we know will be rejected. Behaviour change: machines on this profile without a reachable IMDS now show a failed unit rather than quietly doing nothing (release note included).
- Retry it: `Restart=on-failure`, `RestartSec=10`, `StartLimitIntervalSec=300`, `StartLimitBurst=5`. The failure is usually transient at first boot, and a run takes over ten seconds, so the default start-limit window would never trip and the unit would restart forever.
- `nixosTests.ec2-image`: subtest for an IMDS that rejects the token it just issued, via an optional `latest/api/token-issued` file in the shared mock. Fails on master.

The IMDSv2 success path and the token-less path are unchanged. Same class of failure as #447266, which was closed unreviewed in January.

Fixes #542874

Assisted-by: Claude Code (claude-opus-5)
Claude-Session: https://claude.ai/code/session_01PsqGhkpjsb4kKAdVz25xKN

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
