### PR TITLE
lumux: init at 0.6.2

### DIFF
--- a/pkgs/by-name/lu/lumux/package.nix
+++ b/pkgs/by-name/lu/lumux/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  nix-update-script,
+  gobject-introspection,
+  wrapGAppsHook4,
+  gst_all_1,
+  libadwaita,
+  pipewire,
+}:
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "lumux";
+  version = "0.6.2";
+
+  src = fetchFromGitHub {
+    owner = "enginkirmaci";
+    repo = "lumux";
+    tag = "v${finalAttrs.version}";
+    sha256 = "sha256-LBRuYdKe8Jqewac1KRbKBSr1KVoFQEvKnJ3YRVyTZ1E=";
+  };
+
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
+  nativeBuildInputs = [
+    gobject-introspection
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    libadwaita
+    pipewire # pipewiresrc
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    pygobject3
+    zeroconf
+    urllib3
+    numpy
+    pillow
+    requests
+    pydbus
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Philips Hue Sync for Linux on Wayland";
+    homepage = "https://github.com/enginkirmaci/lumux";
+    mainProgram = "lumux";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    longDescription = "Real-time ambient lighting synchronization for Philips Hue lights on Linux (Wayland) using a GTK4/Adwaita interface";
+    maintainers = with lib.maintainers; [ olillin ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add `lumux`, a Philips Hue Sync-like app for Linux on Wayland.

Repository: [enginkirmaci/lumux](https://github.com/enginkirmaci/lumux)

I messed up the branch while updating the previous pull request (#546766), that is why there are two.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
