### PR TITLE
python3Packages.grpcio-status: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/grpcio-status/default.nix
+++ b/pkgs/development/python-modules/grpcio-status/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   googleapis-common-protos,
   grpcio,
   protobuf,
@@ -13,7 +14,7 @@
 buildPythonPackage rec {
   pname = "grpcio-status";
   version = "1.83.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     pname = "grpcio_status";
@@ -26,7 +27,9 @@ buildPythonPackage rec {
       --replace 'protobuf>=4.21.6' 'protobuf'
   '';
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     googleapis-common-protos
     grpcio
     protobuf

--- a/pkgs/development/python-modules/grpcio-status/default.nix
+++ b/pkgs/development/python-modules/grpcio-status/default.nix
@@ -24,11 +24,6 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-g3IZxt6a/cy29vcrNLxx4VGiAR7wQEDj+qynRqV+VK4=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace-warn 'protobuf>=4.21.6' 'protobuf'
-  '';
-
   build-system = [ setuptools ];
 
   dependencies = [

--- a/pkgs/development/python-modules/grpcio-status/default.nix
+++ b/pkgs/development/python-modules/grpcio-status/default.nix
@@ -11,20 +11,22 @@
 # This package should be updated together with the main grpc package and other
 # related python grpc packages.
 # nixpkgs-update: no auto update
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "grpcio-status";
   version = "1.83.0";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
     pname = "grpcio_status";
-    inherit version;
+    inherit (finalAttrs) version;
     hash = "sha256-g3IZxt6a/cy29vcrNLxx4VGiAR7wQEDj+qynRqV+VK4=";
   };
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace 'protobuf>=4.21.6' 'protobuf'
+      --replace-warn 'protobuf>=4.21.6' 'protobuf'
   '';
 
   build-system = [ setuptools ];
@@ -46,4 +48,4 @@ buildPythonPackage rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
