### PR TITLE
[26.05] goshs: 2.0.8 -> 2.1.5, fix security issues

### DIFF
--- a/pkgs/by-name/go/goshs/CVE-2026-5160.patch
+++ b/pkgs/by-name/go/goshs/CVE-2026-5160.patch
@@ -1,0 +1,14 @@
+diff --git a/go.mod b/go.mod
+index fe507b4678693915f275648ff052c2d2d859f4cc..aeb7e04795d9527edd1c4c100a870b38f4de538c 100644
+--- a/go.mod
++++ b/go.mod
+@@ -104 +104 @@ require (
+-	github.com/yuin/goldmark v1.7.13 // indirect
++	github.com/yuin/goldmark v1.7.17 // indirect
+diff --git a/go.sum b/go.sum
+index 1c56fd543ca070281c9c23e83a3387b16cf3dac3..9cc1bcb4a0fac0eb2e366a9b438da16d6cd13428 100644
+--- a/go.sum
++++ b/go.sum
+@@ -217,0 +218,2 @@ github.com/yuin/goldmark v1.7.13/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Br
++github.com/yuin/goldmark v1.7.17 h1:p36OVWwRb246iHxA/U4p8OPEpOTESm4n+g+8t0EE5uA=
++github.com/yuin/goldmark v1.7.17/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=

--- a/pkgs/by-name/go/goshs/package.nix
+++ b/pkgs/by-name/go/goshs/package.nix
@@ -8,13 +8,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "goshs";
-  version = "2.1.2";
+  version = "2.1.3";
 
   src = fetchFromGitHub {
     owner = "patrickhener";
     repo = "goshs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/9z5WjJN6JTVZO0b0ScPmxegZVb2PhjvDl5BbPwDxSw=";
+    hash = "sha256-bAYnwOg7CHZOKHl8pCC2IDdCkUGsw0A3e47gSuGwuig=";
   };
 
   vendorHash = "sha256-CAl4yYAM/GQaLbUUNjgMN6A3Vqw4D+kpG9G2WXw6mRU=";

--- a/pkgs/by-name/go/goshs/package.nix
+++ b/pkgs/by-name/go/goshs/package.nix
@@ -8,13 +8,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "goshs";
-  version = "2.1.1";
+  version = "2.1.2";
 
   src = fetchFromGitHub {
     owner = "patrickhener";
     repo = "goshs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-BbkAt+pL3M/LBugaUgIV26ziUsMnWe+fOHKpmddE2Ng=";
+    hash = "sha256-/9z5WjJN6JTVZO0b0ScPmxegZVb2PhjvDl5BbPwDxSw=";
   };
 
   vendorHash = "sha256-CAl4yYAM/GQaLbUUNjgMN6A3Vqw4D+kpG9G2WXw6mRU=";

--- a/pkgs/by-name/go/goshs/package.nix
+++ b/pkgs/by-name/go/goshs/package.nix
@@ -8,13 +8,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "goshs";
-  version = "2.0.9";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "patrickhener";
     repo = "goshs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-NAq3fBjhiGIP9zA/s6wYaQ0nDju6hZu/g2RPIIEO41g=";
+    hash = "sha256-pS/Dx3C2c8Rpr2ugcxrElFice6Eildt28zdIfrL/5yk=";
   };
 
   vendorHash = "sha256-nVg+ALvvZYG+9JFiNGaT/EQO8IdZK3EO8UQoAp29KNQ=";

--- a/pkgs/by-name/go/goshs/package.nix
+++ b/pkgs/by-name/go/goshs/package.nix
@@ -8,16 +8,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "goshs";
-  version = "2.0.8";
+  version = "2.0.9";
 
   src = fetchFromGitHub {
     owner = "patrickhener";
     repo = "goshs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-xGV9Sr+IAkGrDv6Qz2mgDS6vL9oBj9l7AuZ13SW91FE=";
+    hash = "sha256-NAq3fBjhiGIP9zA/s6wYaQ0nDju6hZu/g2RPIIEO41g=";
   };
 
-  vendorHash = "sha256-3+MGBaFWmMf2gDiZhYUxHFNmEfD/Xr1lNddlA5FQLUE=";
+  vendorHash = "sha256-nVg+ALvvZYG+9JFiNGaT/EQO8IdZK3EO8UQoAp29KNQ=";
 
   ldflags = [ "-s" ];
 

--- a/pkgs/by-name/go/goshs/package.nix
+++ b/pkgs/by-name/go/goshs/package.nix
@@ -8,16 +8,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "goshs";
-  version = "2.1.0";
+  version = "2.1.1";
 
   src = fetchFromGitHub {
     owner = "patrickhener";
     repo = "goshs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-pS/Dx3C2c8Rpr2ugcxrElFice6Eildt28zdIfrL/5yk=";
+    hash = "sha256-BbkAt+pL3M/LBugaUgIV26ziUsMnWe+fOHKpmddE2Ng=";
   };
 
-  vendorHash = "sha256-nVg+ALvvZYG+9JFiNGaT/EQO8IdZK3EO8UQoAp29KNQ=";
+  vendorHash = "sha256-CAl4yYAM/GQaLbUUNjgMN6A3Vqw4D+kpG9G2WXw6mRU=";
 
   ldflags = [ "-s" ];
 

--- a/pkgs/by-name/go/goshs/package.nix
+++ b/pkgs/by-name/go/goshs/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildGoModule,
   fetchFromGitHub,
