### PR TITLE
folo: 0.11.0 -> 0.12.0; folo: add jsdom runtime dep

### DIFF
--- a/pkgs/by-name/fo/folo/package.nix
+++ b/pkgs/by-name/fo/folo/package.nix
@@ -15,13 +15,13 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "folo";
 
-  version = "1.11.0";
+  version = "1.12.0";
 
   src = fetchFromGitHub {
     owner = "RSSNext";
     repo = "Folo";
     tag = "desktop/v${finalAttrs.version}";
-    hash = "sha256-kJ5FX6whBPTPJoWBmgaMeDSJAF7pGl5WkGmDzQSKLpo=";
+    hash = "sha256-Nq0EKH9Em5U+iNoWG/aZP2eiDYcJOGQGScZIlbrQvTw=";
   };
 
   nativeBuildInputs = [
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
       ;
     pnpm = pnpm_11;
     fetcherVersion = 4;
-    hash = "sha256-W8vzjbBBK3wvr6abIniW5oRpSJU45Gua6EjBTTA326I=";
+    hash = "sha256-HnDXcofw8xUM2W0hoFbjYbCV269XixVA/4hFjoGEVLA=";
   };
 
   __structuredAttrs = true;

--- a/pkgs/by-name/fo/folo/package.nix
+++ b/pkgs/by-name/fo/folo/package.nix
@@ -76,6 +76,8 @@ stdenv.mkDerivation (finalAttrs: {
   # ast-kit from unplugin-ast).
   pnpmInstallFlags = [ "--shamefully-hoist" ];
 
+  patches = [ ./runtime-jsdom.patch ];
+
   postPatch = ''
     # pnpm 11 verifies node_modules before every `pnpm run` which conflicts
     # with --shamefully-hoist

--- a/pkgs/by-name/fo/folo/runtime-jsdom.patch
+++ b/pkgs/by-name/fo/folo/runtime-jsdom.patch
@@ -1,0 +1,29 @@
+diff --git a/package.json b/package.json
+index 35810cc..145d8aa 100644
+--- a/package.json
++++ b/package.json
+@@ -32,6 +32,9 @@
+     "test": "cross-env CI=1 pnpm --recursive run test",
+     "typecheck": "turbo typecheck"
+   },
++  "dependencies": {
++    "jsdom": "29.1.1"
++  },
+   "devDependencies": {
+     "@electron-toolkit/tsconfig": "2.0.0",
+     "@eslint/compat": "2.1.0",
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index 98165cf..3d07d0a 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -82,6 +82,10 @@ importers:
+ 
+   .:
++    dependencies:
++      jsdom:
++        specifier: 29.1.1
++        version: 29.1.1(@noble/hashes@2.0.1)
+     devDependencies:
+       '@electron-toolkit/tsconfig':
+         specifier: 2.0.0
+         version: 2.0.0(@types/node@26.1.1)


### PR DESCRIPTION
Fixes #548046
Changelog: https://github.com/RSSNext/Folo/releases/tag/desktop%2Fv1.12.0

## Things done

Bump the package and add jsdom as a root production dependency. Upstream's Forge packaging copies jsdom into the application, but the nixpkgs build bypasses Forge and prunes it.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
