### PR TITLE
freescout 1.8.230 -> 1.8.232

### DIFF
--- a/nixos/tests/freescout/integration.nix
+++ b/nixos/tests/freescout/integration.nix
@@ -151,7 +151,7 @@ in
       machine.wait_for_unit("freescout-setup")
 
       with subtest("Login works"):
-        machine.succeed("/var/lib/freescout/artisan freescout:create-user --role=admin --firstName=Xenia --lastName=TheFox --email xenia@${freescoutDomain} --no-interaction --password=foo | grep 'User created with id'")
+        machine.succeed("/var/lib/freescout/artisan -- freescout:create-user --role=admin --firstName=Xenia --lastName=TheFox --email xenia@${freescoutDomain} --no-interaction --password=foo | grep 'User created with id'")
         token=machine.succeed("curl -fsSL --cookie-jar cjar 'http://${freescoutDomain}/login' | grep -Po '(?<= name=\"_token\" value=\")(\\w+)(?=\")'").strip()
         data=f"email=xenia%40${freescoutDomain}&password=foo&_token={token}&remember=on"
         machine.succeed(f"curl -sSfX POST --cookie-jar cjar --cookie cjar --data-raw '{data}' 'http://${freescoutDomain}/login' | grep 'Redirecting to'")

--- a/nixos/tests/freescout/integration.nix
+++ b/nixos/tests/freescout/integration.nix
@@ -26,7 +26,6 @@ let
       ...
     }:
     {
-      virtualisation.memorySize = 1024;
       environment.systemPackages = with pkgs; [
         curl
         sendInitial
@@ -99,7 +98,7 @@ let
       };
     };
 
-  mkNode =
+  mkContainer =
     dbType:
     { config, pkgs, ... }:
     {
@@ -118,14 +117,14 @@ in
     e1mo
   ];
 
-  nodes = {
+  containers = {
     # This may lead to duplicate tests, but ensures that
     # it's always tested on the current default version
     # even if the tests are not updated
-    freescout_pgsql = mkNode "pgsql";
+    freescout-pgsql = mkContainer "pgsql";
 
     # Same as the freescout_pgsql_default node
-    freescout_mysql = mkNode "mysql";
+    freescout-mysql = mkContainer "mysql";
   };
 
   testScript = ''

--- a/nixos/tests/freescout/upgrade.nix
+++ b/nixos/tests/freescout/upgrade.nix
@@ -73,7 +73,7 @@ in
 
       with subtest("Create user and log in"):
         # Create uesr
-        machine.succeed("/var/lib/freescout/artisan freescout:create-user --role=admin --firstName=Xenia --lastName=TheFox --email xenia@${freescoutDomain} --no-interaction --password=foo | grep 'User created with id'")
+        machine.succeed("/var/lib/freescout/artisan -- freescout:create-user --role=admin --firstName=Xenia --lastName=TheFox --email xenia@${freescoutDomain} --no-interaction --password=foo | grep 'User created with id'")
         # Obtain CSRF token
         token=machine.succeed("curl -fsSL --cookie-jar cjar 'http://${freescoutDomain}/login' | grep -Po '(?<= name=\"_token\" value=\")(\w+)(?=\")'").strip()
         # Actually log in

--- a/pkgs/by-name/fr/freescout/package.nix
+++ b/pkgs/by-name/fr/freescout/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.tests = lib.attrValues nixosTests.freescout;
+  passthru.tests = nixosTests.freescout;
 
   # Because freescout is searching for some folders only relative to it's own source location, we need to have the symlinks to the actual locations in here
   dontCheckForBrokenSymlinks = true;

--- a/pkgs/by-name/fr/freescout/package.nix
+++ b/pkgs/by-name/fr/freescout/package.nix
@@ -7,13 +7,13 @@
 stdenv.mkDerivation (finalAttrs: {
   preferLocalBuild = true;
   pname = "freescout";
-  version = "1.8.230";
+  version = "1.8.232";
 
   src = fetchFromGitHub {
     owner = "freescout-help-desk";
     repo = "freescout";
     tag = finalAttrs.version;
-    hash = "sha256-QAMZj1tUSaErLTJR8IfzatNw5G8lznA4mNa+a4Bd5rQ=";
+    hash = "sha256-dqUKfj9Y/CoU4hC8rq7XejVswaEOiZtFG6rsSGgljfY=";
   };
 
   patches = [


### PR DESCRIPTION
https://github.com/freescout-help-desk/freescout/releases/tag/1.8.231
https://github.com/freescout-help-desk/freescout/releases/tag/1.8.232

Fixes:  CVE-2026-59882, CVE-2026-45294, CVE-2026-45294

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
