### PR TITLE
ssh-askpass-zigtk: init at 0.1.0

### DIFF
--- a/lib/licenses/licenses.nix
+++ b/lib/licenses/licenses.nix
@@ -1371,6 +1371,12 @@ lib.mapAttrs mkLicense (
       fullName = "Ruby License";
     };
 
+    segv = {
+      fullName = "SEGV License";
+      free = false;
+      url = "https://xn--gckvb8fzb.com/segv/";
+    };
+
     sendmail = {
       spdxId = "Sendmail";
       fullName = "Sendmail License";

--- a/pkgs/by-name/ss/ssh-askpass-zigtk/package.nix
+++ b/pkgs/by-name/ss/ssh-askpass-zigtk/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenv,
+  fetchFromForgejo,
+  zig,
+  pkg-config,
+  gtk4,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ssh-askpass-zigtk";
+  version = "0.1.0";
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromForgejo {
+    domain = "tty.fail";
+    owner = "mrus";
+    repo = "ssh-askpass-zigtk";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2NoM3TLSTJ4Gf+C+qGvq/Y2q9Va+wmmcM9FE9xeunWE=";
+  };
+
+  nativeBuildInputs = [
+    zig
+    pkg-config
+  ];
+
+  propagatedBuildInputs = [ gtk4 ];
+
+  doCheck = true;
+
+  meta = {
+    description = "ssh-askpass using GTK4 without X11 dependencies and written in Zig";
+    homepage = "https://tty.fail/mrus/ssh-askpass-zigtk";
+    license = lib.licenses.segv;
+    maintainers = with lib.maintainers; [ haansn08 ];
+    platforms = lib.platforms.all;
+    mainProgram = "ssh-askpass-zigtk";
+  };
+})


### PR DESCRIPTION
ssh-askpass-zigtk is a GTK4 SSH_ASKPASS helper written in Zig with minimal dependencies.
Upstream: https://tty.fail/mrus/ssh-askpass-zigtk
Blog post by author: https://マリウス.com/a-gtk4-ssh-askpass-in-zig/

This software is released under a custom license called [SEGV](https://マリウス.com/segv/) which I added to `lib.licenses`.
The author of this software, @mrusme, seems to re-license his projects under this license. Several of their projects seem to be packaged in nixpkgs, so this license becomes relevant, if we want to distribute new releases of following packages:
```
$ grep -lr mrusme pkgs
pkgs/by-name/ca/canard/package.nix  --> Repo Archived
pkgs/by-name/jo/journalist/package.nix --> Repo Archived
pkgs/by-name/ne/neonmodem/package.nix --> License changed to SEGV
pkgs/by-name/ov/overpush/package.nix --> still GPL
pkgs/by-name/re/reader/package.nix --> License changed to SEGV
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
