### PR TITLE
ffmpeg: add optional support for mpeg-h decoding

### DIFF
--- a/pkgs/by-name/il/ilo/install-doc.patch
+++ b/pkgs/by-name/il/ilo/install-doc.patch
@@ -1,0 +1,35 @@
+From 6b8302213d37c84a7d4d036c733f68116d738189 Mon Sep 17 00:00:00 2001
+From: jopejoe1 <jopejoe1@missing.ninja>
+Date: Fri, 31 Jul 2026 09:39:27 +0200
+Subject: [PATCH] Install documentation
+
+This makes it so that documentation can be easly installed by distors
+---
+ doc/CMakeLists.txt | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/doc/CMakeLists.txt b/doc/CMakeLists.txt
+index a74cfd8..e886a7e 100644
+--- a/doc/CMakeLists.txt
++++ b/doc/CMakeLists.txt
+@@ -38,6 +38,20 @@ if(DOXYGEN_FOUND)
+     VERBATIM
+     DEPENDS ${PROJECT_NAME}_doc
+   )
++
++  include(GNUInstallDirs)
++
++  install(
++    DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc/html/
++    DESTINATION ${CMAKE_INSTALL_DOCDIR}
++    OPTIONAL
++  )
++
++  install(
++    FILES ${CMAKE_CURRENT_BINARY_DIR}/doc/latex/refman.pdf
++    DESTINATION ${CMAKE_INSTALL_DOCDIR}
++    OPTIONAL
++  )
+ else()
+   message("Doxygen need to be installed to generate the doxygen documentation")
+ endif()

--- a/pkgs/by-name/il/ilo/package.nix
+++ b/pkgs/by-name/il/ilo/package.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  testers,
+  gitUpdater,
+  doxygen,
+  texliveBasic,
+  writableTmpDirAsHomeHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ilo";
+  version = "2.0.2";
+
+  src = fetchFromGitHub {
+    owner = "Fraunhofer-IIS";
+    repo = "ilo";
+    tag = "r${finalAttrs.version}";
+    hash = "sha256-az7fnZG8js+vGVtECcwcHu2JuvME1vJoQlKbkAwgO9w=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  patches = [
+    # https://github.com/Fraunhofer-IIS/ilo/pull/2
+    ./pkg-config.patch
+    # https://github.com/Fraunhofer-IIS/ilo/pull/1
+    ./install-doc.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    doxygen
+    writableTmpDirAsHomeHook
+    (texliveBasic.withPackages (ps: [
+      ps.float
+      ps.varwidth
+      ps.xcolor
+      ps.xltabular
+      ps.ltablex
+      ps.tabularray
+      ps.ninecolors
+      ps.fancyvrb
+      ps.multirow
+      ps.hanging
+      ps.adjustbox
+      ps.stackengine
+      ps.enumitem
+      ps.alphalph
+      ps.ulem
+      ps.wasysym
+      ps.changepage
+      ps.tocloft
+      ps.newunicodechar
+      ps.caption
+      ps.etoc
+      ps.helvetic
+      ps.wasy
+      ps.courier
+    ]))
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "ilo_BUILD_DOC" true)
+  ];
+
+  outputs = [
+    "out"
+    "dev"
+    "doc"
+  ];
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    updateScript = gitUpdater { rev-prefix = "r"; };
+  };
+
+  meta = {
+    description = "Collection of helpful datatypes and algorithms for MPEG-H software";
+    homepage = "https://github.com/Fraunhofer-IIS/ilo";
+    license = lib.licenses.fraunhofer-fdk;
+    maintainers = [ lib.maintainers.jopejoe1 ];
+    pkgConfigModules = [ "ilo" ];
+  };
+})

--- a/pkgs/by-name/il/ilo/pkg-config.patch
+++ b/pkgs/by-name/il/ilo/pkg-config.patch
@@ -1,0 +1,23 @@
+From 13d48426fbcfc94e7e87f3127d925abc37307a63 Mon Sep 17 00:00:00 2001
+From: jopejoe1 <jopejoe1@missing.ninja>
+Date: Fri, 31 Jul 2026 09:03:17 +0200
+Subject: [PATCH] fix pkgconfig generation when install dirs are absolute paths
+
+This makes the .pc files work correctly on destibutions like NixOS and GUIX
+---
+ ilo.pc.in | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/ilo.pc.in b/ilo.pc.in
+index 752c038..4c0f4ee 100644
+--- a/ilo.pc.in
++++ b/ilo.pc.in
+@@ -1,6 +1,6 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
++includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+ 
+ Name: @PROJECT_NAME@
+ Description: @PROJECT_DESCRIPTION@

