### PR TITLE
romm: init at 5.1.0; nixos/romm: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6828,6 +6828,12 @@
     githubId = 27348469;
     name = "Cat";
   };
+  denzonl = {
+    email = "dennis@bogers.xyz";
+    github = "DenzoNL";
+    githubId = 7504556;
+    name = "Dennis Bogers";
+  };
   derchris = {
     email = "derchris@me.com";
     github = "derchrisuk";

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -28,6 +28,8 @@
 
 - [Moonlight Qt](https://moonlight-stream.org/), a client for playing your PC games on almost any device. Available as [programs.moonlight-qt](#opt-programs.moonlight-qt.enable).
 
+- [RomM](https://romm.app/), a self-hosted ROM manager and player. Available as [services.romm](#opt-services.romm.enable).
+
 - [scx_loader](https://github.com/sched-ext/scx-loader), a system daemon and DBus-based loader for sched_ext schedulers. `scxctl` is the command-line client for interacting with the loader, allowing users to switch schedulers, modes, and arguments dynamically. Available as [services.scx-loader](#opt-services.scx-loader.enable)
 
 - [tap](https://github.com/bluesky-social/indigo/tree/main/cmd/tap), an ATProtocol firehose synchronisation utility. Available as [services.tap](#opt-services.tap.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1800,6 +1800,7 @@
   ./services/web-apps/remark42.nix
   ./services/web-apps/reposilite.nix
   ./services/web-apps/rimgo.nix
+  ./services/web-apps/romm.nix
   ./services/web-apps/rss-bridge.nix
   ./services/web-apps/rsshub.nix
   ./services/web-apps/rustical.nix

--- a/nixos/modules/services/web-apps/romm.nix
+++ b/nixos/modules/services/web-apps/romm.nix
@@ -1,0 +1,480 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.romm;
+
+  authSecretFile = "${cfg.dataDir}/.auth-secret.env";
+
+  isIPv6 = addr: lib.hasInfix ":" addr;
+  bracketed = addr: if isIPv6 addr then "[${addr}]" else addr;
+
+  # Wildcard binds are proxied via loopback; specific addresses as-is.
+  proxyHost =
+    if
+      lib.elem cfg.listenAddress [
+        "0.0.0.0"
+        "::"
+      ]
+    then
+      "127.0.0.1"
+    else
+      cfg.listenAddress;
+  proxyTarget = "http://${bracketed proxyHost}:${toString cfg.port}";
+
+  redisHost = if cfg.redis.createLocally then "127.0.0.1" else cfg.redis.host;
+
+  commonEnv = {
+    ROMM_BASE_PATH = cfg.dataDir;
+    ROMM_HOST = bracketed cfg.listenAddress;
+    ROMM_PORT = toString cfg.port;
+    # gunicorn trusts X-Forwarded-* only from nginx's side of the socket.
+    FORWARDED_ALLOW_IPS = proxyHost;
+    ROMM_DB_DRIVER = "postgresql";
+    DB_NAME = cfg.database.name;
+    DB_USER = cfg.database.user;
+    DB_PORT = toString cfg.database.port;
+    REDIS_HOST = redisHost;
+    REDIS_PORT = toString cfg.redis.port;
+    # The rq and rqscheduler CLIs do not read RomM's REDIS_* variables.
+    RQ_REDIS_HOST = redisHost;
+    RQ_REDIS_PORT = toString cfg.redis.port;
+    RQ_REDIS_URL = "redis://${redisHost}:${toString cfg.redis.port}/0";
+  }
+  // lib.optionalAttrs cfg.watcher.enable {
+    # Upstream defaults this to false, which turns the watcher into a no-op.
+    ENABLE_RESCAN_ON_FILESYSTEM_CHANGE = "true";
+  }
+  // lib.optionalAttrs cfg.database.createLocally {
+    # RomM refuses to start without a database password, but with peer
+    # authentication over the unix socket it is never actually used.
+    DB_PASSWD = "peer-auth-unused";
+    DB_QUERY_JSON = builtins.toJSON { host = "/run/postgresql"; };
+  }
+  // lib.optionalAttrs (!cfg.database.createLocally) {
+    DB_HOST = cfg.database.host;
+  }
+  // lib.optionalAttrs cfg.nginx.enable (
+    let
+      vhost = config.services.nginx.virtualHosts.${cfg.nginx.virtualHost};
+      ssl = vhost.forceSSL || vhost.onlySSL;
+    in
+    {
+      # Used to build user-facing absolute URLs (invite and password reset
+      # links); upstream's default is a broken http://0.0.0.0.
+      ROMM_BASE_URL = "http${lib.optionalString ssl "s"}://${cfg.nginx.virtualHost}";
+    }
+    // lib.optionalAttrs ssl {
+      # Upstream leaves this off because the container cannot know how it is
+      # served; here the virtual host tells us TLS is terminated in front.
+      ROMM_SESSION_SECURE_COOKIE = "true";
+    }
+  )
+  // cfg.extraEnvironment;
+
+  environmentFiles = [
+    "-${authSecretFile}"
+  ]
+  ++ lib.optional (cfg.environmentFile != null) cfg.environmentFile;
+
+  commonServiceConfig = {
+    User = cfg.user;
+    Group = cfg.group;
+    WorkingDirectory = cfg.dataDir;
+    EnvironmentFile = environmentFiles;
+    Restart = "on-failure";
+    # Hardening
+    NoNewPrivileges = true;
+    PrivateTmp = true;
+    ProtectHome = true;
+    ProtectSystem = "strict";
+    ReadWritePaths = [ cfg.dataDir ];
+    Environment = [
+      "PATH=${lib.makeBinPath [ pkgs.rahasher ]}:/run/current-system/sw/bin"
+    ];
+  };
+in
+{
+  options.services.romm = {
+    enable = lib.mkEnableOption "RomM, a self-hosted ROM manager";
+
+    package = lib.mkPackageOption pkgs "romm" { };
+
+    listenAddress = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      example = "0.0.0.0";
+      description = ''
+        Address the RomM API binds to. The frontend and downloads are served
+        by the nginx virtual host, not by the API directly.
+      '';
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 8080;
+      description = "Port the RomM API listens on.";
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "romm";
+      description = "User account under which RomM runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "romm";
+      description = "Group under which RomM runs.";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/romm";
+      description = ''
+        Base path for the ROM library and runtime data
+        (`''${dataDir}/{library,resources,assets,config,cache}`).
+
+        The ROM library location is fixed to `''${dataDir}/library` by
+        upstream. To use an existing ROM collection stored elsewhere,
+        bind-mount it there and make sure it is readable and writable by
+        {option}`services.romm.user`.
+      '';
+    };
+
+    database = {
+      createLocally = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Whether to create the PostgreSQL database and user locally (peer
+          authentication over the unix socket).
+        '';
+      };
+      name = lib.mkOption {
+        type = lib.types.str;
+        default = "romm";
+        description = "Database name.";
+      };
+      user = lib.mkOption {
+        type = lib.types.str;
+        default = "romm";
+        description = ''
+          Database user. With {option}`services.romm.database.createLocally`
+          this must equal {option}`services.romm.user`.
+        '';
+      };
+      host = lib.mkOption {
+        type = lib.types.str;
+        default = "127.0.0.1";
+        description = ''
+          PostgreSQL host. Ignored when
+          {option}`services.romm.database.createLocally` is set; the password
+          for a remote database is passed as `DB_PASSWD` via
+          {option}`services.romm.environmentFile`.
+        '';
+      };
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 5432;
+        description = "PostgreSQL port.";
+      };
+    };
+
+    redis = {
+      createLocally = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Whether to create a dedicated local Redis instance
+          (`services.redis.servers.romm`).
+        '';
+      };
+      host = lib.mkOption {
+        type = lib.types.str;
+        default = "127.0.0.1";
+        description = ''
+          Redis host. Ignored when
+          {option}`services.romm.redis.createLocally` is set; credentials for
+          a remote Redis are passed via
+          {option}`services.romm.environmentFile` (`REDIS_PASSWORD`, and
+          `RQ_REDIS_URL` for the job queue).
+        '';
+      };
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 6379;
+        description = ''
+          Redis port. RomM does not support unix sockets for Redis.
+        '';
+      };
+    };
+
+    watcher.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Whether to run the filesystem watcher that rescans the library on changes.";
+    };
+
+    nginx = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Whether to serve RomM through a local nginx virtual host, as
+          upstream's container image does. The backend only exposes the API;
+          nginx serves the frontend, ROM downloads (`X-Accel-Redirect`,
+          `mod_zip`) and the cross-origin isolation headers for the emulator.
+          Point external reverse proxies at this virtual host.
+        '';
+      };
+      virtualHost = lib.mkOption {
+        type = lib.types.str;
+        example = "romm.example.org";
+        description = "Server name of the RomM virtual host.";
+      };
+    };
+
+    environmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        Environment file with secrets such as metadata provider credentials
+        (`IGDB_CLIENT_ID`, `IGDB_CLIENT_SECRET`, `SCREENSCRAPER_USER`, ...).
+        `ROMM_AUTH_SECRET_KEY` may also be set here; when absent, one is
+        generated and persisted under {option}`services.romm.dataDir`.
+      '';
+    };
+
+    extraEnvironment = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      example = {
+        WEB_CONCURRENCY = "4";
+      };
+      description = ''
+        Extra environment variables passed to all RomM services. See
+        <https://docs.romm.app/latest/Getting-Started/Environment-Variables/>.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.database.createLocally -> cfg.database.user == cfg.user;
+        message = "services.romm.database.user must equal services.romm.user when database.createLocally is enabled.";
+      }
+      {
+        assertion = cfg.database.createLocally -> cfg.database.name == cfg.database.user;
+        message = "services.romm.database.name must equal services.romm.database.user when database.createLocally is enabled.";
+      }
+    ];
+
+    users.users.${cfg.user} = lib.mkIf (cfg.user == "romm") {
+      isSystemUser = true;
+      group = cfg.group;
+      home = cfg.dataDir;
+    };
+    users.groups.${cfg.group} = lib.mkIf (cfg.group == "romm") { };
+
+    systemd.tmpfiles.settings."10-romm" =
+      lib.genAttrs
+        (
+          [ cfg.dataDir ]
+          ++ map (dir: "${cfg.dataDir}/${dir}") [
+            "assets"
+            "cache"
+            "config"
+            "library"
+            "resources"
+          ]
+        )
+        (_: {
+          d = {
+            mode = "0750";
+            user = cfg.user;
+            group = cfg.group;
+          };
+        });
+
+    services.postgresql = lib.mkIf cfg.database.createLocally {
+      enable = true;
+      ensureDatabases = [ cfg.database.name ];
+      ensureUsers = [
+        {
+          name = cfg.database.user;
+          ensureDBOwnership = true;
+        }
+      ];
+    };
+
+    services.redis.servers.romm = lib.mkIf cfg.redis.createLocally {
+      enable = true;
+      port = cfg.redis.port;
+      bind = "127.0.0.1";
+    };
+
+    systemd.services.romm = {
+      description = "RomM ROM manager";
+      wantedBy = [ "multi-user.target" ];
+      after = [
+        "network.target"
+      ]
+      ++ lib.optional cfg.redis.createLocally "redis-romm.service"
+      ++ lib.optional cfg.database.createLocally "postgresql.target";
+      requires =
+        lib.optional cfg.redis.createLocally "redis-romm.service"
+        ++ lib.optional cfg.database.createLocally "postgresql.target";
+      environment = commonEnv;
+
+      # EnvironmentFile is already in effect during preStart, so this only
+      # generates a secret when none was configured.
+      preStart = ''
+        if [ -z "''${ROMM_AUTH_SECRET_KEY:-}" ]; then
+          umask 0077
+          echo "ROMM_AUTH_SECRET_KEY=$(${lib.getExe pkgs.openssl} rand -hex 32)" > ${lib.escapeShellArg authSecretFile}
+        fi
+      '';
+
+      serviceConfig = commonServiceConfig // {
+        ExecStartPre = [
+          "${cfg.package}/bin/romm-migrate"
+          "${cfg.package}/bin/romm-startup"
+        ];
+        ExecStart = "${cfg.package}/bin/romm";
+      };
+    };
+
+    systemd.services.romm-worker = {
+      description = "RomM RQ worker";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "romm.service" ];
+      requires = [ "romm.service" ];
+      environment = commonEnv;
+      serviceConfig = commonServiceConfig // {
+        ExecStart = "${cfg.package}/bin/romm-worker";
+      };
+    };
+
+    systemd.services.romm-scheduler = {
+      description = "RomM RQ scheduler";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "romm.service" ];
+      requires = [ "romm.service" ];
+      environment = commonEnv;
+      serviceConfig = commonServiceConfig // {
+        ExecStart = "${cfg.package}/bin/romm-scheduler";
+      };
+    };
+
+    systemd.services.romm-watcher = lib.mkIf cfg.watcher.enable {
+      description = "RomM library watcher";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "romm.service" ];
+      requires = [ "romm.service" ];
+      environment = commonEnv;
+      serviceConfig = commonServiceConfig // {
+        ExecStart = "${cfg.package}/bin/romm-watcher ${cfg.dataDir}/library";
+      };
+    };
+
+    services.nginx = lib.mkIf cfg.nginx.enable {
+      enable = true;
+      # mod_zip assembles the streamed multi-file ZIP downloads; njs provides
+      # the internal base64 /decode endpoint used in mod_zip manifests.
+      additionalModules = with pkgs.nginxModules; [
+        njs
+        zip
+      ];
+      appendHttpConfig = ''
+        js_import romm_decode from ${cfg.package}/share/romm/decode.js;
+
+        # Cross-origin isolation is required on the emulator player paths for
+        # SharedArrayBuffer, which multi-threaded EmulatorJS cores rely on.
+        map $request_uri $romm_coep_header {
+          default "";
+          "~^/rom/.*/ejs$" "require-corp";
+          "~^/console/rom/[0-9]+/play" "require-corp";
+        }
+        map $request_uri $romm_coop_header {
+          default "";
+          "~^/rom/.*/ejs$" "same-origin";
+          "~^/console/rom/[0-9]+/play" "same-origin";
+        }
+      '';
+      virtualHosts.${cfg.nginx.virtualHost} = {
+        root = "${cfg.package.frontend}";
+        extraConfig = ''
+          client_max_body_size 0;
+        '';
+        locations = {
+          "/" = {
+            tryFiles = "$uri $uri/ /index.html";
+            extraConfig = ''
+              # never cache index.html: store paths have epoch mtimes, and
+              # heuristic caching would keep serving it across upgrades
+              add_header Cache-Control "no-cache";
+              add_header Cross-Origin-Embedder-Policy $romm_coep_header;
+              add_header Cross-Origin-Opener-Policy $romm_coop_header;
+            '';
+          };
+          "/assets/romm/resources/" = {
+            alias = "${cfg.dataDir}/resources/";
+          };
+          "/openapi.json" = {
+            proxyPass = proxyTarget;
+            # Per-location instead of the global recommendedProxySettings so
+            # other virtual hosts on the same machine are left untouched.
+            recommendedProxySettings = true;
+          };
+          "/api" = {
+            proxyPass = proxyTarget;
+            recommendedProxySettings = true;
+            extraConfig = ''
+              # Chunked request bodies can only be relayed unbuffered over
+              # HTTP/1.1 (the global recommendedProxySettings used to set this).
+              proxy_http_version 1.1;
+              proxy_request_buffering off;
+              proxy_buffering off;
+              proxy_read_timeout 300s;
+            '';
+          };
+          "~ ^/(ws|netplay)" = {
+            proxyPass = proxyTarget;
+            proxyWebsockets = true;
+            recommendedProxySettings = true;
+          };
+          # X-Accel-Redirect targets used by the backend for ROM downloads.
+          "/library/" = {
+            alias = "${cfg.dataDir}/library/";
+            extraConfig = "internal;";
+          };
+          "/cache/" = {
+            alias = "${cfg.dataDir}/cache/";
+            extraConfig = "internal;";
+          };
+          "/decode" = {
+            extraConfig = ''
+              internal;
+              js_content romm_decode.decodeBase64;
+            '';
+          };
+        };
+      };
+    };
+
+    users.users.${config.services.nginx.user} = lib.mkIf cfg.nginx.enable {
+      extraGroups = [ cfg.group ];
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    denzonl
+    jk
+  ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1509,6 +1509,7 @@ in
   rmfakecloud = runTest ./rmfakecloud.nix;
   rnsd = runTest ./networking/rnsd.nix;
   robustirc-bridge = runTest ./robustirc-bridge.nix;
+  romm = runTest ./romm.nix;
   rosenpass = runTest ./rosenpass.nix;
   roundcube = runTest ./roundcube.nix;
   routinator = handleTest ./routinator.nix { };

--- a/nixos/tests/romm.nix
+++ b/nixos/tests/romm.nix
@@ -1,0 +1,77 @@
+{ lib, ... }:
+
+{
+  name = "romm";
+  meta.maintainers = with lib.maintainers; [ denzonl ];
+
+  nodes.machine = {
+    services.romm = {
+      enable = true;
+      nginx.virtualHost = "localhost";
+    };
+
+    virtualisation.memorySize = 2048;
+    virtualisation.cores = 2;
+  };
+
+  interactive.nodes.machine = {
+    virtualisation.forwardPorts = [
+      {
+        from = "host";
+        host.port = 8080;
+        guest.port = 80;
+      }
+    ];
+    networking.firewall.allowedTCPPorts = [ 80 ];
+  };
+
+  testScript = ''
+    machine.start()
+
+    with subtest("services come up"):
+        machine.wait_for_unit("postgresql.target")
+        machine.wait_for_unit("redis-romm.service")
+        machine.wait_for_unit("romm.service")
+        machine.wait_for_open_port(8080)
+        machine.wait_for_unit("romm-worker.service")
+        machine.wait_for_unit("romm-scheduler.service")
+        machine.wait_for_unit("romm-watcher.service")
+        machine.wait_for_unit("nginx.service")
+
+    with subtest("backend API answers"):
+        machine.succeed("curl -sf http://127.0.0.1:8080/api/heartbeat")
+
+    with subtest("nginx serves the frontend and proxies the API"):
+        machine.succeed("curl -sf http://localhost/ | grep -iq romm")
+        machine.succeed("curl -sf http://localhost/api/heartbeat")
+
+    with subtest("platform icons are served"):
+        machine.succeed(
+            "curl -sf -o /dev/null -w '%{content_type}' http://localhost/assets/platforms/default.ico | grep -qv text/html"
+        )
+
+    with subtest("uploads larger than nginx's 10M default are not rejected"):
+        machine.succeed("dd if=/dev/zero of=/tmp/upload bs=1M count=15")
+        code = machine.succeed(
+            "curl -s -o /dev/null -w '%{http_code}' -X POST --data-binary @/tmp/upload http://localhost/api/roms"
+        ).strip()
+        assert code != "413", code
+
+    with subtest("the internal /decode endpoint exists"):
+        # internal: 404 externally; the SPA fallback would give 200
+        code = machine.succeed(
+            "curl -s -o /dev/null -w '%{http_code}' 'http://localhost/decode?value=aGk='"
+        ).strip()
+        assert code == "404", code
+
+    with subtest("the watcher reacts to library changes"):
+        machine.succeed("install -d -o romm -g romm /var/lib/romm/library/roms/gba")
+        machine.succeed("touch '/var/lib/romm/library/roms/gba/test.gba'")
+        machine.wait_until_succeeds(
+            "journalctl -u romm-watcher | grep -iq rescan", timeout=60
+        )
+
+    with subtest("auth secret is generated and persisted"):
+        machine.succeed("test -s /var/lib/romm/.auth-secret.env")
+  '';
+}

--- a/pkgs/by-name/ra/rahasher/package.nix
+++ b/pkgs/by-name/ra/rahasher/package.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "rahasher";
+  version = "1.8.3";
+
+  src = fetchFromGitHub {
+    owner = "LeXofLeviafan";
+    repo = "RAHasher";
+    rev = finalAttrs.version;
+    fetchSubmodules = true;
+    hash = "sha256-PitP2MUNwkcCwNJTet3D+A4/RTWp7Xl5Fpc63o5KRFc=";
+  };
+
+  # The upstream Makefile derives src/RA_BuildVer.h from `.git/HEAD` by
+  # shelling out to `git describe` etc. (src/RAInterface/MakeBuildVer.sh).
+  # fetchFromGitHub doesn't keep a .git directory, so that rule can never
+  # fire in the sandbox. Drop the rule and drop in a static header instead;
+  # RAHasher only ever prints this version string, it doesn't use it for
+  # anything functional.
+  postPatch = ''
+    sed -i '/^src\/RA_BuildVer\.h: \.git\/HEAD/,+1d' Makefile.RAHasher
+
+    # The vendored zlib-1.3.1 (pulled in via the libchdr submodule for CHD
+    # support) calls read/write/close in gzread.c/gzwrite.c without
+    # including <unistd.h>, relying on old-style implicit declarations.
+    # GCC 14 made -Wimplicit-function-declaration an error by default
+    # (independent of -std), so demote it back to a warning explicitly.
+    sed -i 's/^CFLAGS=-Wall \$(INCLUDES)/CFLAGS=-Wall -Wno-error=implicit-function-declaration $(INCLUDES)/' Makefile.common
+
+    cat > src/RA_BuildVer.h <<EOF
+    #define RA_LIBRETRO_VERSION "${finalAttrs.version}.0"
+    #define RA_LIBRETRO_VERSION_SHORT "${finalAttrs.version}"
+    #define RA_LIBRETRO_VERSION_MAJOR ${lib.versions.major finalAttrs.version}
+    #define RA_LIBRETRO_VERSION_MINOR ${lib.versions.minor finalAttrs.version}
+    #define RA_LIBRETRO_VERSION_PATCH ${lib.versions.patch finalAttrs.version}
+    #define RA_LIBRETRO_VERSION_REVISION 0
+    #define RA_LIBRETRO_VERSION_PRODUCT "${finalAttrs.version}"
+    #define RA_LIBRETRO_VERSION_FULL "${finalAttrs.version}"
+    #define RA_LIBRETRO_VERSION_COMMIT_HASH ""
+    #define RA_LIBRETRO_VERSION_COMMIT_HASH_SHORT ""
+    EOF
+  '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  makeFlags = [
+    "-f"
+    "Makefile.RAHasher"
+    "HAVE_CHD=1"
+  ];
+
+  enableParallelBuilding = true;
+
+  # No `make install` target upstream; ARCH auto-detection in
+  # Makefile.common puts the binary in ./bin (x86) or ./bin64 (x64/arm64).
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 bin*/RAHasher $out/bin/RAHasher
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI utility for verifying ROM checksums with hashing methods used by RetroAchievements";
+    longDescription = ''
+      RAHasher computes ROM/disc checksums using the same hashing methods as
+      RetroAchievements (via the bundled rcheevos library), so you can look
+      up or verify RetroAchievements-compatible hashes for your ROM
+      collection from the command line. It's a CLI-friendly derivative of
+      RALibretro's built-in hasher, and supports CHD disc images.
+    '';
+    homepage = "https://github.com/LeXofLeviafan/RAHasher";
+    changelog = "https://github.com/LeXofLeviafan/RAHasher/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    mainProgram = "RAHasher";
+    maintainers = with lib.maintainers; [ gaelj ];
+  };
+})

