### PR TITLE
python3Packages.bambi: 0.18.0 -> 0.19.0

### DIFF
--- a/pkgs/development/python-modules/bambi/default.nix
+++ b/pkgs/development/python-modules/bambi/default.nix
@@ -28,14 +28,15 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "bambi";
-  version = "0.18.0";
+  version = "0.19.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "bambinos";
     repo = "bambi";
     tag = finalAttrs.version;
-    hash = "sha256-vxsjPYQkqvmB5oKKl29+xq1BPEzBTozz9/W5mICWI4A=";
+    hash = "sha256-2BLbvdVN+wkmP2NCGaBoJO10hbBXUJ1/Q7bjRN4idWM=";
   };
 
   build-system = [
@@ -74,6 +75,9 @@ buildPythonPackage (finalAttrs: {
   ];
 
   disabledTests = [
+    # Requires `nutpie`, which is not packaged in nixpkgs
+    "test_nuts_parameter_forwarded_to_external_samplers"
+
     # ValueError: dtype attribute is not a valid dtype instance
     "test_vonmises_regression"
 
@@ -89,6 +93,8 @@ buildPythonPackage (finalAttrs: {
 
     # Tests require network access
     "test_alias_equal_to_name"
+    "test_exclusion"
+    "test_inplace_false"
     "test_average_by"
     "test_ax"
     "test_basic"

--- a/pkgs/development/python-modules/blackjax/default.nix
+++ b/pkgs/development/python-modules/blackjax/default.nix
@@ -100,6 +100,8 @@ buildPythonPackage (finalAttrs: {
   ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
     # AssertionError: Not equal to tolerance rtol=1e-07, atol=1e-05
     "test_equal_matrices"
+    "test_restart_after_reset_matches_fresh_accumulation"
+    "test_split_pop_k1_degenerate"
   ];
 
   pythonImportsCheck = [ "blackjax" ];


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/bambinos/bambi/compare/0.18.0...0.19.0
Changelog: https://github.com/bambinos/bambi/releases/tag/0.19.0

cc @bcdarwin

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test