### PR TITLE
wlr-utils: init at 1.6.0

### DIFF
--- a/pkgs/by-name/wl/wlr-utils/package.nix
+++ b/pkgs/by-name/wl/wlr-utils/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  libGL,
+  ffmpeg,
+  leptonica,
+  libgbm,
+  libxkbcommon,
+  pipewire,
+  tesseract,
+  wayland,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "wlr-utils";
+  version = "1.6.0";
+
+  src = fetchFromGitHub {
+    owner = "sjourdois";
+    repo = "wlr-utils";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2saQkOldMibdioW0Qma6N01VA+dT8+q3fQrPeld6Efw=";
+  };
+
+  cargoHash = "sha256-N/ovlRjg8DcbQUzLT5XPvxmnd0DbEH2uaecTIOyA3pQ=";
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    ffmpeg
+    leptonica
+    libgbm
+    libxkbcommon
+    pipewire
+    tesseract
+    wayland
+  ];
+
+  postFixup = ''
+    for program in $out/bin/wlr-*; do
+      patchelf --add-needed "${libGL}/lib/libEGL.so.1" $program
+    done
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=stable" ];
+  };
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Native Wayland desktop tools for wlroots";
+    homepage = "https://github.com/sjourdois/wlr-utils";
+    changelog = "https://github.com/sjourdois/wlr-utils/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license =
+      with lib.licenses;
+      OR [
+        asl20
+        mit
+      ];
+    maintainers = with lib.maintainers; [ hexa ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
https://github.com/sjourdois/wlr-utils

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
