### PR TITLE
obscura: fix --version reporting 0.1.0 instead of the packaged release

### DIFF
--- a/pkgs/by-name/ob/obscura/package.nix
+++ b/pkgs/by-name/ob/obscura/package.nix
@@ -6,6 +6,7 @@
   openssl,
   pkg-config,
   nix-update-script,
+  versionCheckHook,
   _experimental-update-script-combinators,
 }:
 
@@ -41,9 +42,19 @@ rustPlatform.buildRustPackage rec {
   # Basic CLI operations (--help, fetch) don't create an isolate, so work fine.
   doCheck = false;
 
+  # --version doesn't create a V8 isolate, so this runs fine in the sandbox
+  # where the tests (see above) crash.
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
   env = {
     OPENSSL_NO_VENDOR = 1;
     RUSTY_V8_ARCHIVE = librusty_v8;
+    # Upstream never bumps the workspace Cargo.toml version per release (still
+    # 0.1.0 at the v0.1.10 tag); obscura-cli/build.rs only reports the git tag
+    # on GitHub Actions and otherwise falls back to CARGO_PKG_VERSION. Pin it
+    # here so `obscura --version` matches the packaged release.
+    OBSCURA_VERSION = version;
   };
 
   passthru = {


### PR DESCRIPTION
## Description of changes

`obscura --version` reported `0.1.0` even though the package builds the
`v0.1.10` tag.

Upstream never bumps the workspace `Cargo.toml` version per release (it is
still `0.1.0` at the `v0.1.10` tag). The version the CLI prints comes from
`OBSCURA_BUILD_VERSION`, which `crates/obscura-cli/build.rs` computes from:

1. the `OBSCURA_VERSION` env var,
2. the git tag, but only on GitHub Actions (`GITHUB_REF_TYPE`/`GITHUB_REF`),
3. otherwise `CARGO_PKG_VERSION` the stale `0.1.0`.

Since none of the GitHub env vars exist in the Nix sandbox, the build always
fell back to `CARGO_PKG_VERSION`, so the binary reported `0.1.0`.

This sets `OBSCURA_VERSION = version` in the build environment the override
mechanism upstream's `build.rs` was designed for so `--version` matches the
packaged release and stays in sync when `nix-update-script` bumps the version.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See `Nix sandboxing`)
  - [ ] `sandbox = true`
- Tested, as applicable:
  - [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` (nixpkgs-review PR nixpkgs/pr/...)
  - [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - [x] `obscura --version` now prints `obscura 0.1.10`
  - [x] Smoke-tested fetch: `obscura fetch https://example.com --dump text`, `--dump original`, and `--eval "1+1"` on a `data:` URL all work
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)
