### PR TITLE
binaryen: make array-bounds non-fatal for gcc 16

### DIFF
--- a/pkgs/development/compilers/binaryen/default.nix
+++ b/pkgs/development/compilers/binaryen/default.nix
@@ -36,6 +36,15 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
 
+  # GCC 16 triggers `array-bounds` warnings on optimized builds with reference
+  # to some code within the STL. Since it does not occur in unoptimized builds,
+  # refers to a mutex that does not appear to exist outside the STL, and the
+  # message matches a known GCC 16 bug, this appears to be a false positive and
+  # we downgrade this error to a warning in order to fix the build.
+  # Related GCC issue: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=122197
+  # Binaryen issue: https://github.com/WebAssembly/binaryen/issues/8950
+  cmakeFlags = [ (lib.cmakeFeature "CMAKE_CXX_FLAGS" "-Wno-error=array-bounds") ];
+
   preConfigure = ''
     if [ -n "$doCheck" ]; then
       sed -i '/gtest/d' third_party/CMakeLists.txt


### PR DESCRIPTION
GCC 16 triggers `array-bounds` warnings on optimized builds with reference to some code within the STL. Since it does not occur in unoptimized builds, refers to a mutex that does not appear to exist outside the STL, and the message matches a known GCC 16 bug, this appears to be a false positive and we downgrade this error to a warning to fix the build.

Related GCC issue: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=122197
Binaryen issue: https://github.com/WebAssembly/binaryen/issues/8950
Example failing build logs: https://hydra.nixos.org/build/339164126/log

working towards: #537781

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
