### PR TITLE
nixos/murmur: Use lib.types.ints.unsigned where it's appropriate

### DIFF
--- a/nixos/modules/services/networking/murmur.nix
+++ b/nixos/modules/services/networking/murmur.nix
@@ -101,7 +101,7 @@ in
       };
 
       autobanAttempts = lib.mkOption {
-        type = lib.types.int;
+        type = lib.types.ints.unsigned;
         default = 10;
         description = ''
           Number of attempts a client is allowed to make in
@@ -111,7 +111,7 @@ in
       };
 
       autobanTimeframe = lib.mkOption {
-        type = lib.types.int;
+        type = lib.types.ints.unsigned;
         default = 120;
         description = ''
           Timeframe in which a client can connect without being banned
@@ -120,7 +120,7 @@ in
       };
 
       autobanTime = lib.mkOption {
-        type = lib.types.int;
+        type = lib.types.ints.unsigned;
         default = 300;
         description = "The amount of time an IP ban lasts (in seconds).";
       };
@@ -154,7 +154,7 @@ in
       };
 
       bandwidth = lib.mkOption {
-        type = lib.types.int;
+        type = lib.types.ints.unsigned;
         default = 72000;
         description = ''
           Maximum bandwidth (in bits per second) that clients may send
@@ -163,19 +163,19 @@ in
       };
 
       users = lib.mkOption {
-        type = lib.types.int;
+        type = lib.types.ints.unsigned;
         default = 100;
         description = "Maximum number of concurrent clients allowed.";
       };
 
       textMsgLength = lib.mkOption {
-        type = lib.types.int;
+        type = lib.types.ints.unsigned;
         default = 5000;
         description = "Max length of text messages. Set 0 for no limit.";
       };
 
       imgMsgLength = lib.mkOption {
-        type = lib.types.int;
+        type = lib.types.ints.unsigned;
         default = 131072;
         description = "Max length of image messages. Set 0 for no limit.";
       };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