--- a/pkgs/by-name/ro/romm/package.nix
+++ b/pkgs/by-name/ro/romm/package.nix
@@ -5,6 +5,7 @@
   buildNpmPackage,
   makeWrapper,
   nix-update-script,
+  nixosTests,
   p7zip,
   python3,
   runtimeShell,
@@ -160,6 +161,10 @@ stdenvNoCC.mkDerivation (
           cp -r assets/. $out/assets/
           runHook postInstall
         '';
+      };
+
+      tests = {
+        inherit (nixosTests) romm;
       };
 
       updateScript = nix-update-script {

--- a/pkgs/by-name/ro/romm/package.nix
+++ b/pkgs/by-name/ro/romm/package.nix
@@ -1,0 +1,186 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  buildNpmPackage,
+  makeWrapper,
+  nix-update-script,
+  p7zip,
+  python3,
+  runtimeShell,
+}:
+
+stdenvNoCC.mkDerivation (
+  finalAttrs:
+  let
+    inherit (finalAttrs.passthru) frontend pythonEnv;
+  in
+  {
+    pname = "romm";
+    version = "5.1.0";
+
+    src = fetchFromGitHub {
+      owner = "rommapp";
+      repo = "romm";
+      tag = finalAttrs.version;
+      hash = "sha256-oFJ0R4m3bH2qQ18uTDm749la4oBMBj17Y5lF/eE/6tU=";
+    };
+
+    __structuredAttrs = true;
+    strictDeps = true;
+
+    nativeBuildInputs = [ makeWrapper ];
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/share/romm
+      cp -r backend $out/share/romm/backend
+      ln -s ${frontend} $out/share/romm/frontend
+      # njs handler for the internal /decode endpoint of upstream's nginx setup
+      cp docker/nginx/js/decode.js $out/share/romm/decode.js
+
+      wrap() {
+        makeWrapper "$1" "$out/bin/$2" \
+          --chdir $out/share/romm/backend \
+          --set PYTHONPATH $out/share/romm/backend \
+          --prefix PATH : ${lib.makeBinPath [ p7zip ]} \
+          "''${@:3}"
+      }
+
+      wrap ${pythonEnv}/bin/alembic romm-migrate --add-flags "upgrade head"
+
+      wrap ${pythonEnv}/bin/python romm-startup --add-flags "startup.py"
+
+      # forwarded-allow-ips is left to gunicorn's FORWARDED_ALLOW_IPS handling
+      # (default 127.0.0.1) rather than upstream's container-only "*".
+      wrap ${pythonEnv}/bin/gunicorn romm --add-flags "main:app" \
+        --set-default ROMM_HOST 127.0.0.1 \
+        --set-default ROMM_PORT 8080 \
+        --run 'export GUNICORN_CMD_ARGS="--bind=''${ROMM_HOST}:''${ROMM_PORT} --worker-class uvicorn_worker.UvicornWorker --workers ''${WEB_SERVER_CONCURRENCY:-''${WEB_CONCURRENCY:-2}} --timeout ''${WEB_SERVER_TIMEOUT:-300} ''${GUNICORN_CMD_ARGS:-}"'
+
+      wrap ${pythonEnv}/bin/rq romm-worker \
+        --add-flags "worker --path $out/share/romm/backend --worker-class handler.rq_worker.RomMWorker high default low"
+
+      wrap ${pythonEnv}/bin/rqscheduler romm-scheduler \
+        --add-flags "--path $out/share/romm/backend"
+
+      cat > $out/bin/romm-watcher <<EOF
+      #!${runtimeShell}
+      export PYTHONPATH="$out/share/romm/backend"
+      export PATH="${lib.makeBinPath [ p7zip ]}:\$PATH"
+      cd "$out/share/romm/backend"
+      exec ${pythonEnv}/bin/watchfiles --target-type command \
+        "${pythonEnv}/bin/python watcher.py" "\''${1:-\''${ROMM_BASE_PATH:-/var/lib/romm}/library}"
+      EOF
+      chmod +x $out/bin/romm-watcher
+
+      runHook postInstall
+    '';
+
+    passthru = {
+      # Upstream is a uv workspace application (`package = false`), so the
+      # backend is not pip-installable; it runs from source with its
+      # dependencies on PYTHONPATH.
+      pythonEnv = python3.withPackages (
+        ps: with ps; [
+          aiohttp
+          alembic
+          anyio
+          asyncssh
+          authlib
+          bcrypt
+          colorama
+          cryptography
+          defusedxml
+          email-validator
+          fastapi
+          fastapi-pagination
+          gunicorn
+          httpx
+          itsdangerous
+          jinja2
+          joserfc
+          mariadb
+          mutagen
+          mysql-connector-python
+          opentelemetry-distro
+          opentelemetry-exporter-otlp
+          opentelemetry-instrumentation-aiohttp-client
+          opentelemetry-instrumentation-fastapi
+          opentelemetry-instrumentation-httpx
+          opentelemetry-instrumentation-redis
+          opentelemetry-instrumentation-sqlalchemy
+          passlib
+          pillow
+          psycopg
+          pydantic
+          pydash
+          python-dotenv
+          python-magic
+          python-multipart
+          python-socketio
+          pyyaml
+          redis
+          rq
+          rq-scheduler
+          sentry-sdk
+          sqlalchemy
+          starlette
+          streaming-form-data
+          strsimpy
+          ua-parser
+          unidecode
+          uvicorn
+          uvicorn-worker
+          watchfiles
+          yarl
+          zipfile-inflate64
+          zstandard
+        ]
+      );
+
+      frontend = buildNpmPackage {
+        pname = "romm-frontend";
+        inherit (finalAttrs) version;
+        src = "${finalAttrs.src}/frontend";
+
+        npmDepsHash = "sha256-rNi0x8vbPkLEiDlf94SPTg4aKguSzVHR5zBouLJulKo=";
+        npmFlags = [ "--ignore-scripts" ];
+        makeCacheWritable = true;
+
+        installPhase = ''
+          runHook preInstall
+          cp -r dist $out
+          # merge static assets into the web root, as upstream's image does
+          chmod u+w $out/assets
+          cp -r assets/. $out/assets/
+          runHook postInstall
+        '';
+      };
+
+      updateScript = nix-update-script {
+        extraArgs = [
+          "--subpackage"
+          "frontend"
+        ];
+      };
+    };
+
+    meta = {
+      description = "Self-hosted ROM manager and player";
+      homepage = "https://romm.app/";
+      changelog = "https://github.com/rommapp/romm/releases/tag/${finalAttrs.version}";
+      license = lib.licenses.agpl3Only;
+      maintainers = with lib.maintainers; [
+        denzonl
+        jk
+      ];
+      mainProgram = "romm";
+      platforms = lib.platforms.linux;
+    };
+  }
+)

