### PR TITLE
zepp-simulator: 2.1.1 -> 2.1.2

### DIFF
--- a/pkgs/by-name/ze/zepp-simulator/package.nix
+++ b/pkgs/by-name/ze/zepp-simulator/package.nix
@@ -41,12 +41,12 @@
 let
   srcs = {
     x86_64-linux = {
-      url = "https://upload-cdn.zepp.com/zepp-applet-and-wechat-applet/20260410/simulator_2.1.1_linux_amd64.deb";
-      hash = "sha256-+cRt2jZexe3hI+jN2Lp58uM8GBDvEDqt/u3rp5F0wPo=";
+      url = "https://upload-cdn.zepp.com/zepp-applet-and-wechat-applet/20260717/simulator_2.1.2_linux_amd64.deb";
+      hash = "sha256-q5s1wErlsBaWX+fQUVB7W1out7XA+FBZKUwQBNK+mqA=";
     };
     aarch64-linux = {
-      url = "https://upload-cdn.zepp.com/zepp-applet-and-wechat-applet/20260509/simulator_2.1.1_arm64.deb";
-      hash = "sha256-JnMfiKmA3tyMYDtO2XoeGYOLE2wANKixcfz9wesXoLk=";
+      url = "https://upload-cdn.zepp.com/zepp-applet-and-wechat-applet/20260717/simulator_2.1.2_arm64.deb";
+      hash = "sha256-I7yklSKHwgHm4QNEVLX4O5eXaoS2+SxLMJJjA3aTFCM=";
     };
   };
 
@@ -54,7 +54,7 @@ in
 
 stdenv.mkDerivation {
   pname = "zepp-simulator";
-  version = "2.1.1";
+  version = "2.1.2";
 
   src = fetchurl srcs.${stdenv.hostPlatform.system};
 


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
