### PR TITLE
nixos/tests/firefox: add font rendering regression test

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -616,6 +616,7 @@ in
     imports = [ ./firefox.nix ];
     _module.args.firefoxPackage = pkgs.firefox-esr-153;
   };
+  firefox-font-rendering = runTest ./firefox/font-rendering.nix;
   firefox-syncserver = discoverTests (import ./firefox-syncserver.nix);
   firefox_decrypt = runTest ./firefox_decrypt.nix;
   firefoxpwa = runTest ./firefoxpwa.nix;

--- a/nixos/tests/firefox/font-rendering.nix
+++ b/nixos/tests/firefox/font-rendering.nix
@@ -1,0 +1,82 @@
+# This test tests following capabilities of Firefox / fontconfig:
+# 1. rendering content of simple HTML body
+#    (least likely to fail -> tested first & basis for screenshot)
+# 2. rendering text in the url bar
+# 3. rendering page title in the tab bar
+#    (preventing regression of https://github.com/NixOS/nixpkgs/issues/540847)
+{
+  lib,
+  ...
+}:
+let
+  inherit (lib.meta) getExe;
+  inherit (lib.strings) escapeNixString;
+
+  # these texts should be different to avoid false positives in the tests
+  pageFileName = "test-page.html";
+  pageTitle = "World Hello"; # mind width of tab bar so everything fits
+  pageBody = "Lorem ipsum dolor sit amet."; # mind maximum width of HTML content so text does not wrap
+
+  # pageTitle must not appear in the body (for 3.)
+  html = ''
+    <!DOCTYPE html>
+    <html>
+      <head><title>${pageTitle}</title></head>
+      <body>
+        <p>${pageBody}</p>
+      </body>
+    </html>
+  '';
+in
+{
+  name = "firefox-font-rendering";
+  meta.maintainers = with lib.maintainers; [
+    Zocker1999NET
+  ];
+  nodes.machine =
+    {
+      config,
+      pkgs,
+      ...
+    }:
+    {
+      imports = [
+        ../common/wayland-cage.nix
+      ];
+
+      programs.firefox.enable = true;
+
+      # increase resolution & scale to help OCR find small text in tab bar
+      services.cage.program = pkgs.writeShellScript "firefox" ''
+        ${getExe pkgs.wlr-randr} --output Virtual-1 --mode 1360x768 --scale 1.3
+        exec firefox file://${pkgs.writeText pageFileName html}
+      '';
+    };
+  enableOCR = true;
+  testScript = ''
+    @polling_condition
+    def firefox_running():
+      "check that firefox is running"
+      # pgrep without -x because /proc/*/comm can be either "firefox" or ".firefox-wrappe", depending on the exact package used
+      machine.succeed("pgrep firefox")
+
+    machine.wait_for_unit("graphical.target")
+
+    firefox_running.wait()
+    with firefox_running:
+      with subtest("1. Firefox renders the page body"):
+        # give cage & Firefox some time to fully open
+        machine.wait_for_text(${escapeNixString pageBody})
+
+      # make screenshot after page is fully loaded to avoid black screenshots
+      machine.screenshot("firefox-page")
+
+      # further timeouts are shorter as page should be fully loaded by now
+
+      with subtest("2. Firefox renders text in url bar"):
+        machine.wait_for_text(${escapeNixString pageFileName}, timeout=20)
+
+      with subtest("3. Firefox renders the page title in tab bar"):
+        machine.wait_for_text(${escapeNixString pageTitle}, timeout=20)
+  '';
+}


### PR DESCRIPTION
Preventing regressions such as https://github.com/NixOS/nixpkgs/issues/540847

The regression was actually due to a bug in fontconfig, see https://gitlab.freedesktop.org/fontconfig/fontconfig/-/commit/9fc06d7048800498e30e168154e7ba7fcc8cc376

But, first, Firefox has applied fixes on their own, see https://bugzilla.mozilla.org/show_bug.cgi?id=2051021, and I think it is not in doubt that such a bug affects firefox in a way making it totally unusasble.
Hence I think this test can be also helpful to detect similar rendering issues making Firefox unusable (e.g. font coloring errors in the default config).

I tested this exact version on following nixpkgs commits (ordered topologically):
- 9a4f6ae01863: test succeeded (before regression)
  (thx for proving the hash in https://github.com/NixOS/nixpkgs/issues/540847#issuecomment-5053636006)
- f7a2e428f5d7: test failed (after regression -> expected)
  (thx for providing the hash in https://github.com/NixOS/nixpkgs/issues/540847#issuecomment-5088667036) 
- 26502e2000a044f17202087ae567a4fedc850f0c: test succeeded (after fix)
  (direct parent of PR)


<details>
<summary>screenshots</summary>

### during regression

<img width="1360" height="768" alt="firefox-page_broken" src="https://github.com/user-attachments/assets/5b68e1c4-9d6f-435a-b7a5-977898b8c78c" />

(screenshot was generated running the test interactively)

### when test succeeds

<img width="1360" height="768" alt="firefox-page_working" src="https://github.com/user-attachments/assets/8bfb5e1a-2f9d-4885-a14c-0b48d98177a9" />

</details>




## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
