### PR TITLE
magnetic-catppuccin-gtk: bring back package at 1.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29495,6 +29495,12 @@
     github = "username-generic";
     githubId = 202454830;
   };
+  Username404-59 = {
+    name = "Charlie Quinet";
+    email = "charlie.quinet@gmail.com";
+    github = "Username404-59";
+    githubId = 53659497;
+  };
   usertam = {
     name = "Samuel Tam";
     email = "code@usertam.dev";

--- a/pkgs/by-name/ma/magnetic-catppuccin-gtk/package.nix
+++ b/pkgs/by-name/ma/magnetic-catppuccin-gtk/package.nix
@@ -1,0 +1,137 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  jdupes,
+  nix-update-script,
+  sassc,
+  accent ? [ "default" ],
+  shade ? "dark",
+  size ? "standard",
+  tweaks ? [ ],
+  radius ? null,
+  shell_radius ? radius,
+  shell_float ? false,
+  shell_opacity ? null,
+  shell_no-border ? false,
+}:
+let
+  validAccents = [
+    "default"
+    "blue"
+    "flamingo"
+    "green"
+    "grey"
+    "lavender"
+    "maroon"
+    "mauve"
+    "peach"
+    "pink"
+    "red"
+    "rosewater"
+    "sapphire"
+    "sky"
+    "teal"
+    "yellow"
+    "all"
+  ];
+  validShades = [
+    "light"
+    "dark"
+  ];
+  validSizes = [
+    "standard"
+    "compact"
+  ];
+  validTweaks = [
+    "frappe"
+    "macchiato"
+    "black"
+    "border"
+    "macos"
+    "files-legacy"
+  ];
+
+  single = x: lib.optional (x != null) x;
+  pname = "Catppuccin-GTK";
+in
+lib.checkListOfEnum "${pname} Valid theme accent(s)" validAccents accent lib.checkListOfEnum
+  "${pname} Valid shades"
+  validShades
+  (single shade)
+  lib.checkListOfEnum
+  "${pname} Valid sizes"
+  validSizes
+  (single size)
+  lib.checkListOfEnum
+  "${pname} Valid tweaks"
+  validTweaks
+  tweaks
+
+  stdenv.mkDerivation
+  (finalAttrs: {
+    pname = "magnetic-${lib.toLower pname}";
+    version = "1.0.1";
+
+    src = fetchFromGitHub {
+      owner = "Fausto-Korpsvart";
+      repo = "Catppuccin-GTK-Theme";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-wS5Pt/Ao4iFY9Nc5ceDUHTVB5pZLyIoaPUSavja3pHw=";
+    };
+
+    nativeBuildInputs = [
+      jdupes
+      sassc
+    ];
+
+    postPatch = ''
+      find -name "*.sh" -print0 | while IFS= read -r -d ''' file; do
+        patchShebangs "$file"
+      done
+
+      rm -r themes/src/main/gtk-2.0
+      sed -i '/gtk-2/Is/^.*$/:/' themes/lib/installers/gtk.sh themes/lib/gtkrc.sh
+
+      substituteInPlace themes/lib/utils.sh \
+        --replace-fail 'LOG_FILE="''${HOME}/.cache/catppuccin-install.log"' 'LOG_FILE=/dev/null'
+    '';
+
+    dontBuild = true;
+
+    passthru.updateScript = nix-update-script { };
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/share/themes
+
+      BATCH_MODE=true ./themes/install.sh \
+        --name ${pname} \
+        ${toString (map (x: "--theme " + x) accent)} \
+        ${lib.optionalString (shade != null) ("--color " + shade)} \
+        ${lib.optionalString (size != null) ("--size " + size)} \
+        ${toString (map (x: "--tweaks " + x) tweaks)} \
+        ${lib.optionalString (radius != null) "--tweaks radius ${toString radius}"} \
+        ${lib.optionalString (shell_radius != null) "--shell radius ${toString shell_radius}"} \
+        ${lib.optionalString (shell_opacity != null) "--shell opacity ${toString shell_opacity}"} \
+        ${lib.optionalString shell_float "--shell float"} \
+        ${lib.optionalString shell_no-border "--shell no-border"} \
+        --dest $out/share/themes
+
+      jdupes --quiet --link-soft --recurse $out/share
+
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "GTK Theme with Catppuccin colour scheme";
+      homepage = "https://github.com/Fausto-Korpsvart/Catppuccin-GTK-Theme";
+      license = lib.licenses.gpl3Only;
+      maintainers = with lib.maintainers; [
+        icy-thought
+        Username404-59
+      ];
+      platforms = lib.platforms.all;
+    };
+  })

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1538,7 +1538,6 @@ mapAliases {
   MACS2 = throw "'MACS2' has been renamed to/replaced by 'macs2'"; # Converted to throw 2025-10-27
   magma_2_6_2 = throw "'magma_2_6_2' has been removed, use the latest 'magma' package instead."; # Added 2025-07-20
   magma_2_7_2 = throw "'magma_2_7_2' has been removed, use the latest 'magma' package instead."; # Added 2025-07-20
-  magnetic-catppuccin-gtk = throw "'magnetic-catppuccin-gtk' has been removed because it depended on 'gtk-engine-murrine', which was removed because it was unmaintained upstream and depended on GTK 2."; # Added 2026-07-22
   magpie = throw "'magpie' has been removed, no longer used by budgie-desktop."; # Added 2025-11-19
   maia-icon-theme = throw "'maia-icon-theme' has been removed due to outdated KF5 dependencies."; # Added 2026-05-01
   mailcore2 = throw "'mailcore2' has been removed due to lack of upstream maintenance."; # Added 2025-06-09


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This re-adds magnetic-catppuccin-gtk which I noticed was removed by ce5d2038330a3196a1f0f7dc6d0664e0671bf4fc
I updated it to v1.0.1, made it it not install its gtk-2.0 part that was dependent on murrine, and took the liberty of adding nix-update-script (+ added myself to meta.maintainers)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Closes #542903