### PR TITLE
ahk_x11: pin crystal version to crystal_1_19

### DIFF
--- a/pkgs/by-name/ah/ahk_x11/package.nix
+++ b/pkgs/by-name/ah/ahk_x11/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   fetchFromGitHub,
-  crystal,
+  crystal_1_19,
   copyDesktopItems,
   gtk3,
   libxkbcommon,
@@ -24,6 +24,10 @@
 let
   pname = "ahk_x11";
   version = "1.0.7";
+  # Pinning to Crystal 1.19.x since ahk_x11 crashes with segmentation
+  # fault when built using >=1.20.0
+  # Refernce: https://github.com/phil294/AHK_X11/pull/127
+  crystal = crystal_1_19;
 in
 crystal.buildCrystalPackage {
   inherit pname version;


### PR DESCRIPTION
ahk_x11 has problems running using Crystal >=1.20.0

There is an PR in the ahk_x11 repository that points out this issue: https://github.com/phil294/AHK_X11/pull/127

Recommended to merge before https://github.com/NixOS/nixpkgs/pull/512881 gets merged to prevent ahk_x11 build fail when the crystal version bumps to 1.20.3

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
