### PR TITLE
eepers: fix build on non-linux platforms

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -31819,6 +31819,11 @@
       { fingerprint = "E22F 760E E074 E57A 21CB  1733 8DD2 9BB5 2C25 EA09"; }
     ];
   };
+  zinzilulo = {
+    name = "zinzilulo";
+    github = "zinzilulo";
+    githubId = 214774502;
+  };
   Zirconium419122 = {
     name = "Rasmus Liaskar";
     github = "Zirconium419122";

--- a/pkgs/by-name/ee/eepers/package.nix
+++ b/pkgs/by-name/ee/eepers/package.nix
@@ -74,7 +74,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/tsoding/eepers";
     changelog = "https://github.com/tsoding/eepers/blob/${finalAttrs.src.rev}/CHANGELOG.txt";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ GaetanLepage ];
+    maintainers = with lib.maintainers; [
+      GaetanLepage
+      zinzilulo
+    ];
     mainProgram = "eepers";
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/ee/eepers/package.nix
+++ b/pkgs/by-name/ee/eepers/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
       -Wall \
       -Wextra \
       -gnat2012 \
-      -o eepers-linux eepers.adb \
+      -o eepers eepers.adb \
       -bargs \
       -largs -lraylib -lm \
       -pthread
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postBuild
   '';
 
-  postFixup = ''
+  postFixup = lib.optionalString stdenv.isLinux ''
     patchelf $out/bin/eepers \
       --add-needed libwayland-client.so \
       --add-needed libwayland-cursor.so \
@@ -62,7 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     mkdir -p $out/bin
-    cp ./eepers-linux $out/bin/eepers
+    cp ./eepers $out/bin/eepers
 
     cp -r ./assets $out/
 


### PR DESCRIPTION
- Changes:
  - [x] Change the Linux-specific binary name
  - [x] Gates the patchelf behind `stdenv.isLinux` since the added Wayland/ALSA dependencies are Linux-only
  - [x] Adds the additional maintainer entry

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