--- a/pkgs/by-name/mm/mmtisobmff/demo.patch
+++ b/pkgs/by-name/mm/mmtisobmff/demo.patch
@@ -1,0 +1,109 @@
+From 226e5da303449d034957621573eecaa1c9fca267 Mon Sep 17 00:00:00 2001
+From: jopejoe1 <jopejoe1@missing.ninja>
+Date: Fri, 31 Jul 2026 10:57:47 +0200
+Subject: [PATCH] install demo bins
+
+---
+ demo/CMakeLists.txt | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/demo/CMakeLists.txt b/demo/CMakeLists.txt
+index 38ab146..8e6632f 100644
+--- a/demo/CMakeLists.txt
++++ b/demo/CMakeLists.txt
+@@ -16,6 +16,7 @@ add_executable(printMP4 print_mp4_boxes.cpp)
+ target_link_libraries(printMP4 mmtisobmff)
+ target_compile_features(printMP4 PUBLIC cxx_std_11)
+ set_target_properties(printMP4 PROPERTIES CXX_EXTENSIONS OFF)
++install(TARGETS printMP4 RUNTIME)
+ 
+ if (EMSCRIPTEN)
+   target_link_options(printMP4 PUBLIC ${emscriptenLinkOptions})
+@@ -27,6 +28,7 @@ add_executable(simpleFileReader simple_file_reader.cpp)
+ target_link_libraries(simpleFileReader mmtisobmff)
+ target_compile_features(simpleFileReader PUBLIC cxx_std_11)
+ set_target_properties(simpleFileReader PROPERTIES CXX_EXTENSIONS OFF)
++install(TARGETS simpleFileReader RUNTIME)
+ 
+ if (EMSCRIPTEN)
+   target_link_options(simpleFileReader PUBLIC ${emscriptenLinkOptions})
+@@ -38,6 +40,7 @@ add_executable(advancedFileReader advanced_file_reader.cpp)
+ target_link_libraries(advancedFileReader mmtisobmff)
+ target_compile_features(advancedFileReader PUBLIC cxx_std_11)
+ set_target_properties(advancedFileReader PROPERTIES CXX_EXTENSIONS OFF)
++install(TARGETS advancedFileReader RUNTIME)
+ 
+ if (EMSCRIPTEN)
+   target_link_options(advancedFileReader PUBLIC ${emscriptenLinkOptions})
+@@ -49,6 +52,7 @@ add_executable(simpleFileReader_c simple_file_reader_c.c)
+ target_link_libraries(simpleFileReader_c mmtisobmff_c)
+ target_compile_features(simpleFileReader_c PUBLIC cxx_std_11)
+ set_target_properties(simpleFileReader_c PROPERTIES CXX_EXTENSIONS OFF)
++install(TARGETS simpleFileReader_c RUNTIME)
+ 
+ if (EMSCRIPTEN)
+   target_link_options(simpleFileReader_c PUBLIC ${emscriptenLinkOptions})
+@@ -60,6 +64,7 @@ add_executable(simpleMemoryReader_c simple_memory_reader_c.c)
+ target_link_libraries(simpleMemoryReader_c mmtisobmff_c)
+ target_compile_features(simpleMemoryReader_c PUBLIC cxx_std_11)
+ set_target_properties(simpleMemoryReader_c PROPERTIES CXX_EXTENSIONS OFF)
++install(TARGETS simpleMemoryReader_c RUNTIME)
+ 
+ if (EMSCRIPTEN)
+   target_link_options(simpleMemoryReader_c PUBLIC ${emscriptenLinkOptions})
+@@ -71,6 +76,7 @@ add_executable(seekingAndTimestampsApiDemo seeking_and_timestamps_api_demo.cpp)
+ target_link_libraries(seekingAndTimestampsApiDemo mmtisobmff)
+ target_compile_features(seekingAndTimestampsApiDemo PUBLIC cxx_std_11)
+ set_target_properties(seekingAndTimestampsApiDemo PROPERTIES CXX_EXTENSIONS OFF)
++install(TARGETS seekingAndTimestampsApiDemo RUNTIME)
+ 
+ if (EMSCRIPTEN)
+   target_link_options(seekingAndTimestampsApiDemo PUBLIC ${emscriptenLinkOptions})
+@@ -82,6 +88,7 @@ add_executable(mp4Defragment mp4_defragment.cpp)
+ target_link_libraries(mp4Defragment mmtisobmff)
+ target_compile_features(mp4Defragment PUBLIC cxx_std_11)
+ set_target_properties(mp4Defragment PROPERTIES CXX_EXTENSIONS OFF)
++install(TARGETS mp4Defragment RUNTIME)
+ 
+ if (EMSCRIPTEN)
+   target_link_options(mp4Defragment PUBLIC ${emscriptenLinkOptions})
+@@ -93,6 +100,7 @@ add_executable( mp4SamplesDiff mp4_samples_diff.cpp )
+ target_link_libraries( mp4SamplesDiff mmtisobmff )
+ target_compile_features(mp4SamplesDiff PUBLIC cxx_std_11)
+ set_target_properties(mp4SamplesDiff PROPERTIES CXX_EXTENSIONS OFF)
++install(TARGETS mp4SamplesDiff RUNTIME)
+ 
+ if (EMSCRIPTEN)
+   target_link_options(mp4SamplesDiff PUBLIC ${emscriptenLinkOptions})
+@@ -104,6 +112,7 @@ add_executable(mp4Combine mp4_combine.cpp)
+ target_link_libraries(mp4Combine mmtisobmff)
+ target_compile_features(mp4Combine PUBLIC cxx_std_11)
+ set_target_properties(mp4Combine PROPERTIES CXX_EXTENSIONS OFF)
++install(TARGETS mp4Combine RUNTIME)
+ 
+ if (EMSCRIPTEN)
+   target_link_options(mp4Combine PUBLIC ${emscriptenLinkOptions})
+@@ -115,6 +124,7 @@ add_executable(mp4Fragment mp4_fragment.cpp)
+ target_link_libraries(mp4Fragment mmtisobmff)
+ target_compile_features(mp4Fragment PUBLIC cxx_std_11)
+ set_target_properties(mp4Fragment PROPERTIES CXX_EXTENSIONS OFF)
++install(TARGETS mp4Fragment RUNTIME)
+ 
+ if (EMSCRIPTEN)
+   target_link_options(mp4Fragment PUBLIC ${emscriptenLinkOptions})
+@@ -126,6 +136,7 @@ add_executable(mp4Segment mp4_segment.cpp)
+ target_link_libraries(mp4Segment mmtisobmff)
+ target_compile_features(mp4Segment PUBLIC cxx_std_11)
+ set_target_properties(mp4Segment PROPERTIES CXX_EXTENSIONS OFF)
++install(TARGETS mp4Segment RUNTIME)
+ 
+ if (EMSCRIPTEN)
+   target_link_options(mp4Segment PUBLIC ${emscriptenLinkOptions})
+@@ -137,6 +148,7 @@ add_executable(simpleFileWriter simple_file_writer.cpp)
+ target_link_libraries(simpleFileWriter mmtisobmff)
+ target_compile_features(simpleFileWriter PUBLIC cxx_std_11)
+ set_target_properties(simpleFileWriter PROPERTIES CXX_EXTENSIONS OFF)
++install(TARGETS simpleFileWriter RUNTIME)
+ 
+ if (EMSCRIPTEN)
+   target_link_options(simpleFileWriter PUBLIC ${emscriptenLinkOptions})

