### PR TITLE
python3Packages.pywebtransport: 0.16.1 -> 0.20.1

### DIFF
--- a/pkgs/development/python-modules/pywebtransport/default.nix
+++ b/pkgs/development/python-modules/pywebtransport/default.nix
@@ -4,35 +4,30 @@
   clang,
   fetchFromGitHub,
   llvmPackages,
-  msgpack,
   pkg-config,
-  protobuf,
-  psutil,
   pytest-asyncio,
   pytest-cov-stub,
   pytest-mock,
   pytestCheckHook,
   rustPlatform,
-  types-psutil,
-  uvloop,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "pywebtransport";
-  version = "0.16.1";
+  version = "0.20.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "wtransport";
     repo = "pywebtransport";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-DKvWSu2ufoIsBODNfFbM9JUtY81mmUISmD+qMQ6UVDI=";
+    hash = "sha256-sgD5+yk6QpNVBXGfELavYNl9E0rBuk6TTH8BDwKzEng=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
     cargoRoot = "crates";
-    hash = "sha256-gplelmBqntws+64DmjOZ5xbo3L/f+3+oasi5qLXT1pg=";
+    hash = "sha256-JgnXV1hRDvXJdIWYxFACsL4dNpyAnperTJZOQS2UT5A=";
   };
 
   build-system = with rustPlatform; [
@@ -54,35 +49,21 @@ buildPythonPackage (finalAttrs: {
     ln -s crates/Cargo.lock Cargo.lock || true
   '';
 
-  optional-dependencies = {
-    msgpack = [ msgpack ];
-    protobuf = [ protobuf ];
-  };
-
   nativeCheckInputs = [
-    psutil
     pytest-asyncio
     pytest-cov-stub
     pytest-mock
     pytestCheckHook
-    types-psutil
-    uvloop
-  ]
-  ++ lib.flatten (builtins.attrValues finalAttrs.passthru.optional-dependencies);
-
-  disabledTestPaths = [
-    # Tests require network access
-    "tests/e2e"
   ];
 
   preCheck = ''
-    cp -v $out/lib/python*/site-packages/pywebtransport/_wtransport*.so src/pywebtransport/
+    cp -v $out/lib/python*/site-packages/pywebtransport/_pywebtransport*.so src/pywebtransport/
   '';
 
   pythonImportsCheck = [ "pywebtransport" ];
 
   meta = {
-    description = "WebTransport stack for Python";
+    description = "Async-native WebTransport stack";
     homepage = "https://github.com/wtransport/pywebtransport";
     changelog = "https://github.com/wtransport/pywebtransport/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.asl20;


### PR DESCRIPTION
Changelog: https://github.com/wtransport/pywebtransport/blob/main/CHANGELOG.md#0201---2026-07-22

Additionally:

- Fixes `meta.description`.
- Removes the `msgpack`/`protobuf` entries from `optional-dependencies`.
- Fixes the `preCheck` artifact filename to `_pywebtransport*.so`.
- Updates `nativeCheckInputs` to match the current `test` extra, dropping `psutil`, `types-psutil`, `uvloop`, and `pytest-benchmark`.
- Removes the redundant `disabledTestPaths` entry for `tests/e2e`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
