### PR TITLE
nixos/*: Fix some pkgs.systemd references

### DIFF
--- a/nixos/modules/services/networking/ifstate.nix
+++ b/nixos/modules/services/networking/ifstate.nix
@@ -87,12 +87,6 @@ let
       "network.target"
     ];
 
-    # We wait for the udev events queue to empty in the *hope* that the
-    # devices needed here become available. This is terribly broken and
-    # essentially no better than a random sleep().
-    # FIXME: use .device units dependecies instead.
-    serviceConfig.ExecStartPre = "-${lib.getExe' pkgs.systemd "udevadm"} settle --timeout=180";
-
     unitConfig = {
       # Avoid default dependencies like "basic.target", which prevents ifstate from starting before luks is unlocked.
       DefaultDependencies = "no";
@@ -193,6 +187,13 @@ in
           ExecStart = "${lib.getExe cfg.package} --config ${
             config.environment.etc."ifstate/ifstate.yaml".source
           } apply";
+
+          # We wait for the udev events queue to empty in the *hope* that the
+          # devices needed here become available. This is terribly broken and
+          # essentially no better than a random sleep(). Same below for initrd.
+          # FIXME: use .device units dependecies instead.
+          ExecStartPre = "-${lib.getExe' config.systemd.package "udevadm"} settle --timeout=180";
+
           # because oneshot services do not have a timeout by default
           TimeoutStartSec = "2min";
         };
@@ -294,6 +295,8 @@ in
               } apply";
               # because oneshot services do not have a timeout by default
               TimeoutStartSec = "2min";
+              # See comment on non-initrd service above
+              ExecStartPre = "-${lib.getExe' config.boot.initrd.systemd.package "udevadm"} settle --timeout=180";
             };
           };
         };

--- a/nixos/tests/predictable-interface-names.nix
+++ b/nixos/tests/predictable-interface-names.nix
@@ -43,10 +43,15 @@ pkgs.lib.listToAttrs (
         meta = { };
 
         nodes.machine =
-          { pkgs, lib, ... }:
+          {
+            config,
+            pkgs,
+            lib,
+            ...
+          }:
           let
             script = ''
-              ${lib.getExe' pkgs.systemd "udevadm"} settle --timeout=180
+              ${lib.getExe' config.boot.initrd.systemd.package "udevadm"} settle --timeout=180
               ip link
               if ${lib.optionalString predictable "!"} ip link show eth0; then
                 echo Success


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

pkgs.systemd does not respect config.systemd.package and config.boot.initrd.systemd.package overrides. Fix references to the systemd package to ensure that the udevadm used is copied into the initrd.

Fixes `nixosTests.predictable-interface-names` (https://github.com/NixOS/nixpkgs/pull/547195#issuecomment-5142087959) Also `nixosTests.ifstate.initrd` no longer complains about udevadm missing.

I also went through all instances of `pkgs.systemd` in `nixos/` and I'll post a comment below listing what I found

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests]. (`nixosTests.predictable-interface-names.*`, `nixosTests.ifstate.*`)
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
