### PR TITLE
python3Packages.{trame-common, trame-client, trame-server, trame, trame-vuetify, trame-vtk, trame-components}: Init

### DIFF
--- a/pkgs/development/python-modules/trame-client/default.nix
+++ b/pkgs/development/python-modules/trame-client/default.nix
@@ -1,0 +1,47 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  setuptools,
+  wheel,
+  trame-common,
+}:
+
+buildPythonPackage (finalAttrs: {
+  name = "trame-client";
+  version = "3.11.4";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Kitware";
+    repo = "trame-client";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-lt0NX206kz8uH7N0Nw5BYoKJojEV5VLyqoT/zPpjibQ=";
+  };
+
+  pyproject = true;
+  build-system = [
+    setuptools
+    wheel
+  ];
+  propagatedBuildInputs = [
+    trame-common
+  ];
+
+  pythonImportsCheck = [
+    "trame_client.encoders"
+    "trame_client.module"
+    "trame_client.resources"
+    "trame_client.ui"
+    "trame_client.utils"
+    "trame_client.widgets"
+  ];
+
+  meta = {
+    description = "Internal client side implementation of trame";
+    homepage = "https://github.com/kitware/trame-client";
+    maintainers = with lib.maintainers; [ BrockoliniMorgan ];
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/development/python-modules/trame-common/default.nix
+++ b/pkgs/development/python-modules/trame-common/default.nix
@@ -1,0 +1,40 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  hatchling,
+}:
+
+buildPythonPackage (finalAttrs: {
+  name = "trame-common";
+  version = "1.1.3";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Kitware";
+    repo = "trame-common";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ymDF29WNChxU4fdIGQlIpIL4mM8GgCMRICEZX5jTTyM=";
+  };
+
+  pyproject = true;
+  build-system = [
+    hatchling
+  ];
+
+  pythonImportsCheck = [
+    "trame_common.assets"
+    "trame_common.decorators"
+    "trame_common.exec"
+    "trame_common.obj"
+    "trame_common.utils"
+  ];
+
+  meta = {
+    description = "Set of common classes and functions with no dependencies for various trame packages";
+    homepage = "https://github.com/kitware/trame-common";
+    maintainers = with lib.maintainers; [ BrockoliniMorgan ];
+    license = lib.licenses.asl20;
+  };
+})

--- a/pkgs/development/python-modules/trame-components/default.nix
+++ b/pkgs/development/python-modules/trame-components/default.nix
@@ -1,0 +1,41 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  setuptools,
+  trame-client,
+}:
+
+buildPythonPackage (finalAttrs: {
+  name = "trame-components";
+  version = "2.5.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Kitware";
+    repo = "trame-components";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Qn3HMVEXPp0H7nqtIbHopT10ZYXf/zB0y++gX+MykOo=";
+  };
+
+  pyproject = true;
+  build-system = [
+    setuptools
+  ];
+  propagatedBuildInputs = [
+    trame-client
+  ];
+
+  pythonImportsCheck = [
+    "trame_components.module"
+    "trame_components.widgets"
+  ];
+
+  meta = {
+    description = "Core widgets for trame";
+    homepage = "https://github.com/kitware/trame-components";
+    maintainers = with lib.maintainers; [ BrockoliniMorgan ];
+    license = lib.licenses.asl20;
+  };
+})

--- a/pkgs/development/python-modules/trame-server/default.nix
+++ b/pkgs/development/python-modules/trame-server/default.nix
@@ -1,0 +1,49 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  setuptools,
+  wslink,
+  more-itertools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  name = "trame-server";
+  version = "3.10.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Kitware";
+    repo = "trame-server";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-M3UQYJlo539y3M0LyxkHeQJgpVt+AkSXyjpVpukdV8w=";
+  };
+
+  pyproject = true;
+  build-system = [
+    setuptools
+  ];
+  propagatedBuildInputs = [
+    wslink
+    more-itertools
+  ];
+
+  pythonImportsCheck = [
+    "trame_server.utils"
+    "trame_server.client"
+    "trame_server.controller"
+    "trame_server.core"
+    "trame_server.http"
+    "trame_server.protocol"
+    "trame_server.state"
+    "trame_server.ui"
+  ];
+
+  meta = {
+    description = "Internal server side implementation of trame";
+    homepage = "https://github.com/kitware/trame-server";
+    maintainers = with lib.maintainers; [ BrockoliniMorgan ];
+    license = lib.licenses.asl20;
+  };
+})

--- a/pkgs/development/python-modules/trame-vtk/default.nix
+++ b/pkgs/development/python-modules/trame-vtk/default.nix
@@ -1,0 +1,45 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  hatchling,
+  trame-client,
+}:
+
+buildPythonPackage (finalAttrs: {
+  name = "trame-vtk";
+  version = "2.11.8";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Kitware";
+    repo = "trame-vtk";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-cNBHQS1nakRnFDbFLMwVEUzQj4zipY/z/5awuObMJJM=";
+  };
+
+  pyproject = true;
+  build-system = [
+    hatchling
+  ];
+  propagatedBuildInputs = [
+    trame-client
+  ];
+
+  pythonImportsCheck = [
+    "trame_vtk.modules"
+    "trame_vtk.tools"
+    "trame_vtk.widgets"
+    "trame.modules"
+    "trame.tools"
+    "trame.widgets"
+  ];
+
+  meta = {
+    description = "VTK/ParaView widgets for trame";
+    homepage = "https://github.com/kitware/trame-vtk";
+    maintainers = with lib.maintainers; [ BrockoliniMorgan ];
+    license = lib.licenses.bsd3;
+  };
+})

