### PR TITLE
github-copilot-app: init at 1.1.2

### DIFF
--- a/pkgs/by-name/gi/github-copilot-app/package.nix
+++ b/pkgs/by-name/gi/github-copilot-app/package.nix
@@ -1,0 +1,95 @@
+{
+  appimageTools,
+  fetchurl,
+  lib,
+  nix-update-script,
+  stdenv,
+  stdenvNoCC,
+}:
+
+let
+  pname = "github-copilot-app";
+  version = "1.1.2";
+
+  sources = {
+    aarch64-darwin = {
+      url = "https://github.com/github/app/releases/download/v${version}/GitHub-Copilot-darwin-arm64.tar.gz";
+      hash = "sha256-HLCeQbeTO0rF7ZaqZhEv9hcyrqPhnBpgNFbXjGpo68g=";
+    };
+    aarch64-linux = {
+      url = "https://github.com/github/app/releases/download/v${version}/GitHub-Copilot-linux-arm64.AppImage";
+      hash = "sha256-6oQmtMcoUL8uhEhvoc14in8xKYS7IB6V8guDZ/vGC8c=";
+    };
+    x86_64-linux = {
+      url = "https://github.com/github/app/releases/download/v${version}/GitHub-Copilot-linux-x64.AppImage";
+      hash = "sha256-EKBbXoMGKaUJPA0s39XuxAtrl1CzjctDXHaofDXsiMo=";
+    };
+  };
+
+  src = fetchurl (
+    sources.${stdenv.hostPlatform.system}
+      or (throw "github-copilot-app: Unsupported system ${stdenv.hostPlatform.system} system detected.")
+  );
+
+  linux = appimageTools.wrapType2 {
+    inherit
+      meta
+      pname
+      src
+      version
+      ;
+
+    extraInstallCommands =
+      let
+        contents = appimageTools.extractType2 { inherit pname src version; };
+      in
+      ''
+        install -Dm444 "${contents}/usr/share/applications/GitHub Copilot.desktop" $out/share/applications/github-copilot-app.desktop
+        substituteInPlace $out/share/applications/github-copilot-app.desktop \
+          --replace-fail "Exec=github %u" "Exec=github-copilot-app %u" \
+          --replace-fail "Icon=github" "Icon=github-copilot-app"
+
+        for icon in ${contents}/usr/share/icons/hicolor/*/apps/github.png; do
+          install -Dm444 "$icon" "$out/share/icons/hicolor/$(basename "$(dirname "$(dirname "$icon")")")/apps/github-copilot-app.png"
+        done
+      '';
+
+    passthru.updateScript = nix-update-script { };
+  };
+
+  darwin = stdenvNoCC.mkDerivation {
+    inherit
+      meta
+      pname
+      src
+      version
+      ;
+
+    sourceRoot = "GitHub Copilot.app";
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p "$out/Applications/GitHub Copilot.app" "$out/bin"
+      cp -R Contents "$out/Applications/GitHub Copilot.app/"
+      ln -s "$out/Applications/GitHub Copilot.app/Contents/MacOS/github" \
+        "$out/bin/github-copilot-app"
+
+      runHook postInstall
+    '';
+
+    passthru.updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Agent-native desktop experience for GitHub Copilot.";
+    homepage = "https://github.com/features/ai/github-app";
+    changelog = "https://github.com/github/app/releases/tag/v${version}";
+    license = lib.licenses.unfree;
+    mainProgram = "github-copilot-app";
+    maintainers = with lib.maintainers; [ sheeeng ];
+    platforms = builtins.attrNames sources;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+in
+if stdenv.hostPlatform.isLinux then linux else darwin


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