--- a/pkgs/by-name/mm/mmtisobmff/install-doc.patch
+++ b/pkgs/by-name/mm/mmtisobmff/install-doc.patch
@@ -1,0 +1,33 @@
+From 6b8302213d37c84a7d4d036c733f68116d738189 Mon Sep 17 00:00:00 2001
+From: jopejoe1 <jopejoe1@missing.ninja>
+Date: Fri, 31 Jul 2026 09:39:27 +0200
+Subject: [PATCH] Install documentation
+
+This makes it so that documentation can be easly installed by distors
+---
+ doc/CMakeLists.txt | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/doc/CMakeLists.txt b/doc/CMakeLists.txt
+index e6c43a5277..880e6bc728 100644
+--- a/doc/CMakeLists.txt
++++ b/doc/CMakeLists.txt
+@@ -38,6 +38,18 @@
+     VERBATIM
+     DEPENDS ${PROJECT_NAME}_doc
+   )
++
++  include(GNUInstallDirs)
++
++  install(
++    DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc/html/
++    DESTINATION ${CMAKE_INSTALL_DOCDIR}
++  )
++
++  install(
++    FILES ${CMAKE_CURRENT_BINARY_DIR}/doc/latex/refman.pdf
++    DESTINATION ${CMAKE_INSTALL_DOCDIR}
++  )
+ else()
+   message("Doxygen need to be installed to generate the doxygen documentation")
+ endif()