--- a/pkgs/development/python-modules/trame-vuetify/default.nix
+++ b/pkgs/development/python-modules/trame-vuetify/default.nix
@@ -1,0 +1,44 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  setuptools,
+  wheel,
+  trame-client,
+}:
+
+buildPythonPackage (finalAttrs: {
+  name = "trame-vuetify";
+  version = "3.2.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Kitware";
+    repo = "trame-vuetify";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Z3E5KTdYmFdfkLHR4FIH3JX2NvQm+9whTRdFsv2gJyk=";
+  };
+
+  pyproject = true;
+  build-system = [
+    setuptools
+    wheel
+  ];
+  propagatedBuildInputs = [
+    trame-client
+  ];
+
+  pythonImportsCheck = [
+    "trame_vuetify.module"
+    "trame_vuetify.ui"
+    "trame_vuetify.widgets"
+  ];
+
+  meta = {
+    description = "trame-vuetify brings Vuetify UI Material Components into trame";
+    homepage = "https://github.com/kitware/trame-vuetify";
+    maintainers = with lib.maintainers; [ BrockoliniMorgan ];
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/development/python-modules/trame/default.nix
+++ b/pkgs/development/python-modules/trame/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  wheel,
+  pyyaml,
+  wslink,
+  trame-common,
+  trame-server,
+  trame-client,
+}:
+buildPythonPackage (finalAttrs: {
+  name = "trame";
+  version = "3.12.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Kitware";
+    repo = "trame";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-U58Tq4/NVcFCZ2vTjilbabnbQhlEf2QS/e/7Zy5l5YU=";
+  };
+
+  pyproject = true;
+  build-system = [
+    setuptools
+    wheel
+  ];
+  propagatedBuildInputs = [
+    pyyaml
+    wslink
+    trame-common
+    trame-server
+    trame-client
+  ];
+
+  pythonImportsCheck = [
+    "trame.app"
+    "trame.assets"
+    "trame.env"
+    "trame.modules"
+    "trame.tools"
+    "trame.ui"
+    "trame.utils"
+    "trame.widgets"
+  ];
+
+  meta = {
+    description = "Trame lets you weave various components and technologies into a Web Application solely written in Python";
+    homepage = "https://github.com/kitware/trame";
+    maintainers = with lib.maintainers; [ BrockoliniMorgan ];
+    license = lib.licenses.asl20;
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20583,6 +20583,8 @@ self: super: with self; {
 
   trakit = callPackage ../development/python-modules/trakit { };
 
+  trame-client = callPackage ../development/python-modules/trame-client { };
+
   trame-common = callPackage ../development/python-modules/trame-common { };
 
   trampoline = callPackage ../development/python-modules/trampoline { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20591,6 +20591,8 @@ self: super: with self; {
 
   trame-server = callPackage ../development/python-modules/trame-server { };
 
+  trame-vuetify = callPackage ../development/python-modules/trame-vuetify { };
+
   trampoline = callPackage ../development/python-modules/trampoline { };
 
   transaction = callPackage ../development/python-modules/transaction { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20583,6 +20583,8 @@ self: super: with self; {
 
   trakit = callPackage ../development/python-modules/trakit { };
 
+  trame-common = callPackage ../development/python-modules/trame-common { };
+
   trampoline = callPackage ../development/python-modules/trampoline { };
 
   transaction = callPackage ../development/python-modules/transaction { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20589,6 +20589,8 @@ self: super: with self; {
 
   trame-common = callPackage ../development/python-modules/trame-common { };
 
+  trame-components = callPackage ../development/python-modules/trame-components { };
+
   trame-server = callPackage ../development/python-modules/trame-server { };
 
   trame-vtk = callPackage ../development/python-modules/trame-vtk { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20583,6 +20583,8 @@ self: super: with self; {
 
   trakit = callPackage ../development/python-modules/trakit { };
 
+  trame = callPackage ../development/python-modules/trame { };
+
   trame-client = callPackage ../development/python-modules/trame-client { };
 
   trame-common = callPackage ../development/python-modules/trame-common { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20587,6 +20587,8 @@ self: super: with self; {
 
   trame-common = callPackage ../development/python-modules/trame-common { };
 
+  trame-server = callPackage ../development/python-modules/trame-server { };
+
   trampoline = callPackage ../development/python-modules/trampoline { };
 
   transaction = callPackage ../development/python-modules/transaction { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20591,6 +20591,8 @@ self: super: with self; {
 
   trame-server = callPackage ../development/python-modules/trame-server { };
 
+  trame-vtk = callPackage ../development/python-modules/trame-vtk { };
+
   trame-vuetify = callPackage ../development/python-modules/trame-vuetify { };
 
   trampoline = callPackage ../development/python-modules/trampoline { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This is a suite of python tools for the web framework [trame](https://kitware.github.io/trame/guide/). 
Links:
https://github.com/Kitware/trame
https://github.com/Kitware/trame-vtk
https://github.com/Kitware/trame-vuetify
https://github.com/Kitware/trame-components

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Since these are all related, I've put them all into the same PR, but I'm happy to split them out if desired.