### PR TITLE
papis: fix build failure with upstream patches

### DIFF
--- a/pkgs/development/python-modules/arxiv/default.nix
+++ b/pkgs/development/python-modules/arxiv/default.nix
@@ -8,7 +8,7 @@
   hatch-vcs,
 
   # dependencies
-  feedparser,
+  lxml,
   requests,
 
   # tests
@@ -17,14 +17,14 @@
 }:
 buildPythonPackage rec {
   pname = "arxiv";
-  version = "3.0.0";
+  version = "4.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "lukasschwab";
     repo = "arxiv.py";
     tag = version;
-    hash = "sha256-o2Vqkr5Tlx7Iv1NEWDSU8X6hvlGUslIl4oHiRQNGdqI=";
+    hash = "sha256-nZhi0dPEiv6VLpacvcGvZhvvDkLalrs4IJvMVzb5MJI=";
   };
 
   build-system = [
@@ -33,7 +33,7 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
-    feedparser
+    lxml
     requests
   ];
 

--- a/pkgs/development/python-modules/papis/default.nix
+++ b/pkgs/development/python-modules/papis/default.nix
@@ -149,7 +149,7 @@ buildPythonPackage (finalAttrs: {
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
       nico202
-      teto
+      octvs
     ];
   };
 })

--- a/pkgs/development/python-modules/papis/default.nix
+++ b/pkgs/development/python-modules/papis/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
 
   # build-system
   hatchling,
@@ -15,7 +16,6 @@
   dominate,
   filetype,
   habanero,
-  isbnlib,
   lxml,
   platformdirs,
   prompt-toolkit,
@@ -25,7 +25,6 @@
   python-slugify,
   pyyaml,
   requests,
-  stevedore,
 
   # optional dependencies
   chardet,
@@ -70,7 +69,6 @@ buildPythonPackage (finalAttrs: {
     dominate
     filetype
     habanero
-    isbnlib
     lxml
     platformdirs
     prompt-toolkit
@@ -80,7 +78,6 @@ buildPythonPackage (finalAttrs: {
     python-slugify
     pyyaml
     requests
-    stevedore
   ]
   ++ lib.optionals withOptDeps finalAttrs.passthru.optional-dependencies.complete;
 
@@ -111,25 +108,37 @@ buildPythonPackage (finalAttrs: {
     "tests"
   ];
 
-  disabledTestPaths = [
-    # Require network access
-    "tests/downloaders"
-    "papis/downloaders/usenix.py"
-  ];
-
   disabledTests = [
     # Require network access
     "test_add_folder_name_cli"
     "test_add_link_cli"
+    "test_download_document"
     "test_get_matching_importers_by_name"
     "test_matching_importers_by_uri"
     "test_yaml_unicode_dump"
-    # FileNotFoundError: Command not found: 'init'
-    "test_git_cli"
   ]
   ++ lib.optionals withOptDeps [
     # Require network access
     "test_csl_style_download"
+  ];
+
+  # Until a release >0.15.0 (that would already contain these commits)
+  patches = [
+    # Commit 44c6463: chore: move isbnlib to optional dependencies
+    (fetchpatch2 {
+      url = "https://github.com/papis/papis/commit/44c6463f79cbc3a09adb541ae7df4e00a194b86b.patch?full_index=1";
+      hash = "sha256-3E18cyzkiZsNvgH/X8dZu+3tGGpbBsaQ3nIoDuIYFqw=";
+    })
+    # Commit 7518e53: chore: remove isbn dependency
+    (fetchpatch2 {
+      url = "https://github.com/papis/papis/commit/7518e53e5d485e3cec1e202af6cb4921b9976b5b.patch?full_index=1";
+      hash = "sha256-iBqlvHfH+6fyhi2C7lpwI1O59DKrKp7p45x29kzPRR0=";
+    })
+    # Commit 15cae59: test: skip tests if missing isbnlib
+    (fetchpatch2 {
+      url = "https://github.com/papis/papis/commit/15cae5986ae9dec75c7d103757adbd73c39feb89.patch?full_index=1";
+      hash = "sha256-kuVZdOd+H99TinM7yAs7NJrfw7rOPyxDlSaT0P2NeC4=";
+    })
   ];
 
   meta = {


### PR DESCRIPTION
Pull three upstream commits that ultimately removes `isbnlib` dependency which fails the build.

Bumps arxiv dependency. This was initially a separate PR but after reaching out to the dev, a new version was released, so  the workaround on that PR is not necessary, a simple version bump woulld fix arxiv build.

Resolves #547839.
Resolves #547831.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] ~Package update: when the change is major or breaking.~
- NixOS Release Notes
  - [x] ~Module addition: when adding a new NixOS module.~
  - [x] ~Module update: when the change is significant.~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
