### PR TITLE
ci/OWNERS: add whole qt-kde team as owner

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -263,15 +263,15 @@ pkgs/development/python-modules/buildcatrust/ @ajs124 @lukegb @mweinelt
 /lib/licenses @alyssais @emilazy @jopejoe1
 
 # Qt
-/pkgs/development/libraries/qt-5 @K900 @NickCao @SuperSandro2000
-/pkgs/development/libraries/qt-6 @K900 @NickCao @SuperSandro2000
+/pkgs/development/libraries/qt-5 @NixOS/qt-kde
+/pkgs/development/libraries/qt-6 @NixOS/qt-kde
 
 # KDE Frameworks 5
-/pkgs/development/libraries/kde-frameworks @K900 @NickCao @SuperSandro2000
+/pkgs/development/libraries/kde-frameworks @NixOS/qt-kde
 
 # KDE / Plasma 6
-/pkgs/kde @K900 @NickCao @SuperSandro2000
-/maintainers/scripts/kde @K900 @NickCao @SuperSandro2000
+/pkgs/kde @NixOS/qt-kde
+/maintainers/scripts/kde @NixOS/qt-kde
 
 # PostgreSQL and related stuff
 /pkgs/by-name/po/postgresqlTestHook @NixOS/postgres


### PR DESCRIPTION
The change in #305356 set only people with commit access as codeowners for qt-kde related packages due to GItHubs requirement of needing to have write access for it to work. Since we are using a custom system in nixpkgs now, this is no longer the case and we can safely set the whole team as codeowners again.
This effectively reverts b1f432c350b4ab50921f0a009e494734e0bc38f6.


## Things done
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
