### PR TITLE
nixos/forgejo: regenerate authorized_principals on startup

### DIFF
--- a/nixos/modules/services/misc/forgejo.nix
+++ b/nixos/modules/services/misc/forgejo.nix
@@ -560,6 +560,17 @@ in
       lfs = mkIf cfg.lfs.enable {
         PATH = cfg.lfs.contentDir;
       };
+
+      # there is no `forgejo admin regenerate principals` to
+      # regenerate `authorized_principals`, but there is an internal
+      # cronjob that does the same. The downside of having it here is
+      # that installations made with `useWizard = true` and using SSH
+      # certificates at the same will still be affected by stale
+      # paths.
+      "cron.resync_all_sshprincipals" = {
+        ENABLED = mkDefault true;
+        RUN_AT_START = mkDefault true;
+      };
     };
 
     services.forgejo.secrets = {


### PR DESCRIPTION
In forgejo's `authorized_keys` and `authorized_principals`, every line has a full `forgejo` binary name - and it points to nix store. After upgrade and garbage collection users are no longer able to authorize.

For `authorized_keys` there were a precaution taken in NixOS module, that refreshed this file on startup - but `forgejo admin regenerate keys` doesn't regenerate `authorized_principals`. And there is no corresponding `forgejo admin regenerate principals` in the CLI.

Turns out that forgejo already has it's own cronjobs specifically for updating those files - and thay can be run not only on schedule, but can also trigger during forgejo starting up.

That's exactly what this PR does - enables 2 forgejo cron-jobs which fully take-over `authorized_keys`/`_principals` generation.

The default schedule runs these jobs once in 72 hours, so enabling these cron-jobs shouldn't have any performance concerns.

Tested by checking that after deploy/reboot the running binary and the ones in the files are the same:
```
[root@forgejo:~]# grep -l $(systemctl show forgejo.service --property=ExecStart | perl -nE 'm|(/nix/store.*?) | and say $1') ~git/.ssh/*
/var/lib/forgejo/.ssh/authorized_keys
/var/lib/forgejo/.ssh/authorized_principals
```



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
