### PR TITLE
giflib: patch CVE-2026-23868 and CVE-2026-26740

### DIFF
--- a/pkgs/by-name/gi/giflib/CVE-2026-23868.patch
+++ b/pkgs/by-name/gi/giflib/CVE-2026-23868.patch
@@ -1,0 +1,33 @@
+From 75acad3e1c9937f2b10330d563c4fa3e6c902d21 Mon Sep 17 00:00:00 2001
+From: "Eric S. Raymond" <esr@thyrsus.com>
+Date: Wed, 4 Mar 2026 18:49:49 -0500
+Subject: [PATCH] [CVE-2026-23868] Avoid potentuial double-free on weird
+ images.
+
+(cherry picked from commit f5b7267aed3665ef025c13823e454170d031c106)
+---
+ gifalloc.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/gifalloc.c b/gifalloc.c
+index 47c653930f6d..479c6c5a21bd 100644
+--- a/gifalloc.c
++++ b/gifalloc.c
+@@ -349,6 +349,14 @@ SavedImage *GifMakeSavedImage(GifFileType *GifFile,
+ 			 * aliasing problems.
+ 			 */
+ 
++			/* Null out aliased pointers before any allocations
++			 * so that FreeLastSavedImage won't free CopyFrom's
++			 * data if an allocation fails partway through. */
++			sp->ImageDesc.ColorMap = NULL;
++			sp->RasterBits = NULL;
++			sp->ExtensionBlocks = NULL;
++			sp->ExtensionBlockCount = 0;
++ 
+ 			/* first, the local color map */
+ 			if (CopyFrom->ImageDesc.ColorMap != NULL) {
+ 				sp->ImageDesc.ColorMap = GifMakeMapObject(
+-- 
+2.54.0
+

--- a/pkgs/by-name/gi/giflib/CVE-2026-26740.patch
+++ b/pkgs/by-name/gi/giflib/CVE-2026-26740.patch
@@ -1,0 +1,37 @@
+From 88a2df92422b0aa5e52e75c5214d60080714abd7 Mon Sep 17 00:00:00 2001
+From: Anthony Hurtado <amhurtado@protonmail.com>
+Date: Mon, 1 Jun 2026 15:40:48 -0500
+Subject: [PATCH] Fix CVE-2026-26740: heap OOB write in EGifGCBToSavedExtension
+
+EGifGCBToSavedExtension calls EGifGCBToExtension which unconditionally
+writes 4 bytes into ep->Bytes without checking ep->ByteCount.  If the
+extension block was allocated with fewer than 4 bytes, this results in
+a heap buffer overflow.
+
+The read-side counterpart DGifExtensionToGCB already validates that
+GifExtensionLength == 4 before reading.  Add the symmetric check on
+the write side: return GIF_ERROR when ep->ByteCount < 4.
+
+Signed-off-by: Anthony Hurtado <amhurtado@pm.me>
+(cherry picked from commit 061605081115bbfd7019bafc119a13b6f17fcf25)
+---
+ egif_lib.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/egif_lib.c b/egif_lib.c
+index 152686828680..8160560a4ab6 100644
+--- a/egif_lib.c
++++ b/egif_lib.c
+@@ -678,6 +678,9 @@ int EGifGCBToSavedExtension(const GraphicsControlBlock *GCB,
+ 		ExtensionBlock *ep =
+ 		    &GifFile->SavedImages[ImageIndex].ExtensionBlocks[i];
+ 		if (ep->Function == GRAPHICS_EXT_FUNC_CODE) {
++			if (ep->ByteCount < 4) {
++				return GIF_ERROR;
++			}
+ 			EGifGCBToExtension(GCB, ep->Bytes);
+ 			return GIF_OK;
+ 		}
+-- 
+2.54.0
+

--- a/pkgs/by-name/gi/giflib/package.nix
+++ b/pkgs/by-name/gi/giflib/package.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     ./CVE-2021-40633.patch
     ./CVE-2025-31344.patch
+    ./CVE-2026-23868.patch
+    ./CVE-2026-26740.patch
   ]
   ++ lib.optionals stdenv.hostPlatform.isMinGW [
     # Build dll libraries.


### PR DESCRIPTION
The unstable branch [upgraded to the next major version of `giflib`](https://github.com/NixOS/nixpkgs/pull/526490), which is a change that cannot be backported.

Fixes https://github.com/NixOS/nixpkgs/issues/498852 for 26.05.

The changes (as the CI tattled on me) were made and tested against `nixos-26.05`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
