### PR TITLE
lsof: modernize

### DIFF
--- a/pkgs/by-name/ls/lsof/package.nix
+++ b/pkgs/by-name/ls/lsof/package.nix
@@ -15,14 +15,14 @@ let
   dialect = lib.last (lib.splitString "-" stdenv.hostPlatform.system);
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "lsof";
   version = "4.99.7";
 
   src = fetchFromGitHub {
     owner = "lsof-org";
     repo = "lsof";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-o95osjMQvpOVx2b0lCXVp61x2GHQV+HW1iaamVhevng=";
   };
 
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
     # Fix references from man page https://github.com/lsof-org/lsof/issues/66
     substituteInPlace Lsof.8 \
       --replace ".so ./00DIALECTS" "" \
-      --replace ".so ./version" ".ds VN ${version}"
+      --replace ".so ./version" ".ds VN ${finalAttrs.version}"
     mkdir -p $out/bin $out/man/man8
     cp Lsof.8 $out/man/man8/lsof.8
     cp lsof $out/bin
@@ -80,7 +80,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "https://github.com/lsof-org/lsof";
-    changelog = "https://github.com/lsof-org/lsof/releases/tag/${src.tag}";
+    changelog = "https://github.com/lsof-org/lsof/releases/tag/${finalAttrs.src.tag}";
     description = "Tool to list open files";
     mainProgram = "lsof";
     longDescription = ''
@@ -92,4 +92,4 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/ls/lsof/package.nix
+++ b/pkgs/by-name/ls/lsof/package.nix
@@ -9,6 +9,7 @@
   nukeReferences,
   freebsd,
   ed,
+  installShellFiles,
 }:
 
 let
@@ -53,6 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     perl
     which
     ed
+    installShellFiles
   ];
   buildInputs = [ ncurses ];
 
@@ -89,9 +91,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   installPhase = ''
     runHook preInstall
-    mkdir -p $out/bin $out/man/man8
-    cp Lsof.8 $out/man/man8/lsof.8
-    cp lsof $out/bin
+    installManPage --name lsof.8 Lsof.8
+    installBin lsof
     runHook postInstall
   '';
 

--- a/pkgs/by-name/ls/lsof/package.nix
+++ b/pkgs/by-name/ls/lsof/package.nix
@@ -61,9 +61,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   buildInputs = [ ncurses ];
 
-  # Stop build scripts from searching global include paths
-  env.LSOF_INCLUDE = "${lib.getInclude stdenv.cc.libc}/include";
-
   configurePhase =
     let
       toVar = name: value: "${name}=\"${value}\"";

--- a/pkgs/by-name/ls/lsof/package.nix
+++ b/pkgs/by-name/ls/lsof/package.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-o95osjMQvpOVx2b0lCXVp61x2GHQV+HW1iaamVhevng=";
   };
 
+  __structuredAttrs = true;
+  strictDeps = true;
   enableParallelBuilding = true;
 
   postPatch = ''

--- a/pkgs/by-name/ls/lsof/package.nix
+++ b/pkgs/by-name/ls/lsof/package.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-o95osjMQvpOVx2b0lCXVp61x2GHQV+HW1iaamVhevng=";
   };
 
+  enableParallelBuilding = true;
+
   postPatch = ''
     patchShebangs --build lib/dialects/*/Mksrc
     # Do not re-build version.h in every 'make' to allow nuke-refs below.

--- a/pkgs/by-name/ls/lsof/package.nix
+++ b/pkgs/by-name/ls/lsof/package.nix
@@ -64,7 +64,11 @@ stdenv.mkDerivation (finalAttrs: {
       linuxFlags = lib.optionalString stdenv.hostPlatform.isLinux "LINUX_CONF_CC=$CC_FOR_BUILD";
       freebsdFlags = lib.optionalString stdenv.hostPlatform.isFreeBSD "FREEBSD_SYS=${freebsd.sys.src}/sys";
     in
-    "${genericFlags} ${linuxFlags} ${freebsdFlags} ./Configure -n ${dialect}";
+    ''
+      runHook preConfigure
+      ${genericFlags} ${linuxFlags} ${freebsdFlags} ./Configure -n ${dialect}
+      runHook postConfigure
+    '';
 
   preBuild = ''
     for filepath in $(find dialects/${dialect} -type f); do
@@ -76,14 +80,19 @@ stdenv.mkDerivation (finalAttrs: {
     nuke-refs version.h
   '';
 
-  installPhase = ''
+  preInstall = ''
     # Fix references from man page https://github.com/lsof-org/lsof/issues/66
     substituteInPlace Lsof.8 \
       --replace ".so ./00DIALECTS" "" \
       --replace ".so ./version" ".ds VN ${finalAttrs.version}"
+  '';
+
+  installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin $out/man/man8
     cp Lsof.8 $out/man/man8/lsof.8
     cp lsof $out/bin
+    runHook postInstall
   '';
 
   meta = {

--- a/pkgs/by-name/ls/lsof/package.nix
+++ b/pkgs/by-name/ls/lsof/package.nix
@@ -29,6 +29,10 @@ stdenv.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
   strictDeps = true;
   enableParallelBuilding = true;
+  outputs = [
+    "out"
+    "man"
+  ];
 
   postPatch = ''
     patchShebangs --build lib/dialects/*/Mksrc

