### PR TITLE
coin3d: unvendor expat

### DIFF
--- a/pkgs/by-name/co/coin3d/package.nix
+++ b/pkgs/by-name/co/coin3d/package.nix
@@ -7,6 +7,7 @@
   libGL,
   libGLU,
   libx11,
+  expat,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -26,8 +27,13 @@ stdenv.mkDerivation (finalAttrs: {
     boost
     libGL
     libGLU
+    expat
   ]
   ++ lib.optional stdenv.hostPlatform.isLinux libx11;
+
+  cmakeFlags = [
+    (lib.cmakeBool "USE_EXTERNAL_EXPAT" true)
+  ];
 
   meta = {
     homepage = "https://github.com/coin3d/coin";


### PR DESCRIPTION
closes #544607

Using the ancient vendored `expat` 2.2.10 from 2020-10-03 is a security nightmare. It also recently started exploding due to symbol collisions with the significantly newer expat used in python3, crashing FreeCAD.

Confirmed our nixpkgs expat gets linked, FreeCAD works, crash is fixed.
In build log:
`Found EXPAT: /nix/store/fz0nvrqb8wwxgxvfc8hg9iwg4183achg-expat-2.8.2/lib/libexpat.so (found version "2.8.2")`

```
$ ldd /nix/store/6xgg2v16dv18jsqw8hlmykjxq8dj7m46-coin-4.0.10/lib/libCoin.so
	linux-vdso.so.1 (0x00007d786c107000)
	libX11.so.6 => /nix/store/45naqds5dkzsmmrh61wbxbfci73san7n-libx11-1.8.13/lib/libX11.so.6 (0x00007d786b66f000)
	libEGL.so.1 => /nix/store/v8x5c24y4zgxv5xmwhz5lz26ir816c31-libglvnd-1.7.0/lib/libEGL.so.1 (0x00007d786b659000)
	libexpat.so.1 => /nix/store/g264nm7psb4b9w31kqxqfnysv376hc9n-expat-2.8.2/lib/libexpat.so.1 (0x00007d786b62a000)
	libdl.so.2 => /nix/store/l8si8gnvvq93yzms1jsgh5aixyf9rl5x-glibc-2.42-67/lib/libdl.so.2 (0x00007d786b625000)
        <omitted>
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
