### PR TITLE
intel-media-driver: 26.1.6 -> 26.2.4

### DIFF
--- a/pkgs/by-name/in/intel-media-driver/cmake4.patch
+++ b/pkgs/by-name/in/intel-media-driver/cmake4.patch
@@ -63,19 +63,6 @@ index af622be19cb..40e4eba171e 100644
  
  project(KrnToHex_IGA)
  
-diff --git a/cmrtlib/CMakeLists.txt b/cmrtlib/CMakeLists.txt
-index 9ecb1e4e10a..54f907b3772 100644
---- a/cmrtlib/CMakeLists.txt
-+++ b/cmrtlib/CMakeLists.txt
-@@ -19,7 +19,7 @@
- # OTHER DEALINGS IN THE SOFTWARE.
- 
- set(BUILD_ALL $ENV{BUILD_ALL})
--cmake_minimum_required(VERSION 2.8)
-+cmake_minimum_required(VERSION 3.5)
- project(CM_RT)
- add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/linux)
- 
 diff --git a/cmrtlib/linux/CMakeLists.txt b/cmrtlib/linux/CMakeLists.txt
 index b066138d9df..df02bab2a69 100644
 --- a/cmrtlib/linux/CMakeLists.txt
@@ -141,16 +128,3 @@ index 6b1f7433596..bba044a97d8 100644
  
  project(devult)
  
-diff --git a/os_release_info.cmake b/os_release_info.cmake
-index b4a84e2c5cb..a3b879d8545 100644
---- a/os_release_info.cmake
-+++ b/os_release_info.cmake
-@@ -29,7 +29,7 @@ set(_os_release_info TRUE)
- # of the local cmake environment.
- 
- # Set cmake policies for at least this level:
--cmake_minimum_required(VERSION 2.8.12)
-+cmake_minimum_required(VERSION 3.5)
- 
- 
- # Function get_os_release_info - Determine and return OS name and version

--- a/pkgs/by-name/in/intel-media-driver/package.nix
+++ b/pkgs/by-name/in/intel-media-driver/package.nix
@@ -17,7 +17,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "intel-media-driver";
-  version = "26.1.6";
+  version = "26.2.4";
 
   outputs = [
     "out"
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "intel";
     repo = "media-driver";
     tag = "intel-media-${finalAttrs.version}";
-    hash = "sha256-Jk9pIZ1V1tKi9l6u10tftClVZhYn2ECvALt26n58XC0=";
+    hash = "sha256-dgdqezwnwY5FCaDhov0ft4gnhRdCDyD2DFJ17sF2d4o=";
   };
 
   patches = [


### PR DESCRIPTION
Diff: https://github.com/intel/media-driver/compare/intel-media-26.1.6...intel-media-26.2.4

Changelog: https://github.com/intel/media-driver/releases/tag/intel-media-26.2.4

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