--- a/pkgs/development/python-modules/parse-crontab/default.nix
+++ b/pkgs/development/python-modules/parse-crontab/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+  python-dateutil,
+  pytz,
+  nix-update-script,
+}:
+
+# Distributed on PyPI as "crontab"; not to be confused with python-crontab,
+# which is packaged as python3Packages.crontab and installs a module with the
+# same name.
+buildPythonPackage (finalAttrs: {
+  pname = "crontab";
+  version = "1.0.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "josiahcarlson";
+    repo = "parse-crontab";
+    tag = finalAttrs.version;
+    hash = "sha256-iZS4vkfp93BK5wp1S3qCg0bC7NcT7o5/nNMRI+SXTws=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    python-dateutil
+    pytz
+  ];
+
+  pythonImportsCheck = [ "crontab" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Parse crontab schedules and compute execution times";
+    homepage = "https://github.com/josiahcarlson/parse-crontab";
+    license = with lib.licenses; [
+      lgpl21Only
+      lgpl3Only
+    ];
+    maintainers = with lib.maintainers; [ denzonl ];
+  };
+})

--- a/pkgs/development/python-modules/rq-scheduler/default.nix
+++ b/pkgs/development/python-modules/rq-scheduler/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  freezegun,
+  parse-crontab,
+  python-dateutil,
+  rq,
+  nix-update-script,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "rq-scheduler";
+  version = "0.14.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-LVoUoashf4aTGE66of4Dg47cvHC092VychwLMwWM0CM=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    freezegun
+    parse-crontab
+    python-dateutil
+    rq
+  ];
+
+  # tests require a running Redis server
+  doCheck = false;
+
+  pythonImportsCheck = [ "rq_scheduler" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Job scheduling capabilities for RQ (Redis Queue)";
+    homepage = "https://github.com/rq/rq-scheduler";
+    changelog = "https://github.com/rq/rq-scheduler/releases/tag/v${lib.versions.majorMinor finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ denzonl ];
+  };
+})

