### PR TITLE
python3Packages.three-merge: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/three-merge/default.nix
+++ b/pkgs/development/python-modules/three-merge/default.nix
@@ -2,20 +2,23 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   diff-match-patch,
 }:
 
 buildPythonPackage rec {
   pname = "three-merge";
   version = "0.1.1";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "0w6rv7rv1zm901wbjkmm6d3vkwyf3csja9p37bb60mar8khszxk0";
   };
 
-  propagatedBuildInputs = [ diff-match-patch ];
+  build-system = [ setuptools ];
+
+  dependencies = [ diff-match-patch ];
 
   pythonImportsCheck = [ "three_merge" ];
 

--- a/pkgs/development/python-modules/three-merge/default.nix
+++ b/pkgs/development/python-modules/three-merge/default.nix
@@ -6,14 +6,17 @@
   diff-match-patch,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "three-merge";
   version = "0.1.1";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "0w6rv7rv1zm901wbjkmm6d3vkwyf3csja9p37bb60mar8khszxk0";
+    pname = "three-merge";
+    inherit (finalAttrs) version;
+    hash = "sha256-YPav4URZVWDWOuMmJTUbzvO5RzO1Trl4AKn+sPPZ2XA=";
   };
 
   build-system = [ setuptools ];
@@ -28,4 +31,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/three-merge/default.nix
+++ b/pkgs/development/python-modules/three-merge/default.nix
@@ -1,9 +1,10 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   setuptools,
   diff-match-patch,
+  pytestCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -13,15 +14,19 @@ buildPythonPackage (finalAttrs: {
 
   __structuredAttrs = true;
 
-  src = fetchPypi {
-    pname = "three-merge";
-    inherit (finalAttrs) version;
-    hash = "sha256-YPav4URZVWDWOuMmJTUbzvO5RzO1Trl4AKn+sPPZ2XA=";
+  # pypi does not contain test files
+  src = fetchFromGitHub {
+    owner = "spyder-ide";
+    repo = "three-merge";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-BtWgBOSddLB7mQoc8vhGKxBBkdnvyASyrwRLA7lGgrs=";
   };
 
   build-system = [ setuptools ];
 
   dependencies = [ diff-match-patch ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "three_merge" ];
 


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
