### PR TITLE
tinyproxy: fix CVE-2026-54387, CVE-2026-54388 and CVE-2026-55202

### DIFF
--- a/pkgs/by-name/ti/tinyproxy/package.nix
+++ b/pkgs/by-name/ti/tinyproxy/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch2,
+  fetchpatch,
   autoreconfHook,
   perl,
   nixosTests,
@@ -22,10 +22,26 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     # Fix case-sensitive matching of "chunked" (CVE-2026-31842)
-    (fetchpatch2 {
+    (fetchpatch {
       name = "fix-chunked-case-sensitivity.patch";
       url = "https://github.com/tinyproxy/tinyproxy/commit/879bf844abffa0bf5fae6aff0c73179024dd9f98.patch";
-      hash = "sha256-Nav3nXyxdoM/tIvfyPJHEYEjAtrRrJlvkMXzsQCZan4=";
+      hash = "sha256-kU9Vqf2YtnKNJU4eQlau/ijtXkGPS/n+YSeficfu7JM=";
+    })
+    # Remove when updating to the first upstream release containing these fixes.
+    (fetchpatch {
+      name = "CVE-2026-54387.patch";
+      url = "https://github.com/tinyproxy/tinyproxy/commit/623bfc093df009296f0b85d40bc677ef9d5c09bb.patch";
+      hash = "sha256-BSnK3XkBFW43cnD937RKr7FJzQT90BxJkILXz/QPZo8=";
+    })
+    (fetchpatch {
+      name = "CVE-2026-54388.patch";
+      url = "https://github.com/tinyproxy/tinyproxy/commit/364cdb67e0ea00a8e4a7037e2693e0711e816adb.patch";
+      hash = "sha256-+Z/Rj/zNldfOPVzWUlFHa37LEfSh/PtXOaN8z++ONJQ=";
+    })
+    (fetchpatch {
+      name = "CVE-2026-55202.patch";
+      url = "https://github.com/tinyproxy/tinyproxy/commit/09312a185ae25cc486b4ff5987638a7917a48bce.patch";
+      hash = "sha256-kwYk5E95KQK42ebLV0nHB706VynDnjHB/5eENKO7Eaw=";
     })
   ];
 


### PR DESCRIPTION
Applies the public upstream security fixes for CVE-2026-54387, CVE-2026-54388, and CVE-2026-55202 to Tinyproxy 1.11.3. No upstream release containing these fixes is available.

The patches remove ambiguous HTTP request framing and make stathost authentication and routing use the same exact-host check.

Addresses #532923

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
