### PR TITLE
multiwatch: init at 1.0.1

### DIFF
--- a/pkgs/by-name/mu/multiwatch/package.nix
+++ b/pkgs/by-name/mu/multiwatch/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  meson,
+  ninja,
+  pkg-config,
+  glib,
+  libev,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "multiwatch";
+  version = "1.0.1";
+
+  src = fetchgit {
+    url = "https://git.lighttpd.net/lighttpd/multiwatch.git";
+    tag = "multiwatch-${finalAttrs.version}";
+    hash = "sha256-v5M/qjvmFzLvOn5hntTBRV/16W8CCFHnZ/Q401Xb83g=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    glib
+    libev
+  ];
+
+  strictDeps = true;
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Forks and watches multiple instances of a program in the same context";
+    longDescription = ''
+      Multiwatch forks multiple instance of one application and keeps them running.
+      It is made to be used with spawn-fcgi, so all forks share the same fastcgi
+      socket (no web server restart needed if you increase/decrease the number of
+      forks), and it is easier than setting up multiple daemontool supervised
+      instances.
+    '';
+    homepage = "https://redmine.lighttpd.net/projects/multiwatch";
+    license = lib.licenses.mit;
+    mainProgram = "multiwatch";
+    maintainers = with lib.maintainers; [ definfo ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add multiwatch, a project from lighttpd that forks multiple instance of one application and keeps them running.
It is made to be used with spawn-fcgi, so all forks share the same fastcgi socket (no web server restart needed if you increase/decrease the number of forks), and it is easier than setting up multiple daemontool supervised instances.

AI/LLM Disclosure: Pi with GPT 5.6 Sol used for assistance, with all generated content reviewed by myself.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
