### PR TITLE
python3Packages.pywidevine: init at 1.9.0

### DIFF
--- a/pkgs/by-name/mu/music-assistant/package.nix
+++ b/pkgs/by-name/mu/music-assistant/package.nix
@@ -191,6 +191,7 @@ pythonPackages.buildPythonApplication (finalAttrs: {
     ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies
     ++ (lib.concatMap (provider: providerPackages.${provider} pythonPackages) [
       "acoustid_lookup"
+      "apple_music"
       "audible"
       "dlna"
       "fastmcp_server"
@@ -224,7 +225,6 @@ pythonPackages.buildPythonApplication (finalAttrs: {
     # "OSError: [Errno 19] No such device"
     "tests/core/test_genres.py"
     # provider is missing dependencies
-    "tests/providers/apple_music"
     "tests/providers/bandcamp"
     "tests/providers/hue_entertainment"
     "tests/providers/kion_music"

--- a/pkgs/by-name/mu/music-assistant/providers.nix
+++ b/pkgs/by-name/mu/music-assistant/providers.nix
@@ -32,8 +32,10 @@
       ps: with ps; [
         alexapy
       ];
-    apple_music = ps: [
-    ]; # missing pywidevine
+    apple_music =
+      ps: with ps; [
+        pywidevine
+      ];
     ard_audiothek =
       ps: with ps; [
         gql

--- a/pkgs/development/python-modules/pywidevine/construct-2.10-compatibility.patch
+++ b/pkgs/development/python-modules/pywidevine/construct-2.10-compatibility.patch
@@ -1,0 +1,20 @@
+--- a/pywidevine/device.py
++++ b/pywidevine/device.py
+@@ -33,7 +33,7 @@ class _Structures:
+     # - Removed vmp and vmp_len as it should already be within the Client ID
+     v2 = Struct(
+         "signature" / magic,
+-        "version" / Const(Int8ub, 2),
++        "version" / Const(2, Int8ub),
+         "type_" / CEnum(
+             Int8ub,
+             **{t.name: t.value for t in DeviceTypes}
+@@ -50,7 +50,7 @@ class _Structures:
+     # - Removed system_id as it can be retrieved from the Client ID's DRM Certificate
+     v1 = Struct(
+         "signature" / magic,
+-        "version" / Const(Int8ub, 1),
++        "version" / Const(1, Int8ub),
+         "type_" / CEnum(
+             Int8ub,
+             **{t.name: t.value for t in DeviceTypes}

--- a/pkgs/development/python-modules/pywidevine/default.nix
+++ b/pkgs/development/python-modules/pywidevine/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  poetry-core,
+  pycryptodome,
+  protobuf,
+  requests,
+  pyyaml,
+  unidecode,
+  click,
+  pymp4,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pywidevine";
+  version = "1.9.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-Z0La9f15fFpIE+sTAO+zGB/83dDIxHjuKMfFNqoOUbI=";
+  };
+
+  patches = [
+    ./construct-2.10-compatibility.patch
+  ];
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    click
+    protobuf
+    pycryptodome
+    pymp4
+    pyyaml
+    requests
+    unidecode
+  ];
+
+  pythonImportsCheck = [ "pywidevine" ];
+
+  meta = {
+    description = "Python implementation of Google's Widevine CDM";
+    homepage = "https://github.com/devine-dl/pywidevine";
+    changelog = "https://github.com/devine-dl/pywidevine/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ bdim404 ];
+    mainProgram = "pywidevine";
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17450,6 +17450,10 @@ self: super: with self; {
 
   pywfa = callPackage ../development/python-modules/pywfa { };
 
+  pywidevine = callPackage ../development/python-modules/pywidevine {
+    protobuf = protobuf6;
+  };
+
   pywikibot = callPackage ../development/python-modules/pywikibot { };
 
   pywilight = callPackage ../development/python-modules/pywilight { };


### PR DESCRIPTION
Adds `pywidevine` 1.9.0 as a Python package. It is required by Music Assistant's Apple Music provider and other Widevine consumers.

Uses `pymp4`, added in #547409.

Automation disclosure: OpenAI Codex (GPT-5) assisted with implementation, testing, and preparation of this pull request.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

