### PR TITLE
gnomeExtensions.appindicator: fix gjs runtime path

### DIFF
--- a/pkgs/desktops/gnome/extensions/extensionOverrides.nix
+++ b/pkgs/desktops/gnome/extensions/extensionOverrides.nix
@@ -54,6 +54,14 @@ in
 # the upstream repository's sources.
 super:
 lib.trivial.pipe super [
+  (patchExtension "appindicatorsupport@rgcjonas.gmail.com" (old: {
+    # gjs is not available on GNOME Shell's runtime PATH by default.
+    postPatch = ''
+      substituteInPlace statusNotifierWatcher.js \
+        --replace-fail "['gjs', '-m', busAnalyzer]" "['${lib.getExe gjs}', '-m', busAnalyzer]"
+    '';
+  }))
+
   (patchExtension "apps-menu@gnome-shell-extensions.gcampax.github.com" (old: {
     patches = [
       (replaceVars


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix broken tray icon for some apps, like ProtonVPN. Journal error:

```
.gnome-shell-wr[3292]: Looking for StatusNotifierItem's: GLib.SpawnError: Failed to execute child process “gjs” (No such file or directory)

                                                         Stack trace:
                                                           _seekStatusNotifierItems@file:///home/user/.nix-profile/share/gnome-shell/extensions/appindicatorsupport@rgcjonas.gmail.com/statusNotifierWatcher.js:162:43
                                                           async*StatusNotifierWatcher@file:///home/user/.nix-profile/share/gnome-shell/extensions/appindicatorsupport@rgcjonas.gmail.com/statusNotifierWatcher.js:70:14
                                                           _maybeEnableAfterNameAvailable@file:///home/user/.nix-profile/share/gnome-shell/extensions/appindicatorsupport@rgcjonas.gmail.com/extension.js:87:39
                                                           enable@file:///home/user/.nix-profile/share/gnome-shell/extensions/appindicatorsupport@rgcjonas.gmail.com/extension.js:57:14
                                                           _callExtensionEnable@resource:///org/gnome/shell/ui/extensionSystem.js:265:38
                                                           _enableAllExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:756:24
                                                           async*_sessionUpdated@resource:///org/gnome/shell/ui/extensionSystem.js:785:20
                                                           async*ExtensionManager/<@resource:///org/gnome/shell/ui/extensionSystem.js:48:18
                                                           _callHandlers@resource:///org/gnome/gjs/modules/core/_signals.js:130:42
                                                           _emit@resource:///org/gnome/gjs/modules/core/_signals.js:119:10
                                                           _sync@resource:///org/gnome/shell/ui/sessionMode.js:207:14
                                                           popMode@resource:///org/gnome/shell/ui/sessionMode.js:178:14
                                                           _continueDeactivate@resource:///org/gnome/shell/ui/screenShield.js:526:30
                                                           deactivate/<@resource:///org/gnome/shell/ui/screenShield.js:517:44
                                                           finish@resource:///org/gnome/shell/gdm/authPrompt.js:834:13
                                                           finish@resource:///org/gnome/shell/ui/unlockDialog.js:944:26
                                                           deactivate@resource:///org/gnome/shell/ui/screenShield.js:517:26
                                                           _getLoginSession/<@resource:///org/gnome/shell/ui/screenShield.js:150:24
                                                           _callHandlers@resource:///org/gnome/gjs/modules/core/_signals.js:130:42
                                                           _emit@resource:///org/gnome/gjs/modules/core/_signals.js:119:10
                                                           _convertToNativeSignal@resource:///org/gnome/gjs/modules/core/overrides/Gio.js:153:19
                                                           @resource:///org/gnome/shell/ui/init.js:20:20
```

Without this patch, the workaround is to put `gjs` in `environment.systemPackages` so appindicator can resolve it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

`nixpkgs-review` was attempted but OOM-killed (it consumed >15 Gb RAM), so its box remains unchecked.

AI disclosure: Assisted by OpenAI Codex (gpt-5.6-sol-xhigh) with analysis, implementation, and validation.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
