### PR TITLE
t3code: 0.0.30 -> 0.0.31

### DIFF
--- a/pkgs/by-name/t3/t3code/package.nix
+++ b/pkgs/by-name/t3/t3code/package.nix
@@ -26,7 +26,9 @@
   jujutsu,
   enableOpencode ? false,
   opencode,
+  enableResourceMonitor ? true,
   t3code-unwrapped ? callPackage ./unwrapped.nix { },
+  t3code-resource-monitor ? callPackage ./resource-monitor.nix { inherit t3code-unwrapped; },
 }:
 
 let
@@ -45,6 +47,23 @@ let
     ++ lib.optionals enableJujutsu [ jujutsu ]
     ++ lib.optionals enableOpencode [ opencode ];
 
+  # The resource monitor sidecar is a separate Rust binary that upstream only
+  # builds in its electron-builder pipeline, not in `build:desktop`. The server
+  # checks this variable before any bundled location, and the desktop app's
+  # server child inherits it.
+  wrapperArgs =
+    lib.optionals (runtimePackages != [ ]) [
+      "--prefix"
+      "PATH"
+      ":"
+      (lib.makeBinPath runtimePackages)
+    ]
+    ++ lib.optionals enableResourceMonitor [
+      "--set-default"
+      "T3CODE_RESOURCE_MONITOR_PATH"
+      (lib.getExe t3code-resource-monitor)
+    ];
+
 in
 symlinkJoin {
   pname = "t3code";
@@ -56,15 +75,15 @@ symlinkJoin {
 
   nativeBuildInputs = [ makeBinaryWrapper ];
 
-  postBuild = lib.optionalString (runtimePackages != [ ]) ''
+  postBuild = lib.optionalString (wrapperArgs != [ ]) ''
     for program in "$out/bin"/*; do
-      wrapProgram "$program" \
-        --prefix PATH : "${lib.makeBinPath runtimePackages}"
+      wrapProgram "$program" ${lib.escapeShellArgs wrapperArgs}
     done
   '';
 
   passthru = {
     unwrapped = t3code-unwrapped;
+    resourceMonitor = t3code-resource-monitor;
   }
   // t3code-unwrapped.passthru;
 

--- a/pkgs/by-name/t3/t3code/resource-monitor.nix
+++ b/pkgs/by-name/t3/t3code/resource-monitor.nix
@@ -1,0 +1,25 @@
+{
+  rustPlatform,
+  t3code-unwrapped,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "t3code-resource-monitor";
+  inherit (t3code-unwrapped) version src;
+
+  sourceRoot = "${t3code-unwrapped.src.name}/native/resource-monitor";
+
+  cargoHash = "sha256-5cmG2daM1bVOA23gjjoalbx0fEL1hmqV6WZov0sUZp8=";
+
+  meta = {
+    description = "Native resource diagnostics sidecar for T3 Code";
+    inherit (t3code-unwrapped.meta)
+      homepage
+      changelog
+      license
+      maintainers
+      platforms
+      ;
+    mainProgram = "t3-resource-monitor";
+  };
+}

--- a/pkgs/by-name/t3/t3code/unwrapped.nix
+++ b/pkgs/by-name/t3/t3code/unwrapped.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (
   in
   {
     pname = "t3code-unwrapped";
-    version = "0.0.30";
+    version = "0.0.31";
     strictDeps = true;
     __structuredAttrs = true;
 
@@ -45,7 +45,7 @@ stdenv.mkDerivation (
       owner = "pingdotgg";
       repo = "t3code";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-8N/TbKjaeog5+fbFr1o/Hs0xgbJijsZigo2FdOFtMco=";
+      hash = "sha256-KFGwgAIOqHbi3enmNAPt95+UAakm6pmClPK1nYNoOlk=";
     };
 
     postPatch = ''
@@ -93,7 +93,7 @@ stdenv.mkDerivation (
         ;
 
       fetcherVersion = 4;
-      hash = "sha256-Qiwbg1EPjcVvt8YGc0YYP+1NbgBIxMkwIyTq5f3gtl4=";
+      hash = "sha256-6tuT9MS+PIMV0PFiw1q6vtZyk3yFB5Y4yHgWohMJczs=";
     };
 
     preBuild = ''


### PR DESCRIPTION
https://github.com/pingdotgg/t3code/releases/tag/v0.0.31
https://github.com/pingdotgg/t3code/compare/v0.0.30...v0.0.31

Routine version bump, plus one packaging change that 0.0.31 makes necessary.

### `enableResourceMonitor`

0.0.31 introduces a native resource diagnostics sidecar written in Rust ([`native/resource-monitor`](https://github.com/pingdotgg/t3code/tree/v0.0.31/native/resource-monitor), upstream PR [#2679](https://github.com/pingdotgg/t3code/pull/2679)). Upstream builds it only in their electron-builder pipeline (`scripts/build-desktop-artifact.ts` shells out to `cargo build`), **not** in the `build:desktop` script this derivation runs, so a plain version bump would ship without it and the server would report resource telemetry as permanently `unavailable`.

It is built as a separate derivation (`resource-monitor.nix`) and the wrapper points at it via `T3CODE_RESOURCE_MONITOR_PATH`, which the server checks ahead of every bundled location ([`ResourceMonitorBinary.ts#L149-L152`](https://github.com/pingdotgg/t3code/blob/v0.0.31/apps/server/src/resourceTelemetry/ResourceMonitorBinary.ts#L149-L152)). That covers both entry points: `t3` directly, and `t3code-desktop`, whose spawned server child inherits the environment. No changes to the `installPhase` were needed.

Enabled by default, to match what upstream ships in official releases; set `enableResourceMonitor = false` to skip the Rust build entirely. The sidecar derivation inherits `version` and `src` from `t3code-unwrapped`, so future bumps stay a single-file change and only `cargoHash` needs separate attention (and only when the crate's dependencies move).

`postBuild` in the wrapper now accumulates its arguments into one list rather than being gated on `runtimePackages != [ ]`, so the environment variable is still set when every `enable*` tool flag is turned off.

### Smoke test

Built with `sandbox = true`.

```console
$ nix-build -A t3code && ./result/bin/t3 --version
t3 v0.0.31

# the sidecar is wired into both wrappers
$ strings ./result/bin/t3 ./result/bin/t3code-desktop | grep -c T3CODE_RESOURCE_MONITOR_PATH
2

# it runs and reports its capability set on stdout
$ $(strings ./result/bin/t3 | grep -oE '/nix/store/\S+/bin/t3-resource-monitor' | head -1)
{"version":2,"type":"hello","sidecarVersion":"0.1.0","platform":"linux","arch":"x86_64","capabilities":{"cumulativeCpuTime":true,"currentCpuPercent":true,"residentMemory":true,"virtualMemory":true,"ioBytes":true,"processStartTime":true,"processTree":true}}

# end to end: the server spawns it from the store path
$ ./result/bin/t3 --port 45711 --host 127.0.0.1 & sleep 15; pgrep -af t3-resource-monitor
… /nix/store/…-t3code-resource-monitor-0.0.31/bin/t3-resource-monitor

# opt-out drops the variable and keeps the PATH wrapping intact
$ nix-build -E 'with import ./. {}; t3code.override { enableResourceMonitor = false; }'
$ strings ./result/bin/t3 | grep -c T3CODE_RESOURCE_MONITOR_PATH
0
```

Desktop entry, icons, and bash/zsh/fish completions are all still installed.

### Notes

- Nothing else in the release needed packaging changes: `apps/web/vite.config.ts`, `scripts/update-release-package-versions.ts`, the `pnpmWorkspaces` members and `assets/prod/*` are all untouched upstream, and electron (41), Node, and pnpm are unchanged. The only lockfile movement is `@pierre/diffs` 1.3.0-beta.5 → 1.3.0-beta.10.
- Leaf package, nothing in Nixpkgs depends on `t3code`.
- Not verified: aarch64-darwin (`sysinfo` 0.39 needs no additional inputs with apple-sdk-in-stdenv, but I have no Darwin machine to confirm on), and I did not launch the `t3code-desktop` GUI. Its wrapper and the server child it spawns are verified, but not the window itself.

cc @iamanaws @qweered

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

*Disclosure: this pull request was prepared with Claude Code (claude-opus-5)