### PR TITLE
doc: render the juce, memcached and redis hook sections

### DIFF
--- a/doc/hooks/index.md
+++ b/doc/hooks/index.md
@@ -21,11 +21,13 @@ gnome.section.md
 haredo.section.md
 installShellFiles.section.md
 installFonts.section.md
+juce.section.md
 julec.section.md
 just.section.md
 libglycin.section.md
 libiconv.section.md
 libxml2.section.md
+memcached-test-hook.section.md
 meson.section.md
 mpi-check-hook.section.md
 ninja.section.md
@@ -41,6 +43,7 @@ pnpm.section.md
 postgresql-test-hook.section.md
 premake.section.md
 python.section.md
+redis-test-hook.section.md
 scons.section.md
 tauri.section.md
 tetex-tex-live.section.md

--- a/doc/hooks/juce.section.md
+++ b/doc/hooks/juce.section.md
@@ -24,10 +24,10 @@ stdenv.mkDerivation {
 
 ## Variables controlling `juce.projucerHook` {#juce-projucer-hook-variables}
 
-### `dontUseProjucerConfigure`
+### `dontUseProjucerConfigure` {#juce-dontuseprojucerconfigure}
 
 Disables `projucerConfigurePhase`
 
-### `dontUseProjucerInstall`
+### `dontUseProjucerInstall` {#juce-dontuseprojucerinstall}
 
 Disables `projucerInstallPhase`

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -218,6 +218,21 @@
   "julec-hook-variables": [
     "index.html#julec-hook-variables"
   ],
+  "juce-projucer-hook": [
+    "index.html#juce-projucer-hook"
+  ],
+  "juce-projucer-hook-example": [
+    "index.html#juce-projucer-hook-example"
+  ],
+  "juce-projucer-hook-variables": [
+    "index.html#juce-projucer-hook-variables"
+  ],
+  "juce-dontuseprojucerconfigure": [
+    "index.html#juce-dontuseprojucerconfigure"
+  ],
+  "juce-dontuseprojucerinstall": [
+    "index.html#juce-dontuseprojucerinstall"
+  ],
   "libcxxhardeningextensive": [
     "index.html#libcxxhardeningextensive"
   ],
@@ -2449,6 +2464,18 @@
   ],
   "sec-checkpoint-build-example": [
     "index.html#sec-checkpoint-build-example"
+  ],
+  "sec-redisTestHook": [
+    "index.html#sec-redisTestHook"
+  ],
+  "sec-redisTestHook-variables": [
+    "index.html#sec-redisTestHook-variables"
+  ],
+  "sec-memcachedTestHook": [
+    "index.html#sec-memcachedTestHook"
+  ],
+  "sec-memcachedTestHook-variables": [
+    "index.html#sec-memcachedTestHook-variables"
   ],
   "chap-images": [
     "index.html#chap-images"


### PR DESCRIPTION
These sections exist on disk under doc/hooks/ but were missing from the index include list.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
