### PR TITLE
vivaldi-ffmpeg-codecs: 123075 -> 0-unstable-2026-05-18 and adapt update script to new versioning scheme

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4229,6 +4229,12 @@
     matrix = "@brsvh:mozilla.org";
     name = "Burgess Chang";
   };
+  brw = {
+    email = "hi@bas.sh";
+    github = "brw";
+    githubId = 7560938;
+    name = "Bas van den Wollenberg";
+  };
   bryango = {
     name = "Bryan Lai";
     email = "bryanlais@gmail.com";

--- a/pkgs/by-name/vi/vivaldi-ffmpeg-codecs/package.nix
+++ b/pkgs/by-name/vi/vivaldi-ffmpeg-codecs/package.nix
@@ -25,7 +25,7 @@ in
 stdenv.mkDerivation (finalAttrs: {
   pname = "chromium-codecs-ffmpeg-extra";
 
-  version = "123075"; # Do not update by hand, use the update script
+  version = "0-unstable-2026-05-18"; # Do not update by hand, use the update script
 
   src = sources."${stdenv.hostPlatform.system}";
 
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   installPhase = ''
-    install -vD chromium-ffmpeg-${finalAttrs.version}/chromium-ffmpeg/libffmpeg.so $out/lib/libffmpeg.so
+    install -vD chromium-ffmpeg-git-${lib.removePrefix "0-unstable-" finalAttrs.version}/chromium-ffmpeg/libffmpeg.so $out/lib/libffmpeg.so
   '';
 
   passthru = {
@@ -54,6 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
       cawilliamson
       fptje
       sarahec
+      brw
     ];
     platforms = [
       "x86_64-linux"

--- a/pkgs/by-name/vi/vivaldi-ffmpeg-codecs/update.sh
+++ b/pkgs/by-name/vi/vivaldi-ffmpeg-codecs/update.sh
@@ -9,19 +9,19 @@ STABLE_RELEASES=$(echo $RELEASES | jq '.["channel-map"] | .[] |  select(.channel
 
 function get_url() {
   local architecture=$1
-  echo $(echo $STABLE_RELEASES | jq -r '. | select(.arch=="'${architecture}'") | .url')
+  echo $STABLE_RELEASES | jq -r '. | select(.arch=="'${architecture}'") | .url'
 }
 
 # TODO If nix ever supports sha3-384, we can get that from the JSON and use it for the download hash
 function get_source() {
   local url=$1
   # returns the source path
-  echo $(nix-prefetch-url --print-path "$url" | tail -n 1)
+  nix-prefetch-url --print-path "$url" | tail -n 1
 }
 
 function max_version() {
   local source=$1
-  local versions="$(unsquashfs -l $source | awk -F- '$0 ~ "^squashfs-root/chromium-ffmpeg-[[:digit:]]+$" { print $NF }')"
+  local versions="$(unsquashfs -l $source | grep -Po '^squashfs-root/chromium-ffmpeg-git-\K[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}')"
   echo "$versions" | sort -V | tail -n 1
 }
 
@@ -32,16 +32,16 @@ function update_source() {
   local version=$4
   local source_hash=$(nix-hash --type sha256 --flat --base32 "$source")
   local hash=$(nix-hash --to-sri --type sha256 "$source_hash")
-  update-source-version vivaldi-ffmpeg-codecs $version $hash "$url" --ignore-same-version --system=$platform --source-key="sources.$platform"
+  update-source-version "vivaldi-ffmpeg-codecs" "$version" "$hash" "$url" --ignore-same-version --system=$platform --source-key="sources.$platform"
 }
 
-x86_url="$(get_url amd64)"
+x86_url="$(get_url "amd64")"
 x86_source="$(get_source ${x86_url})"
-x86_version="$(max_version ${x86_source})"
+x86_version="0-unstable-$(max_version ${x86_source})"
 
 arm64_url="$(get_url "arm64")"
 arm64_source="$(get_source ${arm64_url})"
-arm64_version="$(max_version ${arm64_source})"
+arm64_version="0-unstable-$(max_version ${arm64_source})"
 
 currentVersion=$(nix eval --raw -f . vivaldi-ffmpeg-codecs.version)
 
@@ -52,8 +52,8 @@ fi
 # If this fails too often, we can try using the lesser of the two versions for both
 # as the snap contains the last 4-5 versions.
 if [[ "$x86_version" != "$arm64_version" ]]; then
-    >&2 echo "Multiple chromium versions found: $x86_version (intel) and $arm64_version (arm); no update"
-    exit 1
+  >&2 echo "Multiple chromium versions found: $x86_version (intel) and $arm64_version (arm); no update"
+  exit 1
 fi
 
 update_source "x86_64-linux" "$x86_url" "$x86_source" "$x86_version"


### PR DESCRIPTION
Apologies for breaking the arm builds in #540805. I thought that pulling the URLs and hashes from Vivaldi's /opt/vivaldi/update-ffmpeg script would be enough but I didn't expect the arm one to actually be behind and thus missing the same ffmpeg version.

However, I also see that the version was reverted to the one before upstream switched to using dates for their versions in #544617. As far as I know this is incorrect, and 123075 is actually a much older build. See https://forum.snapcraft.io/t/using-chromium-ffmpeg-in-third-party-browser-snaps/6545/90 @sarahec 

I also realized that using the date alone did not follow the [versioning guidelines](https://github.com/NixOS/nixpkgs/blob/f25248298845468b9ead9b285365abe4c157757b/pkgs/README.md#versioning), but I'm not sure what it should be in the case of a versioning scheme change like this. I've opted for `0-unstable-2026-05-18` to follow the "incompatible versioning or tagging scheme" directive, but that also means this could be seen as a package downgrade by tooling. Would `123075-unstable-2026-05-18` and only updating the date part in the future be more appropriate so that this change isn't seen as a downgrade? Or maybe something else entirely?

Furthermore vivaldi-ffmpeg-codecs/chromium-codecs-ffmpeg-extra is now actually using a newer snap than the one specified in Vivaldi's update-ffmpeg script. Excerpt from the script in the 8.1.4087.61 deb:
```bash
  amd64|x86_64)
    <...>
    FFMPEG_URL_SNAP=https://api.snapcraft.io/api/v1/snaps/download/XXzVIXswXKHqlUATPqGCj2w2l7BxosS8_117.snap
    <...>
    ;;
  arm64|aarch64)
    <...>
    FFMPEG_URL_SNAP=https://api.snapcraft.io/api/v1/snaps/download/XXzVIXswXKHqlUATPqGCj2w2l7BxosS8_116.snap
    <...>
    ;;
```
No idea if this will realistically ever actually pose an issue, but maybe it's better to align these somehow? Should Vivaldi maybe use its own update-ffmpeg script during its build instead of depending on vivaldi-ffmpeg-codecs/chromium-codecs-ffmpg-extra?

I'm also not sure why the folder/package name is different from the pname. Should it be fully renamed to chromium-codecs-ffmpeg-extra or similar (upstream is just called "chromium-ffmpeg")? Given that other packages depend on it as well it would make sense. It has little to do with Vivaldi at this point.

For now updating it is probably the most important thing to do as it's already breaking again for people https://github.com/NixOS/nixpkgs/issues/542284#issuecomment-5136693006.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
