### PR TITLE
pike: 8.0.2042 -> 9.0.13 (and drop pcre)

### DIFF
--- a/pkgs/by-name/pi/pike/package.nix
+++ b/pkgs/by-name/pi/pike/package.nix
@@ -10,7 +10,6 @@
   bison,
   flex,
   gmp,
-  pcre,
   nettle,
   libjpeg,
   libpng,
@@ -120,13 +119,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "pike";
-  version = "8.0.2042";
+  version = "9.0.13";
 
   src = fetchFromGitHub {
     owner = "pikelang";
     repo = "Pike";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-N/hwbH8hhG9v/PJKwvGgS/ttS4TRJeeV2zAcRNDVL4k=";
+    hash = "sha256-H3eF5tz/KMcyDKLD4/LPwtI2oB9JYf09zYeTgdJ9q0E=";
   };
 
   nativeBuildInputs = [
@@ -141,7 +140,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     gmp
-    pcre
     nettle
     libjpeg
     libpng
@@ -190,7 +188,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   makeFlags = [ "INSTALLARGS=--traditional" ];
 
-  passthru.updateScript = gitUpdater { allowedVersions = "^8\\..*"; };
+  passthru.updateScript = gitUpdater { allowedVersions = "^9\\..*"; };
 
   meta = {
     description = "Pike programming language";


### PR DESCRIPTION
## Things done

Pike doesn't build the pcre module on debian. (Can be re-enabled if they switch to pcre2 https://github.com/pikelang/Pike/issues/70)

And upgrade to the latest tag 9.0.13

For: https://github.com/NixOS/nixpkgs/issues/356387

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
