### PR TITLE
emacs: remove unneeded buildWithGit override for elisp packages

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -952,9 +952,6 @@ let
           consult-gh-embark = ignoreCompilationError super.consult-gh-embark;
 
           # needs network during compilation
-          consult-gh-forge = ignoreCompilationError super.consult-gh-forge;
-
-          # needs network during compilation
           consult-gh-with-pr-review = ignoreCompilationError super.consult-gh-with-pr-review;
 
           counsel-gtags = ignoreCompilationError super.counsel-gtags; # elisp error

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -396,10 +396,6 @@ let
             };
           });
 
-          eopengrok = buildWithGit super.eopengrok;
-
-          forge = buildWithGit super.forge;
-
           gnuplot = super.gnuplot.overrideAttrs (attrs: {
             postPatch = attrs.postPatch or "" + ''
               substituteInPlace gnuplot.el \
@@ -414,68 +410,14 @@ let
             '';
           });
 
-          magit = buildWithGit super.magit;
-
-          magit-find-file = buildWithGit super.magit-find-file;
-
-          magit-gh-pulls = buildWithGit super.magit-gh-pulls;
-
-          magit-imerge = buildWithGit super.magit-imerge;
-
-          magit-lfs = buildWithGit super.magit-lfs;
-
-          magit-org-todos = buildWithGit super.magit-org-todos;
-
-          magit-tbdiff = buildWithGit super.magit-tbdiff;
-
-          magit-topgit = ignoreCompilationError (buildWithGit super.magit-topgit); # elisp error
-
-          magit-vcsh = buildWithGit super.magit-vcsh;
-
-          magit-gerrit = buildWithGit super.magit-gerrit;
-
-          magit-annex = buildWithGit super.magit-annex;
-
-          magit-todos = buildWithGit super.magit-todos;
-
-          magit-filenotify = buildWithGit super.magit-filenotify;
-
-          magit-gitflow = buildWithGit super.magit-gitflow;
-
-          magit-svn = buildWithGit super.magit-svn;
-
-          kubernetes = buildWithGit super.kubernetes;
-
-          kubernetes-evil = buildWithGit super.kubernetes-evil;
+          magit-topgit = ignoreCompilationError super.magit-topgit; # elisp error
 
           egg = buildWithGit super.egg;
 
-          kapacitor = buildWithGit super.kapacitor;
-
-          gerrit = buildWithGit super.gerrit;
-
-          github-pullrequest = buildWithGit super.github-pullrequest;
-
-          jist = buildWithGit super.jist;
-
           mandoku = addPackageRequires super.mandoku [ self.git ]; # upstream is archived
 
-          magit-p4 = buildWithGit super.magit-p4;
-
-          magit-rbr = buildWithGit super.magit-rbr;
-
-          magit-diff-flycheck = buildWithGit super.magit-diff-flycheck;
-
-          magit-reviewboard = buildWithGit super.magit-reviewboard;
-
-          magit-patch-changelog = buildWithGit super.magit-patch-changelog;
-
           # https://github.com/dandavison/magit-delta/issues/30
-          magit-delta = addPackageRequires (buildWithGit super.magit-delta) [ self.dash ];
-
-          orgit = buildWithGit super.orgit;
-
-          orgit-forge = buildWithGit super.orgit-forge;
+          magit-delta = addPackageRequires super.magit-delta [ self.dash ];
 
           ormolu = super.ormolu.overrideAttrs (attrs: {
             postPatch = attrs.postPatch or "" + ''
@@ -483,8 +425,6 @@ let
                 --replace-fail 'ormolu-process-path "ormolu"' 'ormolu-process-path "${lib.getExe pkgs.ormolu}"'
             '';
           });
-
-          ox-rss = buildWithGit super.ox-rss;
 
           python-isort = super.python-isort.overrideAttrs (attrs: {
             postPatch = attrs.postPatch or "" + ''
@@ -987,8 +927,6 @@ let
           # depends on distel which is not on any ELPA https://github.com/massemanet/distel/issues/21
           company-distel = ignoreCompilationError super.company-distel;
 
-          company-forge = buildWithGit super.company-forge;
-
           # qmltypes-table.el causing native-compiler-error-empty-byte
           company-qml = ignoreCompilationError super.company-qml;
 
@@ -1014,7 +952,7 @@ let
           consult-gh-embark = ignoreCompilationError super.consult-gh-embark;
 
           # needs network during compilation
-          consult-gh-forge = ignoreCompilationError (buildWithGit super.consult-gh-forge);
+          consult-gh-forge = ignoreCompilationError super.consult-gh-forge;
 
           # needs network during compilation
           consult-gh-with-pr-review = ignoreCompilationError super.consult-gh-with-pr-review;
@@ -1121,8 +1059,6 @@ let
             ];
           });
 
-          embark-vc = buildWithGit super.embark-vc;
-
           # https://github.com/nubank/emidje/issues/23
           emidje = addPackageRequires super.emidje [ self.pkg-info ];
 
@@ -1197,8 +1133,6 @@ let
 
           fold-dwim-org = ignoreCompilationError super.fold-dwim-org; # elisp error
 
-          forge-llm = buildWithGit super.forge-llm;
-
           frontside-javascript = super.frontside-javascript.overrideAttrs (
             finalAttrs: previousAttrs: {
               # https://github.com/melpa/melpa/pull/9182
@@ -1223,8 +1157,6 @@ let
             self.company
             self.flycheck
           ];
-
-          gh-notify = buildWithGit super.gh-notify;
 
           # https://gitlab.com/emacs-stuff/git-commit-insert-issue/-/issues/24
           git-commit-insert-issue = addPackageRequires super.git-commit-insert-issue [ self.glab ];

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -396,8 +396,6 @@ let
             };
           });
 
-          evil-magit = buildWithGit super.evil-magit;
-
           eopengrok = buildWithGit super.eopengrok;
 
           forge = buildWithGit super.forge;
@@ -444,8 +442,6 @@ let
 
           magit-gitflow = buildWithGit super.magit-gitflow;
 
-          magithub = ignoreCompilationError (buildWithGit super.magithub); # elisp error
-
           magit-svn = buildWithGit super.magit-svn;
 
           kubernetes = buildWithGit super.kubernetes;
@@ -457,8 +453,6 @@ let
           kapacitor = buildWithGit super.kapacitor;
 
           gerrit = buildWithGit super.gerrit;
-
-          gerrit-download = buildWithGit super.gerrit-download;
 
           github-pullrequest = buildWithGit super.github-pullrequest;
 
@@ -475,8 +469,6 @@ let
           magit-reviewboard = buildWithGit super.magit-reviewboard;
 
           magit-patch-changelog = buildWithGit super.magit-patch-changelog;
-
-          magit-circleci = buildWithGit super.magit-circleci;
 
           # https://github.com/dandavison/magit-delta/issues/30
           magit-delta = addPackageRequires (buildWithGit super.magit-delta) [ self.dash ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
