### PR TITLE
zvm: 0.8.22 -> 0.8.27

### DIFF
--- a/pkgs/by-name/zv/zvm/package.nix
+++ b/pkgs/by-name/zv/zvm/package.nix
@@ -8,16 +8,21 @@
 
 buildGoModule (finalAttrs: {
   pname = "zvm";
-  version = "0.8.22";
+  version = "0.8.27";
 
   src = fetchFromGitHub {
     owner = "tristanisham";
     repo = "zvm";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-uKn4ysaNuvWpV4fhrpm7pdS61pQJTYr6WfIhBzTfNT8=";
+    hash = "sha256-NDkvTghdqabfzzXSyxYHZj67u+upY0WfLOAO5DWAZ3s=";
   };
 
   vendorHash = "sha256-kJrCUxzbpyxEUF9UQeAI28tWKA+T7zT1DBI1wf3pjjM=";
+
+  postPatch = ''
+    substituteInPlace cli/meta/version.go \
+      --replace-fail 'VERSION = "v0.8.25"' 'VERSION = "v${finalAttrs.version}"'
+  '';
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];


### PR DESCRIPTION
Bump `zvm` from 0.8.22 to 0.8.27

Variable `meta.VERSION` that outputs the version to binary is lagging behind at `v0.8.25` instead of `v0.8.27` (this has since been corrected on `master` in  https://github.com/tristanisham/zvm/commit/4bac2bd7e9dcd9b9d56e9dd2add59f9f9313f675) postPatch added to satisfy `versionCheckHook`.

This `versionCheckHook` fail could be why the `nix-update-script` has not been working lately. (Just a speculation)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
