### PR TITLE
gbenchmark: constrain `-Wno-error=c2y-extensions` to `clang`

### DIFF
--- a/pkgs/by-name/gb/gbenchmark/package.nix
+++ b/pkgs/by-name/gb/gbenchmark/package.nix
@@ -53,9 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
     # This might be a problem with our Clang, as it does not reproduce
     # with Xcode, but we just work around it by silencing the warning.
     NIX_CFLAGS_COMPILE = lib.join " " (
-      [
-        "-Wno-error=c2y-extensions"
-      ]
+      lib.optional stdenv.cc.isClang "-Wno-error=c2y-extensions"
       ++ lib.optional stdenv.cc.isClang "-Wno-c++17-attribute-extensions"
     );
   }


### PR DESCRIPTION
Without the change `gbencmark` will fail the build on upcoming `gcc-17` as:

    cc1plus: error: ‘-Wno-error=c2y-extensions’: no option ‘-Wc2y-extensions’; did you mean ‘-Wc++20-extensions’?
    ninja: build stopped: subcommand failed.

This happens because `gcc` never suported `-Wc2y-extensions` and `gcc-17` not fails on unrecognized `-W` flags.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
