### PR TITLE
python3Packages.groestlcoin-hash: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/groestlcoin-hash/default.nix
+++ b/pkgs/development/python-modules/groestlcoin-hash/default.nix
@@ -5,15 +5,17 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "groestlcoin-hash";
   version = "1.0.3";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
     pname = "groestlcoin_hash";
-    inherit version;
-    sha256 = "31a8f6fa4c19db5258c3c73c071b71702102c815ba862b6015d9e4b75ece231e";
+    inherit (finalAttrs) version;
+    hash = "sha256-Maj2+kwZ21JYw8c8BxtxcCECyBW6hitgFdnkt17OIx4=";
   };
 
   build-system = [ setuptools ];
@@ -26,4 +28,4 @@ buildPythonPackage rec {
     maintainers = with lib.maintainers; [ gruve-p ];
     license = lib.licenses.mit;
   };
-}
+})

--- a/pkgs/development/python-modules/groestlcoin-hash/default.nix
+++ b/pkgs/development/python-modules/groestlcoin-hash/default.nix
@@ -2,18 +2,21 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "groestlcoin-hash";
   version = "1.0.3";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     pname = "groestlcoin_hash";
     inherit version;
     sha256 = "31a8f6fa4c19db5258c3c73c071b71702102c815ba862b6015d9e4b75ece231e";
   };
+
+  build-system = [ setuptools ];
 
   pythonImportsCheck = [ "groestlcoin_hash" ];
 

--- a/pkgs/development/python-modules/groestlcoin-hash/default.nix
+++ b/pkgs/development/python-modules/groestlcoin-hash/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage (finalAttrs: {
 
   meta = {
     description = "Bindings for groestl key derivation function library used in Groestlcoin";
-    homepage = "https://pypi.org/project/groestlcoin_hash/";
+    homepage = "https://github.com/Groestlcoin/groestlcoin-hash-python";
     maintainers = with lib.maintainers; [ gruve-p ];
     license = lib.licenses.mit;
   };


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
