### PR TITLE
exo: enable __structuredAttrs, fix build

### DIFF
--- a/pkgs/by-name/ex/exo/package.nix
+++ b/pkgs/by-name/ex/exo/package.nix
@@ -29,8 +29,12 @@ let
 
   pyo3-bindings = python3Packages.buildPythonPackage (finalAttrs: {
     pname = "exo-pyo3-bindings";
-    inherit version src;
+    # Check version in
+    # https://github.com/exo-explore/exo/blob/v<EXO_VERSION>/rust/exo_pyo3_bindings/pyproject.toml
+    version = "0.2.1";
+    inherit src;
     pyproject = true;
+    __structuredAttrs = true;
 
     buildAndTestSubdir = "rust/exo_pyo3_bindings";
 
@@ -54,6 +58,7 @@ let
   dashboard = buildNpmPackage (finalAttrs: {
     pname = "exo-dashboard";
     inherit src version;
+    __structuredAttrs = true;
 
     sourceRoot = "${finalAttrs.src.name}/dashboard";
     npmDepsFetcherVersion = 3;
@@ -73,6 +78,7 @@ in
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "exo";
   pyproject = true;
+  __structuredAttrs = true;
 
   inherit version src;
 


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
