### PR TITLE
modular-services: only emit ExecReload when there is a reload command

### DIFF
--- a/nixos/modules/system/service/systemd/service.nix
+++ b/nixos/modules/system/service/systemd/service.nix
@@ -125,10 +125,13 @@ in
         `%i` (instance), `%t` (runtime directory), and environment variables using
         `''${VAR}` syntax in your command line.
 
-        By default, it is set to {option}`process.reloadCommand` when specified, or an
-        empty string otherwise. Because {option}`process.reloadCommand` is already a
-        command line (not an argument list), it is used verbatim so that references
-        like `$MAINPID` are preserved.
+        By default, it is set to {option}`process.reloadCommand`. Because
+        {option}`process.reloadCommand` is already a command line (not an argument
+        list), it is used verbatim so that references like `$MAINPID` are preserved.
+
+        When {option}`process.reloadCommand` is unset, this option is `null` and no
+        `ExecReload` is emitted; a service may then set
+        `systemd.service.serviceConfig.ExecReload` itself.
 
         To extend {option}`process.reloadCommand` with systemd specifiers, you can append
         to the command line:
@@ -146,7 +149,7 @@ in
         for available specifiers like `%n`, `%i`, `%t`.
       '';
       type = types.nullOr types.str;
-      default = if config.process.reloadCommand != null then config.process.reloadCommand else "";
+      default = config.process.reloadCommand;
       defaultText = lib.literalExpression "config.process.reloadCommand";
     };
 
@@ -207,7 +210,7 @@ in
       # TODO description;
       wantedBy = lib.mkDefault [ "multi-user.target" ];
       serviceConfig = {
-        ExecReload = config.systemd.mainExecReload;
+        ExecReload = lib.mkIf (config.systemd.mainExecReload != null) config.systemd.mainExecReload;
         Type = lib.mkDefault (if config.notificationProtocol.systemd then "notify" else "simple");
         Restart = lib.mkDefault "always";
         RestartSec = lib.mkDefault "5";

--- a/nixos/modules/system/service/systemd/service.nix
+++ b/nixos/modules/system/service/systemd/service.nix
@@ -118,9 +118,8 @@ in
         Main command line for systemd's ExecReload with systemd's specifier and
         environment variable substitution enabled.
 
-        This option sets the primary ExecRestart entry. Additional ExecReload entries
-        can be added via `systemd.service.serviceConfig.ExecReload` with `lib.mkBefore`
-        or `lib.mkAfter`.
+        This option sets the primary ExecReload entry, and is the way to extend the
+        command line derived from {option}`process.reloadCommand`.
 
         This option allows you to use systemd specifiers like `%n` (unit name),
         `%i` (instance), `%t` (runtime directory), and environment variables using

--- a/nixos/tests/system-services-compliance.nix
+++ b/nixos/tests/system-services-compliance.nix
@@ -81,6 +81,16 @@ let
             process.reloadSignal = "HUP";
           };
         }).config.systemd.services;
+
+      # A service setting `ExecReload` through the systemd escape hatch, without
+      # any `process.reloadCommand` of its own.
+      ownExecReloadUnits =
+        (evalSystemServices {
+          service = {
+            process.argv = [ "${coreutils}/bin/true" ];
+            systemd.service.serviceConfig.ExecReload = "${coreutils}/bin/kill -USR2 $MAINPID";
+          };
+        }).config.systemd.services;
     in
     {
       testDefaultType = {
@@ -96,6 +106,19 @@ let
       testReloadExecReload = {
         expr = reloadUnits.service.serviceConfig.ExecReload;
         expected = "${coreutils}/bin/kill -HUP $MAINPID";
+      };
+
+      # Without a reload command, the framework must not define `ExecReload` at
+      # all, so that it neither conflicts with a service-provided definition nor
+      # renders a bare `ExecReload=` line.
+      testNoReloadExecReloadUnset = {
+        expr = defaultUnits.service.serviceConfig ? ExecReload;
+        expected = false;
+      };
+
+      testServiceOwnExecReload = {
+        expr = ownExecReloadUnits.service.serviceConfig.ExecReload;
+        expected = "${coreutils}/bin/kill -USR2 $MAINPID";
       };
     };
 


### PR DESCRIPTION
Fixes `nix-build -A nixosTests.php85.fpm-modular`, reported broken at https://github.com/NixOS/nixpkgs/pull/535695#issuecomment-5148036579:

```
error: The option `containers.machine.systemd.services.php-fpm.serviceConfig.ExecReload' has conflicting definition values:
- In `nixos/modules/system/service/systemd/service.nix, via option ...system.services.php-fpm.systemd.services.""': ""
- In `nixos/modules/system/service/systemd/service.nix, via option ...system.services.php-fpm.systemd.services.""': "/nix/store/...-coreutils-9.11/bin/kill -USR2 $MAINPID"
```

This happened since `ExecReload` commands would be emitted even when missing, making modular service actually setting `ExecReload` explicitly fail to evaluate as a duplicate definition.

Assisted-by: Claude:claude-opus-5

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
    - `nix-build -A nixosTests.php85.fpm-modular` (fails to evaluate on `master`)
    - `nix-build -A nixosTests.php85.ghostunnel-modular`
    - `nix-build -A nixosTests.php85.snid`
    - `nix-build -A nixosTests.system-services-compliance`
    - `nix-build -A nixosTests.modularService`
    - `(cd nixos/; nix-build release.nix -A manual.x86_64-linux)`
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
