### PR TITLE
doc: document the prune-libtool-files setup hook

### DIFF
--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -1374,6 +1374,9 @@
   "var-stdenv-dontPruneLibtoolFiles": [
     "index.html#var-stdenv-dontPruneLibtoolFiles"
   ],
+  "prune-libtool-files.sh": [
+    "index.html#prune-libtool-files.sh"
+  ],
   "var-stdenv-forceShare": [
     "index.html#var-stdenv-forceShare"
   ],

--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -1480,6 +1480,16 @@ The check for reflexivity is direct and does not account for transitivity, so th
 
 This sets `SOURCE_DATE_EPOCH` to the modification time of the most recent file.
 
+### `prune-libtool-files.sh` {#prune-libtool-files.sh}
+
+This hook removes stale library dependency paths from libtool `.la` files for shared libraries.
+Shared libraries already record the libraries they need.
+`.la` files can also list dependencies in `dependency_libs`, but those paths can be incomplete or point to the wrong package output.
+For example, a path can point to a `dev` output with headers instead of the output that contains the library.
+The hook clears `dependency_libs` so later libtool commands do not use those stale paths.
+It runs during the fixup phase, the cleanup step after install, for every package by default.
+Set [`dontPruneLibtoolFiles`](#var-stdenv-dontPruneLibtoolFiles) to a non-empty value to disable it.
+
 ### `add-bin-to-path.sh` {#add-bin-to-path.sh}
 
 This setup hook checks if the `bin/` directory exists in the `$out` output path


### PR DESCRIPTION
Documents the prune-libtool-files setup hook

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
