### PR TITLE
headlamp: 0.43.0 -> 0.44.0

### DIFF
--- a/pkgs/by-name/he/headlamp-frontend/package.nix
+++ b/pkgs/by-name/he/headlamp-frontend/package.nix
@@ -12,7 +12,7 @@ buildNpmPackage {
 
   sourceRoot = "${headlamp-server.src.name}/frontend";
 
-  npmDepsHash = "sha256-v8aMlOk2JD2DzcUMWTK+2QP44n1Nl0LQPcIry7W51vg=";
+  npmDepsHash = "sha256-VcwKNpHjQlpeDxqhDxNZnTt0BaUPHWZUivU4kqSi6yw=";
 
   postPatch = ''
     chmod -R u+w ../app

--- a/pkgs/by-name/he/headlamp-server/package.nix
+++ b/pkgs/by-name/he/headlamp-server/package.nix
@@ -3,12 +3,13 @@
   buildGoModule,
   fetchFromGitHub,
   nix-update,
+  npm-lockfile-fix,
   writeShellScript,
 }:
 
 buildGoModule rec {
   pname = "headlamp-server";
-  version = "0.43.0";
+  version = "0.44.0";
 
   strictDeps = true;
   __structuredAttrs = true;
@@ -17,12 +18,15 @@ buildGoModule rec {
     owner = "kubernetes-sigs";
     repo = "headlamp";
     tag = "v${version}";
-    hash = "sha256-6TGKBKR0WR4Xv7lGCgMFVG/nc19oMOP5cJcgT0bw6Ag=";
+    hash = "sha256-khDx0/5PEmbfS5iGicVH182ZxysapQG0rqbmp9rBxIk=";
+    postFetch = ''
+      ${lib.getExe npm-lockfile-fix} $out/app/package-lock.json
+    '';
   };
 
   modRoot = "backend";
 
-  vendorHash = "sha256-U0H1Dj38ajRGFqcWszveWckxenaKa4nrPg81GyIpS0U=";
+  vendorHash = "sha256-5nh4IxYr3wdXA8WLlK8LVCm4DqHFB4r+fA+Ix0e5EAc=";
 
   # Don't embed frontend - Electron serves it directly. This also prevents
   # the server from auto-opening a browser window.

--- a/pkgs/by-name/he/headlamp/package.nix
+++ b/pkgs/by-name/he/headlamp/package.nix
@@ -17,7 +17,8 @@ buildNpmPackage {
 
   sourceRoot = "${headlamp-server.src.name}/app";
 
-  npmDepsHash = "sha256-gZr+ni3dmrjqHDwoFxgGM0/Kf3R1Qy2SZetLtGtDY+0=";
+  npmDepsHash = "sha256-D9H3aQ54dWGaZJVknfbTjBxhfJ7UbfHvOzrAx8k62W8=";
+  npmDepsFetcherVersion = 2;
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 


### PR DESCRIPTION
Updates Headlamp from `0.43.0` to `0.44.0`.

Changelog: https://github.com/kubernetes-sigs/headlamp/releases/tag/v0.44.0

Diff: https://github.com/kubernetes-sigs/headlamp/compare/v0.43.0...v0.44.0

The shared source hash, Go vendor hash, and frontend/Electron npm dependency hashes are updated together. Upstream's Electron lockfile requires `npm-lockfile-fix`; npm fetcher version 2 enables the required packument/workspace cache behavior.

Local validation on x86_64-linux:
- full `headlamp-server` build, including backend checks
- full `headlamp-frontend` build
- full Electron `headlamp` build

Automation disclosure: This package update and PR summary were prepared with assistance from Kiro CLI using GPT 5.6 Sol.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

