### PR TITLE
ratatouille: init at 0.90.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6288,6 +6288,11 @@
     githubId = 28959268;
     keys = [ { fingerprint = "4779 D1D5 3C97 2EAE 34A5  ED3D D8AF C4BF 0567 0F9D"; } ];
   };
+  dappermint = {
+    github = "dappermint";
+    githubId = 198710911;
+    name = "millia ampora";
+  };
   dariof4 = {
     name = "dariof4";
     email = "dazedtank@gmail.com";

--- a/pkgs/by-name/ra/ratatouille/package.nix
+++ b/pkgs/by-name/ra/ratatouille/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "ratatouille";
+  version = "0.90.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "dappermint";
+    repo = "ratatouille";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-yzSrI93yRESEPScxh1VyxsYzLBJIfJQLA4VP208vIO8=";
+  };
+
+  vendorHash = null;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  postInstall = ''
+    ln -s ratatouille "$out/bin/rat"
+  '';
+
+  meta = {
+    description = "Whole-surface macOS storage accounting and cleanup TUI";
+    longDescription = ''
+      Terminal app that accounts for every byte of a Mac's storage instead of
+      listing findings. It maps the APFS containers, walks the data volume with
+      a device-bounded scan where each level sums to its parent, names the space
+      it could not read rather than dropping it, and reports filesystem health
+      from SMART and NVMe error counters. Cleanup uses each tool's own supported
+      command and moves path-based removals to Trash.
+    '';
+    homepage = "https://github.com/dappermint/ratatouille";
+    changelog = "https://github.com/dappermint/ratatouille/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "ratatouille";
+    maintainers = with lib.maintainers; [ dappermint ];
+    platforms = lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
## Description of changes

Adds `ratatouille`, a macOS-only terminal app for storage accounting and cleanup.

macOS Storage settings reports a category breakdown it will not let you open, and third-party tools generally list findings without reconciling them against what the volume actually holds. This one accounts for the whole surface: it reads the APFS containers via `diskutil`, maps per-volume usage, then walks the data volume with a device-bounded scan where every level sums to its parent. Space it cannot attribute gets an explicit row rather than being dropped, so the reported total reconciles with `CapacityInUse`.

Cleanup actions delegate to each tool's own supported command (`brew cleanup`, `uv cache prune`, `npm cache verify`, `go clean`, `nix store gc`, `docker system prune`); path-based removals move to Trash. Large application data is shown as protected and is never selectable.

Also reports filesystem health from read-only sources already gathered during the walk: SMART verdict, NVMe media errors and error-log entries, spare blocks, endurance, container accounting, and IO errors seen while reading directory metadata.

Darwin only, by nature: it depends on APFS containers, firmlinks, `diskutil`, and `getfsstat` flags.

- Upstream: https://github.com/dappermint/ratatouille
- License: GPL-3.0-only
- Pure standard library, no vendored dependencies (`vendorHash = null`)
- The upstream test suite runs in `checkPhase` and passes in the sandbox; tests that need real mounts skip when those are absent

Built and run on `aarch64-darwin` from the tagged source. `nixpkgs-review` was not run: this is a new leaf package with no reverse dependencies, so building it directly covers the same ground.

Adds a maintainer entry for myself in the first commit.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/tree/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [ ] 25.11 Release Notes (or backporting 25.05 and 25.11 Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
