### PR TITLE
pipx: fix pytest 9 collection error in test_inject.py

### DIFF
--- a/pkgs/development/python-modules/pipx/default.nix
+++ b/pkgs/development/python-modules/pipx/default.nix
@@ -117,6 +117,8 @@ buildPythonPackage (finalAttrs: {
       --fish <(register-python-argcomplete pipx --shell fish)
   '';
 
+  patches = [ ./fix-pytest-parametrize.patch ];
+
   pythonImportsCheck = [ "pipx" ];
 
   __structuredAttrs = true;

--- a/pkgs/development/python-modules/pipx/fix-pytest-parametrize.patch
+++ b/pkgs/development/python-modules/pipx/fix-pytest-parametrize.patch
@@ -1,0 +1,31 @@
+diff --git a/tests/test_inject.py b/tests/test_inject.py
+index b477886..0110545 100755
+--- a/tests/test_inject.py
++++ b/tests/test_inject.py
+@@ -10,7 +10,7 @@ from package_info import PKG
+ 
+ # Note that this also checks that packages used in other tests can be injected individually
+ @pytest.mark.parametrize(
+-    "pkg_spec,",
++    "pkg_spec",
+     [
+         PKG["black"]["spec"],
+         PKG["nox"]["spec"],
+@@ -51,7 +51,7 @@ def test_inject_simple_legacy_venv(pipx_temp_env, capsys, metadata_version):
+         assert "Please uninstall and install" in capsys.readouterr().err
+ 
+ 
+-@pytest.mark.parametrize("with_suffix,", [(False,), (True,)])
++@pytest.mark.parametrize("with_suffix", [(False,), (True,)])
+ def test_inject_include_apps(pipx_temp_env, capsys, with_suffix):
+     install_args = []
+     suffix = ""
+@@ -70,7 +70,7 @@ def test_inject_include_apps(pipx_temp_env, capsys, with_suffix):
+ 
+ 
+ @pytest.mark.parametrize(
+-    "with_packages,",
++    "with_packages",
+     [
+         (),  # no extra packages
+         ("black",),  # duplicate from requirements file


### PR DESCRIPTION
Fixes #522307
The bug is the likeliest accidental on pipx's side. There is an extra `,` character off at three instances of the `test_inject.py` file.
I believe older Pytest versions silently ignored the trailing empty string when splitting by comma, but Pytest 9 strictly enforces parameter counts and broke.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
