### PR TITLE
nixos/nordvpn: make more secure and robust

### DIFF
--- a/nixos/modules/services/networking/nordvpn.md
+++ b/nixos/modules/services/networking/nordvpn.md
@@ -20,7 +20,17 @@ A minimal configuration in NixOS appears as follows:
 When using a firewall, set `networking.firewall.checkReversePath` to `"loose"` or `false`.
 NordVPN includes a `kill-switch` feature that blocks all packets not associated with the VPN connection.
 
-Additionally, add your user to the `nordvpn` group.
+If you prefer to use your own user and group, you can do so using
+
+```nix
+{
+  services.nordvpn.user = "SOME-USER";
+  services.nordvpn.group = "SOME-GROUP";
+}
+```
+
+Otherwise, the service creates a `nordvpn` user and group,
+in which case you should add your user to the `nordvpn` group.
 
 ```nix
 {
@@ -31,15 +41,6 @@ Additionally, add your user to the `nordvpn` group.
       "nordvpn"
     ];
   };
-}
-```
-
-If you prefer to use your own user and group, you can do so using
-
-```nix
-{
-  services.nordvpn.user = "SOME-USER";
-  services.nordvpn.group = "SOME-GROUP";
 }
 ```
 
@@ -60,6 +61,13 @@ Additionally, if you prefer to use the friendly GUI,
 ```bash
 nordvpn-gui
 ```
+
+Some notes on where the NixOS nordvpn service differs from upstream:
+
+- `nordvpnd` runs as an unprivileged user
+- `norduserd` spawns as a user service
+- `nordvpnd`'s systemd unit applies additional sandboxing,
+further minimizing its blast radius
 
 **Disclaimer:** NixOS currently does not support meshnet.
 Contributions welcome!

--- a/nixos/modules/services/networking/nordvpn.nix
+++ b/nixos/modules/services/networking/nordvpn.nix
@@ -99,6 +99,11 @@ in
       nordvpn
     ];
 
+    boot.kernelModules = [
+      "tun" # needed by openvpn
+      "wireguard" # needed by nordlynx
+    ];
+
     systemd.services.nordvpnd = {
       after = [ "network-online.target" ];
       description = "NordVPN daemon.";
@@ -115,21 +120,40 @@ in
         ++ [ nordvpn ]
       );
       serviceConfig = {
-        # nordvpnd needs CAP_NET_ADMIN to configure network interfaces
-        AmbientCapabilities = "CAP_NET_ADMIN";
-        CapabilityBoundingSet = "CAP_NET_ADMIN";
+        # nordvpnd needs CAP_NET_ADMIN to configure network interfaces.
+        AmbientCapabilities = [
+          "CAP_NET_ADMIN"
+        ];
+        CapabilityBoundingSet = [
+          "CAP_NET_ADMIN"
+        ];
+        DeviceAllow = [
+          "/dev/net/tun rw"
+        ];
         ExecStart = lib.getExe' nordvpn "nordvpnd";
         Group = cfg.group;
         KillMode = "process";
+        NoNewPrivileges = "yes";
         NonBlocking = true;
+        ProtectControlGroups = true;
+        ProtectSystem = "strict";
+        ReadWritePaths = "/tmp/";
         Requires = "nordvpnd.socket";
         Restart = "on-failure";
         RestartSec = 5;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_NETLINK"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = "yes";
         RuntimeDirectory = "nordvpn";
         RuntimeDirectoryMode = "0750";
         StateDirectory = "nordvpn";
         StateDirectoryMode = "0750";
         User = cfg.user;
+        WorkingDirectory = "/var/lib/nordvpn";
       };
       wantedBy = [ "default.target" ];
       wants = [ "network-online.target" ];
@@ -143,7 +167,7 @@ in
         DirectoryMode = "0750";
         NoDelay = true;
         SocketGroup = cfg.group;
-        SocketMode = "0770";
+        SocketMode = "0660";
         SocketUser = cfg.user;
       };
       wantedBy = [ "sockets.target" ];
@@ -158,10 +182,9 @@ in
         Restart = "on-failure";
         RestartSec = 5;
       };
-      wantedBy = [ "graphical-session.target" ];
+      wantedBy = [ "default.target" ];
       wants = [ "network-online.target" ];
     };
