### PR TITLE
weston: 15.0.1 -> 16.0.0

### DIFF
--- a/pkgs/by-name/we/weston/package.nix
+++ b/pkgs/by-name/we/weston/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitLab,
-  fetchpatch, # Added for applying patch
   meson,
   ninja,
   nix-update-script,
@@ -11,7 +10,7 @@
   wayland-scanner,
   cairo,
   libGL,
-  libdisplay-info_0_2,
+  libdisplay-info_0_3,
   libdrm,
   libevdev,
   libinput,
@@ -32,14 +31,12 @@
   lua5_4_compat,
   pangoSupport ? true,
   pango,
-  pipewireSupport ? true,
+  pipewireSupport ? false,
   pipewire,
   rdpSupport ? true,
   freerdp,
-  remotingSupport ? true,
+  remotingSupport ? false,
   gst_all_1,
-  vaapiSupport ? false,
-  libva,
   vncSupport ? true,
   aml,
   neatvnc,
@@ -56,25 +53,15 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "weston";
-  version = "15.0.1";
+  version = "16.0.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "wayland";
     repo = "weston";
     rev = finalAttrs.version;
-    hash = "sha256-c6h8GQt1S3t2+K+8A4ncxBtWLtaV61EABdYA55o9i4o=";
+    hash = "sha256-0TBVyqnfd7GMGPAzbYOmDZgv4gF5kxiqaA8+A0+sEqU=";
   };
-
-  patches = [
-    # backend-vnc, gitlab-ci: Update to Neat VNC 1.0.0, aml 1.0.0
-    # https://gitlab.freedesktop.org/wayland/weston/-/merge_requests/2064
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/wayland/weston/-/commit/8a1c91e771312d1e0d0cd92495ef717402784dae.patch";
-      hash = "sha256-9eBONM7OfzHhCuT8Wnq534KS51q2VtUyOOLjYHohEds=";
-      excludes = [ ".gitlab-ci.yml" ];
-    })
-  ];
 
   depsBuildBuild = [ pkg-config ];
   nativeBuildInputs = [
@@ -89,7 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     cairo
     libGL
-    libdisplay-info_0_2
+    libdisplay-info_0_3
     libdrm
     libevdev
     libinput
@@ -109,7 +96,6 @@ stdenv.mkDerivation (finalAttrs: {
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
   ]
-  ++ lib.optional vaapiSupport libva
   ++ lib.optionals vncSupport [
     aml
     neatvnc
@@ -127,7 +113,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   mesonFlags = [
-    (lib.mesonBool "deprecated-backend-drm-screencast-vaapi" vaapiSupport)
     (lib.mesonBool "backend-pipewire" pipewireSupport)
     (lib.mesonBool "backend-rdp" rdpSupport)
     (lib.mesonBool "backend-vnc" vncSupport)
@@ -135,8 +120,8 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonBool "demo-clients" demoSupport)
     (lib.mesonBool "image-jpeg" jpegSupport)
     (lib.mesonBool "image-webp" webpSupport)
-    (lib.mesonBool "pipewire" pipewireSupport)
-    (lib.mesonBool "remoting" remotingSupport)
+    (lib.mesonBool "deprecated-pipewire" pipewireSupport)
+    (lib.mesonBool "deprecated-remoting" remotingSupport)
     (lib.mesonBool "renderer-vulkan" vulkanSupport)
     (lib.mesonOption "simple-clients" "")
     (lib.mesonBool "shell-lua" luaSupport)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9697,7 +9697,6 @@ with pkgs;
     pipewireSupport = false;
     rdpSupport = false;
     remotingSupport = false;
-    vaapiSupport = false;
     vncSupport = false;
     vulkanSupport = false;
     webpSupport = false;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

After this is merged, `libdisplay-info` 0.2 can be dropped.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
