### PR TITLE
mysql84: 8.4.10 -> 8.4.11

### DIFF
--- a/pkgs/by-name/my/mysql84/package.nix
+++ b/pkgs/by-name/my/mysql84/package.nix
@@ -28,11 +28,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mysql";
-  version = "8.4.10";
+  version = "8.4.11";
 
   src = fetchurl {
     url = "https://dev.mysql.com/get/Downloads/MySQL-${lib.versions.majorMinor finalAttrs.version}/mysql-${finalAttrs.version}.tar.gz";
-    hash = "sha256-1XpnMLrvFK4Rj39KbgKEW1tQkzdY32H7BuEE8nzMj5Y=";
+    hash = "sha256-6zBRFk1iXdNGqCA/duDV1dmuxR2+nVF4jjnsaz8TlMI=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
https://dev.mysql.com/doc/relnotes/mysql/8.4/en/news-8-4-11.html

Fixes:
* CVE-2026-60163
* CVE-2026-60315
* CVE-2026-61094
* CVE-2026-60316
* CVE-2026-60178
* CVE-2026-60585
* CVE-2026-61109
* CVE-2026-47064
* CVE-2026-60183
* CVE-2026-60332
* CVE-2026-60331
* CVE-2026-60747
* CVE-2026-47052
* CVE-2026-60145
* CVE-2026-47023
* CVE-2026-60177
* CVE-2026-60182
* CVE-2026-46936
* CVE-2026-60186
* CVE-2026-47012
* CVE-2026-60184
* CVE-2026-60185
* CVE-2026-60187
* CVE-2026-60188
* CVE-2026-60189
* CVE-2026-60191
* CVE-2026-61096
* CVE-2026-61081
* CVE-2026-60190


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 547503 --additional-package mysql84.tests`
Commit: `782d32e6c88d4e8b88aea1d5ea6b5ab4e9151718`

---
### `x86_64-linux`
<details>
  <summary>:x: 1 package failed to build:</summary>
  <ul>
    <li>vep</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 25 packages built:</summary>
  <ul>
    <li>exim</li>
    <li>libmysqlconnectorcpp</li>
    <li>longview</li>
    <li>mylvmbackup</li>
    <li>mysql-workbench</li>
    <li>mysql84</li>
    <li>mysql84.tests.mysql</li>
    <li>mysql84.tests.mysql-root-can-be-kept-insecure</li>
    <li>mysql84.tests.mysql-secure-root-by-default</li>
    <li>opendmarc</li>
    <li>percona-toolkit</li>
    <li>percona-xtrabackup (percona-xtrabackup_8_4)</li>
    <li>perlPackages.DBDmysql (perl5Packages.DBDmysql)</li>
    <li>perlPackages.MinionBackendmysql (perl5Packages.MinionBackendmysql)</li>
    <li>perlPackages.Mojomysql (perl5Packages.Mojomysql)</li>
    <li>perlPackages.PerconaToolkit (perl5Packages.PerconaToolkit)</li>
    <li>perlPackages.Testmysqld (perl5Packages.Testmysqld)</li>
    <li>perlPackages.maatkit (perl5Packages.maatkit)</li>
    <li>python313Packages.mysql-connector-python</li>
    <li>python314Packages.mysql-connector-python</li>
    <li>sqitchMysql</li>
    <li>sqlit-tui</li>
    <li>sqlite3-to-mysql</li>
    <li>sympa</li>
    <li>zoneminder</li>
  </ul>
</details>
