### PR TITLE
binaryen: add updateScript

### DIFF
--- a/pkgs/development/compilers/binaryen/default.nix
+++ b/pkgs/development/compilers/binaryen/default.nix
@@ -9,6 +9,12 @@
   lit,
   nodejs,
   filecheck,
+  writeShellApplication,
+  common-updater-scripts,
+  curl,
+  jq,
+  nix,
+  nix-update,
 }:
 let
   testsuite = fetchFromGitHub {
@@ -103,5 +109,28 @@ stdenv.mkDerivation rec {
     ];
     license = lib.licenses.asl20;
   };
-  passthru.tests = { inherit emscripten; };
+  passthru = {
+    tests = { inherit emscripten; };
+    inherit testsuite; # For updateScript to use.
+    updateScript = lib.getExe (writeShellApplication {
+      name = "binaryen-update";
+      runtimeInputs = [
+        common-updater-scripts
+        curl
+        jq
+        nix
+        nix-update
+      ];
+      text = ''
+        nix-update binaryen
+
+        # keep the testsuite pin on binaryen's submodule pointer at the new tag
+        tag=$(nix eval --raw --file . binaryen.src.rev)
+        rev=$(curl -fsSL "https://api.github.com/repos/WebAssembly/binaryen/contents/test/spec/testsuite?ref=$tag" | jq -er .sha)
+        if [[ $rev != "$(nix eval --raw --file . binaryen.testsuite.rev)" ]]; then
+          update-source-version binaryen --source-key=testsuite --rev="$rev" --ignore-same-version
+        fi
+      '';
+    });
+  };
 }


### PR DESCRIPTION
Due to the lack of an `updateScript`, the @r-ryantm bot has not been automatically opening update PRs for this package; see [the most recent attempt log](https://nixpkgs-update-logs.nix-community.org/binaryen/2026-07-25.log), for instance:

```
Running nixpkgs-update (https://nix-community.org/update-bot/) with UPDATE_INFO: binaryen 129 -> 131 https://github.com/WebAssembly/binaryen/releases
attrpath: binaryen
Checking auto update branch...
No auto update branch exists
[version] 
[version] generic version rewriter does not support multiple hashes
[rustCrateVersion] 
[rustCrateVersion] No cargoHash found
[golangModuleVersion] 
[golangModuleVersion] Not a buildGoModule package with vendorHash
[npmDepsVersion] 
[npmDepsVersion] No npmDepsHash
[updateScript] 
[updateScript] skipping because derivation has no updateScript
The diff was empty after rewrites.
```

This PR adds an `updateScript` so @r-ryantm will automatically open update PRs in the future whenever possible. Tested by running the following command on `x86_64-linux`; before this commit it gave the same log as above, and after this commit it produced an update to [version 131](https://github.com/WebAssembly/binaryen/blob/version_131/CHANGELOG.md):

```sh
nix run github:nix-community/nixpkgs-update -- update 'binaryen 130 131 https://github.com/WebAssembly/binaryen/releases'
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