--- a/pkgs/by-name/ls/lsof/package.nix
+++ b/pkgs/by-name/ls/lsof/package.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
   strictDeps = true;
   enableParallelBuilding = true;
+  doCheck = false; # Does not play well with the Nix sandbox
   outputs = [
     "out"
     "man"
@@ -37,9 +38,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     patchShebangs --build lib/dialects/*/Mksrc
-    # Do not re-build version.h in every 'make' to allow nuke-refs below.
-    # We remove phony 'FRC' target that forces rebuilds:
-    #   'version.h: FRC ...' is translated to 'version.h: ...'.
+  ''
+  # Do not re-build version.h in every 'make' to allow nuke-refs below.
+  # We remove phony 'FRC' target that forces rebuilds:
+  #   'version.h: FRC ...' is translated to 'version.h: ...'.
+  + ''
     sed -i lib/dialects/*/Makefile -e 's/version.h:\s*FRC/version.h:/'
   ''
   # help Configure find libproc.h in $SDKROOT
@@ -59,21 +62,31 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [ ncurses ];
 
   # Stop build scripts from searching global include paths
-  env.LSOF_INCLUDE = "${lib.getDev stdenv.cc.libc}/include";
+  env.LSOF_INCLUDE = "${lib.getInclude stdenv.cc.libc}/include";
+
   configurePhase =
     let
-      genericFlags = "LSOF_CC=$CC LSOF_AR=\"$AR cr\" LSOF_RANLIB=$RANLIB";
-      linuxFlags = lib.optionalString stdenv.hostPlatform.isLinux "LINUX_CONF_CC=$CC_FOR_BUILD";
-      freebsdFlags = lib.optionalString stdenv.hostPlatform.isFreeBSD "FREEBSD_SYS=${freebsd.sys.src}/sys";
+      toVar = name: value: "${name}=\"${value}\"";
+      configEnv = {
+        LSOF_CC = "$CC";
+        LSOF_AR = "$AR cr";
+        LSOF_RANLIB = "$RANLIB";
+      }
+      // lib.optionalAttrs stdenv.hostPlatform.isLinux {
+        LINUX_CONF_CC = "$CC_FOR_BUILD";
+      }
+      // lib.optionalAttrs stdenv.hostPlatform.isFreeBSD {
+        FREEBSD_SYS = "${freebsd.sys.src}/sys";
+      };
     in
     ''
       runHook preConfigure
-      ${genericFlags} ${linuxFlags} ${freebsdFlags} ./Configure -n ${dialect}
+      ${lib.concatMapAttrsStringSep " " toVar configEnv} ./Configure -n ${dialect}
       runHook postConfigure
     '';
 
   preBuild = ''
-    for filepath in $(find dialects/${dialect} -type f); do
+    for filepath in $(find lib/dialects/${dialect} -type f); do
       sed -i "s,/usr/include,$LSOF_INCLUDE,g" $filepath
     done
 
@@ -82,11 +95,11 @@ stdenv.mkDerivation (finalAttrs: {
     nuke-refs version.h
   '';
 
+  # Fix references from man page https://github.com/lsof-org/lsof/issues/66
   preInstall = ''
-    # Fix references from man page https://github.com/lsof-org/lsof/issues/66
     substituteInPlace Lsof.8 \
-      --replace ".so ./00DIALECTS" "" \
-      --replace ".so ./version" ".ds VN ${finalAttrs.version}"
+      --replace-fail ".so ./00DIALECTS" "" \
+      --replace-fail ".so ./version" ".ds VN ${finalAttrs.version}"
   '';
 
   installPhase = ''


### PR DESCRIPTION
Better reviewed per-commit (also see commit messages).

cc:
- https://github.com/NixOS/nixpkgs/issues/515268
- https://github.com/NixOS/nixpkgs/issues/205690
- https://github.com/NixOS/nixpkgs/issues/178468

___

enableParallelBuilding speedup was 8s -> 2s on my hardware. Did not include that into the commit message because it's too hardware-specific.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
