### PR TITLE
pixieditor: 2.1.1.5->2.1.2.2

### DIFF
--- a/pkgs/by-name/pi/pixieditor/package.nix
+++ b/pkgs/by-name/pi/pixieditor/package.nix
@@ -46,13 +46,13 @@ let
 in
 buildDotnetModule (finalAttrs: {
   pname = "pixieditor";
-  version = "2.1.1.5";
+  version = "2.1.2.2";
 
   src = fetchFromGitHub {
     owner = "PixiEditor";
     repo = "PixiEditor";
     tag = finalAttrs.version;
-    hash = "sha256-XtDcAnMgNc4Su2hj5OV2SP+LFIAMSfH8h2LLw+VbHok=";
+    hash = "sha256-k2dwz1VcXGs0Sh/6nc8Q3bs/dpsHiTnqRbXaGJojBz4=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/by-name/pi/pixieditor/package.nix
+++ b/pkgs/by-name/pi/pixieditor/package.nix
@@ -184,5 +184,7 @@ buildDotnetModule (finalAttrs: {
       "aarch64-linux"
       "aarch64-darwin"
     ];
+    # Temporary disable until the missing DeviceId.Mac missing dependecy get's solved
+    badPlatforms = [ "aarch64-darwin" ];
   };
 })


### PR DESCRIPTION
https://github.com/PixiEditor/PixiEditor/releases/tag/2.1.2.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
