### PR TITLE
shards: 0.19.1 -> 0.20.0

### DIFF
--- a/pkgs/by-name/sh/shards/package.nix
+++ b/pkgs/by-name/sh/shards/package.nix
@@ -6,18 +6,22 @@
 
 crystal.buildCrystalPackage rec {
   pname = "shards";
-  version = "0.19.1";
+  version = "0.20.0";
 
   src = fetchFromGitHub {
     owner = "crystal-lang";
     repo = "shards";
     tag = "v${version}";
-    hash = "sha256-LOdI389nVsFXkKPKco1C+O710kBlWImzCvdBBYEsWQQ=";
+    hash = "sha256-Lij5ErYnX7zz/h+XYejLF/TRV4RMa2sG3TXBC0UOh5c=";
   };
 
   # we cannot use `make` or `shards` here as it would introduce a cyclical dependency
   format = "crystal";
-  shardsFile = ./shards.nix;
+  # the shards package only uses one dependency, which is github.com/crystal-lang/crystal-molinillo
+  # but that dependency got vendored into the same crystal-lang/shards repository, so
+  # a `shards.nix` file is no longer needed.
+  # Reference: https://github.com/crystal-lang/shards/pull/663
+  shardsFile = null;
   crystalBinaries.shards.src = "./src/shards.cr";
 
   # tries to execute git which fails spectacularly

--- a/pkgs/by-name/sh/shards/shards.nix
+++ b/pkgs/by-name/sh/shards/shards.nix
@@ -1,8 +1,0 @@
-{
-  molinillo = {
-    owner = "crystal-lang";
-    repo = "crystal-molinillo";
-    rev = "v0.2.0";
-    sha256 = "0pzi8pbrjn03zgk3kbha2kqqq0crmr8gy98dr05kisafvbghzwnh";
-  };
-}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updates the shards package to 0.20.0 and removes the shards.nix file, since shards has vendored their only dependency (github.com/crystal-lang/crystal-molinillo) into the shards repository.

Reference: https://github.com/crystal-lang/shards/pull/663

Running the output binary gives:

```
$ ./result/bin/shards --version
Shards 0.20.0 (1980-01-01)
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