+  fetchpatch2,
   versionCheckHook,
 }:
 
@@ -18,6 +19,15 @@ buildGoModule (finalAttrs: {
   };
 
   vendorHash = "sha256-yKNJHs6A7Du9NvGOpwaDmABz6SBMPVzJNoQb7W32IfA=";
+
+  patches = [
+    # Remove when updating to 2.1.5 or later.
+    (fetchpatch2 {
+      name = "CVE-2026-66063+CVE-2026-66064.patch";
+      url = "https://github.com/goshs-labs/goshs/commit/f3ef599e409151d1380866e47de8b1afb0bb54fa.patch?full_index=1";
+      hash = "sha256-fIKeqWKraaLcocp7aaWE58ffkA1/2NVwR7KMmJfXL5g=";
+    })
+  ];
 
   ldflags = [ "-s" ];
 

--- a/pkgs/by-name/go/goshs/package.nix
+++ b/pkgs/by-name/go/goshs/package.nix
@@ -8,16 +8,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "goshs";
-  version = "2.1.3";
+  version = "2.1.4";
 
   src = fetchFromGitHub {
     owner = "patrickhener";
     repo = "goshs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-bAYnwOg7CHZOKHl8pCC2IDdCkUGsw0A3e47gSuGwuig=";
+    hash = "sha256-8xSYdLO+2AB044sV3JJw0RXB0RuLQ7eIzWvwgoJdp5k=";
   };
 
-  vendorHash = "sha256-CAl4yYAM/GQaLbUUNjgMN6A3Vqw4D+kpG9G2WXw6mRU=";
+  vendorHash = "sha256-yKNJHs6A7Du9NvGOpwaDmABz6SBMPVzJNoQb7W32IfA=";
 
   ldflags = [ "-s" ];
 

--- a/pkgs/by-name/go/goshs/package.nix
+++ b/pkgs/by-name/go/goshs/package.nix
@@ -3,31 +3,21 @@
   stdenv,
   buildGoModule,
   fetchFromGitHub,
-  fetchpatch2,
   versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "goshs";
-  version = "2.1.4";
+  version = "2.1.5";
 
   src = fetchFromGitHub {
-    owner = "patrickhener";
+    owner = "goshs-labs";
     repo = "goshs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-8xSYdLO+2AB044sV3JJw0RXB0RuLQ7eIzWvwgoJdp5k=";
+    hash = "sha256-mVgBY1QhQ+tDQnfangqylNeCbBJTSJaM0y7vZ95BU3Y=";
   };
 
-  vendorHash = "sha256-yKNJHs6A7Du9NvGOpwaDmABz6SBMPVzJNoQb7W32IfA=";
-
-  patches = [
-    # Remove when updating to 2.1.5 or later.
-    (fetchpatch2 {
-      name = "CVE-2026-66063+CVE-2026-66064.patch";
-      url = "https://github.com/goshs-labs/goshs/commit/f3ef599e409151d1380866e47de8b1afb0bb54fa.patch?full_index=1";
-      hash = "sha256-fIKeqWKraaLcocp7aaWE58ffkA1/2NVwR7KMmJfXL5g=";
-    })
-  ];
+  vendorHash = "sha256-lwZ+F/DaP5pYiaihMxFAo1DokKm6itreX7yG1CNCdWM=";
 
   ldflags = [ "-s" ];
 
@@ -53,7 +43,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Simple, yet feature-rich web server written in Go";
     homepage = "https://goshs.de";
-    changelog = "https://github.com/patrickhener/goshs/releases/tag/${finalAttrs.src.rev}";
+    changelog = "https://github.com/goshs-labs/goshs/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       fab

--- a/pkgs/by-name/go/goshs/package.nix
+++ b/pkgs/by-name/go/goshs/package.nix
@@ -17,7 +17,12 @@ buildGoModule (finalAttrs: {
     hash = "sha256-mVgBY1QhQ+tDQnfangqylNeCbBJTSJaM0y7vZ95BU3Y=";
   };
 
-  vendorHash = "sha256-lwZ+F/DaP5pYiaihMxFAo1DokKm6itreX7yG1CNCdWM=";
+  vendorHash = "sha256-LLYgb0DIFx97+ZXOlQc4yVdjjiw7ebXx76hADfWnlkw=";
+
+  patches = [
+    # No upstream fix yet; remove when updating to a release that uses goldmark 1.7.17 or later.
+    ./CVE-2026-5160.patch
+  ];
 
   ldflags = [ "-s" ];
 


### PR DESCRIPTION
Backports the `goshs` 2.1.5 security update and dependency fix from [#548555](https://redirect.github.com/NixOS/nixpkgs/pull/548555) to `release-26.05`, updating 2.0.8 to 2.1.5. The release fixes all eight published `goshs` advisories that list 2.1.5 as patched. The additional local patch updates `github.com/yuin/goldmark` to 1.7.17, fixing reachable CVE-2026-5160.

The version-update cherry-pick also resolves the upstream repository move from `patrickhener` to `goshs-labs`, which master received in an intervening treewide redirect commit. The resulting `goshs` package files match the merged master PR exactly.

Existing SFTP setups need `-ftp -ftp-sftp`; the port and key options now use the `-ftp-*` names, and the default port is 2121 instead of 2022.

A current `govulncheck` symbol scan reports no reachable vulnerabilities. The enabled upstream suite and targeted HTTP, WebDAV, FTP, and SFTP security regression tests pass.

Addresses #547000
Addresses #547003

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
