### PR TITLE
slimpris2: init at 4.0.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25716,6 +25716,12 @@
     githubId = 5791019;
     name = "Jiuyang Liu";
   };
+  ser = {
+    email = "nixos-github@random.re";
+    github = "ser";
+    githubId = 231537;
+    name = "ᎠᎡ. Ѕϵrgϵ Ѵictor";
+  };
   Sereja313 = {
     name = "Sergey Gulin";
     github = "Sereja313";

--- a/pkgs/by-name/sl/slimpris2/package.nix
+++ b/pkgs/by-name/sl/slimpris2/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  autoreconfHook,
+  gettext,
+  intltool,
+  pandoc,
+  pkg-config,
+  wrapGAppsHook3,
+  gobject-introspection,
+  glib,
+  libsoup_3,
+  systemd,
+}:
+python3Packages.buildPythonApplication {
+  pname = "slimpris2";
+  version = "4.0.2";
+  pyproject = false;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "mavit";
+    repo = "slimpris2";
+    tag = "4.0.2";
+    hash = "sha256-ho3iFWW+qj+nwPlY8VIvqZ9NBI95Cuosk4ibXvp1XYA=";
+  };
+
+  postPatch = ''
+    sed -i '/AC_OUTPUT/i \
+    AC_CONFIG_MACRO_DIRS([m4])\
+    AM_GNU_GETTEXT_VERSION([0.21])\
+    AM_GNU_GETTEXT([external])' configure.ac
+  '';
+
+  preConfigure = ''
+    intltoolize -f
+  '';
+
+  nativeBuildInputs = [
+    autoreconfHook
+    gettext
+    intltool
+    pandoc
+    pkg-config
+    wrapGAppsHook3
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    glib
+    libsoup_3
+    systemd
+  ];
+
+  dependencies = with python3Packages; [
+    dbus-python
+    pygobject3
+    pyxdg
+    simplejson
+    six
+  ];
+
+  configureFlags = [
+    "--sysconfdir=/etc"
+    "--with-systemduserunitdir=$(out)/share/systemd/user"
+    "--with-systemduserpresetdir=$(out)/etc/systemd/user"
+  ];
+
+  meta = {
+    description = "MPRIS 2 remote control for Lyrion Music Server (Squeezebox)";
+    homepage = "https://github.com/mavit/slimpris2";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "slimpris2";
+    maintainers = with lib.maintainers; [ ser ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
slimpris2 provides [MPRIS 2](https://specifications.freedesktop.org/mpris-spec/latest/) remote control of [Lyrion Music Server](https://lyrion.org/), allowing it to be controlled using the user interface integrated into your Linux desktop.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
