### PR TITLE
pymp4: init at 1.4.0

### DIFF
--- a/pkgs/development/python-modules/pymp4/construct-2.10.70.patch
+++ b/pkgs/development/python-modules/pymp4/construct-2.10.70.patch
@@ -1,0 +1,16 @@
+--- a/src/pymp4/parser.py
++++ b/src/pymp4/parser.py
+@@ -16,0 +17 @@
++from io import BytesIO
+@@ -643,0 +645,8 @@
++class RelativePrefixed(Prefixed):
++    def _parse(self, stream, context, path):
++        length = self.lengthfield._parsereport(stream, context, path)
++        if self.includelength:
++            length -= self.lengthfield._sizeof(context, path)
++        data = stream_read(stream, length, path)
++        return self.subcon._parsereport(BytesIO(data), context, path)
++
+@@ -645 +654 @@
+-Box = Prefixed(Int32ub, Struct(
++Box = RelativePrefixed(Int32ub, Struct(

--- a/pkgs/development/python-modules/pymp4/default.nix
+++ b/pkgs/development/python-modules/pymp4/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  construct,
+  pytestCheckHook,
+}:
+
+buildPythonPackage {
+  pname = "pymp4";
+  version = "1.4.0-unstable-2023-08-07";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "devine-dl";
+    repo = "pymp4";
+    rev = "33dc5d620f361cb49d713b60dcb2686ab8696f91";
+    hash = "sha256-tPIbehjYHg5+S62sorsWow+u/eBkqJYf6xMI8q4vEgY=";
+  };
+
+  patches = [ ./construct-2.10.70.patch ];
+
+  pythonRelaxDeps = [ "construct" ];
+
+  build-system = [ poetry-core ];
+
+  dependencies = [ construct ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "pymp4" ];
+
+  meta = {
+    description = "Python library for parsing and manipulating MP4 files";
+    homepage = "https://github.com/devine-dl/pymp4";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ bdim404 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15119,6 +15119,8 @@ self: super: with self; {
 
   pymorphy3-dicts-uk = callPackage ../development/python-modules/pymorphy3-dicts-uk { };
 
+  pymp4 = callPackage ../development/python-modules/pymp4 { };
+
   pympler = callPackage ../development/python-modules/pympler { };
 
   pymsgbox = callPackage ../development/python-modules/pymsgbox { };


### PR DESCRIPTION
Adds the Construct-compatible `devine-dl/pymp4` fork as a Python package. It is required by `pywidevine`.

Automation disclosure: OpenAI Codex (GPT-5) assisted with implementation, testing, and preparation of this pull request.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
