### PR TITLE
nixos/snapserver: add dbus config for avahi

### DIFF
--- a/nixos/modules/services/audio/snapserver.nix
+++ b/nixos/modules/services/audio/snapserver.nix
@@ -229,6 +229,7 @@ in
       restartTriggers = [ configFile ];
       serviceConfig = {
         DynamicUser = true;
+        SupplementaryGroups = [ "avahi-snapserver" ];
         ExecStart = toString [
           (lib.getExe' cfg.package "snapserver")
           "--daemon"
@@ -255,6 +256,24 @@ in
       ]
       ++ lib.optional (cfg.openFirewall && cfg.settings.tcp-control.enabled) cfg.settings.tcp-control.port
       ++ lib.optional (cfg.openFirewall && cfg.settings.http.enabled) cfg.settings.http.port;
+
+    users.groups.avahi-snapserver = { };
+
+    # Add D-Bus policy for avahi
+    services.dbus.packages = [
+      (pkgs.writeTextDir "share/dbus-1/system.d/snapserver.conf" ''
+        <!DOCTYPE busconfig PUBLIC
+          "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+          "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+
+        <busconfig>
+          <policy group="avahi-snapserver">
+              <allow send_destination="org.freedesktop.Avahi"/>
+              <allow receive_sender="org.freedesktop.Avahi"/>
+          </policy>
+        </busconfig>
+      '')
+    ];
   };
 
   meta = {


### PR DESCRIPTION
I noticed that snapserver cannot register itself with avahi.
In the systemd service it logs `(Avahi) Failed to create client: An unexpected D-Bus error occurred`.
I would suggest running snapcast with its own user and not systemd’s `Dynamicuser`.
To me, it would then also make sense to preconfigure avahi and include it in the module, just like shairport-sync also [does](https://github.com/NixOS/nixpkgs/blob/nixos-26.05/nixos/modules/services/networking/shairport-sync.nix#L126-L128).

Starting this service results in `(Avahi) Service 'Snapcast' successfully established.` now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
