### PR TITLE
sage: add OBJC_DISABLE_INITIALIZE_FORK_SAFETY for darwin sage-env

### DIFF
--- a/pkgs/by-name/sa/sage/sage-env.nix
+++ b/pkgs/by-name/sa/sage/sage-env.nix
@@ -186,5 +186,11 @@ writeTextFile rec {
         gap
       ]
     }''${DYLD_LIBRARY_PATH:+:}$DYLD_LIBRARY_PATH"
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # Adapted from src/bin/sage-env in the upstream repo (sagemath/sage).
+    #
+    # See also: sagemath/sage#25921
+    export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
   '';
 }


### PR DESCRIPTION
Adopt OBJC_DISABLE_INITIALIZE_FORK_SAFETY upstream workaround on Darwin.

Context: #545650

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
