### PR TITLE
neonmodem: 1.0.7 -> 1.1.0

### DIFF
--- a/pkgs/by-name/ne/neonmodem/package.nix
+++ b/pkgs/by-name/ne/neonmodem/package.nix
@@ -10,16 +10,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "neonmodem";
-  version = "1.0.7";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "mrusme";
     repo = "neonmodem";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-gwhQG8H1OnGQmawPQ3m6VKVooBh8rZaNr6FDl6fgZXc=";
+    hash = "sha256-O12zkygenzSMNwV5gqJuW5/vCblU/ebbT/0JotrfNiQ=";
   };
 
-  vendorHash = "sha256-zqQtuyFrsDB1xRdl4cbaTsCawMrBvcu78zXgU2jUwHI=";
+  vendorHash = "sha256-PAtt72mGPDyS1wZMHOwrO8crC0mJ1GPAIm3i5T16xQY=";
 
   passthru.updateScript = nix-update-script { };
 
@@ -44,7 +44,10 @@ buildGoModule (finalAttrs: {
     homepage = "https://neonmodem.com";
     downloadPage = "https://github.com/mrusme/neonmodem/releases";
     changelog = "https://github.com/mrusme/neonmodem/releases/tag/v${finalAttrs.version}";
+
+    # license is expected to change with the next release (commit: b3b5ff2)
     license = lib.licenses.gpl3Only;
+
     maintainers = with lib.maintainers; [ acuteaangle ];
     mainProgram = "neonmodem";
   };


### PR DESCRIPTION
Upstream release: https://github.com/mrusme/neonmodem/releases/tag/v1.1.0

I have also added a warning to the nix file because the license of this project might change with the next release:
https://github.com/mrusme/neonmodem/commit/b3b5ff28171bfbd51e4fd485bd8193c8f3d8a838

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
