### PR TITLE
vimPlugins.kenjutu: init at 0.2.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6190,6 +6190,12 @@
     githubId = 24708079;
     name = "Dan Eads";
   };
+  daneov = {
+    github = "daneov";
+    githubId = 7900887;
+    matrix = "@daneov:mozilla.org";
+    name = "daneov";
+  };
   danid3v = {
     email = "sch220233@spengergasse.at";
     github = "DaniD3v";

--- a/pkgs/applications/editors/vim/plugins/non-generated/kenjutu-nvim/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/kenjutu-nvim/default.nix
@@ -1,0 +1,94 @@
+{
+  fetchFromGitHub,
+  jujutsu,
+  lib,
+  makeBinaryWrapper,
+  nix-update-script,
+  openssl,
+  pkg-config,
+  rustPlatform,
+  versionCheckHook,
+  vimUtils,
+  writableTmpDirAsHomeHook,
+}:
+let
+  version = "0.2.4";
+
+  src = fetchFromGitHub {
+    owner = "Yuki-bun";
+    repo = "kenjutu";
+    tag = "kjn/v${version}";
+    hash = "sha256-Ogf8B/h8RZozeZH20YPFs7+3kBWduRuNOkwiKpj+8Hc=";
+  };
+
+  kjn-rust = rustPlatform.buildRustPackage {
+    pname = "kenjutu-kjn";
+    inherit version src;
+    cargoHash = "sha256-eND52/L3kPuuqND7fF7eiOs0nWikFWcGDT2eG2m6+Ho=";
+
+    __structuredAttrs = true;
+
+    # As this is a monorepo, building everything results in unneeded/unwanted dependencies.
+    cargoBuildFlags = [
+      "-p"
+      "kenjutu-nvim"
+    ];
+    cargoTestFlags = [
+      "-p"
+      "kenjutu-nvim"
+    ];
+
+    buildInputs = [ openssl ];
+    nativeBuildInputs = [
+      makeBinaryWrapper
+      pkg-config
+      writableTmpDirAsHomeHook
+    ];
+    # A requirement to execute the tests, as this tool uses it as a dependency by default
+    nativeCheckInputs = [ jujutsu ];
+
+    nativeInstallCheckInputs = [
+      versionCheckHook
+    ];
+
+    doInstallCheck = true;
+
+    postInstall = ''
+      wrapProgram $out/bin/kjn --prefix PATH : ${lib.makeBinPath [ jujutsu ]}
+    '';
+
+    meta = {
+      license = lib.licenses.asl20;
+      mainProgram = "kjn";
+    };
+  };
+in
+vimUtils.buildVimPlugin {
+  pname = "kenjutu-nvim";
+  inherit version src;
+
+  dependencies = [ kjn-rust ];
+  postInstall = ''
+    mkdir -p $out/bin
+    ln -s ${lib.getExe kjn-rust} $out/bin/kjn
+  '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "vimPlugins.kenjutu-nvim.kjn-rust";
+    };
+
+    # needed for the update script
+    inherit kjn-rust;
+  };
+
+  meta = {
+    changelog = "https://github.com/Yuki-bun/kenjutu/releases/tag/${src.tag}";
+    description = "Track your code review progress hunk-by-hunk through history rewrites for jj users";
+    homepage = "https://github.com/Yuki-bun/kenjutu/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      daneov
+    ];
+  };
+}


### PR DESCRIPTION
This would add [Kenjutu](https://github.com/Yuki-bun/kenjutu/tree/main) to NixPkgs. This is a tool built on top of Jujutsu (the VCS) and provides the abillity to review changes from within NeoVim.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
