### PR TITLE
python3Packages.pychromedevtools: init at 1.0.4

### DIFF
--- a/pkgs/development/python-modules/pychromedevtools/default.nix
+++ b/pkgs/development/python-modules/pychromedevtools/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  requests,
+  websocket-client,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pychromedevtools";
+  version = "1.0.4";
+  __structuredAttrs = true;
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "marty90";
+    repo = "PyChromeDevTools";
+    tag = finalAttrs.version;
+    hash = "sha256-oFv8kfIYP0iJlPyA3EulwB4z7z1kZ/1gOBEKsV+SUHY=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    requests
+    websocket-client
+  ];
+
+  pythonImportsCheck = [
+    "PyChromeDevTools"
+  ];
+
+  meta = {
+    description = "Python module that allows one to interact with Google Chrome using Chrome DevTools Protocol";
+    homepage = "https://github.com/marty90/PyChromeDevTools";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      haansn08
+    ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14231,6 +14231,8 @@ self: super: with self; {
 
   pychromecast = callPackage ../development/python-modules/pychromecast { };
 
+  pychromedevtools = callPackage ../development/python-modules/pychromedevtools { };
+
   pycifrw = callPackage ../development/python-modules/pycifrw { };
 
   pycketcasts = callPackage ../development/python-modules/pycketcasts { };


### PR DESCRIPTION
[PyChromeDevTools](https://github.com/marty90/PyChromeDevTools) is a requirement for Anki 26.08.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
