### PR TITLE
nixos-update-notifier: init at 0.9.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27246,6 +27246,12 @@
     githubId = 77596767;
     name = "Scott Teague";
   };
+  stuckj = {
+    email = "stuckj@gmail.com";
+    github = "stuckj";
+    githubId = 2205578;
+    name = "Jonathan Stucklen";
+  };
   stumoss = {
     email = "samoss@gmail.com";
     github = "stumoss";

--- a/pkgs/by-name/ni/nixos-update-notifier/package.nix
+++ b/pkgs/by-name/ni/nixos-update-notifier/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  wrapGAppsHook4,
+  glib,
+  gtk4,
+  gsettings-desktop-schemas,
+  coreutils,
+  makeBinaryWrapper,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "nixos-update-notifier";
+  version = "0.9.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "stuckj";
+    repo = "nixos-update-notifier";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Mj+y1fu9TohFLqNY6K1U0cB0uQULObZwXFfhBPqFpr4=";
+  };
+
+  cargoHash = "sha256-bwmg0mv8MhdPfwz5MJNbO9/Eiy/EK+RiNgBJe8YyY8s=";
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook4
+    makeBinaryWrapper
+  ];
+
+  buildInputs = [
+    glib
+    gtk4
+    gsettings-desktop-schemas
+  ];
+
+  dontWrapGApps = true;
+
+  postInstall = ''
+    install -Dm644 $src/share/applications/nixos-update-notifier.desktop \
+      $out/share/applications/nixos-update-notifier.desktop
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/nixos-update-notifier-gtk \
+      "''${gappsWrapperArgs[@]}"
+
+    wrapProgram $out/bin/nixos-update-notifier \
+      --suffix PATH : ${lib.makeBinPath [ coreutils ]}
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "System-tray update notifier for flake-based NixOS systems";
+    homepage = "https://github.com/stuckj/nixos-update-notifier";
+    license = lib.licenses.mit;
+    mainProgram = "nixos-update-notifier";
+    maintainers = with lib.maintainers; [ stuckj ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
A system-tray update notifier for flake-based NixOS, in the spirit of Ubuntu's
update-notifier: it checks periodically for flake input updates, notifies when
some are available, shows what would change, and applies them on request.

- Upstream: https://github.com/stuckj/nixos-update-notifier
- Rust. Two binaries in one output: the daemon/CLI and a GTK4 client it re-execs
  for its windows. Only the GTK crate links C libraries; the daemon and the core
  logic are pure Rust (ksni, zbus, tokio), which is what lets their tests run on a
  bare runner.
- Tests run in `checkPhase` — 47 pass. Two integration tests need a real `nix`
  daemon and are `#[ignore]`d, so they're skipped in the sandbox rather than
  failing it.
- `nix`, `nixos-rebuild` and `pkexec` are deliberately **not** dependencies. They
  must come from the running system: bundling a second `nix` would evaluate and
  rebuild with a different one than the one that owns the store.
- `dontWrapGApps = true` with a manual `wrapProgram` per binary, because the two
  need different things — the GTK client needs the GApps environment (schemas,
  icon themes), the daemon only needs `coreutils` on PATH. The automatic hook
  would double-wrap the daemon for nothing.
- The tray icon is a StatusNotifierItem, which is what works on Wayland
  compositors such as KDE Plasma 6; `meta.platforms` is Linux, matching that and
  `nixos-rebuild`.

I am the upstream author and am adding myself to `maintainers/maintainer-list.nix`
in this PR.

Assistance disclosure, per the Automation/AI policy: the derivation was drafted
with Claude Code (model Claude Opus 5). I have reviewed it, understand it, and
verified it builds and behaves correctly; the same disclosure appears as an
`Assisted-by:` trailer on the commit.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
