### PR TITLE
python3Packages.{pytango,zapf,quango,pluto}: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28600,6 +28600,13 @@
     githubId = 1334474;
     name = "Timothy Stott";
   };
+  tincotema = {
+    email = "tincotema@tincotema.org";
+    github = "tincotema";
+    githubId = 41209208;
+    name = "tincotema";
+    keys = [ { fingerprint = "F9D5 F663 E497 5CB1 66B5  FEA2 A961 39D7 C110 556C"; } ];
+  };
   tiptenbrink = {
     email = "tip@tenbrinkmeijs.com";
     github = "tiptenbrink";

--- a/pkgs/development/python-modules/pluto/default.nix
+++ b/pkgs/development/python-modules/pluto/default.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchgit,
+  setuptools,
+  setuptools-scm,
+  pyqt5,
+  qt5,
+  zapf,
+  pytango,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pluto";
+  version = "3.4.5";
+  pyproject = true;
+
+  src = fetchgit {
+    url = "https://forge.frm2.tum.de/review/mlz/pils/pluto";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-+H9ubjLpepCVF/rgSTuZfm1pjWjHUvYBc9mKHgL3I1Y=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  buildInputs = [
+    qt5.qtwayland
+  ];
+
+  # setuptools-scm normally derives the version from git tags/history, but
+  # fetchgit gives a shallow, tag-less checkout by default. Pin the version
+  # explicitly instead of also needing `leaveDotGit`/deepClone = true.
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = finalAttrs.version;
+
+  # wraps $out/bin/pluto with QT_PLUGIN_PATH etc. so it can find the
+  # "wayland"/"xcb" platform plugins at runtime - without this you get
+  # `qt.qpa.plugin: Could not find the Qt platform plugin` and a crash.
+  nativeBuildInputs = [
+    qt5.wrapQtAppsHook
+  ];
+
+  # wrapQTAppsHook seems to not find the python script.
+  # Thus the manual preFixup step
+  # https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/qt.section.md
+  dontWrapQtApps = true;
+  preFixup = ''
+    wrapQtApp "$out/bin/pluto"
+  '';
+
+  dependencies = [
+    pytango
+    zapf
+    pyqt5
+  ];
+
+  pythonImportsCheck = [ "pluto" ];
+
+  meta = {
+    description = "PLC debug tool";
+    homepage = "https://forge.frm2.tum.de/review/plugins/gitiles/mlz/pils/pluto";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    mainProgram = "pluto";
+    maintainers = with lib.maintainers; [ tincotema ];
+  };
+})

--- a/pkgs/development/python-modules/pytango/default.nix
+++ b/pkgs/development/python-modules/pytango/default.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  scikit-build-core,
+  pybind11,
+  pybind11-stubgen,
+  ruff,
+  typing-extensions,
+  numpy,
+  cmake,
+  ninja,
+  psutil,
+  docstring-parser,
+  packaging,
+  zeromq,
+  cppzmq,
+  omniorb,
+  tango-cpp,
+  opentelemetry-cpp,
+  opentelemetry-api,
+  opentelemetry-sdk,
+  opentelemetry-exporter-otlp-proto-grpc,
+  opentelemetry-exporter-otlp-proto-http,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pytango";
+  version = "10.3.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-uFEJFeT4WbK5d1sjZBqy4tVpM8niDYnxMj7g1Vw88Ec=";
+  };
+
+  dontUseCmakeConfigure = true;
+
+  postPatch = ''
+    patchShebangs cmake/gen_stubs.sh
+  '';
+
+  build-system = [
+    scikit-build-core
+    pybind11
+    numpy
+    pybind11-stubgen
+    ruff
+    typing-extensions
+  ];
+
+  # nixpkgs currently has tango-cpp at 10.3.0. PyTango's own compatibility
+  # rule is that libtango/cppTango and pytango should share the same
+  # major.minor (10.3 here) - patch version doesn't need to match, so
+  # 10.3.0 cppTango + 10.3.1 pytango is fine. Re-check this if either side
+  # gets bumped later.
+  buildInputs = [
+    zeromq
+    cppzmq
+    omniorb
+    tango-cpp
+    opentelemetry-cpp
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  dependencies = [
+    typing-extensions
+    numpy
+    psutil
+    docstring-parser
+    packaging
+  ];
+
+  passthru.optional-dependencies = {
+    telemetry = [
+      opentelemetry-api
+      opentelemetry-sdk
+      opentelemetry-exporter-otlp-proto-grpc
+      opentelemetry-exporter-otlp-proto-http
+    ];
+  };
+
+  doCheck = false;
+
+  pythonImportsCheck = [ "tango" ];
+
+  meta = {
+    description = "Python bindings for the cppTango library, part of the Tango Distributed Control System toolkit";
+    homepage = "https://www.tango-controls.org/";
+    changelog = "https://gitlab.com/tango-controls/pytango/-/releases";
+    license = lib.licenses.lgpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ tincotema ];
+  };
+})

