### PR TITLE
python3Packages.pipx: fix tests on Darwin

### DIFF
--- a/pkgs/development/python-modules/pipx/default.nix
+++ b/pkgs/development/python-modules/pipx/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   argcomplete,
   buildPythonPackage,
   fetchFromGitHub,
@@ -130,6 +131,11 @@ buildPythonPackage (finalAttrs: {
     "test_remove_stale_venv_resources_keeps_files_pipx_does_not_own"
     "test_shared_libs_create_preserves_pip_args"
   ];
+
+  # Keep long Darwin sandbox paths from wrapping literal test output.
+  preCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    export COLUMNS=200
+  '';
 
   postInstall = ''
     installShellCompletion --cmd pipx \


### PR DESCRIPTION
Follow-up to #536749.

Long Darwin sandbox paths make pipx wrap the output asserted by `test_ensure_pipx_paths_global_reports_existing_configuration`. The resulting line break splits the expected literal substring and fails the otherwise successful test.

Set `COLUMNS=200` during the Darwin check phase to make the terminal-width-dependent output deterministic without disabling the test or modifying upstream source.

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

