### PR TITLE
networkmanager: 1.56.0 -> 1.58.0

### DIFF
--- a/nixos/tests/networking/networkmanager.nix
+++ b/nixos/tests/networking/networkmanager.nix
@@ -245,8 +245,8 @@ let
           client.wait_for_unit("NetworkManager.service")
           router.wait_for_unit("freeradius.service")
           router.wait_for_unit("hostapd.service")
-          router.wait_until_succeeds("journalctl -b --unit freeradius.service | grep \"Sent Access-Accept\"")
-          router.wait_until_succeeds("journalctl -b --unit freeradius.service | grep \"TLS-Client-Cert-Common-Name := \\\"client1.example.com\\\"\"")
+          router.wait_until_succeeds("journalctl -b --unit freeradius.service --grep='Sent Access-Accept'")
+          router.wait_until_succeeds("journalctl -b --unit freeradius.service --grep='TLS-Client-Cert-Common-Name = \"client1.example.com\"'")
         '';
       };
     eapFiles = {
@@ -294,8 +294,8 @@ let
         client.wait_for_unit("NetworkManager.service")
         router.wait_for_unit("freeradius.service")
         router.wait_for_unit("hostapd.service")
-        router.wait_until_succeeds("journalctl -b --unit freeradius.service | grep \"Sent Access-Accept\"")
-        router.wait_until_succeeds("journalctl -b --unit freeradius.service | grep \"TLS-Client-Cert-Common-Name := \\\"client1.example.com\\\"\"")
+        router.wait_until_succeeds("journalctl -b --unit freeradius.service --grep='Sent Access-Accept'")
+        router.wait_until_succeeds("journalctl -b --unit freeradius.service --grep='TLS-Client-Cert-Common-Name = \"client1.example.com\"'")
       '';
     };
   };

--- a/pkgs/by-name/fr/freeradius/package.nix
+++ b/pkgs/by-name/fr/freeradius/package.nix
@@ -32,6 +32,7 @@
   sqlite,
   withYubikey ? false,
   libyubikey,
+  nixosTests,
 }:
 
 assert withRest -> withJson;
@@ -100,6 +101,13 @@ stdenv.mkDerivation rec {
     "man"
     "doc"
   ];
+
+  passthru.tests = {
+    inherit (nixosTests.networking.networkmanager)
+      eap
+      eapFiles
+      ;
+  };
 
   meta = {
     homepage = "https://freeradius.org/";

--- a/pkgs/by-name/ne/networkmanager/fix-paths.patch
+++ b/pkgs/by-name/ne/networkmanager/fix-paths.patch
@@ -10,29 +10,8 @@ index 148acade5c..6395fbfbe5 100644
 +PROGRAM="@runtimeShell@ -c '@ethtool@/bin/ethtool -i $$1 |@gnused@/bin/sed -n s/^driver:\ //p' -- $env{INTERFACE}", ENV{ID_NET_DRIVER}="%c"
  
  LABEL="nm_drivers_end"
-diff --git a/src/core/devices/nm-device.c b/src/core/devices/nm-device.c
-index e310a9c680..ed8d838e43 100644
---- a/src/core/devices/nm-device.c
-+++ b/src/core/devices/nm-device.c
-@@ -15239,14 +15239,14 @@ nm_device_start_ip_check(NMDevice *self)
-             gw = nm_l3_config_data_get_best_default_route(l3cd, AF_INET);
-             if (gw) {
-                 nm_inet4_ntop(NMP_OBJECT_CAST_IP4_ROUTE(gw)->gateway, buf);
--                ping_binary = nm_utils_find_helper("ping", "/usr/bin/ping", NULL);
-+                ping_binary = "@iputils@/bin/ping";
-                 log_domain  = LOGD_IP4;
-             }
-         } else if (priv->ip_data_6.state == NM_DEVICE_IP_STATE_READY) {
-             gw = nm_l3_config_data_get_best_default_route(l3cd, AF_INET6);
-             if (gw) {
-                 nm_inet6_ntop(&NMP_OBJECT_CAST_IP6_ROUTE(gw)->gateway, buf);
--                ping_binary = nm_utils_find_helper("ping6", "/usr/bin/ping6", NULL);
-+                ping_binary = "@iputils@/bin/ping";
-                 log_domain  = LOGD_IP6;
-             }
-         }
 diff --git a/src/libnmc-base/nm-vpn-helpers.c b/src/libnmc-base/nm-vpn-helpers.c
