### PR TITLE
sg3_utils: 1.48 -> 1.49

### DIFF
--- a/pkgs/by-name/sg/sg3_utils/package.nix
+++ b/pkgs/by-name/sg/sg3_utils/package.nix
@@ -2,21 +2,24 @@
   lib,
   stdenv,
   fetchurl,
+  autoreconfHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sg3_utils";
-  version = "1.48";
+  version = "1.49";
 
   src = fetchurl {
     url = "https://sg.danny.cz/sg/p/sg3_utils-${finalAttrs.version}.tgz";
-    sha256 = "sha256-1itsPPIDkPpzVwRDkAhBZtJfHZMqETXEULaf5cKD13M=";
+    sha256 = "sha256-hLpQlRCN2Xz7VU17OHIfKqK0P8H5PPgqvW7+TJ2iIKc=";
   };
 
   postPatch = ''
     substituteInPlace scripts/rescan-scsi-bus.sh \
       --replace-fail '/usr/bin/sg_' "$out/bin/sg_"
   '';
+
+  nativeBuildInputs = [ autoreconfHook ];
 
   outputs = [
     "out"


### PR DESCRIPTION
Fixes #547002
Changelog:
  https://sg.danny.cz/sg/p/sg3_utils.ChangeLog

References:
  https://github.com/doug-gilbert/sg3_utils/pull/83
  https://bugzilla.redhat.com/show_bug.cgi?id=2502845
  https://www.linuxfromscratch.org/blfs/view/git/general/sg3_utils.html

The home page of the author has version 1.49 released. Updates are released more often on the author's own page than the github mirror. The CVE-2026-16313 has been corrected via code submitted in PR#83 on doug-gilbert's github mirror for sg3_utils. This code has been added to version 1.49 as per the changelog.

Added [autoreconfHook] to nativeBuildInputs:
  unlike version 1.48, version 1.49 is missing a configure script so autoreconf was required to produce a configuration for building the package.
  this is in line with installation instructions for sg3_utils v1.49 available on linuxfromscratch(see References).

Also verified  sg_inq` --export --inhex=vpd_di_name_inject.hex with the vpd_di_name_inject.hex provided in sg3_utils:PR#83 added as test for the CVE.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
