### PR TITLE
matrix-media-repo: bump `libheif` dependency to fix build-failure

### DIFF
--- a/pkgs/by-name/ma/matrix-media-repo/libheif-bump.patch
+++ b/pkgs/by-name/ma/matrix-media-repo/libheif-bump.patch
@@ -1,0 +1,41 @@
+From 5b0900ea0767edbbaa7ef46b751f1e703bdb27fa Mon Sep 17 00:00:00 2001
+From: "Katja Ramona Sophie Kwast (zaphyra)" <git@zaphyra.eu>
+Date: Thu, 30 Jul 2026 12:33:17 +0200
+Subject: [PATCH] update libheif to v1.23.1
+
+---
+ go.mod | 2 +-
+ go.sum | 4 ++--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/go.mod b/go.mod
+index b228f3e..4175ef7 100644
+--- a/go.mod
++++ b/go.mod
+@@ -54,7 +54,7 @@ require (
+ 	github.com/redis/go-redis/v9 v9.7.0
+ 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
+ 	github.com/stretchr/testify v1.10.0
+-	github.com/strukturag/libheif v1.19.5
++	github.com/strukturag/libheif v1.23.1
+ 	github.com/t2bot/go-leaky-bucket v1.0.0
+ 	github.com/t2bot/go-singleflight-streams v1.0.0
+ 	github.com/t2bot/go-typed-singleflight v0.0.3
+diff --git a/go.sum b/go.sum
+index c15be35..895f091 100644
+--- a/go.sum
++++ b/go.sum
+@@ -368,8 +368,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
+ github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+ github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+-github.com/strukturag/libheif v1.19.5 h1:YLf0RO6mNQYeeNkFSk/Uto8EyUOCzDpLPjbEBoeV9Io=
+-github.com/strukturag/libheif v1.19.5/go.mod h1:E/PNRlmVtrtj9j2AvBZlrO4dsBDu6KfwDZn7X1Ce8Ks=
++github.com/strukturag/libheif v1.23.1 h1:bEjYArYIXfTqWzLYBOM+Wax1yCV5oWMCM3hJRq1aQOQ=
++github.com/strukturag/libheif v1.23.1/go.mod h1:E/PNRlmVtrtj9j2AvBZlrO4dsBDu6KfwDZn7X1Ce8Ks=
+ github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203 h1:QVqDTf3h2WHt08YuiTGPZLls0Wq99X9bWd0Q5ZSBesM=
+ github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203/go.mod h1:oqN97ltKNihBbwlX8dLpwxCl3+HnXKV/R0e+sRLd9C8=
+ github.com/t2bot/go-leaky-bucket v1.0.0 h1:w16tqQj4pslBFNc8xEYvOcu5rt8QhLugx1e5TKyT9zI=
+-- 
+2.54.0
+

--- a/pkgs/by-name/ma/matrix-media-repo/package.nix
+++ b/pkgs/by-name/ma/matrix-media-repo/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildGoModule,
+  applyPatches,
   fetchFromGitHub,
   pkg-config,
   libde265,
@@ -10,14 +11,19 @@ let
   pname = "matrix-media-repo";
   version = "1.3.8";
 
-  src = fetchFromGitHub {
-    owner = "t2bot";
-    repo = "matrix-media-repo";
-    rev = "v${version}";
-    hash = "sha256-KP1ZyHqeATxk1PCLuM6lPk+GB4Rd0f7ppKVETIURx28=";
+  src = applyPatches {
+    src = fetchFromGitHub {
+      owner = "t2bot";
+      repo = "matrix-media-repo";
+      rev = "v${version}";
+      hash = "sha256-KP1ZyHqeATxk1PCLuM6lPk+GB4Rd0f7ppKVETIURx28=";
+    };
+    patches = [
+      ./libheif-bump.patch
+    ];
   };
 
-  vendorHash = "sha256-+sHy4Lgufs5jdN/V9W06U4dOZrsPiX87zmR1UwGHhQg=";
+  vendorHash = "sha256-AzWZGhqJlHC9MI2jv6Z54C8OqGZIZm8CPqoaLwbtyA8=";
 
   asset-compiler = buildGoModule {
     pname = "${pname}-compile_assets";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Bumped it's `libheif` dependency so it builds again

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
