### PR TITLE
google-java-format: use `finalAttrs` instead of `rec`

### DIFF
--- a/pkgs/by-name/go/google-java-format/package.nix
+++ b/pkgs/by-name/go/google-java-format/package.nix
@@ -6,13 +6,14 @@
   makeWrapper,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "google-java-format";
   version = "1.36.0";
+  __structuredAttrs = true;
 
   src = fetchurl {
-    url = "https://github.com/google/google-java-format/releases/download/v${version}/google-java-format-${version}-all-deps.jar";
     sha256 = "sha256-I2lt4F3SDYXBRJyN6fJBkDB5lQj1NWVw6Xn3+W5Z2NY=";
+    url = "https://github.com/google/google-java-format/releases/download/v${finalAttrs.version}/google-java-format-${finalAttrs.version}-all-deps.jar";
   };
 
   dontUnpack = true;
@@ -23,17 +24,17 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/{bin,share/${pname}}
-    install -D ${src} $out/share/${pname}/google-java-format-${version}-all-deps.jar
+    mkdir -p $out/{bin,share/${finalAttrs.pname}}
+    install -D ${finalAttrs.src} $out/share/${finalAttrs.pname}/google-java-format-${finalAttrs.version}-all-deps.jar
 
-    makeWrapper ${jre}/bin/java $out/bin/${pname} \
-      --argv0 ${pname} \
+    makeWrapper ${jre}/bin/java $out/bin/${finalAttrs.pname} \
+      --argv0 ${finalAttrs.pname} \
       --add-flags "--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED" \
       --add-flags "--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED" \
       --add-flags "--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED" \
       --add-flags "--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED" \
       --add-flags "--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED" \
-      --add-flags "-jar $out/share/${pname}/google-java-format-${version}-all-deps.jar"
+      --add-flags "-jar $out/share/${finalAttrs.pname}/google-java-format-${finalAttrs.version}-all-deps.jar"
 
     runHook postInstall
   '';
@@ -50,4 +51,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.all;
     mainProgram = "google-java-format";
   };
-}
+})


### PR DESCRIPTION
I look at #547202 and saw that the derivation was still using `rec`, so I converted it to `finalAttrs`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
