### PR TITLE
libfaketime: fix Darwin build

### DIFF
--- a/pkgs/by-name/li/libfaketime/package.nix
+++ b/pkgs/by-name/li/libfaketime/package.nix
@@ -34,15 +34,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./nix-store-date.patch
-
-    # GCC 16's unused variable analysis is more advanced than previous
-    # versions, and detects that these variables are unused.
-    # https://github.com/wolfcw/libfaketime/pull/528
-    (fetchpatch {
-      name = "libfaketime-silence-unused-variable-warning.patch";
-      url = "https://github.com/wolfcw/libfaketime/commit/712733e5f01e45372f3160cfdbcfd91520cb093d.patch";
-      hash = "sha256-Gu13gFhgvkncj8aowAnSRbHbUCctF5sakbX4uRwdy+A=";
-    })
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     (fetchpatch {
@@ -57,6 +48,16 @@ stdenv.mkDerivation (finalAttrs: {
     })
     # https://github.com/wolfcw/libfaketime/issues/277
     ./0001-Remove-unsupported-clang-flags.patch
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+    # GCC 16's unused variable analysis is more advanced than previous
+    # versions, and detects that these variables are unused.
+    # https://github.com/wolfcw/libfaketime/pull/528
+    (fetchpatch {
+      name = "libfaketime-silence-unused-variable-warning.patch";
+      url = "https://github.com/wolfcw/libfaketime/commit/712733e5f01e45372f3160cfdbcfd91520cb093d.patch";
+      hash = "sha256-Gu13gFhgvkncj8aowAnSRbHbUCctF5sakbX4uRwdy+A=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
This patch does not apply against v0.9.10.

Introduced by #537420
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
