### PR TITLE
dusklight: 1.3.1 -> 1.4.1

### DIFF
--- a/pkgs/by-name/du/dusklight/package.nix
+++ b/pkgs/by-name/du/dusklight/package.nix
@@ -41,18 +41,18 @@ let
   auroraSrc = fetchFromGitHub {
     owner = "encounter";
     repo = "aurora";
-    rev = "cb2c340d6cde6827387f14c31ce19e5f28a40e09";
-    hash = "sha256-fiAe5DChCFeakI3pga/g0tXd27osnhQtMBQchuP2NwQ=";
+    rev = "22351fb0b76a4f4f2c4a4dff95aa300101e861aa";
+    hash = "sha256-gDY09IKlTu1Pj7mKw4eQYVXFDJ7j/aTp0iT/Ke93s6s=";
   };
   dawnSrc = fetchzip (
     {
       x86_64-linux = {
-        url = "https://github.com/encounter/dawn-build/releases/download/v20260523.201736/dawn-linux-x86_64.tar.gz";
-        hash = "sha256-KkdlSeiaw2gbQa+phZOpgbequshxQaFITzFdiuGBZvc=";
+        url = "https://github.com/encounter/dawn-build/releases/download/v20260603.191052/dawn-linux-x86_64.tar.gz";
+        hash = "sha256-yTanM4TUIv6akgpt2tai/2W6q4RAt48CxKobRgxK8WU=";
       };
       aarch64-linux = {
-        url = "https://github.com/encounter/dawn-build/releases/download/v20260523.201736/dawn-linux-aarch64.tar.gz";
-        hash = "sha256-accDTIBzgByQ8Rk2a1dAm85s8hj9SYI7NoHkih0vvAg=";
+        url = "https://github.com/encounter/dawn-build/releases/download/v20260603.191052/dawn-linux-aarch64.tar.gz";
+        hash = "sha256-C9pMaUOkSknwQfIw45+WIFve+noTiqud+RiQ0/kV4fA=";
       };
     }
     .${stdenv.hostPlatform.system}
@@ -77,13 +77,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "dusklight";
-  version = "1.3.1";
+  version = "1.4.1";
 
   src = fetchFromGitHub {
     owner = "TwilitRealm";
     repo = "dusklight";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-TarPuCE6bjn4nGtHU54pE2gAo/dIgTyghWn7hjdFFgk=";
+    hash = "sha256-wrbsgK9lAiO3+qfQcQ/o+6zEFS27CymJm76FAEanrdM=";
   };
 
   strictDeps = true;
@@ -154,6 +154,8 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "AURORA_SDL3_PROVIDER" "system")
     (lib.cmakeFeature "AURORA_NOD_PROVIDER" "system")
     (lib.cmakeFeature "AURORA_NOD_LINKAGE" "static")
+    (lib.cmakeFeature "CMAKE_CXX_FLAGS_INIT" "-include cstring")
+    (lib.cmakeBool "BUILD_SHARED_LIBS" false)
     (lib.cmakeBool "CMAKE_CROSSCOMPILING" true)
     (lib.cmakeBool "DUSK_ENABLE_SENTRY_NATIVE" false)
   ];


### PR DESCRIPTION
Diff : https://github.com/TwilitRealm/dusklight/compare/v1.3.1...v1.4.1
Changelog : https://github.com/TwilitRealm/dusklight/releases/tag/v1.4.1
Fix : https://github.com/NixOS/nixpkgs/issues/553376

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
