### PR TITLE
Draft: epkowa: remove dependency on gtk2

### DIFF
--- a/pkgs/by-name/ep/epkowa/package.nix
+++ b/pkgs/by-name/ep/epkowa/package.nix
@@ -8,7 +8,6 @@
   symlinkJoin,
   pkg-config,
   libtool,
-  gtk2,
   libxml2,
   libxslt,
   libusb-compat-0_1,
@@ -70,7 +69,6 @@ stdenv.mkDerivation rec {
     makeWrapper
   ];
   buildInputs = [
-    gtk2
     libxml2
     libusb-compat-0_1
     sane-backends
@@ -95,9 +93,21 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--enable-dependency-reduction"
     "--disable-frontend"
+    "--disable-gimp"
     # fix build with gcc 15
     "CFLAGS=-std=gnu17"
   ];
+
+  preConfigure = ''
+    mkdir pkg-config
+    cat > pkg-config/gtk+-2.0.pc << EOF
+    Name: GTK+
+    Version: 2.24.thisisfake
+    Description: gtk is only needed for the frontend, which we do not build, but the configure script really insists on having gtk
+    EOF
+    export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(readlink -f pkg-config)"
+    $PKG_CONFIG --cflags gtk+-2.0 --debug
+  '';
 
   postConfigure = ''
     echo '#define NIX_ESCI_PREFIX "'${fwdir}'"' >> config.h


### PR DESCRIPTION
Rationale: #410814

gtk was needed for a custom sane frontend which we were already not building. However the configure script really really wants gtk. So gtk presence is faked.

unfortunately I won't have access to the correct hardware to test this PR for some time. I am marking this as draft until somebody with hardware needing this driver confirms it still works.

cc @dominikh for testing

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