--- a/pkgs/development/python-modules/strsimpy/default.nix
+++ b/pkgs/development/python-modules/strsimpy/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  pytestCheckHook,
+  nix-update-script,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "strsimpy";
+  version = "0.2.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-CELrV/evhsiCpZobyHIewlgKJn5WP9BQPO0pcgQDcsk=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  # uses unittest assertion aliases removed in python 3.12
+  disabledTests = [ "testSIFT4" ];
+
+  pythonImportsCheck = [ "strsimpy" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "String similarity and distance measures library";
+    homepage = "https://github.com/luozhouyang/python-string-similarity";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ denzonl ];
+  };
+})

--- a/pkgs/development/python-modules/zipfile-inflate64/default.nix
+++ b/pkgs/development/python-modules/zipfile-inflate64/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromCodeberg,
+  setuptools,
+  setuptools-scm,
+  inflate64,
+  pytestCheckHook,
+  nix-update-script,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "zipfile-inflate64";
+  version = "0.2";
+  pyproject = true;
+
+  src = fetchFromCodeberg {
+    owner = "miurahr";
+    repo = "zipfile-inflate64";
+    tag = "v${finalAttrs.version}";
+    # test fixtures are stored in git-lfs
+    fetchLFS = true;
+    hash = "sha256-Q1nRi3Kcmy8seE+DpxkCGHtYSz7Hw1dQSZKxv1eltYg=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [ inflate64 ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "zipfile_inflate64" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Extract Enhanced Deflate ZIP archives with Python's zipfile API";
+    homepage = "https://codeberg.org/miurahr/zipfile-inflate64";
+    changelog = "https://zipfile-inflate64.readthedocs.io/en/latest/changelog.html";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ denzonl ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12829,6 +12829,8 @@ self: super: with self; {
 
   parse = callPackage ../development/python-modules/parse { };
 
+  parse-crontab = callPackage ../development/python-modules/parse-crontab { };
+
   parse-type = callPackage ../development/python-modules/parse-type { };
 
   parsedatetime = callPackage ../development/python-modules/parsedatetime { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22643,6 +22643,8 @@ self: super: with self; {
 
   zinvolt = callPackage ../development/python-modules/zinvolt { };
 
+  zipfile-inflate64 = callPackage ../development/python-modules/zipfile-inflate64 { };
+
   zipfile2 = callPackage ../development/python-modules/zipfile2 { };
 
   zipp = callPackage ../development/python-modules/zipp { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19677,6 +19677,8 @@ self: super: with self; {
 
   strpdatetime = callPackage ../development/python-modules/strpdatetime { };
 
+  strsimpy = callPackage ../development/python-modules/strsimpy { };
+
   structlog = callPackage ../development/python-modules/structlog { };
 
   stubserver = callPackage ../development/python-modules/stubserver { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17971,6 +17971,8 @@ self: super: with self; {
 
   rq = callPackage ../development/python-modules/rq { };
 
+  rq-scheduler = callPackage ../development/python-modules/rq-scheduler { };
+
   rrdtool = callPackage ../development/python-modules/rrdtool { };
 
   rsa = callPackage ../development/python-modules/rsa { };


### PR DESCRIPTION
Adds [RomM](https://romm.app/), a self-hosted ROM manager and player, with a NixOS module and test.

Upstream only ships a container image: the backend is a non-installable uv workspace application, and the frontend is a Vue SPA served by a bundled nginx that also handles ROM downloads (`X-Accel-Redirect`, mod_zip). The package builds the backend against `python3Packages` and the frontend with `buildNpmPackage`; the module reproduces the nginx setup (`nginxModules.zip` + njs for streamed multi-file downloads, cross-origin isolation headers for the built-in emulator) and can set up PostgreSQL (peer authentication over the unix socket) and a dedicated Redis instance locally.

New python packages, all RomM dependencies:

- `parse-crontab` 1.0.5 — PyPI `crontab`. Not the same project as the existing `crontab` attribute (python-crontab); both install a `crontab` module, so they cannot coexist in one environment.
- `strsimpy` 0.2.1
- `zipfile-inflate64` 0.2 — built from the Codeberg source; PyPI only has a 0.1 wheel.
- `rq-scheduler` 0.14.0

Upstream pins a fork of rq-scheduler that adds Redis username/SSL flags to the `rqscheduler` CLI (rq/rq-scheduler#325). The library API is unchanged, so this packages plain upstream and the module passes connection settings through `RQ_REDIS_*` instead.

Also adds `rahasher` 1.8.3 ([RAHasher](https://github.com/LeXofLeviafan/RAHasher)), a CLI utility that computes RetroAchievements-compatible ROM hashes, which RomM invokes at runtime for RetroAchievements matching; the module exposes it on the services' `PATH`. Thanks to @gaelj for contributing the package and the module wiring!

Not bundled: the EmulatorJS/Ruffle distributions that upstream's image overlays into the web root (cores load from CDN, matching the source layout). Prior art: https://github.com/rommson/nix-romm packages RomM out-of-tree with uv2nix; this is a from-scratch nixpkgs-native packaging.

Besides the NixOS test, tested against a real deployment: library scan and metadata matching, chunked uploads >10M, browser emulation, single-file and mod_zip multi-file downloads, filesystem watcher rescans.

Commits and this PR description were written with assistance from Claude Code (claude-fable-5); see the `Assisted-by` commit trailers. Everything was reviewed and tested as described above.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin *(the python packages; romm itself is linux-only)*
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

