### PR TITLE
spotiflac: 7.1.8 -> 7.2.0

### DIFF
--- a/pkgs/by-name/sp/spotiflac/package.nix
+++ b/pkgs/by-name/sp/spotiflac/package.nix
@@ -18,14 +18,14 @@
 
 buildGoModule (finalAttrs: {
   pname = "spotiflac";
-  version = "7.1.8";
+  version = "7.2.0";
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
-    owner = "afkarxyz";
+    owner = "spotbye";
     repo = "SpotiFLAC";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Uz+9vsneP8xLGi5pgwYIufCPUzKSH4CRAdt0o+FifAM=";
+    hash = "sha256-T73zf/ji9wqUytVQbn8GswBAlZ/RUu8+xg6B6bhqxhU=";
   };
 
   nativeBuildInputs = [
@@ -53,7 +53,7 @@ buildGoModule (finalAttrs: {
       sourceRoot = "${finalAttrs.src.name}/frontend";
       pnpm = pnpm_10;
       fetcherVersion = 3;
-      hash = "sha256-mecNGWbUATjNl1uWByxE1W1b8tfNyPIRMndcZSBl+XM=";
+      hash = "sha256-fAb+8IgtxfDRZeUJaEq0SMvfoUAkoMXQWfQSIEaTwy4=";
     };
     pnpmRoot = "frontend";
   };
@@ -88,7 +88,7 @@ buildGoModule (finalAttrs: {
     runHook postInstall;
   '';
 
-  vendorHash = "sha256-dTrfLnuo7W3m3mg32wBDv8IbmQA44KXsazRLdanIi/Y=";
+  vendorHash = "sha256-NRpuPFymdNeG1Wzeyis9k2V/GqbIu1M+nfag8GG7ILc=";
 
   desktopItems = [
     (makeDesktopItem {
@@ -103,8 +103,8 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Get Spotify tracks in true FLAC from Tidal, Qobuz & Amazon Music — no account required";
-    homepage = "https://github.com/afkarxyz/SpotiFLAC/";
-    changelog = "https://github.com/afkarxyz/SpotiFLAC/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/spotbye/SpotiFLAC/";
+    changelog = "https://github.com/spotbye/SpotiFLAC/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
     mainProgram = "spotiflac";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Changelog:
https://github.com/spotbye/SpotiFLAC/releases/tag/v7.2.0

## Things done
- Update version ( 7.1.8 -> 7.2.0 ) and hash
- Change  afkarxyz/SpotiFLAC/ to spotbye/SpotiFLAC 
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
