### PR TITLE
python3Packages.whoisdomain: 1.20260326.1 -> 2.20260709.1

### DIFF
--- a/pkgs/development/python-modules/whoisdomain/default.nix
+++ b/pkgs/development/python-modules/whoisdomain/default.nix
@@ -3,21 +3,28 @@
   buildPythonPackage,
   fetchFromGitHub,
   hatchling,
+  tld,
+  whodap,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "whoisdomain";
-  version = "1.20260326.1";
+  version = "2.20260709.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mboot-github";
     repo = "WhoisDomain";
     tag = finalAttrs.version;
-    hash = "sha256-4EWxQq88RWH3yQYVfo07U7jG5ws+SJ7SAq2Mc8nyeRU=";
+    hash = "sha256-9oXKqMdZZFC0orrWMgcpL1mmJil3ENRY5fZjlISupF0=";
   };
 
   build-system = [ hatchling ];
+
+  dependencies = [
+    tld
+    whodap
+  ];
 
   pythonImportsCheck = [ "whoisdomain" ];
 


### PR DESCRIPTION
Changelog: https://github.com/mboot-github/WhoisDomain/releases/tag/2.20260709.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
