### PR TITLE
suwayomi-server: 2.1.1867 -> 2.3.2243

### DIFF
--- a/nixos/modules/services/web-apps/suwayomi-server.nix
+++ b/nixos/modules/services/web-apps/suwayomi-server.nix
@@ -216,6 +216,15 @@ in
         wants = [ "network-online.target" ];
         after = [ "network-online.target" ];
 
+        environment.JAVA_TOOL_OPTIONS = "-Djava.io.tmpdir=${cfg.dataDir}/tmp";
+
+        preStart = lib.optionalString (cfg.package ? kcefRuntime) ''
+          kcefBinDir="${cfg.dataDir}/.local/share/Tachidesk/bin"
+          rm -rf "$kcefBinDir/kcef"
+          mkdir -p "$kcefBinDir" "${cfg.dataDir}/tmp/Tachidesk/webUI-serve"
+          ln -s ${cfg.package.kcefRuntime} "$kcefBinDir/kcef"
+        '';
+
         script = ''
           ${lib.optionalString cfg.settings.server.basicAuthEnabled ''
             export TACHIDESK_SERVER_BASIC_AUTH_PASSWORD="$(<${cfg.settings.server.basicAuthPasswordFile})"

--- a/pkgs/by-name/su/suwayomi-server/package.nix
+++ b/pkgs/by-name/su/suwayomi-server/package.nix
@@ -4,6 +4,9 @@
   fetchurl,
   makeWrapper,
   jdk21_headless,
+  xvfb-run,
+  runCommand,
+  jetbrains,
   nixosTests,
 }:
 
@@ -13,11 +16,11 @@ in
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "suwayomi-server";
-  version = "2.1.1867";
+  version = "2.3.2243";
 
   src = fetchurl {
     url = "https://github.com/Suwayomi/Suwayomi-Server/releases/download/v${finalAttrs.version}/Suwayomi-Server-v${finalAttrs.version}.jar";
-    hash = "sha256-UeMHwlgeThoAKZGrPjp3UDyLB0xCaVmHqYSnOC0Kxa8=";
+    hash = "sha256-ghFBsy4XDUoC08vf7Vd+2PB70iOD/19BMuu1rkDpjdU=";
   };
 
   nativeBuildInputs = [
@@ -29,15 +32,23 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   buildPhase = ''
     runHook preBuild
 
-    makeWrapper ${jdk}/bin/java $out/bin/tachidesk-server \
-      --add-flags "-Dsuwayomi.tachidesk.config.server.initialOpenInBrowserEnabled=false -jar $src"
+    makeWrapper ${xvfb-run}/bin/xvfb-run $out/bin/tachidesk-server \
+      --add-flags "-a ${jdk}/bin/java -Dsuwayomi.tachidesk.config.server.initialOpenInBrowserEnabled=false -jar $src"
 
     runHook postBuild
   '';
 
-  passthru.tests = {
-    suwayomi-server-with-auth = nixosTests.suwayomi-server.with-auth;
-    suwayomi-server-without-auth = nixosTests.suwayomi-server.without-auth;
+  passthru = {
+    kcefRuntime = runCommand "suwayomi-server-kcef-runtime" { } ''
+      mkdir -p $out
+      ln -s ${jetbrains.jdk-21}/lib/openjdk/lib/* $out/
+      ln -s ${jetbrains.jdk-21}/lib/openjdk/release $out/release
+    '';
+
+    tests = {
+      suwayomi-server-with-auth = nixosTests.suwayomi-server.with-auth;
+      suwayomi-server-without-auth = nixosTests.suwayomi-server.without-auth;
+    };
   };
 
   meta = {


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested package build via local overlay
- [x] Runtime-tested with `services.suwayomi-server` on NixOS

Changelog: https://github.com/Suwayomi/Suwayomi-Server/releases/tag/v2.3.2243

## Runtime notes

Suwayomi 2.3.x switched WebView handling to JCEF/CEF, so this includes runtime fixes in addition to the version/hash bump:

- provide a patched JCEF/CEF runtime from nixpkgs' `jetbrains.jdk-21` via `passthru.kcefRuntime`
- symlink that runtime into `Tachidesk/bin/kcef` so Suwayomi does not download an unpatched runtime into the state dir
- run under `xvfb-run -a` for headless systemd services because CEF requires X11
- set Java's tmpdir under the service data directory and create the WebUI serve temp directory to avoid `/tmp/Tachidesk` ownership/collision issues
