### PR TITLE
python3Packages.deep-gemm: fix build

### DIFF
--- a/pkgs/development/python-modules/deep-gemm/default.nix
+++ b/pkgs/development/python-modules/deep-gemm/default.nix
@@ -39,6 +39,7 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
   pname = "deep-gemm";
   version = "2.1.1.post3";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "deepseek-ai";
@@ -68,7 +69,20 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
     })
   ];
 
-  env = optionalAttrs cudaSupport {
+  # Upstream hardcodes `__version__ = '2.1.1'` in `deep_gemm/__init__.py`, which does not match the
+  # release tag and fails the metadata check.
+  postPatch = ''
+    substituteInPlace deep_gemm/__init__.py \
+      --replace-fail \
+        "__version__ = '2.1.1'" \
+        "__version__ = '${finalAttrs.version}'"
+  '';
+
+  env = {
+    # Do not append a `+local` revision to the version (no git repository available)
+    DG_USE_LOCAL_VERSION = "0";
+  }
+  // optionalAttrs cudaSupport {
     CUDA_HOME = (getBin cudaPackages.cuda_nvcc).outPath;
 
     LDFLAGS = toString [


### PR DESCRIPTION
## Things done

```
Executing pythonMetadataCheckPhase
The 'deep-gemm' derivation has version '2.1.1.post3' but .dist-info/METADATA specifies version '2.1.1+local'.
This usually means that the wrong version is hardcoded in pyproject.toml or setup.{py,cfg}.
Use the pyprojectVersionPatchHook or patch the version manually so that the project metadata matches the derivation's version.
```

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
