### PR TITLE
ratspeak: init at 1.0.25

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8045,6 +8045,13 @@
     githubId = 7494394;
     name = "Karim Elatov";
   };
+  eldios = {
+    email = "emanuele.lele.calo@gmail.com";
+    github = "eldios";
+    githubId = 483767;
+    name = "Emanuele 'Lele' Calo";
+    keys = [ { fingerprint = "AA6B C774 3F8F 9AD8 4BBA  15C7 2CCB F4B7 1EFF DD46"; } ];
+  };
   eleanor = {
     email = "dejan@proteansec.com";
     github = "proteansec";

--- a/pkgs/by-name/ra/ratspeak/package.nix
+++ b/pkgs/by-name/ra/ratspeak/package.nix
@@ -1,0 +1,118 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  cargo-tauri,
+  alsa-lib,
+  dbus,
+  glib-networking,
+  libayatana-appindicator,
+  libsoup_3,
+  openssl,
+  pcsclite,
+  perl,
+  pkg-config,
+  udev,
+  webkitgtk_4_1,
+  wrapGAppsHook4,
+}:
+
+let
+  # Ratspeak resolves its protocol crates by relative path from sibling
+  # checkouts (../rsReticulum and friends). Upstream does not tag the
+  # siblings together with every app release, so each one is pinned to the
+  # revision current at the v1.0.25 release date.
+  rsReticulum = fetchFromGitHub {
+    owner = "ratspeak";
+    repo = "rsReticulum";
+    rev = "17e6107aa8fb9a5b0c2cac2f4fe4b68655593bd8";
+    hash = "sha256-0HjeGZ57eiz9z9akc+ESdZLAN+/uR9LyNaMLgYiTPO8=";
+  };
+  rsLXMF = fetchFromGitHub {
+    owner = "ratspeak";
+    repo = "rsLXMF";
+    rev = "393478019b3a076abc7af5f0d2c7b980b3329550";
+    hash = "sha256-uCoU4HtdRy6sB8vi5BtifKFAy0a7FPuHuuRb1EJTJ2c=";
+  };
+  rsLXST = fetchFromGitHub {
+    owner = "ratspeak";
+    repo = "rsLXST";
+    rev = "e3f80815bcf1c1d6af1c07135dfe05b6163d596a";
+    hash = "sha256-921xMNdneOTurUoUR5ImPEB8ztfEQLl9jCZY+s9Cjuo=";
+  };
+  lrgp-rs = fetchFromGitHub {
+    owner = "ratspeak";
+    repo = "lrgp-rs";
+    rev = "0b55361ebf91c1caa09d5ed8ab88ac0a6d955de6";
+    hash = "sha256-MZGWGCWLc+suHCD9NFV6m8A4EP4pLfogaqm93pMk/ss=";
+  };
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ratspeak";
+  version = "1.0.25";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "ratspeak";
+    repo = "Ratspeak";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-HJH31dAnmSK85AkX+ufvmo+Nmd9X6xmLO06Lys8kces=";
+  };
+
+  # The app expects the protocol repos next to its own checkout.
+  postUnpack = ''
+    cp -r ${rsReticulum} rsReticulum
+    cp -r ${rsLXMF} rsLXMF
+    cp -r ${rsLXST} rsLXST
+    cp -r ${lrgp-rs} lrgp-rs
+    chmod -R u+w rsReticulum rsLXMF rsLXST lrgp-rs
+  '';
+
+  cargoHash = "sha256-XumEJazJux0FFLS6qcruaXdOLsZ9hfn8Q/hA9Ot4RzM=";
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    perl
+    pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapGAppsHook4 ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    alsa-lib
+    dbus
+    glib-networking
+    libayatana-appindicator
+    libsoup_3
+    openssl
+    pcsclite
+    udev
+    webkitgtk_4_1
+  ];
+
+  # The dashboard ships modular CSS; the app serves the concatenated file.
+  preBuild = ''
+    bash dashboard/build-css.sh
+  '';
+
+  # The tray icon library is dlopened at runtime, not linked.
+  preFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    gappsWrapperArgs+=(
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libayatana-appindicator ]}
+    )
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Reticulum and LXMF client with messaging, file sharing, voice calls and LoRa support";
+    homepage = "https://github.com/ratspeak/Ratspeak";
+    changelog = "https://github.com/ratspeak/Ratspeak/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ eldios ];
+    platforms = lib.platforms.linux;
+    mainProgram = "ratspeak";
+  };
+})

