### PR TITLE
emacs.pkgs.ghostel: further ease overrideAttrs of local bumps

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/ghostel/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/ghostel/package.nix
@@ -10,13 +10,12 @@
 }:
 
 let
-  zig = zig_0_16;
-
   mkModule =
     {
       pname,
       version,
       src,
+      zig,
       zigDeps,
     }:
     stdenv.mkDerivation (finalAttrs: {
@@ -24,10 +23,11 @@ let
         pname
         version
         src
+        zig
         zigDeps
         ;
 
-      nativeBuildInputs = [ zig ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ xcbuild ];
+      nativeBuildInputs = [ finalAttrs.zig ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ xcbuild ];
 
       env.EMACS_INCLUDE_DIR = "${emacs}/include";
 
@@ -67,8 +67,9 @@ melpaBuild (finalAttrs: {
     hash = "sha256-upIcL4wf2zAc3/3QeERF619nSDml2wEZCOl6/XOaT3E=";
   };
 
-  # this can be put into mkModule, but we put it here to ease user overrideAttrs
-  zigDeps = zig.fetchDeps {
+  # these can be put into mkModule, but we put them here to ease user overrideAttrs
+  zig = zig_0_16;
+  zigDeps = finalAttrs.zig.fetchDeps {
     inherit (finalAttrs) src pname version;
     fetchAll = true;
     hash = "sha256-NcNp0FnMy6FfZ63+pwiTRCmJ8FIovJEOhNvxVr1+uSQ=";
@@ -91,6 +92,7 @@ melpaBuild (finalAttrs: {
       inherit (finalAttrs)
         version
         src
+        zig
         zigDeps
         ;
     };


### PR DESCRIPTION
Even with the changes from
https://github.com/NixOS/nixpkgs/commit/99800dd6b5955e2955848a9e0bbf95c899ccf814, local bumps break if they need a different version of Zig, like the upgrade from Zig 0.15 to 0.16 in
https://github.com/NixOS/nixpkgs/commit/78f9fbc2273f534abe17222a5319b616ba946e47.

Fix this by using finalAttrs for zig too, so it can be overridden along with src and zigDeps.

Tested using a modified version of https://github.com/marienz/nix-doom-emacs-unstraightened: with this change, it can build an older version of ghostel using Zig 0.15 by overriding `zig` and `zigDeps.outputHash` (and automatically overriding `src`).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
