### PR TITLE
ocsinventory-agent: 2.10.4 -> 2.10.5

### DIFF
--- a/pkgs/by-name/oc/ocsinventory-agent/package.nix
+++ b/pkgs/by-name/oc/ocsinventory-agent/package.nix
@@ -106,7 +106,7 @@ perlPackages.buildPerlPackage rec {
     homepage = "https://ocsinventory-ng.org";
     changelog = "https://github.com/OCSInventory-NG/UnixAgent/releases/tag/v${version}";
     downloadPage = "https://github.com/OCSInventory-NG/UnixAgent/releases";
-    license = lib.licenses.gpl2Only;
+    license = lib.licenses.gpl2Plus;
     mainProgram = "ocsinventory-agent";
     maintainers = with lib.maintainers; [
       totoroot

--- a/pkgs/by-name/oc/ocsinventory-agent/package.nix
+++ b/pkgs/by-name/oc/ocsinventory-agent/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   perlPackages,
   fetchFromGitHub,
-  fetchpatch,
   makeWrapper,
   coreutils,
   dmidecode,
@@ -24,23 +23,14 @@
 
 perlPackages.buildPerlPackage rec {
   pname = "ocsinventory-agent";
-  version = "2.10.4";
+  version = "2.10.5";
 
   src = fetchFromGitHub {
     owner = "OCSInventory-NG";
     repo = "UnixAgent";
     tag = "v${version}";
-    hash = "sha256-MKUYf3k47lHc9dTGo1wYd7r4GrX98dU+04mF0Jm5e9U=";
+    hash = "sha256-BIR93ABiE3wzuw9Q0fZMm7ClKyDmsxE+UcPTYd6P7No=";
   };
-
-  patches = [
-    # Fix Getopt-Long warnings
-    # See https://github.com/OCSInventory-NG/UnixAgent/pull/490
-    (fetchpatch {
-      url = "https://github.com/OCSInventory-NG/UnixAgent/commit/c4899cef6b797df471ddf41c427970de47302f80.patch";
-      hash = "sha256-HxcWb9jmHiL0r6VWlsvmKUuybnM9W5471FLBBe3Zrfs=";
-    })
-  ];
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/by-name/oc/ocsinventory-agent/package.nix
+++ b/pkgs/by-name/oc/ocsinventory-agent/package.nix
@@ -1,24 +1,23 @@
 {
   lib,
   stdenv,
-  perlPackages,
-  fetchFromGitHub,
-  makeWrapper,
   coreutils,
   dmidecode,
+  fetchFromGitHub,
   findutils,
   inetutils,
   ipmitool,
   iproute2,
   lvm2,
+  makeWrapper,
+  nix-update-script,
+  nixosTests,
   nmap,
   pciutils,
+  perlPackages,
   usbutils,
   util-linux,
-  nixosTests,
-  testers,
-  ocsinventory-agent,
-  nix-update-script,
+  versionCheckHook,
 }:
 
 perlPackages.buildPerlPackage rec {
@@ -31,6 +30,8 @@ perlPackages.buildPerlPackage rec {
     tag = "v${version}";
     hash = "sha256-BIR93ABiE3wzuw9Q0fZMm7ClKyDmsxE+UcPTYd6P7No=";
   };
+
+  strictDeps = true;
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -87,14 +88,11 @@ perlPackages.buildPerlPackage rec {
       wrapProgram $out/bin/ocsinventory-agent --prefix PATH : ${lib.makeBinPath runtimeDependencies}
     '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
-    tests = {
-      inherit (nixosTests) ocsinventory-agent;
-      version = testers.testVersion {
-        package = ocsinventory-agent;
-        command = "ocsinventory-agent --version";
-      };
-    };
+    tests.ocsinventory-agent = nixosTests.ocsinventory-agent;
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/oc/ocsinventory-agent/package.nix
+++ b/pkgs/by-name/oc/ocsinventory-agent/package.nix
@@ -18,6 +18,7 @@
   usbutils,
   util-linux,
   versionCheckHook,
+  which,
 }:
 
 perlPackages.buildPerlPackage rec {
@@ -75,6 +76,7 @@ perlPackages.buildPerlPackage rec {
         ipmitool # ipmitool
         nmap # nmap
         pciutils # lspci
+        which # which
       ]
       ++ lib.optionals stdenv.hostPlatform.isLinux [
         dmidecode # dmidecode


### PR DESCRIPTION
Changelog: https://github.com/OCSInventory-NG/UnixAgent/releases/tag/v2.10.5
Diff: https://github.com/OCSInventory-NG/UnixAgent/compare/v2.10.4...v2.10.5


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
