### PR TITLE
yosys: add slang support

### DIFF
--- a/pkgs/by-name/yo/yosys/package.nix
+++ b/pkgs/by-name/yo/yosys/package.nix
@@ -16,6 +16,7 @@
   libffi,
   readline,
   tcl,
+  sv-lang,
   zlib,
 
   # tests
@@ -112,6 +113,7 @@ stdenv.mkDerivation (finalAttrs: {
     libffi
     readline
     tcl
+    sv-lang
     zlib
   ]
   ++ lib.optionals enablePython [
@@ -121,8 +123,6 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "YOSYS_SKIP_ABC_SUBMODULE_CHECK" true)
     (lib.cmakeFeature "YOSYS_CHECKOUT_INFO" "v${finalAttrs.version}")
-    # slang is not packaged yet.
-    (lib.cmakeBool "YOSYS_WITHOUT_SLANG" true)
     (lib.cmakeBool "YOSYS_WITH_PYTHON" enablePython)
   ]
   ++ lib.optionals enablePython [


### PR DESCRIPTION
Since [yosys version 0.67](https://github.com/YosysHQ/yosys/releases/tag/v0.67) slang support is directly included in yosys.
https://github.com/NixOS/nixpkgs/pull/542197 disabled the slang support and wrote `slang is not packaged yet` but slang was packaged as `sv-lang` (slang was already the name of another package).

This should close https://github.com/NixOS/nixpkgs/pull/472800.

The new `read_slang` command has been tested and works fine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
