### PR TITLE
various: fix meta urls

### DIFF
--- a/pkgs/by-name/do/dokieli/package.nix
+++ b/pkgs/by-name/do/dokieli/package.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Clientside editor for decentralised article publishing, annotations and social interactions";
-    homepage = "https://github.com/linkeddata/dokieli";
+    homepage = "https://github.com/dokieli/dokieli";
     license = with lib.licenses; [
       cc-by-40
       mit

--- a/pkgs/by-name/ga/galene/package.nix
+++ b/pkgs/by-name/ga/galene/package.nix
@@ -45,7 +45,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Videoconferencing server that is easy to deploy, written in Go";
     homepage = "https://github.com/jech/galene";
-    changelog = "https://github.com/jech/galene/raw/${finalAttrs.src.tag}/CHANGES";
+    changelog = "https://github.com/jech/galene/blob/${finalAttrs.src.tag}/CHANGES";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
     teams = [ lib.teams.ngi ];

--- a/pkgs/by-name/gn/gnunet/package.nix
+++ b/pkgs/by-name/gn/gnunet/package.nix
@@ -122,7 +122,7 @@ stdenv.mkDerivation (finalAttrs: {
       network are rewarded with better service.
     '';
 
-    homepage = "https://gnunet.org/";
+    homepage = "https://www.gnunet.org/en/";
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [ pstn ];
     teams = with lib.teams; [ ngi ];

--- a/pkgs/by-name/ta/taler-exchange/package.nix
+++ b/pkgs/by-name/ta/taler-exchange/package.nix
@@ -132,7 +132,7 @@ stdenv.mkDerivation (finalAttrs: {
       Taler includes code examples to help Merchants integrate Taler as a
       payment system.
     '';
-    homepage = "https://taler.net/";
+    homepage = "https://www.taler.net/en/";
     changelog = "https://git-www.taler.net/exchange.git/tree/ChangeLog?h=v${finalAttrs.version}";
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [ astro ];

--- a/pkgs/by-name/ta/taler-merchant/package.nix
+++ b/pkgs/by-name/ta/taler-merchant/package.nix
@@ -112,7 +112,7 @@ stdenv.mkDerivation (finalAttrs: {
       course, this applies mostly for digital goods, as the merchant does not need
       to know the customer's physical address.
     '';
-    homepage = "https://taler.net/";
+    homepage = "https://www.taler.net/en/";
     changelog = "https://git-www.taler.net/merchant.git/tree/ChangeLog?h=v${finalAttrs.version}";
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [ astro ];

--- a/pkgs/development/python-modules/cryptolyzer/default.nix
+++ b/pkgs/development/python-modules/cryptolyzer/default.nix
@@ -71,7 +71,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Cryptographic protocol analyzer";
     homepage = "https://gitlab.com/coroner/cryptolyzer";
-    changelog = "https://gitlab.com/coroner/cryptolyzer/-/blob/v${finalAttrs.version}/CHANGELOG.md";
+    changelog = "https://gitlab.com/coroner/cryptolyzer/-/blob/v${finalAttrs.version}/CHANGELOG.rst";
     license = lib.licenses.mpl20;
     mainProgram = "cryptolyze";
     teams = with lib.teams; [ ngi ];

--- a/pkgs/development/python-modules/cryptoparser/default.nix
+++ b/pkgs/development/python-modules/cryptoparser/default.nix
@@ -65,7 +65,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Security protocol parser and generator";
     homepage = "https://gitlab.com/coroner/cryptoparser";
-    changelog = "https://gitlab.com/coroner/cryptoparser/-/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    changelog = "https://gitlab.com/coroner/cryptoparser/-/blob/${finalAttrs.src.tag}/CHANGELOG.rst";
     license = lib.licenses.mpl20;
     teams = with lib.teams; [ ngi ];
   };

--- a/pkgs/development/python-modules/scancode-toolkit/default.nix
+++ b/pkgs/development/python-modules/scancode-toolkit/default.nix
@@ -145,8 +145,8 @@ buildPythonPackage (finalAttrs: {
 
   meta = {
     description = "Tool to scan code for license, copyright, package and their documented dependencies and other interesting facts";
-    homepage = "https://github.com/nexB/scancode-toolkit";
-    changelog = "https://github.com/nexB/scancode-toolkit/blob/v${finalAttrs.version}/CHANGELOG.rst";
+    homepage = "https://github.com/aboutcode-org/scancode-toolkit";
+    changelog = "https://github.com/aboutcode-org/scancode-toolkit/blob/v${finalAttrs.version}/CHANGELOG.rst";
     license = with lib.licenses; [
       asl20
       cc-by-40


### PR DESCRIPTION
I used a script to check meta urls for packages maintained by ngi team using https://lychee.cli.rs/. And
fixed these manually.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core"
        functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in
      `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and
      other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
