### PR TITLE
proxyman: add darwin support

### DIFF
--- a/pkgs/by-name/pr/proxyman/darwin.nix
+++ b/pkgs/by-name/pr/proxyman/darwin.nix
@@ -1,0 +1,48 @@
+{
+  stdenvNoCC,
+  fetchurl,
+  _7zz,
+  makeWrapper,
+  pname,
+  updateScript,
+  meta,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  inherit pname;
+  version = "6.14.0";
+
+  src = fetchurl {
+    url = "https://github.com/ProxymanApp/Proxyman/releases/download/${finalAttrs.version}/Proxyman_${finalAttrs.version}.dmg";
+    hash = "sha256-bdIitfbr5Pr0glJcVDMfE/1ehpbRy5/pwXmUz0ivuvo=";
+  };
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [
+    _7zz
+    makeWrapper
+  ];
+
+  unpackCmd = "7zz x -snld -xr'!*:com.apple.*' $curSrc";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    cp -R Proxyman.app $out/Applications
+    makeWrapper $out/Applications/Proxyman.app/Contents/MacOS/Proxyman $out/bin/proxyman
+
+    runHook postInstall
+  '';
+
+  dontFixup = true;
+
+  passthru = {
+    inherit updateScript;
+  };
+
+  meta = meta // {
+    changelog = "https://proxyman.com/changelog";
+    platforms = [ "aarch64-darwin" ];
+  };
+})

