### PR TITLE
 fluent-gtk-theme: revert & remove GTK2 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27284,6 +27284,12 @@
     githubId = 285829;
     keys = [ { fingerprint = "09BE 3BAE 8D55 D4CD 8579  285A 9675 EAC3 4897 E6E2"; } ];
   };
+  stzx = {
+    name = "Stzx";
+    github = "Stzx";
+    githubId = 19950702;
+    email = "silence.m@hotmail.com";
+  };
   SubhrajyotiSen = {
     email = "subhrajyoti12@gmail.com";
     github = "SubhrajyotiSen";

--- a/pkgs/by-name/fl/fluent-gtk-theme/package.nix
+++ b/pkgs/by-name/fl/fluent-gtk-theme/package.nix
@@ -1,0 +1,111 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  gitUpdater,
+  gtk-engine-murrine,
+  jdupes,
+  sassc,
+  themeVariants ? [ ], # default: blue
+  colorVariants ? [ ], # default: all
+  sizeVariants ? [ ], # default: standard
+  tweaks ? [ ],
+}:
+
+let
+  pname = "fluent-gtk-theme";
+in
+lib.checkListOfEnum "${pname}: theme variants"
+  [
+    "default"
+    "purple"
+    "pink"
+    "red"
+    "orange"
+    "yellow"
+    "green"
+    "teal"
+    "grey"
+    "all"
+  ]
+  themeVariants
+  lib.checkListOfEnum
+  "${pname}: color variants"
+  [
+    "standard"
+    "light"
+    "dark"
+  ]
+  colorVariants
+  lib.checkListOfEnum
+  "${pname}: size variants"
+  [
+    "standard"
+    "compact"
+  ]
+  sizeVariants
+  lib.checkListOfEnum
+  "${pname}: tweaks"
+  [
+    "solid"
+    "float"
+    "round"
+    "blur"
+    "noborder"
+    "square"
+  ]
+  tweaks
+
+  stdenvNoCC.mkDerivation
+  (finalAttrs: {
+    inherit pname;
+    version = "2025-04-17";
+
+    src = fetchFromGitHub {
+      owner = "vinceliuice";
+      repo = "fluent-gtk-theme";
+      rev = finalAttrs.version;
+      hash = "sha256-AaFj9lG9lWg0a0ksJ0ufoUpsunR3uDhcdb7oSrvAmPI=";
+    };
+
+    nativeBuildInputs = [
+      jdupes
+      sassc
+    ];
+
+    propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+    postPatch = ''
+      patchShebangs install.sh
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      name= HOME="$TMPDIR" ./install.sh \
+        ${lib.optionalString (themeVariants != [ ]) "--theme " + toString themeVariants} \
+        ${lib.optionalString (colorVariants != [ ]) "--color " + toString colorVariants} \
+        ${lib.optionalString (sizeVariants != [ ]) "--size " + toString sizeVariants} \
+        ${lib.optionalString (tweaks != [ ]) "--tweaks " + toString tweaks} \
+        --icon nixos \
+        --dest $out/share/themes
+
+      jdupes --quiet --link-soft --recurse $out/share
+
+      runHook postInstall
+    '';
+
+    passthru.updateScript = gitUpdater { };
+
+    meta = {
+      description = "Fluent design gtk theme";
+      changelog = "https://github.com/vinceliuice/Fluent-gtk-theme/releases/tag/${finalAttrs.version}";
+      homepage = "https://github.com/vinceliuice/Fluent-gtk-theme";
+      license = lib.licenses.gpl3Only;
+      platforms = lib.platforms.unix;
+      maintainers = with lib.maintainers; [
+        luftmensch-luftmensch
+        romildo
+      ];
+    };
+  })

--- a/pkgs/by-name/fl/fluent-gtk-theme/package.nix
+++ b/pkgs/by-name/fl/fluent-gtk-theme/package.nix
@@ -105,6 +105,7 @@ lib.checkListOfEnum "${pname}: theme variants"
       maintainers = with lib.maintainers; [
         luftmensch-luftmensch
         romildo
+        stzx
       ];
     };
   })

--- a/pkgs/by-name/fl/fluent-gtk-theme/package.nix
+++ b/pkgs/by-name/fl/fluent-gtk-theme/package.nix
@@ -3,7 +3,6 @@
   stdenvNoCC,
   fetchFromGitHub,
   gitUpdater,
-  gtk-engine-murrine,
   jdupes,
   sassc,
   themeVariants ? [ ], # default: blue
@@ -73,10 +72,10 @@ lib.checkListOfEnum "${pname}: theme variants"
       sassc
     ];
 
-    propagatedUserEnvPkgs = [ gtk-engine-murrine ];
-
     postPatch = ''
       patchShebangs install.sh
+
+      sed -i '/"$THEME_DIR\/gtk-2.0/d' install.sh
     '';
 
     installPhase = ''

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -836,7 +836,6 @@ mapAliases {
   fltk13-minimal = warnAlias "'fltk13-minimal' has been renamed to 'fltk_1_3-minimal'" fltk_1_3-minimal; # Added 2026-01-14
   fltk14 = warnAlias "'fltk14' has been renamed to 'fltk_1_4'" fltk_1_4; # Added 2026-01-14
   fltk14-minimal = warnAlias "'fltk14-minimal' has been renamed to 'fltk_1_4-minimal'" fltk_1_4-minimal; # Added 2026-01-14
-  fluent-gtk-theme = throw "'fluent-gtk-theme' has been removed because it depended on 'gtk-engine-murrine', which was removed because it was unmaintained upstream and depended on GTK 2."; # Added 2026-07-22
   flut-renamer = throw "flut-renamer is unmaintained and has been removed"; # Added 2025-08-26
   flutter324 = throw "flutter324 has been removed because it isn't updated anymore, and no packages in nixpkgs use it. If you still need it, use flutter.mkFlutter to get a custom version"; # Added 2025-10-28
   flutter326 = throw "flutter326 has been removed because it isn't updated anymore, and no packages in nixpkgs use it. If you still need it, use flutter.mkFlutter to get a custom version"; # Added 2025-06-08


### PR DESCRIPTION
Revert the changes to `fluent-gtk-theme` made in #544598.

The theme can work properly on `GTK3/4` without `gtk-engine-murrine`.

Drop unneeded GTK2 files.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
