### PR TITLE
[26.05] rapidraw: fix CVE-2026-64816

### DIFF
--- a/pkgs/by-name/ra/rapidraw/fix-cve-2026-64816.patch
+++ b/pkgs/by-name/ra/rapidraw/fix-cve-2026-64816.patch
@@ -1,0 +1,32 @@
+diff --git a/src-tauri/src/lut_processing.rs b/src-tauri/src/lut_processing.rs
+index 5bfbb5b9..51db4bab 100644
+--- a/src-tauri/src/lut_processing.rs
++++ b/src-tauri/src/lut_processing.rs
+@@ -187,6 +187,26 @@ fn parse_hald(image: DynamicImage) -> Result<Lut> {
+ }
+ 
+ pub fn parse_lut_file(path_str: &str) -> Result<Lut> {
++    if path_str.starts_with(r"\\") || path_str.starts_with("//") {
++        return Err(anyhow!("Network paths (UNC) are not allowed for LUTs"));
++    }
++
++    if path_str.contains("..") {
++        return Err(anyhow!("Directory traversal (..) is not allowed"));
++    }
++
++    let path = std::path::Path::new(path_str);
++    if let Some(std::path::Component::Prefix(prefix)) = path.components().next() {
++        match prefix.kind() {
++            std::path::Prefix::UNC(_, _)
++            | std::path::Prefix::VerbatimUNC(_, _)
++            | std::path::Prefix::DeviceNS(_) => {
++                return Err(anyhow!("Device/UNC prefix paths are not allowed"));
++            }
++            _ => {}
++        }
++    }
++
+     let (extension, bytes): (String, Option<Vec<u8>>) =
+         if cfg!(target_os = "android") && is_android_content_uri(path_str) {
+             #[cfg(target_os = "android")]
+

--- a/pkgs/by-name/ra/rapidraw/package.nix
+++ b/pkgs/by-name/ra/rapidraw/package.nix
@@ -58,6 +58,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-JtkzeCt21KIEshvoCHWo1QoxUgvVJN1loJrUHgvV4qE=";
   };
 
+  patches = [
+    # Patch CVE-2026-64816
+    ./fix-cve-2026-64816.patch
+  ];
+
   nativeBuildInputs = [
     pkg-config
     makeWrapper


### PR DESCRIPTION
Closes #547735

The patch to fix this CVE (https://github.com/CyberTimon/RapidRAW/commit/83852f36ba4a260beec45b9420ca3caed2542640) could not be applied directly, hence I backported it to v1.5.8 and included the patch file here.

Not a cherry pick because unstable could update to the latest version. The release-branch can't anymore due to a Rust version mismatch.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