--- a/pkgs/by-name/mm/mmtisobmff/package.nix
+++ b/pkgs/by-name/mm/mmtisobmff/package.nix
@@ -1,0 +1,100 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  testers,
+  gitUpdater,
+  doxygen,
+  pkg-config,
+  texliveBasic,
+  writableTmpDirAsHomeHook,
+  ilo,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mmtisobmff";
+  version = "1.0.4";
+
+  src = fetchFromGitHub {
+    owner = "Fraunhofer-IIS";
+    repo = "mmtisobmff";
+    tag = "r${finalAttrs.version}";
+    hash = "sha256-2W5H4GfJu2tOOWp8x1z1DJe5yJ3htc0o8nIeEdwiMd4=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  patches = [
+    # https://github.com/Fraunhofer-IIS/mmtisobmff/pull/4
+    ./pkg-config.patch
+    # https://github.com/Fraunhofer-IIS/mmtisobmff/pull/5
+    ./install-doc.patch
+    # https://github.com/Fraunhofer-IIS/mmtisobmff/pull/6
+    ./demo.patch
+  ];
+
+  buildInputs = [
+    ilo
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    doxygen
+    writableTmpDirAsHomeHook
+    (texliveBasic.withPackages (ps: [
+      ps.float
+      ps.varwidth
+      ps.xcolor
+      ps.xltabular
+      ps.ltablex
+      ps.tabularray
+      ps.ninecolors
+      ps.fancyvrb
+      ps.multirow
+      ps.hanging
+      ps.adjustbox
+      ps.stackengine
+      ps.enumitem
+      ps.alphalph
+      ps.ulem
+      ps.wasysym
+      ps.changepage
+      ps.tocloft
+      ps.newunicodechar
+      ps.caption
+      ps.etoc
+      ps.helvetic
+      ps.wasy
+      ps.courier
+    ]))
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "mmtisobmff_BUILD_BINARIES" true)
+    (lib.cmakeBool "mmtisobmff_BUILD_DOC" true)
+    (lib.cmakeBool "USE_PKGCONFIG_DEPS" true)
+  ];
+
+  outputs = [
+    "out"
+    "dev"
+    "doc"
+    "bin"
+  ];
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    updateScript = gitUpdater { rev-prefix = "r"; };
+  };
+
+  meta = {
+    description = "ISOBMFF reader and writer library with MPEG-H 3D Audio support";
+    homepage = "https://github.com/Fraunhofer-IIS/mmtisobmff";
+    license = lib.licenses.fraunhofer-fdk;
+    maintainers = [ lib.maintainers.jopejoe1 ];
+    pkgConfigModules = [ "mmtisobmff" ];
+  };
+})

