### PR TITLE
python3Packages.arxiv: fix build w/ relaxed deps

### DIFF
--- a/pkgs/development/python-modules/arxiv/default.nix
+++ b/pkgs/development/python-modules/arxiv/default.nix
@@ -9,6 +9,7 @@
 
   # dependencies
   feedparser,
+  pythonRelaxDepsHook,
   requests,
 
   # tests
@@ -36,6 +37,13 @@ buildPythonPackage rec {
     feedparser
     requests
   ];
+
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
+  ];
+
+  # Until upstream accepts requests >= 2.34
+  pythonRelaxDeps = [ "requests" ];
 
   nativeCheckInputs = [
     pytestCheckHook


### PR DESCRIPTION
Relax `requests` dependency that is currently specified at upstream as `>=2.32,<2.34` to allow working with the current nixpkgs version `2.34`. When upstream bumps the version for this dependency the added lines should be removed.

Resolves #547831.


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
