### PR TITLE
nixl: 1.3.1 -> 1.3.2

### DIFF
--- a/pkgs/by-name/ni/nixl/package.nix
+++ b/pkgs/by-name/ni/nixl/package.nix
@@ -36,7 +36,7 @@ let
 in
 effectiveStdenv.mkDerivation (finalAttrs: {
   pname = "nixl";
-  version = "1.3.1";
+  version = "1.3.2";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -45,7 +45,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     owner = "ai-dynamo";
     repo = "nixl";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-nimu8WSeG+BHPx0VQ56TwL0ThVwuGOi2OHLvso46oe4=";
+    hash = "sha256-aSZ9kiEAQlVFW3+XJih5Ujk1mxOvaepX19u3Xfz4iSg=";
   };
 
   postPatch =

--- a/pkgs/development/python-modules/nixl/default.nix
+++ b/pkgs/development/python-modules/nixl/default.nix
@@ -82,6 +82,10 @@ buildPythonPackage.override { inherit (nixl) stdenv; } (finalAttrs: {
   # No tests we can run in the sandbox
   doCheck = false;
 
+  # The wheel installs as `nixl_cu{12,13}`, while the plain `nixl` module is a metadata-less shim
+  # (see postInstall), so there is no `nixl` .dist-info to check.
+  dontCheckPythonMetadata = true;
+
   meta = nixl.meta // {
     description = "Python API for nixl";
   };


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/ai-dynamo/nixl/compare/v1.3.1...v1.3.2
Changelog: https://github.com/ai-dynamo/nixl/releases/tag/v1.3.2

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test