### PR TITLE
ibm-plex: 0-unstable-2026-05-26 > 0-unstable-2026-07-30

### DIFF
--- a/pkgs/by-name/ib/ibm-plex/fonts.nix
+++ b/pkgs/by-name/ib/ibm-plex/fonts.nix
@@ -11,6 +11,13 @@
     url = "https://github.com/IBM/plex/releases/download/%40ibm/plex-mono%402.5.0/ibm-plex-mono.zip";
     version = "2.5.0";
   };
+  mono-variable = {
+    hash = "sha256-lvgkqijKYDpUUJF/YsFHesy8I4w+qhduObzM7m3xZas=";
+    name = "IBM Plex Mono (Variable)";
+    stripRoot = false;
+    url = "https://github.com/IBM/plex/releases/download/%40ibm/plex-mono-variable%401.0.0/plex-mono-variable.zip";
+    version = "1.0.0";
+  };
   sans = {
     hash = "sha256-mK+8GGl2ugF2+fS6yd3p5NWPHHcKEJWiShDS3lihOlI=";
     name = "IBM Plex Sans";

--- a/pkgs/by-name/ib/ibm-plex/package.nix
+++ b/pkgs/by-name/ib/ibm-plex/package.nix
@@ -62,7 +62,7 @@ in
 assert lib.assertMsg (unknownFamilies == [ ]) "Unknown font(s): ${toString unknownFamilies}";
 symlinkJoin {
   pname = "ibm-plex";
-  version = "0-unstable-2026-05-26";
+  version = "0-unstable-2026-07-30";
   paths = lib.attrValues fontDerivations;
   passthru = fontDerivations // {
     updateScript = ./update.py;


### PR DESCRIPTION
The font now has an explicit `plex-mono-variable` variant.

Changelog: https://github.com/IBM/plex/releases#release-@ibm/plex-mono-variable@1.0.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
