### PR TITLE
python3Packages.checksumdir: cleanup, fix

### DIFF
--- a/pkgs/development/python-modules/checksumdir/default.nix
+++ b/pkgs/development/python-modules/checksumdir/default.nix
@@ -5,6 +5,9 @@
 
   # build-system
   poetry-core,
+
+  # tests
+  versionCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -30,8 +33,12 @@ buildPythonPackage (finalAttrs: {
     poetry-core
   ];
 
-  doCheck = false; # Package does not contain tests
   pythonImportsCheck = [ "checksumdir" ];
+
+  # No python tests
+  nativeCheckInputs = [
+    versionCheckHook
+  ];
 
   meta = {
     description = "Simple package to compute a single deterministic hash of the file contents of a directory";

--- a/pkgs/development/python-modules/checksumdir/default.nix
+++ b/pkgs/development/python-modules/checksumdir/default.nix
@@ -2,22 +2,27 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "checksumdir";
   version = "1.3.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "to-mc";
     repo = "checksumdir";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-rOHRJAK+Or8bwAtzpbINdnEjK3WQcU+4sEZI91tMvAk=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [
+    setuptools
+  ];
 
   doCheck = false; # Package does not contain tests
   pythonImportsCheck = [ "checksumdir" ];
@@ -25,7 +30,9 @@ buildPythonPackage rec {
   meta = {
     description = "Simple package to compute a single deterministic hash of the file contents of a directory";
     homepage = "https://github.com/to-mc/checksumdir";
+    changelog = "https://github.com/to-mc/checksumdir/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = [ ];
+    mainProgram = "checksumdir";
   };
-}
+})

--- a/pkgs/development/python-modules/checksumdir/default.nix
+++ b/pkgs/development/python-modules/checksumdir/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
 
   # build-system
-  setuptools,
+  poetry-core,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -20,8 +20,14 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-rOHRJAK+Or8bwAtzpbINdnEjK3WQcU+4sEZI91tMvAk=";
   };
 
+  # Upstream's pyproject.toml has no [build-system] table (PEP 517), so a source build falls back
+  # to setuptools and loses the version.
+  postPatch = ''
+    printf '\n[build-system]\nrequires = ["poetry-core"]\nbuild-backend = "poetry.core.masonry.api"\n' >> pyproject.toml
+  '';
+
   build-system = [
-    setuptools
+    poetry-core
   ];
 
   doCheck = false; # Package does not contain tests


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **python3Packages.checksumdir: cleanup**
- **python3Packages.checksumdir: fix build**
- **python3Packages.checksumdir: add versionCheckHook**

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
