### PR TITLE
ossim: 2.12.0 -> 2.12.1-unstable-2026-07-24

### DIFF
--- a/pkgs/by-name/os/ossim/fix-include-paths.patch
+++ b/pkgs/by-name/os/ossim/fix-include-paths.patch
@@ -1,0 +1,41 @@
+diff --git a/src/support_data/ossimNitfGenericTag.cpp b/src/support_data/ossimNitfGenericTag.cpp
+index 9aa0519..4bd2583 100644
+--- a/src/support_data/ossimNitfGenericTag.cpp
++++ b/src/support_data/ossimNitfGenericTag.cpp
+@@ -13,8 +13,8 @@
+ #include <ossim/support_data/ossimNitfCommon.h>
+ #include <ossim/base/ossimKeywordlist.h>
+ #include <ossim/base/ossimNotify.h>
+-#include <base/ossimException.h>
+-#include <base/ossimTrace.h>
++#include <ossim/base/ossimException.h>
++#include <ossim/base/ossimTrace.h>
+ 
+ #include <istream>
+ #include <iostream>
+diff --git a/src/support_data/ossimNitfRegisteredDesFactory.cpp b/src/support_data/ossimNitfRegisteredDesFactory.cpp
+index 6609d9a..a007409 100644
+--- a/src/support_data/ossimNitfRegisteredDesFactory.cpp
++++ b/src/support_data/ossimNitfRegisteredDesFactory.cpp
+@@ -17,7 +17,7 @@
+ #include <ossim/support_data/ossimNitfCscsdbDes.h>
+ #include <ossim/support_data/ossimNitfCssfabDes.h>
+ 
+-#include "support_data/ossimNitfCsephbDes.h"
++#include <ossim/support_data/ossimNitfCsephbDes.h>
+ 
+ RTTI_DEF1(ossimNitfRegisteredDesFactory, "ossimNitfRegisteredDesFactory", ossimNitfDesFactory);
+ 
+diff --git a/src/support_data/ossimNitfXmlTag.cpp b/src/support_data/ossimNitfXmlTag.cpp
+index aefdddc..59e2b7f 100644
+--- a/src/support_data/ossimNitfXmlTag.cpp
++++ b/src/support_data/ossimNitfXmlTag.cpp
+@@ -14,7 +14,7 @@
+ #include <ossim/support_data/ossimNitfXmlTag.h>
+ #include <iomanip>
+ #include <sstream>
+-#include <base/ossimPreferences.h>
++#include <ossim/base/ossimPreferences.h>
+ 
+ ossimNitfXmlTag::ossimNitfXmlTag(ossimString tagName)
+    : ossimNitfRegisteredTag(tagName, 0)

--- a/pkgs/by-name/os/ossim/package.nix
+++ b/pkgs/by-name/os/ossim/package.nix
@@ -2,9 +2,9 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
-  cmake,
   makeWrapper,
+
+  cmake,
   curl,
   freetype,
   geos,
@@ -12,27 +12,27 @@
   libgeotiff,
   libjpeg,
   libtiff,
+  libuuid,
   proj,
   sqlite,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ossim";
-  version = "2.12.0";
+  version = "2.12.1-unstable-2026-07-24";
 
   src = fetchFromGitHub {
     owner = "ossimlabs";
     repo = "ossim";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-nVQN+XnCYpVQSkgKsolqbR3KtPGTkvpym4cDl7IqjUc=";
+    rev = "9efc0b6a21af7e0017fe2a40027026e9f887ed59";
+    hash = "sha256-ExW1tpFe7LAKAj9JqZchJepP648hooF33ue0kDL+q+A=";
   };
 
   patches = [
-    # Fixed build error gcc version 15.0.1
-    (fetchpatch {
-      url = "https://github.com/ossimlabs/ossim/commit/13b9fa9ae54f79a7e7728408de6246e00d38f399.patch";
-      hash = "sha256-AKzOT+JurB/54gvzn2a5amw+uIupaNxssnEhc8CSfPM=";
-    })
+    # Fix incorrect (non-"ossim/"-prefixed) includes that a few files use,
+    # inconsistent with the rest of the tree, causing them to fail to find headers.
+    # https://github.com/ossimlabs/ossim/pull/357
+    ./fix-include-paths.patch
   ];
 
   postPatch = ''
@@ -54,11 +54,13 @@ stdenv.mkDerivation (finalAttrs: {
     libgeotiff
     libjpeg
     libtiff
+    libuuid
     proj
     sqlite
   ];
 
   cmakeFlags = [
+    (lib.cmakeBool "USE_OSSIM_JSONCPP" false)
     (lib.cmakeBool "BUILD_OSSIM_TESTS" false)
     (lib.cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.10")
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Update ossim to the latest version from master to make it working with
cmake 4.3.

Unbreaking from https://hydra.nixos.org/build/338727738/nixlog/1 .

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
