### PR TITLE
collada-dom: 2.5.3 -> 2.5.4, clean, doCheck, fix for gcc16

### DIFF
--- a/pkgs/by-name/co/collada-dom/package.nix
+++ b/pkgs/by-name/co/collada-dom/package.nix
@@ -4,9 +4,14 @@
   fetchFromGitHub,
   cmake,
   boost,
+  bzip2,
   libxml2,
   minizip,
+  pkg-config,
+  pcre-cpp,
   readline,
+  uriparser,
+  zlib,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -27,13 +32,20 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s $out/include/*/* $out/include
   '';
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
 
   buildInputs = [
     boost
+    bzip2
     libxml2
     minizip
+    pcre-cpp
     readline
+    uriparser
+    zlib
   ];
 
   meta = {

--- a/pkgs/by-name/co/collada-dom/package.nix
+++ b/pkgs/by-name/co/collada-dom/package.nix
@@ -16,7 +16,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "collada-dom";
-  version = "2.5.3";
+  version = "2.5.4";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "Gepetto";
     repo = "collada-dom";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-vkbQvgY1ISOhbDeEmLuOWRfwQsOZRffUi3tpT/G33KY=";
+    hash = "sha256-6V1Ew1YWybgqt0dikNdXwK+4D1odgVN/7NvaikjRqE4=";
   };
 
   postInstall = ''

--- a/pkgs/by-name/co/collada-dom/package.nix
+++ b/pkgs/by-name/co/collada-dom/package.nix
@@ -48,6 +48,12 @@ stdenv.mkDerivation (finalAttrs: {
     zlib
   ];
 
+  cmakeFlags = [
+    (lib.cmakeBool "OPT_COMPILE_TESTS" finalAttrs.doCheck)
+  ];
+
+  doCheck = true;
+
   meta = {
     description = "API that provides a C++ object representation of a COLLADA XML instance document";
     longDescription = "This is a fork of [rdiankov/collada-dom](https://github.com/rdiankov/collada-dom) which has been unmaintained for six years.";


### PR DESCRIPTION
Hi,

This fix https://hydra.nixos.org/build/339166318/log/tail:
```cpp
In file included from /build/source/dom/include/dae/daeMetaElement.h:15,
                 from /build/source/dom/include/dae.h:39,
                 from /build/source/dom/src/dae/daeMetaElement.cpp:9:
/build/source/dom/include/dae/daeMetaAttribute.h:171:30: warning: 'virtual daeChar* daeMetaAttribute::get(daeElement*)' was hidden [[-Woverloaded-virtual=](https://gcc.gnu.org/onlinedocs/gcc-16.1.0/gcc/C_002b_002b-Dialect-Options.html#index-Wno-overloaded-virtual)]
  171 |         virtual daeMemoryRef get(daeElement* e);
      |                              ^~~
In file included from /build/source/dom/src/dae/daeMetaElement.cpp:14:
/build/source/dom/include/dae/daeMetaElementAttribute.h:93:30: note:   by 'virtual daeChar* daeMetaElementAttribute::get(daeElement*, daeInt)'
   93 |         virtual daeMemoryRef get(daeElement* e, daeInt index);
      |                              ^~~
/build/source/dom/src/dae/daeMetaElement.cpp: In member function 'void daeMetaElement::appendAttribute(daeMetaAttribute*)':
/build/source/dom/src/dae/daeMetaElement.cpp:178:26: error: ambiguous overload for 'operator!=' (operand types are 'daeStringRef' and 'long int')
  178 |     if ((attr->getName() != NULL) &&
      |                          ^
  • there are 2 candidates
In file included from /build/source/dom/include/dae/daeDocument.h:15,
                 from /build/source/dom/include/dae/daeDatabase.h:18,
                 from /build/source/dom/include/dae.h:36:
    • candidate 1: 'bool daeStringRef::operator==(const daeStringRef&) const' (rewritten)
      /build/source/dom/include/dae/daeStringRef.h:88:21:
         88 |         inline bool operator==(const daeStringRef& other) const{
            |                     ^~~~~~~~
    • candidate 2: 'operator!=(daeString {aka const char*}, daeString {aka const char*})' (built-in)
      /build/source/dom/src/dae/daeMetaElement.cpp:178:26:
        178 |     if ((attr->getName() != NULL) &&
            |                          ^
```

ref. https://github.com/NixOS/nixpkgs/pull/537781

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
