### PR TITLE
Xfce updates 2026-08-02

### DIFF
--- a/pkgs/by-name/gr/greybird/package.nix
+++ b/pkgs/by-name/gr/greybird/package.nix
@@ -1,0 +1,50 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  gdk-pixbuf,
+  glib,
+  meson,
+  ninja,
+  pkg-config,
+  sassc,
+  librsvg,
+  gitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "greybird";
+  version = "3.23.4";
+
+  src = fetchFromGitHub {
+    owner = "shimmerproject";
+    repo = "greybird";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-De8y+LRQ26UKrUECLCcbCg7p9Z+aRssQ/7YzegAUPw4=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    gdk-pixbuf
+    glib
+    meson
+    ninja
+    pkg-config
+    sassc
+  ];
+
+  buildInputs = [
+    librsvg
+  ];
+
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+
+  meta = {
+    description = "Desktop suite for Xfce";
+    homepage = "https://github.com/shimmerproject/Greybird";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    teams = [ lib.teams.xfce ];
+  };
+})

--- a/pkgs/by-name/tu/tumbler/package.nix
+++ b/pkgs/by-name/tu/tumbler/package.nix
@@ -25,14 +25,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tumbler";
-  version = "4.20.1";
+  version = "4.20.2";
 
   src = fetchFromGitLab {
     domain = "gitlab.xfce.org";
     owner = "xfce";
     repo = "tumbler";
     tag = "tumbler-${finalAttrs.version}";
-    hash = "sha256-p4lAFNvCakqrsDa2FP0xbc/khx6eYqAlHwWkk8yEB7Y=";
+    hash = "sha256-jLSJr3QUl6f1gpdfKw8ycb2+hw9sr1cudBeBwJWI1mk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xfce4-panel/package.nix
+++ b/pkgs/by-name/xf/xfce4-panel/package.nix
@@ -31,7 +31,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xfce4-panel";
-  version = "4.20.7";
+  version = "4.20.8";
 
   outputs = [
     "out"
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "xfce";
     repo = "xfce4-panel";
     tag = "xfce4-panel-${finalAttrs.version}";
-    hash = "sha256-tL32ymLhV1QK84223iEgGrKdZXm5/nB3MumDyDIrSHQ=";
+    hash = "sha256-Q+QV0NFM3vL92o6ApPI9qmkkmZiqyjo/Q+lRHLudtGg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xfce4-power-manager/package.nix
+++ b/pkgs/by-name/xf/xfce4-power-manager/package.nix
@@ -22,14 +22,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xfce4-power-manager";
-  version = "4.20.0";
+  version = "4.20.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.xfce.org";
     owner = "xfce";
     repo = "xfce4-power-manager";
     tag = "xfce4-power-manager-${finalAttrs.version}";
-    hash = "sha256-qKUdrr+giLzNemhT3EQsOKTSiIx50NakmK14Ak7ZOCE=";
+    hash = "sha256-0Pgk5N+Cr75RwOp2dbYB8OOEzmXDVUHzoqFbaUF/Z0k=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xf/xfce4-settings/package.nix
+++ b/pkgs/by-name/xf/xfce4-settings/package.nix
@@ -36,14 +36,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xfce4-settings";
-  version = "4.20.4";
+  version = "4.20.5";
 
   src = fetchFromGitLab {
     domain = "gitlab.xfce.org";
     owner = "xfce";
     repo = "xfce4-settings";
     tag = "xfce4-settings-${finalAttrs.version}";
-    hash = "sha256-EAiu29wctXg0EjdFVJOl+0nh1A0l2E44v+i/o5l/PQ8=";
+    hash = "sha256-sHhoxE9YTlIcrJ/G414pwc3wy3Gv0ksnBePqgEbmV8Q=";
   };
 
   depsBuildBuild = [

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1035,7 +1035,6 @@ mapAliases {
   graphia = throw "'graphia' has been removed due to being unmaintained and broken"; # Added 2026-05-05
   graphite-gtk-theme = throw "'graphite-gtk-theme' has been removed because it depended on 'gtk-engine-murrine', which was removed because it was unmaintained upstream and depended on GTK 2."; # Added 2026-07-22
   graphite-kde-theme = throw "'graphite-kde-theme' has been removed, as it is only compatible with Plasma 5, which is EOL"; # Added 2025-08-20
-  greybird = throw "'greybird' has been removed because it depended on 'gtk-engine-murrine', which was removed because it was unmaintained upstream and depended on GTK 2."; # Added 2026-07-22
   gringo = throw "'gringo' has been renamed to/replaced by 'clingo'"; # Converted to throw 2025-10-27
   grip = throw "'grip' has been removed because it depended on the deprecated GTK2 engine."; # Added 2026-07-30
   grub2_full = throw "'grub2_full' has been renamed to/replaced by 'grub2'"; # Converted to throw 2025-10-27


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
