### PR TITLE
icebreaker-chat: init at 2026.2

### DIFF
--- a/pkgs/by-name/ic/icebreaker-chat/package.nix
+++ b/pkgs/by-name/ic/icebreaker-chat/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  cmake,
+  nix-update-script,
+  libxkbcommon,
+  vulkan-loader,
+  wayland,
+  libxi,
+  libxcursor,
+  libx11,
+  libxcb,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "icebreaker-chat";
+  version = "2026.2";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "hecrj";
+    repo = "icebreaker";
+    tag = finalAttrs.version;
+    hash = "sha256-2CW8GhYEJgW/2PNCS3fp1OlwtN6+wL2gCV9404gBaUk=";
+  };
+
+  cargoHash = "sha256-2VcZvL0HPdbkOxKTY4rnDl42hXFmvXG8Ua6cEa/MBCE=";
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    libxkbcommon
+    vulkan-loader
+    wayland
+    libx11
+    libxcursor
+    libxi
+    libxcb
+  ];
+
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux (
+    let
+      rpath = lib.makeLibraryPath [
+        wayland
+        vulkan-loader
+        libxkbcommon
+      ];
+    in
+    ''
+      patchelf --set-rpath "$(patchelf --print-rpath $out/bin/icebreaker):${rpath}" $out/bin/icebreaker
+    ''
+  );
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Local AI chat app powered by Rust, iced, Hugging Face, and llama.cpp";
+    homepage = "https://github.com/hecrj/icebreaker";
+    changelog = "https://github.com/hecrj/icebreaker/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ DerGrumpf ];
+    mainProgram = "icebreaker";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Description of changes

Adds `icebreaker-chat`, a local AI chat app powered by Rust, iced, Hugging Face, and llama.cpp (https://github.com/hecrj/icebreaker).

Named `icebreaker-chat` instead of `icebreaker` because that attribute name is already taken by an unrelated Go package (jonhoo/icebreaker).

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].