### PR TITLE
lib: improve implementation of `foldAttrs`

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -832,9 +832,7 @@ rec {
   */
   foldAttrs =
     op: nul: list_of_attrs:
-    foldr (
-      n: a: foldr (name: o: o // { ${name} = op n.${name} (a.${name} or nul); }) a (attrNames n)
-    ) { } list_of_attrs;
+    mapAttrs (name: foldr op nul) (zipAttrs list_of_attrs);
 
   /**
     Recursively collect sets that verify a given predicate named `pred`


### PR DESCRIPTION
This PR improves on the implementation of `lib.attrsets.foldAttrs`.

It's not used a lot throughout nixpkgs, so it unfortunately doesn't lead to any big eval gains here. But it might be beneficial out of tree.

Here's my test setup:

```nix
lib:
let
  foldAttrsOld =
    op: nul: list_of_attrs:
    lib.foldr (
      n: a: lib.foldr (name: o: o // { ${name} = op n.${name} (a.${name} or nul); }) a (builtins.attrNames n)
    ) { } list_of_attrs;

  foldAttrsNew =
    op: nul: list_of_attrs:
    builtins.mapAttrs (name: lib.foldr op nul) (builtins.zipAttrsWith (name: values: values) list_of_attrs);

  smalldata = builtins.genList (i: { "${toString (lib.mod i 5)}" = i; }) 3;
  bigdata = builtins.genList (i: { "${toString (lib.mod i 5)}" = i; }) 999;
in {
  old = foldAttrsOld (i: acc: acc + i) 0 bigdata;
  new = foldAttrsNew (i: acc: acc + i) 0 bigdata;
  oldS = foldAttrsOld (i: acc: acc + i) 0 smalldata;
  newS = foldAttrsNew (i: acc: acc + i) 0 smalldata;
  sanity = (foldAttrsOld (i: acc: acc ++ [i]) [ ] bigdata) == (foldAttrsNew (i: acc: acc ++ [i]) [ ] bigdata);
}
```

Here are the stats:

<details>
  <summary><code>NIX_SHOW_STATS=1 nix eval .#old</code></summary>

```json
{
  "cpuTime": 0.0770770013332367,
  "envs": {
    "bytes": 266640,
    "elements": 17294,
    "number": 16036
  },
  "gc": {
    "cycles": 1,
    "heapSize": 402915328,
    "totalBytes": 811376
  },
  "list": {
    "bytes": 15992,
    "concats": 0,
    "elements": 1999
  },
  "nrAvoided": 15039,
  "nrExprs": 2738,
  "nrFunctionCalls": 15015,
  "nrLookups": 6036,
  "nrOpUpdateValuesCopied": 1520,
  "nrOpUpdates": 2014,
  "nrPrimOpCalls": 8010,
  "nrThunks": 16681,
  "sets": {
    "bytes": 147000,
    "elements": 4623,
    "number": 3043
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 24,
    "Env": 8,
    "Value": 16
  },
  "symbols": {
    "bytes": 7996,
    "number": 820
  },
  "time": {
    "cpu": 0.0770770013332367,
    "gc": 0.0,
    "gcFraction": 0.0
  },
  "values": {
    "bytes": 301632,
    "number": 18852
  }
}
```

</details>

<details>
  <summary><code>NIX_SHOW_STATS=1 nix eval .#new</code></summary>

```json
{
  "cpuTime": 0.0678580030798912,
  "envs": {
    "bytes": 99400,
    "elements": 6344,
    "number": 6081
  },
  "gc": {
    "cycles": 1,
    "heapSize": 402915328,
    "totalBytes": 381296
  },
  "list": {
    "bytes": 15992,
    "concats": 0,
    "elements": 1999
  },
  "nrAvoided": 9063,
  "nrExprs": 2738,
  "nrFunctionCalls": 6055,
  "nrLookups": 2046,
  "nrOpUpdateValuesCopied": 26,
  "nrOpUpdates": 16,
  "nrPrimOpCalls": 5019,
  "nrThunks": 6700,
  "sets": {
    "bytes": 57408,
    "elements": 2016,
    "number": 1048
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 24,
    "Env": 8,
    "Value": 16
  },
  "symbols": {
    "bytes": 7996,
    "number": 820
  },
  "time": {
    "cpu": 0.0678580030798912,
    "gc": 0.0,
    "gcFraction": 0.0
  },
  "values": {
    "bytes": 142336,
    "number": 8896
  }
}
```

</details>

<details>
  <summary><code>NIX_SHOW_STATS=1 nix eval .#oldS</code></summary>

```json
{
  "cpuTime": 0.05178799852728844,
  "envs": {
    "bytes": 3696,
    "elements": 362,
    "number": 100
  },
  "gc": {
    "cycles": 1,
    "heapSize": 402915328,
    "totalBytes": 57136
  },
  "list": {
    "bytes": 56,
    "concats": 0,
    "elements": 7
  },
  "nrAvoided": 99,
  "nrExprs": 2738,
  "nrFunctionCalls": 75,
  "nrLookups": 60,
  "nrOpUpdateValuesCopied": 28,
  "nrOpUpdates": 22,
  "nrPrimOpCalls": 42,
  "nrThunks": 745,
  "sets": {
    "bytes": 17560,
    "elements": 1015,
    "number": 55
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 24,
    "Env": 8,
    "Value": 16
  },
  "symbols": {
    "bytes": 7994,
    "number": 818
  },
  "time": {
    "cpu": 0.05178799852728844,
    "gc": 0.0,
    "gcFraction": 0.0
  },
  "values": {
    "bytes": 14784,
    "number": 924
  }
}
```

</details>

<details>
  <summary><code>NIX_SHOW_STATS=1 nix eval .#newS</code></summary>

```json
{
  "cpuTime": 0.060467999428510666,
  "envs": {
    "bytes": 3512,
    "elements": 350,
    "number": 89
  },
  "gc": {
    "cycles": 1,
    "heapSize": 402915328,
    "totalBytes": 57312
  },
  "list": {
    "bytes": 56,
    "concats": 0,
    "elements": 7
  },
  "nrAvoided": 91,
  "nrExprs": 2738,
  "nrFunctionCalls": 65,
  "nrLookups": 52,
  "nrOpUpdateValuesCopied": 26,
  "nrOpUpdates": 16,
  "nrPrimOpCalls": 37,
  "nrThunks": 720,
  "sets": {
    "bytes": 17504,
    "elements": 1016,
    "number": 52
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 24,
    "Env": 8,
    "Value": 16
  },
  "symbols": {
    "bytes": 7994,
    "number": 818
  },
  "time": {
    "cpu": 0.060467999428510666,
    "gc": 0.0,
    "gcFraction": 0.0
  },
  "values": {
    "bytes": 14624,
    "number": 914
  }
}
```

</details>

For large numbers, the numbers seem to suggest that the new implementation is more efficient. For small number, the difference is negligible.

The sanity check passes with a non-commutative operator as well, so the results should be completely equal.

`nix-instantiate --eval --strict lib/tests/misc.nix` passes successfully.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [X] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
