### PR TITLE
bast: init at 0.6.6

### DIFF
--- a/pkgs/by-name/ba/bast/package.nix
+++ b/pkgs/by-name/ba/bast/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  makeWrapper,
+  openssh,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "bast";
+  version = "0.6.6";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "ellipse-software";
+    repo = "bast";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-e5rXlHmSIDTH5sDJO+ivaPgreHobtbVYT2tY/N6Db7E=";
+  };
+
+  modRoot = "apps/bast";
+  vendorHash = "sha256-PZVzmdRrElupXiaPGJrTK2uILGEa05R6OjEwdNWXOLw=";
+
+  env.CGO_ENABLED = 0;
+
+  nativeBuildInputs = [ makeWrapper ];
+  nativeCheckInputs = [ openssh ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=v${finalAttrs.version}"
+  ];
+
+  postInstall = ''
+    wrapProgram "$out/bin/bast" \
+      --prefix PATH : ${lib.makeBinPath [ openssh ]}
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $out/bin/bast --version | grep -F "bast v${finalAttrs.version}"
+
+    runHook postInstallCheck
+  '';
+
+  meta = {
+    description = "Fast terminal SSH host picker, key manager, and CLI";
+    homepage = "https://github.com/ellipse-software/bast";
+    changelog = "https://github.com/ellipse-software/bast/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kevinpita ];
+    mainProgram = "bast";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+  };
+})


### PR DESCRIPTION
Packages [Bast 0.6.6](https://github.com/ellipse-software/bast), a terminal SSH host picker, key manager, and CLI.

The package builds the Go CLI from source, runs its upstream tests, and wraps it with OpenSSH so `ssh`, `ssh-keygen`, and `ssh-add` are available at runtime.

Validation performed:
- `nix-build -A bast` with sandboxing enabled
- `./ci/nixpkgs-vet.sh master`
- `nixpkgs-review rev HEAD --no-shell -p bast`
- `bast --help` and `bast --version`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, using `bast --help` and `bast --version`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
