### PR TITLE
treewide: follow some GitHub redirects for fetchFromGitHub

### DIFF
--- a/pkgs/by-name/si/simplebluez/package.nix
+++ b/pkgs/by-name/si/simplebluez/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.11.0";
 
   src = fetchFromGitHub {
-    owner = "OpenBluetoothToolbox";
+    owner = "simpleble";
     repo = "SimpleBLE";
     rev = "v${finalAttrs.version}";
     hash = "sha256-SWZdVWBC8udwkn195FdvsXSniMtzd8+WfnMsARLYSQ4=";
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "C++ abstraction layer for BlueZ over DBus";
-    homepage = "https://github.com/OpenBluetoothToolbox/SimpleBLE";
+    homepage = "https://github.com/simpleble/simpleble";
     # SimpleBLE (which SimpleBluez is part of) is under the Business Source License 1.1 (BUSL-1.1)
     # since version 0.9.0
     license = lib.licenses.bsl11;

--- a/pkgs/by-name/si/simpledbus/package.nix
+++ b/pkgs/by-name/si/simpledbus/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.0.0";
 
   src = fetchFromGitHub {
-    owner = "OpenBluetoothToolbox";
+    owner = "simpleble";
     repo = "SimpleBLE";
     rev = "v${finalAttrs.version}";
     hash = "sha256-I6uZm3CSkOS2is2KZ6DRjEsryLms6k5UtwtZUq8Tbn0=";
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "C++ wrapper for libdbus-1";
-    homepage = "https://github.com/OpenBluetoothToolbox/SimpleBLE";
+    homepage = "https://github.com/simpleble/simpleble";
     # SimpleBLE (which SimpleDBus is part of) is under the Business Source License 1.1 (BUSL-1.1)
     # since version 0.9.0
     license = lib.licenses.bsl11;

--- a/pkgs/by-name/sk/skhd/package.nix
+++ b/pkgs/by-name/sk/skhd/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.3.9";
 
   src = fetchFromGitHub {
-    owner = "koekeishiya";
+    owner = "asmvik";
     repo = "skhd";
     rev = "v${finalAttrs.version}";
     hash = "sha256-fnkWws/g4BdHKDRhqoCpdPFUavOHdk8R7h7H1dAdAYI=";
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Simple hotkey daemon for macOS";
-    homepage = "https://github.com/koekeishiya/skhd";
+    homepage = "https://github.com/asmvik/skhd";
     license = lib.licenses.mit;
     mainProgram = "skhd";
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/sk/skopeo/package.nix
+++ b/pkgs/by-name/sk/skopeo/package.nix
@@ -23,7 +23,7 @@ buildGoModule rec {
 
   src = fetchFromGitHub {
     rev = "v${version}";
-    owner = "containers";
+    owner = "podman-container-tools";
     repo = "skopeo";
     hash = "sha256-RAK6fGy6qCHuJogUeWNoUVOccS7IfRJRozYVrcftQhU=";
   };
@@ -95,10 +95,10 @@ buildGoModule rec {
   };
 
   meta = {
-    changelog = "https://github.com/containers/skopeo/releases/tag/${src.rev}";
+    changelog = "https://github.com/podman-container-tools/skopeo/releases/tag/${src.rev}";
     description = "Command line utility for various operations on container images and image repositories";
     mainProgram = "skopeo";
-    homepage = "https://github.com/containers/skopeo";
+    homepage = "https://github.com/podman-container-tools/skopeo";
     maintainers = with lib.maintainers; [
       lewo
       developer-guy

--- a/pkgs/by-name/sl/slack-term/package.nix
+++ b/pkgs/by-name/sl/slack-term/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "0.5.0";
 
   src = fetchFromGitHub {
-    owner = "erroneousboat";
+    owner = "jpbruinsslot";
     repo = "slack-term";
     rev = "v${finalAttrs.version}";
     sha256 = "1fbq7bdhy70hlkklppimgdjamnk0v059pg73xm9ax1f4616ki1m6";
@@ -18,7 +18,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Slack client for your terminal";
-    homepage = "https://github.com/erroneousboat/slack-term";
+    homepage = "https://github.com/jpbruinsslot/slack-term";
     license = lib.licenses.mit;
     maintainers = [ ];
     mainProgram = "slack-term";

--- a/pkgs/by-name/sl/slack-term/package.nix
+++ b/pkgs/by-name/sl/slack-term/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "jpbruinsslot";
     repo = "slack-term";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "1fbq7bdhy70hlkklppimgdjamnk0v059pg73xm9ax1f4616ki1m6";
   };
   vendorHash = null;

--- a/pkgs/by-name/sl/slsk-batchdl/package.nix
+++ b/pkgs/by-name/sl/slsk-batchdl/package.nix
@@ -11,14 +11,14 @@ buildDotnetModule (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "fiso64";
-    repo = "slsk-batchdl";
+    repo = "sockseek";
     tag = "v${finalAttrs.version}";
     hash = "sha256-H10pApWZ6zUkL1FuSrpbEzGGpDVAiBJB2aZtV9jDTz4=";
   };
 
   postPatch = ''
     # .NET 6 is EOL, .NET 8 works fine modulo the trimming flag.
-    # See: https://github.com/fiso64/slsk-batchdl/issues/112
+    # See: https://github.com/fiso64/sockseek/issues/112
     substituteInPlace \
         slsk-batchdl/slsk-batchdl.csproj \
         slsk-batchdl.Tests/slsk-batchdl.Tests.csproj \
@@ -28,7 +28,7 @@ buildDotnetModule (finalAttrs: {
   projectFile = "slsk-batchdl/slsk-batchdl.csproj";
 
   # Tests fail to build.
-  # See: https://github.com/fiso64/slsk-batchdl/issues/111
+  # See: https://github.com/fiso64/sockseek/issues/111
   # testProjectFile = "slsk-batchdl.Tests/slsk-batchdl.Tests.csproj";
 
   dotnet-sdk = dotnetCorePackages.sdk_10_0;
@@ -38,7 +38,7 @@ buildDotnetModule (finalAttrs: {
   dotnetFlags = [
     "--property:PublishSingleFile=true"
     # Note: This breaks Spotify authentication!
-    # See: https://github.com/fiso64/slsk-batchdl/issues/112
+    # See: https://github.com/fiso64/sockseek/issues/112
     # "--property:PublishTrimmed=true"
   ];
 
@@ -47,7 +47,7 @@ buildDotnetModule (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    homepage = "https://github.com/fiso64/slsk-batchdl";
+    homepage = "https://github.com/fiso64/sockseek";
     description = "Advanced download tool for Soulseek";
     license = lib.licenses.gpl3Only;
     maintainers = [

--- a/pkgs/by-name/sn/snapcast/package.nix
+++ b/pkgs/by-name/sn/snapcast/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.35.0";
 
   src = fetchFromGitHub {
-    owner = "badaix";
+    owner = "snapcast";
     repo = "snapcast";
     rev = "v${finalAttrs.version}";
     hash = "sha256-kUw4yQpCxgjP4hH2Lpxc7l+ufhYSKs7xL80aJuPrqOo=";
@@ -80,7 +80,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Synchronous multi-room audio player";
-    homepage = "https://github.com/badaix/snapcast";
+    homepage = "https://github.com/snapcast/snapcast";
     maintainers = with lib.maintainers; [ fpletz ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     license = lib.licenses.gpl3Plus;

--- a/pkgs/by-name/sn/snapweb/package.nix
+++ b/pkgs/by-name/sn/snapweb/package.nix
@@ -11,7 +11,7 @@ buildNpmPackage rec {
   version = "0.9.2";
 
   src = fetchFromGitHub {
-    owner = "badaix";
+    owner = "snapcast";
     repo = "snapweb";
     rev = "v${version}";
     hash = "sha256-7W7rvJPVcRtXcQt+wWAvrl0DOIh7zEfXZdFDcH23/ls=";
@@ -33,7 +33,7 @@ buildNpmPackage rec {
 
   meta = {
     description = "Web client for Snapcast";
-    homepage = "https://github.com/badaix/snapweb";
+    homepage = "https://github.com/snapcast/snapweb";
     maintainers = with lib.maintainers; [ ettom ];
     license = lib.licenses.gpl3Plus;
   };

--- a/pkgs/by-name/sn/snarkos/package.nix
+++ b/pkgs/by-name/sn/snarkos/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
   version = "2.2.7";
 
   src = fetchFromGitHub {
-    owner = "AleoHQ";
+    owner = "ProvableHQ";
     repo = "snarkOS";
     rev = "v${version}";
     sha256 = "sha256-+z9dgg5HdR+Gomug03gI1zdCU6t4SBHkl1Pxoq69wrc=";

--- a/pkgs/by-name/sn/snippetpixie/package.nix
+++ b/pkgs/by-name/sn/snippetpixie/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.5.3";
 
   src = fetchFromGitHub {
-    owner = "bytepixie";
+    owner = "ianmjones";
     repo = "snippetpixie";
     rev = finalAttrs.version;
     sha256 = "0gs3d9hdywg4vcfbp4qfcagfjqalfgw9xpvywg4pw1cm3rzbdqmz";

--- a/pkgs/by-name/sn/snmpen/package.nix
+++ b/pkgs/by-name/sn/snmpen/package.nix
@@ -11,7 +11,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "fabaff";
+    owner = "affolter-engineering";
     repo = "snmpen";
     tag = finalAttrs.version;
     hash = "sha256-4/QLPq4td2o17lIhktl5aVKz5esWibVoVm8OdVIxWmM=";

--- a/pkgs/by-name/sn/snore/package.nix
+++ b/pkgs/by-name/sn/snore/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "snore";
 
   src = fetchFromGitHub {
-    owner = "clamiax";
+    owner = "bitsmanent";
     repo = "snore";
     tag = finalAttrs.version;
     hash = "sha256-bKPGSePzp4XEZFY0QQr37fm3R1v3hLD6FeySFd7zNJc=";
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "'sleep' with feedback";
-    homepage = "https://github.com/clamiax/snore";
+    homepage = "https://github.com/bitsmanent/snore";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ cafkafk ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/sp/spaceship-prompt/package.nix
+++ b/pkgs/by-name/sp/spaceship-prompt/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation rec {
   version = "4.22.5";
 
   src = fetchFromGitHub {
-    owner = "denysdovhan";
+    owner = "spaceship-prompt";
     repo = "spaceship-prompt";
     rev = "v${version}";
     sha256 = "sha256-GRFgCvOSwRYHgs7SbXJwyqpwPjD7xS4eZss3sVkBiYE=";
@@ -35,7 +35,7 @@ stdenvNoCC.mkDerivation rec {
 
   meta = {
     description = "Zsh prompt for Astronauts";
-    homepage = "https://github.com/denysdovhan/spaceship-prompt/";
+    homepage = "https://github.com/spaceship-prompt/spaceship-prompt/";
     changelog = "https://github.com/spaceship-prompt/spaceship-prompt/releases/tag/v${version}";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/sp/span-lite/package.nix
+++ b/pkgs/by-name/sp/span-lite/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.11.0";
 
   src = fetchFromGitHub {
-    owner = "martinmoene";
+    owner = "nonstd-lite";
     repo = "span-lite";
     rev = "v${finalAttrs.version}";
     hash = "sha256-BYRSdGzIvrOjPXxeabMj4tPFmQ0wfq7y+zJf6BD/bTw=";
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "C++20-like span for C++98, C++11 and later in a single-file header-only library";
-    homepage = "https://github.com/martinmoene/span-lite";
+    homepage = "https://github.com/nonstd-lite/span-lite";
     license = lib.licenses.bsd1;
     maintainers = with lib.maintainers; [ icewind1991 ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/sp/spike/package.nix
+++ b/pkgs/by-name/sp/spike/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   version = "1.1.0-unstable-2024-09-21";
 
   src = fetchFromGitHub {
-    owner = "riscv";
+    owner = "riscv-software-src";
     repo = "riscv-isa-sim";
     rev = "de5094a1a901d77ff44f89b38e00fefa15d4018e";
     sha256 = "sha256-mAgR2VzDgeuIdmPEgrb+MaA89BnWfmNanOVidqn0cgc=";
@@ -45,7 +45,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "RISC-V ISA Simulator";
-    homepage = "https://github.com/riscv/riscv-isa-sim";
+    homepage = "https://github.com/riscv-software-src/riscv-isa-sim";
     license = lib.licenses.bsd3;
     platforms = [
       "x86_64-linux"

--- a/pkgs/by-name/sp/spip/package.nix
+++ b/pkgs/by-name/sp/spip/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation {
   version = "0-unstable-2023-04-19";
 
   src = fetchFromGitHub {
-    owner = "raphaelleman";
+    owner = "LBGC-CFB";
     repo = "SPiP";
     rev = "cae95fe0ee7a2602630b7a4eacbf7cfa0e1763f0";
     hash = "sha256-/CufUaQYnsdo8Rij/24JmixPgMi7o1CApLxeTneWAVc=";
@@ -61,7 +61,7 @@ stdenv.mkDerivation {
   meta = {
     description = "Random forest model for splice prediction in genomics";
     license = lib.licenses.mit;
-    homepage = "https://github.com/raphaelleman/SPiP";
+    homepage = "https://github.com/LBGC-CFB/SPiP";
     maintainers = with lib.maintainers; [ apraga ];
     platforms = lib.platforms.unix;
     mainProgram = "spip";

--- a/pkgs/by-name/sp/spotiflac/package.nix
+++ b/pkgs/by-name/sp/spotiflac/package.nix
@@ -22,7 +22,7 @@ buildGoModule (finalAttrs: {
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
-    owner = "afkarxyz";
+    owner = "spotbye";
     repo = "SpotiFLAC";
     tag = "v${finalAttrs.version}";
     hash = "sha256-Uz+9vsneP8xLGi5pgwYIufCPUzKSH4CRAdt0o+FifAM=";
@@ -103,8 +103,8 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Get Spotify tracks in true FLAC from Tidal, Qobuz & Amazon Music — no account required";
-    homepage = "https://github.com/afkarxyz/SpotiFLAC/";
-    changelog = "https://github.com/afkarxyz/SpotiFLAC/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/spotbye/SpotiFLAC/";
+    changelog = "https://github.com/spotbye/SpotiFLAC/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
     mainProgram = "spotiflac";

--- a/pkgs/by-name/sp/spread/package.nix
+++ b/pkgs/by-name/sp/spread/package.nix
@@ -15,7 +15,7 @@ buildGoModule {
   version = "2026.07.12";
 
   src = fetchFromGitHub {
-    owner = "snapcore";
+    owner = "canonical";
     repo = "spread";
     rev = "d6447c43754c8ca0741901e9db73d5fdb4d21c93";
     hash = "sha256-6d7FuEzO5Ond3xjKpf5iRIp9LEV/4O5g3j/tZQEDCZg=";
@@ -59,7 +59,7 @@ buildGoModule {
     mainProgram = "spread";
     license = lib.licenses.gpl3Only;
     description = "Convenient full-system test (task) distribution";
-    homepage = "https://github.com/snapcore/spread";
+    homepage = "https://github.com/canonical/spread";
     maintainers = with lib.maintainers; [ jnsgruk ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/sq/sqlboiler/package.nix
+++ b/pkgs/by-name/sq/sqlboiler/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "4.19.7";
 
   src = fetchFromGitHub {
-    owner = "volatiletech";
+    owner = "aarondl";
     repo = "sqlboiler";
     tag = "v${finalAttrs.version}";
     hash = "sha256-I67MRrsFCLVdslMFwFnrx1EvyR4eUsupRsqD0T9ZCQg=";
@@ -34,8 +34,8 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Generate a Go ORM tailored to your database schema";
-    homepage = "https://github.com/volatiletech/sqlboiler";
-    changelog = "https://github.com/volatiletech/sqlboiler/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/aarondl/sqlboiler";
+    changelog = "https://github.com/aarondl/sqlboiler/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ mrityunjaygr8 ];
     mainProgram = "sqlboiler";

--- a/pkgs/by-name/sq/sqlitestudio/package.nix
+++ b/pkgs/by-name/sq/sqlitestudio/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "pawelsalawa";
-    repo = "sqlitestudio";
+    repo = "letos";
     rev = finalAttrs.version;
     hash = "sha256-xs0+bB0gPoDkIldaTA/nFofx9KPvIcyxe6kzcHuboxA=";
   };

--- a/pkgs/by-name/st/stalonetray/package.nix
+++ b/pkgs/by-name/st/stalonetray/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.8.5";
 
   src = fetchFromGitHub {
-    owner = "kolbusa";
+    owner = "d3adb5";
     repo = "stalonetray";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-/55oP6xA1LeLawOBkhh9acaDcObO4L4ojcy7e3vwnBw=";
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Stand alone tray";
-    homepage = "https://github.com/kolbusa/stalonetray";
+    homepage = "https://github.com/d3adb5/stalonetray";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ raskin ];

--- a/pkgs/by-name/st/stargate-libcds/package.nix
+++ b/pkgs/by-name/st/stargate-libcds/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.0.0";
 
   src = fetchFromGitHub {
-    owner = "stargateaudio";
+    owner = "d3v-t00Lz";
     repo = "libcds";
     rev = finalAttrs.version;
     sha256 = "sha256-THThEzS8gGdwn3h0EBttaX5ljZH9Ma2Rcg143+GIdU8=";
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Fix for building on darwin
     (fetchpatch {
       name = "malloc-to-stdlib.patch";
-      url = "https://github.com/stargateaudio/libcds/commit/65dc08f059deda8ba5707ba6116b616d0ad0bd8d.patch";
+      url = "https://github.com/d3v-t00Lz/libcds/commit/65dc08f059deda8ba5707ba6116b616d0ad0bd8d.patch";
       sha256 = "sha256-FIGlobUVrDYOtnHjsWyE420PoULPHEK/3T9Fv8hfTl4=";
     })
   ];
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "C data structure library";
-    homepage = "https://github.com/stargateaudio/libcds";
+    homepage = "https://github.com/d3v-t00Lz/libcds";
     maintainers = [ ];
     license = lib.licenses.lgpl3Only;
   };

--- a/pkgs/by-name/st/stderred/package.nix
+++ b/pkgs/by-name/st/stderred/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "unstable-2021-04-28";
 
   src = fetchFromGitHub {
-    owner = "sickill";
+    owner = "ku1ik";
     repo = "stderred";
     rev = "b2238f7c72afb89ca9aaa2944d7f4db8141057ea";
     sha256 = "sha256-k/EA327AsRHgUYu7QqSF5yzOyO6h5XcE9Uv4l1VcIPI=";
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Colorize all stderr output that goes to terminal, making it distinguishable from stdout";
-    homepage = "https://github.com/sickill/stderred";
+    homepage = "https://github.com/ku1ik/stderred";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ vojta001 ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/st/strawberry/package.nix
+++ b/pkgs/by-name/st/strawberry/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.2.21";
 
   src = fetchFromGitHub {
-    owner = "jonaski";
+    owner = "strawberrymusicplayer";
     repo = "strawberry";
     rev = finalAttrs.finalPackage.version;
     hash = "sha256-FI+lyVx9x82o2HZ9YysIlPsSAl94YUD8nrHP0HsmO2E=";

--- a/pkgs/by-name/st/string-view-lite/package.nix
+++ b/pkgs/by-name/st/string-view-lite/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.8.0";
 
   src = fetchFromGitHub {
-    owner = "martinmoene";
+    owner = "nonstd-lite";
     repo = "string-view-lite";
     tag = "v${finalAttrs.version}";
     hash = "sha256-hXm3MLskeZzTegSj79dQV+VcwBatT1VIAUydjisd19U=";
@@ -30,8 +30,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "C++17-like string_view for C++98, C++11 and later in a single-file header-only library";
-    homepage = "https://github.com/martinmoene/string-view-lite";
-    changelog = "https://github.com/martinmoene/string-view-lite/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/nonstd-lite/string-view-lite";
+    changelog = "https://github.com/nonstd-lite/string-view-lite/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.boost;
     maintainers = with lib.maintainers; [ titaniumtown ];
   };

--- a/pkgs/by-name/su/super-productivity/package.nix
+++ b/pkgs/by-name/su/super-productivity/package.nix
@@ -25,7 +25,7 @@ buildNpmPackage rec {
   inherit nodejs;
 
   src = fetchFromGitHub {
-    owner = "johannesjo";
+    owner = "super-productivity";
     repo = "super-productivity";
     tag = "v${version}";
     hash = "sha256-1Iu4aJLlT2VllAALcJFBV7GQ1+ujgHjolbkYLjGM1qI=";

--- a/pkgs/by-name/sw/swapview/package.nix
+++ b/pkgs/by-name/sw/swapview/package.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage {
 
   src = fetchFromGitHub {
     owner = "lilydjwg";
-    repo = "swapview";
+    repo = "smapview";
     rev = "cc8e863acd2084413b91572357dab34551c27ed7";
     sha256 = "sha256-H5jMdmtZoN9nQfjXFQyYbuvPY58jmEP2j/XWGdBocFo=";
   };
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage {
   meta = {
     description = "Simple program to view processes' swap usage on Linux";
     mainProgram = "swapview";
-    homepage = "https://github.com/lilydjwg/swapview";
+    homepage = "https://github.com/lilydjwg/smapview";
     platforms = lib.platforms.linux;
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ oxalica ];

--- a/pkgs/by-name/sx/sxiv/package.nix
+++ b/pkgs/by-name/sx/sxiv/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
-    owner = "muennich";
+    owner = "xyb3rt";
     repo = "sxiv";
     tag = "v${finalAttrs.version}";
     hash = "sha256-jrCEx1o7Go0jgwQ3YJ0L97Q5BCHvVTTqOWId3xzlSnU=";
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Simple X Image Viewer";
-    homepage = "https://github.com/muennich/sxiv";
+    homepage = "https://github.com/xyb3rt/sxiv";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ h7x4 ];

--- a/pkgs/by-name/sy/synergy/package.nix
+++ b/pkgs/by-name/sy/synergy/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "symless";
     repo = "synergy";
-    rev = finalAttrs.version;
+    tag = "v${finalAttrs.version}";
     hash = "sha256-0QqklfSsvcXh7I2jaHk82k0nY8gQOj9haA4WOjGqBqY=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/sy/synergy/package.nix
+++ b/pkgs/by-name/sy/synergy/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "symless";
-    repo = "synergy-core";
+    repo = "synergy";
     rev = finalAttrs.version;
     hash = "sha256-0QqklfSsvcXh7I2jaHk82k0nY8gQOj9haA4WOjGqBqY=";
     fetchSubmodules = true;
@@ -140,7 +140,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Share one mouse and keyboard between multiple computers";
     homepage = "https://symless.com/synergy";
-    changelog = "https://github.com/symless/synergy-core/blob/${finalAttrs.version}/ChangeLog";
+    changelog = "https://github.com/symless/synergy/blob/${finalAttrs.version}/ChangeLog";
     mainProgram = lib.optionalString (!withGUI) "synergyc";
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ talyz ];

--- a/pkgs/by-name/ta/tagger/package.nix
+++ b/pkgs/by-name/ta/tagger/package.nix
@@ -19,8 +19,8 @@ buildDotnetModule rec {
   version = "2024.6.0-1";
 
   src = fetchFromGitHub {
-    owner = "nlogozzo";
-    repo = "NickvisionTagger";
+    owner = "NickvisionApps";
+    repo = "Tagger";
     rev = version;
     hash = "sha256-4OfByQYhLXmeFWxzhqt8d7pLUyuMLhDM20E2YcA9Q3s=";
   };

--- a/pkgs/by-name/ta/tandem-aligner/package.nix
+++ b/pkgs/by-name/ta/tandem-aligner/package.nix
@@ -13,15 +13,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "seryrzu";
-    repo = "tandem_aligner";
+    repo = "unialigner";
     rev = "v${finalAttrs.version}";
     hash = "sha256-iMDj1HZ8LzmZckuAM3lbG3eSJSd/5JGVA6SBs7+AgX8=";
   };
 
   patches = [
     (fetchpatch {
-      # https://github.com/seryrzu/tandem_aligner/pull/4
-      url = "https://github.com/seryrzu/tandem_aligner/commit/8b516c94f90aaa9cb84278aa811285d4204b03a9.patch";
+      # https://github.com/seryrzu/unialigner/pull/4
+      url = "https://github.com/seryrzu/unialigner/commit/8b516c94f90aaa9cb84278aa811285d4204b03a9.patch";
       hash = "sha256-kD46SykXklG/avK0+sc61YKFw9Bes8ZgFAjVXmcpN8k=";
       stripLen = 1;
     })
@@ -58,8 +58,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Parameter-free algorithm for sequence alignment";
-    homepage = "https://github.com/seryrzu/tandem_aligner";
-    changelog = "https://github.com/seryrzu/tandem_aligner/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/seryrzu/unialigner";
+    changelog = "https://github.com/seryrzu/unialigner/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ matthiasbeyer ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/ta/tango/package.nix
+++ b/pkgs/by-name/ta/tango/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "1.1.0";
 
   src = fetchFromGitHub {
-    owner = "masakichi";
+    owner = "yuanji-dev";
     repo = "tango";
     rev = "v${finalAttrs.version}";
     hash = "sha256-e/M2iRm/UwfnRVnMo1PmQTkz4IGTxnsCXNSSUkhsiHk=";
@@ -19,7 +19,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Local command-line Japanese dictionary tool using yomichan's dictionary files";
-    homepage = "https://github.com/masakichi/tango";
+    homepage = "https://github.com/yuanji-dev/tango";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ donovanglover ];
     mainProgram = "tango";

--- a/pkgs/by-name/tb/tbe/package.nix
+++ b/pkgs/by-name/tb/tbe/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.9.3.1";
 
   src = fetchFromGitHub {
-    owner = "kaa-ching";
+    owner = "the-butterfly-effect";
     repo = "tbe";
     tag = "v${finalAttrs.version}";
     hash = "sha256-UnvFr/ofk6CgtBv6ua8XjZAWScFGfeNx+is5Q8Zl4qk=";

--- a/pkgs/by-name/te/tektoncd-cli-pac/package.nix
+++ b/pkgs/by-name/te/tektoncd-cli-pac/package.nix
@@ -13,7 +13,7 @@ buildGoModule (finalAttrs: {
   version = "0.41.1";
 
   src = fetchFromGitHub {
-    owner = "openshift-pipelines";
+    owner = "tektoncd";
     repo = "pipelines-as-code";
     tag = "v${finalAttrs.version}";
     hash = "sha256-ZuYaYBSDpU2NCBssw+j3cP4jV6t+pCezFrQRQBS/zKk=";
@@ -51,7 +51,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     homepage = "https://pipelinesascode.com";
-    changelog = "https://github.com/openshift-pipelines/pipelines-as-code/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/tektoncd/pipelines-as-code/releases/tag/v${finalAttrs.version}";
     description = "CLI for interacting with Tekton Pipelines as Code";
     longDescription = ''
       tkn-pac CLI Plugin – Easily manage Pipelines-as-Code repositories.

--- a/pkgs/by-name/te/teler/package.nix
+++ b/pkgs/by-name/te/teler/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "2.0.0";
 
   src = fetchFromGitHub {
-    owner = "kitabisa";
+    owner = "teler-sh";
     repo = "teler";
     tag = "v${finalAttrs.version}";
     hash = "sha256-3+A1QloZQlH31snWfwYa6rprpKUf3fQc/HQgmKQgV9c=";
@@ -33,8 +33,8 @@ buildGoModule (finalAttrs: {
       based on web log that runs in a terminal with resources that
       we collect and provide by the community.
     '';
-    homepage = "https://github.com/kitabisa/teler";
-    changelog = "https://github.com/kitabisa/teler/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/teler-sh/teler";
+    changelog = "https://github.com/teler-sh/teler/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "teler.app";

--- a/pkgs/by-name/te/telescope/package.nix
+++ b/pkgs/by-name/te/telescope/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.11";
 
   src = fetchFromGitHub {
-    owner = "omar-polo";
+    owner = "telescope-browser";
     repo = "telescope";
     tag = finalAttrs.version;
     hash = "sha256-GKeUXa4RKYkoywrCrpenfLt10Rdj9L0xYI3tf2hFAbk=";

--- a/pkgs/by-name/te/terranix/package.nix
+++ b/pkgs/by-name/te/terranix/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.9.0";
 
   src = fetchFromGitHub {
-    owner = "mrVanDalo";
+    owner = "terranix";
     repo = "terranix";
     rev = finalAttrs.version;
     sha256 = "sha256-Jh0Zk+g0pEbNopADEtqvrnhrl83rlNFHpn3Zhz4s+VM=";

--- a/pkgs/by-name/te/terrascan/package.nix
+++ b/pkgs/by-name/te/terrascan/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "1.19.9";
 
   src = fetchFromGitHub {
-    owner = "accurics";
+    owner = "tenable";
     repo = "terrascan";
     tag = "v${finalAttrs.version}";
     hash = "sha256-4XIhmUUOSROwEPSB+DcMOfG5+q/pmWkVUwKGrWVcNtM=";
@@ -33,7 +33,7 @@ buildGoModule (finalAttrs: {
       mitigate risk before provisioning cloud native infrastructure. It contains
       500+ polices and support for Terraform and Kubernetes.
     '';
-    homepage = "https://github.com/accurics/terrascan";
+    homepage = "https://github.com/tenable/terrascan";
     changelog = "https://github.com/tenable/terrascan/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];

--- a/pkgs/by-name/te/testssl/package.nix
+++ b/pkgs/by-name/te/testssl/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.2.3";
 
   src = fetchFromGitHub {
-    owner = "drwetter";
+    owner = "testssl";
     repo = "testssl.sh";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-hR+EhAkv7EXMhBu8wEF6yjpvMzLJZcjH+Jdji0EQkgY=";

--- a/pkgs/by-name/th/theforceengine/package.nix
+++ b/pkgs/by-name/th/theforceengine/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.22.420";
 
   src = fetchFromGitHub {
-    owner = "luciusDXL";
+    owner = "TheForceEngine";
     repo = "TheForceEngine";
     tag = "v${finalAttrs.version}";
     hash = "sha256-8JhaCIJgyaikoDLesshKiIhOO6OFis0xBYDq4vio4F4=";

--- a/pkgs/by-name/th/thunderbolt/package.nix
+++ b/pkgs/by-name/th/thunderbolt/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "thunderbolt";
   version = "0.9.3";
   src = fetchFromGitHub {
-    owner = "01org";
+    owner = "intel";
     repo = "thunderbolt-software-user-space";
     rev = "v${finalAttrs.version}";
     sha256 = "02w1bfm7xvq0dzkhwqiq0camkzz9kvciyhnsis61c8vzp39cwx0x";

--- a/pkgs/by-name/tl/tlrender/package.nix
+++ b/pkgs/by-name/tl/tlrender/package.nix
@@ -56,14 +56,14 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.10.0";
 
   src = fetchFromGitHub {
-    owner = "darbyjohnston";
+    owner = "grizzlypeak3d";
     repo = "tlRender";
     tag = finalAttrs.version;
     hash = "sha256-TxiDZtMvNmrV1FKXZnekCZHnr/eCWZlsP6VJRnaoWg4=";
   };
 
   patches = [
-    # Minizip-ng 4 support: https://github.com/darbyjohnston/tlRender/pull/145
+    # Minizip-ng 4 support: https://github.com/grizzlypeak3d/tlRender/pull/145
     ./minizip-ng-4.patch
   ];
 
@@ -147,7 +147,7 @@ stdenv.mkDerivation (finalAttrs: {
       image sequences, audio clips, and transitions. Examples are provided for
       integrating the library with Qt and OpenGL applications.
     '';
-    homepage = "https://github.com/darbyjohnston/tlRender";
+    homepage = "https://github.com/grizzlypeak3d/tlRender";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ yzx9 ];
     platforms = with lib.platforms; linux ++ darwin;

--- a/pkgs/by-name/to/tola/package.nix
+++ b/pkgs/by-name/to/tola/package.nix
@@ -13,8 +13,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.7.1";
 
   src = fetchFromGitHub {
-    owner = "KawaYww";
-    repo = "tola";
+    owner = "tola-rs";
+    repo = "tola-ssg";
     tag = "v${finalAttrs.version}";
     hash = "sha256-zgPKsIRXp5na2d0X7j5+9xJBGFSlvIKIRmzVVo/dcLk=";
   };
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "A static site generator for typst-based blog, written in Rust";
-    homepage = "https://github.com/KawaYww/tola";
+    homepage = "https://github.com/tola-rs/tola-ssg";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       matthiasbeyer

--- a/pkgs/by-name/to/topiary/package.nix
+++ b/pkgs/by-name/to/topiary/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.7.3";
 
   src = fetchFromGitHub {
-    owner = "tweag";
+    owner = "topiary";
     repo = "topiary";
     tag = "v${finalAttrs.version}";
     hash = "sha256-3zHO+a/m4Rv+pUm0Y1dBjFfHPZCfjsyAq56EiHSGJ1Y=";
@@ -86,8 +86,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Uniform formatter for simple languages, as part of the Tree-sitter ecosystem";
-    homepage = "https://github.com/tweag/topiary";
-    changelog = "https://github.com/tweag/topiary/blob/v${finalAttrs.version}/CHANGELOG.md";
+    homepage = "https://github.com/topiary/topiary";
+    changelog = "https://github.com/topiary/topiary/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       nartsiss

--- a/pkgs/development/compilers/swift/libdispatch/default.nix
+++ b/pkgs/development/compilers/swift/libdispatch/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Grand Central Dispatch";
-    homepage = "https://github.com/apple/swift-corelibs-libdispatch";
+    homepage = "https://github.com/swiftlang/swift-corelibs-libdispatch";
     platforms = lib.platforms.linux;
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ cmm ];

--- a/pkgs/development/compilers/swift/sourcekit-lsp/default.nix
+++ b/pkgs/development/compilers/swift/sourcekit-lsp/default.nix
@@ -81,7 +81,7 @@ stdenv.mkDerivation {
   meta = {
     description = "Language Server Protocol implementation for Swift and C-based languages";
     mainProgram = "sourcekit-lsp";
-    homepage = "https://github.com/apple/sourcekit-lsp";
+    homepage = "https://github.com/swiftlang/sourcekit-lsp";
     platforms = with lib.platforms; linux ++ darwin;
     license = lib.licenses.asl20;
     teams = [ lib.teams.swift ];

--- a/pkgs/development/compilers/swift/swift-format/default.nix
+++ b/pkgs/development/compilers/swift/swift-format/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Formatting technology for Swift source code";
-    homepage = "https://github.com/apple/swift-format";
+    homepage = "https://github.com/swiftlang/swift-format";
     platforms = with lib.platforms; linux ++ darwin;
     license = lib.licenses.asl20;
     teams = [ lib.teams.swift ];

--- a/pkgs/development/compilers/swift/swiftpm/default.nix
+++ b/pkgs/development/compilers/swift/swiftpm/default.nix
@@ -320,7 +320,7 @@ let
   swift-crypto = mkBootstrapDerivation {
     name = "swift-crypto";
     src = fetchFromGitHub {
-      owner = "apple";
+      owner = "swiftlang";
       repo = "swift-crypto";
       rev = "95ba0316a9b733e92bb6b071255ff46263bbe7dc"; # 3.15.1, as opposed to the pinned version of 3.0.0
       sha256 = "sha256-RzoUBx4l12v0ZamSIAEpHHCRQXxJkXJCwVBEj7Qwg9I=";
@@ -492,7 +492,7 @@ stdenv.mkDerivation (
 
     meta = {
       description = "Package Manager for the Swift Programming Language";
-      homepage = "https://github.com/apple/swift-package-manager";
+      homepage = "https://github.com/swiftlang/swift-package-manager";
       platforms = with lib.platforms; linux ++ darwin;
       license = lib.licenses.asl20;
       teams = [ lib.teams.swift ];

--- a/pkgs/development/python-modules/stac-validator/default.nix
+++ b/pkgs/development/python-modules/stac-validator/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "stac-utils";
+    owner = "StacLabs";
     repo = "stac-validator";
     tag = "v${version}";
     hash = "sha256-JrLpny4PDXvjKN1iQ0uxcTuPgNTykZzv7RdQDoMLQT4=";
@@ -44,7 +44,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Validator for the SpatioTemporal Asset Catalog (STAC) specification";
-    homepage = "https://github.com/stac-utils/stac-validator";
+    homepage = "https://github.com/StacLabs/stac-validator";
     license = lib.licenses.asl20;
     teams = [ lib.teams.geospatial ];
   };

--- a/pkgs/tools/security/stoken/default.nix
+++ b/pkgs/tools/security/stoken/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   version = "0.93";
 
   src = fetchFromGitHub {
-    owner = "cernekee";
+    owner = "stoken-dev";
     repo = "stoken";
     rev = "v${version}";
     hash = "sha256-8N7TXdBu37eXWIKCBdaXVW0pvN094oRWrdlcy9raddI=";
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Software Token for Linux/UNIX";
-    homepage = "https://github.com/cernekee/stoken";
+    homepage = "https://github.com/stoken-dev/stoken";
     license = lib.licenses.lgpl21Plus;
     maintainers = [ ];
     platforms = lib.platforms.all;


### PR DESCRIPTION
This PR updates some `fetchFromGitHub` calls and corresponding `github.com/<owner>/<repo>` links in the same location to point directly to canonical repositories instead of redirecting URLs.

This doesn't update all `fetchFromGitHub` redirects since that would produce a diff too large for maintainers to review.

**Motivation:**
This avoids silent failures if upstream redirects ever change or disappear, and improves reliability and reproducibility of fetches.

**How:**
Changes were generated using [this script](https://git.kybe.xyz/2kybe3/nixpkgs-github-redirect).

**How to verify:**
You can verify that all modified package sources still build using the following script with a `changed.txt` file containing the changed package list.

<details>
  <summary>Verify script</summary>

```bash
#!/usr/bin/env bash

out="result.txt"
: > "$out"

while read -r pkg; do
    echo "=== $pkg ==="

    output=$(nix build "./nixpkgs#$pkg.src" -L -v --rebuild --no-link --print-out-paths)
    status=$?

    if [ $status -eq 0 ]; then
        echo "$pkg: success | $output" | tee -a "$out"
    else
        echo "$pkg: failed" | tee -a "$out"
    fi
done < ./changed.txt
```
</details>

<details>
  <summary>Changed Packages</summary>

```
simpleBluez
simpleDBus
skhd
skopeo
slack-term
snapweb
slsk-batchdl
snapcast
snarkos
snippetpixie
snore
snmpen
spaceship-prompt
sourcekit-lsp
span-lite
spike
spip
sqlboiler
spread
spotiflac
sqlitestudio
stalonetray
stac-validator
stargate-libcds
stderred
stoken
string-view-lite
strawberry
super-productivity
swapview
swift-corelibs-libdispatch
swift-format
swiftpm
sxiv
synergy
tagger
tango
tandem-aligner
tbe
tektoncd-cli-pac
teler
telescope
terrascan
testssl
terranix
theforceengine
thunderbolt
tlrender
topiary
tola
```
</details>

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
