### PR TITLE
python3Packages: various updates and fixes

### DIFF
--- a/pkgs/development/python-modules/blackjax/default.nix
+++ b/pkgs/development/python-modules/blackjax/default.nix
@@ -78,6 +78,10 @@ buildPythonPackage (finalAttrs: {
     # too slow
     "test_adaptive_tempered_smc"
 
+    # AssertionError: False is not true : f32: controller never escalated (U=0);
+    # axis-aligned spike would do this, ensure u_dir is non-axis-aligned
+    "test_escalated_e2e_smoke_f32_and_x64"
+
     # AssertionError on numerical values
     "test_barker"
     "test_imm_shrinkage_seed_influence_persists_diagonal"

--- a/pkgs/development/python-modules/distrax/default.nix
+++ b/pkgs/development/python-modules/distrax/default.nix
@@ -16,13 +16,14 @@
 
   # tests
   dm-haiku,
+  mock,
   pytest-xdist,
   pytestCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "distrax";
-  version = "0.1.8";
+  version = "0.1.9";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -30,7 +31,7 @@ buildPythonPackage (finalAttrs: {
     owner = "google-deepmind";
     repo = "distrax";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-MZGaK55FHQPVwgzZ2RPOohYgotw+o1ca0k6bLd/sjFQ=";
+    hash = "sha256-mX05qWyGTye+ZIXzU+W8ICz691UgVNIYXFN7oJHPssc=";
   };
 
   build-system = [
@@ -51,6 +52,7 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [
     dm-haiku
+    mock
     pytest-xdist
     pytestCheckHook
   ];
@@ -58,45 +60,17 @@ buildPythonPackage (finalAttrs: {
   pythonImportsCheck = [ "distrax" ];
 
   disabledTests = [
-    # execnet.gateway_base.DumpError: can't serialize <class 'method'>
-    "test_raises_on_invalid_input_shape"
-
     # Flaky: AssertionError: 1 not less than 0.7000000000000001
+    "test_von_mises_sample_gradient"
+    "test_von_mises_sample_moments"
     "test_von_mises_sample_uniform_ks_test"
 
     # Flaky: AssertionError: Not equal to tolerance
+    "StraightThroughTest"
     "test_composite_methods_are_consistent__with_jit"
-
-    # NotImplementedError: Primitive 'square' does not have a registered inverse.
-    "test_against_tfp_bijectors_square"
-    "test_log_dets_square__with_device"
-    "test_log_dets_square__without_device"
-    "test_log_dets_square__without_jit"
-
-    # AssertionError on numerical values
-    # Reported upstream in https://github.com/google-deepmind/distrax/issues/267
-    "test_method_with_input_unnormalized_probs__with_device"
-    "test_method_with_input_unnormalized_probs__with_jit"
-    "test_method_with_input_unnormalized_probs__without_device"
-    "test_method_with_input_unnormalized_probs__without_jit"
-    "test_method_with_value_1d"
-    "test_nested_distributions__with_device"
-    "test_nested_distributions__without_device"
-    "test_nested_distributions__with_jit"
-    "test_nested_distributions__without_jit"
-    "test_stability__with_device"
-    "test_stability__with_jit"
-    "test_stability__without_device"
-    "test_stability__without_jit"
-    "test_von_mises_sample_gradient"
-    "test_von_mises_sample_moments"
   ];
 
   disabledTestPaths = [
-    # Since jax 0.6.0:
-    # TypeError: <lambda>() got an unexpected keyword argument 'accuracy'
-    "distrax/_src/bijectors/lambda_bijector_test.py"
-
     # TypeErrors
     "distrax/_src/bijectors/tfp_compatible_bijector_test.py"
     "distrax/_src/distributions/distribution_from_tfp_test.py"
@@ -108,21 +82,8 @@ buildPythonPackage (finalAttrs: {
     "distrax/_src/distributions/tfp_compatible_distribution_test.py"
     "distrax/_src/distributions/transformed_test.py"
     "distrax/_src/distributions/uniform_test.py"
-    "distrax/_src/utils/transformations_test.py"
-    # https://github.com/google-deepmind/distrax/pull/270
-    "distrax/_src/distributions/deterministic_test.py"
-    "distrax/_src/distributions/epsilon_greedy_test.py"
-    "distrax/_src/distributions/gamma_test.py"
-    "distrax/_src/distributions/greedy_test.py"
-    "distrax/_src/distributions/gumbel_test.py"
-    "distrax/_src/distributions/logistic_test.py"
-    "distrax/_src/distributions/log_stddev_normal_test.py"
-    "distrax/_src/distributions/mvn_diag_test.py"
-    "distrax/_src/distributions/mvn_full_covariance_test.py"
-    "distrax/_src/distributions/mvn_tri_test.py"
-    "distrax/_src/distributions/one_hot_categorical_test.py"
-    "distrax/_src/distributions/softmax_test.py"
     "distrax/_src/utils/hmm_test.py"
+    "distrax/_src/utils/transformations_test.py"
   ];
 
   meta = {
@@ -131,9 +92,5 @@ buildPythonPackage (finalAttrs: {
     changelog = "https://github.com/google-deepmind/distrax/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ onny ];
-    badPlatforms = [
-      # SystemError: nanobind::detail::nb_func_error_except(): exception could not be translated!
-      lib.systems.inspect.patterns.isDarwin
-    ];
   };
 })

--- a/pkgs/development/python-modules/dm-haiku/default.nix
+++ b/pkgs/development/python-modules/dm-haiku/default.nix
@@ -37,6 +37,7 @@ buildPythonPackage (finalAttrs: {
   pname = "dm-haiku";
   version = "0.0.16";
   pyproject = true;
+  __srtructuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "deepmind";

--- a/pkgs/development/python-modules/dm-haiku/default.nix
+++ b/pkgs/development/python-modules/dm-haiku/default.nix
@@ -33,120 +33,111 @@
   tensorflow,
 }:
 
-let
-  dm-haiku = buildPythonPackage rec {
-    pname = "dm-haiku";
-    version = "0.0.16";
-    pyproject = true;
+buildPythonPackage (finalAttrs: {
+  pname = "dm-haiku";
+  version = "0.0.16";
+  pyproject = true;
 
-    src = fetchFromGitHub {
-      owner = "deepmind";
-      repo = "dm-haiku";
-      tag = "v${version}";
-      hash = "sha256-XugzzHapnqXD8w17k6HaNeqWcxRe49r7OIb8v5LI2NM=";
-    };
-
-    patches = [
-      # https://github.com/deepmind/dm-haiku/pull/672
-      (fetchpatch {
-        name = "fix-find-namespace-packages.patch";
-        url = "https://github.com/deepmind/dm-haiku/commit/728031721f77d9aaa260bba0eddd9200d107ba5d.patch";
-        hash = "sha256-qV94TdJnphlnpbq+B0G3KTx5CFGPno+8FvHyu/aZeQE=";
-      })
-    ];
-
-    build-system = [ setuptools ];
-
-    dependencies = [
-      absl-py
-      jaxlib # implicit runtime dependency
-      jmp
-      numpy
-      tabulate
-    ];
-
-    optional-dependencies = {
-      jax = [
-        jax
-        jaxlib
-      ];
-      flax = [ flax ];
-    };
-
-    pythonImportsCheck = [ "haiku" ];
-
-    nativeCheckInputs = [
-      bsuite
-      chex
-      cloudpickle
-      dill
-      dm-env
-      dm-haiku
-      dm-tree
-      flax
-      jaxlib
-      optax
-      pytest-xdist
-      pytestCheckHook
-      # rlax (broken dependency tensorflow-probability)
-      tensorflow
-    ];
-
-    disabledTests = [
-      # See https://github.com/deepmind/dm-haiku/issues/366.
-      "test_jit_Recurrent"
-
-      # Assertion errors
-      "testShapeChecking0"
-      "testShapeChecking1"
-
-      # This test requires a more recent version of tensorflow. The current one (2.13) is not enough.
-      "test_reshape_convert"
-
-      # This test requires JAX support for double precision (64bit), but enabling this causes several
-      # other tests to fail.
-      # https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#double-64bit-precision
-      "test_doctest_haiku.experimental"
-
-      # AssertionError: 1 != 0 : 1 doctests failed
-      "test_doctest_haiku"
-
-      # ValueError: pmap wrapped function must be passed at least one argument containing an array,
-      # got empty *args=() and **kwargs={}
-      "test_equivalent_when_passing_transformed_fn2"
-
-      # AssertionError: ValueError not raised
-      "test_passing_function_to_transform_pmap_transform"
-      "test_passing_function_to_transform_pmap_transform_with_state"
-    ];
-
-    disabledTestPaths = [
-      # Require rlax which is unavailable as its dependency tensorflow-probability is broken
-      "examples/impala/actor_test.py"
-      "examples/impala/learner_test.py"
-      "examples/impala_lite_test.py"
-    ];
-
-    doCheck = false;
-
-    # check in passthru.tests.pytest to escape infinite recursion with bsuite
-    passthru.tests.pytest = dm-haiku.overridePythonAttrs (_: {
-      pname = "${pname}-tests";
-      doCheck = true;
-
-      # We don't have to install because the only purpose
-      # of this passthru test is to, well, test.
-      # This fixes having to set `catchConflicts` to false.
-      dontInstall = true;
-    });
-
-    meta = {
-      description = "Haiku is a simple neural network library for JAX developed by some of the authors of Sonnet";
-      homepage = "https://github.com/deepmind/dm-haiku";
-      changelog = "https://github.com/google-deepmind/dm-haiku/releases/tag/${src.tag}";
-      license = lib.licenses.asl20;
-      maintainers = with lib.maintainers; [ ndl ];
-    };
+  src = fetchFromGitHub {
+    owner = "deepmind";
+    repo = "dm-haiku";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-XugzzHapnqXD8w17k6HaNeqWcxRe49r7OIb8v5LI2NM=";
   };
-in
-dm-haiku
+
+  patches = [
+    # https://github.com/deepmind/dm-haiku/pull/672
+    (fetchpatch {
+      name = "fix-find-namespace-packages.patch";
+      url = "https://github.com/deepmind/dm-haiku/commit/728031721f77d9aaa260bba0eddd9200d107ba5d.patch";
+      hash = "sha256-qV94TdJnphlnpbq+B0G3KTx5CFGPno+8FvHyu/aZeQE=";
+    })
+  ];
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    absl-py
+    jaxlib # implicit runtime dependency
+    jmp
+    numpy
+    tabulate
+  ];
+
+  optional-dependencies = {
+    jax = [
+      jax
+      jaxlib
+    ];
+    flax = [ flax ];
+  };
+
+  pythonImportsCheck = [ "haiku" ];
+
+  nativeCheckInputs = [
+    bsuite
+    chex
+    cloudpickle
+    dill
+    dm-env
+    dm-tree
+    flax
+    jaxlib
+    optax
+    pytest-xdist
+    pytestCheckHook
+    # rlax (broken dependency tensorflow-probability)
+    tensorflow
+  ];
+
+  disabledTests = [
+    # See https://github.com/deepmind/dm-haiku/issues/366.
+    "test_jit_Recurrent"
+
+    # Assertion errors
+    "testShapeChecking0"
+    "testShapeChecking1"
+
+    # This test requires a more recent version of tensorflow. The current one (2.13) is not enough.
+    "test_reshape_convert"
+
+    # This test requires JAX support for double precision (64bit), but enabling this causes several
+    # other tests to fail.
+    # https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#double-64bit-precision
+    "test_doctest_haiku.experimental"
+
+    # AssertionError: 1 != 0 : 1 doctests failed
+    "test_doctest_haiku"
+
+    # ValueError: pmap wrapped function must be passed at least one argument containing an array,
+    # got empty *args=() and **kwargs={}
+    "test_equivalent_when_passing_transformed_fn2"
+
+    # AssertionError: ValueError not raised
+    "test_passing_function_to_transform_pmap_transform"
+    "test_passing_function_to_transform_pmap_transform_with_state"
+  ];
+
+  disabledTestPaths = [
+    # Require rlax which is unavailable as its dependency tensorflow-probability is broken
+    "examples/impala/actor_test.py"
+    "examples/impala/learner_test.py"
+    "examples/impala_lite_test.py"
+  ];
+
+  doCheck = false;
+
+  # check in passthru.tests.pytest to escape infinite recursion with bsuite
+  passthru.tests.pytest = finalAttrs.finalPackage.overrideAttrs {
+    pname = "${finalAttrs.pname}-tests";
+    doInstallCheck = true;
+  };
+
+  meta = {
+    description = "Haiku is a simple neural network library for JAX developed by some of the authors of Sonnet";
+    homepage = "https://github.com/deepmind/dm-haiku";
+    changelog = "https://github.com/google-deepmind/dm-haiku/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ndl ];
+  };
+})

--- a/pkgs/development/python-modules/dm-haiku/default.nix
+++ b/pkgs/development/python-modules/dm-haiku/default.nix
@@ -35,7 +35,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "dm-haiku";
-  version = "0.0.16";
+  version = "0.0.17";
   pyproject = true;
   __srtructuredAttrs = true;
 
@@ -43,17 +43,16 @@ buildPythonPackage (finalAttrs: {
     owner = "deepmind";
     repo = "dm-haiku";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-XugzzHapnqXD8w17k6HaNeqWcxRe49r7OIb8v5LI2NM=";
+    hash = "sha256-CXEMEuQY6VyQ3Ahn1vYYN6slyqABSbIBeJuxJTPapvw=";
   };
 
-  patches = [
-    # https://github.com/deepmind/dm-haiku/pull/672
-    (fetchpatch {
-      name = "fix-find-namespace-packages.patch";
-      url = "https://github.com/deepmind/dm-haiku/commit/728031721f77d9aaa260bba0eddd9200d107ba5d.patch";
-      hash = "sha256-qV94TdJnphlnpbq+B0G3KTx5CFGPno+8FvHyu/aZeQE=";
-    })
-  ];
+  # https://github.com/deepmind/dm-haiku/pull/672
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail \
+        "packages=find_namespace_packages(exclude=['*_test.py', 'examples'])," \
+        "packages=find_namespace_packages(exclude=['*_test.py', 'examples*', 'docs*']),"
+  '';
 
   build-system = [ setuptools ];
 
@@ -87,11 +86,16 @@ buildPythonPackage (finalAttrs: {
     optax
     pytest-xdist
     pytestCheckHook
-    # rlax (broken dependency tensorflow-probability)
+    rlax
     tensorflow
   ];
 
   disabledTests = [
+    # tensorflow.python.framework.errors_impl.InvalidArgumentError: Graph execution error:
+    # Cannot deserialize computation: UNKNOWN: <unknown>:0: error: loc("erf"):
+    # unregistered operation 'vhlo.composite_v2' found in dialect ('vhlo') that does not allow unknown operations
+    "JaxToTfTest"
+
     # See https://github.com/deepmind/dm-haiku/issues/366.
     "test_jit_Recurrent"
 
@@ -132,6 +136,9 @@ buildPythonPackage (finalAttrs: {
   passthru.tests.pytest = finalAttrs.finalPackage.overrideAttrs {
     pname = "${finalAttrs.pname}-tests";
     doInstallCheck = true;
+
+    # This is only a test derivation; its metadata still identifies the package as "dm-haiku"
+    dontCheckPythonMetadata = true;
   };
 
   meta = {

--- a/pkgs/development/python-modules/flax/default.nix
+++ b/pkgs/development/python-modules/flax/default.nix
@@ -35,7 +35,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "flax";
-  version = "0.12.7";
+  version = "0.12.8";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -43,16 +43,8 @@ buildPythonPackage (finalAttrs: {
     owner = "google";
     repo = "flax";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-a78KiTsCCARWZvbxz9QKdUKnjkDJGXcPVVJu5rU4m/U=";
+    hash = "sha256-0I5RwA1ORlWtSawOZhgsZMBQSOusyxD0WnIoPgZdxZw=";
   };
-
-  # DeprecationWarning: `with mesh:` context manager has been deprecated. Please use `with jax.set_mesh(mesh):` instead.
-  postPatch = ''
-    substituteInPlace tests/nnx/transforms_test.py \
-      --replace-fail \
-        "with mesh:" \
-        "with jax.set_mesh(mesh):"
-  '';
 
   build-system = [
     setuptools

--- a/pkgs/development/python-modules/jax-tap/default.nix
+++ b/pkgs/development/python-modules/jax-tap/default.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "jax-tap";
-  version = "0.3.0";
+  version = "0.3.1";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -27,7 +27,7 @@ buildPythonPackage (finalAttrs: {
     owner = "arcueil";
     repo = "jax-tap";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-B6Y8+9FXLhHZwQ9ayomffP3P7Uz7zuL52oxzJwCE2hM=";
+    hash = "sha256-xMBiEuACoPFSIlhR+/k4dBCGxqDqN7jkioSmsBlpWYk=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/rlax/default.nix
+++ b/pkgs/development/python-modules/rlax/default.nix
@@ -24,7 +24,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "rlax";
-  version = "0.1.8";
+  version = "0.1.9";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -32,14 +32,8 @@ buildPythonPackage (finalAttrs: {
     owner = "google-deepmind";
     repo = "rlax";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-E/zYFd5bfx58FfA3uR7hzRAIs844QzJA8TZTwmwDByk=";
+    hash = "sha256-CDHoRY6QcgedudojID4Cxw7RWb/LCT5FvZ1dOVDWGMA=";
   };
-
-  # TypeError: clip() got an unexpected keyword argument 'a_min'
-  postPatch = ''
-    substituteInPlace rlax/_src/mpo_ops.py \
-      --replace-fail "a_min=" "min="
-  '';
 
   build-system = [
     flit-core


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **python3Packages.dm-haiku: use finalAttrs**
- **python3Packages.dm-haiku: enable __structuredAttrs**
- **python3Packages.dm-haiku: 0.0.16 -> 0.0.17** ([Diff](https://github.com/google-deepmind/dm-haiku/compare/v0.0.16...v0.0.17), [Changelog](https://github.com/google-deepmind/dm-haiku/releases/tag/v0.0.17))
- **python3Packages.distrax: 0.1.8 -> 0.1.9** ([Diff](https://github.com/google-deepmind/distrax/compare/v0.1.8...v0.1.9), [Changelog](https://github.com/google-deepmind/distrax/releases/tag/v0.1.9))
- **python3Packages.rlax: 0.1.8 -> 0.1.9** ([Diff](https://github.com/google-deepmind/rlax/compare/v0.1.8...v0.1.9), [Changelog](https://github.com/google-deepmind/rlax/releases/tag/v0.1.9))
- **python3Packages.flax: 0.12.7 -> 0.12.8** ([Diff](https://github.com/google/flax/compare/v0.12.7...v0.12.8), [Changelog](https://github.com/google/flax/releases/tag/v0.12.8))
- **python3Packages.jax-tap: 0.3.0 -> 0.3.1** ([Diff](https://github.com/arcueil/jax-tap/compare/v0.3.0...v0.3.1), [Changelog](https://github.com/arcueil/jax-tap/blob/v0.3.1/CHANGELOG.md))
- **python3Packages.blackjax: disable failing test**

cc @ndl

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
