### PR TITLE
hexagonrpc: add tools output with sscregistrygen

### DIFF
--- a/pkgs/by-name/he/hexagonrpc/package.nix
+++ b/pkgs/by-name/he/hexagonrpc/package.nix
@@ -4,6 +4,8 @@
   fetchFromGitHub,
   meson,
   ninja,
+  pkg-config,
+  json_c,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -17,10 +19,26 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-OC6wXBCIW4XznWG0zzxRK3BzWMVK2Jq/gTL36sJV1PE=";
   };
 
+  outputs = [
+    "out"
+    "tools"
+  ];
+
   nativeBuildInputs = [
     meson
     ninja
+    pkg-config
   ];
+
+  buildInputs = [
+    json_c
+  ];
+
+  # sscregistrygen is only compiled when json-c is available and meson doesn't install it
+  postInstall = ''
+    mkdir -p $tools/bin
+    install -Dm755 tools/sscregistrygen $tools/bin/sscregistrygen
+  '';
 
   meta = {
     description = "Daemon to communicate with Qualcomm DSPs";


### PR DESCRIPTION
`sscregistrygen` is used to create (sensor) registry files.

Put into a separate tools output to not pollute the closures of devices not needing this.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
