### PR TITLE
 atmos: 1.220.0 -> 1.224.1, fix tests

### DIFF
--- a/pkgs/by-name/at/atmos/package.nix
+++ b/pkgs/by-name/at/atmos/package.nix
@@ -2,7 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  terraform,
+  versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
@@ -25,32 +25,23 @@ buildGoModule (finalAttrs: {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/cloudposse/atmos/cmd.Version=v${finalAttrs.version}"
+    "-X github.com/cloudposse/atmos/pkg/version.Version=v${finalAttrs.version}"
   ];
 
-  nativeCheckInputs = [ terraform ];
+  nativeCheckInputs = [ versionCheckHook ];
 
   preCheck = ''
     # Remove tests that depend on a network connection.
     rm -f \
-      pkg/vender/component_vendor_test.go \
+      main_hooks_and_keychain_store_integration_test.go \
+      main_hooks_and_store_integration_test.go \
+      main_plan_diff_integration_test.go \
       pkg/atlantis/atlantis_generate_repo_config_test.go \
-      pkg/describe/describe_affected_test.go
+      pkg/describe/describe_affected_test.go \
+      pkg/vender/component_vendor_test.go
   '';
 
-  # depend on a network connection.
-  doCheck = false;
-
-  # depend on a network connection.
-  doInstallCheck = false;
-
-  installCheckPhase = ''
-    runHook preInstallCheck
-
-    $out/bin/atmos version | grep "v${finalAttrs.version}"
-
-    runHook postInstallCheck
-  '';
+  doInstallCheck = true;
 
   meta = {
     homepage = "https://atmos.tools";

--- a/pkgs/by-name/at/atmos/package.nix
+++ b/pkgs/by-name/at/atmos/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "atmos";
-  version = "1.220.0";
+  version = "1.224.1";
 
   src = fetchFromGitHub {
     owner = "cloudposse";
     repo = "atmos";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-kUCSa6Kw8wfGfMi3swqwt9mT0ZmniQVE/h5XWkjh+SM=";
+    hash = "sha256-ew07sucTTLLUU2bdN3HKyJJ6i5z6jqgfYR3fHLnzcHA=";
   };
 
-  vendorHash = "sha256-X8R0hRTDKvKmBWgV4ujVQrHIE935wG6sogQAzv2fdTg=";
+  vendorHash = "sha256-MP30jhbhcf6+TWB0q/VLPY6DYd0TLUWZmg3D+d8IpXg=";
 
   env.CGO_ENABLED = 0; # Compiles a pure statically linked Go binary.
 

--- a/pkgs/by-name/at/atmos/package.nix
+++ b/pkgs/by-name/at/atmos/package.nix
@@ -49,5 +49,6 @@ buildGoModule (finalAttrs: {
     description = "Universal Tool for DevOps and Cloud Automation (works with terraform, helm, helmfile, etc)";
     mainProgram = "atmos";
     license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nevivurn ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- Supercedes #532698
- Enable tests, and fix the version check. It was previously not setting the correct value & it was not being checked at all.
- Disable integration tests that require networking selectively & enable tests overall. We could also enable the terraform-based tests, but that would prevent atmos from being cached in hydra due to unfree terraform.
- Add myself to maintaners.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
