### PR TITLE
treewide: follow some GitHub redirects for fetchFromGitHub

### DIFF
--- a/pkgs/applications/misc/redshift/default.nix
+++ b/pkgs/applications/misc/redshift/default.nix
@@ -138,7 +138,7 @@ rec {
     version = "1.12";
 
     src = fetchFromGitHub {
-      owner = "jonls";
+      owner = "sharpbracket";
       repo = "redshift";
       rev = "v${version}";
       sha256 = "12cb4gaqkybp4bkkns8pam378izr2mwhr2iy04wkprs2v92j7bz6";

--- a/pkgs/by-name/pe/pekwm/package.nix
+++ b/pkgs/by-name/pe/pekwm/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.3.2";
 
   src = fetchFromGitHub {
-    owner = "pekdon";
+    owner = "pekwm";
     repo = "pekwm";
     rev = "release-${finalAttrs.version}";
     hash = "sha256-rwvecE9T+/zZg0rRUDl/DEMGH9ZmuvYj/Rz6vzmMv1I=";

--- a/pkgs/by-name/pg/pgmodeler/package.nix
+++ b/pkgs/by-name/pg/pgmodeler/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.2.3";
 
   src = fetchFromGitHub {
-    owner = "pgmodeler";
+    owner = "nullptrlabs";
     repo = "pgmodeler";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-WA3EOJm9RrKk7DrzdrpiihW+LhJOvvE2uajGwPCsBIk=";

--- a/pkgs/by-name/ph/phpantom-lsp/package.nix
+++ b/pkgs/by-name/ph/phpantom-lsp/package.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
-    owner = "AJenbo";
+    owner = "PHPantom-dev";
     repo = "phpantom_lsp";
     tag = finalAttrs.version;
     hash = "sha256-euWaFH40VHefZewUcKvsLwwHZP+GwfTN8kfuAkaABB8=";
@@ -55,9 +55,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   meta = {
-    changelog = "https://github.com/AJenbo/phpantom_lsp/releases/tag/${finalAttrs.src.tag}";
+    changelog = "https://github.com/PHPantom-dev/phpantom_lsp/releases/tag/${finalAttrs.src.tag}";
     description = "Fast, lightweight PHP language server written in Rust";
-    homepage = "https://github.com/AJenbo/phpantom_lsp";
+    homepage = "https://github.com/PHPantom-dev/phpantom_lsp";
     license = lib.licenses.mit;
     mainProgram = "phpantom_lsp";
     maintainers = with lib.maintainers; [ nanoyaki ];

--- a/pkgs/by-name/pi/pietrasanta-traceroute/package.nix
+++ b/pkgs/by-name/pi/pietrasanta-traceroute/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "catchpoint";
-    repo = "Networking.traceroute";
+    repo = "Pietrasanta-traceroute";
     rev = "e4a5cf94dccd646e03b9b75a762e9b014e3a3128";
     hash = "sha256-5FbuITewgSh6UFUU1vttkokk8uZ2IrzkDwsCuWJPKlM=";
   };
@@ -31,8 +31,8 @@ stdenv.mkDerivation (finalAttrs: {
       - Similar QUIC-based traceroute.
       - Enhanced ToS (DSCP/ECN) field report.
     '';
-    homepage = "https://github.com/catchpoint/Networking.traceroute/";
-    changelog = "https://github.com/catchpoint/Networking.traceroute/blob/${finalAttrs.src.rev}/ChangeLog";
+    homepage = "https://github.com/catchpoint/Pietrasanta-traceroute/";
+    changelog = "https://github.com/catchpoint/Pietrasanta-traceroute/blob/${finalAttrs.src.rev}/ChangeLog";
     license = with lib.licenses; [
       gpl2Only
       lgpl21Only

--- a/pkgs/by-name/pi/pinniped/package.nix
+++ b/pkgs/by-name/pi/pinniped/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
   version = "0.46.0";
 
   src = fetchFromGitHub {
-    owner = "vmware-tanzu";
+    owner = "vmware";
     repo = "pinniped";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-C7N6iPD4caTUXR6gB+9sdfBlWyT1tfE8KwE5WaiUdQM=";

--- a/pkgs/by-name/pi/pip-audit/package.nix
+++ b/pkgs/by-name/pi/pip-audit/package.nix
@@ -11,7 +11,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "trailofbits";
+    owner = "pypa";
     repo = "pip-audit";
     tag = "v${finalAttrs.version}";
     hash = "sha256-+R8X7KIQz6Gm88IigZmMagz5l1eJ2bO8zAUNZqunotI=";
@@ -63,7 +63,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   meta = {
     description = "Tool for scanning Python environments for known vulnerabilities";
-    homepage = "https://github.com/trailofbits/pip-audit";
+    homepage = "https://github.com/pypa/pip-audit";
     changelog = "https://github.com/pypa/pip-audit/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];

--- a/pkgs/by-name/pl/playerctl/package.nix
+++ b/pkgs/by-name/pl/playerctl/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.4.1";
 
   src = fetchFromGitHub {
-    owner = "acrisci";
+    owner = "altdesktop";
     repo = "playerctl";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-OiGKUnsKX0ihDRceZoNkcZcEAnz17h2j2QUOSVcxQEY=";
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Command-line utility and library for controlling media players that implement MPRIS";
-    homepage = "https://github.com/acrisci/playerctl";
+    homepage = "https://github.com/altdesktop/playerctl";
     license = lib.licenses.lgpl3;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/pl/plecost/package.nix
+++ b/pkgs/by-name/pl/plecost/package.nix
@@ -12,7 +12,7 @@ python3Packages.buildPythonApplication {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "iniqua";
+    owner = "Plecost";
     repo = "plecost";
     # Release is untagged
     rev = "4895e345d71bffe956be43530632e303dd379a5f";
@@ -38,7 +38,7 @@ python3Packages.buildPythonApplication {
   meta = {
     description = "Vulnerability fingerprinting and vulnerability finder for Wordpress blog engine";
     mainProgram = "plecost";
-    homepage = "https://github.com/iniqua/plecost";
+    homepage = "https://github.com/Plecost/plecost";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ emilytrau ];
   };

--- a/pkgs/by-name/pm/pms/package.nix
+++ b/pkgs/by-name/pm/pms/package.nix
@@ -9,7 +9,7 @@ buildGoModule {
   version = "unstable-2022-11-12";
 
   src = fetchFromGitHub {
-    owner = "ambientsound";
+    owner = "kimtore";
     repo = "pms";
     rev = "40d6e37111293187ab4542c7a64bd73d1b13974f";
     sha256 = "sha256-294MiS4c2PO2lFSSRrg8ns7sXzZsEUAqPG3q2z3TRUg=";

--- a/pkgs/by-name/po/podman/package.nix
+++ b/pkgs/by-name/po/podman/package.nix
@@ -45,7 +45,7 @@ buildGoModule (finalAttrs: {
   version = "5.8.4";
 
   src = fetchFromGitHub {
-    owner = "containers";
+    owner = "podman-container-tools";
     repo = "podman";
     tag = "v${finalAttrs.version}";
     hash = "sha256-zhEtMZVKiv1L72EMlwgz8sHpmvhejGp98oW63aPj+rQ=";
@@ -200,7 +200,7 @@ buildGoModule (finalAttrs: {
 
       To install on NixOS, please use the option `virtualisation.podman.enable = true`.
     '';
-    changelog = "https://github.com/containers/podman/blob/v${finalAttrs.version}/RELEASE_NOTES.md";
+    changelog = "https://github.com/podman-container-tools/podman/blob/v${finalAttrs.version}/RELEASE_NOTES.md";
     license = lib.licenses.asl20;
     teams = [ lib.teams.podman ];
     mainProgram = "podman";

--- a/pkgs/by-name/pr/pritunl-client/package.nix
+++ b/pkgs/by-name/pr/pritunl-client/package.nix
@@ -24,7 +24,7 @@ let
   version = "1.3.4275.94";
   src = fetchFromGitHub {
     owner = "pritunl";
-    repo = "pritunl-client-electron";
+    repo = "pritunl-client";
     rev = version;
     sha256 = "sha256-a1arRI4qQy5niKV8JAyusAjheMa/LtEXPZGhngsH+TU=";
   };

--- a/pkgs/by-name/pr/projecteur/package.nix
+++ b/pkgs/by-name/pr/projecteur/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.10";
 
   src = fetchFromGitHub {
-    owner = "jahnf";
+    owner = "gbin";
     repo = "Projecteur";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = false;
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Linux/X11 application for the Logitech Spotlight device (and similar devices)";
-    homepage = "https://github.com/jahnf/Projecteur";
+    homepage = "https://github.com/gbin/Projecteur";
     license = lib.licenses.mit;
     mainProgram = "projecteur";
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/pr/projecteur/package.nix
+++ b/pkgs/by-name/pr/projecteur/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
     repo = "Projecteur";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = false;
-    hash = "sha256-F7o93rBjrDTmArTIz8RB/uGBOYE6ny/U7ppk+jEhM5A=";
+    hash = "sha256-4g0h46kKOyk7r0bF9l4T28NAE/NEjtYjdPfLZUsGK/M=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/pr/prometheus-nginx-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-nginx-exporter/package.nix
@@ -10,7 +10,7 @@ buildGoModule rec {
   version = "1.5.1";
 
   src = fetchFromGitHub {
-    owner = "nginxinc";
+    owner = "nginx";
     repo = "nginx-prometheus-exporter";
     rev = "v${version}";
     sha256 = "sha256-BJf5gL+bkT6g28OVhGM29IwuLfFz3HPAo/DZzg5Eoqk=";
@@ -36,7 +36,7 @@ buildGoModule rec {
   meta = {
     description = "NGINX Prometheus Exporter for NGINX and NGINX Plus";
     mainProgram = "nginx-prometheus-exporter";
-    homepage = "https://github.com/nginxinc/nginx-prometheus-exporter";
+    homepage = "https://github.com/nginx/nginx-prometheus-exporter";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       benley

--- a/pkgs/by-name/pu/pulseeffects-legacy/package.nix
+++ b/pkgs/by-name/pu/pulseeffects-legacy/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation {
 
   src = fetchFromGitHub {
     owner = "wwmm";
-    repo = "pulseeffects";
+    repo = "easyeffects";
     rev = "fbe0a724c1405cee624802f381476cf003dfcfa";
     hash = "sha256-tyVUWc8w08WUnJRTjJVTIiG/YBWTETNYG+4amwEYezY=";
   };
@@ -109,7 +109,7 @@ stdenv.mkDerivation {
   meta = {
     description = "Limiter, compressor, reverberation, equalizer and auto volume effects for Pulseaudio applications";
     mainProgram = "pulseeffects";
-    homepage = "https://github.com/wwmm/pulseeffects";
+    homepage = "https://github.com/wwmm/easyeffects";
     license = lib.licenses.gpl3Plus;
     maintainers = [ ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/qr/qrrs/package.nix
+++ b/pkgs/by-name/qr/qrrs/package.nix
@@ -9,7 +9,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.1.11";
 
   src = fetchFromGitHub {
-    owner = "lenivaya";
+    owner = "cureforpain";
     repo = "qrrs";
     rev = "v${finalAttrs.version}";
     hash = "sha256-lXfqKMJx9vtljQlYvbUAONFqMO3HKa4hx/29/YERw2U=";
@@ -33,7 +33,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     maintainers = with lib.maintainers; [ lenivaya ];
     description = "CLI QR code generator and reader written in rust";
     license = lib.licenses.mit;
-    homepage = "https://github.com/Lenivaya/qrrs";
+    homepage = "https://github.com/cureforpain/qrrs";
     mainProgram = "qrrs";
   };
 })

--- a/pkgs/by-name/qu/quark-engine/package.nix
+++ b/pkgs/by-name/qu/quark-engine/package.nix
@@ -20,7 +20,7 @@ pythonPackages.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "quark-engine";
+    owner = "ev-flow";
     repo = "quark-engine";
     tag = "v${finalAttrs.version}";
     hash = "sha256-DAD37fzswY3c0d+ubOCYImxs4qyD4fhC3m2l0iD977A=";
@@ -57,7 +57,7 @@ pythonPackages.buildPythonApplication (finalAttrs: {
   meta = {
     description = "Android malware (analysis and scoring) system";
     homepage = "https://quark-engine.readthedocs.io/";
-    changelog = "https://github.com/quark-engine/quark-engine/releases/tag/${finalAttrs.src.tag}";
+    changelog = "https://github.com/ev-flow/quark-engine/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/by-name/qu/quint/package.nix
+++ b/pkgs/by-name/qu/quint/package.nix
@@ -31,7 +31,7 @@ let
   };
 
   src = fetchFromGitHub {
-    owner = "informalsystems";
+    owner = "quint-co";
     repo = "quint";
     tag = "v${version}";
     hash = "sha256-GTbphBmALx/gDc/iV/wtE1ovpK43VtCQoneN5AqUmvg=";

--- a/pkgs/by-name/re/release-plz/package.nix
+++ b/pkgs/by-name/re/release-plz/package.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.3.160";
 
   src = fetchFromGitHub {
-    owner = "MarcoIeni";
+    owner = "release-plz";
     repo = "release-plz";
     rev = "release-plz-v${finalAttrs.version}";
     hash = "sha256-rPYRYAp5grTgASFHKGBdOcO0TvbP7iD+GgL0ZLmHhos=";
@@ -45,7 +45,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Publish Rust crates from CI with a Release PR";
     homepage = "https://release-plz.ieni.dev";
-    changelog = "https://github.com/MarcoIeni/release-plz/blob/release-plz-v${finalAttrs.version}/CHANGELOG.md";
+    changelog = "https://github.com/release-plz/release-plz/blob/release-plz-v${finalAttrs.version}/CHANGELOG.md";
     license = with lib.licenses; [
       asl20
       mit

--- a/pkgs/by-name/re/restish/package.nix
+++ b/pkgs/by-name/re/restish/package.nix
@@ -19,7 +19,7 @@ buildGoModule (finalAttrs: {
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
-    owner = "danielgtaylor";
+    owner = "rest-sh";
     repo = "restish";
     tag = "v${finalAttrs.version}";
     hash = "sha256-wGchbKSEbzr1vQlYWgUTubA1xQVcxq7iyRUIuWqVL0Y=";
@@ -55,7 +55,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "CLI tool for interacting with REST-ish HTTP APIs";
     homepage = "https://rest.sh/";
-    changelog = "https://github.com/danielgtaylor/restish/releases/tag/${finalAttrs.src.tag}";
+    changelog = "https://github.com/rest-sh/restish/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "restish";

--- a/pkgs/by-name/re/resvg/package.nix
+++ b/pkgs/by-name/re/resvg/package.nix
@@ -9,7 +9,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.47.0";
 
   src = fetchFromGitHub {
-    owner = "RazrFalcon";
+    owner = "linebender";
     repo = "resvg";
     rev = "v${finalAttrs.version}";
     hash = "sha256-BCYjVOWFpOZm7ocmfszFpaBxnd96vhf3/yGlvAVRtCw=";
@@ -29,8 +29,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "SVG rendering library";
-    homepage = "https://github.com/RazrFalcon/resvg";
-    changelog = "https://github.com/RazrFalcon/resvg/blob/v${finalAttrs.version}/CHANGELOG.md";
+    homepage = "https://github.com/linebender/resvg";
+    changelog = "https://github.com/linebender/resvg/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mpl20;
     maintainers = [ ];
     mainProgram = "resvg";

--- a/pkgs/by-name/ri/rime-wanxiang/package.nix
+++ b/pkgs/by-name/ri/rime-wanxiang/package.nix
@@ -11,7 +11,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "amzxyz";
-    repo = "rime_wanxiang";
+    repo = "rime-wanxiang";
     tag = "v" + finalAttrs.version;
     hash = "sha256-lSfoL7fX1SYlcgGz24vpgjBq/ixomISnWDuOuPh/0eE=";
   };
@@ -59,9 +59,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
         __include: wanxiang_suggested_default:/
       ```
     '';
-    homepage = "https://github.com/amzxyz/rime_wanxiang";
-    downloadPage = "https://github.com/amzxyz/rime_wanxiang/releases";
-    changelog = "https://github.com/amzxyz/rime_wanxiang/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/amzxyz/rime-wanxiang";
+    downloadPage = "https://github.com/amzxyz/rime-wanxiang/releases";
+    changelog = "https://github.com/amzxyz/rime-wanxiang/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.cc-by-40;
     maintainers = with lib.maintainers; [ rc-zb ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/ri/ripunzip/package.nix
+++ b/pkgs/by-name/ri/ripunzip/package.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "2.0.4";
 
   src = fetchFromGitHub {
-    owner = "google";
+    owner = "GoogleChrome";
     repo = "ripunzip";
     rev = "v${finalAttrs.version}";
     hash = "sha256-oujRw/4yKNNqLJLTN4wxaOllSUGMu077YgWZkD0DJ4M=";
@@ -46,7 +46,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     fetchzipWithRipunzip =
       testers.invalidateFetcherByDrvHash (fetchzip.override { unzip = ripunzip; })
         {
-          url = "https://github.com/google/ripunzip/archive/cb9caa3ba4b0e27a85e165be64c40f1f6dfcc085.zip";
+          url = "https://github.com/GoogleChrome/ripunzip/archive/cb9caa3ba4b0e27a85e165be64c40f1f6dfcc085.zip";
           hash = "sha256-BoErC5VL3Vpvkx6xJq6J+eUJrBnjVEdTuSo7zh98Jy4=";
         };
     version = testers.testVersion {
@@ -57,7 +57,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Tool to unzip files in parallel";
     mainProgram = "ripunzip";
-    homepage = "https://github.com/google/ripunzip";
+    homepage = "https://github.com/GoogleChrome/ripunzip";
     license = with lib.licenses; [
       mit
       asl20

--- a/pkgs/by-name/ri/riscv-pk/package.nix
+++ b/pkgs/by-name/ri/riscv-pk/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   version = "1.0.0-unstable-2024-10-09";
 
   src = fetchFromGitHub {
-    owner = "riscv";
+    owner = "riscv-software-src";
     repo = "riscv-pk";
     rev = "abadfdc507d5a75b6272dc360e70a80a510c758a";
     sha256 = "sha256-02qcj0TAs7g4CSorWWbUzouS6mNthUOSdeocibw5g2A=";
@@ -40,7 +40,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "RISC-V Proxy Kernel and Bootloader";
-    homepage = "https://github.com/riscv/riscv-pk";
+    homepage = "https://github.com/riscv-software-src/riscv-pk";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.riscv;
     maintainers = [ lib.maintainers.shlevy ];

--- a/pkgs/by-name/ri/risor/package.nix
+++ b/pkgs/by-name/ri/risor/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
   version = "2.1.0";
 
   src = fetchFromGitHub {
-    owner = "risor-io";
+    owner = "deepnoodle-ai";
     repo = "risor";
     rev = "v${finalAttrs.version}";
     hash = "sha256-SXUaSJmtWul4LYRdoxv4lXBB4HHp62xrWbEchI691YY=";
@@ -40,8 +40,8 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Fast and flexible scripting for Go developers and DevOps";
     mainProgram = "risor";
-    homepage = "https://github.com/risor-io/risor";
-    changelog = "https://github.com/risor-io/risor/releases/tag/${finalAttrs.src.rev}";
+    homepage = "https://github.com/deepnoodle-ai/risor";
+    changelog = "https://github.com/deepnoodle-ai/risor/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };

--- a/pkgs/by-name/rm/rmount/package.nix
+++ b/pkgs/by-name/rm/rmount/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     rev = "v${finalAttrs.version}";
-    owner = "Luis-Hebendanz";
+    owner = "Qubasa";
     repo = "rmount";
     sha256 = "0j1ayncw1nnmgna7vyx44vwinh4ah1b0l5y8agc7i4s8clbvy3h0";
   };
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "https://github.com/Luis-Hebendanz/rmount";
+    homepage = "https://github.com/Qubasa/rmount";
     description = "Remote mount utility which parses a json file";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.qubasa ];

--- a/pkgs/by-name/ro/rofi-systemd/package.nix
+++ b/pkgs/by-name/ro/rofi-systemd/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   version = "1.1.0";
 
   src = fetchFromGitHub {
-    owner = "IvanMalison";
+    owner = "colonelpanic8";
     repo = "rofi-systemd";
     tag = "v${version}";
     sha256 = "1zwbw119mblp5b6dj4h92fi0y2ymimlgh4bawi5ks2051hpq6c1a";
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Control your systemd units using rofi";
-    homepage = "https://github.com/IvanMalison/rofi-systemd";
+    homepage = "https://github.com/colonelpanic8/rofi-systemd";
     maintainers = with lib.maintainers; [ imalison ];
     license = lib.licenses.gpl3;
     platforms = with lib.platforms; linux;

--- a/pkgs/by-name/ru/ruplacer/package.nix
+++ b/pkgs/by-name/ru/ruplacer/package.nix
@@ -9,7 +9,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.10.0";
 
   src = fetchFromGitHub {
-    owner = "TankerHQ";
+    owner = "your-tools";
     repo = "ruplacer";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-Zvbb9pQpxbJZi0qcDU6f2jEgavl9cA7gIYU7NRXZ9fc=";
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Find and replace text in source files";
     mainProgram = "ruplacer";
-    homepage = "https://github.com/TankerHQ/ruplacer";
+    homepage = "https://github.com/your-tools/ruplacer";
     license = lib.licenses.bsd3;
   };
 })

--- a/pkgs/by-name/ru/rustcast/package.nix
+++ b/pkgs/by-name/ru/rustcast/package.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.5.6";
 
   src = fetchFromGitHub {
-    owner = "unsecretised";
+    owner = "MystikoLab";
     repo = "rustcast";
     tag = "v${finalAttrs.version}";
     hash = "sha256-88vg+xdASskbYwLbEPGmHf8P1PL4PihJDXT1ua/cfCQ=";
@@ -25,9 +25,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    changelog = "https://github.com/unsecretised/rustcast/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/MystikoLab/rustcast/releases/tag/v${finalAttrs.version}";
     description = "Modern Spotlight Alternative made opensource";
-    homepage = "https://github.com/unsecretised/rustcast";
+    homepage = "https://github.com/MystikoLab/rustcast";
     license = lib.licenses.mit;
     platforms = lib.platforms.darwin;
     maintainers = with lib.maintainers; [ eveeifyeve ];

--- a/pkgs/by-name/ru/rustscan/package.nix
+++ b/pkgs/by-name/ru/rustscan/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "2.4.1";
 
   src = fetchFromGitHub {
-    owner = "RustScan";
+    owner = "bee-san";
     repo = "RustScan";
     tag = finalAttrs.version;
     hash = "sha256-+qPSeDpOeCq+KwZb5ANXx6z+pYbgdT1hVgcrSzxyGp0=";
@@ -41,8 +41,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Faster Nmap Scanning with Rust";
-    homepage = "https://github.com/RustScan/RustScan";
-    changelog = "https://github.com/RustScan/RustScan/releases/tag/${finalAttrs.version}";
+    homepage = "https://github.com/bee-san/RustScan";
+    changelog = "https://github.com/bee-san/RustScan/releases/tag/${finalAttrs.version}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ bodier123 ];
     mainProgram = "rustscan";

--- a/pkgs/by-name/ry/rye/package.nix
+++ b/pkgs/by-name/ry/rye/package.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.44.0";
 
   src = fetchFromGitHub {
-    owner = "mitsuhiko";
+    owner = "astral-sh";
     repo = "rye";
     tag = finalAttrs.version;
     hash = "sha256-K9xad5Odza0Oxz49yMJjqpfh3cCgmWnbAlv069fHV6Q=";
@@ -101,8 +101,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Tool to easily manage python dependencies and environments";
-    homepage = "https://github.com/mitsuhiko/rye";
-    changelog = "https://github.com/mitsuhiko/rye/releases/tag/${finalAttrs.version}";
+    homepage = "https://github.com/astral-sh/rye";
+    changelog = "https://github.com/astral-sh/rye/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ GaetanLepage ];
     mainProgram = "rye";

--- a/pkgs/by-name/sa/safe/package.nix
+++ b/pkgs/by-name/sa/safe/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "1.8.0";
 
   src = fetchFromGitHub {
-    owner = "starkandwayne";
+    owner = "egen";
     repo = "safe";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-sg0RyZ5HpYu7M11bNy17Sjxm7C3pkQX3I17edbALuvU=";
@@ -26,7 +26,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Vault CLI";
     mainProgram = "safe";
-    homepage = "https://github.com/starkandwayne/safe";
+    homepage = "https://github.com/egen/safe";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ eonpatapon ];
   };

--- a/pkgs/by-name/sa/satty/package.nix
+++ b/pkgs/by-name/sa/satty/package.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.21.1";
 
   src = fetchFromGitHub {
-    owner = "gabm";
+    owner = "Satty-org";
     repo = "Satty";
     rev = "v${finalAttrs.version}";
     hash = "sha256-pD91+MbieZ5/YoUR0lcKnJ9bA1fn7I97NbnIwm/kL7E=";
@@ -60,7 +60,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Screenshot annotation tool inspired by Swappy and Flameshot";
-    homepage = "https://github.com/gabm/Satty";
+    homepage = "https://github.com/Satty-org/Satty";
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [
       pinpox

--- a/pkgs/by-name/sa/saunafs/package.nix
+++ b/pkgs/by-name/sa/saunafs/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "leil-io";
-    repo = "saunafs";
+    repo = "leilfs";
     rev = "v${finalAttrs.version}";
     hash = "sha256-73d8FG/qOTF0nYKETFl0YTXkyd5NuTRh9pr9uNR3i9o=";
   };

--- a/pkgs/by-name/sa/savepagenow/package.nix
+++ b/pkgs/by-name/sa/savepagenow/package.nix
@@ -10,7 +10,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "pastpages";
+    owner = "palewire";
     repo = "savepagenow";
     tag = finalAttrs.version;
     sha256 = "sha256-ztM1g71g8SN1LTyFF7sxaLhC3+nVsC9fJwfYPjkUsdE=";
@@ -30,7 +30,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   meta = {
     description = "Simple Python wrapper for archive.org's \"Save Page Now\" capturing service";
-    homepage = "https://github.com/pastpages/savepagenow";
+    homepage = "https://github.com/palewire/savepagenow";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ SuperSandro2000 ];
     mainProgram = "savepagenow";

--- a/pkgs/by-name/sb/sbt-extras/package.nix
+++ b/pkgs/by-name/sb/sbt-extras/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   version = "2025-08-25";
 
   src = fetchFromGitHub {
-    owner = "paulp";
+    owner = "dwijnand";
     repo = "sbt-extras";
     inherit rev;
     sha256 = "UlxZsCi4EdcHvGwatQm1sPyamfcqJs9o8qo2HWLedQw=";
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "More featureful runner for sbt, the simple/scala/standard build tool";
-    homepage = "https://github.com/paulp/sbt-extras";
+    homepage = "https://github.com/dwijnand/sbt-extras";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
       puffnfresh

--- a/pkgs/by-name/sc/scip-go/package.nix
+++ b/pkgs/by-name/sc/scip-go/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "0.2.7";
 
   src = fetchFromGitHub {
-    owner = "sourcegraph";
+    owner = "scip-code";
     repo = "scip-go";
     rev = "v${finalAttrs.version}";
     hash = "sha256-Him9V4+cXxQxG6a3L960rXEhxJYKl7n8mRlRK2PeMIg=";
@@ -26,7 +26,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "SCIP (SCIP Code Intelligence Protocol) indexer for Golang";
-    homepage = "https://github.com/sourcegraph/scip-go/tree/v${finalAttrs.version}";
+    homepage = "https://github.com/scip-code/scip-go/tree/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ arikgrahl ];
     mainProgram = "scip-go";

--- a/pkgs/by-name/sc/scope-lite/package.nix
+++ b/pkgs/by-name/sc/scope-lite/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.3.0";
 
   src = fetchFromGitHub {
-    owner = "martinmoene";
+    owner = "nonstd-lite";
     repo = "scope-lite";
     tag = "v${finalAttrs.version}";
     hash = "sha256-EZ+bBnMPpgATANa+al5SnVEfUFYc0TkaPTLNHD6zcWU=";
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Migration path to C++ library extensions scope_exit, scope_fail, scope_success, unique_resource";
     license = lib.licenses.boost;
     maintainers = [ lib.maintainers.shlevy ];
-    homepage = "https://github.com/martinmoene/scope-lite";
+    homepage = "https://github.com/nonstd-lite/scope-lite";
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/sc/screen-pipe/package.nix
+++ b/pkgs/by-name/sc/screen-pipe/package.nix
@@ -17,8 +17,8 @@ rustPlatform.buildRustPackage rec {
   version = "0.1.48";
 
   src = fetchFromGitHub {
-    owner = "louis030195";
-    repo = "screen-pipe";
+    owner = "screenpipe";
+    repo = "screenpipe";
     rev = "v${version}";
     hash = "sha256-rWKRCqWFuPO84C52mMrrS4euD6XdJU8kqZsAz28+vWE=";
   };
@@ -64,7 +64,7 @@ rustPlatform.buildRustPackage rec {
     # Marked broken 2025-11-28 because it has failed on Hydra for at least one year.
     broken = true;
     description = "Personalized AI powered by what you've seen, said, or heard";
-    homepage = "https://github.com/louis030195/screen-pipe";
+    homepage = "https://github.com/screenpipe/screenpipe";
     license = lib.licenses.mit;
     maintainers = [ ];
     mainProgram = "screen-pipe";

--- a/pkgs/by-name/sd/sdate/package.nix
+++ b/pkgs/by-name/sd/sdate/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.7";
 
   src = fetchFromGitHub {
-    owner = "ChristophBerg";
+    owner = "df7cb";
     repo = "sdate";
     rev = finalAttrs.version;
     hash = "sha256-jkwe+bSBa0p1Xzfetsdpw0RYw/gSRxnY2jBOzC5HtJ8=";

--- a/pkgs/by-name/sh/shadowfox/package.nix
+++ b/pkgs/by-name/sh/shadowfox/package.nix
@@ -10,7 +10,7 @@ buildGoModule (finalAttrs: {
   version = "2.2.0";
 
   src = fetchFromGitHub {
-    owner = "SrKomodo";
+    owner = "arguablykomodo";
     repo = "shadowfox-updater";
     rev = "v${finalAttrs.version}";
     sha256 = "125mw70jidbp436arhv77201jdp6mpgqa2dzmrpmk55f9bf29sg6";

--- a/pkgs/by-name/sh/shepherd/package.nix
+++ b/pkgs/by-name/sh/shepherd/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.16.0";
 
   src = fetchFromGitHub {
-    owner = "NerdWalletOSS";
+    owner = "shepherd-tools";
     repo = "shepherd";
     rev = "v${finalAttrs.version}";
     hash = "sha256-LY8Vde4YpGuKnQ5UnSOpsQDY7AOyZRziUrfZb5dRiX4=";
@@ -67,9 +67,9 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    changelog = "https://github.com/NerdWalletOSS/shepherd/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/shepherd-tools/shepherd/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     description = "Utility for applying code changes across many repositories";
-    homepage = "https://github.com/NerdWalletOSS/shepherd";
+    homepage = "https://github.com/shepherd-tools/shepherd";
     license = lib.licenses.asl20;
     mainProgram = "shepherd";
     maintainers = with lib.maintainers; [ dbirks ];

--- a/pkgs/development/python-modules/pinboard/default.nix
+++ b/pkgs/development/python-modules/pinboard/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "lionheart";
-    repo = "pinboard";
+    repo = "pinboard.py";
     rev = version;
     sha256 = "sha256-+JWr2QmdqASK/X10U0ZOZ95K2ctWceSW167raxZjIW4=";
   };

--- a/pkgs/development/python-modules/plover/4.nix
+++ b/pkgs/development/python-modules/plover/4.nix
@@ -29,7 +29,7 @@ buildPythonPackage (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "openstenoproject";
+    owner = "opensteno";
     repo = "plover";
     tag = "v${finalAttrs.version}";
     hash = "sha256-VpQT25bl8yPG4J9IwLkhSkBt31Y8BgPJdwa88WlreA8=";

--- a/pkgs/development/python-modules/plover/5.nix
+++ b/pkgs/development/python-modules/plover/5.nix
@@ -58,7 +58,7 @@ buildPythonPackage (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "openstenoproject";
+    owner = "opensteno";
     repo = "plover";
     tag = "v${finalAttrs.version}";
     hash = "sha256-qaEuzPVqh+e3qq778VdUaRufGzOx9HyUnygIbA0+6kw=";

--- a/pkgs/development/python-modules/pyinfra/default.nix
+++ b/pkgs/development/python-modules/pyinfra/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage (finalAttrs: {
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
-    owner = "Fizzadar";
+    owner = "pyinfra-dev";
     repo = "pyinfra";
     tag = "v${finalAttrs.version}";
     hash = "sha256-5qgPfBtPqysEtNCLFAgGAxlVK/CRH9VYmiC/98VWomI=";
@@ -86,7 +86,7 @@ buildPythonPackage (finalAttrs: {
     '';
     homepage = "https://pyinfra.com";
     downloadPage = "https://pyinfra.com/Fizzadar/pyinfra/releases";
-    changelog = "https://github.com/Fizzadar/pyinfra/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/pyinfra-dev/pyinfra/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       robsliwi

--- a/pkgs/development/python-modules/python-matter-server/default.nix
+++ b/pkgs/development/python-modules/python-matter-server/default.nix
@@ -37,7 +37,7 @@ let
   version = "8.1.2";
 
   src = fetchFromGitHub {
-    owner = "home-assistant-libs";
+    owner = "matter-js";
     repo = "python-matter-server";
     tag = version;
     hash = "sha256-vnI57h/aesnaDYorq1PzcMCLmV0z0ZBJvMg4Nzh1Dtc=";
@@ -155,10 +155,10 @@ buildPythonPackage rec {
   env.dontCheckPythonMetadata = true;
 
   meta = {
-    changelog = "https://github.com/home-assistant-libs/python-matter-server/releases/tag/${src.tag}";
+    changelog = "https://github.com/matter-js/python-matter-server/releases/tag/${src.tag}";
     description = "Python server to interact with Matter";
     mainProgram = "matter-server";
-    homepage = "https://github.com/home-assistant-libs/python-matter-server";
+    homepage = "https://github.com/matter-js/python-matter-server";
     license = lib.licenses.asl20;
     teams = [ lib.teams.home-assistant ];
   };

--- a/pkgs/development/tools/analysis/radare2/default.nix
+++ b/pkgs/development/tools/analysis/radare2/default.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "6.1.8";
 
   src = fetchFromGitHub {
-    owner = "radare";
+    owner = "radareorg";
     repo = "radare2";
     tag = finalAttrs.version;
     hash = "sha256-Gh+W0vWsIscbew1u5cuOXWC20azCxYuA7D+qVTkfEN0=";

--- a/pkgs/development/tools/replay-io/default.nix
+++ b/pkgs/development/tools/replay-io/default.nix
@@ -136,7 +136,7 @@ rec {
     pname = "replay-node-cli";
     version = "0.1.7-" + builtins.head (builtins.match ".*/linux-node-(.*)" metadata.replay-node.url);
     src = fetchFromGitHub {
-      owner = "RecordReplay";
+      owner = "replayio";
       repo = "replay-node-cli";
       rev = "5269c8b8e7c5c7a9618a68f883d19c11a68be837";
       sha256 = "04d22q3dvs9vxpb9ps64pdxq9ziwgvnzdgsn6p9p0lzjagh0f5n0";


### PR DESCRIPTION
This PR updates some `fetchFromGitHub` calls and corresponding `github.com/<owner>/<repo>` links in the same location to point directly to canonical repositories instead of redirecting URLs.

This doesn't update all `fetchFromGitHub` redirects since that would produce a diff too large for maintainers to review.

**Motivation:**
This avoids silent failures if upstream redirects ever change or disappear, and improves reliability and reproducibility of fetches.

**How:**
Changes were generated using [this script](https://git.kybe.xyz/2kybe3/nixpkgs-github-redirect).

**How to verify:**
You can verify that all modified package sources still build using the following script with a `changed.txt` file containing the changed package list.

<details>
  <summary>Verify script</summary>

```bash
#!/usr/bin/env bash

out="result.txt"
: > "$out"

while read -r pkg; do
    echo "=== $pkg ==="

    output=$(nix build "./nixpkgs#$pkg.src" -L -v --rebuild --no-link --print-out-paths)
    status=$?

    if [ $status -eq 0 ]; then
        echo "$pkg: success | $output" | tee -a "$out"
    else
        echo "$pkg: failed" | tee -a "$out"
    fi
done < ./changed.txt
```
</details>

<details>
  <summary>Changed Packages</summary>

```
pekwm
pgmodeler
phpantom-lsp
pietrasanta-traceroute
pinniped
pinboard
pip-audit
playerctl
plover
plecost
pms
plover_4
podman
pritunl-client
projecteur
prometheus-nginx-exporter
pulseeffects-legacy
pyinfra
python-matter-server
qrrs
quark-engine
quint
radare2
redshift
release-plz
replay-node-cli
restish
resvg
riscv-pk
ripunzip
rime-wanxiang
risor
rmount
ruplacer
rofi-systemd
rustcast
rustscan
rye
satty
saunafs
sbt-extras
safe
savepagenow
scip-go
screen-pipe
scope-lite
sdate
shadowfox
shepherd
simple64-netplay-server
```
</details>

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
