### PR TITLE
nixos/syncthing-relay: make private relays possible

### DIFF
--- a/nixos/modules/services/networking/syncthing-relay.nix
+++ b/nixos/modules/services/networking/syncthing-relay.nix
@@ -21,6 +21,7 @@ let
   ++ optional (cfg.pools != null) "--pools=${escapeShellArg (concatStringsSep "," cfg.pools)}"
   ++ optional (cfg.globalRateBps != null) "--global-rate=${toString cfg.globalRateBps}"
   ++ optional (cfg.perSessionRateBps != null) "--per-session-rate=${toString cfg.perSessionRateBps}"
+  ++ optional (cfg.tokenFile != null) "--token=$(cat ${cfg.tokenFile})"
   ++ cfg.extraOptions;
 in
 {
@@ -94,6 +95,14 @@ in
       default = null;
       description = ''
         Per session bandwidth rate limit in bytes per second.
+      '';
+    };
+
+    tokenFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = ''
+        Token to restrict access to the relay. Disables joining any pools.
       '';
     };
 

--- a/nixos/modules/services/networking/syncthing-relay.nix
+++ b/nixos/modules/services/networking/syncthing-relay.nix
@@ -15,9 +15,9 @@ let
   relayOptions = [
     "--keys=${dataDirectory}"
     "--listen=${cfg.listenAddress}:${toString cfg.port}"
-    "--status-srv=${cfg.statusListenAddress}:${toString cfg.statusPort}"
     "--provided-by=${escapeShellArg cfg.providedBy}"
   ]
+  ++ optional (cfg.statusPort != null) "--status-srv=${cfg.statusListenAddress}:${toString cfg.statusPort}"
   ++ optional (cfg.pools != null) "--pools=${escapeShellArg (concatStringsSep "," cfg.pools)}"
   ++ optional (cfg.globalRateBps != null) "--global-rate=${toString cfg.globalRateBps}"
   ++ optional (cfg.perSessionRateBps != null) "--per-session-rate=${toString cfg.perSessionRateBps}"
@@ -58,7 +58,7 @@ in
     };
 
     statusPort = mkOption {
-      type = types.port;
+      type = types.nullOr types.port;
       default = 22070;
       description = ''
         Port to listen on for serving the relay status API. This port should be


### PR DESCRIPTION
`syncthing-relay` defaults to report status to a server specified in `statusListenAddress`.
While this is fine for public relays, private relays don't report status to any server.
Hosting private relays was also blocked by the lack of option for configuring private relay secret access token.

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
