### PR TITLE
noctalia-greeter: 1.0.0 -> 1.1.0

### DIFF
--- a/pkgs/by-name/no/noctalia-greeter/package.nix
+++ b/pkgs/by-name/no/noctalia-greeter/package.nix
@@ -8,25 +8,41 @@
   pkg-config,
   wayland-scanner,
 
+  bashNonInteractive,
   cairo,
   fontconfig,
   freetype,
   glib,
-  gtk4,
   libGL,
   librsvg,
   libwebp,
   libxkbcommon,
+  nlohmann_json,
   pango,
+  stb,
+  tomlplusplus,
   wayland,
   wayland-protocols,
+  wlroots_0_20,
 
   nix-update-script,
 }:
 
+let
+  # nixpkgs stb doesn't have stb_image_resize2.h which noctalia-greeter needs
+  stb' = stb.overrideAttrs {
+    version = "0-unstable-2025-10-26";
+    src = fetchFromGitHub {
+      owner = "nothings";
+      repo = "stb";
+      rev = "f1c79c02822848a9bed4315b12c8c8f3761e1296";
+      hash = "sha256-BlyXJtAI7WqXCTT3ylww8zoG0hBxaojJnQDvdQOXJPE=";
+    };
+  };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "noctalia-greeter";
-  version = "1.0.0";
+  version = "1.1.0";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -34,8 +50,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "noctalia-dev";
     repo = "noctalia-greeter";
-    rev = "367ab83dcd9190010f093cfe0e123ba132a75b5a";
-    hash = "sha256-/jQ/lkgjaH5EOTZRXk4YZaFrjrKhq/fzZsU6nm7wPt0=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-3t/+o8Cbve8z43IekUNBj7Ecn/T+v7+p4Ivgs3IEQtk=";
   };
 
   nativeBuildInputs = [
@@ -46,18 +62,22 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    bashNonInteractive
     cairo
     fontconfig
     freetype
     glib
-    gtk4
     libGL
     librsvg
     libwebp
     libxkbcommon
+    nlohmann_json
     pango
+    stb'
+    tomlplusplus
     wayland
     wayland-protocols
+    wlroots_0_20
   ];
 
   passthru.updateScript = nix-update-script { };
@@ -65,7 +85,6 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "`greetd` greeter for Noctalia";
     homepage = "https://github.com/noctalia-dev/noctalia-greeter";
-    changelog = "https://github.com/noctalia-dev/noctalia-greeter/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       dtomvan

--- a/pkgs/by-name/no/noctalia-greeter/package.nix
+++ b/pkgs/by-name/no/noctalia-greeter/package.nix
@@ -88,6 +88,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       dtomvan
+      samiser
       spacedentist
     ];
     mainProgram = "noctalia-greeter-session";


### PR DESCRIPTION
bumped the version, which required some changes to get working:

- added new required dependencies
  - stb required manual override
- removed unused gtk4 dependency

and some other package fixes:
- added bashNonInteractive so scripts get shebangs with nix store bash
- version by tag rather than commit rev
- removed changelog link (there isn't one released)

also added myself as a maintainer

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
