### PR TITLE
deluge: fix certificate generation with PyOpenSSL 26

### DIFF
--- a/pkgs/applications/networking/p2p/deluge/default.nix
+++ b/pkgs/applications/networking/p2p/deluge/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  fetchpatch,
   fetchurl,
   intltool,
   libtorrent-rasterbar,
@@ -32,11 +31,8 @@ let
       };
 
       patches = [
-        (fetchpatch {
-          name = "deluge-replace-pyopenssl-certificate-generation.patch";
-          url = "https://github.com/deluge-torrent/deluge/commit/b763626ce88f9f9b82616de0a29087fde6d8828f.patch";
-          hash = "sha256-EtHcdZU1nCmLFrZiysoazRu9657NnuIbFdwRMhAWjI0=";
-        })
+        # https://github.com/deluge-torrent/deluge/pull/514
+        ./replace-pyopenssl-certificate-generation.patch
       ];
 
       propagatedBuildInputs =

--- a/pkgs/applications/networking/p2p/deluge/default.nix
+++ b/pkgs/applications/networking/p2p/deluge/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  fetchpatch,
   fetchurl,
   intltool,
   libtorrent-rasterbar,
@@ -30,12 +31,21 @@ let
         hash = "sha256-ubonK1ukKq8caU5sKWKKuBbMGnAKN7rAiqy1JXFgas0=";
       };
 
+      patches = [
+        (fetchpatch {
+          name = "deluge-replace-pyopenssl-certificate-generation.patch";
+          url = "https://github.com/deluge-torrent/deluge/commit/b763626ce88f9f9b82616de0a29087fde6d8828f.patch";
+          hash = "sha256-EtHcdZU1nCmLFrZiysoazRu9657NnuIbFdwRMhAWjI0=";
+        })
+      ];
+
       propagatedBuildInputs =
         with pypkgs;
         [
           twisted
           mako
           chardet
+          cryptography
           pyxdg
           pyopenssl
           service-identity

--- a/pkgs/applications/networking/p2p/deluge/replace-pyopenssl-certificate-generation.patch
+++ b/pkgs/applications/networking/p2p/deluge/replace-pyopenssl-certificate-generation.patch
@@ -1,0 +1,80 @@
+--- a/deluge/crypto_utils.py
++++ b/deluge/crypto_utils.py
+@@ -8,8 +8,12 @@
+
+ import os
+ import stat
++from datetime import datetime, timedelta, timezone
+
+-from OpenSSL import crypto
++from cryptography import x509
++from cryptography.hazmat.primitives import hashes, serialization
++from cryptography.hazmat.primitives.asymmetric import rsa
++from cryptography.x509.oid import NameOID
+ from OpenSSL.crypto import FILETYPE_PEM
+ from twisted.internet.ssl import (
+     AcceptableCiphers,
+@@ -102,35 +106,35 @@
+     """
+     This method generates a new SSL key/cert.
+     """
+-    digest = 'sha256'
+-
+     # Generate key pair
+-    pkey = crypto.PKey()
+-    pkey.generate_key(crypto.TYPE_RSA, 2048)
+-
+-    # Generate cert request
+-    req = crypto.X509Req()
+-    subj = req.get_subject()
+-    setattr(subj, 'CN', 'Deluge Daemon')
+-    req.set_pubkey(pkey)
+-    req.sign(pkey, digest)
++    pkey = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+     # Generate certificate
+-    cert = crypto.X509()
+-    cert.set_serial_number(0)
+-    cert.gmtime_adj_notBefore(0)
+-    cert.gmtime_adj_notAfter(60 * 60 * 24 * 365 * 3)  # Three Years
+-    cert.set_issuer(req.get_subject())
+-    cert.set_subject(req.get_subject())
+-    cert.set_pubkey(req.get_pubkey())
+-    cert.sign(pkey, digest)
+-
+-    # Write out files
++    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, 'Deluge Daemon')])
++    now = datetime.now(timezone.utc)
++    cert = (
++        x509.CertificateBuilder()
++        .subject_name(subject)
++        .issuer_name(subject)
++        .public_key(pkey.public_key())
++        .serial_number(x509.random_serial_number())
++        .not_valid_before(now)
++        .not_valid_after(now + timedelta(days=365 * 3))  # Three Years
++        .sign(pkey, hashes.SHA256())
++    )
++
+     ssl_dir = deluge.configmanager.get_config_dir('ssl')
+-    with open(os.path.join(ssl_dir, 'daemon.pkey'), 'wb') as _file:
+-        _file.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, pkey))
+-    with open(os.path.join(ssl_dir, 'daemon.cert'), 'wb') as _file:
+-        _file.write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert))
+-    # Make the files only readable by this user
+-    for f in ('daemon.pkey', 'daemon.cert'):
+-        os.chmod(os.path.join(ssl_dir, f), stat.S_IREAD | stat.S_IWRITE)
++    files = {
++        'daemon.pkey': pkey.private_bytes(
++            encoding=serialization.Encoding.PEM,
++            format=serialization.PrivateFormat.PKCS8,
++            encryption_algorithm=serialization.NoEncryption(),
++        ),
++        'daemon.cert': cert.public_bytes(serialization.Encoding.PEM),
++    }
++    for name, data in files.items():
++        path = os.path.join(ssl_dir, name)
++        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, stat.S_IRUSR | stat.S_IWUSR)
++        with os.fdopen(fd, 'wb') as _file:
++            _file.write(data)
++        os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)


### PR DESCRIPTION
Upstream change: https://github.com/deluge-torrent/deluge/pull/514

PyOpenSSL 26 removed `OpenSSL.crypto.X509Req`, causing Deluge 2.2.0 to fail when generating TLS certificates for a fresh configuration. Backport the proposed upstream fix to use `cryptography` and declare it as a direct dependency.

The failure can be reproduced on the unmodified base revision using a fresh configuration directory:

```console
$ config_dir="$(mktemp -d)"
$ nix run 'github:NixOS/nixpkgs/9a314239649d405e57dae2d0640b9df93f608dda#deluged' -- \
    --do-not-daemonize \
    --config "$config_dir"
...
Unable to start deluged: module 'OpenSSL.crypto' has no attribute 'X509Req'
```

With this change, certificate generation succeeds and the existing `deluged.tests.deluge` integration test passes.

Assisted by OpenAI Codex (gpt-5.6-sol-xhigh).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

All of the following works:

```console
$ nix build .#deluged .#deluge-gtk
$ nix build .#deluged.tests.deluge
$ nix run .#deluged -- --version
$ nix run .#deluge-gtk -- --version
$ nix shell .#deluge-gtk --command deluge-web --version
$ nix shell .#deluge-gtk --command deluge-console --version
```

`nixpkgs-review` successfully built both affected packages:

```console
$ nixpkgs-review rev HEAD \
    --branch 9a314239649d405e57dae2d0640b9df93f608dda \
    --package deluged \
    --package deluge-gtk \
    --no-shell
--------- Report for 'x86_64-linux' ---------
2 packages built:
deluge-gtk deluged
```

The generic `deluge` launcher fails because `setuptools` is unavailable at runtime. This is a pre-existing bug:

```console
$ nix shell .#deluge-gtk --command deluge --version
# or
$ nix shell 'github:NixOS/nixpkgs/9a314239649d405e57dae2d0640b9df93f608dda#deluge-gtk' --command deluge --version
# Both print:
# ...
pkg_resources.DistributionNotFound: The 'setuptools' distribution was not found and is required by the application
```

This is why the all-binaries checkbox is left unchecked.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test