### PR TITLE
nixos/asusd: restore declarative configs on restart

### DIFF
--- a/nixos/modules/services/hardware/asusd.nix
+++ b/nixos/modules/services/hardware/asusd.nix
@@ -7,6 +7,22 @@
 
 let
   cfg = config.services.asusd;
+  configFiles = {
+    "anime.ron" = cfg.animeConfig;
+    "asusd.ron" = cfg.asusdConfig;
+    "profile.ron" = cfg.profileConfig;
+    "fan_curves.ron" = cfg.fanCurvesConfig;
+    "asusd_user_ledmodes.ron" = cfg.userLedModesConfig;
+  }
+  // lib.mapAttrs' (
+    productId: value: lib.nameValuePair "aura_${productId}.ron" value
+  ) cfg.auraConfigs;
+  managedConfigFiles = lib.filterAttrs (_: value: value != null) configFiles;
+  configPath = name: "asusd/${name}";
+  managedConfigDescription = ''
+    The declared content is restored before each asusd start. Changes made at runtime
+    persist until the service restarts.
+  '';
 in
 {
   imports = [
@@ -62,6 +78,7 @@ in
           description = ''
             The content of /etc/asusd/anime.ron.
             See <https://asus-linux.org/manual/asusctl-manual/#anime-control>.
+            ${managedConfigDescription}
           '';
         };
 
@@ -71,6 +88,7 @@ in
           description = ''
             The content of /etc/asusd/asusd.ron.
             See <https://asus-linux.org/manual/asusctl-manual/>.
+            ${managedConfigDescription}
           '';
         };
 
@@ -80,6 +98,7 @@ in
           description = ''
             The content of /etc/asusd/aura_<name>.ron.
             See <https://asus-linux.org/manual/asusctl-manual/#led-keyboard-control>.
+            ${managedConfigDescription}
           '';
         };
 
@@ -89,6 +108,7 @@ in
           description = ''
             The content of /etc/asusd/profile.ron.
             See <https://asus-linux.org/manual/asusctl-manual/#profiles>.
+            ${managedConfigDescription}
           '';
         };
 
@@ -98,6 +118,7 @@ in
           description = ''
             The content of /etc/asusd/fan_curves.ron.
             See <https://asus-linux.org/manual/asusctl-manual/#fan-curves>.
+            ${managedConfigDescription}
           '';
         };
 
@@ -107,6 +128,7 @@ in
           description = ''
             The content of /etc/asusd/asusd-user-ledmodes.ron.
             See <https://asus-linux.org/manual/asusctl-manual/#led-keyboard-control>.
+            ${managedConfigDescription}
           '';
         };
       };
@@ -115,27 +137,40 @@ in
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
 
-    environment.etc =
-      let
-        maybeConfig =
-          name: cfg:
-          lib.mkIf (cfg != null) (
-            (if (cfg.source != null) then { source = cfg.source; } else { text = cfg.text; })
-            // {
-              mode = "0644";
-            }
-          );
-      in
-      {
-        "asusd/anime.ron" = maybeConfig "anime.ron" cfg.animeConfig;
-        "asusd/asusd.ron" = maybeConfig "asusd.ron" cfg.asusdConfig;
-        "asusd/profile.ron" = maybeConfig "profile.ron" cfg.profileConfig;
-        "asusd/fan_curves.ron" = maybeConfig "fan_curves.ron" cfg.fanCurvesConfig;
-        "asusd/asusd_user_ledmodes.ron" = maybeConfig "asusd_user_ledmodes.ron" cfg.userLedModesConfig;
-      }
-      // lib.attrsets.concatMapAttrs (prod_id: value: {
-        "asusd/aura_${prod_id}.ron" = maybeConfig "aura_${prod_id}.ron" value;
-      }) cfg.auraConfigs;
+    assertions = lib.mapAttrsToList (name: file: {
+      assertion = file.mode != "symlink";
+      message = ''
+        `/etc/${name}` must be writable by asusd. Use the matching
+        `services.asusd.*Config` option or set `environment.etc."${name}".mode` to a regular file mode.
+      '';
+    }) (lib.filterAttrs (name: _: lib.hasPrefix "asusd/" name) config.environment.etc);
+
+    environment.etc = lib.mapAttrs' (
+      name: value:
+      lib.nameValuePair (configPath name) (
+        (if value.source != null then { source = value.source; } else { text = value.text; })
+        // {
+          mode = "0644";
+        }
+      )
+    ) managedConfigFiles;
+
+    systemd.services.asusd = lib.mkIf (managedConfigFiles != { }) {
+      preStart = lib.concatMapStringsSep "\n" (
+        name:
+        let
+          path = configPath name;
+        in
+        ''
+          ${lib.getExe' pkgs.coreutils "install"} -m 0644 -- ${
+            lib.escapeShellArg (toString config.environment.etc.${path}.source)
+          } ${lib.escapeShellArg "/etc/${path}"}
+        ''
+      ) (lib.attrNames managedConfigFiles);
+      restartTriggers = map (name: config.environment.etc.${configPath name}.source) (
+        lib.attrNames managedConfigFiles
+      );
+    };
 
     services.dbus.enable = true;
     systemd.packages = [ cfg.package ];

