### PR TITLE
python3Packages.gtts-token: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/gtts-token/default.nix
+++ b/pkgs/development/python-modules/gtts-token/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
   requests,
   pytestCheckHook,
 }:
@@ -9,7 +10,7 @@
 buildPythonPackage rec {
   pname = "gtts-token";
   version = "1.1.4";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "boudewijn26";
@@ -18,7 +19,9 @@ buildPythonPackage rec {
     sha256 = "0vr52zc0jqyfvsccl67j1baims3cdx2is1y2lpx2kav9gadkn8hp";
   };
 
-  propagatedBuildInputs = [ requests ];
+  build-system = [ setuptools ];
+
+  dependencies = [ requests ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/gtts-token/default.nix
+++ b/pkgs/development/python-modules/gtts-token/default.nix
@@ -7,16 +7,18 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "gtts-token";
   version = "1.1.4";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "boudewijn26";
     repo = "gTTS-token";
-    rev = "v${version}";
-    sha256 = "0vr52zc0jqyfvsccl67j1baims3cdx2is1y2lpx2kav9gadkn8hp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-FyI7m3ppqyn6pcIHHUVvbOga1QryGMqY3s5jCdgXJW8=";
   };
 
   build-system = [ setuptools ];
@@ -28,10 +30,12 @@ buildPythonPackage rec {
   # requires internet access
   disabledTests = [ "test_real" ];
 
+  pythonImportsCheck = [ "gtts_token" ];
+
   meta = {
     description = "Calculates a token to run the Google Translate text to speech";
     homepage = "https://github.com/boudewijn26/gTTS-token";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ makefu ];
   };
-}
+})

--- a/pkgs/development/python-modules/gtts-token/default.nix
+++ b/pkgs/development/python-modules/gtts-token/default.nix
@@ -35,6 +35,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Calculates a token to run the Google Translate text to speech";
     homepage = "https://github.com/boudewijn26/gTTS-token";
+    changelog = "https://github.com/Boudewijn26/gTTS-token/blob/${finalAttrs.src.tag}/CHANGES.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ makefu ];
   };


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
