### PR TITLE
mullvad: use rust-jemalloc-sys to fix 16k pagesize

### DIFF
--- a/pkgs/by-name/mu/mullvad/package.nix
+++ b/pkgs/by-name/mu/mullvad/package.nix
@@ -11,6 +11,7 @@
   libnftnl,
   pkg-config,
   protobuf,
+  rust-jemalloc-sys,
   versionCheckHook,
 }:
 
@@ -70,15 +71,17 @@ rustPlatform.buildRustPackage (finalAttrs: {
     protobuf
   ];
 
-  buildInputs =
-    lib.optionals stdenv.hostPlatform.isLinux [
-      dbus.dev
-      libmnl
-      libnftnl
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      darwin.libpcap
-    ];
+  buildInputs = [
+    rust-jemalloc-sys
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    dbus.dev
+    libmnl
+    libnftnl
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    darwin.libpcap
+  ];
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     compdir=$(mktemp -d)


### PR DESCRIPTION
Fixes running mullvad daemon on Apple Silicon hardware.

Closes #547489


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
