### PR TITLE
microscheme: 0.9.3 -> 0.9.4

### DIFF
--- a/pkgs/by-name/mi/microscheme/package.nix
+++ b/pkgs/by-name/mi/microscheme/package.nix
@@ -8,17 +8,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "microscheme";
-  version = "0.9.3";
+  version = "0.9.4";
 
   src = fetchFromGitHub {
     owner = "ryansuchocki";
     repo = "microscheme";
-    rev = "v${finalAttrs.version}";
-    sha256 = "5qTWsBCfj5DCZ3f9W1bdo6WAc1DZqVxg8D7pwC95duQ=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/LUiPZRV1AuCvKS1+0S0JCHauZMPGr2eXag0dnPk1K0=";
   };
 
   postPatch = ''
-    substituteInPlace makefile --replace gcc ${stdenv.cc.targetPrefix}cc
+    substituteInPlace makefile \
+      --replace-fail gcc ${stdenv.cc.targetPrefix}cc \
+      --replace-fail " -Werror" ""
   '';
 
   nativeBuildInputs = [
@@ -27,6 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
+  buildFlags = [ "build" ];
 
   meta = {
     homepage = "https://ryansuchocki.github.io/microscheme/";


### PR DESCRIPTION
bumps microscheme 0.9.3 -> 0.9.4.

also tidied the derivation while bumping:
- `tag` + `hash` instead of the deprecated `rev` + `sha256`
- `--replace-fail` instead of the deprecated `--replace`
- the 0.9.4 makefile has the default `all` target run cppcheck and clang-format (upstream dev lint) and compiles with `-Werror`. `-Werror` breaks on current gcc (maybe-uninitialized in scoper.c) and cppcheck isnt something that should gate the build, so i drop `-Werror` and build only the `build` target, which skips the lint. binary builds fine and reports 0.9.4.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests]
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test].
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
