### PR TITLE
nixos/servarr: disable dotnet diagnostic port

### DIFF
--- a/nixos/modules/services/misc/servarr/lidarr.nix
+++ b/nixos/modules/services/misc/servarr/lidarr.nix
@@ -61,7 +61,10 @@ in
       description = "Lidarr";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      environment = servarr.mkServarrSettingsEnvVars "LIDARR" cfg.settings;
+      environment = servarr.mkServarrSettingsEnvVars "LIDARR" cfg.settings // {
+        # Disable debug socket: https://github.com/dotnet/docs/blob/6b96e8456f7eb67f7a4df6b25ad2d298fdc0989f/docs/core/diagnostics/diagnostic-port.md#security-considerations
+        DOTNET_EnableDiagnostics = "0";
+      };
 
       serviceConfig = {
         Type = "simple";

--- a/nixos/modules/services/misc/servarr/prowlarr.nix
+++ b/nixos/modules/services/misc/servarr/prowlarr.nix
@@ -47,6 +47,8 @@ in
         wantedBy = [ "multi-user.target" ];
         environment = servarr.mkServarrSettingsEnvVars "PROWLARR" cfg.settings // {
           HOME = "/var/empty";
+          # Disable debug socket: https://github.com/dotnet/docs/blob/6b96e8456f7eb67f7a4df6b25ad2d298fdc0989f/docs/core/diagnostics/diagnostic-port.md#security-considerations
+          DOTNET_EnableDiagnostics = "0";
         };
 
         serviceConfig = {

--- a/nixos/modules/services/misc/servarr/radarr.nix
+++ b/nixos/modules/services/misc/servarr/radarr.nix
@@ -55,7 +55,10 @@ in
       description = "Radarr";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      environment = servarr.mkServarrSettingsEnvVars "RADARR" cfg.settings;
+      environment = servarr.mkServarrSettingsEnvVars "RADARR" cfg.settings // {
+        # Disable debug socket: https://github.com/dotnet/docs/blob/6b96e8456f7eb67f7a4df6b25ad2d298fdc0989f/docs/core/diagnostics/diagnostic-port.md#security-considerations
+        DOTNET_EnableDiagnostics = "0";
+      };
 
       serviceConfig = {
         Type = "simple";

--- a/nixos/modules/services/misc/servarr/readarr.nix
+++ b/nixos/modules/services/misc/servarr/readarr.nix
@@ -61,7 +61,10 @@ in
       description = "Readarr";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      environment = servarr.mkServarrSettingsEnvVars "READARR" cfg.settings;
+      environment = servarr.mkServarrSettingsEnvVars "READARR" cfg.settings // {
+        # Disable debug socket: https://github.com/dotnet/docs/blob/6b96e8456f7eb67f7a4df6b25ad2d298fdc0989f/docs/core/diagnostics/diagnostic-port.md#security-considerations
+        DOTNET_EnableDiagnostics = "0";
+      };
 
       serviceConfig = {
         Type = "simple";

--- a/nixos/modules/services/misc/servarr/sonarr.nix
+++ b/nixos/modules/services/misc/servarr/sonarr.nix
@@ -74,7 +74,10 @@ in
       description = "Sonarr";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      environment = servarr.mkServarrSettingsEnvVars "SONARR" cfg.settings;
+      environment = servarr.mkServarrSettingsEnvVars "SONARR" cfg.settings // {
+        # Disable debug socket: https://github.com/dotnet/docs/blob/6b96e8456f7eb67f7a4df6b25ad2d298fdc0989f/docs/core/diagnostics/diagnostic-port.md#security-considerations
+        DOTNET_EnableDiagnostics = "0";
+      };
       serviceConfig = {
         Type = "simple";
         User = cfg.user;

--- a/nixos/modules/services/misc/servarr/whisparr.nix
+++ b/nixos/modules/services/misc/servarr/whisparr.nix
@@ -53,7 +53,10 @@ in
       description = "Whisparr";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      environment = servarr.mkServarrSettingsEnvVars "WHISPARR" cfg.settings;
+      environment = servarr.mkServarrSettingsEnvVars "WHISPARR" cfg.settings // {
+        # Disable debug socket: https://github.com/dotnet/docs/blob/6b96e8456f7eb67f7a4df6b25ad2d298fdc0989f/docs/core/diagnostics/diagnostic-port.md#security-considerations
+        DOTNET_EnableDiagnostics = "0";
+      };
 
       serviceConfig = {
         Type = "simple";


### PR DESCRIPTION
This diagnostic port allows dumping memory from the running process, as well as altering program execution. As such, it should not be left enabled on a production deployment.

Given that processes are running in separate users/groups, and that radarr and sonarr are using PrivateTmp, it is unlikely other processes can connect to diagnostic port, but it is still good defence-in-depth to disable it.

This commit disables the diagnostic port on lidarr, prowlarr, radarr, readarr, sonarr, and whisparr.

https://github.com/dotnet/docs/blob/6b96e8456f7eb67f7a4df6b25ad2d298fdc0989f/docs/core/diagnostics/diagnostic-port.md#security-considerations

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
