### PR TITLE
poppler: 26.06.0 -> 26.09.0

### DIFF
--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -111,6 +111,8 @@ stdenv.mkDerivation (finalAttrs: {
     })
     # https://gitlab.com/inkscape/inkscape/-/merge_requests/7968
     ./fix-build-poppler-26.06.0.patch
+    # https://gitlab.com/inkscape/inkscape/-/merge_requests/8034
+    ./fix-build-poppler-26.07.0.patch
   ];
 
   postPatch = ''

--- a/pkgs/applications/graphics/inkscape/fix-build-poppler-26.07.0.patch
+++ b/pkgs/applications/graphics/inkscape/fix-build-poppler-26.07.0.patch
@@ -1,0 +1,331 @@
+From fc52525f8d8d7d3e772c5bfa1bdfe9b33c7f9709 Mon Sep 17 00:00:00 2001
+From: KrIr17 <elendil.krir17@gmail.com>
+Date: Sat, 4 Jul 2026 14:07:44 +0200
+Subject: [PATCH] Fix building with Poppler 26.07.0
+
+1. `arrayGetfoo()` to `getArray()->getFoo()`  [1]
+2. `streamGetFoo()` to `getStream()->getFoo()` [2]
+3. indextolabel now requires an `std::string *` and not `GooString *`
+   introduced _POPPLER_STRING_26_7 that changes accordingly.
+
+Relevant poppler commits:
+
+[1]  [Remove Object::arrayGetNF](https://gitlab.freedesktop.org/poppler/poppler/-/commit/d9ffc4c29d1975a5c81d6bac9d8a1b6dc5aa1f50): Technically only arrayGetNF was removed, but perusing the commit shows that all `arrayGetFoo` are being changed. I assume they are slated for removal in future releases.
+
+[2]  [Remove Object::streamGetDict](gitlab.freedesktop.org/poppler/poppler/-/commit/87edb5a5c40e67e782e54a14a2251547b4acdfb5)
+
+[3]  [Use std::string instead of GooString for label](https://gitlab.freedesktop.org/poppler/poppler/-/commit/9e34004aae04064f1b798b5e711e13d0dddacf9e)
+---
+ src/extension/internal/pdfinput/pdf-input.cpp |  5 +-
+ .../internal/pdfinput/pdf-parser.cpp          | 54 +++++++++----------
+ .../pdfinput/poppler-transition-api.h         |  6 +++
+ .../internal/pdfinput/poppler-utils.cpp       | 29 +++++-----
+ .../internal/pdfinput/poppler-utils.h         |  1 +
+ 5 files changed, 54 insertions(+), 41 deletions(-)
+
+diff --git a/src/extension/internal/pdfinput/pdf-input.cpp b/src/extension/internal/pdfinput/pdf-input.cpp
+index 4030a95882..0d46a0577f 100644
+--- a/src/extension/internal/pdfinput/pdf-input.cpp
++++ b/src/extension/internal/pdfinput/pdf-input.cpp
+@@ -891,9 +891,10 @@ PdfInput::add_builder_page(std::shared_ptr<PDFDoc>pdf_doc, SvgBuilder *builder,
+ 
+     // Parse the annotations
+     if (auto annots = page->getAnnotsObject(); annots.isArray()) {
+-        auto const size = annots.arrayGetLength();
++        auto* annotsArray = annots.getArray();
++        auto const size = annotsArray->getLength();
+         for (int i = 0; i < size; i++) {
+-            pdf_parser.build_annots(annots.arrayGet(i), page_num);
++            pdf_parser.build_annots(annotsArray->get(i), page_num);
+         }
+     }
+ }
+diff --git a/src/extension/internal/pdfinput/pdf-parser.cpp b/src/extension/internal/pdfinput/pdf-parser.cpp
+index 86fc51b1f2..fac5326988 100644
+--- a/src/extension/internal/pdfinput/pdf-parser.cpp
++++ b/src/extension/internal/pdfinput/pdf-parser.cpp
+@@ -289,8 +289,8 @@ PdfParser::PdfParser(std::shared_ptr<PDFDoc> pdf_doc, Inkscape::Extension::Inter
+     if (page) {
+         // Increment the page building here and set page label
+         Catalog *catalog = pdf_doc->getCatalog();
+-        GooString *label = new GooString("");
+-        catalog->indexToLabel(page->getNum() - 1, label);
++        _POPPLER_STRING_26_7 label;
++        catalog->indexToLabel(page->getNum() - 1, &label);
+         builder->pushPage(getString(label), state);
+     }
+ 
+@@ -374,8 +374,8 @@ void PdfParser::parse(Object *obj, GBool topLevel) {
+   Object obj2;
+ 
+   if (obj->isArray()) {
+-    for (int i = 0; i < obj->arrayGetLength(); ++i) {
+-      _POPPLER_CALL_ARGS(obj2, obj->arrayGet, i);
++    for (int i = 0; i < obj->getArray()->getLength(); ++i) {
++      _POPPLER_CALL_ARGS(obj2, obj->getArray()->get, i);
+       if (!obj2.isStream()) {
+ 	error(errInternal, -1, "Weird page contents");
+ 	_POPPLER_FREE(obj2);
+@@ -782,8 +782,8 @@ void PdfParser::opSetExtGState(Object args[], int /*numArgs*/)
+                 for (int &i : backdropColor.c) {
+                     i = 0;
+                 }
+-                for (int i = 0; i < obj3.arrayGetLength() && i < gfxColorMaxComps; ++i) {
+-                    _POPPLER_CALL_ARGS(obj4, obj3.arrayGet, i);
++                for (int i = 0; i < obj3.getArray()->getLength() && i < gfxColorMaxComps; ++i) {
++                    _POPPLER_CALL_ARGS(obj4, obj3.getArray()->get, i);
+                     if (obj4.isNum()) {
+                         backdropColor.c[i] = dblToCol(obj4.getNum());
+                     }
+@@ -792,7 +792,7 @@ void PdfParser::opSetExtGState(Object args[], int /*numArgs*/)
+             }
+             _POPPLER_FREE(obj3);
+             if (_POPPLER_CALL_ARGS_DEREF(obj3, obj2.dictLookup, "G").isStream()) {
+-                if (_POPPLER_CALL_ARGS_DEREF(obj4, obj3.streamGetDict()->lookup, "Group").isDict()) {
++                if (_POPPLER_CALL_ARGS_DEREF(obj4, obj3.getStream()->getDict()->lookup, "Group").isDict()) {
+                     std::unique_ptr<GfxColorSpace> blendingColorSpace;
+                     GBool isolated = gFalse;
+                     GBool knockout = gFalse;
+@@ -855,7 +855,7 @@ void PdfParser::doSoftMask(Object *str, GBool alpha,
+   }
+ 
+   // get stream dict
+-  dict = str->streamGetDict();
++  dict = str->getStream()->getDict();
+ 
+   // check form type
+   _POPPLER_CALL_ARGS(obj1, dict->lookup, "FormType");
+@@ -872,7 +872,7 @@ void PdfParser::doSoftMask(Object *str, GBool alpha,
+     return;
+   }
+   for (i = 0; i < 4; ++i) {
+-    _POPPLER_CALL_ARGS(obj2, obj1.arrayGet, i);
++    _POPPLER_CALL_ARGS(obj2, obj1.getArray()->get, i);
+     bbox[i] = obj2.getNum();
+     _POPPLER_FREE(obj2);
+   }
+@@ -882,7 +882,7 @@ void PdfParser::doSoftMask(Object *str, GBool alpha,
+   _POPPLER_CALL_ARGS(obj1, dict->lookup, "Matrix");
+   if (obj1.isArray()) {
+     for (i = 0; i < 6; ++i) {
+-      _POPPLER_CALL_ARGS(obj2, obj1.arrayGet, i);
++      _POPPLER_CALL_ARGS(obj2, obj1.getArray()->get, i);
+       m[i] = obj2.getNum();
+       _POPPLER_FREE(obj2);
+     }
+@@ -2396,7 +2396,7 @@ void PdfParser::opXObject(Object args[], int /*numArgs*/)
+     }
+ 
+ //add layer at root if xObject has type OCG
+-    _POPPLER_CALL_ARGS(obj2, obj1.streamGetDict()->lookup, "OC");
++    _POPPLER_CALL_ARGS(obj2, obj1.getStream()->getDict()->lookup, "OC");
+     if(obj2.isDict()){
+         auto type_dict = obj2.getDict();
+         if (type_dict->lookup("Type").isName("OCG")) {
+@@ -2406,7 +2406,7 @@ void PdfParser::opXObject(Object args[], int /*numArgs*/)
+         }
+     }
+ 
+-    _POPPLER_CALL_ARGS(obj2, obj1.streamGetDict()->lookup, "Subtype");
++    _POPPLER_CALL_ARGS(obj2, obj1.getStream()->getDict()->lookup, "Subtype");
+     if (obj2.isName(const_cast<char*>("Image"))) {
+         _POPPLER_CALL_ARGS(refObj, res->lookupXObjectNF, name);
+         doImage(&refObj, obj1.getStream(), gFalse);
+@@ -2414,7 +2414,7 @@ void PdfParser::opXObject(Object args[], int /*numArgs*/)
+     } else if (obj2.isName(const_cast<char*>("Form"))) {
+         doForm(&obj1);
+     } else if (obj2.isName(const_cast<char*>("PS"))) {
+-        _POPPLER_CALL_ARGS(obj3, obj1.streamGetDict()->lookup, "Level1");
++        _POPPLER_CALL_ARGS(obj3, obj1.getStream()->getDict()->lookup, "Level1");
+     } else if (obj2.isName()) {
+         error(errSyntaxError, getPos(), "Unknown XObject subtype '{0:s}'", obj2.getName());
+     } else {
+@@ -2545,7 +2545,7 @@ void PdfParser::doImage(Object * /*ref*/, Stream *str, GBool inlineImg)
+             _POPPLER_CALL_ARGS(obj1, dict->lookup, "D");
+         }
+         if (obj1.isArray()) {
+-            _POPPLER_CALL_ARGS(obj2, obj1.arrayGet, 0);
++            _POPPLER_CALL_ARGS(obj2, obj1.getArray()->get, 0);
+             if (obj2.isInt() && obj2.getInt() == 1) {
+                 invert = gTrue;
+             }
+@@ -2607,7 +2607,7 @@ void PdfParser::doImage(Object * /*ref*/, Stream *str, GBool inlineImg)
+ 	            goto err1;
+             }
+             maskStr = smaskObj.getStream();
+-            maskDict = smaskObj.streamGetDict();
++            maskDict = smaskObj.getStream()->getDict();
+             _POPPLER_CALL_ARGS(obj1, maskDict->lookup, "Width");
+             if (obj1.isNull()) {
+                     _POPPLER_FREE(obj1);
+@@ -2673,8 +2673,8 @@ void PdfParser::doImage(Object * /*ref*/, Stream *str, GBool inlineImg)
+         } else if (maskObj.isArray()) {
+             // color key mask
+             int i;
+-            for (i = 0; i < maskObj.arrayGetLength() && i < 2*gfxColorMaxComps; ++i) {
+-                _POPPLER_CALL_ARGS(obj1, maskObj.arrayGet, i);
++            for (i = 0; i < maskObj.getArray()->getLength() && i < 2*gfxColorMaxComps; ++i) {
++                _POPPLER_CALL_ARGS(obj1, maskObj.getArray()->get, i);
+                 maskColors[i] = obj1.getInt();
+                 _POPPLER_FREE(obj1);
+             }
+@@ -2685,7 +2685,7 @@ void PdfParser::doImage(Object * /*ref*/, Stream *str, GBool inlineImg)
+                 goto err1;
+             }
+             maskStr = maskObj.getStream();
+-            maskDict = maskObj.streamGetDict();
++            maskDict = maskObj.getStream()->getDict();
+             _POPPLER_CALL_ARGS(obj1, maskDict->lookup, "Width");
+             if (obj1.isNull()) {
+                 _POPPLER_FREE(obj1);
+@@ -2732,7 +2732,7 @@ void PdfParser::doImage(Object * /*ref*/, Stream *str, GBool inlineImg)
+                 _POPPLER_CALL_ARGS(obj1, maskDict->lookup, "D");
+             }
+             if (obj1.isArray()) {
+-                _POPPLER_CALL_ARGS(obj2, obj1.arrayGet, 0);
++                _POPPLER_CALL_ARGS(obj2, obj1.getArray()->get, 0);
+                 if (obj2.isInt() && obj2.getInt() == 1) {
+                     maskInvert = gTrue;
+                 }
+@@ -2785,7 +2785,7 @@ void PdfParser::doForm(Object *str, double *offset)
+     }
+ 
+     // get stream dict
+-    dict = str->streamGetDict();
++    dict = str->getStream()->getDict();
+ 
+     // check form type
+     _POPPLER_CALL_ARGS(obj1, dict->lookup, "FormType");
+@@ -2802,7 +2802,7 @@ void PdfParser::doForm(Object *str, double *offset)
+         return;
+     }
+     for (i = 0; i < 4; ++i) {
+-        _POPPLER_CALL_ARGS(obj1, bboxObj.arrayGet, i);
++        _POPPLER_CALL_ARGS(obj1, bboxObj.getArray()->get, i);
+         bbox[i] = obj1.getNum();
+         _POPPLER_FREE(obj1);
+     }
+@@ -2812,7 +2812,7 @@ void PdfParser::doForm(Object *str, double *offset)
+     _POPPLER_CALL_ARGS(matrixObj, dict->lookup, "Matrix");
+     if (matrixObj.isArray()) {
+         for (i = 0; i < 6; ++i) {
+-        _POPPLER_CALL_ARGS(obj1, matrixObj.arrayGet, i);
++        _POPPLER_CALL_ARGS(obj1, matrixObj.getArray()->get, i);
+         m[i] = obj1.getNum();
+         _POPPLER_FREE(obj1);
+         }
+@@ -3248,10 +3248,10 @@ void PdfParser::loadColorProfile()
+         return;
+ 
+     Object outputIntents = catDict.dictLookup("OutputIntents");
+-    if (!outputIntents.isArray() || outputIntents.arrayGetLength() != 1)
++    if (!outputIntents.isArray() || outputIntents.getArray()->getLength() != 1)
+         return;
+ 
+-    Object firstElement = outputIntents.arrayGet(0);
++    Object firstElement = outputIntents.getArray()->get(0);
+     if (!firstElement.isDict())
+         return;
+ 
+@@ -3300,7 +3300,7 @@ void PdfParser::build_annots(const Object &annot, int page_num)
+             _POPPLER_CALL_ARGS(Rect_obj, annot_dict->lookup, "Rect");
+             if (Rect_obj.isArray()) {
+                 for (int i = 0; i < 2; i++) {
+-                    _POPPLER_CALL_ARGS(xy_obj, Rect_obj.arrayGet, i);
++                    _POPPLER_CALL_ARGS(xy_obj, Rect_obj.getArray()->get, i);
+                     offset[i] = xy_obj.getNum();
+                 }
+                 doForm(&first_state_obj, offset);
+diff --git a/src/extension/internal/pdfinput/poppler-transition-api.h b/src/extension/internal/pdfinput/poppler-transition-api.h
+index 23550a3068..22bc8d223d 100644
+--- a/src/extension/internal/pdfinput/poppler-transition-api.h
++++ b/src/extension/internal/pdfinput/poppler-transition-api.h
+@@ -15,6 +15,12 @@
+ #include <glib/poppler-features.h>
+ #include <UTF.h>
+ 
++#if POPPLER_CHECK_VERSION(26, 7, 0)
++#define _POPPLER_STRING_26_7 std::string
++#else
++#define _POPPLER_STRING_26_7 GooString
++#endif
++
+ #if POPPLER_CHECK_VERSION(26, 6, 0)
+ #define _POPPLER_GET_GRAY(color, gray) getGray(color, gray)
+ #define _POPPLER_GET_RGB(color, rgb) getRGB(color, rgb)
+diff --git a/src/extension/internal/pdfinput/poppler-utils.cpp b/src/extension/internal/pdfinput/poppler-utils.cpp
+index 66dcf85e1d..0a82574209 100644
+--- a/src/extension/internal/pdfinput/poppler-utils.cpp
++++ b/src/extension/internal/pdfinput/poppler-utils.cpp
+@@ -187,15 +187,16 @@ void InkFontDict::hashFontObject1(const Object *obj, FNVHash *h)
+         case objNull:
+             h->hash('z');
+             break;
+-        case objArray:
+-            h->hash('a');
+-            n = obj->arrayGetLength();
+-            h->hash((char *)&n, sizeof(int));
+-            for (i = 0; i < n; ++i) {
+-                const Object &obj2 = obj->arrayGetNF(i);
+-                hashFontObject1(&obj2, h);
+-            }
+-            break;
++        case objArray: {
++                h->hash('a');
++                Array * objArray = obj->getArray();
++                n = objArray->getLength();
++                h->hash((char *)&n, sizeof(int));
++                for (i = 0; i < n; ++i) {
++                    const Object &obj2 = objArray->getNF(i);
++                    hashFontObject1(&obj2, h);
++                }
++            } break;
+         case objDict: {
+                 h->hash('d');
+                 auto objdict = obj->getDict();
+@@ -207,8 +208,7 @@ void InkFontDict::hashFontObject1(const Object *obj, FNVHash *h)
+                     const Object &obj2 = objdict->getValNF(i);
+                     hashFontObject1(&obj2, h);
+                 }
+-            }
+-            break;
++            } break;
+         case objStream:
+             // this should never happen - streams must be indirect refs
+             break;
+@@ -546,7 +546,7 @@ void _getFontsRecursive(std::shared_ptr<PDFDoc> pdf_doc, Dict *resources, const
+                 continue;
+ 
+             Ref resourcesRef;
+-            const Object resObj = obj2.streamGetDict()->lookup("Resources", &resourcesRef);
++            const Object resObj = obj2.getStream()->getDict()->lookup("Resources", &resourcesRef);
+             if (resourcesRef != Ref::INVALID() && !visitedObjects.insert(resourcesRef.num).second)
+                 continue;
+ 
+@@ -661,6 +661,11 @@ std::string getString(const GooString *value)
+     return "";
+ }
+ 
++std::string getString(const GooString &value)
++{
++    return getString(value.toStr());
++}
++
+ /**
+  * Convert PDF strings, which can be formatted as UTF8, UTF16BE or UTF16LE into
+  * a predictable UTF8 string consistant with svg requirements.
+diff --git a/src/extension/internal/pdfinput/poppler-utils.h b/src/extension/internal/pdfinput/poppler-utils.h
+index b11ecd11e5..27675b758e 100644
+--- a/src/extension/internal/pdfinput/poppler-utils.h
++++ b/src/extension/internal/pdfinput/poppler-utils.h
+@@ -86,6 +86,7 @@ std::string getDictString(Dict *dict, const char *key);
+ std::string getString(const std::string &value);
+ std::string getString(const std::unique_ptr<GooString> &value);
+ std::string getString(const GooString *value);
++std::string getString(const GooString &value);
+ std::string validateString(std::string const &in);
+ std::string sanitizeId(std::string const &in);
+ 
+-- 
+GitLab
+

--- a/pkgs/by-name/sc/scribus/package.nix
+++ b/pkgs/by-name/sc/scribus/package.nix
@@ -114,6 +114,11 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/scribusproject/scribus/commit/2b9405a00a96a09e0183190ddc9f83d44963d4e0.patch";
       hash = "sha256-4v+Ba+JODwNg4YLmwpFeBfIxk1j+RcZdtznPFeQ+H+w=";
     })
+    (fetchpatch {
+      name = "fix-build-with-poppler-26.07.0.patch";
+      url = "https://github.com/scribusproject/scribus/commit/ba246c3a2dd086b4e84517723beab159736ba9ba.patch";
+      hash = "sha256-nfJ3eKBhuWC4IO2+IbqNOz0UWTD4UOKtfZXz5ch6NVE=";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -56,13 +56,13 @@ let
     domain = "gitlab.freedesktop.org";
     owner = "poppler";
     repo = "test";
-    rev = "f0068e9c530017ad811d1f28b95f9b7f59264e37";
-    hash = "sha256-Xf8duSh0r1o09b5BKB7mBvzrMfXYlzTuTOuK2ZCeItc=";
+    rev = "5368d7e64682ab07a22ce241fe0671234229ab84";
+    hash = "sha256-HKCRfSodCmGR6wn8G9o1g96Q5rEO07TCTuHFigJw2FU=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "poppler-${suffix}";
-  version = "26.06.0"; # beware: updates often break cups-filters build, check scribus too!
+  version = "26.08.0"; # beware: updates often break cups-filters build, check scribus too!
 
   outputs = [
     "out"
@@ -71,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://poppler.freedesktop.org/poppler-${finalAttrs.version}.tar.xz";
-    hash = "sha256-TLTlo9yMte7HUciiPIuhn2H5be3AzQfSruawyOLPa6Q=";
+    hash = "sha256-3JBuaM6mmBCXBqxqo9LJ1FEvz8rELZC4r82khtG5q9A=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
changelog: https://gitlab.freedesktop.org/poppler/poppler/-/raw/e661b7b61a1b1feeb3193e5eced6274cc03e0ffa/NEWS
diff: https://gitlab.freedesktop.org/poppler/poppler/-/compare/poppler-26.06.0...e661b7b61a1b1feeb3193e5eced6274cc03e0ffa

Closes: #564871 (except [CVE-2026-93311](https://nvd.nist.gov/vuln/detail/CVE-2026-93311)?)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
    - [x] `cups-filters`
    - [x] `inkscape`
    - [x] `scribus`
    - [x] `gegl`
    - [x] `vips`
    - [x] `gdal`
    - [x] `python-poppler-qt5`
    - [x] `pkg-config`
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- Successfully built the following dependencies:
  - [x] `atril`
  - [x] `diffpdf`
  - [x] `enlightenment.efl`
  - [x] `gimp`
  - [x] `kdePackages.calligra` (with #548178)
  - [x] `kdePackages.poppler`
  - [x] `libreoffice-collabora`
  - [x] `libreoffice-stable`
  - [x] `miktex`
  - [x] `qpdfview`
  - [x] `python3Packages.python-poppler`
  - [x] `tumbler`
  - [x] `zathuraPkgs.zathura_pdf_poppler`
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test