--- a/pkgs/development/python-modules/quango/default.nix
+++ b/pkgs/development/python-modules/quango/default.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchgit,
+  setuptools,
+  setuptools-scm,
+  numpy,
+  pyqt5,
+  qt5,
+  psutil,
+  pytango,
+  qtconsole,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "quango";
+  version = "3.3.8";
+  pyproject = true;
+
+  src = fetchgit {
+    url = "https://forge.frm2.tum.de/review/frm2/tango/apps/quango";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-0txeDVX8ohtZFoIm/5rAmdCz3JyNFIXr0X3E/1GN0G4=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  buildInputs = [
+    qt5.qtwayland
+  ];
+
+  # setuptools-scm normally derives the version from git tags/history, but
+  # fetchgit gives a shallow, tag-less checkout by default. Pin the version
+  # explicitly instead of also needing `leaveDotGit`/deepClone = true.
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = finalAttrs.version;
+
+  nativeBuildInputs = [
+    qt5.wrapQtAppsHook
+  ];
+
+  # wrapQTAppsHook seems to not find the python script.
+  # Thus the manual preFixup step
+  # https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/qt.section.md
+  dontWrapQtApps = true;
+  preFixup = ''
+    wrapQtApp "$out/bin/quango"
+    wrapQtApp "$out/bin/quango-mlzgui"
+  '';
+
+  dependencies = [
+    numpy
+    pyqt5
+    psutil
+    pytango
+  ];
+
+  passthru.optional-dependencies = {
+    console = [
+      qtconsole
+    ];
+  };
+
+  pythonImportsCheck = [ "quango" ];
+
+  meta = {
+    description = "Nice generic user interface for Tango devices";
+    homepage = "https://forge.frm2.tum.de/review/plugins/gitiles/frm2/tango/apps/quango";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    mainProgram = "quango";
+    maintainers = with lib.maintainers; [ tincotema ];
+  };
+})

--- a/pkgs/development/python-modules/zapf/default.nix
+++ b/pkgs/development/python-modules/zapf/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchgit,
+  setuptools,
+  setuptools-scm,
+  numpy,
+  pytango,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "zapf";
+  version = "0.6.1";
+  pyproject = true;
+
+  src = fetchgit {
+    url = "https://forge.frm2.tum.de/review/mlz/pils/zapf";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-dY3pmYbLzReXrMLjN5aZ2BVoKi1EtFGB/Gs1GoP4IDE=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  # setuptools-scm normally derives the version from git tags/history, but
+  # fetchgit gives a shallow, tag-less checkout by default. Pin the version
+  # explicitly instead of also needing `leaveDotGit`/deepClone = true.
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = finalAttrs.version;
+
+  dependencies = [
+    numpy
+  ];
+
+  passthru.optional-dependencies = {
+    tango = [ pytango ];
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "zapf" ];
+
+  meta = {
+    description = "Client library for the PILS PLC interface specification";
+    homepage = "https://forge.frm2.tum.de/review/plugins/gitiles/mlz/pils/zapf";
+    changelog = "https://forge.frm2.tum.de/review/plugins/gitiles/mlz/pils/zapf/+/refs/tags/v${finalAttrs.version}";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ tincotema ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13397,6 +13397,8 @@ self: super: with self; {
 
   pluthon = callPackage ../development/python-modules/pluthon { };
 
+  pluto = callPackage ../development/python-modules/pluto { };
+
   plux = callPackage ../development/python-modules/plux { };
 
   ply = callPackage ../development/python-modules/ply { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22540,6 +22540,8 @@ self: super: with self; {
 
   zammad-py = callPackage ../development/python-modules/zammad-py { };
 
+  zapf = callPackage ../development/python-modules/zapf { };
+
   zarr = callPackage ../development/python-modules/zarr { };
 
   zc-buildout = callPackage ../development/python-modules/zc-buildout { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17297,6 +17297,8 @@ self: super: with self; {
 
   quandl = callPackage ../development/python-modules/quandl { };
 
+  quango = callPackage ../development/python-modules/quango { };
+
   quantile-forest = callPackage ../development/python-modules/quantile-forest { };
 
   quantile-python = callPackage ../development/python-modules/quantile-python { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15990,6 +15990,8 @@ self: super: with self; {
 
   pytaglib = callPackage ../development/python-modules/pytaglib { };
 
+  pytango = callPackage ../development/python-modules/pytango { };
+
   pytankerkoenig = callPackage ../development/python-modules/pytankerkoenig { };
 
   pytap2 = callPackage ../development/python-modules/pytap2 { };


### PR DESCRIPTION
# Adding New Packages
## Packages
### PyTango
Python binding to [Tango C++](https://gitlab.com/tango-controls/cpptango)
https://gitlab.com/tango-controls/pytango

### Zapf
Python client library for the MLZ PILS PLC interface specification
The source code is hosted on a publicly accessible Gerrit instance
at the Forschungs-Neutronenquelle Heinz Maier-Leibnitz (FRM II)
https://forge.frm2.tum.de/review/plugins/gitiles/mlz/pils/zapf

### Pluto
MLZ PLC debug tool
The source code is hosted on a publicly accessible Gerrit instance
at the Forschungs-Neutronenquelle Heinz Maier-Leibnitz (FRM II)
https://forge.frm2.tum.de/review/plugins/gitiles/mlz/pils/pluto

### Quango
Nice generic user interface for Tango devices
The source code is hosted on a publicly accessible Gerrit instance
at the Forschungs-Neutronenquelle Heinz Maier-Leibnitz (FRM II)
https://forge.frm2.tum.de/review/plugins/gitiles/frm2/tango/apps/quango


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
