### PR TITLE
tuxbox: 3.1.6 -> 3.2.0

### DIFF
--- a/pkgs/by-name/tu/tuxbox/package.nix
+++ b/pkgs/by-name/tu/tuxbox/package.nix
@@ -5,14 +5,14 @@
 }:
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "tuxbox";
-  version = "3.1.6";
+  version = "3.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "AndyCappDev";
     repo = "tuxbox";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-BZUo02q2szaxnJYx8UvYvfCErJX4KFzToCvZLuBRJKQ=";
+    hash = "sha256-ZPfZ/0UtwZp0HdDc99EZx+Z0drmk0yPx1taoIXcHP+g=";
   };
 
   build-system = [ python3Packages.setuptools ];
@@ -36,6 +36,12 @@ python3Packages.buildPythonApplication (finalAttrs: {
     mkdir -p $out/lib/udev/rules.d/
     echo 'KERNEL=="uinput", MODE="0660", GROUP="input", OPTIONS+="static_node=uinput"' > $out/lib/udev/rules.d/99-tuxbox-uinput.rules
     chmod 0744 $out/lib/udev/rules.d/99-tuxbox-uinput.rules
+
+    # Keep ModemManager off the TourBox serial port
+    cat > $out/lib/udev/rules.d/99-tuxbox-modemmanager.rules <<'EOF'
+    SUBSYSTEM=="tty", ATTRS{idVendor}=="c251", ATTRS{idProduct}=="2005", ENV{ID_MM_DEVICE_IGNORE}="1"
+    SUBSYSTEM=="tty", ATTRS{idVendor}=="2e3c", ATTRS{idProduct}=="5740", ENV{ID_MM_DEVICE_IGNORE}="1"
+    EOF
   '';
 
   meta = {


### PR DESCRIPTION
Upstream changelog: https://github.com/AndyCappDev/tuxbox/compare/v3.1.6...v3.2.0

Adds a second udev rule (`99-tuxbox-modemmanager.rules`) requested by
upstream in #546943, which stops ModemManager from probing the TourBox's
CDC-ACM serial port. Without it, affected users hit a disconnect/reconnect
loop (see AndyCappDev/tuxbox#53 for the original report on hardware).

Probably fixes: #546943

I can't fully verify the ModemManager fix, since I built and tested this
under NixOS-WSL, which doesn't have a real udev daemon or the physical
USB device attached. The build itself succeeds and both udev rule files
end up in `$out/lib/udev/rules.d/` as expected.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test