--- a/nixos/modules/services/hardware/asusd.nix
+++ b/nixos/modules/services/hardware/asusd.nix
@@ -20,8 +20,8 @@ let
   managedConfigFiles = lib.filterAttrs (_: value: value != null) configFiles;
   configPath = name: "asusd/${name}";
   managedConfigDescription = ''
-    The declared content is restored before each asusd start. Changes made at runtime
-    persist until the service restarts.
+    By default, the declared content is restored before each asusd start. Set
+    {option}`services.asusd.restoreConfigs` to `false` to preserve runtime changes.
   '';
 in
 {
@@ -71,6 +71,15 @@ in
         enable = lib.mkEnableOption "the asusd service for ASUS ROG laptops";
 
         package = lib.mkPackageOption pkgs "asusctl" { };
+
+        restoreConfigs = lib.mkOption {
+          type = bool;
+          default = true;
+          description = ''
+            Whether to restore declared configuration files before each asusd start.
+            Disable this to preserve runtime changes across service restarts.
+          '';
+        };
 
         animeConfig = lib.mkOption {
           type = nullOr configType;
@@ -156,17 +165,19 @@ in
     ) managedConfigFiles;
 
     systemd.services.asusd = lib.mkIf (managedConfigFiles != { }) {
-      preStart = lib.concatMapStringsSep "\n" (
-        name:
-        let
-          path = configPath name;
-        in
-        ''
-          ${lib.getExe' pkgs.coreutils "install"} -m 0644 -- ${
-            lib.escapeShellArg (toString config.environment.etc.${path}.source)
-          } ${lib.escapeShellArg "/etc/${path}"}
-        ''
-      ) (lib.attrNames managedConfigFiles);
+      preStart = lib.mkIf cfg.restoreConfigs (
+        lib.concatMapStringsSep "\n" (
+          name:
+          let
+            path = configPath name;
+          in
+          ''
+            ${lib.getExe' pkgs.coreutils "install"} -m 0644 -- ${
+              lib.escapeShellArg (toString config.environment.etc.${path}.source)
+            } ${lib.escapeShellArg "/etc/${path}"}
+          ''
+        ) (lib.attrNames managedConfigFiles)
+      );
       restartTriggers = map (name: config.environment.etc.${configPath name}.source) (
         lib.attrNames managedConfigFiles
       );

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -242,6 +242,7 @@ in
   aria2 = runTest ./aria2.nix;
   armagetronad = runTest ./armagetronad.nix;
   artalk = runTest ./artalk.nix;
+  asusd = runTest ./asusd.nix;
   atd = runTest ./atd.nix;
   atop = import ./atop.nix { inherit pkgs runTest; };
   atticd = runTest ./atticd.nix;

--- a/nixos/tests/asusd.nix
+++ b/nixos/tests/asusd.nix
@@ -9,14 +9,7 @@ let
   emptyAsusctl = pkgs.runCommand "asusctl-test-package" { } ''
     mkdir -p "$out"
   '';
-  checkConfig = pkgs.writeShellScript "check-asusd-config" ''
-    ${lib.getExe pkgs.gnugrep} -Fx ${lib.escapeShellArg expectedConfig} /etc/asusd/fan_curves.ron
-  '';
-in
-{
-  name = "asusd";
-
-  nodes.machine = {
+  commonNode = {
     services.asusd = {
       enable = true;
       package = emptyAsusctl;
@@ -28,22 +21,36 @@ in
       serviceConfig = {
         Type = "oneshot";
         RemainAfterExit = true;
-        ExecStart = checkConfig;
+        ExecStart = lib.getExe' pkgs.coreutils "true";
         ConfigurationDirectory = "asusd";
         ProtectSystem = "strict";
         ReadWritePaths = [ "/etc/asusd" ];
       };
     };
   };
+in
+{
+  name = "asusd";
+
+  nodes = {
+    restored = commonNode;
+    mutable = {
+      imports = [ commonNode ];
+      services.asusd.restoreConfigs = false;
+    };
+  };
 
   testScript = ''
-    machine.start()
-    machine.wait_for_unit("asusd.service")
-    machine.succeed("test -f /etc/asusd/fan_curves.ron")
-    machine.succeed("test ! -L /etc/asusd/fan_curves.ron")
-    machine.succeed("printf '%s' 'runtime fan curves' > /etc/asusd/fan_curves.ron")
-    machine.succeed("systemctl restart asusd.service")
-    machine.wait_for_unit("asusd.service")
-    machine.succeed("grep -Fx '${expectedConfig}' /etc/asusd/fan_curves.ron")
+    start_all()
+    for machine in (restored, mutable):
+        machine.wait_for_unit("asusd.service")
+        machine.succeed("test -f /etc/asusd/fan_curves.ron")
+        machine.succeed("test ! -L /etc/asusd/fan_curves.ron")
+        machine.succeed("printf '%s' 'runtime fan curves' > /etc/asusd/fan_curves.ron")
+        machine.succeed("systemctl restart asusd.service")
+        machine.wait_for_unit("asusd.service")
+
+    restored.succeed("grep -Fx '${expectedConfig}' /etc/asusd/fan_curves.ron")
+    mutable.succeed("grep -Fx 'runtime fan curves' /etc/asusd/fan_curves.ron")
   '';
 }

--- a/nixos/tests/asusd.nix
+++ b/nixos/tests/asusd.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  expectedConfig = "declarative fan curves";
+  emptyAsusctl = pkgs.runCommand "asusctl-test-package" { } ''
+    mkdir -p "$out"
+  '';
+  checkConfig = pkgs.writeShellScript "check-asusd-config" ''
+    ${lib.getExe pkgs.gnugrep} -Fx ${lib.escapeShellArg expectedConfig} /etc/asusd/fan_curves.ron
+  '';
+in
+{
+  name = "asusd";
+
+  nodes.machine = {
+    services.asusd = {
+      enable = true;
+      package = emptyAsusctl;
+      fanCurvesConfig.text = expectedConfig;
+    };
+
+    systemd.services.asusd = {
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = checkConfig;
+        ConfigurationDirectory = "asusd";
+        ProtectSystem = "strict";
+        ReadWritePaths = [ "/etc/asusd" ];
+      };
+    };
+  };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("asusd.service")
+    machine.succeed("test -f /etc/asusd/fan_curves.ron")
+    machine.succeed("test ! -L /etc/asusd/fan_curves.ron")
+    machine.succeed("printf '%s' 'runtime fan curves' > /etc/asusd/fan_curves.ron")
+    machine.succeed("systemctl restart asusd.service")
+    machine.wait_for_unit("asusd.service")
+    machine.succeed("grep -Fx '${expectedConfig}' /etc/asusd/fan_curves.ron")
+  '';
+}


### PR DESCRIPTION
`asusd` opens its RON configuration files for writing and rewrites them when it starts. The NixOS module currently copies declared files into `/etc/asusd` only during activation, so runtime changes can replace the declared settings across service restarts. Pointing an `environment.etc` entry there at the Nix store also makes the daemon abort because the target is read-only.

This restores every config declared through `services.asusd.*Config` before the daemon starts and restarts the service when a declared source changes. `services.asusd.restoreConfigs` defaults to `true`; setting it to `false` preserves runtime changes across restarts. Config files that are not declared through the module remain mutable as before.

The NixOS test covers both modes: the default restores a modified `fan_curves.ron` after restart, while the opt-out preserves the runtime change.

Resolves #453262

Validation: [`nixosTests.asusd` on x86_64-linux](https://github.com/caniko/nixpkgs-review-gha/actions/runs/32779613318) at `c76a902bca9b`.

Automation disclosure: I used OpenCode with `openai/gpt-5.6-sol` to investigate the failure, draft the module changes and test, and prepare this PR text. I reviewed the diff and validation results.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
