### PR TITLE
sbcl_2_4_6: skip `elf-sans-immobile.test.sh` to avoid ZFS hang

### DIFF
--- a/pkgs/development/compilers/sbcl/default.nix
+++ b/pkgs/development/compilers/sbcl/default.nix
@@ -186,6 +186,19 @@ stdenv.mkDerivation (finalAttrs: {
         ./patches/dynamic-space-size-envvar-2.5.2-tests.patch
       ];
 
+  postPatch =
+    # On SBCL < 2.5.0, `elf-sans-immobile.test.sh` triggers a bug in ZFS and
+    # causes the build to hang indefinitely. See:
+    # https://github.com/NixOS/nixpkgs/issues/544703#issuecomment-5141409041
+    # https://github.com/openzfs/zfs/issues/18135#issuecomment-5141375047
+    # To unbreak Hydra, skip the test.
+    if lib.versionOlder finalAttrs.version "2.5.0" then
+      ''
+        rm tests/elf-sans-immobile.test.sh
+      ''
+    else
+      null;
+
   sbclPatchPhase =
     lib.optionalString (finalAttrs.disabledTestFiles != [ ]) ''
       (cd tests ; rm -f ${lib.concatStringsSep " " finalAttrs.disabledTestFiles})


### PR DESCRIPTION
This is a workaround for https://github.com/NixOS/nixpkgs/issues/544703. The real issue is with ZFS, and will hopefully be fixed soon (https://github.com/openzfs/zfs/issues/18135).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
