### PR TITLE
yaru-theme: revert removal and remove gtk-engine-murrine dependency

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18198,6 +18198,11 @@
     github = "merrkry";
     githubId = 124278440;
   };
+  mershl = {
+    name = "Mershl";
+    github = "mershl";
+    githubId = 520251;
+  };
   mert-kurttutan = {
     email = "mert-kurttutan@gmail.com";
     name = "Mert Kurttutan";

--- a/pkgs/by-name/ya/yaru-theme/package.nix
+++ b/pkgs/by-name/ya/yaru-theme/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  sassc,
+  pkg-config,
+  glib,
+  ninja,
+  python3,
+  gtk3,
+  gnome-themes-extra,
+  gtk-engine-murrine,
+  humanity-icon-theme,
+  hicolor-icon-theme,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "yaru";
+  version = "25.10.3";
+
+  src = fetchFromGitHub {
+    owner = "ubuntu";
+    repo = "yaru";
+    rev = finalAttrs.version;
+    hash = "sha256-3cSVPObfmr62S6yTD2c8AO3s7lxb9KFVuYSydTIJ1jE=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    sassc
+    pkg-config
+    glib
+    ninja
+    python3
+  ];
+  buildInputs = [
+    gtk3
+    gnome-themes-extra
+  ];
+  propagatedBuildInputs = [
+    humanity-icon-theme
+    hicolor-icon-theme
+  ];
+  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+  dontDropIconThemeCache = true;
+
+  postPatch = "patchShebangs .";
+
+  meta = {
+    description = "Ubuntu community theme 'yaru' - default Ubuntu theme since 18.10";
+    homepage = "https://github.com/ubuntu/yaru";
+    license = with lib.licenses; [
+      cc-by-sa-40
+      gpl3Plus
+      lgpl21Only
+      lgpl3Only
+    ];
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ moni ];
+  };
+})

--- a/pkgs/by-name/ya/yaru-theme/package.nix
+++ b/pkgs/by-name/ya/yaru-theme/package.nix
@@ -10,7 +10,6 @@
   python3,
   gtk3,
   gnome-themes-extra,
-  gtk-engine-murrine,
   humanity-icon-theme,
   hicolor-icon-theme,
 }:
@@ -42,7 +41,6 @@ stdenv.mkDerivation (finalAttrs: {
     humanity-icon-theme
     hicolor-icon-theme
   ];
-  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
 
   dontDropIconThemeCache = true;
 

--- a/pkgs/by-name/ya/yaru-theme/package.nix
+++ b/pkgs/by-name/ya/yaru-theme/package.nix
@@ -56,6 +56,9 @@ stdenv.mkDerivation (finalAttrs: {
       lgpl3Only
     ];
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ moni ];
+    maintainers = with lib.maintainers; [
+      mershl
+      moni
+    ];
   };
 })

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -2916,7 +2916,6 @@ mapAliases {
   yarGen = warnAlias "'yarGen' has been renamed to 'yargen'" yargen; # Added 2026-02-12
   yarn2nix = throw "'yarn2nix' and its tooling has been removed as it was unusable within nodePackages. Use the standard yarn v1 hooks available in nixpkgs instead."; # Added 2026-04-25
   yarn2nix-moretea = throw "'yarn2nix' and its tooling has been removed as it was unusable within nodePackages. Use the standard yarn v1 hooks available in nixpkgs instead."; # Added 2026-04-25
-  yaru-theme = throw "'yaru-theme' has been removed because it depended on 'gtk-engine-murrine', which was removed because it was unmaintained upstream and depended on GTK 2."; # Added 2026-07-22
   yeahwm = throw "'yeahwm' has been removed, as it was broken and unmaintained upstream."; # Added 2025-06-12
   yojimbo = throw "'yojimbo' has been removed as it used an EOL TLS library and was broken."; # Added 2026-05-06
   yosys-synlig = throw "yosys-synlig has been removed because it is unmaintained upstream and incompatible with current Yosys versions."; # Added 2026-01-06


### PR DESCRIPTION
Similar to #547790:

Revert the changes to `yaru-theme` made in #544598.

The theme can work properly on GTK3+4 without `gtk-engine-murrine`.
upstream of `yaru-theme` already switched to gtk3+gtk4 only -> [upstream meson.build](https://github.com/ubuntu/yaru/blob/3e51d0325e7b060538e662b9ff179ec3b4e611b1/gtk/src/meson.build#L5-L8)

No regressions found when building and using without `gtk-engine-murrine`, tested on nixos-unstable x86_64.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
