### PR TITLE
zulu26: init at 26.32.13

### DIFF
--- a/pkgs/development/compilers/zulu/26.nix
+++ b/pkgs/development/compilers/zulu/26.nix
@@ -1,0 +1,45 @@
+{
+  callPackage,
+  enableJavaFX ? false,
+  ...
+}@args:
+
+let
+  zuluVersion = "26.32.13";
+  jdkVersion = "26.0.2";
+in
+callPackage ./common.nix (
+  {
+    # Details from https://www.azul.com/downloads/?version=java-26&package=jdk
+    # Note that the latest build may differ by platform
+    dists = {
+      x86_64-linux = {
+        inherit zuluVersion jdkVersion;
+        hash =
+          if enableJavaFX then
+            "sha256-Fhp5IZQVxbMeuJkA9ou1IcLknV+RSchvKSZ0qvknEAg="
+          else
+            "sha256-S3wRSReuvQ/GKE/HERJF13R6TZYDvRLYazhLGrydV10=";
+      };
+
+      aarch64-linux = {
+        inherit zuluVersion jdkVersion;
+        hash =
+          if enableJavaFX then
+            "sha256-2R2xJ1s2phCOqE4riZP2PmvSLrnI4Vh6pOHXCJYQX8k="
+          else
+            "sha256-WyIvzgtwdqEKx647EAmmwsr081vE6B3nIBCvZ1DF4UY=";
+      };
+
+      aarch64-darwin = {
+        inherit zuluVersion jdkVersion;
+        hash =
+          if enableJavaFX then
+            "sha256-CpWtHU/wMi/qicTQSSvSFIUBvn6+dgsTiXjJynaPjXE="
+          else
+            "sha256-TplY/EWdjdcvxRshMUsgtngTL8VCkV2fqojRCkoTe6I=";
+      };
+    };
+  }
+  // removeAttrs args [ "callPackage" ]
+)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4237,12 +4237,14 @@ with pkgs;
       zulu17 = callPackage ../development/compilers/zulu/17.nix { };
       zulu21 = callPackage ../development/compilers/zulu/21.nix { };
       zulu25 = callPackage ../development/compilers/zulu/25.nix { };
+      zulu26 = callPackage ../development/compilers/zulu/26.nix { };
     })
     zulu8
     zulu11
     zulu17
     zulu21
     zulu25
+    zulu26
     ;
   zulu = zulu21;
 


### PR DESCRIPTION
Since there are only LTS releases of zulu packaged in nixpkgs, I'm not sure if this STS should be added.
A package update (https://github.com/NixOS/nixpkgs/pull/548135) needs jdk 26 that was using zulu25, maybe it's better to patch it to use an LTS zulu?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
