### PR TITLE
nixos/greetd: generate INI-style config instead of TOML

### DIFF
--- a/nixos/modules/services/display-managers/greetd.nix
+++ b/nixos/modules/services/display-managers/greetd.nix
@@ -8,7 +8,30 @@
 let
   cfg = config.services.greetd;
   tty = "tty1";
-  settingsFormat = pkgs.formats.toml { };
+
+  # greetd no longer uses TOML for its configuration file: it now uses its own
+  # line-oriented "inish" format, which looks like TOML/INI but doesn't support
+  # TOML features such as multi-line strings, and requires string values to be
+  # escaped and quoted on a single line rather than emitted as-is.
+  # See https://github.com/NixOS/nixpkgs/issues/527565 and
+  # https://lists.sr.ht/~kennylevinsen/greetd-devel/%3C9bf809bb-c941-4672-8868-41d1e1d70b0b@arne.beer%3E
+  escapeGreetdString =
+    builtins.replaceStrings
+      [ "\\" "\"" "\n" "\r" "\t" ]
+      [ "\\\\" "\\\"" "\\n" "\\r" "\\t" ];
+
+  settingsFormat = pkgs.formats.ini {
+    mkKeyValue =
+      k: v:
+      let
+        valueString =
+          if builtins.isString v then
+            ''"${escapeGreetdString v}"''
+          else
+            lib.generators.mkValueStringDefault { } v;
+      in
+      "${lib.escape [ "=" ] k} = ${valueString}";
+  };
 in
 {
   imports = [
@@ -136,7 +159,7 @@ in
       };
 
       serviceConfig = {
-        ExecStart = "${lib.getExe cfg.package} --config ${settingsFormat.generate "greetd.toml" cfg.settings}";
+        ExecStart = "${lib.getExe cfg.package} --config ${settingsFormat.generate "greetd.conf" cfg.settings}";
 
         Restart = lib.mkIf cfg.restart "on-success";
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -728,6 +728,7 @@ in
   graphite = runTest ./graphite.nix;
   grav = runTest ./web-apps/grav.nix;
   graylog = runTest ./graylog.nix;
+  greetd-multiline-command = runTest ./greetd-multiline-command.nix;
   greetd-no-shadow = runTest ./greetd-no-shadow.nix;
   grocy = runTest ./grocy.nix;
   grow-partition = runTest ./grow-partition.nix;

--- a/nixos/tests/greetd-multiline-command.nix
+++ b/nixos/tests/greetd-multiline-command.nix
@@ -1,0 +1,58 @@
+{ ... }:
+{
+  name = "greetd-multiline-command";
+  meta = {
+    maintainers = [ ];
+  };
+
+  nodes.machine =
+    { pkgs, lib, ... }:
+    {
+      users.users.alice = {
+        isNormalUser = true;
+        group = "alice";
+        password = "foobar";
+      };
+      users.groups.alice = { };
+
+      # This means login(1) breaks, so we must use greetd/agreety instead.
+      security.shadow.enable = false;
+
+      # Regression test for https://github.com/NixOS/nixpkgs/issues/527565:
+      # greetd's configuration format is line-oriented and cannot represent a
+      # literal newline inside a value, so a multi-line `command` (as commonly
+      # written with Nix's `''...''` strings and shell line continuations)
+      # must still be serialized correctly instead of producing a config file
+      # that greetd fails to parse.
+      services.greetd = {
+        enable = true;
+        settings = {
+          default_session = {
+            command = ''
+              ${pkgs.greetd}/bin/agreety \
+                --cmd bash
+            '';
+          };
+        };
+      };
+    };
+
+  testScript = ''
+    machine.start()
+
+    machine.wait_for_unit("multi-user.target")
+    machine.wait_until_succeeds("pgrep -f 'agretty.*tty1'")
+    machine.screenshot("postboot")
+
+    with subtest("Log in as alice on a virtual console"):
+        machine.wait_until_tty_matches("1", "login: ")
+        machine.send_chars("alice\n")
+        machine.wait_until_tty_matches("1", "login: alice")
+        machine.wait_until_succeeds("pgrep login")
+        machine.wait_until_tty_matches("1", "Password: ")
+        machine.send_chars("foobar\n")
+        machine.wait_until_succeeds("pgrep -u alice bash")
+        machine.send_chars("touch done\n")
+        machine.wait_for_file("/home/alice/done")
+  '';
+}


### PR DESCRIPTION
greetd replaced its TOML config parser with its own line-oriented "inish" format a while ago (see the mailing list threads linked in the issue). This format cannot represent multi-line strings, but `pkgs.formats.toml` serializes any Nix string containing a newline (e.g. a `default_session.command` written with `''...''` and shell line-continuations) as a TOML triple-quoted string, which greetd fails to parse ("expected equals sign on line, but found none").

This switches `services.greetd.settings` to `pkgs.formats.ini`, matching greetd's actual flat `[section]` / `key = value` shape, and adds a custom serializer that quotes and escapes string values (backslashes, quotes, newlines) using the exact escape rules greetd's parser (`inish` + `enquote`) expects. Multi-line commands now fit on one physical line and decode back byte-for-byte, verified against greetd's own source.

Also renames the generated file from `greetd.toml` to `greetd.conf`, matching greetd's current default name (cosmetic, since `--config` is always passed explicitly).

Resolves #527565

## Things done

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]: added `nixos/tests/greetd-multiline-command.nix`, reproducing the bug report's scenario and verifying greetd starts and login succeeds.
- [ ] Ran `nixpkgs-review` on this PR.
- Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy]: this contribution was substantially produced with Claude Code (claude-sonnet-5), under my review and direction; disclosed here and via the `Assisted-by:` commit trailer.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests