### PR TITLE
vid-stab: 1.1.1-unstable-2025-08-21 -> 1.1.2

### DIFF
--- a/pkgs/development/libraries/vid-stab/default.nix
+++ b/pkgs/development/libraries/vid-stab/default.nix
@@ -6,28 +6,20 @@
   openmp,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "vid.stab";
-  version = "1.1.1-unstable-2025-08-21";
+  version = "1.1.2";
 
   src = fetchFromGitHub {
     owner = "georgmartius";
     repo = "vid.stab";
-    rev = "4bd81e3cdd778e2e0edc591f14bba158ec40cfa1";
-    hash = "sha256-imSy1ywpGWbghP65NoPgUJBJmHUY5OsLWmIXk6Q1MQ4=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8YyIBYp3/tThQBrnZsiusKyhP2kO0qAsxTwy9mVQiRk=";
   };
 
   nativeBuildInputs = [ cmake ];
 
   propagatedBuildInputs = lib.optionals stdenv.cc.isClang [ openmp ];
-
-  # Fix the build with CMake 4.
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace-fail \
-        'cmake_minimum_required (VERSION 2.8.5)' \
-        'cmake_minimum_required (VERSION 3.10)'
-  '';
 
   meta = {
     description = "Video stabilization library";
@@ -36,4 +28,4 @@ stdenv.mkDerivation {
     maintainers = [ ];
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
Changes: https://github.com/georgmartius/vid.stab/compare/v1.1.1...v1.1.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
