### PR TITLE
man-db: test installed binaries

### DIFF
--- a/pkgs/by-name/ma/man-db/package.nix
+++ b/pkgs/by-name/ma/man-db/package.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
     groff
     libiconv'
   ]; # (Yes, 'groff' is both native and build input)
-  nativeCheckInputs = [ libiconv' ]; # for 'iconv' binary; make very sure it matches buildinput libiconv
+  nativeInstallCheckInputs = [ libiconv' ]; # for 'iconv' binary; make very sure it matches buildinput libiconv
 
   patches = [
     ./systemwide-man-db-conf.patch
@@ -128,9 +128,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  doCheck =
-    !stdenv.hostPlatform.isMusl # iconv binary
-  ;
+  # XProtect may reject uninstalled libtool binaries on Darwin, so we run tests
+  # from $out. Linux doesn't *have* to do it, but it makes sense to test
+  # installed binaries anyway.
+  doInstallCheck = !stdenv.hostPlatform.isMusl; # no iconv binary
+  installCheckTarget = "check";
+  installCheckFlags = [ "MAN_TEST_INSTALLED=1" ];
+  preInstallCheck = ''
+    export PATH="$out/bin:$PATH"
+  '';
 
   passthru = {
     tests = {


### PR DESCRIPTION
In staging merges, we experience flaky man-db test failures. When it
happens, a batch of uninstalled `man` binary calls crash with exit
status 139. A build restart usually helps.

These tests were previously disabled for darwin in staging-25.11:
1551a606a7030a90d9681e00f997dfe4c62a9ced (For some reason it was only
done in 25.11, which is why the failures are back.) The current failure
only reports exit status 139, but that patch documented apparently
similar failures with:

```
XprotectService: [com.apple.xprotect:xprotect] File
$buildDir/$name/src/.libs/mandb failed on loadCmd
$out/lib/man-db/libmandb-$version.dylib (loadCmd resolved to: (path not
found), bundleURL: (null))
```

The path does not exist because `check` target runs before installPhase.

There is some evidence that libtool has issues with recent Darwin
versions with uninstalled binaries, e.g.:

https://lists.gnu.org/archive/html/libtool/2020-09/msg00002.html

This is *probably* a deficiency in libtool and how it interacts with
latest MacOS versions. Regardless, we can avoid the whole "uninstalled
binaries" scenario by running the same test suite post-install: man-db
`make check` target supports a flag for just that.

Note: I was not able to reproduce the crash myself, nor I had a chance
to see .ips reports from when this happens, so this patch is solely
based on a hypothesis that is yet to be proved.

Note: an older Apple technote documents the same `failed on loadCmd`
diagnostic but in different context (app bundles):
https://developer.apple.com/library/archive/technotes/tn2206/_index.html

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
