### PR TITLE
fluent-gtk-theme: improve readability

### DIFF
--- a/pkgs/by-name/fl/fluent-gtk-theme/package.nix
+++ b/pkgs/by-name/fl/fluent-gtk-theme/package.nix
@@ -13,9 +13,8 @@
 
 let
   pname = "fluent-gtk-theme";
-in
-lib.checkListOfEnum "${pname}: theme variants"
-  [
+
+  checkThemes = lib.checkListOfEnum "${pname}: theme variants" [
     "default"
     "purple"
     "pink"
@@ -26,34 +25,31 @@ lib.checkListOfEnum "${pname}: theme variants"
     "teal"
     "grey"
     "all"
-  ]
-  themeVariants
-  lib.checkListOfEnum
-  "${pname}: color variants"
-  [
+  ] themeVariants;
+
+  checkColors = lib.checkListOfEnum "${pname}: color variants" [
     "standard"
     "light"
     "dark"
-  ]
-  colorVariants
-  lib.checkListOfEnum
-  "${pname}: size variants"
-  [
+  ] colorVariants;
+
+  checkSizes = lib.checkListOfEnum "${pname}: size variants" [
     "standard"
     "compact"
-  ]
-  sizeVariants
-  lib.checkListOfEnum
-  "${pname}: tweaks"
-  [
+  ] sizeVariants;
+
+  checkTweaks = lib.checkListOfEnum "${pname}: tweaks" [
     "solid"
     "float"
     "round"
     "blur"
     "noborder"
     "square"
-  ]
-  tweaks
+  ] tweaks;
+
+  checkAll = checkThemes checkColors checkSizes checkTweaks;
+in
+checkAll
 
   stdenvNoCC.mkDerivation
   (finalAttrs: {


### PR DESCRIPTION
Improve the readability of the check code mentioned in [#547751](https://github.com/NixOS/nixpkgs/pull/547751#discussion_r3691805154).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
