### PR TITLE
cockpit: scrub compiler and -dev store paths from runtime closure

### DIFF
--- a/pkgs/by-name/co/cockpit/package.nix
+++ b/pkgs/by-name/co/cockpit/package.nix
@@ -35,6 +35,7 @@
   pkg-config,
   polkit,
   python312Packages,
+  removeReferencesTo,
   sscg,
   systemd,
   udev,
@@ -78,6 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
     pam
     pkg-config
     python3Packages.setuptools
+    removeReferencesTo
     systemd
     xmlto
   ];
@@ -250,8 +252,33 @@ stdenv.mkDerivation (finalAttrs: {
       popd
     ''}
 
+    remove-references-to \
+      -t ${stdenv.cc.cc} \
+      -t ${lib.getDev stdenv.cc.libc} \
+      -t ${lib.getDev glib} \
+      -t ${lib.getDev json-glib} \
+      -t ${lib.getDev systemd} \
+      -t ${lib.getDev gnutls} \
+      -t ${lib.getDev krb5} \
+      "$out/lib/security/pam_ssh_add.so" \
+      "$out/libexec/cockpit-certificate-ensure" \
+      "$out/libexec/cockpit-session" \
+      "$out/libexec/cockpit-tls" \
+      "$out/libexec/cockpit-ws" \
+      "$out/libexec/cockpit-wsinstance-factory"
+
     runHook postFixup
   '';
+
+  disallowedRequisites = [
+    stdenv.cc.cc
+    (lib.getDev stdenv.cc.libc)
+    (lib.getDev glib)
+    (lib.getDev json-glib)
+    (lib.getDev systemd)
+    (lib.getDev gnutls)
+    (lib.getDev krb5)
+  ];
 
   nativeCheckInputs = [ python3Packages.pytestCheckHook ];
 


### PR DESCRIPTION
Reduced closure size from 800ish MB to 500ishMB. NixOS tests are passing.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test