### PR TITLE
python3Packages.signxml: 4.5.1 -> 5.1.0; fixes for pyhanko, python-pskc

### DIFF
--- a/pkgs/by-name/py/pyhanko-cli/package.nix
+++ b/pkgs/by-name/py/pyhanko-cli/package.nix
@@ -38,6 +38,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
       tzlocal
       pyhanko
       pyhanko-certvalidator
+      pyyaml
       click
       platformdirs
     ]

--- a/pkgs/development/python-modules/pyhanko/default.nix
+++ b/pkgs/development/python-modules/pyhanko/default.nix
@@ -4,6 +4,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   pyprojectVersionPatchHook,
+  stdenv,
 
   # build-system
   setuptools,
@@ -39,14 +40,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pyhanko";
-  version = "0.35.2";
+  version = "0.36.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "MatthiasValvekens";
     repo = "pyHanko";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-CY+YgUu8za5c0t2OKStKvCN9X8hVXT2sN42KSDiyMX8=";
+    hash = "sha256-Dv1Pz4ri574vh50ter9TbFSvQ+0Mbbifw8kjjv04qs8=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/pkgs/pyhanko";
@@ -172,5 +173,7 @@ buildPythonPackage (finalAttrs: {
     changelog = "https://github.com/MatthiasValvekens/pyHanko/blob/${finalAttrs.src.tag}/docs/changelog.rst#pyhanko";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.antonmosich ];
+    # OSError: One or more parameters passed to a function were not valid.
+    broken = stdenv.hostPlatform.isDarwin;
   };
 })

--- a/pkgs/development/python-modules/pyhanko/default.nix
+++ b/pkgs/development/python-modules/pyhanko/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   pyprojectVersionPatchHook,
@@ -14,7 +13,6 @@
   cryptography,
   lxml,
   pyhanko-certvalidator,
-  pyyaml,
   requests,
   tzlocal,
 
@@ -69,7 +67,6 @@ buildPythonPackage (finalAttrs: {
     cryptography
     lxml
     pyhanko-certvalidator
-    pyyaml
     requests
     tzlocal
   ];

--- a/pkgs/development/python-modules/python-pskc/default.nix
+++ b/pkgs/development/python-modules/python-pskc/default.nix
@@ -10,18 +10,19 @@
   python-dateutil,
   setuptools,
   signxml,
+  stdenv,
 }:
 
 buildPythonPackage rec {
   pname = "python-pskc";
-  version = "1.4";
+  version = "1.4-unstable-2026-07-18";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "arthurdejong";
     repo = "python-pskc";
-    tag = version;
-    hash = "sha256-WBpS0EJA4arAn7O47ZHq3sBOd9D4tjYZKIi24xX5Hvs=";
+    rev = "6bcd0274db24467f7c9c410b31461228f70d6620";
+    hash = "sha256-0Pf803akJdTTCeMYC0/CwZNMySYQReFNbt69nl24AII=";
   };
 
   build-system = [
@@ -48,6 +49,16 @@ buildPythonPackage rec {
   preCheck = ''
     export TZ=Europe/Amsterdam
   '';
+
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
+    # Assert difference between tzinfo=tzutc() and tzinfo=tzlocal()
+    "tests/test_draft_ietf_keyprov_pskc_02.doctest::test_draft_ietf_keyprov_pskc_02.doctest"
+    "tests/test_draft_keyprov.doctest::test_draft_keyprov.doctest"
+    "tests/test_feitian.doctest::test_feitian.doctest"
+    "tests/test_misc.doctest::test_misc.doctest"
+    "tests/test_rfc6030.doctest::test_rfc6030.doctest"
+    "tests/test_yubico.doctest::test_yubico.doctest"
+  ];
 
   pythonImportsCheck = [ "pskc" ];
 

--- a/pkgs/development/python-modules/signxml/default.nix
+++ b/pkgs/development/python-modules/signxml/default.nix
@@ -5,7 +5,6 @@
   cryptography,
   fetchFromGitHub,
   lxml,
-  pyopenssl,
   pytestCheckHook,
   hatchling,
   hatch-vcs,
@@ -13,14 +12,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "signxml";
-  version = "4.5.1";
+  version = "5.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "XML-Security";
     repo = "signxml";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-0DzHw7E2sAJE3O7io++zjsi07FbkBD24EjGDOVo8/9s=";
+    hash = "sha256-SvM+wqlJd2n3gg1ROzWTuUvwSlOrMQIPDO39IyVNrRA=";
   };
 
   build-system = [
@@ -32,7 +31,6 @@ buildPythonPackage (finalAttrs: {
     certifi
     cryptography
     lxml
-    pyopenssl
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];


### PR DESCRIPTION
The update to the head of the branch of python-pskc is to include a fix which makes python-pskc not break with
signxml 5.1.0.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
