### PR TITLE
viber: fix libxshmfence library

### DIFF
--- a/pkgs/by-name/vi/viber/package.nix
+++ b/pkgs/by-name/vi/viber/package.nix
@@ -62,6 +62,7 @@
   libxcb-image,
   libxtst,
   libxscrnsaver,
+  libxshmfence,
   libxrender,
   libxrandr,
   libxi,
@@ -163,6 +164,7 @@ stdenv.mkDerivation (finalAttrs: {
     libxrandr
     libxrender
     libxscrnsaver
+    libxshmfence
     libxtst
     libxcb
     libxcb-image


### PR DESCRIPTION
fix: error while loading shared libraries: libxshmfence.so.1: cannot open shared object file: No such file or directory