### PR TITLE
hyprlandPlugins.hyprglass: init at 0.8.1

### DIFF
--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/default.nix
@@ -40,6 +40,7 @@ let
     { hypr-darkwindow = import ./hypr-darkwindow.nix; }
     { hypr-dynamic-cursors = import ./hypr-dynamic-cursors.nix; }
     { hyprfocus = import ./hyprfocus.nix; }
+    { hyprglass = import ./hyprglass.nix; }
     { hyprgrass = import ./hyprgrass.nix; }
     { hyprspace = import ./hyprspace.nix; }
     { hyprsplit = import ./hyprsplit.nix; }

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprglass.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprglass.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  mkHyprlandPlugin,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+mkHyprlandPlugin (finalAttrs: {
+  pluginName = "hyprglass";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "hyprnux";
+    repo = "hyprglass";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-x/584kY+XXlU/OWKtZAFo89VtowjLXs1DiP9PC0o0Os=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+    mv hyprglass.so "$out/lib/libhyprglass.so"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Plugin to add effects inspired by liquid glass design to transparent windows.";
+    homepage = "https://github.com/hyprnux/hyprglass";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ Username404-59 ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds hyprglass plugin for hyprland which adds liquid glass effects in transparent windows

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
