### PR TITLE
stdenv: disallow passing a custom config

### DIFF
--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -19,11 +19,11 @@
     else
       throw "Unsupported platform for the Darwin stdenv"
   ),
+  genericStdenv,
 }:
 
 let
   inherit (localSystem) system;
-  genericStdenv = import ../generic { defaultConfig = config; };
 
   llvmVersion = "21"; # This needs to be updated when the default LLVM version is changed.
   sdkMajorVersion = lib.versions.major localSystem.darwinSdkVersion;

--- a/pkgs/stdenv/default.nix
+++ b/pkgs/stdenv/default.nix
@@ -24,6 +24,7 @@ let
   # custom stage; cross compilation uses replaceCrossStdenv instead.
   bootArgs = {
     inherit lib localSystem overlays;
+    genericStdenv = import ./generic { inherit config; };
     config =
       if useCrossStdenv || useCustomStdenv then removeAttrs config [ "replaceStdenv" ] else config;
   };

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -15,12 +15,12 @@
           or (throw "unsupported platform ${localSystem.system} for the pure FreeBSD stdenv");
     in
     files,
+  genericStdenv,
 }:
 
 let
-  genericStdenv = import ../generic { defaultConfig = config; };
-
   inherit (localSystem) system;
+
   mkExtraBuildCommands0 = cc: ''
     rsrc="$out/resource-root"
     mkdir "$rsrc"

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -1,19 +1,14 @@
 {
-  defaultConfig ? null,
-}@args:
+  config,
+}:
 let
   lib = import ../../../lib;
 
-  # By taking defaultConfig early, we can cache the result of calling
-  # make-derivation.nix with config, which leads to more memoisation between
-  # bootstrapping stages. We only have to re-call the file with another config
-  # if stdenv-overridable is actually called with config, otherwise we stick to
-  # defaultConfig. No stdenvs currently specify a non-default config, but we
-  # leave it open as a possibility.
-  makeDerivationFile = import ./make-derivation.nix lib;
-  makeDerivationFileWithConfig =
-    assert args ? defaultConfig;
-    makeDerivationFile args.defaultConfig;
+  # By taking `lib` and `config` early, we can cache the result of calling
+  # make-derivation.nix with them. This leads to more memoisation between
+  # bootstrapping stages. We still need to call with the current `stdenv` on
+  # each stage, but that's less important, as we've already cached what matters.
+  makeDerivationFile = import ./make-derivation.nix lib config;
 
   defaultNativeBuildInputs0 = [
     ../../build-support/setup-hooks/no-broken-symlinks.sh
@@ -53,7 +48,6 @@ let
       allowedRequisites ? null,
       extraAttrs ? { },
       overrides ? (self: super: { }),
-      config ? args.defaultConfig,
       disallowedRequisites ? [ ],
 
       # The `fetchurl' to use for downloading curl and its dependencies
@@ -95,12 +89,7 @@ let
 
       # The implementation of `mkDerivation`, parameterized with the final stdenv so we can tie the knot.
       # This is convenient to have as a parameter so the stdenv "adapters" work better
-      mkDerivationFromStdenv ?
-        let
-          makeDerivationWithConfig' =
-            if argsStdenv ? config then makeDerivationFile config else makeDerivationFileWithConfig;
-        in
-        stdenv: (makeDerivationWithConfig' stdenv).mkDerivation,
+      mkDerivationFromStdenv ? stdenv: (makeDerivationFile stdenv).mkDerivation,
     }:
 
     let

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -6,7 +6,9 @@
 #
 # See https://github.com/NixOS/nixpkgs/pull/430969 for measurements.
 
-lib:
+# These are passed early before the boot stages are run, so we get as much ready
+# as possible with them alone
+lib: config:
 let
   # Lib attributes are inherited to the lexical scope for performance reasons.
   inherit (lib)
@@ -182,9 +184,7 @@ let
       ${if (attrs ? allowedRequisites) then "allowedRequisites" else null} =
         mapNullable unsafeDerivationToUntrackedOutpath attrs.allowedRequisites;
     };
-in
-config:
-let
+
   doCheckByDefault = config.doCheckByDefault or false;
   structuredAttrsByDefault = config.structuredAttrsByDefault or false;
   inherit (config) enableParallelBuildingByDefault contentAddressedByDefault;
@@ -193,8 +193,9 @@ let
     inherit lib config;
   };
 in
+# This is passed on every stage, for frustrating splicing reasons (see #547754).
+# Anything that doesn't need stdenv should come before this to memoise properly
 stdenv:
-
 let
   inherit (import ../../build-support/lib/cmake.nix { inherit lib stdenv; }) makeCMakeFlags;
   inherit (import ../../build-support/lib/meson.nix { inherit lib stdenv; }) makeMesonFlags;

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -113,11 +113,10 @@
         );
     in
     (config.replaceBootstrapFiles or lib.id) files,
