### PR TITLE
python3Packages.pipx: cleanup

### DIFF
--- a/pkgs/development/python-modules/pipx/default.nix
+++ b/pkgs/development/python-modules/pipx/default.nix
@@ -1,35 +1,45 @@
 {
   lib,
   stdenv,
-  argcomplete,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
   docutils,
-  hatchling,
   hatch-vcs,
+  hatchling,
+
+  # nativeBuildInputs
   installShellFiles,
+
+  # dependencies
+  argcomplete,
   colorama,
   filelock,
   packaging,
   platformdirs,
-  tomli,
   userpath,
+
+  # optional-dependencies
   uv,
-  git,
-  writableTmpDirAsHomeHook,
-  pytestCheckHook,
+
+  # tests
+  gitMinimal,
   pypiserver,
   pytest-cov-stub,
   pytest-mock,
   pytest-subprocess,
   pytest-xdist,
+  pytestCheckHook,
   watchdog,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "pipx";
   version = "1.16.5";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "pypa";
@@ -55,10 +65,8 @@ buildPythonPackage (finalAttrs: {
     filelock
     packaging
     platformdirs
-    tomli
     userpath
-  ]
-  ++ finalAttrs.passthru.optional-dependencies.uv;
+  ];
 
   optional-dependencies = {
     uv = [
@@ -67,20 +75,20 @@ buildPythonPackage (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    installShellFiles
     argcomplete
+    installShellFiles
   ];
 
   nativeCheckInputs = [
-    pytestCheckHook
-    git
-    writableTmpDirAsHomeHook
+    gitMinimal
     pypiserver
     pytest-cov-stub
     pytest-mock
     pytest-subprocess
     pytest-xdist
+    pytestCheckHook
     watchdog
+    writableTmpDirAsHomeHook
   ];
 
   pytestFlags = [
@@ -90,46 +98,46 @@ buildPythonPackage (finalAttrs: {
 
   disabledTests = [
     # disable tests, which require internet connection
-    "install"
-    "inject"
-    "ensure_null_pythonpath"
-    "missing_interpreter"
     "cache"
+    "determination"
+    "ensure_null_pythonpath"
+    "execute"
+    "expose"
+    "health"
+    "inject"
+    "install"
     "internet"
+    "json"
+    "legacy_venv"
+    "manifest"
+    "missing_interpreter"
+    "outdated"
+    "reset"
     "run"
     "runpip"
-    "upgrade"
     "suffix"
-    "legacy_venv"
-    "determination"
-    "json"
     "test_auto_update_shared_libs"
     "test_cli"
     "test_cli_global"
+    "test_contract_success_envelope"
+    "test_download_standalone_python_sets_tar_filter"
+    "test_download_standalone_python_supports_early_python_310"
     "test_fetch_missing_python"
     "test_list_does_not_trigger_maintenance"
     "test_list_pinned_packages"
+    "test_list_selected_package"
     "test_list_short"
     "test_list_standalone_interpreter"
     "test_list_unused_standalone_interpreters"
     "test_list_used_standalone_interpreters"
     "test_pin"
+    "test_remove_stale_venv_resources_keeps_files_pipx_does_not_own"
+    "test_shared_libs_create_preserves_pip_args"
+    "test_shared_libs_excludes_setuptools"
     "test_skip_maintenance"
     "test_unpin"
     "test_unpin_warning"
-    "test_shared_libs_excludes_setuptools"
-    "execute"
-    "expose"
-    "health"
-    "manifest"
-    "outdated"
-    "reset"
-    "test_contract_success_envelope"
-    "test_download_standalone_python_sets_tar_filter"
-    "test_download_standalone_python_supports_early_python_310"
-    "test_list_selected_package"
-    "test_remove_stale_venv_resources_keeps_files_pipx_does_not_own"
-    "test_shared_libs_create_preserves_pip_args"
+    "upgrade"
   ];
 
   # Keep long Darwin sandbox paths from wrapping literal test output.
@@ -145,8 +153,6 @@ buildPythonPackage (finalAttrs: {
   '';
 
   pythonImportsCheck = [ "pipx" ];
-
-  __structuredAttrs = true;
 
   meta = {
     description = "Install and run Python applications in isolated environments";


### PR DESCRIPTION


## Things done


cc @yshym

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test