### PR TITLE
[26.05] radicle-httpd: 0.26.0 -> 0.27.0; radicle-explorer: 0-unstable-2026-07-16 -> 0-unstable-2026-07-29

### DIFF
--- a/pkgs/by-name/ra/radicle-explorer/package.nix
+++ b/pkgs/by-name/ra/radicle-explorer/package.nix
@@ -23,16 +23,16 @@ in
 
 buildNpmPackage (finalAttrs: {
   pname = "radicle-explorer";
-  version = "0-unstable-2026-07-21";
+  version = "0-unstable-2026-07-29";
 
   src = fetchFromRadicle {
     seed = "seed.radicle.dev";
     repo = "z4V1sjrXqjvFdnCUbxPFqd5p4DtH5";
-    rev = "2afde78941226a6d791f8a7392713864457ec772";
-    hash = "sha256-fEfr2jt1NY7rFt2/BO61ukRYEpyH4ATsuheAz8MdKpY=";
+    rev = "427cece9850944d30f0d49ccd016f98dacd77d75";
+    hash = "sha256-FC78GCaC8IcBtXDRotYcaw040cggGWnrI2lgnWLwU68=";
   };
 
-  npmDepsHash = "sha256-74r7cyggbuva9XpW++HdAHHFqEBJ6BgNuJJUR+8HE4c=";
+  npmDepsHash = "sha256-L/JOhI7KVXNDGHzk8RVNNcd8hHL+I7YKVg8sZyRSBtA=";
 
   postPatch = ''
     patchShebangs --build ./scripts

--- a/pkgs/by-name/ra/radicle-explorer/package.nix
+++ b/pkgs/by-name/ra/radicle-explorer/package.nix
@@ -23,13 +23,13 @@ in
 
 buildNpmPackage (finalAttrs: {
   pname = "radicle-explorer";
-  version = "0-unstable-2026-07-16";
+  version = "0-unstable-2026-07-21";
 
   src = fetchFromRadicle {
     seed = "seed.radicle.dev";
     repo = "z4V1sjrXqjvFdnCUbxPFqd5p4DtH5";
-    rev = "3c2935704f5767d60b3caf609ef772948bbecb10";
-    hash = "sha256-EpHKuFNgRLwCVdDDRKjPJEvfDpS9qka75B2fQEVc1ns=";
+    rev = "2afde78941226a6d791f8a7392713864457ec772";
+    hash = "sha256-fEfr2jt1NY7rFt2/BO61ukRYEpyH4ATsuheAz8MdKpY=";
   };
 
   npmDepsHash = "sha256-74r7cyggbuva9XpW++HdAHHFqEBJ6BgNuJJUR+8HE4c=";

--- a/pkgs/by-name/ra/radicle-httpd/package.nix
+++ b/pkgs/by-name/ra/radicle-httpd/package.nix
@@ -15,7 +15,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "radicle-httpd";
-  version = "0.26.0";
+  version = "0.27.0";
 
   env.RADICLE_VERSION = finalAttrs.version;
 
@@ -29,10 +29,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
       "/Cargo.toml"
       "/Cargo.lock"
     ];
-    hash = "sha256-zSU8B5IwOEUS9d4Y/UWJ6eD0p3zvp0nWVgJmZ/kVB1Q=";
+    hash = "sha256-OJrHV5WdFNzoYrOkqpN1ctrJDB3JTJhH54q/C6IV9ZU=";
   };
 
-  cargoHash = "sha256-rdW+WLkQ4UEn6hRZfgJhJkJWb7A26MayXVnVwAlLAG8=";
+  cargoHash = "sha256-FjYhw27pAX9Tilgm/Tg18Vkv4/K5kEFJAbhv1mDY0rg=";
 
   nativeBuildInputs = [
     asciidoctor


### PR DESCRIPTION
Backport of #547762, #544396, and #547591

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