--- a/pkgs/by-name/pr/proxyman/linux.nix
+++ b/pkgs/by-name/pr/proxyman/linux.nix
@@ -1,0 +1,57 @@
+{
+  appimageTools,
+  fetchurl,
+  asar,
+  pname,
+  updateScript,
+  meta,
+}:
+let
+  version = "3.16.1";
+
+  src = fetchurl {
+    url = "https://github.com/ProxymanApp/proxyman-windows-linux/releases/download/${version}/Proxyman-${version}.AppImage";
+    hash = "sha256-rykOZVrh3MATFDzwLS7gEj5sMD9udsWAi+68Quqzk0c=";
+  };
+
+  appimageContents = appimageTools.extract {
+    inherit pname version src;
+    postExtract = ''
+      ${asar}/bin/asar extract $out/resources/app.asar app
+
+      # This will fix the issue with Proxyman not detecting NixOS as a valid Linux environment
+      substituteInPlace app/dist/main/main.js \
+        --replace-fail 'systemTrustFilename:"/etc/ca-certificates/trust-source/anchors/%s.crt",trustCommands:["update-ca-trust extract"]' 'systemTrustFilename:"/etc/ssl/certs/%s.crt",trustCommands:[]' \
+        --replace-fail '{path:"/etc/ca-certificates/trust-source/anchors/",distroFamily:"arch"}' '{path:"/etc/ssl/certs/",distroFamily:"arch"}'
+
+      # This will permanently mark the certificate as installed, as this should be done through Nix config rather than
+      # placing / editing a file in /etc like Proxyman would expect.
+      # Configure the certificate located in "~/.config/Proxyman/certificate/certs/ca.pem" using security.pki.certificates in your nix config
+      substituteInPlace app/dist/main/main.js --replace-fail "return this.isFile(this.getNewCertPath(e))" "return true"
+
+      ${asar}/bin/asar pack app $out/resources/app.asar
+    '';
+  };
+
+in
+appimageTools.wrapAppImage {
+  inherit pname version;
+  src = appimageContents;
+
+  extraInstallCommands = ''
+    install -Dm444 ${appimageContents}/proxyman.desktop -t $out/share/applications
+    install -Dm444 ${appimageContents}/proxyman.png -t $out/share/icons/hicolor/256x256/apps
+    substituteInPlace $out/share/applications/proxyman.desktop \
+      --replace-fail "Exec=AppRun" "Exec=proxyman --"
+  '';
+
+  passthru = {
+    inherit updateScript;
+    inherit src;
+  };
+
+  meta = meta // {
+    changelog = "https://proxyman.com/changelog-windows";
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/by-name/pr/proxyman/package.nix
+++ b/pkgs/by-name/pr/proxyman/package.nix
@@ -1,63 +1,65 @@
 {
   lib,
-  appimageTools,
-  fetchurl,
-  asar,
-  nix-update-script,
+  stdenv,
+  callPackage,
+  writeShellScript,
+  curl,
+  jq,
+  common-updater-scripts,
 }:
 let
   pname = "proxyman";
-  version = "3.16.1";
 
-  src = fetchurl {
-    url = "https://github.com/ProxymanApp/proxyman-windows-linux/releases/download/${version}/Proxyman-${version}.AppImage";
-    hash = "sha256-rykOZVrh3MATFDzwLS7gEj5sMD9udsWAi+68Quqzk0c=";
-  };
+  updateScript = {
+    command = writeShellScript "proxyman-update-script" ''
+      set -euo pipefail
 
-  appimageContents = appimageTools.extract {
-    inherit pname version src;
-    postExtract = ''
-      ${asar}/bin/asar extract $out/resources/app.asar app
+      updateArtifact() {
+        local repo=$1 url=$2 file=$3 system=$4 label=$5
+        local version hash
+        version=$(${lib.getExe curl} --fail -s ''${GITHUB_TOKEN:+-H "Authorization: bearer $GITHUB_TOKEN"} \
+          "https://api.github.com/repos/$repo/releases/latest" | ${lib.getExe jq} -r .tag_name)
+        if [[ -z "$version" || "$version" == "null" ]]; then
+          echo "could not determine latest release of $repo" >&2
+          return 1
+        fi
+        if grep -q "version = \"$version\";" "$file"; then
+          echo '[]'
+          return
+        fi
+        url=''${url//@version@/$version}
+        hash=$(nix store prefetch-file --json "$url" | ${lib.getExe jq} -r .hash)
+        ${lib.getExe' common-updater-scripts "update-source-version"} proxyman "$version" "$hash" \
+          --file="$file" --system="$system" --print-changes \
+          | ${lib.getExe jq} --arg label "$label" \
+              'map(.commitMessage = "proxyman: (\($label)) \(.oldVersion) -> \(.newVersion)")'
+      }
 
-      # This will fix the issue with Proxyman not detecting NixOS as a valid Linux environment
-      substituteInPlace app/dist/main/main.js \
-        --replace-fail 'systemTrustFilename:"/etc/ca-certificates/trust-source/anchors/%s.crt",trustCommands:["update-ca-trust extract"]' 'systemTrustFilename:"/etc/ssl/certs/%s.crt",trustCommands:[]' \
-        --replace-fail '{path:"/etc/ca-certificates/trust-source/anchors/",distroFamily:"arch"}' '{path:"/etc/ssl/certs/",distroFamily:"arch"}'
+      # Electron app for Linux
+      linuxChanges=$(updateArtifact ProxymanApp/proxyman-windows-linux \
+        "https://github.com/ProxymanApp/proxyman-windows-linux/releases/download/@version@/Proxyman-@version@.AppImage" \
+        pkgs/by-name/pr/proxyman/linux.nix x86_64-linux linux)
 
-      # This will permanently mark the certificate as installed, as this should be done through Nix config rather than
-      # placing / editing a file in /etc like Proxyman would expect.
-      # Configure the certificate located in "~/.config/Proxyman/certificate/certs/ca.pem" using security.pki.certificates in your nix config
-      substituteInPlace app/dist/main/main.js --replace-fail "return this.isFile(this.getNewCertPath(e))" "return true"
+      # Native macOS app (independent versioning)
+      darwinChanges=$(updateArtifact ProxymanApp/Proxyman \
+        "https://github.com/ProxymanApp/Proxyman/releases/download/@version@/Proxyman_@version@.dmg" \
+        pkgs/by-name/pr/proxyman/darwin.nix aarch64-darwin darwin)
 
-      ${asar}/bin/asar pack app $out/resources/app.asar
+      ${lib.getExe jq} -n "$linuxChanges + $darwinChanges"
     '';
-  };
-
-in
-appimageTools.wrapAppImage {
-  inherit pname version;
-  src = appimageContents;
-
-  extraInstallCommands = ''
-    install -Dm444 ${appimageContents}/proxyman.desktop -t $out/share/applications
-    install -Dm444 ${appimageContents}/proxyman.png -t $out/share/icons/hicolor/256x256/apps
-    substituteInPlace $out/share/applications/proxyman.desktop \
-      --replace-fail "Exec=AppRun" "Exec=proxyman --"
-  '';
-
-  passthru = {
-    updateScript = nix-update-script { };
-    inherit src; # needed for nix-update to find the GitHub URL
+    supportedFeatures = [ "commit" ];
   };
 
   meta = {
     description = "Capture, inspect, and manipulate HTTP(s) requests/responses with ease";
     homepage = "https://proxyman.com";
-    changelog = "https://proxyman.com/changelog-windows";
     license = lib.licenses.unfree;
     mainProgram = "proxyman";
     maintainers = with lib.maintainers; [ nilathedragon ];
-    platforms = [ "x86_64-linux" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
-}
+in
+if stdenv.hostPlatform.isDarwin then
+  callPackage ./darwin.nix { inherit pname updateScript meta; }
+else
+  callPackage ./linux.nix { inherit pname updateScript meta; }

--- a/pkgs/by-name/pr/proxyman/package.nix
+++ b/pkgs/by-name/pr/proxyman/package.nix
@@ -55,7 +55,10 @@ let
     homepage = "https://proxyman.com";
     license = lib.licenses.unfree;
     mainProgram = "proxyman";
-    maintainers = with lib.maintainers; [ nilathedragon ];
+    maintainers = with lib.maintainers; [
+      nilathedragon
+      matteopacini
+    ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
 in


### PR DESCRIPTION
Adds Proxyman's native macOS app (currently `6.14.0`), which is versioned independently from the Electron Windows/Linux app (currently `3.16.1`) and released from a separate upstream repository.

Split the derivation into `linux.nix` (existing, moved) and `darwin.nix` (new), with shared attrs and platform selection living in `package.nix`.

The update script has been rewritten so it works on the auto-update bot: `nix-update` computes hashes by building the fixed-output derivation, which fails for the non-native system (the bot runs on `x86_64-linux` and could never update the `aarch64-darwin` hash). Hashes are now prefetched with `nix store prefetch-file` and passed explicitly to `update-source-version`, so both files update from any host.

Also added myself as maintainer for Darwin.

Tested locally on `aarch64-darwin`: app launches and intercepts traffic correctly. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
