### PR TITLE
aws-workspaces: 2025.1.5526-1 -> 2026.0.5677-1

### DIFF
--- a/pkgs/by-name/aw/aws-workspaces/workspacesclient.nix
+++ b/pkgs/by-name/aw/aws-workspaces/workspacesclient.nix
@@ -14,13 +14,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "workspacesclient";
-  version = "2025.1.5526-1";
+  version = "2026.0.5677-1";
 
   src = fetchurl {
     urls = [
       "https://d3nt0h4h6pmmc4.cloudfront.net/ubuntu/dists/noble/main/binary-amd64/workspacesclient_${finalAttrs.version}_amd64.ubuntu2404.deb"
     ];
-    hash = "sha256-iGYKpbpzGNeEUKgozhSwVd9dWRgQEbozIAWRu7wu2D8=";
+    hash = "sha256-11bSNQANgLIoi2FbAtJSlEXzKe9KPRlbFdbLQAPQQ5g=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Updates AWS WorkSpaces from `2025.1.5526-1` to `2026.0.5677-1`.

This is the minimal binary-package update: only the AWS APT version and fixed-output hash change. Packaging and wrapper logic are unchanged.

Local validation:
- full x86_64-linux build with `filter-syscalls=false`; both old and new upstream DEBs contain the same setuid `chrome-sandbox`, which rootless Podman otherwise rejects
- structural wrapper smoke test

Automation disclosure: This package update and PR summary were prepared with assistance from Kiro CLI using GPT 5.6 Sol.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