-
   };
 
   meta = {

--- a/nixos/tests/nordvpn.nix
+++ b/nixos/tests/nordvpn.nix
@@ -31,88 +31,172 @@
       userOnly =
         { ... }:
         lib.recursiveUpdate {
-          users.users.kanye = {
+          users.users.bob = {
             extraGroups = [ "nordvpn" ];
             isNormalUser = true;
           };
-          # run nordvpnd as kanye:nordvpn
+          # run nordvpnd as bob:nordvpn
           services.nordvpn = {
             enable = true;
-            user = "kanye";
+            user = "bob";
           };
-        } (commonConfig "kanye");
+        } (commonConfig "bob");
       groupOnly =
         { ... }:
         lib.recursiveUpdate {
           users.users.alice = {
-            extraGroups = [ "kanye" ];
+            extraGroups = [ "bob" ];
             isNormalUser = true;
           };
-          users.groups.kanye = { };
-          # run nordvpnd as nordvpn:kanye
+          users.groups.bob = { };
+          # run nordvpnd as nordvpn:bob
           services.nordvpn = {
             enable = true;
-            group = "kanye";
+            group = "bob";
           };
         } (commonConfig "alice");
       userAndGroup =
         { ... }:
         lib.recursiveUpdate {
-          users.users.kanye = {
-            group = "kanye";
+          users.users.bob = {
+            group = "bob";
             isNormalUser = true;
           };
-          users.groups.kanye = { };
-          # run nordvpnd as kanye:kanye
+          users.groups.bob = { };
+          # run nordvpnd as bob:bob
           services.nordvpn = {
             enable = true;
-            group = "kanye";
-            user = "kanye";
+            group = "bob";
+            user = "bob";
           };
-        } (commonConfig "kanye");
+        } (commonConfig "bob");
     };
 
   testScript = ''
+    ALICE = "alice"
+    BOB = "bob"
+    NORDVPN = "nordvpn"
+    ALLOWED = [ ALICE, BOB, NORDVPN ]
+    KERNEL_MODULES = [ "tun", "wireguard" ]
+
+    def is_in_allowed(s):
+      assert s in ALLOWED, f"{s} is not in ALLOWED"
+
     class UserGroupTestCase:
-      def __init__(self, machine, user, has_nordvpn_usr, has_nordvpn_gp):
+      def __init__(self, machine, machine_user, nordvpn_user, nordvpn_group):
         self.machine = machine
-        self.user = user
-        self.has_nordvpn_usr = has_nordvpn_usr
-        self.has_nordvpn_gp = has_nordvpn_gp
+
+        self.machine_user = machine_user
+        self.nordvpn_user = NORDVPN if nordvpn_user is None else nordvpn_user
+        self.nordvpn_group = NORDVPN if nordvpn_group is None else nordvpn_group
+
+        is_in_allowed(self.machine_user)
+        is_in_allowed(self.nordvpn_user)
+        is_in_allowed(self.nordvpn_group)
 
       def run(self):
         self.machine.start()
         self.verify_nordvpn_user()
         self.verify_nordvpn_group()
         self.verify_services()
+        self.verify_polkit_rules()
+        self.verify_kernel_modules_loaded()
+
+        # nordvpnd related tests
+        self.verify_nordvpnd_process_ownership()
+        self.verify_nordvpnd_process_capabilities()
+        self.verify_nordvpnd_can_access_tun()
+        self.verify_nordvpnd_runtime_directory()
+        self.verify_nordvpnd_state_directory()
+
         self.machine.shutdown()
 
       def verify_nordvpn_user(self):
-          if self.has_nordvpn_usr:
+          if self.nordvpn_user == NORDVPN:
             self.machine.succeed("id nordvpn")
           else:
             self.machine.fail("id nordvpn")
 
       def verify_nordvpn_group(self):
-        group_str = self.machine.succeed(f"sudo -u {self.user} groups")
+        group_str = self.machine.succeed(f"sudo -u {self.machine_user} groups")
         groups = [x.strip() for x in group_str.split(" ")]
-        if self.has_nordvpn_gp:
-          assert "nordvpn" in groups, f"nordvpn is not in {groups} but should be"
+        if self.nordvpn_group == NORDVPN:
+          assert NORDVPN in groups, f"{NORDVPN} is not in {groups} but should be"
         else:
-          assert "nordvpn" not in groups, f"nordvpn is in {groups} but should not be"
+          assert NORDVPN not in groups, f"{NORDVPN} is in {groups} but should not be"
 
       def verify_services(self):
         self.machine.wait_for_unit("nordvpnd", timeout=60)
-        self.machine.wait_for_unit("norduserd", self.user, timeout=90)
+        self.machine.wait_for_unit("norduserd", self.machine_user, timeout=90)
         # verify can talk to nordvpnd. give nordvpnd at most 5s to initialize.
         self.machine.wait_until_succeeds("nordvpn status", timeout=5)
         self.machine.succeed("nordvpn status")
 
