### PR TITLE
cryptomator: 1.19.2 -> 1.19.3

### DIFF
--- a/pkgs/by-name/cr/cryptomator/downgrade-fuse.patch
+++ b/pkgs/by-name/cr/cryptomator/downgrade-fuse.patch
@@ -3,11 +3,11 @@ index fdaf9b328..2dbc69fb8 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -39,7 +39,7 @@
- 		<cryptomator.integrations.win.version>1.6.0</cryptomator.integrations.win.version>
+ 		<cryptomator.integrations.win.version>1.6.1</cryptomator.integrations.win.version>
  		<cryptomator.integrations.mac.version>1.5.0</cryptomator.integrations.mac.version>
  		<cryptomator.integrations.linux.version>1.7.0</cryptomator.integrations.linux.version>
 -		<cryptomator.fuse.version>6.0.1</cryptomator.fuse.version>
 +		<cryptomator.fuse.version>5.1.0</cryptomator.fuse.version>
- 		<cryptomator.webdav.version>3.0.1</cryptomator.webdav.version>
+ 		<cryptomator.webdav.version>3.0.2</cryptomator.webdav.version>
  		<cryptomator.webdav-servlet.version>1.2.12</cryptomator.webdav-servlet.version>
  

--- a/pkgs/by-name/cr/cryptomator/package.nix
+++ b/pkgs/by-name/cr/cryptomator/package.nix
@@ -3,7 +3,7 @@
   fetchFromGitHub,
   fuse3,
   glib,
-  zulu25,
+  zulu26,
   lib,
   libayatana-appindicator,
   makeShellWrapper,
@@ -14,17 +14,17 @@
 }:
 
 let
-  jdk = zulu25.override { enableJavaFX = true; };
+  jdk = zulu26.override { enableJavaFX = true; };
 in
 maven.buildMavenPackage rec {
   pname = "cryptomator";
-  version = "1.19.2";
+  version = "1.19.3";
 
   src = fetchFromGitHub {
     owner = "cryptomator";
     repo = "cryptomator";
     tag = version;
-    hash = "sha256-9JWZaTsL2sfnGQAZI56T2iQnTNhERsFNFFCeLMB7WC0=";
+    hash = "sha256-TpTDLIW62oBnoET2vnbWJY4ZOM7Fz2RH+oDg3nQ3Ias=";
   };
 
   patches = [
@@ -34,7 +34,7 @@ maven.buildMavenPackage rec {
 
   mvnJdk = jdk;
   mvnParameters = "-Dmaven.test.skip=true -Plinux";
-  mvnHash = "sha256-IVOcDFW5YKgUHJKX3ZXYVnOevwmOwN5yEU8jfPtCY1I=";
+  mvnHash = "sha256-gPVguRlhjec8B535GlEcT9KDtg/yZTikyfletyQ4hUo=";
   mvnFetchExtraArgs.env = {
     inherit (env) SOURCE_DATE_EPOCH;
   };

--- a/pkgs/development/compilers/zulu/26.nix
+++ b/pkgs/development/compilers/zulu/26.nix
@@ -1,0 +1,45 @@
+{
+  callPackage,
+  enableJavaFX ? false,
+  ...
+}@args:
+
+let
+  zuluVersion = "26.32.13";
+  jdkVersion = "26.0.2";
+in
+callPackage ./common.nix (
+  {
+    # Details from https://www.azul.com/downloads/?version=java-26&package=jdk
+    # Note that the latest build may differ by platform
+    dists = {
+      x86_64-linux = {
+        inherit zuluVersion jdkVersion;
+        hash =
+          if enableJavaFX then
+            "sha256-Fhp5IZQVxbMeuJkA9ou1IcLknV+RSchvKSZ0qvknEAg="
+          else
+            "sha256-S3wRSReuvQ/GKE/HERJF13R6TZYDvRLYazhLGrydV10=";
+      };
+
+      aarch64-linux = {
+        inherit zuluVersion jdkVersion;
+        hash =
+          if enableJavaFX then
+            "sha256-2R2xJ1s2phCOqE4riZP2PmvSLrnI4Vh6pOHXCJYQX8k="
+          else
+            "sha256-WyIvzgtwdqEKx647EAmmwsr081vE6B3nIBCvZ1DF4UY=";
+      };
+
+      aarch64-darwin = {
+        inherit zuluVersion jdkVersion;
+        hash =
+          if enableJavaFX then
+            "sha256-CpWtHU/wMi/qicTQSSvSFIUBvn6+dgsTiXjJynaPjXE="
+          else
+            "sha256-TplY/EWdjdcvxRshMUsgtngTL8VCkV2fqojRCkoTe6I=";
+      };
+    };
+  }
+  // removeAttrs args [ "callPackage" ]
+)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4237,12 +4237,14 @@ with pkgs;
       zulu17 = callPackage ../development/compilers/zulu/17.nix { };
       zulu21 = callPackage ../development/compilers/zulu/21.nix { };
       zulu25 = callPackage ../development/compilers/zulu/25.nix { };
+      zulu26 = callPackage ../development/compilers/zulu/26.nix { };
     })
     zulu8
     zulu11
     zulu17
     zulu21
     zulu25
+    zulu26
     ;
   zulu = zulu21;
 


### PR DESCRIPTION
The backport will close this issue: https://github.com/NixOS/nixpkgs/issues/547949

Release: https://github.com/cryptomator/cryptomator/releases/tag/1.19.3

Depends on https://github.com/NixOS/nixpkgs/pull/548123, or we need to downgrade to zulu25 or use another JDK.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