--- a/pkgs/by-name/mm/mmtisobmff/pkg-config.patch
+++ b/pkgs/by-name/mm/mmtisobmff/pkg-config.patch
@@ -1,0 +1,23 @@
+From c4faec1c717fb9d2edd2c967c180c3a3f6b4c268 Mon Sep 17 00:00:00 2001
+From: jopejoe1 <jopejoe1@missing.ninja>
+Date: Fri, 31 Jul 2026 10:34:31 +0200
+Subject: [PATCH] fix pkgconfig generation when install dirs are absolute paths
+
+This makes the .pc files work correctly on destibutions like NixOS and GUIX
+---
+ mmtisobmff.pc.in | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/mmtisobmff.pc.in b/mmtisobmff.pc.in
+index 752c038..4c0f4ee 100644
+--- a/mmtisobmff.pc.in
++++ b/mmtisobmff.pc.in
+@@ -1,6 +1,6 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
++includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+ 
+ Name: @PROJECT_NAME@
+ Description: @PROJECT_DESCRIPTION@

--- a/pkgs/by-name/mp/mpeghdec/install-bin.patch
+++ b/pkgs/by-name/mp/mpeghdec/install-bin.patch
@@ -1,0 +1,18 @@
+diff --git a/demo/CMakeLists.txt b/demo/CMakeLists.txt
+index 5af09d86ae..971eee7774 100755
+--- a/demo/CMakeLists.txt
++++ b/demo/CMakeLists.txt
+@@ -20,6 +20,7 @@
+       "mpeghUiManager/mpeghUiManagerProcessor.h"
+     )
+   endif()
++  install(TARGETS mpeghDecoder RUNTIME)
+ endif()
+
+ if(${mpeghdec_BUILD_UIMANAGER})
+@@ -30,4 +31,5 @@
+     "mpeghUiManager/mpeghUiManagerProcessor.h"
+   )
+   target_link_libraries(mpeghUiManager mpeghdec mmtisobmff ilo)
++  install(TARGETS mpeghUiManager RUNTIME)
+ endif()

--- a/pkgs/by-name/mp/mpeghdec/install-doc.patch
+++ b/pkgs/by-name/mp/mpeghdec/install-doc.patch
@@ -1,0 +1,23 @@
+diff --git a/doc/CMakeLists.txt b/doc/CMakeLists.txt
+index eb60d2dc69..69d937b55f 100644
+--- a/doc/CMakeLists.txt
++++ b/doc/CMakeLists.txt
+@@ -41,6 +41,18 @@
+     VERBATIM
+     DEPENDS ${PROJECT_NAME}_doc
+   )
++
++  include(GNUInstallDirs)
++
++  install(
++    DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc/html/
++    DESTINATION ${CMAKE_INSTALL_DOCDIR}
++  )
++
++  install(
++    FILES ${CMAKE_CURRENT_BINARY_DIR}/doc/latex/refman.pdf
++    DESTINATION ${CMAKE_INSTALL_DOCDIR}
++  )
+ else()
+   message("Doxygen need to be installed to generate the doxygen documentation")
+ endif()

--- a/pkgs/by-name/mp/mpeghdec/package.nix
+++ b/pkgs/by-name/mp/mpeghdec/package.nix
@@ -1,0 +1,103 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  testers,
+  gitUpdater,
+  cmake,
+  pkg-config,
+  doxygen,
+  writableTmpDirAsHomeHook,
+  texliveBasic,
+  ilo,
+  mmtisobmff,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mpeghdec";
+  version = "4.0.1";
+
+  src = fetchFromGitHub {
+    owner = "Fraunhofer-IIS";
+    repo = "mpeghdec";
+    tag = "r${finalAttrs.version}";
+    hash = "sha256-P+xPaigy9YkXCyk9iIMdJzkXVipUHM68cLr4nepb2yc=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  patches = [
+    # https://github.com/Fraunhofer-IIS/mpeghdec/pull/19
+    ./pkg-config.patch
+    # https://github.com/Fraunhofer-IIS/mpeghdec/pull/20
+    ./install-doc.patch
+    # https://github.com/Fraunhofer-IIS/mpeghdec/pull/21
+    ./install-bin.patch
+  ];
+
+  buildInputs = [
+    ilo
+    mmtisobmff
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    doxygen
+    writableTmpDirAsHomeHook
+    (texliveBasic.withPackages (ps: [
+      ps.float
+      ps.varwidth
+      ps.xcolor
+      ps.xltabular
+      ps.ltablex
+      ps.tabularray
+      ps.ninecolors
+      ps.fancyvrb
+      ps.multirow
+      ps.hanging
+      ps.adjustbox
+      ps.stackengine
+      ps.enumitem
+      ps.alphalph
+      ps.ulem
+      ps.wasysym
+      ps.changepage
+      ps.tocloft
+      ps.newunicodechar
+      ps.caption
+      ps.etoc
+      ps.helvetic
+      ps.wasy
+      ps.courier
+    ]))
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "mpeghdec_BUILD_BINARIES" true)
+    (lib.cmakeBool "mpeghdec_BUILD_DOC" true)
+    (lib.cmakeBool "USE_PKGCONFIG_DEPS" true)
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+  ];
+
+  outputs = [
+    "out"
+    "dev"
+    "doc"
+    "bin"
+  ];
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    updateScript = gitUpdater { rev-prefix = "r"; };
+  };
+
+  meta = {
+    description = "C/C++ implementation of the MPEG-H Audio standard as defined in ISO/IEC 23008-3:2022";
+    homepage = "https://github.com/Fraunhofer-IIS/mpeghdec";
+    license = lib.licenses.fraunhofer-fdk;
+    maintainers = [ lib.maintainers.jopejoe1 ];
+    pkgConfigModules = [ "mpeghdec" ];
+  };
+})

