### PR TITLE
[26.05] python3Packages.jupyterlab-git: fix CVE-2026-54527 and CVE-2026-54528

### DIFF
--- a/pkgs/development/python-modules/jupyterlab-git/CVE-2026-54528.patch
+++ b/pkgs/development/python-modules/jupyterlab-git/CVE-2026-54528.patch
@@ -1,0 +1,46 @@
+diff --git a/jupyterlab_git/handlers.py b/jupyterlab_git/handlers.py
+index d463bf9..1470435 100644
+--- a/jupyterlab_git/handlers.py
++++ b/jupyterlab_git/handlers.py
+@@ -63,7 +63,7 @@ class GitHandler(APIHandler):
+         if path is not None:
+             excluded_paths = self.git.excluded_paths
+             for excluded_path in excluded_paths:
+-                if fnmatch.fnmatchcase(path, excluded_path):
++                if fnmatch.fnmatchcase(path.casefold(), excluded_path.casefold()):
+                     raise tornado.web.HTTPError(404)
+
+     @functools.lru_cache()
+diff --git a/jupyterlab_git/tests/test_handlers.py b/jupyterlab_git/tests/test_handlers.py
+index 0c8c9ca..a4fd435 100644
+--- a/jupyterlab_git/tests/test_handlers.py
++++ b/jupyterlab_git/tests/test_handlers.py
+@@ -143,21 +143,18 @@ async def test_git_show_prefix_nested_directory(mock_execute, jp_fetch, jp_root_
+     )
+
+
+-async def test_git_show_prefix_for_excluded_path(
+-    jp_fetch, jp_server_config, jp_root_dir
+-):
+-    local_path = jp_root_dir / "ignored-path"
+-
+-    try:
+-        response = await jp_fetch(
++@pytest.mark.parametrize("path", ["ignored-path/subdir", "Ignored-Path/subdir"])
++async def test_git_show_prefix_for_excluded_path(path, jp_fetch, jp_server_config):
++    with pytest.raises(HTTPClientError) as error:
++        await jp_fetch(
+             NAMESPACE,
+-            local_path.name + "/subdir",
++            path,
+             "show_prefix",
+             body="{}",
+             method="POST",
+         )
+-    except HTTPClientError as e:
+-        assert e.code == 404
++
++    assert_http_error(error, 404)
+
+
+ @patch("jupyterlab_git.git.execute")

--- a/pkgs/development/python-modules/jupyterlab-git/default.nix
+++ b/pkgs/development/python-modules/jupyterlab-git/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
   git,
   gitMinimal,
   nodejs,
@@ -34,6 +35,18 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-BMzn+134hSYUFrDF+4+Bs81hzSURP9VNX4D9x2UuPMQ=";
   };
+
+  # Remove both patches when updating to 0.54.0 or later.
+  patches = [
+    (fetchpatch2 {
+      name = "CVE-2026-54527.patch";
+      url = "https://github.com/jupyterlab/jupyterlab-git/commit/c6d37b88f36aa59aee317930b95e427fb9d6b09b.patch?full_index=1";
+      hash = "sha256-eWE8TVetOyMWAlgjuNL03yxGoPMke+rGiU2H3qSBzM0=";
+    })
+    # Adapted from upstream commit 460035275b5963dc96e364e60ba6a73717fbd033
+    # to the pre-workspace 0.52.0 source layout.
+    ./CVE-2026-54528.patch
+  ];
 
   nativeBuildInputs = [
     nodejs
@@ -80,6 +93,14 @@ buildPythonPackage rec {
     "test_Git_get_nbdiff_file"
     "test_Git_get_nbdiff_dict"
   ];
+
+  preCheck = ''
+    jlpm test --runInBand \
+      src/__tests__/test-components/NotebookDiff.spec.tsx \
+      src/__tests__/test-components/PlainTextDiff.spec.tsx
+    pytest jupyterlab_git/tests/test_handlers.py \
+      -k test_git_show_prefix_for_excluded_path
+  '';
 
   pythonImportsCheck = [ "jupyterlab_git" ];
 


### PR DESCRIPTION
Backports the fixes for CVE-2026-54527 and CVE-2026-54528 to jupyterlab-git 0.52.0 on release-26.05.

The [Master fix](https://redirect.github.com/NixOS/nixpkgs/pull/547220) updated to 0.54.0 and adopted upstream's split Python workspace, so it cannot be cherry-picked without unrelated packaging changes. This keeps the Stable package layout and applies the two upstream security changes plus their regression tests.

Both vulnerabilities were reproduced on unpatched 0.52.0. With the backports applied, the regression tests and remaining enabled test suite pass on Python 3.13 and 3.14, and both JupyterLab extensions are enabled and valid.

Closes #539881.

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