--- a/pkgs/by-name/ra/ratspeak/update.sh
+++ b/pkgs/by-name/ra/ratspeak/update.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Update ratspeak to the latest upstream release tag.
+#
+# Ratspeak resolves its protocol crates from sibling checkouts, so a version
+# bump means updating five pins together: the app tag plus the four sibling
+# revisions current at that tag's date. Requires: curl, jq, nix, sed.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+github_api() {
+    curl -sfL -H "Accept: application/vnd.github+json" \
+        ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"} \
+        "https://api.github.com/$1"
+}
+
+# Works both from the standalone packaging flake and from a nixpkgs checkout.
+build() {
+    if [ -f flake.nix ]; then
+        nix build .#ratspeak
+    else
+        nix-build "$(git rev-parse --show-toplevel)" -A ratspeak --no-out-link
+    fi
+}
+
+prefetch() {
+    nix flake prefetch --json "github:ratspeak/$1/$2" | jq -r .hash
+}
+
+current=$(sed -nE 's/^ *version = "([^"]+)";$/\1/p' package.nix | head -1)
+# releases/latest skips pre-releases (rc tags) on purpose.
+tag=${RATSPEAK_TAG:-$(github_api repos/ratspeak/Ratspeak/releases/latest | jq -r .tag_name)}
+new=${tag#v}
+
+if [ "$new" = "$current" ] && [ -z "${RATSPEAK_TAG:-}" ]; then
+    echo "ratspeak is up to date ($current)"
+    exit 0
+fi
+
+tag_date=$(github_api "repos/ratspeak/Ratspeak/commits/$tag" | jq -r .commit.committer.date)
+echo "updating ratspeak $current -> $new (tagged $tag_date)"
+
+sed -i -E "s|^( *version = )\"[^\"]+\";|\1\"$new\";|" package.nix
+
+app_hash=$(prefetch Ratspeak "$tag")
+sed -i "/repo = \"Ratspeak\";/,/hash = / s|hash = \".*\";|hash = \"$app_hash\";|" package.nix
+
+for repo in rsReticulum rsLXMF rsLXST lrgp-rs; do
+    rev=$(github_api "repos/ratspeak/$repo/commits?until=$tag_date&per_page=1" | jq -r '.[0].sha')
+    hash=$(prefetch "$repo" "$rev")
+    echo "  $repo -> $rev"
+    sed -i \
+        -e "/repo = \"$repo\";/,/hash = / s|rev = \".*\";|rev = \"$rev\";|" \
+        -e "/repo = \"$repo\";/,/hash = / s|hash = \".*\";|hash = \"$hash\";|" \
+        package.nix
+done
+
+# Two-pass cargoHash: reset to the fake hash, read the real one from the
+# vendor mismatch error, write it back. The build failure is expected here,
+# so it must not trip set -e/pipefail.
+fake="sha256-$(printf 'A%.0s' {1..43})="
+sed -i -E "s|^( *cargoHash = )\".*\";|\1\"$fake\";|" package.nix
+build_log=$(build 2>&1 || true)
+cargo_hash=$(printf '%s\n' "$build_log" | sed -nE 's/^ *got: *(sha256-.*)$/\1/p' | head -1)
+if [ -z "$cargo_hash" ]; then
+    echo "error: could not extract cargoHash from build output" >&2
+    exit 1
+fi
+sed -i -E "s|^( *cargoHash = )\".*\";|\1\"$cargo_hash\";|" package.nix
+
+echo "verifying build..."
+build
+echo "ratspeak updated to $new"


### PR DESCRIPTION
Adds [Ratspeak](https://github.com/ratspeak/Ratspeak), a Tauri-based desktop client for E2EE messaging over [Reticulum](https://github.com/ratspeak/rsReticulum): messaging, file sharing, experimental voice calls, LoRa/RNode support.

The app resolves its protocol crates by relative path from sibling checkouts (`rsReticulum`, `rsLXMF`, `rsLXST`, `lrgp-rs`), and upstream does not tag the siblings on every app release. The derivation therefore pins the app to the `v1.0.25` release tag and each sibling to the revision current at the tag's date; the bundled `update.sh` bumps all five pins together.

Related packages already in nixpkgs from the same upstream org: `rs-reticulum` and `rs-lxmf`. cc @drupol in case you want to take a look, since you maintain those.

Notes for review:

- `versionCheckHook` is not applicable: the binary initializes GTK before argument parsing, so `--version` aborts headless.
- The check phase runs but the Tauri crate ships no tests; the real test suites live in the sibling workspaces.
- Disclosure per the automation/AI policy: the packaging was developed with LLM assistance (Claude Code, Claude Fable 5). I reviewed, built and tested everything, and I run the packaged app daily on NixOS.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
