### PR TITLE
python3Packages.garminconnect: 0.3.6 -> 0.3.8

### DIFF
--- a/pkgs/by-name/ga/garmin-grafana/package.nix
+++ b/pkgs/by-name/ga/garmin-grafana/package.nix
@@ -1,12 +1,12 @@
 {
+  lib,
   fetchFromGitHub,
   python3Packages,
-  lib,
 }:
+
 python3Packages.buildPythonPackage rec {
   pname = "garmin-grafana";
   version = "0.5.0";
-
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -16,9 +16,9 @@ python3Packages.buildPythonPackage rec {
     hash = "sha256-NrT4erpdWwqFBUumQdd5GqpmhIayszzkPd8fUgDRwXY=";
   };
 
-  build-system = with python3Packages; [
-    setuptools
-  ];
+  build-system = with python3Packages; [ setuptools ];
+
+  nativeBuildInputs = with python3Packages; [ pyprojectVersionPatchHook ];
 
   dependencies = with python3Packages; [
     fitparse

--- a/pkgs/development/python-modules/garminconnect/default.nix
+++ b/pkgs/development/python-modules/garminconnect/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "garminconnect";
-  version = "0.3.6";
+  version = "0.3.8";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "cyberjunky";
     repo = "python-garminconnect";
     tag = finalAttrs.version;
-    hash = "sha256-2nhBLaITFZPzk6fWnS6VAllPxkFofTIU8M+2yLvQMdA=";
+    hash = "sha256-IdxecBvJW22G1pasmUdeU4mN2Ru0Y8GGZIorSzEkKAU=";
   };
 
   pythonRelaxDeps = [ "garth" ];


### PR DESCRIPTION
Diff: https://github.com/cyberjunky/python-garminconnect/compare/0.3.6...0.3.8

Changelog: https://github.com/cyberjunky/python-garminconnect/releases/tag/0.3.8


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
