### PR TITLE
sable-desktop: init at 1.21

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16949,6 +16949,12 @@
     githubId = 7243615;
     name = "Luna";
   };
+  lunar-seal = {
+    email = "lunar-seal@ff15.eu";
+    github = "lunar-seal";
+    githubId = 44544539;
+    name = "lunar-seal";
+  };
   lunarequest = {
     email = "nullarequest@vivlaid.net";
     github = "Lunarequest";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17145,6 +17145,12 @@
     githubId = 7243615;
     name = "Luna";
   };
+  lunar-seal = {
+    email = "lunar-seal@ff15.eu";
+    github = "lunar-seal";
+    githubId = 44544539;
+    name = "lunar-seal";
+  };
   lunarequest = {
     email = "nullarequest@vivlaid.net";
     github = "Lunarequest";

--- a/pkgs/by-name/sa/sable-desktop/package.nix
+++ b/pkgs/by-name/sa/sable-desktop/package.nix
@@ -1,0 +1,184 @@
+{
+  lib,
+  rustPlatform,
+  addDriverRunpath,
+  cargo-tauri,
+  cef-binary,
+  dbus,
+  desktop-file-utils,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  gtk3,
+  libGL,
+  libpulseaudio,
+  libxkbcommon,
+  nix-update-script,
+  nodejs-slim_24,
+  pipewire,
+  pkg-config,
+  pnpm_10,
+  pnpmConfigHook,
+  symlinkJoin,
+  webkitgtk_4_1,
+  writeText,
+  xdg-utils,
+  libayatana-appindicator,
+  wrapGAppsHook3,
+}:
+
+# this uses the current default runtime for sable, which is the cef runtime.
+# the wry (webkitgtk based) runtime does not have working webrtc yet.
+# (July 2026) estimate for webrtc with wry is march 2027 https://blogs.igalia.com/webkit/blog/2026/wip-71/
+
+let
+  nodejs-slim = nodejs-slim_24;
+  pnpm = pnpm_10.override { inherit nodejs-slim; };
+  cef = cef-binary.override {
+    version = "150.0.14";
+    gitRevision = "7c1aa68";
+    chromiumVersion = "150.0.7871.129";
+    srcHashes = {
+      x86_64-linux = "sha256-QO9hPkVcrNB6p8gfQl76qLb3frg/E8wo1HDuuk5h+Y8=";
+      aarch64-linux = "sha256-tA4hWg9G/UDQSxXUuDO+IRjvc8Qx1cEdGOtiXg3ktk0=";
+    };
+  };
+  # fake archive.json to prevent automatically downloading CEF here
+  # as per https://github.com/tauri-apps/cef-rs/issues/426
+  fakeArchiveJson = writeText "archive.json" (
+    builtins.toJSON {
+      name = cef.src.name;
+      sha1 = "";
+      type = "minimal";
+    }
+  );
+  cefFlat = symlinkJoin {
+    name = "cef-${cef.version}-flat";
+    paths = [
+      "${cef}/${cef.buildType}"
+      "${cef}/Resources"
+    ];
+    postBuild = ''
+      ln -s ${cef}/libcef_dll "$out/"
+      ln -s ${fakeArchiveJson} "$out/archive.json"
+    '';
+  };
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "sable-desktop";
+  version = "1.21.0";
+
+  src = fetchFromGitHub {
+    owner = "SableClient";
+    repo = "Sable";
+    tag = "v1.21.0";
+    hash = "sha256-vYoKNflV4vdJpgYVxYCxAQhvqDh1Qf+7qgIFHxriTTU=";
+  };
+
+  # patch to use version-identical binary packages, delete at version 1.21.1
+  patches = [ ./sableclient-npm-dist.patch ];
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      patches
+      ;
+    inherit pnpm;
+    fetcherVersion = 3;
+    hash = "sha256-BPUVRre9+SXV0wrZxT0PeHl7YWv6+DmPDjy57gpt8hc=";
+  };
+
+  # vite would try to use git to set these otherwise
+  env = {
+    VITE_BUILD_HASH = "nix";
+    VITE_IS_RELEASE_TAG = "true";
+    CEF_PATH = "${cefFlat}";
+  };
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+
+  cargoHash = "sha256-E38C5pttAidLLRLI3+UPYJqQbBhFsMI1nnYu06gvSF8=";
+  cargoDepsName = finalAttrs.pname;
+
+  tauriBuildFlags = "--no-sign";
+  buildNoDefaultFeatures = true;
+  buildFeatures = [
+    "cef"
+    "custom-protocol"
+  ];
+
+  # prevent writing into the user's home dir
+  postPatch = ''
+    substituteInPlace src-tauri/src/lib.rs \
+      --replace-fail "                use tauri_plugin_deep_link::DeepLinkExt;" "" \
+      --replace-fail "                app.deep_link().register_all()?;" ""
+  '';
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    dbus
+    desktop-file-utils
+    nodejs-slim
+    pkg-config
+    pnpm
+    pnpmConfigHook
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    gtk3
+    libayatana-appindicator
+    # always needed at least until https://github.com/tauri-apps/tauri/pull/15068 gets merged
+    webkitgtk_4_1
+  ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : "${lib.makeBinPath [ xdg-utils ]}"
+      --prefix LD_LIBRARY_PATH : "${
+        lib.makeLibraryPath [
+          libayatana-appindicator
+          libGL
+          libpulseaudio
+          libxkbcommon
+          pipewire
+        ]
+      }:${addDriverRunpath.driverLink}/lib"
+      --suffix VK_ADD_DRIVER_FILES : "${addDriverRunpath.driverLink}/share/vulkan/icd.d"
+    )
+  '';
+
+  # fix the the desktop file so e.g. oidc redirect still works, despite removing the deeplink plugin
+  postFixup = ''
+    desktop-file-edit \
+      --set-key="Categories" --set-value="Network;InstantMessaging;Chat;" \
+      --set-key="Exec" --set-value="sable %u" \
+      "$out/share/applications/Sable.desktop"
+    ln -s ${cef}/${cef.buildType}/* ${cef}/Resources/* "$out/bin/"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "An almost stable Matrix client";
+    homepage = "https://github.com/SableClient/Sable";
+    changelog = "https://github.com/SableClient/Sable/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    maintainers = with lib.maintainers; [
+      fugi
+      lunar-seal
+      toasteruwu
+    ];
+    license = [
+      lib.licenses.agpl3Only
+    ];
+    mainProgram = "sable";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+})

--- a/pkgs/by-name/sa/sable-desktop/sableclient-npm-dist.patch
+++ b/pkgs/by-name/sa/sable-desktop/sableclient-npm-dist.patch
@@ -1,0 +1,76 @@
+diff --git a/package.json b/package.json
+index f29ee60..ef16ae8 100644
+--- a/package.json
++++ b/package.json
+@@ -54,8 +54,8 @@
+     "@lottiefiles/dotlottie-web": "0.79.1",
+     "@noble/hashes": "^2.3.0",
+     "@phosphor-icons/react": "^2.1.10",
+-    "@sableclient/matrixrtc": "github:SableClient/matrix-rtc#519fe6b863cfac78700f4e2b1748649103bb8a8d",
+-    "@sableclient/tauri-plugin-livekit-mobile": "github:SableClient/tauri-plugin-livekit-mobile#c6f0d02ab3da1174535bc1dc8e598a2e6873f977",
++    "@sableclient/matrixrtc": "^0.1.0",
++    "@sableclient/tauri-plugin-livekit-mobile": "^0.2.0",
+     "@sableclient/twemoji-font": "^1.0.4",
+     "@sentry/react": "^10.70.0",
+     "@tanstack/react-query": "^5.101.4",
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index 14abed5..2962d11 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -62,11 +62,11 @@ importers:
+         specifier: ^2.1.10
+         version: 2.1.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+       '@sableclient/matrixrtc':
+-        specifier: github:SableClient/matrix-rtc#519fe6b863cfac78700f4e2b1748649103bb8a8d
+-        version: https://codeload.github.com/SableClient/matrix-rtc/tar.gz/519fe6b863cfac78700f4e2b1748649103bb8a8d(livekit-client@2.21.0(@types/dom-mediacapture-record@1.0.22))(matrix-js-sdk@42.0.0)
++        specifier: ^0.1.0
++        version: 0.1.0(livekit-client@2.21.0(@types/dom-mediacapture-record@1.0.22))(matrix-js-sdk@42.0.0)
+       '@sableclient/tauri-plugin-livekit-mobile':
+-        specifier: github:SableClient/tauri-plugin-livekit-mobile#c6f0d02ab3da1174535bc1dc8e598a2e6873f977
+-        version: https://codeload.github.com/SableClient/tauri-plugin-livekit-mobile/tar.gz/c6f0d02ab3da1174535bc1dc8e598a2e6873f977
++        specifier: ^0.2.0
++        version: 0.2.0
+       '@sableclient/twemoji-font':
+         specifier: ^1.0.4
+         version: 1.0.4
+@@ -2684,9 +2684,8 @@ packages:
+     cpu: [x64]
+     os: [win32]
+ 
+-  '@sableclient/matrixrtc@https://codeload.github.com/SableClient/matrix-rtc/tar.gz/519fe6b863cfac78700f4e2b1748649103bb8a8d':
+-    resolution: {tarball: https://codeload.github.com/SableClient/matrix-rtc/tar.gz/519fe6b863cfac78700f4e2b1748649103bb8a8d}
+-    version: 0.1.0
++  '@sableclient/matrixrtc@0.1.0':
++    resolution: {integrity: sha512-2odY8NRY2QYFGdqnuPg3ix4f2crSqY45zH+h4RrLxPCRmUxWERkZY419b3NOeLfC6QN9dYzX8LFUW24+CgIwJQ==}
+     engines: {node: '>=20'}
+     peerDependencies:
+       livekit-client: ^2.21.0
+@@ -2695,9 +2694,8 @@ packages:
+   '@sableclient/sable-call-embedded@1.1.8':
+     resolution: {integrity: sha512-+95vxaqTxh5gIrIwMX+FWH4n+K82rv/hlVIO/KIhIl2udJ2+r/GESiAElnTXa1bom1+FWrdekNvkCEEuh7m2Jw==}
+ 
+-  '@sableclient/tauri-plugin-livekit-mobile@https://codeload.github.com/SableClient/tauri-plugin-livekit-mobile/tar.gz/c6f0d02ab3da1174535bc1dc8e598a2e6873f977':
+-    resolution: {tarball: https://codeload.github.com/SableClient/tauri-plugin-livekit-mobile/tar.gz/c6f0d02ab3da1174535bc1dc8e598a2e6873f977}
+-    version: 0.2.0
++  '@sableclient/tauri-plugin-livekit-mobile@0.2.0':
++    resolution: {integrity: sha512-xpv+9qDEIYM1lmbdLpLgD8fwctyT7QNq8R7uwhm7T1Wt95MF7TqgtGUo8kHAUZq4v4ung0jxacbvkp9POMVutw==}
+ 
+   '@sableclient/twemoji-font@1.0.4':
+     resolution: {integrity: sha512-LzvQB/VZtv5KEq1VYq2azr7v7cYT8oklOVRGkAN2RNwa3sF0XcnqM3lBHSYRFXQleGLSUgs3gA0slbwkD2+sJw==}
+@@ -7885,14 +7883,14 @@ snapshots:
+   '@rollup/rollup-win32-x64-msvc@4.62.4':
+     optional: true
+ 
+-  '@sableclient/matrixrtc@https://codeload.github.com/SableClient/matrix-rtc/tar.gz/519fe6b863cfac78700f4e2b1748649103bb8a8d(livekit-client@2.21.0(@types/dom-mediacapture-record@1.0.22))(matrix-js-sdk@42.0.0)':
++  '@sableclient/matrixrtc@0.1.0(livekit-client@2.21.0(@types/dom-mediacapture-record@1.0.22))(matrix-js-sdk@42.0.0)':
+     dependencies:
+       livekit-client: 2.21.0(@types/dom-mediacapture-record@1.0.22)
+       matrix-js-sdk: 42.0.0
+ 
+   '@sableclient/sable-call-embedded@1.1.8': {}
+ 
+-  '@sableclient/tauri-plugin-livekit-mobile@https://codeload.github.com/SableClient/tauri-plugin-livekit-mobile/tar.gz/c6f0d02ab3da1174535bc1dc8e598a2e6873f977':
++  '@sableclient/tauri-plugin-livekit-mobile@0.2.0':
+     dependencies:
+       '@tauri-apps/api': 2.11.1
+ 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Sable https://github.com/SableClient/Sable recently has added support for a Tauri desktop app.
A stable version (1.21) is to be released soon. This PR is currently based on the nightly branch, which will become the stable release soon. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