+      def verify_polkit_rules(self):
+        rules = self.machine.succeed("cat /etc/polkit-1/rules.d/10-nixos.rules")
+        expected = f'subject.isInGroup("{self.nordvpn_group}")'
+        assert expected in rules, f"expected polkit rules to reference group {self.nordvpn_group}"
+
+      def verify_kernel_modules_loaded(self):
+        lines = self.machine.succeed("lsmod").splitlines()
+        loaded = {line.split()[0] for line in lines[1:] if line.strip()}
+        for module in KERNEL_MODULES:
+          assert module in loaded, f"expected kernel module {module} to be loaded, got {loaded}"
+
+      def verify_nordvpnd_process_ownership(self):
+        pid = self.machine.succeed("pidof nordvpnd").strip()
+        user, group = self.machine.succeed(
+          f"ps -o user=,group= -p {pid}"
+        ).strip().split()
+        assert user == self.nordvpn_user, f"expected nordvpnd to run as user {self.nordvpn_user}, got {user}"
+        assert group == self.nordvpn_group, f"expected nordvpnd to run as group {self.nordvpn_group}, got {group}"
+
+      def verify_nordvpnd_process_capabilities(self):
+        pid = self.machine.succeed("pidof nordvpnd").strip()
+        status = self.machine.succeed(f"cat /proc/{pid}/status")
+        caps = {}
+        for line in status.splitlines():
+          if line.startswith("Cap"):
+            key, value = line.split(":")
+            caps[key.strip()] = int(value.strip(), base=16)
+
+        # CAP_NET_ADMIN (bit 12)
+        expected = (1 << 12)
+        for cap_set in ["CapAmb", "CapBnd", "CapEff", "CapPrm"]:
+          assert caps[cap_set] == expected, (
+            f"expected {cap_set} to be exactly CAP_NET_ADMIN"
+            f"({expected:#x}), got {caps[cap_set]:#x}"
+          )
+
+      def verify_nordvpnd_can_access_tun(self):
+        cgroup = self.machine.get_unit_property("nordvpnd", "ControlGroup").strip()
+
+        # enter the cgroup of nordvpnd service and verify access to /dev/net/tun
+        self.machine.succeed(
+          f"sh -c 'echo $$ > /sys/fs/cgroup{cgroup}/cgroup.procs && exec 3<>/dev/net/tun'"
+        )
+
+      def verify_nordvpnd_runtime_directory(self):
+        self.__verify_group_and_permissions("/run/nordvpn", perm="750")
+
+      def verify_nordvpnd_state_directory(self):
+        self.__verify_group_and_permissions("/var/lib/nordvpn", perm="750")
+
+      def __verify_group_and_permissions(self, path, perm):
+        # has the correct group
+        actual_group, actual_perm = self.machine.succeed(
+          f"stat -c '%G %a' {path}"
+        ).strip().split()
+        assert actual_group == self.nordvpn_group, f"expected {path} group {self.nordvpn_group}, got {actual_group}"
+
+        # has correct permissions
+        assert actual_perm == perm, f"expected {path} permission {perm}, got {actual_perm}"
+
     test_cases = [
-      UserGroupTestCase(basic, "alice", has_nordvpn_usr=True,  has_nordvpn_gp=True),
-      UserGroupTestCase(userOnly, "kanye", has_nordvpn_usr=False, has_nordvpn_gp=True),
-      UserGroupTestCase(groupOnly, "alice", has_nordvpn_usr=True,  has_nordvpn_gp=False),
-      UserGroupTestCase(userAndGroup, "kanye", has_nordvpn_usr=False, has_nordvpn_gp=False),
+      UserGroupTestCase(basic, machine_user=ALICE, nordvpn_user=None,  nordvpn_group=None),
+      UserGroupTestCase(userOnly, machine_user=BOB, nordvpn_user=BOB, nordvpn_group=None),
+      UserGroupTestCase(groupOnly, machine_user=ALICE, nordvpn_user=None,  nordvpn_group=BOB),
+      UserGroupTestCase(userAndGroup, machine_user=BOB, nordvpn_user=BOB, nordvpn_group=BOB),
     ]
 
     # NADA


### PR DESCRIPTION
- add *systemd sandboxing* to **nordvpnd**; sandboxing shrinks the blast radius of a compromised **nordvpnd** process
- add more comprehensive nixos tests to verify service prerequisites and capability bounds: loaded kernel modules, capabilities, socket permissions, tun device access

Assisted-by: Claude Code (Sonnet 5)

(edit note: I initially patched nordvpn-linux's source directly; I decided to move that change upstream instead)

---

Spin up a VM for manual verification:

```nix
{
  pkgs,
  lib,
  ...
}:

{
  imports = [
    ./hardware-configuration.nix
  ];

  boot.loader.systemd-boot.enable = true;
  boot.loader.efi.canTouchEfiVariables = true;
  networking.firewall.enable = true;
  networking.firewall.checkReversePath = "loose";

  services.xserver.enable = true;
  services.displayManager.gdm.enable = true;
  services.desktopManager.plasma6.enable = true;

  services.timesyncd.enable = lib.mkForce true;
  services.timesyncd.servers = [
    "time.google.com"
    "pool.ntp.org"
  ];

  services.nordvpn = {
    enable = true;
  };

  virtualisation.vmVariant = {
    virtualisation = {
      memorySize = 8192;
      cores = 3;
    };
  };
  users.groups.alice = { };
  users.users.alice = {
    isNormalUser = true;
    password = "alice";
    group = "alice";
    extraGroups = [
      "wheel"
      "nordvpn"
    ];
    shell = pkgs.bash;
    home = "/home/alice";
    createHome = true;
    packages = with pkgs; [
      dunst
      firefox
      libnotify
      nftables
      socat
      tmux
      tree
      vim
    ];
  };
  system.stateVersion = "24.11"; # Did you read the comment?
}
```

```nix
nixos-rebuild build-vm \
  -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/pull/547437/head.tar.gz \
  -I nixos-config=/path/to/configuration.nix
```

---

Note: since this package/service hasn't made it to stable yet, I've not updated the release notes.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