--- a/pkgs/by-name/mp/mpeghdec/pkg-config.patch
+++ b/pkgs/by-name/mp/mpeghdec/pkg-config.patch
@@ -1,0 +1,13 @@
+diff --git a/mpeghdec.pc.in b/mpeghdec.pc.in
+index 752c038bfd..4c0f4ee0fb 100644
+--- a/mpeghdec.pc.in
++++ b/mpeghdec.pc.in
+@@ -1,6 +1,6 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
++includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+
+ Name: @PROJECT_NAME@
+ Description: @PROJECT_DESCRIPTION@

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -109,6 +109,7 @@
   withMfx ? false, # Hardware acceleration via intel-media-sdk/libmfx
   withModplug ? withFullDeps && !stdenv.hostPlatform.isDarwin, # ModPlug support
   withMp3lame ? withHeadlessDeps, # LAME MP3 encoder
+  withMpeghdec ? withFullDeps && (!withGPL || withUnfree) && lib.versionAtLeast version "8.1", # MPEG-H decoder
   withMysofa ? withFullDeps, # HRTF support via SOFAlizer
   withNpp ? withFullDeps && withUnfree && config.cudaSupport, # Nvidia Performance Primitives-based code
   withNvdec ? withHeadlessDeps && withNvcodec,
@@ -319,6 +320,7 @@
   libxext,
   libxml2,
   libxv,
+  mpeghdec,
   nv-codec-headers,
   nv-codec-headers-12,
   ocl-icd, # OpenCL ICD
@@ -672,6 +674,11 @@ stdenv.mkDerivation (
       (enableFeature withMfx "libmfx")
       (enableFeature withModplug "libmodplug")
       (enableFeature withMp3lame "libmp3lame")
+    ]
+    ++ optionals (versionAtLeast version "8.1") [
+      (enableFeature withMpeghdec "libmpeghdec")
+    ]
+    ++ [
       (enableFeature withMysofa "libmysofa")
       (enableFeature withNpp "libnpp")
       (enableFeature withNvdec "nvdec")
@@ -899,6 +906,7 @@ stdenv.mkDerivation (
       ++ optionals withMfx [ intel-media-sdk ]
       ++ optionals withModplug [ libmodplug ]
       ++ optionals withMp3lame [ lame ]
+      ++ optionals withMpeghdec [ mpeghdec ]
       ++ optionals withMysofa [ libmysofa ]
       ++ optionals withNpp [
         libnpp


### PR DESCRIPTION
Can be tested with this [file](https://github.com/Fraunhofer-IIS/mpegh-test-content/raw/refs/heads/main/TRI_Fileset_17_514H_D1_D2_D3_O1_24bit1080p50.mp4?download=) and the following command:

```bash
ffplay -ch_layout stereo ./TRI_Fileset_17_514H_D1_D2_D3_O1_24bit1080p50.mp4
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