+  genericStdenv,
 }:
 
 let
-  genericStdenv = import ../generic { defaultConfig = config; };
-
   inherit (localSystem) system;
 
   isFromNixpkgs = pkg: !(isFromBootstrapFiles pkg);

--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -3,11 +3,10 @@
   localSystem,
   config,
   overlays,
+  genericStdenv,
 }:
 
 let
-  genericStdenv = import ../generic { defaultConfig = config; };
-
   inherit (localSystem) system;
 
   shell =

--- a/pkgs/stdenv/nix/default.nix
+++ b/pkgs/stdenv/nix/default.nix
@@ -4,11 +4,9 @@
   config,
   overlays,
   bootStages,
+  genericStdenv,
 }:
 
-let
-  genericStdenv = import ../generic { defaultConfig = config; };
-in
 bootStages
 ++ [
   (prevStage: {


### PR DESCRIPTION
First, a little writeup. I now understand why everyone hates splicing.

Stdenv stages are annoying. Each stage wants to call `mkDerivation`, but to do that, they need to pass stdenv. And `stdenv` keeps changing on every stage. So on each stage, `make-derivation.nix` gets re-called with the _new_`stdenv`.

Now, fun fact, this is _almost_ unnecessary. Almost everything `make-derivation.nix` uses from `stdenv` remains constant between stages. Except two exceptions.

## Logic with `cc`

`cc` is used in `make-derivation.nix` as such:
```nix
# most logic is omitted here, only the relevant values are pasted in
let
  defaultHardeningFlags = stdenv.cc.defaultHardeningFlags or knownHardeningFlags;
  hostSuffixNecessary = hostPlatform != buildPlatform && stdenv.hasCC;
in
  # a bunch of logic later, we use hostSuffixNecessary here:
  hostSuffix = optionalString (
    hostSuffixNecessary
    && (
      !(attrs ? outputHash)
      ||
        depsBuildTarget == [ ]
        && depsBuildTargetPropagated == [ ]
        && depsHostHost == [ ]
        && depsHostHostPropagated == [ ]
        && buildInputs == [ ]
        && propagatedBuildInputs == [ ]
        && depsTargetTarget == [ ]
        && depsTargetTargetPropagated == [ ]

    )
  ) stdenvHostSuffix;

  # and we use defaultHardeningFlags here
 ${
      if (hardeningDisable != [ ] || hardeningEnable != [ ] || isMusl) then
        "NIX_HARDENING_ENABLE"
      else
        null
  } =
    concatStringsSep " " (
      if elem "all" hardeningDisable then
        [ ]
      else
        filter (
          flag:
          !(elem flag hardeningDisable)
          # disabling fortify implies fortify3 should also be disabled
          && (flag == "fortify3" -> !elem "fortify" hardeningDisable)
          # disabling strictflexarrays1 implies strictflexarrays3 should also be disabled
          && (flag == "strictflexarrays3" -> !elem "strictflexarrays1" hardeningDisable)
          # disabling libcxxhardeningfast implies libcxxhardeningextensive should also be disabled
          && (flag == "libcxxhardeningextensive" -> !elem "libcxxhardeningfast" hardeningDisable)
        ) (defaultHardeningFlags ++ hardeningEnable)
    );
```
Now, it's unclear to me why we don't suffix with the host if `stdenv.hasCC = false` - so we could hypothetically remove that, but it doesn't matter to me much.

The `defaultHardeningFlags` is more annoying. In the platform stages I've looked at, `cc` will be null for the first few stages, so `stdenv ? cc.defaultHardeningFlags` will be false, and we fall back to `knownHardeningFlags`. Once it stops being null, we get a different set of hardening flags than the known ones - and the hardening flags even seem to be appended to inside one of our `pkgsCross` variants. So, it looks hard to avoid this - but I don't think `setup.sh` even uses `NIX_HARDENING_ENABLE`. `bintools-wrapper` seems to concatenate with the `NIX_HARDENING_ENABLE` list, but I don't get why it doesn't own the hardening logic. I'd love it to be out of `mkDerivation`, as it's very slow on eval time.

So, if we wanted to, these do appear avoidable. I don't really care about the `hasCC` usage, but getting rid of hardening flags would be a dream come true.

But I said there were two exceptions. What's the other one?

## Splicing, splicing, I hate splicing
A bunch of `mkDerivation` behavior relies on `buildPlatform`, and it potentially being different from `hostPlatform`. I'm very unfamiliar with this logic, so the docs are helpful for me:

> Now, for most of Nixpkgs's history, there were no `pkgs<theirHost><theirTarget>` attributes, and most packages have not been refactored to use it explicitly. Prior to those, there were just `buildPackages`, `pkgs`, and `targetPackages`. Those are now redefined as aliases to `pkgsBuildHost`, `pkgsHostTarget`, and `pkgsTargetTarget`. It is acceptable, even recommended, to use them to show that only their host platform matters. That is, use `buildPackages` where any of `pkgsBuild*` would do, and `targetPackages` when any of `pkgsTarget*` would do (if we had more than just `pkgsTargetTarget`).
> 
> But before that, there was just `pkgs`, even though both `buildInputs` and `nativeBuildInputs` existed. (Cross barely worked, and those were implemented with some hacks on `mkDerivation` to override dependencies.) What this means is the vast majority of packages do not use any explicit package set to populate their dependencies, just using whatever `callPackage` gives them even if they do correctly sort their dependencies into the multiple lists described above. And indeed, asking that users both sort their dependencies, _and_ take them from the right attribute set, is both too onerous and redundant, so the recommended approach (for now) is to continue just categorizing by list and not using an explicit package set.
> 
> To make this work, we "splice" together the six `pkgs<theirHost><theirTarget>` package sets and have `callPackage` actually take its arguments from that. This is currently implemented in `pkgs/top-level/splice.nix`. `mkDerivation` then, for each dependency attribute, pulls the right derivation out from the splice. This splicing can be skipped when not cross-compiling as the package sets are the same, but still is a bit slow for cross-compiling. We'd like to do something better, but haven't come up with anything yet.

I don't think I can fix splicing (or more accurately, I don't want to put myself through attempting to fix it). It seems a little stupid to me that we define this logic inside `make-derivation.nix`, instead of having cross own this logic. Cross already has a way to do this kind of thing via `overrideMkDerivationArgs` in `stdenv/adapters.nix`. But sure. Fine. It's not _that_ big a deal that `make-derivation.nix` is called multiple times on different stages. Why? Well, it _used_ to be a meaningful problem, but I fixed it!

## How we currently cache (as best as possible)

In my work on `check-meta` and `meta.problems`, I noticed that our cache was being recomputed multiple times. The meta logic attempts to precompute a lot of its logic based on the value of `config`. For example, checks for broken packages are done as such:
```nix
  condition =
    config:
    let
      allowBroken = config.allowBroken || builtins.getEnv "NIXPKGS_ALLOW_BROKEN" == "1";
      allowBrokenPredicate = config.allowBrokenPredicate;
    in
    if allowBroken then
      attrs: false
    else if config ? allowBrokenPredicate then
      attrs: attrs ? meta.broken && attrs.meta.broken && !allowBrokenPredicate attrs
    else
      attrs: attrs ? meta.broken && attrs.meta.broken;
```
Since this condition is called with `config` early on, if `allowBroken = true`, we can immediately return false on every package, and avoid doing extra work.

However, when I added some trace statements, the cache was being created multiple times. This was because of the stdenv stages. Each stage would reimport `make-derivation.nix`, which would then reimport `check-meta.nix` and `problems.nix`. I fixed this in #525312 using partial application. Whereas before we did:
```nix
# make-derivation.nix
{ lib, config, stdenv }:
let
  checkMeta = import ./check-meta.nix { inherit lib config; };
  mkDerivation = ...;
in
mkDerivation
```
We now do:
```nix
lib:
let
  # attributes that only need `lib`
in
config:
iet
  # attributes that only need `lib` and `config`
  checkMeta = import ./check-meta.nix { inherit lib config; };
in
stdenv:
let
  # attributes that need stdenv as well
  mkDerivation = ...;
in
mkDerivation
```
We pass `lib` and `config` early, because they're expected to remain the same. This means our caches only get created once, and only the few attributes that _do_ need stdenv need to be recomputed. This is why it's not really a big deal that `make-derivation.nix` is re-called with different stdenvs - all the important caches are being partially applied already.

## What this PR does

Yes, we've finally finished giving an unreasonable amount of context, and have arrived at a description of the changes.

Previously, `stdenv/generic/default.nix` supported overriding the `config` attrset. If a set of stages did this, we would have to re-call `make-derivation.nix`. But since nobody ever did, we wanted to still cache the `config` application. This was done in a very gross way: 
```nix
{
  defaultConfig ? null,
}@args:
let
  makeDerivationFile = import ./make-derivation.nix lib;
  makeDerivationFileWithConfig =
    assert args ? defaultConfig;
    makeDerivationFile args.defaultConfig;
```
We would use the `makeDerivationFileWithConfig` only if `config` wasn't overridden. This was done to preserve existing behavior, since I wanted that PR to be a performance-only change.

With this PR, `config` remains the same between stages, and a more simple partial application is performed.
```nix
{ config }:
let
  makeDerivationFile = import ./make-derivation.nix lib config;
```
I don't see a good reason for a platform to ever override config in one of its stages. Cross comes close to changing it, but it actually performs a reimport of `stdenv/default.nix` with a new `config`, and the value it _does_ change doesn't affect `mkDerivation` anyways.

To be clear, this isn't a performance win - just a cleanup.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
