### PR TITLE
ejabberd: 26.04 -> 26.07

### DIFF
--- a/pkgs/by-name/ej/ejabberd/package.nix
+++ b/pkgs/by-name/ej/ejabberd/package.nix
@@ -144,7 +144,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "ejabberd";
-  version = "26.04";
+  version = "26.07";
 
   nativeBuildInputs = [
     makeWrapper
@@ -184,7 +184,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "processone";
     repo = "ejabberd";
     tag = finalAttrs.version;
-    hash = "sha256-PF65TgHvKeSEudEqqJVEotu2zgiWgGtRuNvbiyE0nwc=";
+    hash = "sha256-YCcRXbhlIYV0cP4RLTknYnfSpkknLenvWOYs9kt7m3c=";
   };
 
   passthru.tests = {

--- a/pkgs/by-name/ej/ejabberd/rebar-deps.nix
+++ b/pkgs/by-name/ej/ejabberd/rebar-deps.nix
@@ -24,11 +24,11 @@ let
     };
     xmpp = builder {
       name = "xmpp";
-      version = "1.13.3";
+      version = "1.13.4";
       src = fetchHex {
         pkg = "xmpp";
-        version = "1.13.3";
-        sha256 = "sha256-BWSKpNvM/uYqqnlLKSowWEY50DyR9cCGa+jDQ0tqb0g=";
+        version = "1.13.4";
+        sha256 = "sha256-SzH/TjBtpKkwzgZ1/tTzw6+D9rOalgnootR0ffvq4NQ=";
       };
       beamDeps = [
         ezlib


### PR DESCRIPTION
Changelog: https://github.com/processone/ejabberd/releases/tag/26.07

No real breaking changes, and includes security fixes, so marking for backport.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
