### PR TITLE
doc: document dieHook

### DIFF
--- a/doc/hooks/dieHook.section.md
+++ b/doc/hooks/dieHook.section.md
@@ -1,0 +1,23 @@
+# `dieHook` {#diehook}
+
+`dieHook` provides the `die` shell function.
+`die` prints an error message and a backtrace, then exits the build with status 1.
+
+Use this hook when your package runs custom shell code that should fail with a clear error message.
+Add it to `nativeBuildInputs`, the input list for tools used while building the package:
+
+```nix
+{
+  stdenv,
+  dieHook,
+}:
+stdenv.mkDerivation {
+  nativeBuildInputs = [ dieHook ];
+}
+```
+
+Then call it with the message to display:
+
+```bash
+die "something went wrong"
+```

--- a/doc/hooks/index.md
+++ b/doc/hooks/index.md
@@ -16,6 +16,7 @@ cernlib.section.md
 check-phase-thread-limit-hook.section.md
 cmake.section.md
 desktop-file-utils.section.md
+dieHook.section.md
 gdk-pixbuf.section.md
 ghc.section.md
 gnome.section.md

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -2759,6 +2759,9 @@
   "desktop-file-utils": [
     "index.html#desktop-file-utils"
   ],
+  "diehook": [
+    "index.html#diehook"
+  ],
   "setup-hook-gdk-pixbuf": [
     "index.html#setup-hook-gdk-pixbuf"
   ],


### PR DESCRIPTION
Document the die shell function from pkgs/by-name/di/dieHook/die.sh, which prints a message and backtrace and exits 1.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
