### PR TITLE
photoprism: 260601-a7d098548 -> 260728-bbde8f452

### DIFF
--- a/pkgs/by-name/ph/photoprism/backend.nix
+++ b/pkgs/by-name/ph/photoprism/backend.nix
@@ -8,6 +8,7 @@
   pkg-config,
   vips,
   symlinkJoin,
+  nix-update-script,
 }:
 
 let
@@ -56,6 +57,8 @@ buildGoModule {
   CGO_CFLAGS = "-Wno-return-local-addr -I${libtensorflow}/include";
 
   CGO_LDFLAGS = "-L${libtensorflow} -ltensorflow_framework";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://photoprism.app";

--- a/pkgs/by-name/ph/photoprism/backend.nix
+++ b/pkgs/by-name/ph/photoprism/backend.nix
@@ -49,7 +49,7 @@ buildGoModule {
     substituteInPlace internal/commands/passwd.go --replace-fail '/bin/stty' "${coreutils}/bin/stty"
   '';
 
-  vendorHash = "sha256-mF07Lz61IIvUi4SLIMkMlKMH9zm6Zrp/KAdutl+mUzI=";
+  vendorHash = "sha256-coFrVxlriIlHe06BrzuyuB297pCLEMZnGiAgActEIcM=";
 
   subPackages = [ "cmd/photoprism" ];
 

--- a/pkgs/by-name/ph/photoprism/frontend.nix
+++ b/pkgs/by-name/ph/photoprism/frontend.nix
@@ -10,7 +10,7 @@ buildNpmPackage {
   inherit src version;
   pname = "photoprism-frontend";
 
-  npmDepsHash = "sha256-HBzul2fyISwOqf8w92yt0friMnLhMmvKPm8yI2I3ngE=";
+  npmDepsHash = "sha256-8vi5ETVO2t7evJRPge2Ck7iMNAOIbArNHZ8R8Nrx0o8=";
 
   npmWorkspace = "frontend";
 

--- a/pkgs/by-name/ph/photoprism/frontend.nix
+++ b/pkgs/by-name/ph/photoprism/frontend.nix
@@ -3,6 +3,7 @@
   buildNpmPackage,
   src,
   version,
+  nix-update-script,
 }:
 
 buildNpmPackage {
@@ -21,6 +22,8 @@ buildNpmPackage {
 
     runHook postInstall
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://photoprism.app";

--- a/pkgs/by-name/ph/photoprism/package.nix
+++ b/pkgs/by-name/ph/photoprism/package.nix
@@ -18,14 +18,14 @@
 }:
 
 let
-  version = "260601-a7d098548";
+  version = "260728-bbde8f452";
   pname = "photoprism";
 
   src = fetchFromGitHub {
     owner = "photoprism";
     repo = "photoprism";
     rev = version;
-    hash = "sha256-6zE9bqHFF9ifcqbvA0yjSF69+BA/M2U6ABnPta4dpl4=";
+    hash = "sha256-NRVaTrYrYpOdeNLM+GY6Ae7jXR3uNpAVjhLWWoHCdyc=";
   };
 
   backend = callPackage ./backend.nix { inherit src version; };

--- a/pkgs/by-name/ph/photoprism/package.nix
+++ b/pkgs/by-name/ph/photoprism/package.nix
@@ -14,6 +14,7 @@
   callPackage,
   nixosTests,
   librsvg,
+  nix-update-script,
 }:
 
 let
@@ -56,7 +57,7 @@ let
   assets_path = "$out/share/photoprism";
 in
 stdenv.mkDerivation (finalAttrs: {
-  inherit pname version;
+  inherit pname version src;
 
   nativeBuildInputs = [
     makeWrapper
@@ -96,8 +97,23 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
-  passthru.tests.photoprism = nixosTests.photoprism;
+  passthru = {
+    inherit backend frontend;
+
+    tests = {
+      version = testers.testVersion { package = finalAttrs.finalPackage; };
+      photoprism = nixosTests.photoprism;
+    };
+
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--subpackage"
+        "backend"
+        "--subpackage"
+        "frontend"
+      ];
+    };
+  };
 
   meta = {
     homepage = "https://photoprism.app";

--- a/pkgs/by-name/ph/photoprism/package.nix
+++ b/pkgs/by-name/ph/photoprism/package.nix
@@ -35,8 +35,26 @@ let
     { name, hash }:
     fetchzip {
       inherit hash;
-      url = "https://dl.photoprism.app/tensorflow/${name}.zip";
+      extension = "zip";
+      url = "https://dl.photoprism.app/tensorflow/${name}.zip?${version}";
       stripRoot = false;
+    };
+
+  # NB: needs to be a derivation with a src attribute so the update script
+  # can ensure that these hashes remain up to date
+  wrapModelForUpdate =
+    src:
+    stdenv.mkDerivation {
+      inherit pname version src;
+
+      dontUnpack = true;
+      dontBuild = true;
+
+      installPhase = ''
+        mkdir $out
+      '';
+
+      passthru.updateScript = nix-update-script { };
     };
 
   facenet = fetchModel {
@@ -100,6 +118,10 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     inherit backend frontend;
 
+    facenet = wrapModelForUpdate facenet;
+    nasnet = wrapModelForUpdate nasnet;
+    nsfw = wrapModelForUpdate nsfw;
+
     tests = {
       version = testers.testVersion { package = finalAttrs.finalPackage; };
       photoprism = nixosTests.photoprism;
@@ -111,6 +133,12 @@ stdenv.mkDerivation (finalAttrs: {
         "backend"
         "--subpackage"
         "frontend"
+        "--subpackage"
+        "facenet"
+        "--subpackage"
+        "nasnet"
+        "--subpackage"
+        "nsfw"
       ];
     };
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/photoprism/photoprism/releases/tag/260728-bbde8f452

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
