### PR TITLE
mkvdup: init at 1.9.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27246,6 +27246,12 @@
     githubId = 77596767;
     name = "Scott Teague";
   };
+  stuckj = {
+    email = "stuckj@gmail.com";
+    github = "stuckj";
+    githubId = 2205578;
+    name = "Jonathan Stucklen";
+  };
   stumoss = {
     email = "samoss@gmail.com";
     github = "stumoss";

--- a/pkgs/by-name/mk/mkvdup/package.nix
+++ b/pkgs/by-name/mk/mkvdup/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "mkvdup";
+  version = "1.9.1";
+
+  src = fetchFromGitHub {
+    owner = "stuckj";
+    repo = "mkvdup";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-BkzqzRZYlqRVwp4vqU/7hUMx6P5o73o40fLoZ6R9l6Q=";
+  };
+
+  vendorHash = "sha256-rp2M/Fe5P+ganzJ6/0c75PO9Kg38LL7+vwb6pwIOgSE=";
+
+  __structuredAttrs = true;
+
+  subPackages = [ "cmd/mkvdup" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  # docs/mkvdup.1 is a template; upstream's release tooling expands these before
+  # packaging. --replace-fail so a rename upstream breaks the build loudly
+  # instead of silently shipping a man page full of placeholders.
+  postPatch = ''
+    substituteInPlace docs/mkvdup.1 \
+      --replace-fail '@PACKAGE_NAME_UPPER@' 'MKVDUP' \
+      --replace-fail '@PACKAGE_NAME@' 'mkvdup'
+  '';
+
+  postInstall = ''
+    installManPage docs/mkvdup.1
+    installShellCompletion --cmd mkvdup \
+      --bash scripts/mkvdup-completion.bash \
+      --zsh scripts/mkvdup-completion.zsh \
+      --fish scripts/mkvdup.fish
+    install -Dm755 scripts/mount.fuse.mkvdup $out/bin/mount.fuse.mkvdup
+  '';
+
+  meta = {
+    description = "MKV deduplication tool using FUSE — stores MKV files as references to source media";
+    homepage = "https://github.com/stuckj/mkvdup";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ stuckj ];
+    mainProgram = "mkvdup";
+    # Left unset this defaults to every platform the Go compiler supports, which
+    # includes FreeBSD and WASI. mkvdup is a FUSE filesystem shipping a bash
+    # mount helper, and upstream builds and tests only Linux and macOS.
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
mkvdup deduplicates MKV files against their source media (DVD ISOs, Blu-ray backups), storing an
MKV as an index into the source plus whatever bytes are unique to it, and exposing the
reconstructed files through FUSE.

- Upstream: https://github.com/stuckj/mkvdup
- Pure Go, no cgo. Tests run in `checkPhase`.
- Runtime dependency on fuse3 for `fusermount3`; a `mount.fuse.mkvdup` helper is installed so the
  filesystem can be mounted from fstab. 
- `meta.platforms` is Linux and Darwin, matching what upstream builds and tests.

I am the upstream author and am adding myself to `maintainers/maintainer-list.nix` in this PR.

Assistance disclosure, per the Automation/AI policy: the derivation was drafted with Claude Code
(model Claude Opus 5). I have reviewed it, understand it, and verified it builds and behaves
correctly; the same disclosure appears as an `Assisted-by:` trailer on the commit.

NOTE: I have [another PR](https://github.com/NixOS/nixpkgs/pull/547638) where I added myself as a maintainer as well.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
