### PR TITLE
[26.05] vivaldi: 8.1.4087.48 -> 8.1.4087.58

### DIFF
--- a/pkgs/by-name/vi/vivaldi/package.nix
+++ b/pkgs/by-name/vi/vivaldi/package.nix
@@ -67,7 +67,7 @@
 
 stdenv.mkDerivation rec {
   pname = "vivaldi";
-  version = "8.1.4087.55";
+  version = "8.1.4087.58";
 
   suffix =
     {
@@ -80,8 +80,8 @@ stdenv.mkDerivation rec {
     url = "https://downloads.vivaldi.com/stable/vivaldi-stable_${version}-1_${suffix}.deb";
     hash =
       {
-        aarch64-linux = "sha256-cSDu1cjfCIkn0wWm6cWaBrfgGZH4+qs3JnXYx+JfC7k=";
-        x86_64-linux = "sha256-GicxDYZJxerEEDu08ZlyegLLZSknZtuRZrCUYT+Q1N0=";
+        aarch64-linux = "sha256-Yvs3HRbsrgTeYXAKrRliLArXtK96jnjjf7x/sdpwvig=";
+        x86_64-linux = "sha256-/2GdNvj9+O6LDfqJdjNNdNWJymNAtnpTnzznW/4jINE=";
       }
       .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
   };

--- a/pkgs/by-name/vi/vivaldi/package.nix
+++ b/pkgs/by-name/vi/vivaldi/package.nix
@@ -67,7 +67,7 @@
 
 stdenv.mkDerivation rec {
   pname = "vivaldi";
-  version = "8.1.4087.48";
+  version = "8.1.4087.55";
 
   suffix =
     {
@@ -80,8 +80,8 @@ stdenv.mkDerivation rec {
     url = "https://downloads.vivaldi.com/stable/vivaldi-stable_${version}-1_${suffix}.deb";
     hash =
       {
-        aarch64-linux = "sha256-T6mBi4FpHz2iGXeF91giTbuVp4KjFG1DUnPNpKEV06c=";
-        x86_64-linux = "sha256-/Bgh+Y6DHWe7al9vLsWWH1HM5JQGwv91KUxQ9TNkqjs=";
+        aarch64-linux = "sha256-cSDu1cjfCIkn0wWm6cWaBrfgGZH4+qs3JnXYx+JfC7k=";
+        x86_64-linux = "sha256-GicxDYZJxerEEDu08ZlyegLLZSknZtuRZrCUYT+Q1N0=";
       }
       .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
   };


### PR DESCRIPTION
Backports #543292 and #546453. The two merged commits are cherry-picked in order because `release-26.05` was still on 8.1.4087.48.

#547133 handles the separate `libffmpeg.so` rpath fix. Its patch applies cleanly on top of this branch.

Tests:

- `nixpkgs-review rev HEAD --branch release-26.05 --package vivaldi --systems aarch64-linux --extra-nixpkgs-config '{ allowUnfree = true; }'`
- `NIXPKGS_ALLOW_UNFREE=1 nix build --impure --no-link --rebuild .#vivaldi` on `aarch64-linux`
- `vivaldi --version` reports `Vivaldi 8.1.4087.58 stable`
- Verified both source hashes with `nix store prefetch-file`

Automation disclosure: OpenAI Codex (GPT-5) assisted with investigating and validating this backport and drafting this PR description.
