### PR TITLE
python3Packages.meraki: 3.0.1 -> 4.3.1

### DIFF
--- a/pkgs/by-name/me/meraki-cli/package.nix
+++ b/pkgs/by-name/me/meraki-cli/package.nix
@@ -23,6 +23,11 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "TestUpgrade"
   ];
 
+  disabledTestPaths = [
+    # requests-mock cannot intercept meraki's httpx client
+    "tests/test_user_agent.py"
+  ];
+
   build-system = with python3Packages; [
     setuptools
   ];
@@ -36,7 +41,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   nativeCheckInputs = with python3Packages; [
     pytestCheckHook
-    requests-mock
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/meraki/default.nix
+++ b/pkgs/development/python-modules/meraki/default.nix
@@ -1,32 +1,26 @@
 {
   lib,
-  aiohttp,
   buildPythonPackage,
   fetchFromGitHub,
   hatchling,
-  requests,
+  httpx,
 }:
 
 buildPythonPackage rec {
   pname = "meraki";
-  version = "3.0.1";
+  version = "4.3.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "meraki";
     repo = "dashboard-api-python";
     tag = version;
-    hash = "sha256-XP0wvq9CoUpjGsIKmzgLrAmxhJ0F2mHDXJZdeU+AEkE=";
+    hash = "sha256-X4ndUNSnn7Dx2le9Ryfio1/x8J3NjCGcjVHg0JmVoMk=";
   };
-
-  pythonRelaxDeps = [ "aiohttp" ];
 
   build-system = [ hatchling ];
 
-  dependencies = [
-    aiohttp
-    requests
-  ];
+  dependencies = [ httpx ];
 
   # All tests require an API key
   doCheck = false;


### PR DESCRIPTION
Updates `python3Packages.meraki` from `3.0.1` to `4.3.1`.

Changelog: https://github.com/meraki/dashboard-api-python/releases/tag/4.3.1

Diff: https://github.com/meraki/dashboard-api-python/compare/3.0.1...4.3.1

Meraki 4.x replaces the previous `aiohttp`/`requests` dependencies with `httpx`, so the Nix dependency metadata is updated accordingly and the obsolete relaxation is removed. The downstream `meraki-cli` user-agent test is disabled because its `requests-mock` fixture cannot intercept Meraki 4.x's `httpx` client; the remaining downstream suite continues to pass.

Local validation on x86_64-linux:
- `python3Packages.meraki` full build and import check
- `meraki-cli` full build and import check
- 86 enabled `meraki-cli` tests passed
- `meraki --help` smoke test

Automation disclosure: This package update and PR summary were prepared with assistance from Kiro CLI using GPT 5.6 Sol.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

