### PR TITLE
python3Packages.trampoline: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/trampoline/default.nix
+++ b/pkgs/development/python-modules/trampoline/default.nix
@@ -11,6 +11,8 @@ buildPythonPackage {
   version = "0.1.2";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   # only wheel on pypi, no tags on git
   src = fetchFromGitLab {
     owner = "ferreum";

--- a/pkgs/development/python-modules/trampoline/default.nix
+++ b/pkgs/development/python-modules/trampoline/default.nix
@@ -2,13 +2,14 @@
   lib,
   buildPythonPackage,
   fetchFromGitLab,
+  setuptools,
   pytestCheckHook,
 }:
 
 buildPythonPackage {
   pname = "trampoline";
   version = "0.1.2";
-  format = "setuptools";
+  pyproject = true;
 
   # only wheel on pypi, no tags on git
   src = fetchFromGitLab {
@@ -17,6 +18,8 @@ buildPythonPackage {
     rev = "1d98f39c3015594e2ac8ed48dccc2f393b4dd82b";
     hash = "sha256-A/tuR+QW9sKh76Qjwn1uQxlVJgWrSFzXeBRDdnSi2o4=";
   };
+
+  build-system = [ setuptools ];
 
   pythonImportsCheck = [ "trampoline" ];
 


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
