### PR TITLE
prime-server: 0.7.0 -> 0.13.1

### DIFF
--- a/pkgs/by-name/pr/prime-server/package.nix
+++ b/pkgs/by-name/pr/prime-server/package.nix
@@ -8,6 +8,7 @@
   zeromq,
   czmq,
   libsodium,
+  runCommand,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -32,6 +33,24 @@ stdenv.mkDerivation (finalAttrs: {
     czmq
     zeromq
   ];
+
+  passthru.tests.simple =
+    runCommand "prime-server-test"
+      {
+        nativeBuildInputs = [
+          finalAttrs.finalPackage
+          curl
+        ];
+      }
+      ''
+        prime_serverd tcp://127.0.0.1:8001 1 0 &
+        pid=$!
+        trap 'kill $pid' EXIT
+
+        test "$(curl -fsS --retry 30 --retry-delay 1 --retry-connrefused 'http://127.0.0.1:8001/is_prime?possible_prime=17')" = 17
+
+        touch "$out"
+      '';
 
   meta = {
     description = "Non-blocking (web)server API for distributed computing and SOA based on zeromq";

--- a/pkgs/by-name/pr/prime-server/package.nix
+++ b/pkgs/by-name/pr/prime-server/package.nix
@@ -56,7 +56,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Non-blocking (web)server API for distributed computing and SOA based on zeromq";
     homepage = "https://github.com/kevinkreiser/prime_server";
     license = lib.licenses.bsd2;
-    maintainers = [ lib.maintainers.Thra11 ];
+    maintainers = with lib.maintainers; [
+      Thra11
+      karlbeecken
+    ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })

--- a/pkgs/by-name/pr/prime-server/package.nix
+++ b/pkgs/by-name/pr/prime-server/package.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "prime-server";
-  version = "0.7.0";
+  version = "0.13.1";
 
   src = fetchFromGitHub {
     owner = "kevinkreiser";
     repo = "prime_server";
     tag = finalAttrs.version;
-    sha256 = "0izmmvi3pvidhlrgfpg4ccblrw6fil3ddxg5cfxsz4qbh399x83w";
+    hash = "sha256-B6vy/y4PDEpnxXuMpAisBq5avNpW84q/+9zbuNBOnko=";
     fetchSubmodules = true;
   };
 
@@ -26,24 +26,12 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     pkg-config
   ];
-  buildInputs = [
+  buildInputs = [ libsodium ];
+  propagatedBuildInputs = [
     curl
-    zeromq
     czmq
-    libsodium
+    zeromq
   ];
-
-  env.NIX_CFLAGS_COMPILE = toString (
-    [
-      # https://github.com/kevinkreiser/prime_server/issues/95
-      "-Wno-error=unused-variable"
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      # logging.hpp calls sprintf, which the macOS SDK marks deprecated. The
-      # build uses -Werror, so the deprecation stops it.
-      "-Wno-error=deprecated-declarations"
-    ]
-  );
 
   meta = {
     description = "Non-blocking (web)server API for distributed computing and SOA based on zeromq";


### PR DESCRIPTION
https://github.com/kevinkreiser/prime_server/issues/95 was fixed in the meantime

https://github.com/kevinkreiser/prime_server/compare/0.7.0...0.13.1

Bumping this also fixes an issue with building this on recent darwin versions: https://github.com/kevinkreiser/prime_server/issues/130

Thus required for allowing valhalla to run on darwin

I also took the liberty to add myself as maintainer
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
