### PR TITLE
colloid-gtk-theme: revert removal and remove GTK2

### DIFF
--- a/pkgs/by-name/co/colloid-gtk-theme/package.nix
+++ b/pkgs/by-name/co/colloid-gtk-theme/package.nix
@@ -1,0 +1,103 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  gtk-engine-murrine,
+  jdupes,
+  sassc,
+  themeVariants ? [ ], # default: blue
+  colorVariants ? [ ], # default: all
+  sizeVariants ? [ ], # default: standard
+  tweaks ? [ ],
+}:
+
+let
+  pname = "colloid-gtk-theme";
+
+in
+lib.checkListOfEnum "colloid-gtk-theme: theme variants"
+  [
+    "default"
+    "purple"
+    "pink"
+    "red"
+    "orange"
+    "yellow"
+    "green"
+    "teal"
+    "grey"
+    "all"
+  ]
+  themeVariants
+  lib.checkListOfEnum
+  "colloid-gtk-theme: color variants"
+  [ "standard" "light" "dark" ]
+  colorVariants
+  lib.checkListOfEnum
+  "colloid-gtk-theme: size variants"
+  [ "standard" "compact" ]
+  sizeVariants
+  lib.checkListOfEnum
+  "colloid-gtk-theme: tweaks"
+  [
+    "nord"
+    "dracula"
+    "gruvbox"
+    "everforest"
+    "catppuccin"
+    "all"
+    "black"
+    "rimless"
+    "normal"
+    "float"
+  ]
+  tweaks
+
+  stdenvNoCC.mkDerivation
+  (finalAttrs: {
+    inherit pname;
+    version = "2025-07-31";
+
+    src = fetchFromGitHub {
+      owner = "vinceliuice";
+      repo = "colloid-gtk-theme";
+      tag = finalAttrs.version;
+      hash = "sha256-0pXbeeBAkk6v2DBWfUYhWWdyrQhgr/JfDbhyS33maMM=";
+    };
+
+    nativeBuildInputs = [
+      jdupes
+      sassc
+    ];
+
+    propagatedUserEnvPkgs = [
+      gtk-engine-murrine
+    ];
+
+    postPatch = ''
+      patchShebangs install.sh
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      name= HOME="$TMPDIR" ./install.sh \
+        ${lib.optionalString (themeVariants != [ ]) "--theme " + toString themeVariants} \
+        ${lib.optionalString (colorVariants != [ ]) "--color " + toString colorVariants} \
+        ${lib.optionalString (sizeVariants != [ ]) "--size " + toString sizeVariants} \
+        ${lib.optionalString (tweaks != [ ]) "--tweaks " + toString tweaks} \
+        --dest $out/share/themes
+
+      jdupes --quiet --link-soft --recurse $out/share
+
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Modern and clean Gtk theme";
+      homepage = "https://github.com/vinceliuice/Colloid-gtk-theme";
+      license = lib.licenses.gpl3Only;
+      platforms = lib.platforms.unix;
+      maintainers = [ lib.maintainers.romildo ];
+    };
+  })

--- a/pkgs/by-name/co/colloid-gtk-theme/package.nix
+++ b/pkgs/by-name/co/colloid-gtk-theme/package.nix
@@ -95,6 +95,9 @@ lib.checkListOfEnum "colloid-gtk-theme: theme variants"
       homepage = "https://github.com/vinceliuice/Colloid-gtk-theme";
       license = lib.licenses.gpl3Only;
       platforms = lib.platforms.unix;
-      maintainers = [ lib.maintainers.romildo ];
+      maintainers = [
+        lib.maintainers.chvp
+        lib.maintainers.romildo
+      ];
     };
   })

--- a/pkgs/by-name/co/colloid-gtk-theme/package.nix
+++ b/pkgs/by-name/co/colloid-gtk-theme/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
-  gtk-engine-murrine,
   jdupes,
   sassc,
   themeVariants ? [ ], # default: blue
@@ -70,12 +69,10 @@ lib.checkListOfEnum "colloid-gtk-theme: theme variants"
       sassc
     ];
 
-    propagatedUserEnvPkgs = [
-      gtk-engine-murrine
-    ];
-
     postPatch = ''
       patchShebangs install.sh
+
+      sed -i '/"$THEME_DIR\/gtk-2.0/d' install.sh
     '';
 
     installPhase = ''

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -576,7 +576,6 @@ mapAliases {
   code-browser-qt = throw "'code-browser-qt' has been removed, as it was broken since 22.11"; # Added 2025-08-22
   CoinMP = throw "'CoinMP' has been renamed to/replaced by 'coinmp'"; # Converted to throw 2025-10-27
   collada2gltf = throw "collada2gltf has been removed from Nixpkgs, as it has been unmaintained upstream for 5 years and does not build with supported GCC versions"; # Addd 2025-08-08
-  colloid-gtk-theme = throw "'colloid-gtk-theme' has been removed because it depended on 'gtk-engine-murrine', which was removed because it was unmaintained upstream and depended on GTK 2."; # Added 2026-07-22
   colloid-kde = throw "'colloid-kde' has been removed, as it is only compatible with Plasma 5, which is EOL"; # Added 2025-08-20
   colorstorm = throw "'colorstorm' has been removed because it was unmaintained in nixpkgs and upstream was rewritten."; # Added 2025-06-15
   commonsBcel = warnAlias "'commonsBcel' has been renamed to 'commons-bcel'" commons-bcel; # Added 2026-02-08


### PR DESCRIPTION
Similar to https://github.com/NixOS/nixpkgs/pull/547751:

Revert the changes to `colloid-gtk-theme` made in https://github.com/NixOS/nixpkgs/pull/544598.

The theme can work properly on GTK3/4 without `gtk-engine-murrine`.

Drop unneeded GTK2 files.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
