### PR TITLE
docker: add extraCliPlugins to package definition

### DIFF
--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -38,6 +38,7 @@ let
       docker-compose,
       docker-sbom,
       docker-init,
+      extraCliPlugins ? [ ],
       iptables,
       nftables,
       e2fsprogs,
@@ -261,7 +262,8 @@ let
         lib.optionals buildxSupport [ docker-buildx ]
         ++ lib.optionals composeSupport [ docker-compose ]
         ++ lib.optionals sbomSupport [ docker-sbom ]
-        ++ lib.optionals initSupport [ docker-init ];
+        ++ lib.optionals initSupport [ docker-init ]
+        ++ extraCliPlugins;
 
       dockerCliPluginsDirs = lib.strings.concatStringsSep ":" (
         map (p: "${p}/libexec/docker/cli-plugins") plugins


### PR DESCRIPTION

Adds an `extraCliPlugins` option to the package definition to include
additional arbitrary docker plugins. This allows injecting plugins that
aren't included by default in the package definition to be usable by the
CLI without changing the full package definition which allows overrides
to include extra packages that aren't included in nixpkgs.
