### PR TITLE
glab-tui: init at 0.8.4

### DIFF
--- a/pkgs/by-name/gl/glab-tui/package.nix
+++ b/pkgs/by-name/gl/glab-tui/package.nix
@@ -1,0 +1,72 @@
+{
+  fetchFromGitHub,
+  gh,
+  glab,
+  lib,
+  makeWrapper,
+  nix-update-script,
+  rustPlatform,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "glab-tui";
+  version = "0.8.4";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "rcieri";
+    repo = "glab-tui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-SJpIYrtYirbk72/XZsQ1DqicGzovrUqp99KZ+/xD01I=";
+  };
+
+  cargoHash = "sha256-IcScQ4vY5Q1BusNSgpwF2EiykACBlFr6GZK3t0V8fV4=";
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/glab-tui \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          glab
+          gh
+        ]
+      }
+  '';
+
+  checkFlags = [
+    /*
+      These tests (https://github.com/rcieri/glab-tui/blob/main/tests/e2e/pagination.rs) are a bit flaky and non critical :
+      1. They relly on a mock glab and gh, which for some reason does not work well with nix sandbox, building process and environment.
+      2. They address pagination issue (ex: Is there the correct number of issues shown on each glab-tui page?). It is unlikely that pagination will fail only on nixos build and not in CI and other distribution packages.
+      3. In the case they do fail, it's not a big deal that glab-tui shows 101 or 99 issues on the first page instead of 100.
+    */
+    "--skip=pagination::test_pagination_custom_per_endpoint"
+    "--skip=pagination::test_pagination_empty_response"
+    "--skip=pagination::test_pagination_fallback_invalid"
+    "--skip=pagination::test_pagination_large_limit"
+    "--skip=pagination::test_pagination_max_bounds"
+    "--skip=pagination::test_pagination_negative"
+    "--skip=pagination::test_pagination_normal_limit"
+    "--skip=pagination::test_pagination_single_item"
+    "--skip=pagination::test_pagination_small_limit"
+    "--skip=pagination::test_pagination_zero"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Terminal user interface for GitLab/GitHub.";
+    homepage = "https://github.com/rcieri/glab-tui";
+    changelog = "https://github.com/rcieri/glab-tui/blob/main/CHANGELOG.md";
+    license = lib.licenses.mit;
+    mainProgram = "glab-tui";
+    maintainers = with lib.maintainers; [ tomasrivera ];
+  };
+})


### PR DESCRIPTION
[homepage](https://github.com/rcieri/glab-tui)

ChatGPT 5.6 Luna helped me understand what the problematic tests were doing as I don't read rust.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
