### PR TITLE
sage: work around gap/flint intermittent failures

### DIFF
--- a/pkgs/by-name/sa/sage/patches/faster-flint.patch
+++ b/pkgs/by-name/sa/sage/patches/faster-flint.patch
@@ -1,0 +1,22 @@
+diff --git a/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx b/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
+index 191667c0d8d..8dff6c52aa0 100644
+--- a/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
++++ b/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
+@@ -4659,7 +4659,7 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
+         Ensure interrupt does not make the internal state inconsistent::
+ 
+             sage: R.<x,y,z> = QQ[]
+-            sage: n = 11  # chosen so that the computation takes > 1 second but not excessively long.
++            sage: n = 12  # chosen so that the computation takes > 1 second but not excessively long.
+             ....: # when Singular improves the algorithm or hardware gets faster, increase n.
+             sage: alarm(0.5); h = (x^2^n-y^2^n).factor()
+             Traceback (most recent call last):
+@@ -4671,7 +4671,7 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
+             AlarmInterrupt
+             sage: h = (x^2^n-y^2^n).factor()
+             sage: h
+-            (x - y) * (x + y) * (x^2 + y^2) * (x^4 + y^4) * (x^8 + y^8) * (x^16 + y^16) * (x^32 + y^32) * (x^64 + y^64) * (x^128 + y^128) * (x^256 + y^256) * (x^512 + y^512) * (x^1024 + y^1024)
++            (x - y) * (x + y) * (x^2 + y^2) * (x^4 + y^4) * (x^8 + y^8) * (x^16 + y^16) * (x^32 + y^32) * (x^64 + y^64) * (x^128 + y^128) * (x^256 + y^256) * (x^512 + y^512) * (x^1024 + y^1024) * (x^2048 + y^2048)
+         """
+         cdef ring *_ring = self._parent_ring
+         cdef intvec *iv

--- a/pkgs/by-name/sa/sage/sage-src.nix
+++ b/pkgs/by-name/sa/sage/sage-src.nix
@@ -53,8 +53,7 @@ stdenv.mkDerivation rec {
     # "undefined symbol: cblas_ctrmv" errors.
     ./patches/revert-blas-mesonification.patch
 
-    # Darwin linkers fail unless some NTL-backed Cython C++ extensions link
-    # NTL directly instead of relying on transitive linkage.
+    # https://github.com/sagemath/sage/pull/42587
     ./patches/link-ntl-directly-for-ntl-cython-extensions.patch
 
     # https://github.com/sagemath/sage/pull/41637 causes problems when
@@ -84,6 +83,16 @@ stdenv.mkDerivation rec {
 
     # https://github.com/sagemath/sage/issues/42473
     ./patches/lower-sleep2-test-threshold.patch
+
+    # https://github.com/sagemath/sage/pull/42611
+    ./patches/faster-flint.patch
+
+    # https://github.com/sagemath/sage/pull/41954, landed in 10.10.beta0
+    (fetchpatch2 {
+      name = "gap-element-stability.patch";
+      url = "https://github.com/sagemath/sage/commit/11da83dd3666c2509288a828c54eb0273ee0cf50.patch?full_index=1";
+      hash = "sha256-CjZyeUJVIevDaStLs+9BMT9JlISEdRw3TyTIso/BXi0=";
+    })
 
     # https://github.com/sagemath/sage/pull/42009, landed in 10.10.beta0
     (fetchpatch2 {


### PR DESCRIPTION
Imports two patches from sagemath/sage#41954 and sagemath/sage#42611, fixing one intermittent GAP-related test failure and one almost-permafail resulting from the FLINT 3.6 upgrade (https://github.com/NixOS/nixpkgs/pull/538506#issuecomment-5085550287).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
