### PR TITLE
raindrop: init at 5.7.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29043,6 +29043,12 @@
     githubId = 10110;
     name = "Travis B. Hartwell";
   };
+  travisty- = {
+    email = "travis@traviskinney.co";
+    github = "travisty-";
+    githubId = 10015877;
+    name = "Travis Kinney";
+  };
   traxys = {
     email = "quentin+dev@familleboyer.net";
     github = "traxys";

--- a/pkgs/by-name/ra/raindrop/package.nix
+++ b/pkgs/by-name/ra/raindrop/package.nix
@@ -1,0 +1,135 @@
+{
+  asar,
+  buildNpmPackage,
+  copyDesktopItems,
+  electron,
+  fetchFromGitHub,
+  lib,
+  makeDesktopItem,
+  makeWrapper,
+}:
+let
+  sources = lib.importJSON ./sources.json;
+  inherit (sources) version;
+
+  webapp = buildNpmPackage {
+    pname = "raindrop-webapp";
+    inherit version;
+
+    src = fetchFromGitHub {
+      owner = "raindropio";
+      repo = "app";
+      rev = sources.webappRev;
+      hash = sources.webappHash;
+    };
+
+    npmDepsHash = sources.webappNpmHash;
+
+    npmBuildScript = "build:electron";
+
+    # The post-install script for @sentry/cli tries to download a native binary
+    # which won't work in the Nix sandbox, and we don't want the telemetry anyway.
+    env.SENTRYCLI_SKIP_DOWNLOAD = "1";
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out
+      cp -r dist/electron/prod/* $out/
+      runHook postInstall
+    '';
+  };
+in
+buildNpmPackage {
+  pname = "raindrop";
+  inherit version;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "raindropio";
+    repo = "desktop";
+    rev = sources.desktopRev;
+    hash = sources.desktopHash;
+  };
+
+  npmDepsHash = sources.desktopNpmHash;
+
+  makeCacheWritable = true;
+  dontNpmBuild = true;
+
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+  # The "0.0.0" placeholder is normally replaced by electron-builder at
+  # release time. We skip that process, so we have to patch it ourselves.
+  postPatch = ''
+    substituteInPlace package.json \
+      --replace-fail '"version": "0.0.0"' '"version": "${version}"'
+  '';
+
+  nativeBuildInputs = [
+    asar
+    copyDesktopItems
+    makeWrapper
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/raindrop
+
+    # The path must match how the desktop app references the webapp submodule.
+    mkdir -p app/webapp/dist/electron/prod
+    cp package.json app/
+    cp -r src app/
+    cp -r ${webapp}/* app/webapp/dist/electron/prod/
+    cp -r node_modules app/
+
+    # --ignore-scripts prevents post-install hooks from running (and failing).
+    npm prune --prefix app --omit=dev --ignore-scripts 2>/dev/null || true
+
+    asar pack app $out/share/raindrop/app.asar
+
+    for size in 16 32 48 64 128 256 512; do
+      install -Dm 644 "build/linux/''${size}x''${size}.png" \
+        "$out/share/icons/hicolor/''${size}x''${size}/apps/raindrop.png"
+    done
+
+    makeWrapper ${lib.getExe electron} $out/bin/raindrop \
+      --add-flags $out/share/raindrop/app.asar \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+      --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
+      --set-default ELECTRON_IS_DEV 0 \
+      --inherit-argv0
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "raindrop";
+      icon = "raindrop";
+      exec = "raindrop %U";
+      desktopName = "Raindrop.io";
+      genericName = "Bookmark Manager";
+      comment = "All-in-one bookmark manager";
+      categories = [
+        "Archiving"
+        "Utility"
+      ];
+      startupWMClass = "Raindrop.io";
+      mimeTypes = [ "x-scheme-handler/rnio" ];
+    })
+  ];
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "All-in-one bookmark manager";
+    homepage = "https://raindrop.io";
+    changelog = "https://github.com/raindropio/desktop/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ travisty- ];
+    mainProgram = "raindrop";
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/by-name/ra/raindrop/sources.json
+++ b/pkgs/by-name/ra/raindrop/sources.json
@@ -1,0 +1,9 @@
+{
+  "version": "5.7.9",
+  "desktopRev": "v5.7.9",
+  "desktopHash": "sha256-l80wujoB+tTDg6sE13ilnu/RQxHqqwPDukO+nIfznec=",
+  "desktopNpmHash": "sha256-+m9Fvt3NCvf0DBe/79sPWOgiewfZC4XOV4O7p76uSy8=",
+  "webappRev": "c062e549efc885beaf630e433102f6a2cbbee6b0",
+  "webappHash": "sha256-PrxE2RL+1nEcLPxe5uRHpibokFxzRH+gZqpkw9imeaY=",
+  "webappNpmHash": "sha256-UP3E6ZXRSGJlP+j7qidf2jRSQ3v07ymMhJHm+FvGjQA="
+}

--- a/pkgs/by-name/ra/raindrop/update.sh
+++ b/pkgs/by-name/ra/raindrop/update.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl git jq nix prefetch-npm-deps
+# shellcheck shell=bash
+
+# Regenerates the hashes in sources.json. Pass a version to pin a
+# release, or no arguments to auto-detect the latest GitHub release.
+
+# Usage: ./update.sh [version]
+
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+
+# Outputs the source hash (SRI) and npm deps hash (SRI).
+prefetch() {
+  local this hash path
+  this="$(nix-prefetch-url --unpack --print-path --type sha256 "$1" 2>/dev/null)"
+  hash="$(head -1 <<< "$this")"
+  path="$(tail -1 <<< "$this")"
+  nix hash convert --hash-algo sha256 "$hash"
+  prefetch-npm-deps "${path}/package-lock.json" 2>/dev/null | tail -1
+}
+
+version="${1:-}"
+if [ -z "$version" ]; then
+  version="$(curl -fsSL 'https://api.github.com/repos/raindropio/desktop/releases/latest' | jq -r '.tag_name | ltrimstr("v")')"
+fi
+
+echo "Updating raindrop to v${version}..."
+
+# The webapp is a Git submodule of desktop; the Contents API returns the commit SHA it's pinned to.
+webapp_rev="$(curl -fsSL "https://api.github.com/repos/raindropio/desktop/contents/webapp?ref=v${version}" | jq -r '.sha')"
+
+echo "  Fetching desktop..."
+readarray -t desktop < <(prefetch "https://github.com/raindropio/desktop/archive/refs/tags/v${version}.tar.gz")
+
+echo "  Fetching webapp..."
+readarray -t webapp < <(prefetch "https://github.com/raindropio/app/archive/${webapp_rev}.tar.gz")
+
+jq -n \
+  --arg version "$version" \
+  --arg desktopRev "v${version}" \
+  --arg desktopHash "${desktop[0]}" \
+  --arg desktopNpmHash "${desktop[1]}" \
+  --arg webappRev "$webapp_rev" \
+  --arg webappHash "${webapp[0]}" \
+  --arg webappNpmHash "${webapp[1]}" \
+  '$ARGS.named' > "$root/pkgs/by-name/ra/raindrop/sources.json"
+
+echo "Updated sources.json to v${version}"


### PR DESCRIPTION
Add [Raindrop.io](https://raindrop.io), an all-in-one bookmark manager.

Built from source: This package contains a React web app that's embedded into an Electron desktop shell.
- [raindropio/app](https://github.com/raindropio/app)
- [raindropio/desktop](https://github.com/raindropio/desktop)

Related: #249780 (earlier package request, closed)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
