### PR TITLE
treewide: follow some GitHub redirects for fetchFromGitHub

### DIFF
--- a/pkgs/by-name/tr/trimal/package.nix
+++ b/pkgs/by-name/tr/trimal/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     repo = "trimal";
-    owner = "scapella";
+    owner = "inab";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-ONSkYceCgYGSpABj0iOx6yj2hMyFHqCHflYRW+Q6RVc=";
   };

--- a/pkgs/by-name/tr/trunk-recorder/package.nix
+++ b/pkgs/by-name/tr/trunk-recorder/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "5.1.1";
 
   src = fetchFromGitHub {
-    owner = "robotastic";
+    owner = "TrunkRecorder";
     repo = "trunk-recorder";
     rev = "v${finalAttrs.version}";
     hash = "sha256-2qy6krI5NglkC+bUFfJaEuHIcBoYJrxBRnFs8O0NcZA=";
@@ -72,7 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Record calls from trunked radio systems";
     homepage = "https://trunkrecorder.com/";
-    changelog = "https://github.com/robotastic/trunk-recorder/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/TrunkRecorder/trunk-recorder/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ PapayaJackal ];
     mainProgram = "trunk-recorder";

--- a/pkgs/by-name/tu/tuner/package.nix
+++ b/pkgs/by-name/tu/tuner/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.0.0";
 
   src = fetchFromGitHub {
-    owner = "louis77";
+    owner = "tuner-labs";
     repo = "tuner";
     tag = "v${finalAttrs.version}";
     hash = "sha256-i6I5NSwiS8FJuZaHbrXvUcumo9RZvEVPcfKOkHUXiLo=";
@@ -55,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
-    homepage = "https://github.com/louis77/tuner";
+    homepage = "https://github.com/tuner-labs/tuner";
     description = "App to discover and play internet radio stations";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/tv/tvm/package.nix
+++ b/pkgs/by-name/tv/tvm/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "apache";
-    repo = "incubator-tvm";
+    repo = "tvm";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-+YnxYIGaPMgfLDsQEiCpqGuJRBTFEbXWI1L2JdnUyfI=";

--- a/pkgs/by-name/ty/tyson/package.nix
+++ b/pkgs/by-name/ty/tyson/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
   version = "0.1.1-unstable-2024-04-10";
 
   src = fetchFromGitHub {
-    owner = "jetpack-io";
+    owner = "jetify-com";
     repo = "tyson";
     rev = "d6b38819db9b260928b29f4d39bf4c72841c6a01";
     hash = "sha256-NoQJBEedV3NDNQ4PVvvjjsO7N+rq40LWKp962P+naEY=";

--- a/pkgs/by-name/ue/uesave/package.nix
+++ b/pkgs/by-name/ue/uesave/package.nix
@@ -9,7 +9,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.7.1";
   src = fetchFromGitHub {
     owner = "trumank";
-    repo = "uesave-rs";
+    repo = "uesave";
     rev = "v${finalAttrs.version}";
     hash = "sha256-lGtRe3AYJ59CwRaDznO6RNqVFCSKJPWVDhj0tnY5xcs=";
   };
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     maintainers = with lib.maintainers; [ xddxdd ];
     description = "Reading and writing Unreal Engine save files (commonly referred to as GVAS)";
-    homepage = "https://github.com/trumank/uesave-rs";
+    homepage = "https://github.com/trumank/uesave";
     license = lib.licenses.mit;
     mainProgram = "uesave";
   };

--- a/pkgs/by-name/ul/ultimate-doom-builder/package.nix
+++ b/pkgs/by-name/ul/ultimate-doom-builder/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0-unstable-2026-02-01";
 
   src = fetchFromGitHub {
-    owner = "jewalky";
+    owner = "UltimateDoomBuilder";
     repo = "UltimateDoomBuilder";
     rev = "9d7a12b1164dc53964b594395f9d5d825a43ac12";
     hash = "sha256-FwGfrvF+UrmEw1lvcU4qL9OOP0n/ZmQTsIjQIxRvkmg=";
@@ -129,7 +129,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = unstableGitUpdater { };
 
   meta = {
-    homepage = "https://github.com/jewalky/UltimateDoomBuilder";
+    homepage = "https://github.com/UltimateDoomBuilder/UltimateDoomBuilder";
     description = "Advanced Doom map editor based on Doom Builder 2 with Mono support";
     mainProgram = "ultimate-doom-builder";
     longDescription = ''

--- a/pkgs/by-name/ul/ultralist/package.nix
+++ b/pkgs/by-name/ul/ultralist/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "1.7.0";
 
   src = fetchFromGitHub {
-    owner = "ultralist";
+    owner = "gammons";
     repo = "ultralist";
     rev = finalAttrs.version;
     sha256 = "sha256-GGBW6rpwv1bVbLTD//cU8jNbq/27Ls0su7DymCJTSmY=";

--- a/pkgs/by-name/un/unpackerr/package.nix
+++ b/pkgs/by-name/un/unpackerr/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "0.15.2";
 
   src = fetchFromGitHub {
-    owner = "davidnewhall";
+    owner = "Unpackerr";
     repo = "unpackerr";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-npq0CXsaWaFa6RazQXRKVaqTyK87VhzaF/hd/d952Po=";

--- a/pkgs/by-name/ut/utpm/package.nix
+++ b/pkgs/by-name/ut/utpm/package.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.3.0";
 
   src = fetchFromGitHub {
-    owner = "Thumuss";
+    owner = "typst-community";
     repo = "utpm";
     tag = "v${finalAttrs.version}";
     hash = "sha256-MGvPj+qF05zc2rPf1LxWVIpkZGOoDj09UfCZbQ/lBOM=";
@@ -53,7 +53,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       new projects and templates from a singular tool, and then publish it directly
       to Typst!
     '';
-    homepage = "https://github.com/Thumuss/utpm";
+    homepage = "https://github.com/typst-community/utpm";
     license = lib.licenses.mit;
     mainProgram = "utpm";
     maintainers = with lib.maintainers; [ louis-thevenet ];

--- a/pkgs/by-name/uw/uwufetch/package.nix
+++ b/pkgs/by-name/uw/uwufetch/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.1";
 
   src = fetchFromGitHub {
-    owner = "TheDarkBug";
+    owner = "ad-oliviero";
     repo = "uwufetch";
     rev = finalAttrs.version;
     hash = "sha256-cA8sajh+puswyKikr0Jp9ei+EpVkH+vhEp+pTerkUqA=";
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Meme system info tool for Linux";
-    homepage = "https://github.com/TheDarkBug/uwufetch";
+    homepage = "https://github.com/ad-oliviero/uwufetch";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ bbjubjub ];

--- a/pkgs/by-name/va/vale-ls/package.nix
+++ b/pkgs/by-name/va/vale-ls/package.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.4.0";
 
   src = fetchFromGitHub {
-    owner = "errata-ai";
+    owner = "vale-cli";
     repo = "vale-ls";
     tag = "v${finalAttrs.version}";
     hash = "sha256-lRRKRQTxgXF4E+XghJ5AOp+mtWtiCT13EcsPVydn4Uo=";
@@ -51,7 +51,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "LSP implementation for the Vale command-line tool";
-    homepage = "https://github.com/errata-ai/vale-ls";
+    homepage = "https://github.com/vale-cli/vale-ls";
     license = lib.licenses.mit;
     mainProgram = "vale-ls";
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/va/vale/package.nix
+++ b/pkgs/by-name/va/vale/package.nix
@@ -16,7 +16,7 @@ buildGoModule rec {
   subPackages = [ "cmd/vale" ];
 
   src = fetchFromGitHub {
-    owner = "errata-ai";
+    owner = "vale-cli";
     repo = "vale";
     tag = "v${version}";
     hash = "sha256-FChOhCgvV/jO795nKlkbnGiB9oFCA8XmJBlgH+DyYvs=";
@@ -61,7 +61,7 @@ buildGoModule rec {
       ```
     '';
     homepage = "https://vale.sh/";
-    changelog = "https://github.com/errata-ai/vale/releases/tag/v${version}";
+    changelog = "https://github.com/vale-cli/vale/releases/tag/v${version}";
     mainProgram = "vale";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ pbsds ];

--- a/pkgs/by-name/va/vapoursynth-eedi3/package.nix
+++ b/pkgs/by-name/va/vapoursynth-eedi3/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   version = "unstable-2019-09-30";
 
   src = fetchFromGitHub {
-    owner = "HomeOfVapourSynthEvolution";
+    owner = "HolyWu";
     repo = "VapourSynth-EEDI3";
     rev = "d11bdb37c7a7118cd095b53d9f8fbbac02a06ac0";
     hash = "sha256-MIUf6sOnJ2uqGw3ixEHy1ijzlLFkQauwtm1vfgmYmcg=";
@@ -47,7 +47,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Filter for VapourSynth";
-    homepage = "https://github.com/HomeOfVapourSynthEvolution/VapourSynth-EEDI3";
+    homepage = "https://github.com/HolyWu/VapourSynth-EEDI3";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ snaki ];
     platforms = lib.platforms.x86_64;

--- a/pkgs/by-name/va/vapoursynth-mvtools/package.nix
+++ b/pkgs/by-name/va/vapoursynth-mvtools/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "24";
 
   src = fetchFromGitHub {
-    owner = "dubhater";
+    owner = "dubhatervapoursynth";
     repo = "vapoursynth-mvtools";
     rev = "v${finalAttrs.version}";
     hash = "sha256-bEifU1PPNOBr6o9D6DGIzTaG4xjygBxkQYnZxd/4SwQ=";
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Set of filters for motion estimation and compensation";
-    homepage = "https://github.com/dubhater/vapoursynth-mvtools";
+    homepage = "https://github.com/dubhatervapoursynth/vapoursynth-mvtools";
     license = lib.licenses.gpl2;
     maintainers = with lib.maintainers; [ rnhmjoj ];
   };

--- a/pkgs/by-name/va/variant-lite/package.nix
+++ b/pkgs/by-name/va/variant-lite/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.0.0";
 
   src = fetchFromGitHub {
-    owner = "martinmoene";
+    owner = "nonstd-lite";
     repo = "variant-lite";
     tag = "v${finalAttrs.version}";
     hash = "sha256-+1eSnn7eN8iN6vZg3Qz2m7u1ukWimhUQ+WHXQL4rQco=";
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    # https://github.com/martinmoene/variant-lite/issues/50
+    # https://github.com/nonstd-lite/variant-lite/issues/50
     (lib.cmakeBool "VARIANT_LITE_OPT_BUILD_TESTS" false)
   ];
 
@@ -35,8 +35,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "C++17-like variant, a type-safe union for C++98, C++11 and later in a single-file header-only library";
-    homepage = "https://github.com/martinmoene/variant-lite";
-    changelog = "https://github.com/martinmoene/variant-lite/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/nonstd-lite/variant-lite";
+    changelog = "https://github.com/nonstd-lite/variant-lite/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.boost;
     maintainers = with lib.maintainers; [ titaniumtown ];
   };

--- a/pkgs/by-name/ve/velero/package.nix
+++ b/pkgs/by-name/ve/velero/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
   version = "1.18.0";
 
   src = fetchFromGitHub {
-    owner = "vmware-tanzu";
+    owner = "velero-io";
     repo = "velero";
     tag = "v${finalAttrs.version}";
     hash = "sha256-LhoJDIK0S3w2RTpMC7QDcU1nHMUk4rNZSCY/1Wfiaqc=";
@@ -35,7 +35,7 @@ buildGoModule (finalAttrs: {
     "velero-restic-restore-helper"
   ];
 
-  doCheck = false; # Tests expect a running cluster see https://github.com/vmware-tanzu/velero/tree/main/test/e2e
+  doCheck = false; # Tests expect a running cluster see https://github.com/velero-io/velero/tree/main/test/e2e
   doInstallCheck = true;
   installCheckPhase = ''
     $out/bin/velero version --client-only | grep ${finalAttrs.version} > /dev/null
@@ -51,7 +51,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Utility for managing disaster recovery, specifically for your Kubernetes cluster resources and persistent volumes";
     homepage = "https://velero.io/";
-    changelog = "https://github.com/vmware-tanzu/velero/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/velero-io/velero/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       mbode

--- a/pkgs/by-name/ve/vendir/package.nix
+++ b/pkgs/by-name/ve/vendir/package.nix
@@ -9,8 +9,8 @@ buildGoModule (finalAttrs: {
   version = "0.46.0";
 
   src = fetchFromGitHub {
-    owner = "vmware-tanzu";
-    repo = "carvel-vendir";
+    owner = "carvel-dev";
+    repo = "vendir";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-X9tyEeE6QrUQaRlbhRkd+Lz7+bFJrWO2Dn8e0ax7Pdg=";
   };

--- a/pkgs/by-name/vi/vipsdisp/package.nix
+++ b/pkgs/by-name/vi/vipsdisp/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   version = "4.1.4";
 
   src = fetchFromGitHub {
-    owner = "jcupitt";
+    owner = "libvips";
     repo = "vipsdisp";
     tag = "v${version}";
     hash = "sha256-DXXDU/EtpWfNvV0PhQ+qjlxTBNERn9GGNeD00n9ejN0=";
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   doCheck = false;
 
   meta = {
-    homepage = "https://github.com/jcupitt/vipsdisp";
+    homepage = "https://github.com/libvips/vipsdisp";
     description = "Tiny image viewer with libvips";
     license = lib.licenses.mit;
     mainProgram = "vipsdisp";

--- a/pkgs/by-name/vm/vmaware/package.nix
+++ b/pkgs/by-name/vm/vmaware/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
-    owner = "kernelwernel";
+    owner = "NotRequiem";
     repo = "VMAware";
     tag = "v${finalAttrs.version}";
     hash = "sha256-KPjIk5nm27RcxGg3owfLVt+b1sL0y90IPPgeGv7fTgQ=";
@@ -30,8 +30,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Cross-platform C++ library and CLI tool for virtual machine detection";
-    homepage = "https://github.com/kernelwernel/VMAware";
-    changelog = "https://github.com/kernelwernel/VMAware/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/NotRequiem/VMAware";
+    changelog = "https://github.com/NotRequiem/VMAware/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ patrickdag ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/vt/vtm/package.nix
+++ b/pkgs/by-name/vt/vtm/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.9.99.61";
 
   src = fetchFromGitHub {
-    owner = "netxs-group";
+    owner = "directvt";
     repo = "vtm";
     rev = "v${finalAttrs.version}";
     hash = "sha256-IlJbJw2c2Zgl+W5Jh01Iga8duiLgl/GurT620IhPh68=";

--- a/pkgs/by-name/wa/wagyu/package.nix
+++ b/pkgs/by-name/wa/wagyu/package.nix
@@ -9,7 +9,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.6.3";
 
   src = fetchFromGitHub {
-    owner = "AleoHQ";
+    owner = "howardwu";
     repo = "wagyu";
     rev = "v${finalAttrs.version}";
     hash = "sha256-5n8BmETv5jUvgu0rskAPYaBgYyNL2QU2t/iUb3hNMMw=";
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Rust library for generating cryptocurrency wallets";
-    homepage = "https://github.com/AleoHQ/wagyu";
+    homepage = "https://github.com/howardwu/wagyu";
     license = with lib.licenses; [
       mit
       asl20

--- a/pkgs/by-name/wa/wamr/package.nix
+++ b/pkgs/by-name/wa/wamr/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.4.4";
 
   src = fetchFromGitHub {
-    owner = "bytecodealliance";
+    owner = "wasm-micro-runtime";
     repo = "wasm-micro-runtime";
     tag = "WAMR-${finalAttrs.version}";
     hash = "sha256-pNudBKnhdR/Ye0m2tVZB/wSfJZYK8+gdCpCp0rDp0o4=";
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "WebAssembly Micro Runtime";
-    homepage = "https://github.com/bytecodealliance/wasm-micro-runtime";
+    homepage = "https://github.com/wasm-micro-runtime/wasm-micro-runtime";
     license = lib.licenses.asl20;
     mainProgram = "iwasm";
     maintainers = with lib.maintainers; [ ereslibre ];

--- a/pkgs/by-name/wa/wamrc/package.nix
+++ b/pkgs/by-name/wa/wamrc/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.4.5";
 
   src = fetchFromGitHub {
-    owner = "bytecodealliance";
+    owner = "wasm-micro-runtime";
     repo = "wasm-micro-runtime";
     tag = "WAMR-${finalAttrs.version}";
     hash = "sha256-HBew8kbi7AaKrAEZbPIlXqiO+1wDljSzEsE9+FWzxHE=";
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "WebAssembly Micro Runtime AOT compiler";
-    homepage = "https://github.com/bytecodealliance/wasm-micro-runtime";
+    homepage = "https://github.com/wasm-micro-runtime/wasm-micro-runtime";
     license = lib.licenses.asl20;
     mainProgram = "wamrc";
     maintainers = with lib.maintainers; [ bubblepipe ];

--- a/pkgs/by-name/wa/wasynth/package.nix
+++ b/pkgs/by-name/wa/wasynth/package.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.13.0";
 
   src = fetchFromGitHub {
-    owner = "Rerumu";
+    owner = "SovereignSatellite";
     repo = "Wasynth";
     tag = "v${finalAttrs.version}";
     hash = "sha256-0Gtqet6KKLtooh9cU2R/top142AeT+uIxFwe1dPTvAU=";
@@ -41,7 +41,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
        * wasm2luajit: translate WebAssembly to LuaJIT source code
        * wasm2luau: translate WebAssembly Luau source code
     '';
-    homepage = "https://github.com/Rerumu/Wasynth";
+    homepage = "https://github.com/SovereignSatellite/Wasynth";
     license = lib.licenses.gpl3Only;
     maintainers = [ ];
   };

--- a/pkgs/by-name/wa/waydroid-helper/package.nix
+++ b/pkgs/by-name/wa/waydroid-helper/package.nix
@@ -30,7 +30,7 @@ let
   version = "0.2.9";
 
   src = fetchFromGitHub {
-    owner = "ayasa520";
+    owner = "waydroid-helper";
     repo = "waydroid-helper";
     tag = "v${version}";
     hash = "sha256-6mVb4GPD2NCsvyaqQAOFox0rNIlyOttiaZKbHBS40Rg=";
@@ -122,9 +122,9 @@ python3Packages.buildPythonApplication {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    changelog = "https://github.com/ayasa520/waydroid-helper/releases/tag/${src.tag}";
+    changelog = "https://github.com/waydroid-helper/waydroid-helper/releases/tag/${src.tag}";
     description = "User-friendly way to configure Waydroid and install extensions, including Magisk and ARM translation";
-    homepage = "https://github.com/ayasa520/waydroid-helper";
+    homepage = "https://github.com/waydroid-helper/waydroid-helper";
     license = lib.licenses.gpl3Plus;
     mainProgram = "waydroid-helper";
     maintainers = [ ];

--- a/pkgs/by-name/wa/wayvr/package.nix
+++ b/pkgs/by-name/wa/wayvr/package.nix
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "26.7.1";
 
   src = fetchFromGitHub {
-    owner = "wlx-team";
+    owner = "wayvr-org";
     repo = "wayvr";
     tag = "v${finalAttrs.version}";
     hash = "sha256-SdHN3jDe2QJaRORy452RP7kTMxPOZOB/yjpApUOLhRU=";
@@ -92,7 +92,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Your way to enjoy VR on Linux! Access your Wayland/X11 desktop from SteamVR/Monado (OpenVR+OpenXR support)";
-    homepage = "https://github.com/wlx-team/wayvr";
+    homepage = "https://github.com/wayvr-org/wayvr";
     license = with lib.licenses; [
       gpl3Only
       mit # wayvr-ipc

--- a/pkgs/by-name/wa/wazero/package.nix
+++ b/pkgs/by-name/wa/wazero/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
   version = "1.12.0";
 
   src = fetchFromGitHub {
-    owner = "tetratelabs";
+    owner = "wazero";
     repo = "wazero";
     tag = "v${finalAttrs.version}";
     hash = "sha256-wq6fj6NDKaJbd+8lhrC5tH9lyUL/2Rc/T4Y39LYADsk=";
@@ -42,9 +42,9 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Zero dependency WebAssembly runtime for Go developers";
-    homepage = "https://github.com/tetratelabs/wazero";
+    homepage = "https://github.com/wazero/wazero";
     maintainers = with lib.maintainers; [ liberodark ];
-    changelog = "https://github.com/tetratelabs/wazero/releases/tag/${finalAttrs.src.tag}";
+    changelog = "https://github.com/wazero/wazero/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     mainProgram = "wazero";
   };

--- a/pkgs/by-name/we/wealthfolio/package.nix
+++ b/pkgs/by-name/we/wealthfolio/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.6.2";
 
   src = fetchFromGitHub {
-    owner = "afadil";
+    owner = "wealthfolio";
     repo = "wealthfolio";
     rev = "v${finalAttrs.version}";
     hash = "sha256-2Chwr7OifQ5PgRAnxDEeAxyYaxVQqS32mezqzUBKKyU=";

--- a/pkgs/by-name/wl/wlcs/package.nix
+++ b/pkgs/by-name/wl/wlcs/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.8.1";
 
   src = fetchFromGitHub {
-    owner = "MirServer";
+    owner = "canonical";
     repo = "wlcs";
     tag = "v${finalAttrs.version}";
     hash = "sha256-W4/a7neFcaqdPIAWDk5TcIuIWZ76rC7xCk3beJVqE/E=";
@@ -65,8 +65,8 @@ stdenv.mkDerivation (finalAttrs: {
       standard debugging tools can follow control flow from the test client to the
       compositor and back again.
     '';
-    homepage = "https://github.com/MirServer/wlcs";
-    changelog = "https://github.com/MirServer/wlcs/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/canonical/wlcs";
+    changelog = "https://github.com/canonical/wlcs/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ OPNA2608 ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/wl/wlinhibit/package.nix
+++ b/pkgs/by-name/wl/wlinhibit/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   version = "0.1.2";
 
   src = fetchFromGitHub {
-    owner = "0x5a4";
+    owner = "einetuer";
     repo = "wlinhibit";
     rev = "v0.1.2";
     hash = "sha256-mAEBnlIfW1R5+3CMH4ZumQ39Ss2K7PfW28I4/O9saWE=";
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
   meta = {
     description = "Simple, stupid idle inhibitor for wayland";
     license = lib.licenses.mit;
-    homepage = "https://github.com/0x5a4/wlinhibit";
+    homepage = "https://github.com/einetuer/wlinhibit";
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ _0x5a4 ];
   };

--- a/pkgs/by-name/wl/wluma/package.nix
+++ b/pkgs/by-name/wl/wluma/package.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "4.11.1";
 
   src = fetchFromGitHub {
-    owner = "maximbaz";
+    owner = "max-baz";
     repo = "wluma";
     tag = finalAttrs.version;
     hash = "sha256-va+y/dwJ4vTyuqn4VwVXQo8F2qWJPq6F6e9/7V4qDQQ=";
@@ -59,8 +59,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Automatic brightness adjustment based on screen contents and ALS";
-    homepage = "https://github.com/maximbaz/wluma";
-    changelog = "https://github.com/maximbaz/wluma/releases/tag/${finalAttrs.version}";
+    homepage = "https://github.com/max-baz/wluma";
+    changelog = "https://github.com/max-baz/wluma/releases/tag/${finalAttrs.version}";
     license = lib.licenses.isc;
     maintainers = with lib.maintainers; [
       yshym

--- a/pkgs/by-name/wo/world-serpant-search/package.nix
+++ b/pkgs/by-name/wo/world-serpant-search/package.nix
@@ -11,7 +11,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "Latrodect";
-    repo = "wss-repo-vulnerability-search-manager";
+    repo = "WSS";
     tag = "v${finalAttrs.version}";
     hash = "sha256-jXTivaXHHt63u9N7w40jyLUU2kg5LxAn50PVpqwUc0M=";
   };
@@ -32,7 +32,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   meta = {
     description = "Command-line tool for vulnerability detection";
-    homepage = "https://github.com/Latrodect/wss-repo-vulnerability-search-manager";
+    homepage = "https://github.com/Latrodect/WSS";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "serpant";

--- a/pkgs/by-name/wp/wprecon/package.nix
+++ b/pkgs/by-name/wp/wprecon/package.nix
@@ -9,7 +9,7 @@ buildGoModule rec {
   version = "2.4.5";
 
   src = fetchFromGitHub {
-    owner = "blackbinn";
+    owner = "ffx64";
     repo = "wprecon";
     rev = version;
     hash = "sha256-23zJD3Nnkeko+J2FjPq5RA5dIjORMXvwt3wtAYiVlQs=";
@@ -24,9 +24,9 @@ buildGoModule rec {
 
   meta = {
     description = "WordPress vulnerability recognition tool";
-    homepage = "https://github.com/blackbinn/wprecon";
+    homepage = "https://github.com/ffx64/wprecon";
     # License Zero Noncommercial Public License 2.0.1
-    # https://github.com/blackbinn/wprecon/blob/master/LICENSE
+    # https://github.com/ffx64/wprecon/blob/master/LICENSE
     license = lib.licenses.unfree;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/by-name/wr/wrap/package.nix
+++ b/pkgs/by-name/wr/wrap/package.nix
@@ -12,7 +12,7 @@ buildGoModule (finalAttrs: {
   version = "0.3.1";
 
   src = fetchFromGitHub {
-    owner = "Wraparound";
+    owner = "eprovst";
     repo = "wrap";
     rev = "v${finalAttrs.version}";
     hash = "sha256-58wsH/e3X72S7tJUObazyvvkI8+B7DLPTBmQO9A+jmk=";
@@ -25,12 +25,12 @@ buildGoModule (finalAttrs: {
   patches = [
     (fetchpatch {
       name = "courier-prime-variants.patch";
-      url = "https://github.com/Wraparound/wrap/commit/b72c280b6eddba9ec7b3507c1f143eb28a85c9c1.patch";
+      url = "https://github.com/eprovst/wrap/commit/b72c280b6eddba9ec7b3507c1f143eb28a85c9c1.patch";
       hash = "sha256-hcUsRyv6XVN+GyMN7LXzXPsp8jYUKTJPaK+e5p4CO7U=";
     })
     # Fix build on Go 1.17+
     (fetchpatch {
-      url = "https://github.com/Wraparound/wrap/commit/a222c18a7e0810486741684781ff6158a359a8ba.patch";
+      url = "https://github.com/eprovst/wrap/commit/a222c18a7e0810486741684781ff6158a359a8ba.patch";
       hash = "sha256-eIKvA91olfbNJhOhIUu3GOL/rbgX3m6unmU8nRdKbtc=";
     })
   ];
@@ -41,7 +41,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Fountain export tool with some extras";
-    homepage = "https://github.com/Wraparound/wrap";
+    homepage = "https://github.com/eprovst/wrap";
     license = lib.licenses.gpl3Only;
     maintainers = [ lib.maintainers.austinbutler ];
   };

--- a/pkgs/by-name/wy/wyoming-faster-whisper/package.nix
+++ b/pkgs/by-name/wy/wyoming-faster-whisper/package.nix
@@ -10,7 +10,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "rhasspy";
+    owner = "OHF-Voice";
     repo = "wyoming-faster-whisper";
     tag = "v${finalAttrs.version}";
     hash = "sha256-+RmP552zsvWbxIpfhmKNdU4EZSeEImUdaF827g6Tuco=";
@@ -58,9 +58,9 @@ python3Packages.buildPythonApplication (finalAttrs: {
   doCheck = false;
 
   meta = {
-    changelog = "https://github.com/rhasspy/wyoming-faster-whisper/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/OHF-Voice/wyoming-faster-whisper/releases/tag/v${finalAttrs.version}";
     description = "Wyoming Server for Faster Whisper";
-    homepage = "https://github.com/rhasspy/wyoming-faster-whisper";
+    homepage = "https://github.com/OHF-Voice/wyoming-faster-whisper";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ hexa ];
     mainProgram = "wyoming-faster-whisper";

--- a/pkgs/by-name/wy/wyoming-piper/package.nix
+++ b/pkgs/by-name/wy/wyoming-piper/package.nix
@@ -11,7 +11,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "rhasspy";
+    owner = "OHF-Voice";
     repo = "wyoming-piper";
     tag = "v${finalAttrs.version}";
     hash = "sha256-LKt1BNa9jrZIDUZxZvniZcPrAuUkwOs85uIiA5mFWyY=";
@@ -56,10 +56,10 @@ python3Packages.buildPythonApplication (finalAttrs: {
   ];
 
   meta = {
-    changelog = "https://github.com/rhasspy/wyoming-piper/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/OHF-Voice/wyoming-piper/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     description = "Wyoming Server for Piper";
     mainProgram = "wyoming-piper";
-    homepage = "https://github.com/rhasspy/wyoming-piper";
+    homepage = "https://github.com/OHF-Voice/wyoming-piper";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ hexa ];
   };

--- a/pkgs/by-name/x4/x4/package.nix
+++ b/pkgs/by-name/x4/x4/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.1.0";
 
   src = fetchFromGitHub {
-    owner = "pwnwriter";
+    owner = "bytehunt";
     repo = "x4";
     rev = "v${finalAttrs.version}";
     hash = "sha256-IF+8lu56fzYM79p7MiNpVLFIs2GKPlzw5pNXD/hT6BM=";
@@ -35,8 +35,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Execute shell commands to server(s) via ssh protocol";
-    homepage = "https://github.com/pwnwriter/x4";
-    changelog = "https://github.com/pwnwriter/x4/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    homepage = "https://github.com/bytehunt/x4";
+    changelog = "https://github.com/bytehunt/x4/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ pwnwriter ];
     mainProgram = "x4";

--- a/pkgs/by-name/xc/xcbuild/package.nix
+++ b/pkgs/by-name/xc/xcbuild/package.nix
@@ -68,7 +68,7 @@ stdenv'.mkDerivation (finalAttrs: {
 
   version = "0.1.1-unstable-2019-11-20";
   src = fetchFromGitHub {
-    owner = "facebook";
+    owner = "facebookarchive";
     repo = "xcbuild";
     rev = "dbaee552d2f13640773eb1ad3c79c0d2aca7229c";
     hash = "sha256-7mvSuRCWU/LlIBdmnC59F4SSzJPEcQhlmEK13PNe1xc=";
@@ -168,7 +168,7 @@ stdenv'.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Xcode-compatible build tool";
-    homepage = "https://github.com/facebook/xcbuild";
+    homepage = "https://github.com/facebookarchive/xcbuild";
     license = with lib.licenses; [
       bsd2
       bsd3

--- a/pkgs/by-name/xd/xdelta/package.nix
+++ b/pkgs/by-name/xd/xdelta/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     sha256 = "09mmsalc7dwlvgrda56s2k927rpl3a5dzfa88aslkqcjnr790wjy";
     rev = "v${finalAttrs.version}";
-    repo = "xdelta-devel";
+    repo = "xdelta-gpl";
     owner = "jmacd";
   };
 

--- a/pkgs/by-name/xi/xits-math/package.nix
+++ b/pkgs/by-name/xi/xits-math/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.302";
 
   src = fetchFromGitHub {
-    owner = "alif-type";
+    owner = "aliftype";
     repo = "xits";
     rev = "v${finalAttrs.version}";
     sha256 = "1x3r505dylz9rz8dj98h5n9d0zixyxmvvhnjnms9qxdrz9bxy9g1";
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "https://github.com/alif-type/xits";
+    homepage = "https://github.com/aliftype/xits";
     description = "OpenType implementation of STIX fonts with math support";
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;

--- a/pkgs/by-name/xk/xkb-switch/package.nix
+++ b/pkgs/by-name/xk/xkb-switch/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.8.5";
 
   src = fetchFromGitHub {
-    owner = "ierton";
+    owner = "sergei-mironov";
     repo = "xkb-switch";
     rev = finalAttrs.version;
     sha256 = "sha256-DZAIL6+D+Hgs+fkJwRaQb9BHrEjAkxiqhOZyrR+Mpuk=";
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Switch your X keyboard layouts from the command line";
-    homepage = "https://github.com/ierton/xkb-switch";
+    homepage = "https://github.com/sergei-mironov/xkb-switch";
     license = lib.licenses.gpl2Plus;
     maintainers = [ ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/xm/xmcp/package.nix
+++ b/pkgs/by-name/xm/xmcp/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
   version = "0-unstable-2020-10-10";
 
   src = fetchFromGitHub {
-    owner = "blblapco";
+    owner = "glblapco";
     repo = "xmcp";
     rev = "ee56225f1665f9edc04fe5c165809f2fe160a420";
     sha256 = "sha256-B3YkYrVEg6UJ2ApaVook4N2XvrCboxDMUG5CN9I79Sg=";
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Tiny color picker for X11";
-    homepage = "https://github.com/blblapco/xmcp";
+    homepage = "https://github.com/glblapco/xmcp";
     license = lib.licenses.gpl3Plus;
     maintainers = [ ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/xs/xscast/package.nix
+++ b/pkgs/by-name/xs/xscast/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
   version = "2016-07-26";
 
   src = fetchFromGitHub {
-    owner = "KeyboardFire";
+    owner = "tckmn";
     repo = "xscast";
     rev = "9e6fd3c28d3f5ae630619f6dbccaf1f6ca594b21";
     sha256 = "0br27bq9bpglfdpv63h827bipgvhlh10liyhmhcxls4227kagz72";
@@ -47,7 +47,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    homepage = "https://github.com/KeyboardFire/xscast";
+    homepage = "https://github.com/tckmn/xscast";
     license = lib.licenses.mit;
     description = "Screencasts of windows with list of keystrokes overlayed";
     maintainers = [ ];

--- a/pkgs/by-name/ya/yaml-schema-router/package.nix
+++ b/pkgs/by-name/ya/yaml-schema-router/package.nix
@@ -10,7 +10,7 @@ buildGoModule (finalAttrs: {
   version = "0.2.0";
 
   src = fetchFromGitHub {
-    owner = "traiproject";
+    owner = "tepea-code";
     repo = "yaml-schema-router";
     tag = "v${finalAttrs.version}";
     hash = "sha256-GFe5NPW8nxv+bQsG5G26WCf2Z6qrW1WAZBMWFZD8MFI=";
@@ -27,8 +27,8 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Content-based JSON schema routing for yaml-language-server";
-    homepage = "https://github.com/traiproject/yaml-schema-router";
-    changelog = "https://github.com/traiproject/yaml-schema-router/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/tepea-code/yaml-schema-router";
+    changelog = "https://github.com/tepea-code/yaml-schema-router/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ kpbaks ];
     mainProgram = "yaml-schema-router";

--- a/pkgs/by-name/ye/yek/package.nix
+++ b/pkgs/by-name/ye/yek/package.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage {
   version = version;
 
   src = fetchFromGitHub {
-    owner = "bodo-run";
+    owner = "mohsen1";
     repo = "yek";
     tag = "v${version}";
     hash = "sha256-CuTIBAZjlAnacrCEUf8zwclyNQHNUPhjc+9Uk2QQ5HY=";
@@ -48,8 +48,8 @@ rustPlatform.buildRustPackage {
     longDescription = ''
       Tool to read text-based files, chunk them, and serialize them for LLM consumption.
     '';
-    homepage = "https://github.com/bodo-run/yek";
-    changelog = "https://github.com/bodo-run/yek/releases/tag/v${version}";
+    homepage = "https://github.com/mohsen1/yek";
+    changelog = "https://github.com/mohsen1/yek/releases/tag/v${version}";
     license = lib.licenses.mit;
     mainProgram = "yek";
     maintainers = with lib.maintainers; [ louis-thevenet ];

--- a/pkgs/by-name/yo/youki/package.nix
+++ b/pkgs/by-name/yo/youki/package.nix
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.6.0";
 
   src = fetchFromGitHub {
-    owner = "containers";
+    owner = "youki-dev";
     repo = "youki";
     rev = "v${finalAttrs.version}";
     hash = "sha256-O5tk/W2Bybq+6aY7FX/AcJtBKWEYI2Ywk7vYLqvuFos=";

--- a/pkgs/by-name/yu/yubikey-touch-detector/package.nix
+++ b/pkgs/by-name/yu/yubikey-touch-detector/package.nix
@@ -14,7 +14,7 @@ buildGoModule (finalAttrs: {
   version = "1.13.0";
 
   src = fetchFromGitHub {
-    owner = "maximbaz";
+    owner = "max-baz";
     repo = "yubikey-touch-detector";
     tag = finalAttrs.version;
     hash = "sha256-aHR/y8rAKS+dMvRdB3oAmOiI7hTA6qlF4Z05OjwYOO4=";
@@ -50,7 +50,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Tool to detect when your YubiKey is waiting for a touch";
-    homepage = "https://github.com/maximbaz/yubikey-touch-detector";
+    homepage = "https://github.com/max-baz/yubikey-touch-detector";
     maintainers = with lib.maintainers; [ sumnerevans ];
     license = lib.licenses.isc;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/z6/z64decompress/package.nix
+++ b/pkgs/by-name/z6/z64decompress/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.0.3-unstable-2023-12-21";
 
   src = fetchFromGitHub {
-    owner = "z64tools";
+    owner = "z64dev";
     repo = "z64decompress";
     rev = "e2b3707271994a2a1b3afc6c3997a7cf6b479765";
     hash = "sha256-PHiOeEB9njJPsl6ScdoDVwJXGqOdIIJCZRbIXSieBIY=";
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Zelda 64 rom decompressor";
-    homepage = "https://github.com/z64tools/z64decompress";
+    homepage = "https://github.com/z64dev/z64decompress";
     license = with lib.licenses; [
       gpl3Only
 

--- a/pkgs/by-name/zi/zincsearch/package.nix
+++ b/pkgs/by-name/zi/zincsearch/package.nix
@@ -8,7 +8,7 @@
 let
   version = "0.4.10-unstable-2024-10-25";
   src = fetchFromGitHub {
-    owner = "zinclabs";
+    owner = "zincsearch";
     repo = "zincsearch";
     rev = "0652db6d39badc753f28ee1122dcbc0e5da1c35e";
     hash = "sha256-Py4fiZJ2fMwPe2afd19brR+62PGVoU67nMDMPlUFhKQ=";

--- a/pkgs/by-name/zs/zsh-powerlevel9k/package.nix
+++ b/pkgs/by-name/zs/zsh-powerlevel9k/package.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
   pname = "powerlevel9k";
   version = "2017-11-10";
   src = fetchFromGitHub {
-    owner = "bhilburn";
+    owner = "Powerlevel9k";
     repo = "powerlevel9k";
     rev = "87acc51acab3ed4fd33cda2386abed6f98c80720";
     sha256 = "0v1dqg9hvycdkcvklg2njff97xwr8rah0nyldv4xm39r77f4yfvq";
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
       To make use of this derivation, use
       `programs.zsh.promptInit = "source ''${pkgs.zsh-powerlevel9k}/share/zsh-powerlevel9k/powerlevel9k.zsh-theme";`
     '';
-    homepage = "https://github.com/bhilburn/powerlevel9k";
+    homepage = "https://github.com/Powerlevel9k/powerlevel9k";
     license = lib.licenses.mit;
 
     platforms = lib.platforms.unix;

--- a/pkgs/tools/networking/openvpn/update-resolv-conf.nix
+++ b/pkgs/tools/networking/openvpn/update-resolv-conf.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
   version = "unstable-2017-06-21";
 
   src = fetchFromGitHub {
-    owner = "masterkorp";
+    owner = "alfredopalhares";
     repo = "openvpn-update-resolv-conf";
     rev = "43093c2f970bf84cd374e18ec05ac6d9cae444b8";
     sha256 = "1lf66bsgv2w6nzg1iqf25zpjf4ckcr45adkpgdq9gvhkfnvlp8av";
@@ -40,7 +40,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Script to update your /etc/resolv.conf with DNS settings that come from the received push dhcp-options";
-    homepage = "https://github.com/masterkorp/openvpn-update-resolv-conf/";
+    homepage = "https://github.com/alfredopalhares/openvpn-update-resolv-conf/";
     maintainers = [ ];
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.unix;


### PR DESCRIPTION
This PR updates some `fetchFromGitHub` calls and corresponding `github.com/<owner>/<repo>` links in the same location to point directly to canonical repositories instead of redirecting URLs.

This doesn't update all `fetchFromGitHub` redirects since that would produce a diff too large for maintainers to review.

**Motivation:**
This avoids silent failures if upstream redirects ever change or disappear, and improves reliability and reproducibility of fetches.

**How:**
Changes were generated using [this script](https://git.kybe.xyz/2kybe3/nixpkgs-github-redirect).

**How to verify:**
You can verify that all modified package sources still build using the following script with a `changed.txt` file containing the changed package list.

<details>
  <summary>Verify script</summary>

```bash
#!/usr/bin/env bash

out="result.txt"
: > "$out"

while read -r pkg; do
    echo "=== $pkg ==="

    output=$(nix build "./nixpkgs#$pkg.src" -L -v --rebuild --no-link --print-out-paths)
    status=$?

    if [ $status -eq 0 ]; then
        echo "$pkg: success | $output" | tee -a "$out"
    else
        echo "$pkg: failed" | tee -a "$out"
    fi
done < ./changed.txt
```
</details>

<details>
  <summary>Changed Packages</summary>

```
trimal
trunk-recorder
tuner
tvm
tyson
uesave
ultimate-doom-builder
ultralist
unpackerr
update-resolv-conf
utpm
vale
vale-ls
uwufetch
vapoursynth-mvtools
vapoursynth-eedi3
variant-lite
vendir
velero
vipsdisp
vmaware
wagyu
wamr
vtm
wamrc
wasynth
wayvr
wazero
waydroid-helper
wealthfolio
wlinhibit
wlcs
wluma
wprecon
wrap
world-serpant-search
wyoming-faster-whisper
x4
wyoming-piper
xcbuild
xdelta
xits-math
xmcp
xkb-switch
xscast
yaml-schema-router
yek
youki
z64decompress
yubikey-touch-detector
zincsearch
zsh-powerlevel9k
```
</details>

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
