### PR TITLE
minimal-bootstrap: Package updates

### DIFF
--- a/pkgs/os-specific/linux/minimal-bootstrap/binutils/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/binutils/default.nix
@@ -20,11 +20,11 @@ let
   # Based on https://github.com/ZilchOS/bootstrap-from-tcc/blob/2e0c68c36b3437386f786d619bc9a16177f2e149/using-nix/2a1-static-binutils.nix
   inherit (import ./common.nix { inherit lib; }) meta;
   pname = "binutils";
-  version = "2.46.0";
+  version = "2.47";
 
   src = fetchurl {
     url = "mirror://gnu/binutils/binutils-${version}.tar.xz";
-    hash = "sha256-11qU9Nc+ekCG91E+Z+Q56Pzcu3Jv/mP0ZhdE5iVrLPI=";
+    hash = "sha256-FUqyO2AHDo8nATwil38RKUJdZ9HorNbhMBDmF4EeTP8=";
   };
 
   patches = [

--- a/pkgs/os-specific/linux/minimal-bootstrap/binutils/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/binutils/static.nix
@@ -20,11 +20,11 @@
 let
   inherit (import ./common.nix { inherit lib; }) meta;
   pname = "binutils-static";
-  version = "2.46.0";
+  version = "2.47";
 
   src = fetchurl {
     url = "mirror://gnu/binutils/binutils-${version}.tar.xz";
-    hash = "sha256-11qU9Nc+ekCG91E+Z+Q56Pzcu3Jv/mP0ZhdE5iVrLPI=";
+    hash = "sha256-FUqyO2AHDo8nATwil38RKUJdZ9HorNbhMBDmF4EeTP8=";
   };
 
   patches = [

--- a/pkgs/os-specific/linux/minimal-bootstrap/coreutils/musl.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/coreutils/musl.nix
@@ -15,11 +15,11 @@
 let
   inherit (import ./common.nix { inherit lib; }) meta;
   pname = "bootstrap-coreutils-musl";
-  version = "9.10";
+  version = "9.11";
 
   src = fetchurl {
     url = "mirror://gnu/coreutils/coreutils-${version}.tar.gz";
-    hash = "sha256-4L3h+2hQlEf8cjzyUX6KjH+kZ2mRm7dJDtNQoukjhWI=";
+    hash = "sha256-IDO4owScBr/0mp486nK99Gg7zQy+uXUhHdVtuvi3Nq4=";
   };
 
   configureFlags = [

--- a/pkgs/os-specific/linux/minimal-bootstrap/coreutils/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/coreutils/static.nix
@@ -19,11 +19,11 @@
 let
   inherit (import ./common.nix { inherit lib; }) meta;
   pname = "coreutils-static";
-  version = "9.10";
+  version = "9.11";
 
   src = fetchurl {
     url = "mirror://gnu/coreutils/coreutils-${version}.tar.gz";
-    hash = "sha256-4L3h+2hQlEf8cjzyUX6KjH+kZ2mRm7dJDtNQoukjhWI=";
+    hash = "sha256-IDO4owScBr/0mp486nK99Gg7zQy+uXUhHdVtuvi3Nq4=";
   };
 
   configureFlags = [

--- a/pkgs/os-specific/linux/minimal-bootstrap/findutils/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/findutils/default.nix
@@ -14,11 +14,11 @@
 }:
 let
   pname = "findutils";
-  version = "4.10.0";
+  version = "4.11.0";
 
   src = fetchurl {
     url = "mirror://gnu/findutils/findutils-${version}.tar.xz";
-    hash = "sha256-E4fgtn/yR9Kr3pmPkN+/cMFJE5Glnd/suK5ph4nwpPU=";
+    hash = "sha256-v9GcsGzHHzNS1WfpAoTYzawCrIl3S76t8LUzsMEUMv0=";
   };
 in
 bash.runCommand "${pname}-${version}"

--- a/pkgs/os-specific/linux/minimal-bootstrap/findutils/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/findutils/static.nix
@@ -17,11 +17,11 @@
 }:
 let
   pname = "findutils-static";
-  version = "4.10.0";
+  version = "4.11.0";
 
   src = fetchurl {
     url = "mirror://gnu/findutils/findutils-${version}.tar.xz";
-    hash = "sha256-E4fgtn/yR9Kr3pmPkN+/cMFJE5Glnd/suK5ph4nwpPU=";
+    hash = "sha256-v9GcsGzHHzNS1WfpAoTYzawCrIl3S76t8LUzsMEUMv0=";
   };
 in
 bash.runCommand "${pname}-${version}"

--- a/pkgs/os-specific/linux/minimal-bootstrap/gawk/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gawk/default.nix
@@ -7,6 +7,7 @@
   tinycc,
   gnumake,
   gnugrep,
+  gnupatch,
   gnused,
   gnutar,
   gzip,
@@ -15,12 +16,16 @@
 let
   inherit (import ./common.nix { inherit lib; }) meta;
   pname = "gawk";
-  version = "5.3.2";
+
+  version = "5.4.1";
 
   src = fetchurl {
     url = "mirror://gnu/gawk/gawk-${version}.tar.gz";
-    hash = "sha256-hjmhqI+0EaG+AmY3OdA+kCptMTtcb+Ak0L/rM0GhmhE=";
+    hash = "sha256-izsOqDkwMRo/MJBdPOiY0yxhA8L+INapC0A0EXGxdN4=";
   };
+  patches = [
+    ./node-struct-without-gmp-mpfr.patch
+  ];
 in
 bash.runCommand "${pname}-${version}"
   {
@@ -28,6 +33,7 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       tinycc.compiler
+      gnupatch
       gnumake
       gnused
       gnugrep
@@ -47,6 +53,9 @@ bash.runCommand "${pname}-${version}"
     # Unpack
     tar xzf ${src}
     cd gawk-${version}
+
+    # Patch
+    ${lib.concatMapStringsSep "\n" (f: "patch -Np1 -i ${f}") patches}
 
     # Configure
     export CC="tcc -B ${tinycc.libs}/lib"

--- a/pkgs/os-specific/linux/minimal-bootstrap/gawk/node-struct-without-gmp-mpfr.patch
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gawk/node-struct-without-gmp-mpfr.patch
@@ -1,0 +1,79 @@
+From bf85f8a3175af703597082d4c7e0abc2066a44d3 Mon Sep 17 00:00:00 2001
+From: "Arnold D. Robbins" <arnold@skeeve.com>
+Date: Tue, 14 Jul 2026 10:14:50 +0300
+Subject: [PATCH] Workaround fix for systems without MPFR and GMP.
+
+---
+ ChangeLog |  8 ++++++++
+ awk.h     | 23 ++++++++++++++---------
+ 2 files changed, 22 insertions(+), 9 deletions(-)
+
+diff --git a/ChangeLog b/ChangeLog
+index 6a955eed..42bd2c48 100644
+--- a/ChangeLog
++++ b/ChangeLog
+@@ -3,6 +3,14 @@
+ 	* builtin.c (do_dump_node): Add the size of each object to
+ 	the printout.
+ 
++	Unrelated: Make things works when built on systems without
++	the GMP and MPFR libraries.  Thanks to Thomas Trepl <ttrepl@yahoo.de>
++	and Bruce Dubbs <bdubbs@linuxfromscratch.org> for the reports.
++
++	* awk.h (struct exp_node): Add alignment padding when we don't
++	have MPFR. This is a hack, pending a total refactoring of
++	the NODE structure.
++
+ 2026-07-08         Arnold D. Robbins     <arnold@skeeve.com>
+ 
+ 	* 5.4.1: Release tar ball made.
+diff --git a/awk.h b/awk.h
+index dbad0d81..f4a84300 100644
+--- a/awk.h
++++ b/awk.h
+@@ -406,17 +406,24 @@ typedef struct exp_node {
+ 		} nodep;
+ 
+ 		struct {
+-#ifdef HAVE_MPFR
+ 			union {
+ 				AWKNUM fltnum;
++#ifdef HAVE_MPFR
+ 				mpfr_t mpnum;
+ 				mpz_t mpi;
+-			} nm;
+-			int rndmode;
+ #else
+-			AWKNUM fltnum;
+-			int for_alignment_only;	// especially on 32-bit
+-#endif
++				// 7/2026:
++				// This is a workaround for systems that build
++				// gawk without MPFR and GMP.  The NODE struct
++				// desperately needs to be refactored.
++#if SIZEOF_VOID_P == 4
++				char alignment[28];
++#else	// SIZEOF_VOID_P != 4
++				char alignment[48];
++#endif	// SIZEOF_VOID_P != 4
++#endif	// HAVE_MPFR
++			} nm;
++			int rndmode;	// only used for MPFR.
+ 			char *sp;
+ 			size_t slen;
+ 			int idx;
+@@ -561,10 +568,8 @@ typedef struct exp_node {
+ #ifdef HAVE_MPFR
+ #define mpg_numbr	sub.val.nm.mpnum
+ #define mpg_i		sub.val.nm.mpi
+-#define numbr		sub.val.nm.fltnum
+-#else
+-#define numbr		sub.val.fltnum
+ #endif
++#define numbr		sub.val.nm.fltnum
+ #define typed_re	sub.val.typre
+ 
+ /*
+-- 
+2.54.0
+

--- a/pkgs/os-specific/linux/minimal-bootstrap/gawk/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gawk/static.nix
@@ -6,6 +6,7 @@
   bash,
   gcc,
   binutils,
+  gnupatch,
   gnumake,
   gnused,
   gnugrep,
@@ -18,12 +19,15 @@
 let
   inherit (import ./common.nix { inherit lib; }) meta;
   pname = "gawk-static";
-  version = "5.3.2";
+  version = "5.4.1";
 
   src = fetchurl {
     url = "mirror://gnu/gawk/gawk-${version}.tar.gz";
-    hash = "sha256-hjmhqI+0EaG+AmY3OdA+kCptMTtcb+Ak0L/rM0GhmhE=";
+    hash = "sha256-izsOqDkwMRo/MJBdPOiY0yxhA8L+INapC0A0EXGxdN4=";
   };
+  patches = [
+    ./node-struct-without-gmp-mpfr.patch
+  ];
 in
 bash.runCommand "${pname}-${version}"
   {
@@ -32,6 +36,7 @@ bash.runCommand "${pname}-${version}"
     nativeBuildInputs = [
       gcc
       binutils
+      gnupatch
       gnumake
       gnused
       gnugrep
@@ -54,6 +59,9 @@ bash.runCommand "${pname}-${version}"
     # Unpack
     tar xf ${src}
     cd gawk-${version}
+
+    # Patch
+    ${lib.concatMapStringsSep "\n" (f: "patch -Np1 -i ${f}") patches}
 
     # Configure
     bash ./configure \

--- a/pkgs/os-specific/linux/minimal-bootstrap/glibc/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/glibc/default.nix
@@ -20,11 +20,11 @@
 }:
 let
   pname = "glibc";
-  version = "2.42";
+  version = "2.44";
 
   src = fetchurl {
     url = "mirror://gnu/libc/glibc-${version}.tar.xz";
-    hash = "sha256-0XdeMuRijmTvkw9DW2e7Y691may2viszW58Z8WUJ8X8=";
+    hash = "sha256-N/YA8r7zxegwAUcFlWiyouQKetbMxlzpQlVtSUKcxmc=";
   };
 
   linkerFile =

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnused/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnused/static.nix
@@ -13,16 +13,17 @@
   diffutils,
   findutils,
   gnutar,
+  linux-headers,
   xz,
 }:
 let
   inherit (import ./common.nix { inherit lib; }) meta;
   pname = "gnused-static";
-  version = "4.9";
+  version = "4.10";
 
   src = fetchurl {
     url = "mirror://gnu/sed/sed-${version}.tar.xz";
-    hash = "sha256-biJrcy4c1zlGStaGK9Ghq6QteYKSLaelNRljHSSXUYE=";
+    hash = "sha256-uOchgrLslqNXTimYxHt6qmTMIM4ADY6awxPMB87PKMc=";
   };
 in
 bash.runCommand "${pname}-${version}"
@@ -60,7 +61,8 @@ bash.runCommand "${pname}-${version}"
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
       --disable-dependency-tracking \
-      --disable-nls
+      --disable-nls \
+      CFLAGS="-I${linux-headers}/include"
 
     # Build
     make -j $NIX_BUILD_CORES

--- a/pkgs/os-specific/linux/minimal-bootstrap/patchelf/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/patchelf/static.nix
@@ -17,11 +17,11 @@
 }:
 let
   pname = "patchelf-static";
-  version = "0.18.0";
+  version = "0.19.1";
 
   src = fetchurl {
     url = "https://github.com/NixOS/patchelf/releases/download/${version}/patchelf-${version}.tar.gz";
-    sha256 = "sha256-ZN4Q5Ma4uDedt+h/WAMPM26nR8BRXzgRMugQ2/hKhuc=";
+    sha256 = "sha256-SREIco8SDOBbU5k0tBp1AjUDGm34q8a0flev994VCU0=";
   };
 in
 bash.runCommand "${pname}-${version}"

--- a/pkgs/os-specific/linux/minimal-bootstrap/python/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/python/default.nix
@@ -19,11 +19,11 @@
 }:
 let
   pname = "python";
-  version = "3.14.4";
+  version = "3.14.6";
 
   src = fetchurl {
     url = "https://www.python.org/ftp/python/${version}/Python-${version}.tar.xz";
-    hash = "sha256-2SPFEwPjjiSRNvwb3zVo1W7LAyFO/e9IUWF209f6rvg=";
+    hash = "sha256-FDsd3e+uw70uIeO4ObNKK3+5hCJyiDxXZCDWBenzDGM=";
   };
 
   patches = [


### PR DESCRIPTION
Updates binutils, coreutils, findutils, gawk, glibc, gnused, patchelf and python to latest versions, where supported by the available compiler and libc.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (glibc and musl)
  - [x] i686-linux-gnu
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
