### PR TITLE
stdenv/check-meta: mention `allowUnfreePackages` in help text

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -221,6 +221,33 @@ let
         ];
       }
   '';
+  remediate_list_or_predicate =
+    listAttr: predicateAttr: pkg:
+    let
+      pkgName = getName pkg;
+      # split the blocked package's name into individual words so we can
+      # make a good "match against prefix" example in the error message
+      attrsWords = lib.splitStringBy (
+        prev: curr:
+        elem curr [
+          "-"
+          "_"
+          " "
+        ]
+      ) false pkgName;
+    in
+    ''
+
+      Alternatively, you can specify a list of individual packages to allow:
+        { nixpkgs.config.${listAttr} = [ "${pkgName}" ]; }
+
+      To get more control, you can configure a predicate to allow specific packages:
+        { nixpkgs.config.${predicateAttr} = pkg:
+            lib.hasPrefix "${lib.head attrsWords}" (lib.getName pkg)
+        }
+
+      Note: Setting `${predicateAttr}` will overwrite any changes to `${listAttr}`.
+    '';
 
   # flakeNote will be printed in the remediation messages below.
   flakeNote = "
@@ -431,7 +458,9 @@ let
       {
         reason = "unfree";
         msg = "has an unfree license (‘${showLicense attrs.meta.license}’)";
-        remediation = remediate_allowlist "Unfree" (remediate_predicate "allowUnfreePredicate" attrs);
+        remediation = remediate_allowlist "Unfree" (
+          remediate_list_or_predicate "allowUnfreePackages" "allowUnfreePredicate" attrs
+        );
       }
     else if blocklist != [ ] && hasBlocklistedLicense attrs then
       {


### PR DESCRIPTION
When using an unfree package, the current error message mentions both `allowUnfree` and `allowUnfreePredicate`, but does not demonstrate `allowUnfreePackages` at all; in fact, `allowUnfreePredicate` is used to basically reimplement `allowUnfreePackages`, which is even more confusing.

This change adds a mention of `allowUnfreePackages` to that error message, and takes the opportunity to change the `allowUnfreePredicate` example into something more powerful:

<details>
<summary>Example output</summary>

```
$ nix-build -A firefox-bin
  error: Refusing to evaluate package 'firefox-bin-153.0.1' in /home/courvoie/nixpkgs/pkgs/applications/networking/browsers/firefox/wrapper.nix:598 because it has an unfree license (‘firefox’)
  a) To temporarily allow unfree packages, you can use an environment variable
    for a single invocation of the nix tools.

      $ export NIXPKGS_ALLOW_UNFREE=1

    Note: When using `nix shell`, `nix build`, `nix develop`, etc with a flake,
          then pass `--impure` in order to allow use of environment variables.

  b) For `nixos-rebuild` you can set
    { nixpkgs.config.allowUnfree = true; }
  in configuration.nix to override this.

  Alternatively, you can specify a list of individual packages to allow:
    { nixpkgs.config.allowUnfreePackages = [ "firefox-bin" ]; }

  To get more control, you can configure a predicate to allow specific packages:
    { nixpkgs.config.allowUnfreePredicate = pkg:
        lib.hasPrefix "firefox" (lib.getName pkg)
    }

  Note: Setting `allowUnfreePredicate` will overwrite any changes to `allowUnfreePackages`.

  c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
    { allowUnfree = true; }
  to ~/.config/nixpkgs/config.nix.
```

(note: uh, i never noticed how the (a) is aligned completely differently to (b) and (c), but now i'm not gonna be able to unsee it... maybe we need a `indent`/`dedent` function in nixpkgs?)

</details>

(unfortunately, the other `remediate_predicate` user is for non-source packages, but there is no `allowNonSourcePackages`; adding one is out-of-scope of this PR (and not my decision to make, although it'd make sense to me) so i just created a *separate* `remediate_list_or_predicate`. if non-source ever gets a *Packages counterpart then removing `remediate_predicate` would make sense to me as it would then encourage future similar options to provide the whole bool/list/function trio.)

## Things done

These are not really applicable, I hope the example output above serves as an appropriate test.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
