### PR TITLE
gh-attach: init at 0.4.2

### DIFF
--- a/pkgs/by-name/gh/gh-attach/package.nix
+++ b/pkgs/by-name/gh/gh-attach/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "gh-attach";
+  version = "0.4.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "sudosubin";
+    repo = "gh-attach";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-pe0lzjSI19QsFhQ4MnDFEzIFi2zoZU8lM9AI7fMX7CU=";
+  };
+
+  vendorHash = "sha256-q4ZI6sCbId0TTJQwrPOQC0pse4tqegK+btoQ4PUcAOE=";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/sudosubin/gh-attach/releases/tag/${finalAttrs.src.rev}";
+    description = "GitHub CLI extension to upload and download images and files as user-attachments";
+    longDescription = ''
+      Uploads a local file such as a screenshot, image, PDF, zip, or video to
+      GitHub user-attachments, downloads GitHub user-attachments, and embeds
+      local files in a pull request, issue, or comment.
+    '';
+    homepage = "https://github.com/sudosubin/gh-attach";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sudosubin ];
+    mainProgram = "gh-attach";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added [`gh-attach`](https://github.com/sudosubin/gh-attach).

`gh-attach` is a GitHub CLI (`gh`) extension that uploads and downloads GitHub user-attachments (screenshots, PDFs, zips, videos) from the terminal, producing `github.com/user-attachments` URLs that respect repository visibility.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
