### PR TITLE
mcaselector: add desktop entry and icon

### DIFF
--- a/pkgs/by-name/mc/mcaselector/package.nix
+++ b/pkgs/by-name/mc/mcaselector/package.nix
@@ -3,17 +3,26 @@
   stdenvNoCC,
   fetchurl,
   makeWrapper,
+  makeDesktopItem,
+  copyDesktopItems,
   wrapGAppsHook3,
   jre,
 }:
 let
+  version = "2.8";
+
   jre' = jre.override {
     enableJavaFX = true;
+  };
+
+  icon = fetchurl {
+    url = "https://github.com/Querz/mcaselector/raw/${version}/installer/linux/icon.png";
+    hash = "sha256-nUHTxFHKhp//AL3/B43iXPmp/gcCQPgrEqGAV23U/Vs=";
   };
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "mcaselector";
-  version = "2.8";
+  inherit version;
 
   src = fetchurl {
     url = "https://github.com/Querz/mcaselector/releases/download/${finalAttrs.version}/mcaselector-${finalAttrs.version}.jar";
@@ -27,6 +36,22 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     jre'
     makeWrapper
     wrapGAppsHook3
+    copyDesktopItems
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "mcaselector";
+      desktopName = "MCA Selector";
+      comment = "Select, edit, and export chunks of your Minecraft world";
+      exec = "mcaselector";
+      icon = "mcaselector";
+      categories = [
+        "Game"
+        "Java"
+      ];
+      startupWMClass = "net.querz.mcaselector.ui.Window";
+    })
   ];
 
   dontWrapGApps = true;
@@ -34,8 +59,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/{bin,lib/mcaselector}
+    mkdir -p $out/{bin,lib/mcaselector,share/icons/hicolor/512x512/apps}
     cp $src $out/lib/mcaselector/mcaselector.jar
+    cp ${icon} $out/share/icons/hicolor/512x512/apps/mcaselector.png
 
     runHook postInstall
   '';


### PR DESCRIPTION
Added the desktop entry and icon for the `mcaselector` package. The desktop entry is based on the [one provided by upstream](https://github.com/Querz/mcaselector/blob/2.8/installer/linux/mcaselector.desktop) and the icon is [fetched from the upstream repository](https://github.com/Querz/mcaselector/blob/2.8/installer/linux/icon.png).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
