### PR TITLE
mitmproxy: drop unused msgpack dependency

### DIFF
--- a/pkgs/by-name/mi/mitmproxy2swagger/package.nix
+++ b/pkgs/by-name/mi/mitmproxy2swagger/package.nix
@@ -26,6 +26,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   dependencies = with python3.pkgs; [
     json-stream
     mitmproxy
+    msgpack
     ruamel-yaml
   ];
 

--- a/pkgs/development/python-modules/mitmproxy/default.nix
+++ b/pkgs/development/python-modules/mitmproxy/default.nix
@@ -17,7 +17,6 @@
   kaitaistruct,
   ldap3,
   mitmproxy-rs,
-  msgpack,
   nixosTests,
   publicsuffix2,
   pyopenssl,
@@ -53,6 +52,10 @@ buildPythonPackage rec {
   # pins many dependencies way to strict
   pythonRelaxDeps = true;
 
+  # msgpack is unused and was removed upstream:
+  # https://github.com/mitmproxy/mitmproxy/pull/8319
+  pythonRemoveDeps = [ "msgpack" ];
+
   build-system = [ setuptools ];
 
   dependencies = [
@@ -70,7 +73,6 @@ buildPythonPackage rec {
     kaitaistruct
     ldap3
     mitmproxy-rs
-    msgpack
     publicsuffix2
     pyopenssl
     pyparsing


### PR DESCRIPTION
Upstream change: https://github.com/mitmproxy/mitmproxy/pull/8319

MsgPack rendering has been provided by `mitmproxy-rs` since mitmproxy 12, so mitmproxy's Python `msgpack` dependency is unused. Remove it from mitmproxy and declare it directly in mitmproxy2swagger, which still requires it.

Assisted by OpenAI Codex (gpt-5.6-sol-xhigh).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

`nixpkgs-review rev HEAD --no-shell` was attempted with an 8 GiB memory cap (through `systemd-run`), but the Nix evaluator reached the cap and was OOM-killed. The affected packages and `nixosTests.mitmproxy` were built separately and passed.

Additional checks:

- Ran `mitmproxy`, `mitmdump`, and `mitmweb` with `--version`.
- Ran `mitmproxy2swagger --help`.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