-index cbe76f5f1c..6ec684f9fe 100644
+index cbe76f5f1c..0fc28b83e7 100644
 --- a/src/libnmc-base/nm-vpn-helpers.c
 +++ b/src/libnmc-base/nm-vpn-helpers.c
 @@ -284,15 +284,6 @@ nm_vpn_openconnect_authenticate_helper(NMSettingVpn *s_vpn, GPtrArray *secrets,
@@ -51,7 +30,7 @@ index cbe76f5f1c..6ec684f9fe 100644
      const char *oc_argv[(12 + 2 * G_N_ELEMENTS(oc_property_args))];
      const char *gw;
      int         port;
-@@ -311,13 +302,8 @@ nm_vpn_openconnect_authenticate_helper(NMSettingVpn *s_vpn, GPtrArray *secrets,
+@@ -311,13 +302,7 @@ nm_vpn_openconnect_authenticate_helper(NMSettingVpn *s_vpn, GPtrArray *secrets,
  
      port = extract_url_port(gw);
  
@@ -63,7 +42,6 @@ index cbe76f5f1c..6ec684f9fe 100644
 -                                         NULL,
 -                                         error);
 +    path = g_find_program_in_path("openconnect");
-+
      if (!path)
          return FALSE;
  

--- a/pkgs/by-name/ne/networkmanager/package.nix
+++ b/pkgs/by-name/ne/networkmanager/package.nix
@@ -1,68 +1,84 @@
 {
-  lib,
-  stdenv,
   fetchurl,
-  replaceVars,
-  bpftools,
-  gettext,
-  pkg-config,
-  clang,
-  dbus,
   gitUpdater,
-  slang,
-  libbpf,
-  libuuid,
-  polkit,
-  gnutls,
-  ppp,
-  dhcpcd,
-  iptables,
-  nftables,
-  python3,
-  vala,
-  libgcrypt,
-  dnsmasq,
-  bluez5,
-  readline,
-  libselinux,
-  audit,
-  gobject-introspection,
-  perl,
-  modemmanager,
-  openresolv,
-  libndp,
-  newt,
-  ethtool,
-  gnused,
-  kmod,
-  jansson,
+  lib,
+  nixosTests,
+  replaceVars,
+  stdenv,
+
+  # build
+  bpftools,
+  clang,
   elfutils,
-  gtk-doc,
-  libxslt,
-  docbook_xsl,
-  docbook_xml_dtd_412,
-  docbook_xml_dtd_42,
-  docbook_xml_dtd_43,
-  curl,
+  gettext,
+  gnused,
   meson,
   mesonEmulatorHook,
   ninja,
-  libnvme,
-  libpsl,
-  mobile-broadband-provider-info,
+  perl,
+  pkg-config,
+  vala,
   runtimeShell,
   buildPackages,
-  nixosTests,
+
+  # libs
+  audit,
+  curl,
+  dbus,
+  gnutls,
+  gobject-introspection,
+  jansson,
+  libbpf,
+  libnvme,
+  libpsl,
+  libselinux,
+  libuuid,
+  polkit,
+  readline,
+  slang,
   systemd,
   udev,
-  udevCheckHook,
   withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
+
+  # external deps
+  bluez5,
+  dhcpcd,
+  dnsmasq,
+  ethtool,
+  iptables,
+  kmod,
+  libgcrypt,
+  libndp,
+  modemmanager,
+  mobile-broadband-provider-info,
+  newt,
+  nftables,
+  openresolv,
+  ppp,
+
+  # docs
+  docbook_xml_dtd_412,
+  docbook_xml_dtd_42,
+  docbook_xml_dtd_43,
+  docbook_xsl,
+  gtk-doc,
+  libxslt,
+  python3,
+
+  # install tests
+  udevCheckHook,
+
   # NBFT (NVMe Boot Firmware Table) support, opt-in due to closure size
   # https://github.com/NixOS/nixpkgs/pull/446121#discussion_r2380598419
   withNbft ? false,
 }:
 
 let
+  inherit (lib)
+    mesonBool
+    mesonOption
+    ;
+
   pythonForDocs = python3.pythonOnBuildForHost.withPackages (pkgs: with pkgs; [ pygobject3 ]);
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -93,48 +109,47 @@ stdenv.mkDerivation (finalAttrs: {
     # System paths
     "--sysconfdir=/etc"
     "--localstatedir=/var"
-    (lib.mesonOption "systemdsystemunitdir" (
+    (mesonOption "systemdsystemunitdir" (
       if withSystemd then "${placeholder "out"}/etc/systemd/system" else "no"
     ))
     # to enable link-local connections
-    "-Dudev_dir=${placeholder "out"}/lib/udev"
-    "-Ddbus_conf_dir=${placeholder "out"}/share/dbus-1/system.d"
-    "-Dkernel_firmware_dir=/run/current-system/firmware"
+    (mesonOption "udev_dir" "${placeholder "out"}/lib/udev")
+    (mesonOption "dbus_conf_dir" "${placeholder "out"}/share/dbus-1/system.d")
+    (mesonOption "kernel_firmware_dir" "/run/current-system/firmware")
 
     # Platform
-    "-Dmodprobe=${kmod}/bin/modprobe"
-    (lib.mesonOption "session_tracking" (if withSystemd then "systemd" else "no"))
-    (lib.mesonBool "systemd_journal" withSystemd)
-    "-Dlibaudit=yes-disabled-by-default"
-    "-Dpolkit_agent_helper_1=/run/wrappers/bin/polkit-agent-helper-1"
+    (mesonOption "modprobe" (lib.getExe' kmod "modprobe"))
+    (mesonOption "session_tracking" (if withSystemd then "systemd" else "no"))
+    (mesonBool "systemd_journal" withSystemd)
+    (mesonOption "libaudit" "yes-disabled-by-default")
+    (mesonOption "polkit_agent_helper_1" "/run/wrappers/bin/polkit-agent-helper-1")
 
     # Features
-    # Allow using iwd when configured to do so
-    (lib.mesonBool "clat" (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)) # fails to find UAPI headers
-    "-Diwd=true"
-    "-Dpppd=${ppp}/bin/pppd"
-    "-Diptables=${iptables}/bin/iptables"
-    "-Dnft=${nftables}/bin/nft"
-    "-Dmodem_manager=true"
-    "-Dnmtui=true"
-    "-Ddnsmasq=${dnsmasq}/bin/dnsmasq"
-    "-Dqt=false"
-    (lib.mesonBool "nbft" withNbft)
+    (mesonBool "clat" (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)) # fails to find UAPI headers
+    (mesonBool "iwd" true)
+    (mesonOption "pppd" (lib.getExe' ppp "pppd"))
+    (mesonOption "iptables" (lib.getExe iptables))
+    (mesonOption "nft" (lib.getExe nftables))
+    (mesonBool "modem_manager" true)
+    (mesonBool "nmtui" true)
+    (mesonOption "dnsmasq" (lib.getExe dnsmasq))
+    (mesonBool "qt" false)
+    (mesonBool "nbft" withNbft)
 
     # Handlers
-    "-Dresolvconf=${openresolv}/bin/resolvconf"
+    (mesonOption "resolvconf" (lib.getExe openresolv))
 
     # DHCP clients
-    "-Ddhcpcd=${dhcpcd}/bin/dhcpcd"
+    (mesonOption "dhcpcd" (lib.getExe dhcpcd))
 
     # Miscellaneous
     # almost cross-compiles, however fails with
     # ** (process:9234): WARNING **: Failed to load shared library '/nix/store/...-networkmanager-aarch64-unknown-linux-gnu-1.38.2/lib/libnm.so.0' referenced by the typelib: /nix/store/...-networkmanager-aarch64-unknown-linux-gnu-1.38.2/lib/libnm.so.0: cannot open shared object file: No such file or directory
-    "-Ddocs=${lib.boolToString (stdenv.buildPlatform == stdenv.hostPlatform)}"
-    "-Dman=${lib.boolToString (stdenv.buildPlatform == stdenv.hostPlatform)}"
-    "-Dtests=no"
-    "-Dcrypto=gnutls"
-    "-Dmobile_broadband_provider_info_database=${mobile-broadband-provider-info}/share/mobile-broadband-provider-info/serviceproviders.xml"
+    (mesonBool "docs" (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform))
+    (mesonBool "man" (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform))
+    (mesonOption "tests" "no")
+    (mesonOption "crypto" "gnutls")
+    (mesonOption "mobile_broadband_provider_info_database" "${mobile-broadband-provider-info}/share/mobile-broadband-provider-info/serviceproviders.xml")
   ];
 
   patches = [
@@ -151,26 +166,52 @@ stdenv.mkDerivation (finalAttrs: {
     ./fix-install-paths.patch
   ];
 
+  nativeBuildInputs = [
+    bpftools
+    clang
+    elfutils # used to find jansson soname
+    gettext
+    gobject-introspection
+    meson
+    ninja
+    perl
+    pkg-config
+    vala
+    udevCheckHook
+
+    # Docs
+    gtk-doc
+    libxslt
+    docbook_xsl
+    docbook_xml_dtd_412
+    docbook_xml_dtd_42
+    docbook_xml_dtd_43
+    pythonForDocs
+  ]
+  ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    mesonEmulatorHook
+  ];
+
   buildInputs = [
-    (if withSystemd then systemd else udev)
-    libbpf
-    libselinux
     audit
+    bluez5
+    curl
+    dbus # used to get directory paths with pkg-config during configuration
+    dnsmasq
+    jansson
+    libbpf
+    libndp
     libpsl
+    libselinux
     libuuid
+    mobile-broadband-provider-info
+    modemmanager
+    newt
     polkit
     ppp
-    libndp
-    curl
-    mobile-broadband-provider-info
-    bluez5
-    dnsmasq
-    modemmanager
     readline
-    newt
-    jansson
-    dbus # used to get directory paths with pkg-config during configuration
     slang
+    (if withSystemd then systemd else udev)
   ]
   ++ lib.optionals withNbft [
     libnvme
@@ -181,30 +222,7 @@ stdenv.mkDerivation (finalAttrs: {
     libgcrypt
   ];
 
-  nativeBuildInputs = [
-    bpftools
-    clang
-    meson
-    ninja
-    gettext
-    pkg-config
-    vala
-    gobject-introspection
-    perl
-    elfutils # used to find jansson soname
-    # Docs
-    gtk-doc
-    libxslt
-    docbook_xsl
-    docbook_xml_dtd_412
-    docbook_xml_dtd_42
-    docbook_xml_dtd_43
-    pythonForDocs
-    udevCheckHook
-  ]
-  ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
-    mesonEmulatorHook
-  ];
+  nativeInstallCheckInputs = [ udevCheckHook ];
 
   doCheck = false; # requires /sys, the net
 
@@ -218,7 +236,7 @@ stdenv.mkDerivation (finalAttrs: {
   ''
   + lib.optionalString withSystemd ''
     substituteInPlace data/NetworkManager.service.in \
-      --replace-fail /usr/bin/busctl ${systemd}/bin/busctl
+      --replace-fail /usr/bin/busctl ${lib.getExe' systemd "busctl"}
   '';
 
   preBuild = ''
@@ -230,7 +248,7 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s $PWD/src/libnm-client-impl/libnm.so.0 ${placeholder "out"}/lib/libnm.so.0
   '';
 
-  postFixup = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+  postFixup = lib.optionalString (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) ''
     cp -r ${buildPackages.networkmanager.devdoc} $devdoc
     cp -r ${buildPackages.networkmanager.man} $man
   '';

--- a/pkgs/by-name/ne/networkmanager/package.nix
+++ b/pkgs/by-name/ne/networkmanager/package.nix
@@ -260,9 +260,7 @@ stdenv.mkDerivation (finalAttrs: {
       odd-unstable = true;
       url = "https://gitlab.freedesktop.org/NetworkManager/NetworkManager.git";
     };
-    tests = {
-      inherit (nixosTests.networking) networkmanager;
-    };
+    tests = nixosTests.networking.networkmanager;
   };
 
   meta = {

--- a/pkgs/by-name/ne/networkmanager/package.nix
+++ b/pkgs/by-name/ne/networkmanager/package.nix
@@ -3,10 +3,14 @@
   stdenv,
   fetchurl,
   replaceVars,
+  bpftools,
   gettext,
   pkg-config,
+  clang,
   dbus,
   gitUpdater,
+  slang,
+  libbpf,
   libuuid,
   polkit,
   gnutls,
@@ -30,7 +34,6 @@
   newt,
   ethtool,
   gnused,
-  iputils,
   kmod,
   jansson,
   elfutils,
@@ -64,11 +67,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "networkmanager";
-  version = "1.56.0";
+  version = "1.58.0";
 
   src = fetchurl {
     url = "https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/releases/${finalAttrs.version}/downloads/NetworkManager-${finalAttrs.version}.tar.xz";
-    hash = "sha256-WaMtOFzB564m5DeYxvEtB/9hmKvQQewGILOgjPwCHMw=";
+    hash = "sha256-DG8nA6LJsBfNaPv+HS6KGl1/8FE3x1HsQhy6NulFRro=";
   };
 
   outputs = [
@@ -78,6 +81,10 @@ stdenv.mkDerivation (finalAttrs: {
     "man"
     "doc"
   ];
+
+  # TODO: only disable for clang used for bpf builds
+  # this breaks clang target bpf, which does not support -fzero-call-used-regs=used-gpr
+  hardeningDisable = [ "zerocallusedregs" ];
 
   # Right now we hardcode quite a few paths at build time. Probably we should
   # patch networkmanager to allow passing these path in config file. This will
@@ -103,6 +110,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Features
     # Allow using iwd when configured to do so
+    (lib.mesonBool "clat" (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform)) # fails to find UAPI headers
     "-Diwd=true"
     "-Dpppd=${ppp}/bin/pppd"
     "-Diptables=${iptables}/bin/iptables"
@@ -132,7 +140,6 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     (replaceVars ./fix-paths.patch {
       inherit
-        iputils
         ethtool
         gnused
         ;
@@ -146,6 +153,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     (if withSystemd then systemd else udev)
+    libbpf
     libselinux
     audit
     libpsl
@@ -162,6 +170,7 @@ stdenv.mkDerivation (finalAttrs: {
     newt
     jansson
     dbus # used to get directory paths with pkg-config during configuration
+    slang
   ]
   ++ lib.optionals withNbft [
     libnvme
@@ -173,6 +182,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   nativeBuildInputs = [
+    bpftools
+    clang
     meson
     ninja
     gettext


### PR DESCRIPTION
https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/raw/1.58.0/NEWS

> * Validate hostnames and MUD URLs before pasting them into the dhclient
>  configuration file, rejecting characters that could alter the config
>   syntax (CVE-2026-10805).

Not super relevant, we haven't had dhclient for years now.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-multiplatform (cross)
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
