### PR TITLE
kernel updates for 2026-07-30

### DIFF
--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -15,8 +15,8 @@
         "lts": true
     },
     "5.10": {
-        "version": "5.10.261",
-        "hash": "sha256:1i6pzaib30r1nmyxsrhqmfsdxy1jvvlmzc9f8lxzv9a00q8a3751",
+        "version": "5.10.262",
+        "hash": "sha256:10xlfmblynqcba5ab4h75p7pzqcbm34cbhrx19pkircpkf5dmrzs",
         "lts": true
     },
     "6.6": {

--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -10,8 +10,8 @@
         "lts": true
     },
     "5.15": {
-        "version": "5.15.212",
-        "hash": "sha256:1zk51f3pv7ghz68hxkxhds9cjwmk35651pxbyyvyqyhcr7msx5n3",
+        "version": "5.15.213",
+        "hash": "sha256:1n71f4im5jg836wk2g4llkxxvmdzbxj7172pxqcf9wrmhm5inwn4",
         "lts": true
     },
     "5.10": {

--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -5,8 +5,8 @@
         "lts": false
     },
     "6.1": {
-        "version": "6.1.178",
-        "hash": "sha256:03vjdk7lk9zgydzamhwvrg066f8748vrfjggqqd2n0vmr9kzm0vx",
+        "version": "6.1.180",
+        "hash": "sha256:0spql1ybfr879wl35rfd2nwlzirvp5chi6gl1d6zqp5mb4bn03jg",
         "lts": true
     },
     "5.15": {

--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -30,8 +30,8 @@
         "lts": true
     },
     "6.18": {
-        "version": "6.18.40",
-        "hash": "sha256:0cd42fb4390x73jdzbhacm9g9s0ji58whxhik2ndmr1rr0ggq4ip",
+        "version": "6.18.41",
+        "hash": "sha256:1skk2aimvhhymsvs15p83v2mwnlwbmghh82x79isia6lz3q75z0p",
         "lts": true
     },
     "7.1": {

--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -25,8 +25,8 @@
         "lts": true
     },
     "6.12": {
-        "version": "6.12.97",
-        "hash": "sha256:0vswyjh91x52ay99mqrdfhwnvd6nnzv4hpncywk908njpfixzgbc",
+        "version": "6.12.100",
+        "hash": "sha256:147fvkpsa9n5gv207xyb6if0vmahmvpvrb2bfy32wj866i9p7yb7",
         "lts": true
     },
     "6.18": {

--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -20,8 +20,8 @@
         "lts": true
     },
     "6.6": {
-        "version": "6.6.145",
-        "hash": "sha256:09h1pzcai0i10pdyyfbsmq03rgk1x5wv2d937m5nz2xdv0rhw46y",
+        "version": "6.6.147",
+        "hash": "sha256:1fsavd2armiwrnz0w556dmm54z76zwy2as0qbbaq6s04xsvjjqz7",
         "lts": true
     },
     "6.12": {


### PR DESCRIPTION
- **linux_6_18: 6.18.40 -> 6.18.41**
- **linux_6_12: 6.12.97 -> 6.12.100**
- **linux_6_6: 6.6.145 -> 6.6.147**
- **linux_6_1: 6.1.178 -> 6.1.180**
- **linux_5_15: 5.15.212 -> 5.15.213**
- **linux_5_10: 5.10.261 -> 5.10.262**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
