### PR TITLE
zoraxy: 3.3.1 -> 3.3.3

### DIFF
--- a/pkgs/by-name/zo/zoraxy/package.nix
+++ b/pkgs/by-name/zo/zoraxy/package.nix
@@ -2,22 +2,23 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "zoraxy";
-  version = "3.3.1";
+  version = "3.3.3";
 
   src = fetchFromGitHub {
     owner = "tobychui";
     repo = "zoraxy";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-NhjT1z/O2KJtlF/LkGWgxhm2/i83mJUZeBHDiZke0FE=";
+    hash = "sha256-TpkDGFmYKKMeU62mcCM0YWtvADdQk7/uP0KkskelnBI=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/src";
 
-  vendorHash = "sha256-HaQP6ZARSHwEnW/G95t5NHdM8/EcXEfN2Q1wPVRWIzQ=";
+  vendorHash = "sha256-yQyq4RrRdIzmx6O19/ogt6zid+7HDTIYvZtpMcQKuqY=";
 
   checkFlags =
     let
@@ -34,8 +35,14 @@ buildGoModule (finalAttrs: {
         "TestGetPluginListFromURL"
         "TestUpdateDownloadablePluginList"
       ];
+      # Upstream test bug: AccessRuleCreatedEvent gained a `trust_proxy_headers_only`
+      # field in 3.3.3 but the test's hardcoded expectedJson was not updated.
+      brokenTests = [ "TestEventDeSerialization/AccessRuleCreated" ];
     in
-    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+    [ "-skip=^${builtins.concatStringsSep "$|^" (skippedTests ++ brokenTests)}$" ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   meta = {
     description = "General purpose HTTP reverse proxy and forwarding tool written in Go";


### PR DESCRIPTION
Bump `zoraxy` from 3.3.1 to 3.3.3

Updated `checkFlags` - Skip `TestEventDeSerialization` test (Upstream test bug). This test does not require a network access and so I added it under a new attrs `brokenTests` to differentiate the other skipped tests. And to allow for easy code removal if fixed in future versions.
Added `versionCheckHook`


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
