### PR TITLE
clickup: 3.5.185 -> 3.5.262

### DIFF
--- a/pkgs/by-name/cl/clickup/package.nix
+++ b/pkgs/by-name/cl/clickup/package.nix
@@ -7,15 +7,16 @@
   writeShellApplication,
   curl,
   common-updater-scripts,
+  desktop-file-utils,
 }:
 let
   pname = "clickup";
-  version = "3.5.185";
+  version = "3.5.262";
 
   src = fetchurl {
     # Using archive.org because the website doesn't store older versions of the software.
-    url = "https://web.archive.org/web/20260323060753/https://desktop.clickup.com/linux";
-    hash = "sha256-szPbhY1vsEG0Zq4TD2I9qVTa4wAUYfoVA2O2xP4HGeE=";
+    url = "https://web.archive.org/web/20260727110257/https://desktop.clickup.com/linux";
+    hash = "sha256-8stmEBpvU75JSMBZCjcObLndq+51bqTYb0PK1Yypudc=";
   };
 
   appimage = appimageTools.wrapType2 {
@@ -30,7 +31,10 @@ stdenvNoCC.mkDerivation {
 
   src = appimage;
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    makeWrapper
+    desktop-file-utils
+  ];
 
   installPhase = ''
     runHook preInstall
@@ -46,9 +50,10 @@ stdenvNoCC.mkDerivation {
 
     install -m 444 -D ${appimageContents}/desktop.desktop $out/share/applications/clickup.desktop
 
-    substituteInPlace $out/share/applications/clickup.desktop \
-      --replace-fail 'Exec=AppRun --no-sandbox %U' 'Exec=clickup' \
-      --replace-fail 'Icon=desktop' 'Icon=clickup'
+    desktop-file-edit \
+      --set-key=Exec --set-value=clickup \
+      --set-key=Icon --set-value=clickup \
+      "$out/share/applications/clickup.desktop"
 
     wrapProgram $out/bin/${pname} \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations,WebRTCPipeWireCapturer}} --no-update"
@@ -82,7 +87,8 @@ stdenvNoCC.mkDerivation {
         exit 1
       fi
 
-      update-source-version clickup "$upstream_version" "" "$archived_url"
+      update-source-version clickup "$upstream_version" "" "$archived_url" \
+        --source-key=src.src
     '';
   });
 


### PR DESCRIPTION
Supersedes #542323 with the requested updater fix and a newer upstream version.

This updates ClickUp from 3.5.185 to 3.5.262.

The existing update script failed because `clickup.src` is the wrapped AppImage derivation, while the fixed-output source is nested at `clickup.src.src`. Passing `--source-key=src.src` allows `update-source-version` to update the correct source.

The desktop entry is now modified with `desktop-file-edit` rather than matching the upstream `Exec` value using `substituteInPlace`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
