### PR TITLE
pi-coding-agent: pin jiti cache to a persistent directory

### DIFF
--- a/pkgs/by-name/pi/pi-coding-agent/package.nix
+++ b/pkgs/by-name/pi/pi-coding-agent/package.nix
@@ -51,6 +51,14 @@ buildNpmPackage (finalAttrs: {
     makeBinaryWrapper
   ];
 
+  # We pin jiti's transpile cache to a persistent dir.
+  # The default tmpdir() that jiti uses is wiped by nix shell on each session
+  # resulting in a cold recompile each time.
+  postPatch = ''
+    substituteInPlace packages/coding-agent/src/core/extensions/loader.ts \
+      --replace-fail 'moduleCache: false,' 'moduleCache: false, fsCache: path.join(process.env.XDG_CACHE_HOME || path.join(process.env.HOME || "", ".cache"), "pi", "jiti"),'
+  '';
+
   # Build workspace dependencies in order, then the coding-agent.
   # We invoke tsgo directly for workspace deps to skip pi-ai's
   # generate-models script, which requires network access; the model


### PR DESCRIPTION
pi (pi-coding-agent) loads TypeScript extensions through jiti, which transpiles TS to JS and caches the result on disk. The cache defaults to tmpdir()/jiti, which nix shell wipes on each session exit, that results in pi doing a full cold recompile every session.

This PR pins the cache to a persistent directory ($XDG_CACHE_HOME/pi/jiti, else ~/.cache/pi/jiti).

Test results before and after the fix (automatized with pi/GLM-5.2):
| metric                        | patched                         | unpatched                 |
| ----------------------------- | ------------------------------- | ------------------------- |
| jiti cache location           | `~/.cache/pi/jiti` (persistent) | `TMPDIR/jiti` (ephemeral) |
| run 1 (cold)                  | 3771 ms                         | 4073 ms                   |
| run 2 (after wiping `TMPDIR`) | 1517 ms                         | 3821 ms                   |
| survives shell exit           | yes                             | no                        |

**Upstream followup:**
I also opened a PR to add a native `PI_JITI_CACHE` env var so in the futureto specify the persistent cache directory without source patching. 

nixpkgs would set the env var in the wrapper instead of patching loader.js, and this patch would no longer need --replace-fail to track the createJiti call site across upgrades: https://github.com/earendil-works/pi/pull/7462. 

It is currently auto-closed pending maintainer approval (the repo requires pre-approval before PRs are accepted), so this nixpkgs patch is self-contained and does not depend on it.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).
Command: `nixpkgs-review`
Commit: `cc7fd5c29ced152b0b4a0e8c7f1d7a14801204ee`
`x86_64-linux`
<details>
 <summary>:white_check_mark: 1 package built:</summary>
 <ul>
   <li>pi-coding-agent</li>
 </ul>
</details>

Here the logs: https://gist.github.com/marcelmanz/3ecbbaae5b84f1e7f49f0f9ad2705257

- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

