### PR TITLE
jetbrains.jdk: Remove JDK from rpath reference and fix homePath for jdk-no-jcef

### DIFF
--- a/pkgs/development/compilers/jetbrains-jdk/21.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/21.nix
@@ -21,6 +21,5 @@ callPackage ./common.nix
     # run `git log -1 --pretty=%ct` in jdk repo for new value on update
     sourceDateEpoch = 1765114563;
     srcHash = "sha256-Qmffu7p6frBoH2Zh+EiqvEoMNNBE79qfkgLSC3+XuI0=";
-    homePath = "${jetbrains.jdk-21}/lib/openjdk";
     jcefPackage = jetbrains.jcef-21;
   }

--- a/pkgs/development/compilers/jetbrains-jdk/common.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/common.nix
@@ -35,7 +35,6 @@
   build,
   sourceDateEpoch,
   srcHash,
-  homePath,
   jcefPackage ? null,
   extraBuildPhase ? "",
   vendorVersionString ? null,
@@ -182,13 +181,15 @@ jdk.overrideAttrs (oldAttrs: {
       if [ "$output" = debug ]; then continue; fi
       LIBDIRS="$(find $(eval echo \$$output) -name \*.so\* -exec dirname {} \+ | sort -u | tr '\n' ':'):$LIBDIRS"
     done
-    # Add the local library paths to remove dependencies on the bootstrap
+    # Add the local library paths and drop rpath entries pointing at the
+    # boot JDK
     for output in ${lib.concatStringsSep " " oldAttrs.outputs}; do
       if [ "$output" = debug ]; then continue; fi
       OUTPUTDIR=$(eval echo \$$output)
       BINLIBS=$(find $OUTPUTDIR/bin/ -type f; find $OUTPUTDIR -name \*.so\*)
       echo "$BINLIBS" | while read i; do
-        patchelf --set-rpath "$LIBDIRS:$(patchelf --print-rpath "$i")" "$i" || true
+        OLD_RPATH="$(patchelf --print-rpath "$i" 2>/dev/null | tr ':' '\n' | grep -v "^${jdk}" | tr '\n' ':')" || true
+        patchelf --set-rpath "$LIBDIRS:''${OLD_RPATH%:}" "$i" || true
       done
     done
   '';
@@ -228,9 +229,5 @@ jdk.overrideAttrs (oldAttrs: {
     ];
 
     broken = stdenv.hostPlatform.isDarwin;
-  };
-
-  passthru = oldAttrs.passthru // {
-    home = homePath;
   };
 })

--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -40,7 +40,6 @@ callPackage ./common.nix
     # run `git log -1 --pretty=%ct` in jdk repo for new value on update
     sourceDateEpoch = 1780959777;
     srcHash = "sha256-N+7D++Cxu0RGWChEWW8gtNz7E2I8qM2AFbXv4luAXto=";
-    homePath = "${jetbrains.jdk}/lib/openjdk";
     jcefPackage = jetbrains.jcef;
     extraBuildPhase = ''
       cp -r ${gtk-protocols.out} gtk-shell.xml


### PR DESCRIPTION
This fixes: #547183

I tested this patch together with #546636. Since idea bundles jcef itself I'm not sure jetbrains.jdk is needed anymore. 

Also confirm that `nix why-depends --precise -f . jetbrains.jdk openjdk25` returns nothing. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
