### PR TITLE
python3Packages.busylight-*: update

### DIFF
--- a/pkgs/development/python-modules/busylight-core/default.nix
+++ b/pkgs/development/python-modules/busylight-core/default.nix
@@ -12,20 +12,16 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "busylight-core";
-  version = "2.2.0";
+  version = "2.4.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "JnyJny";
-    repo = "busylight-core";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-as2IvaxyMjGKPGlBmz1cntAhbpuW+f3INtnNIcwpWh8=";
+    repo = "busylight";
+    tag = "busylight-core/v${finalAttrs.version}";
+    hash = "sha256-m7ZxZkaWnkQV/KZ/xm3+uSfftL1V5Lxolx2lB63Mzyk=";
+    rootDir = "packages/busylight-core";
   };
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail "uv_build>=0.7.19,<0.8" "uv_build"
-  '';
 
   build-system = [ uv-build ];
 
@@ -44,8 +40,8 @@ buildPythonPackage (finalAttrs: {
 
   meta = {
     description = "Library for interacting programmatically with USB-connected LED lights";
-    homepage = "https://github.com/JnyJny/busylight-core";
-    changelog = "https://github.com/JnyJny/busylight-core/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    homepage = "https://github.com/JnyJny/busylight";
+    changelog = "https://github.com/JnyJny/busylight/blob/${finalAttrs.src.tag}/${finalAttrs.src.rootDir}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/busylight-for-humans/default.nix
+++ b/pkgs/development/python-modules/busylight-for-humans/default.nix
@@ -5,7 +5,6 @@
   busylight-core,
   fastapi,
   fetchFromGitHub,
-  hatchling,
   hidapi,
   httpx,
   loguru,
@@ -14,26 +13,27 @@
   pytestCheckHook,
   typer,
   udevCheckHook,
+  uv-build,
   uvicorn,
   webcolors,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "busylight-for-humans";
-  version = "0.48.0";
+  version = "1.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "JnyJny";
     repo = "busylight";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-5sQXW55P/iWhDWY6bGzN8IrWCJyrSvu2ObtIOolo2X0=";
+    tag = "busylight-cli/v${finalAttrs.version}";
+    hash = "sha256-h+YPrcf32SgzdQDYCeQlh4enzsXfsHr470W3tiFBO7g=";
+    rootDir = "packages/busylight";
   };
 
-  build-system = [ hatchling ];
+  build-system = [ uv-build ];
 
   dependencies = [
-    bitvector-for-humans
     busylight-core
     hidapi
     loguru
@@ -53,12 +53,9 @@ buildPythonPackage (finalAttrs: {
   nativeCheckInputs = [
     httpx
     pytestCheckHook
-    pytest-mock
     udevCheckHook
   ]
   ++ lib.flatten (builtins.attrValues finalAttrs.passthru.optional-dependencies);
-
-  disabledTestPaths = [ "tests/test_pydantic_models.py" ];
 
   pythonImportsCheck = [ "busylight" ];
 
@@ -70,7 +67,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Control USB connected presence lights from multiple vendors via the command-line or web API";
     homepage = "https://github.com/JnyJny/busylight";
-    changelog = "https://github.com/JnyJny/busylight/releases/tag/${finalAttrs.src.tag}";
+    changelog = "https://github.com/JnyJny/busylight/blob/${finalAttrs.src.tag}/${finalAttrs.src.rootDir}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       das_j


### PR DESCRIPTION
Updating to follow [JnyJny/busylight](https://github.com/JnyJny/busylight)’s reorganization into a monorepo.

Upstream change logs:

- https://github.com/JnyJny/busylight/blob/busylight-core/v2.4.0/packages/busylight-core/CHANGELOG.md
- https://github.com/JnyJny/busylight/blob/busylight-cli/v1.0.1/packages/busylight/CHANGELOG.md

Resolves [incompatibility](https://hydra.nixos.org/build/338591485) with fastapi ≥0.137 via JnyJny/busylight@38f99fb8581bc162f88f6bdad510e04f14fa5858.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
