### PR TITLE
nodejs, buildNpmPackage, importNpmLock: fix Git dependencies and npm flags with structured attributes

### DIFF
--- a/pkgs/build-support/node/build-npm-package/hooks/npm-build-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-build-hook.sh
@@ -14,7 +14,12 @@ npmBuildHook() {
         exit 1
     fi
 
-    if ! npm run ${npmWorkspace+--workspace=$npmWorkspace} "$npmBuildScript" $npmBuildFlags "${npmBuildFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}"; then
+    local flagsArray=()
+    concatTo flagsArray npmBuildFlags npmBuildFlagsArray npmFlags npmFlagsArray
+
+    echoCmd 'npmBuildHook flags' "${flagsArray[@]}"
+
+    if ! npm run ${npmWorkspace+--workspace=$npmWorkspace} "$npmBuildScript" "${flagsArray[@]}"; then
         echo
         echo "ERROR: \`npm run $npmBuildScript [...]\` failed"
         echo

--- a/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
@@ -17,6 +17,13 @@ npmConfigHook() {
     export forceGitDeps
     export prefetchNpmDeps="@prefetchNpmDeps@"
 
+    local -a nixNpmFlags=()
+    local -a nixNpmInstallFlags=()
+    local -a nixNpmRebuildFlags=()
+    concatTo nixNpmFlags npmFlags npmFlagsArray
+    concatTo nixNpmInstallFlags npmInstallFlags npmInstallFlagsArray
+    concatTo nixNpmRebuildFlags npmRebuildFlags npmRebuildFlagsArray
+
     if [ -n "${npmRoot-}" ]; then
       pushd "$npmRoot"
     fi
@@ -132,7 +139,9 @@ npmConfigHook() {
 
     echo "Installing dependencies"
 
-    if ! npm ci --ignore-scripts $npmInstallFlags "${npmInstallFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}"; then
+    echoCmd 'npmConfigHook ci flags' "${nixNpmInstallFlags[@]}" "${nixNpmFlags[@]}"
+
+    if ! npm ci --ignore-scripts "${nixNpmInstallFlags[@]}" "${nixNpmFlags[@]}"; then
         echo
         echo "ERROR: npm failed to install dependencies"
         echo
@@ -148,7 +157,9 @@ npmConfigHook() {
 
     patchShebangs node_modules
 
-    npm rebuild $npmRebuildFlags "${npmRebuildFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}"
+    echoCmd 'npmConfigHook rebuild flags' "${nixNpmRebuildFlags[@]}" "${nixNpmFlags[@]}"
+
+    npm rebuild "${nixNpmRebuildFlags[@]}" "${nixNpmFlags[@]}"
 
     patchShebangs node_modules
 

--- a/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
@@ -24,6 +24,19 @@ npmConfigHook() {
     concatTo nixNpmInstallFlags npmInstallFlags npmInstallFlagsArray
     concatTo nixNpmRebuildFlags npmRebuildFlags npmRebuildFlagsArray
 
+    # The nested npm process needs these flags as well, but an environment
+    # variable can not hold a list. Pass them as a quoted string, which the
+    # patch turns back into an array with `eval`. `[*]` joins on the first
+    # character of IFS, so make sure that it is a space.
+    #
+    # This is also why the lists above are kept apart instead of being
+    # concatenated into one array per npm invocation, like the way the other
+    # hooks do.
+    local IFS=$' \t\n'
+    export NIX_NPM_FLAGS="${nixNpmFlags[*]@Q}"
+    export NIX_NPM_INSTALL_FLAGS="${nixNpmInstallFlags[*]@Q}"
+    export NIX_NPM_REBUILD_FLAGS="${nixNpmRebuildFlags[*]@Q}"
+
     if [ -n "${npmRoot-}" ]; then
       pushd "$npmRoot"
     fi

--- a/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
@@ -5,6 +5,16 @@ npmConfigHook() {
 
     # Use npm patches in the nodejs package
     export NIX_NODEJS_BUILDNPMPACKAGE=1
+
+    # Git dependencies with install scripts are prepared by a nested npm
+    # process (see node-npm-build-npm-package-logic.patch), which expects these
+    # from its environment. With `__structuredAttrs = true`, derivation
+    # attributes are shell variables instead of environment variables, so they
+    # need to be exported explicitly. Note that this exports them for every
+    # child process of the build, not just for npm; `prefetchNpmDeps` below has
+    # always been like this.
+    export stdenv
+    export forceGitDeps
     export prefetchNpmDeps="@prefetchNpmDeps@"
 
     if [ -n "${npmRoot-}" ]; then

--- a/pkgs/build-support/node/build-npm-package/hooks/npm-install-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-install-hook.sh
@@ -7,12 +7,17 @@ npmInstallHook() {
 
     local -r packageOut="$out/lib/node_modules/$(@jq@ --raw-output '.name' package.json)"
 
+    local packFlagsArray=()
+    concatTo packFlagsArray npmPackFlags npmPackFlagsArray npmFlags npmFlagsArray
+
+    echoCmd 'npmInstallHook pack flags' "${packFlagsArray[@]}"
+
     # `npm pack` writes to cache so temporarily override it
     while IFS= read -r file; do
         local dest="$packageOut/$(dirname "$file")"
         mkdir -p "$dest"
         cp "${npmWorkspace-.}/$file" "$dest"
-    done < <(@jq@ --raw-output '.[0].files | map(.path | select(. | startswith("node_modules/") | not)) | join("\n")' <<< "$(npm_config_cache="$HOME/.npm" npm pack --json --dry-run --loglevel=warn --no-foreground-scripts ${npmWorkspace+--workspace=$npmWorkspace} $npmPackFlags "${npmPackFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}")")
+    done < <(@jq@ --raw-output '.[0].files | map(.path | select(. | startswith("node_modules/") | not)) | join("\n")' <<< "$(npm_config_cache="$HOME/.npm" npm pack --json --dry-run --loglevel=warn --no-foreground-scripts ${npmWorkspace+--workspace=$npmWorkspace} "${packFlagsArray[@]}")")
 
     nodejsInstallExecutables "${npmWorkspace-.}/package.json"
 
@@ -22,7 +27,12 @@ npmInstallHook() {
 
     if [ ! -d "$nodeModulesPath" ]; then
         if [ -z "${dontNpmPrune-}" ]; then
-            if ! npm prune --omit=dev --no-save ${npmWorkspace+--workspace=$npmWorkspace} $npmPruneFlags "${npmPruneFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}"; then
+            local pruneFlagsArray=()
+            concatTo pruneFlagsArray npmPruneFlags npmPruneFlagsArray npmFlags npmFlagsArray
+
+            echoCmd 'npmInstallHook prune flags' "${pruneFlagsArray[@]}"
+
+            if ! npm prune --omit=dev --no-save ${npmWorkspace+--workspace=$npmWorkspace} "${pruneFlagsArray[@]}"; then
               echo
               echo
               echo "ERROR: npm prune step failed"

--- a/pkgs/build-support/node/import-npm-lock/hooks/npm-config-hook.sh
+++ b/pkgs/build-support/node/import-npm-lock/hooks/npm-config-hook.sh
@@ -34,7 +34,12 @@ npmConfigHook() {
 
     echo "Installing dependencies"
 
-    if ! npm install --ignore-scripts $npmInstallFlags "${npmInstallFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}"; then
+    local flagsArray=()
+    concatTo flagsArray npmInstallFlags npmInstallFlagsArray npmFlags npmFlagsArray
+
+    echoCmd 'npmConfigHook install flags' "${flagsArray[@]}"
+
+    if ! npm install --ignore-scripts "${flagsArray[@]}"; then
         echo
         echo "ERROR: npm failed to install dependencies"
         echo
@@ -47,7 +52,12 @@ npmConfigHook() {
 
     patchShebangs node_modules
 
-    npm rebuild $npmRebuildFlags "${npmRebuildFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}"
+    flagsArray=()
+    concatTo flagsArray npmRebuildFlags npmRebuildFlagsArray npmFlags npmFlagsArray
+
+    echoCmd 'npmConfigHook rebuild flags' "${flagsArray[@]}"
+
+    npm rebuild "${flagsArray[@]}"
 
     patchShebangs node_modules
 

--- a/pkgs/development/web/nodejs/node-npm-build-npm-package-logic.patch
+++ b/pkgs/development/web/nodejs/node-npm-build-npm-package-logic.patch
@@ -7,6 +7,8 @@ This introduces fixes for 4 issues:
 3. We get useless warnings that clog up logs when using a v1 lockfile, so we silence them.
 4. npm looks at a hidden lockfile to determine if files have binaries to link into `node_modules/.bin`. When using a v1 lockfile offline, this lockfile does not contain enough info, leading to binaries for packages such as Webpack not being available to scripts. We used to work around this by making npm ignore the hidden lockfile by creating a file, but now we just disable the code path entirely.
 
+The Git dependency fix above reads NIX_NPM_FLAGS, NIX_NPM_INSTALL_FLAGS and NIX_NPM_REBUILD_FLAGS from the environment. They are set by npmHooks.npmConfigHook and have to be kept in sync with it.
+
 To update:
 1. Run `git diff` from an npm checkout
 2. Run `fix-npm-patch-paths.sh`
@@ -42,14 +44,17 @@ diff --git a/deps/npm/node_modules/pacote/lib/git.js b/deps/npm/node_modules/pac
 index 1fa8b1f96..a026bb50d 100644
 --- a/deps/npm/node_modules/pacote/lib/git.js
 +++ b/deps/npm/node_modules/pacote/lib/git.js
-@@ -188,6 +188,24 @@ class GitFetcher extends Fetcher {
+@@ -188,6 +188,27 @@ class GitFetcher extends Fetcher {
        }
        noPrepare.push(this.resolved)
  
 +      if (process.env['NIX_NODEJS_BUILDNPMPACKAGE']) {
 +        const spawn = require('@npmcli/promise-spawn')
 +
-+        const npmWithNixFlags = (args, cmd) => spawn('bash', ['-c', 'npm ' + args + ` $npm${cmd}Flags "$\{npm${cmd}FlagsArray[@]}" $npmFlags "$\{npmFlagsArray[@]}" || [ -n "$forceGitDeps" ]`], { cwd: dir, env: { ...process.env, _PACOTE_NO_PREPARE_: noPrepare.join('\n') } }, { message: `\`npm ${args}\` failed` })
++        // The NIX_NPM_*_FLAGS variables are set by npmConfigHook and hold the
++        // npm flags quoted with `@Q`. The eval only builds the argument list;
++        // the npm invocation itself is never part of the evaluated string.
++        const npmWithNixFlags = (args, cmd) => spawn('bash', ['-c', `eval "flags=($\{NIX_NPM_${cmd.toUpperCase()}_FLAGS-} $\{NIX_NPM_FLAGS-})"; npm ${args} "$\{flags[@]}" || [ -n "$forceGitDeps" ]`], { cwd: dir, env: { ...process.env, _PACOTE_NO_PREPARE_: noPrepare.join('\n') } }, { message: `\`npm ${args}\` failed` })
 +        const patchShebangs = () => spawn('bash', ['-c', 'source $stdenv/setup; patchShebangs node_modules'], { cwd: dir })
 +
 +        // the DirFetcher will do its own preparation to run the prepare scripts


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Problem

Two bugs, both only affecting derivations with `__structuredAttrs = true` (#205690):

1. A package whose lockfile contains a Git dependency that npm has to prepare[^1] fails in `npmConfigHook` with:

[^1]: its manifest has an install/prepare/build script

```
npm error command bash -c source $stdenv/setup; patchShebangs node_modules
npm error bash: line 1: /setup: No such file or directory
npm error bash: line 1: patchShebangs: command not found
```

The reproducer was eez-studio (#493671), whose lockfile has a Git dependency on `lv_font_conv`. The same package successfully builds without `__structuredAttrs = true`.

The same missing environment also meant the npm flags never reached that nested process, since the patch read them from its environment too.

2. `npmFlags`, `npmInstallFlags`, `npmRebuildFlags`, `npmBuildFlags`, `npmPackFlags` and `npmPruneFlags` were almost entirely ignored: only the first element of each list reached npm and it was subject to word splitting. The same expansion bug exists in `importNpmLock`'s `npmConfigHook` and it matters more there because `importNpmLock.buildNodeModules` enables `__structuredAttrs` by default[^2].

[^2]: unless the caller uses `passAsFile`
## Cause

With structured attributes, derivation attributes become shell variables rather than environment variables and Nix lists become Bash arrays.

1. Nixpkgs patches npm's bundled copy of Pacote (`pkgs/development/web/nodejs/node-npm-build-npm-package-logic.patch`) so that Git dependencies are prepared by a nested npm process. That patch reads `stdenv`, `prefetchNpmDeps`, `forceGitDeps` and the npm flags from its environment. With plain derivation attributes every attribute is an environment variable and therefore inherited by child processes and everything worked. With structured attributes the variables are shell local and the nested process doesn't inherit them, so `$stdenv/setup` expanded to `/setup`.

2. The hooks expanded flags as `$npmFlags "${npmFlagsArray[@]}"`. When `npmFlags` is a Bash array, `$npmFlags` expands to its first element only.

## Fix

1. `npmConfigHook` now also exports `stdenv` and `forceGitDeps`, the two variables the nested npm process relies on that were not already exported[^3]. This restores what plain attributes provided, also when structured attributes are enabled.

[^3]: `prefetchNpmDeps` always has been

2. All three `buildNpmPackage` hooks[^4] build their npm argument lists with stdenv's `concatTo`, which handles both cases: a normal string like `npmFlags` is split to words and structured lists like `npmFlagsArray` keep their arguments. The same `concatTo` change is also applied to `importNpmLock`'s `npmConfigHook`.

[^4]: config, build and install
3. The npm flags are passed to the nested npm process as well. An environment variable can not hold a list, so `npmConfigHook` exports them as `${array[*]@Q}` quoted strings in `NIX_NPM_FLAGS`, `NIX_NPM_INSTALL_FLAGS` and `NIX_NPM_REBUILD_FLAGS`, and the patch turns them back into an array instead of word splitting a string:

```
eval "flags=(${NIX_NPM_INSTALL_FLAGS-} ${NIX_NPM_FLAGS-})"; npm ci --ignore-scripts "${flags[@]}" || [ -n "$forceGitDeps" ]
```

`@Q` quotes each element the way Bash's own parser reads it back, so the flags come out of the `eval` exactly as they went in. The `eval` is also limited to the array assignment, so the npm invocation itself is never part of the evaluated string[^5].

[^5]: a malformed value can then drop the flags, but it can not rewrite the command that runs

These variables are an internal protocol between `npmConfigHook` and the patch, so the two have to be kept in sync; this is noted in the patch's frontmatter. Setting `NIX_NODEJS_BUILDNPMPACKAGE` without using the hook, as `code-server` and `openvscode-server` do, keeps working; the variables are simply unset and that nested npm process receives no flags. Neither package sets any npm flags today.

## Testing

All testing was done on `x86_64-linux`, no darwin coverage.

### End-to-end

Commit 1 fixes a failure I hit while packaging eez-studio (#493671), an Electron application that has a Git dependency with a build script and where `__structuredAttrs = true` due to it being a new package. Building the package fails without the commit and the error mentioned above is produced. After the commit the package builds successfully.

The other three commits come from reading the surrounding code, not from a failing build. eez-studio sets a single element `npmFlags` and a single element `npmRebuildFlags`; the old unquoted expansion of a Bash array yields its first element, so there were no flags lost. The controls below use two element lists to confirm the fix.

`electron-unwrapped` itself is a consumer of `npmHooks.npmConfigHook` and does not set `__structuredAttrs`, so it exercises the plain attribute path on a real package. It was rebuilt with these commits applied and built successfully and the log showed the hook running to completion. Its flag lists are empty, so this shows the new code working when there are no flags to pass, not that flags reach npm.

### Per-commit checks

Each commit was checked against a control that isolates it:

**1. `buildNpmPackage: fix Git dependencies with structured attributes`**

A minimal `buildNpmPackage` with a single Git dependency that has a `build` script[^6] was built four times: with `__structuredAttrs` enabled and disabled, each normally and with a pre-fix `npmConfigHook`, where the `export stdenv` and `export forceGitDeps` lines are removed.

Only the structured build with the pre-fix hook fails. With plain attributes those two are environment variables anyway, so the nested process inherits them and the pre-fix hook works.

[^6]: which is what makes pacote take the `#prepareDir` path

**2. `buildNpmPackage: pass npm flags correctly with structured attributes`**

A minimal `buildNpmPackage` with no Git dependency was used. `npmInstallFlags` is a two element list whose second element is `--workspace=nix-probe-nonexistent`, naming a workspace no package declares, so npm rejects it outright. It was built four times: with `__structuredAttrs` enabled and disabled, each normally and with a pre-fix `npmConfigHook`, where the `npm ci` call site keeps the old expansion.

Only the structured build with the pre-fix hook succeeds, because there the array expands to its first element and the flag is dropped. The other three fail, the plain pre-fix one included, since word splitting a string delivers both elements.[^7] Note that the commit makes the same change at the other four call sites, spread over the three hooks.

[^7]: `npmPruneFlags` defaults to `npmInstallFlags`, so it was set to an empty list to keep this test to `npm ci`

**3. `importNpmLock: pass npm flags correctly with structured attributes`**

A minimal `importNpmLock` consumer with a two element `npmInstallFlags` was built four times: with `__structuredAttrs` enabled and disabled[^8], each normally and with a pre-fix hook. With the fix both representations fail. With the pre-fix hook they diverge: the structured one drops the second flag and builds, the plain one keeps it through word splitting and fails.

[^8]: `buildNodeModules` forces `__structuredAttrs = true` unless the caller passes `passAsFile`, which is how it was disabled

**4. `nodejs, buildNpmPackage: pass npm flags to Git dependency preparation`**

A minimal `buildNpmPackage` with `__structuredAttrs = true` and a single Git dependency was built twice, once normally and once with a pre-fix `npmConfigHook`, where the three `NIX_NPM_*_FLAGS` exports are removed. `npmRebuildFlags` is a two element list whose second element is `--workspace=probe-ws`, naming a workspace the test package itself declares, so the outer `npm rebuild` accepts it and only the nested npm rejects it.

The first fails while the second one builds. The nested npm process's output is only visible when it fails, so the failing one shows the whole exchange:

```
npm error `npm rebuild` failed
npm error command bash -c eval "flags=(${NIX_NPM_REBUILD_FLAGS-} ${NIX_NPM_FLAGS-})"; npm rebuild "${flags[@]}" || [ -n "$forceGitDeps" ]
npm error npm error No workspaces found:
npm error npm error   --workspace=probe-ws
```

The nested `npm rebuild` is what fails and it runs while the Git dependency is being prepared. The pre-fix build still shows the Git dependency being prepared in its log, so the nested npm ran there too, it just received no flags.

### Branch this was tested on

The builds were run on `nixos-26.05`[^9] rather than `staging` to maximise cache hits. I don't think this weaken the result because every file these commits touch is unchanged between `nixos-26.05` & `staging`.

A neighbouring file does differ: nodejs is `24.18.0` (nixos-26.05) versus `24.18.1` (staging). Comparing the two upstream tags shows no changes under `deps/npm` at all, so the patch applies to identical npm sources.

[^9]: in hindsight, I should have used `nixos-unstable`

## Notes

- The last commit changes the nodejs patch, which is shared by `v22`, `v24` and `v26`, so it rebuilds nodejs and its dependents rather than only `buildNpmPackage` consumers.
- `export stdenv` and `export forceGitDeps` export those variables to every child process of the build, not just to npm. This is not ideal but the pre-existing `export prefetchNpmDeps` already set that precedent and scoping them narrowly is not possible from the hook since the nested npm is spawned from inside npm itself.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test