### PR TITLE
tsm-client: 8.2.1.0 -> 8.2.2.0 (and strictDeps, and structuredAttrs)

### DIFF
--- a/nixos/modules/programs/tsm-client.nix
+++ b/nixos/modules/programs/tsm-client.nix
@@ -71,7 +71,7 @@ let
     {
       freeformType = attrsOf (either scalarType (listOf scalarType));
       # Client system-options file directives are explained here:
-      # https://www.ibm.com/docs/en/storage-protect/8.2.1?topic=utilities-processing-options
+      # https://www.ibm.com/docs/en/storage-protect/8.2.2?topic=utilities-processing-options
       options.servername = mkOption {
         type = servernameType;
         default = name;

--- a/pkgs/by-name/ts/tsm-client/package.nix
+++ b/pkgs/by-name/ts/tsm-client/package.nix
@@ -101,6 +101,7 @@ let
     inherit meta passthru;
 
     __structuredAttrs = true;
+    strictDeps = true;
 
     nativeBuildInputs = [
       autoPatchelfHook

--- a/pkgs/by-name/ts/tsm-client/package.nix
+++ b/pkgs/by-name/ts/tsm-client/package.nix
@@ -100,6 +100,8 @@ let
     };
     inherit meta passthru;
 
+    __structuredAttrs = true;
+
     nativeBuildInputs = [
       autoPatchelfHook
       rpmextract

--- a/pkgs/by-name/ts/tsm-client/package.nix
+++ b/pkgs/by-name/ts/tsm-client/package.nix
@@ -46,7 +46,7 @@
 # point to this derivations `/dsmi_dir` directory symlink.
 # Other environment variables might be necessary,
 # depending on local configuration or usage; see:
-# https://www.ibm.com/docs/en/storage-protect/8.2.1?topic=solaris-set-api-environment-variables
+# https://www.ibm.com/docs/en/storage-protect/8.2.2?topic=solaris-set-api-environment-variables
 
 let
 
@@ -93,10 +93,10 @@ let
 
   unwrapped = stdenv.mkDerivation (finalAttrs: {
     pname = "tsm-client-unwrapped";
-    version = "8.2.1.0";
+    version = "8.2.2.0";
     src = fetchurl {
       url = mkSrcUrl finalAttrs.version;
-      hash = "sha512-Hlm4sk78I/+hVKwGsSDpwIihMqMeAlLtu4H/DLo2NVNMQnixZTYRch69hAR1PNaSS7qz8/oiI51AYTc6+JYdtA==";
+      hash = "sha512-cK0IL3D5IDJmN9SKIHDXB5wcO6vPtn7XwHVq3dEgg3feZS8FhE62wZopLQoGLYKg11kz34JVOqBtfouthZWbUA==";
     };
     inherit meta passthru;
 


### PR DESCRIPTION
Release notes ("What's new"): https://www.ibm.com/docs/en/storage-protect/8.2.2?topic=whats-new#r_wn_tsmserver__title__3

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

More:

- [x] Successfully tested with a real tsm-server: uploaded some files for backup without errors/problems.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `027a9b289dd8ec02a57a1753d6201f698ab40bdb`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 2 packages blacklisted:</summary>
  <ul>
    <li>nixos-install-tools</li>
    <li>tests.nixos-functions.nixos-test</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>tsm-client</li>
    <li>tsm-client-withGui</li>
  </ul>
</details>