### PR TITLE
python3Packages.scipp: 26.3.1 -> 26.7.0

### DIFF
--- a/pkgs/development/python-modules/scipp/default.nix
+++ b/pkgs/development/python-modules/scipp/default.nix
@@ -3,7 +3,6 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
 
   # build-system
   scikit-build-core,
@@ -40,30 +39,16 @@
 
 buildPythonPackage rec {
   pname = "scipp";
-  version = "26.3.1";
+  version = "26.7.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "scipp";
     repo = "Scipp";
     tag = version;
-    hash = "sha256-Jbp7dOEAnXe9kBcYt35iC01i6FnZkFY5n9okGCeuuL4=";
+    hash = "sha256-0IkLdkkqCw8qUKIh/ch9x1rbhKvAJAkjBSIz9y/GwSU=";
   };
 
-  patches = [
-    # Fixes pytest deprecation failure:
-    # https://github.com/scipp/scipp/pull/3907
-    (fetchpatch {
-      url = "https://github.com/scipp/scipp/commit/b3ad0c15e565737595f405b1d7bd1258b7bed422.patch";
-      hash = "sha256-zxcZzuZMdm9WUKXPc8q2KkB+nCS8j+jZjfZAnLiGv6c=";
-    })
-    # Fixes Numpy related issue observed in tests:
-    # https://github.com/scipp/scipp/pull/3920
-    (fetchpatch {
-      url = "https://github.com/scipp/scipp/commit/217b3baaf0696b12e39511d51a5d5270722ec48a.patch";
-      hash = "sha256-jVzayIkJq93nwtmbpDQ5kcirtpLZqua6KRXY/eN3fQg=";
-    })
-  ];
   env = {
     SKIP_REMOTE_SOURCES = "true";
   };


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test