### PR TITLE
tuigreet: 0.9.1 -> 0.11.0, switch to GitHub org

### DIFF
--- a/pkgs/by-name/tu/tuigreet/package.nix
+++ b/pkgs/by-name/tu/tuigreet/package.nix
@@ -37,6 +37,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://github.com/apognu/tuigreet/releases/tag/${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
+      NotAShelf
       antoineco
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/tu/tuigreet/package.nix
+++ b/pkgs/by-name/tu/tuigreet/package.nix
@@ -10,6 +10,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tuigreet";
   version = "0.11.0";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "tuigreet";
     repo = "tuigreet";

--- a/pkgs/by-name/tu/tuigreet/package.nix
+++ b/pkgs/by-name/tu/tuigreet/package.nix
@@ -8,16 +8,16 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tuigreet";
-  version = "0.9.1";
+  version = "0.11.0";
 
   src = fetchFromGitHub {
-    owner = "apognu";
+    owner = "tuigreet";
     repo = "tuigreet";
     tag = finalAttrs.version;
-    hash = "sha256-e0YtpakEaaWdgu+bMr2VFoUc6+SUMFk4hYtSyk5aApY=";
+    hash = "sha256-4DB4Pl2UwIeab/MJaX3VfVNMsPWE6Q513z1NDdxvG3o=";
   };
 
-  cargoHash = "sha256-w6ZOqpwogKoN4oqqI1gFqY8xAnfvhEBVaL8/6JXpKXs=";
+  cargoHash = "sha256-5Q4E8nnmQ109gcfxxctn/rne5N4Qvz2Pft6o7as2fSc=";
 
   nativeBuildInputs = [
     installShellFiles
@@ -33,8 +33,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Graphical console greeter for greetd";
-    homepage = "https://github.com/apognu/tuigreet";
-    changelog = "https://github.com/apognu/tuigreet/releases/tag/${finalAttrs.version}";
+    homepage = "https://github.com/tuigreet/tuigreet";
+    changelog = "https://github.com/tuigreet/tuigreet/releases/tag/${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       NotAShelf

--- a/pkgs/by-name/tu/tuigreet/package.nix
+++ b/pkgs/by-name/tu/tuigreet/package.nix
@@ -36,7 +36,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/apognu/tuigreet";
     changelog = "https://github.com/apognu/tuigreet/releases/tag/${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      antoineco
+    ];
     platforms = lib.platforms.linux;
     mainProgram = "tuigreet";
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

:newspaper: `tuigreet` has a new home: https://github.com/tuigreet/
The project's owner recently created it to enable more contributors to maintain the project.

This PR bumps the version to the latest release under the new org.

I would additionally like to volunteer as a maintainer, together with @NotAShelf (on their request).

<details><summary>Outdated description</summary>
<p>

tuigreet's maintainer seems to have abandoned his project. The last commit was about [2 years ago](https://github.com/apognu/tuigreet/commit/2aeca1b63dec977fc4e2ac6f97432386bedbc546), and many contributions (bug fixes, etc.) have been left unanswered for just as long.

Users have taken notice and been patient. I believe it is now time to move forward with @NotAShelf's fork, who has been putting in tremendous work over the past 6 months reviewing and merging patches, and greatly improving the status of the project overall.

For reference, Arch Linux is likely to switch to this fork in the near future as well:
- https://github.com/apognu/tuigreet/issues/185#issuecomment-5046282938
- [archlinux/packaging/packages/greetd-tuigreet#1](https://gitlab.archlinux.org/archlinux/packaging/packages/greetd-tuigreet/-/work_items/1#note_512981)

</p>
</details> 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
