### PR TITLE
secp256k1-jdk: 0.3 -> 0.3.1

### DIFF
--- a/pkgs/by-name/se/secp256k1-jdk/package.nix
+++ b/pkgs/by-name/se/secp256k1-jdk/package.nix
@@ -7,20 +7,20 @@
 
 maven.buildMavenPackage (finalAttrs: {
   pname = "secp256k1-jdk";
-  version = "0.3";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "bitcoinj";
     repo = "secp256k1-jdk";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-kIWBgJ9OueNNDRKf1HHaxt6PFxK2iCuO0TFr8swbiL0=";
+    hash = "sha256-F2e4NDPEU7ZAu4+fvEd4BRbE2JwCvUiMeXHTMDXbIJE=";
   };
 
   mvnJdk = jdk25;
   mvnGoal = "deploy"; # The secp256k1-jdk POM targets a `local-staging` repository using a file URL
   mvnOffline = false; # We need actions not allowed in Maven offline mode, but Nix sandboxing will still be enforced
   mvnParameters = "-Drevision=${finalAttrs.version}"; # make snapshot builds reproducible
-  mvnHash = "sha256-87iDewdy/7lSyvROf1YyrsgvVUJtaivdHdSLig3Ea1Y=";
+  mvnHash = "sha256-a62jDFapnYV/mguZ/5PDzI5Unz7BnuvieLmpsocYMO4=";
 
   strictDeps = true;
   __structuredAttrs = true;


### PR DESCRIPTION
Update from 0.3 to 0.3.1.

See the [CHANGELOG](https://github.com/bitcoinj/secp256k1-jdk/blob/master/CHANGELOG.adoc#v031).

## Things done


- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
