### PR TITLE
treewide: remove hallucinated npmDepsFetcherVersion 3

### DIFF
--- a/pkgs/build-support/node/prefetch-npm-deps/default.nix
+++ b/pkgs/build-support/node/prefetch-npm-deps/default.nix
@@ -300,8 +300,19 @@
           NIX_NPM_REGISTRY_OVERRIDES = npmRegistryOverridesString;
 
           # Fetcher version controls which features are enabled in prefetch-npm-deps
-          # Version 2+ enables packument fetching for workspace support
-          NPM_FETCHER_VERSION = toString fetcherVersion;
+          NPM_FETCHER_VERSION =
+            let
+              # Increment when we introduce a new version.
+              validFetcherVersions = [
+                1 # Initial version
+                2 # enables packument fetching for workspace support
+              ];
+            in
+            assert lib.assertMsg (lib.elem fetcherVersion validFetcherVersions)
+              "fetchNpmDeps: fetcher version must be one of: ${
+                lib.concatMapStringsSep ", " toString validFetcherVersions
+              }.";
+            (toString fetcherVersion);
 
           SSL_CERT_FILE =
             if

--- a/pkgs/by-name/bi/bitwarden-desktop/package.nix
+++ b/pkgs/by-name/bi/bitwarden-desktop/package.nix
@@ -73,8 +73,8 @@ buildNpmPackage (finalAttrs: {
   ];
 
   npmWorkspace = "apps/desktop";
-  npmDepsFetcherVersion = 3;
-  npmDepsHash = "sha256-8wjt5wnJG4S4EeGWGxbo6Bwt76GIqrSiwqwwwQ17Y5Y=";
+  npmDepsFetcherVersion = 2;
+  npmDepsHash = "sha256-WRxlvkgWboO0ukUHgjC5CrfgfwnmUfDXI4r5dx9CKww=";
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs)

--- a/pkgs/by-name/ex/exo/package.nix
+++ b/pkgs/by-name/ex/exo/package.nix
@@ -56,7 +56,7 @@ let
     inherit src version;
 
     sourceRoot = "${finalAttrs.src.name}/dashboard";
-    npmDepsFetcherVersion = 3;
+    npmDepsFetcherVersion = 2;
 
     npmDeps = fetchNpmDeps {
       inherit (finalAttrs)
@@ -65,8 +65,8 @@ let
         src
         sourceRoot
         ;
-      fetcherVersion = 3;
-      hash = "sha256-gBWJP0dF2zDEWLYxfKYQSn9O5hVRkcviDv9oP267pQQ=";
+      fetcherVersion = 2;
+      hash = "sha256-d/+54lpNe0tXrC+Mrhpc1cdXOMjYblE0QByIdiaDgU0=";
     };
   });
 in

--- a/pkgs/by-name/gh/ghui/package.nix
+++ b/pkgs/by-name/gh/ghui/package.nix
@@ -31,8 +31,8 @@ buildNpmPackage (finalAttrs: {
     cp ${./package-lock.json} package-lock.json
   '';
 
-  npmDepsHash = "sha256-pg+USHnvcxaXG/floNItLXNFJOPvuDltQCcN1qT/nng=";
-  npmDepsFetcherVersion = 3;
+  npmDepsHash = "sha256-JxyG7qMJS7zchxLIxYCmsFajUVW4fONnqgeq2iKlt4A=";
+  npmDepsFetcherVersion = 2;
 
   nativeBuildInputs = [ bun ];
 

--- a/pkgs/by-name/gl/glitchtip/frontend.nix
+++ b/pkgs/by-name/gl/glitchtip/frontend.nix
@@ -21,11 +21,12 @@ buildNpmPackage (finalAttrs: {
 
   nodejs = nodejs_22;
 
+  npmDepsFetcherVersion = 2;
   npmDeps = fetchNpmDeps {
     name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
     inherit (finalAttrs) src;
-    npmDepsFetcherVersion = 3;
-    hash = "sha256-V9aRKoJ6+BN/q7NS21eZBopzkWje8sOGGL1AgO4cUM0=";
+    fetcherVersion = 2;
+    hash = "sha256-xobZg0Hc+Yi9+q6kMwuKtBb4pjdYNS4T9VdFy5hARlw=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/qw/qwen-code/package.nix
+++ b/pkgs/by-name/qw/qwen-code/package.nix
@@ -23,8 +23,8 @@ buildNpmPackage (finalAttrs: {
     hash = "sha256-XWhQ5GlAGW0WAyiPwBULLz1yQps2IdjVkusQ0a88tCs=";
   };
 
-  npmDepsFetcherVersion = 3;
-  npmDepsHash = "sha256-dRc+hTk5ELw0rJhT71heFnLjTmjN1UpIOHUMXKt4YwU=";
+  npmDepsFetcherVersion = 2;
+  npmDepsHash = "sha256-2vr8Yspm6CCVnO6Jf8B3wiL6X+Tp6hZZEPr+WC/Dcak=";
 
   # npm 11 incompatible with fetchNpmDeps
   # https://github.com/NixOS/nixpkgs/issues/474535

--- a/pkgs/by-name/sn/snyk/package.nix
+++ b/pkgs/by-name/sn/snyk/package.nix
@@ -24,9 +24,9 @@ buildNpmPackage (finalAttrs: {
     '';
   };
 
-  npmDepsFetcherVersion = 3;
+  npmDepsFetcherVersion = 2;
 
-  npmDepsHash = "sha256-AmJNFEw7IF9PjgeRma6vp3I7a60ZkekfRkPXJtjVIik=";
+  npmDepsHash = "sha256-e7C2ZG7SH9xjfU07lX8rzPeox6k2Fdz7AowOduLxvvs=";
 
   nodejs = nodejs_24;
 

--- a/pkgs/by-name/va/vaultwarden/webvault.nix
+++ b/pkgs/by-name/va/vaultwarden/webvault.nix
@@ -19,8 +19,8 @@ buildNpmPackage rec {
     hash = "sha256-Uz0wPdhTVy2yOlKWAy5phr+30NmFaIPQQh5bsiWCDLA=";
   };
 
-  npmDepsFetcherVersion = 3;
-  npmDepsHash = "sha256-PaDxqVsq00QIKDmhDhsEbKdM4QXfXn28PgpOyZjB60k=";
+  npmDepsFetcherVersion = 2;
+  npmDepsHash = "sha256-SkzEM54nMFqiYUqIRTbp3+yaZEJMgjFkjRLT5NZTN94=";
 
   nativeBuildInputs = [
     python3


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Not sure if it was just a mistake which started spreading or if some LLMs hallucinated a third version.
Let's remove it, hashes would break if we introduce version 3.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
