### PR TITLE
bazel_8, bazel_9: pass proxyImpureEnvVars to the fetch FODs

### DIFF
--- a/pkgs/by-name/ba/bazel_8/build-support/bazelPackage.nix
+++ b/pkgs/by-name/ba/bazel_8/build-support/bazelPackage.nix
@@ -30,6 +30,9 @@
   buildInputs ? [ ],
   nativeBuildInputs ? [ ],
   autoPatchelfIgnoreMissingDeps ? null,
+  # Extra impure env vars for the dependency-fetching derivations,
+  # in addition to the proxy variables which are always passed
+  impureEnvVars ? [ ],
 }:
 let
   # FOD produced by `bazel fetch`
@@ -62,6 +65,7 @@ let
         command = "fetch";
         outputHashMode = "recursive";
         commandArgs = [ "--repository_cache=repo_cache" ] ++ commandArgs;
+        impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ impureEnvVars;
         bazelPreBuild = ''
           mkdir repo_cache
         '';
@@ -106,6 +110,7 @@ let
             command = "vendor";
             outputHashMode = "recursive";
             commandArgs = [ "--vendor_dir=vendor_dir" ] ++ commandArgs;
+            impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ impureEnvVars;
             bazelPreBuild = ''
               mkdir vendor_dir
             '';

--- a/pkgs/by-name/ba/bazel_9/build-support/bazelPackage.nix
+++ b/pkgs/by-name/ba/bazel_9/build-support/bazelPackage.nix
@@ -30,6 +30,9 @@
   buildInputs ? [ ],
   nativeBuildInputs ? [ ],
   autoPatchelfIgnoreMissingDeps ? null,
+  # Extra impure env vars for the dependency-fetching derivations,
+  # in addition to the proxy variables which are always passed
+  impureEnvVars ? [ ],
   patches ? [ ],
 }:
 let
@@ -68,6 +71,7 @@ let
           "--repo_contents_cache="
         ]
         ++ commandArgs;
+        impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ impureEnvVars;
         bazelPreBuild = ''
           mkdir repo_cache
         '';
@@ -113,6 +117,7 @@ let
             command = "vendor";
             outputHashMode = "recursive";
             commandArgs = [ "--vendor_dir=vendor_dir" ] ++ commandArgs;
+            impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ impureEnvVars;
             bazelPreBuild = ''
               mkdir vendor_dir
             '';


### PR DESCRIPTION
The `bazel fetch` and `bazel vendor` fixed-output derivations in
`bazelPackage.nix` pass no impure environment variables, so the proxy variables
never reach them and fetching from behind a proxy fails. The legacy
`buildBazelPackage` has passed `lib.fetchers.proxyImpureEnvVars` since #87314
(closing #52008), so this is a regression for the newer helpers.

Letting callers name additional variables also makes an authenticated registry
usable: Bazel reads `NETRC` from the environment, and the helper resets `HOME` to
a fresh `mktemp -d`.

The argument defaults to empty. Both `bazel_8` and `bazel_9` are touched because
they keep separate copies of `build-support/`.

## Things done

`nixpkgs-review` reports no impacted packages, since the only callers are the
`passthru.tests` examples, which aren't enumerated in the top-level package set.
Building those explicitly gives 6/6 on x86_64-linux.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Written with AI assistance (Kiro CLI / Claude Opus 5, Anthropic), reviewed by me
before submission.

cc @cbley @groodt @boltzmannrain

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
