### PR TITLE
lcalc: fix build

### DIFF
--- a/pkgs/by-name/lc/lcalc/package.nix
+++ b/pkgs/by-name/lc/lcalc/package.nix
@@ -19,6 +19,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-L9502+lwSPLk63C14Pxa8OZWhnY4OqKv9WudZO2vP7E=";
   };
 
+  # upstream ships a patched ltmain.sh from libtool 2.5.4. the patch
+  # is already included in libtool 2.6.1.
+  postPatch = "sed -i '/ltmain.sh/d' configure.ac";
+
   nativeBuildInputs = [
     autoreconfHook
     gengetopt


### PR DESCRIPTION
Lcalc upstream is shipping a file from libtool 2.5.2 in order to patch it. [The patch](https://lists.gnu.org/archive/html/libtool/2026-02/msg00002.html) is included in libtool 2.6.1, so we can just ignore the corresponding file (it currently breaks the build due to a version mismatch). Upstream [knows about this](https://gitlab.com/sagemath/lcalc/-/commit/0f83383d94eb680b65eca211332b9bbee80feccf#note_3226299138), but I'm not sure they care about building from the git repo. 

Noticed by @vcunat in https://github.com/NixOS/nixpkgs/pull/546304#issuecomment-5150093742. Thanks for the report!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
