### PR TITLE
ollama: use merged CUDA toolkit root

### DIFF
--- a/pkgs/by-name/ol/ollama/package.nix
+++ b/pkgs/by-name/ol/ollama/package.nix
@@ -172,7 +172,12 @@ goBuild (finalAttrs: {
       CFLAGS = "-Wno-c++17-extensions -I${rocmPath}/include";
       CXXFLAGS = "-Wno-c++17-extensions -I${rocmPath}/include";
     }
-    // lib.optionalAttrs enableCuda { CUDA_PATH = cudaPath; }
+    // lib.optionalAttrs enableCuda {
+      CUDA_PATH = cudaPath;
+      # Nested llama.cpp builds require one toolkit root containing
+      # nvcc and the split CUDA libraries.
+      CUDAToolkit_ROOT = cudaToolkit;
+    }
     // lib.optionalAttrs enableVulkan { VULKAN_SDK = shaderc.bin; };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Pass `CUDAToolkit_ROOT` to Ollama's CUDA build, pointing it at the existing merged toolkit environment that contains both `nvcc` and the split CUDA libraries.

Ollama builds llama.cpp as a nested CMake project. CMake's CUDA toolkit discovery expects a single toolkit root, while `CUDA_PATH` remains the version-normalized path required by Ollama's presets. Without an explicit merged root, the nested build can fail to find the compiler and libraries together.

This affects only `ollama-cuda`; CPU, ROCm, and Vulkan builds are unchanged.

Validation performed:

- `nix-instantiate --parse pkgs/by-name/ol/ollama/package.nix`
- `nix-instantiate --system x86_64-linux --arg config '{ allowUnfree = true; }' -A ollama-cuda .`
- `git diff --check`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

