### PR TITLE
qcom-diag: init at unstable-2026-04-18

### DIFF
--- a/pkgs/by-name/qc/qcom-diag/package.nix
+++ b/pkgs/by-name/qc/qcom-diag/package.nix
@@ -1,0 +1,54 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  qrtr,
+  systemdLibs,
+  lib,
+  fetchpatch,
+}:
+stdenv.mkDerivation {
+  pname = "qcom-diag";
+  version = "unstable-2026-04-18";
+
+  src = fetchFromGitHub {
+    owner = "linux-msm";
+    repo = "diag";
+    rev = "23c12c167e93215853af4e59c021551767f6fec8";
+    hash = "sha256-rDtXNYwXzd29iTv6ZXobX7WfTRruT6jGT7TQUIgiZPY=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  patches = [
+    # https://github.com/linux-msm/diag/pull/25
+    (fetchpatch {
+      name = "ssid-null-deref.patch";
+      url = "https://github.com/linux-msm/diag/commit/809dcac76b534f5908437bc096e3712be4cf26a8.patch";
+      hash = "sha256-NCiUlwP5/SJ1Zp17+nADccSysAof5MfqEe1MRTuNB/c=";
+    })
+  ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    qrtr
+    systemdLibs
+  ];
+
+  installFlags = [
+    "prefix=/"
+    "DESTDIR=$(out)"
+  ];
+
+  meta = {
+    maintainers = with lib.maintainers; [ matthewcroughan ];
+    description = "Routing of diagnostics related messages between host and various Qualcomm subsystems";
+    homepage = "https://github.com/linux-msm/diag";
+    license = lib.licenses.bsd3;
+    platforms = [
+      "aarch64-linux"
+    ];
+  };
+}


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
