### PR TITLE
python3Packages.azure-mgmt-automation: 1.0.1 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/azure-mgmt-automation/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-automation/default.nix
@@ -4,27 +4,30 @@
   fetchPypi,
   setuptools,
   msrest,
-  azure-common,
+  azure-core,
   azure-mgmt-core,
+  isodate,
+  typing-extensions,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "azure-mgmt-automation";
-  version = "1.0.1";
+  version = "2.0.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "azure_mgmt_automation";
     inherit (finalAttrs) version;
-    hash = "sha256-A/NYbg/gllws7cp5plM4CHKuYnwm6lNlpVuqTq1aeO8=";
+    hash = "sha256-nRVIwul58bj8PtUXc/yEo0BkVSAzU+f3v19A5YEQmRY=";
   };
 
   build-system = [ setuptools ];
 
   dependencies = [
-    msrest
-    azure-common
+    azure-core
     azure-mgmt-core
+    isodate
+    typing-extensions
   ];
 
   # has no tests


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
[ChangeLog](https://github.com/Azure/azure-sdk-for-python/blob/azure-mgmt-automation_2.0.0/sdk/automation/azure-mgmt-automation/CHANGELOG.md)

The `azure-core` dependency is not mentioned in the `pyproject.toml` but is imported at runtime.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
