### PR TITLE
proxyman: 3.11.0 -> 3.16.1

### DIFF
--- a/pkgs/by-name/pr/proxyman/package.nix
+++ b/pkgs/by-name/pr/proxyman/package.nix
@@ -7,11 +7,11 @@
 }:
 let
   pname = "proxyman";
-  version = "3.11.0";
+  version = "3.16.1";
 
   src = fetchurl {
     url = "https://github.com/ProxymanApp/proxyman-windows-linux/releases/download/${version}/Proxyman-${version}.AppImage";
-    hash = "sha256-hzpSei0gR9apcJ6AVNoiqSUJLMvP0V/6STmGKeUg5vI=";
+    hash = "sha256-rykOZVrh3MATFDzwLS7gEj5sMD9udsWAi+68Quqzk0c=";
   };
 
   appimageContents = appimageTools.extract {
@@ -20,7 +20,9 @@ let
       ${asar}/bin/asar extract $out/resources/app.asar app
 
       # This will fix the issue with Proxyman not detecting NixOS as a valid Linux environment
-      substituteInPlace app/dist/main/main.js --replace-fail "/etc/ca-certificates/trust-source/anchors/" "/etc/ssl/certs/"
+      substituteInPlace app/dist/main/main.js \
+        --replace-fail 'systemTrustFilename:"/etc/ca-certificates/trust-source/anchors/%s.crt",trustCommands:["update-ca-trust extract"]' 'systemTrustFilename:"/etc/ssl/certs/%s.crt",trustCommands:[]' \
+        --replace-fail '{path:"/etc/ca-certificates/trust-source/anchors/",distroFamily:"arch"}' '{path:"/etc/ssl/certs/",distroFamily:"arch"}'
 
       # This will permanently mark the certificate as installed, as this should be done through Nix config rather than
       # placing / editing a file in /etc like Proxyman would expect.


### PR DESCRIPTION
Manual update that replaces #513020 as the patches needed to be adjusted.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
