### PR TITLE
libbass: update instructions, libbassmidi: 2.4.15.3 -> 2.4.16

### DIFF
--- a/pkgs/development/libraries/audio/libbass/default.nix
+++ b/pkgs/development/libraries/audio/libbass/default.nix
@@ -9,10 +9,10 @@
 
 # Upstream changes files in-place, to update:
 # 1. Check latest version at http://www.un4seen.com/
-# 2. Update `version`s and `hash` sums.
+# 2. Upload that URL to the internet archive (https://web.archive.org/save).
+# 3. Use the internet archive URL.
+# 4. Update `version`s and `hash` sums.
 # See also http://www.un4seen.com/forum/?topic=18614.0
-
-# Internet Archive used due to upstream URLs being unstable
 
 let
   allBass = {

--- a/pkgs/development/libraries/audio/libbass/default.nix
+++ b/pkgs/development/libraries/audio/libbass/default.nix
@@ -69,10 +69,10 @@ let
 
     bassmidi = {
       h = {
-        linux = "bassmidi.h";
-        darwin = "bassmidi.h";
+        linux = "c/bassmidi.h";
+        darwin = "c/bassmidi.h";
       };
-      version = "2.4.15.3";
+      version = "2.4.16";
       so = {
         i686_linux = "libs/x86/libbassmidi.so";
         x86_64-linux = "libs/x86_64/libbassmidi.so";
@@ -81,12 +81,12 @@ let
         aarch64-darwin = "libbassmidi.dylib";
       };
       url = {
-        linux = "https://web.archive.org/web/20240501180447/http://www.un4seen.com/files/bassmidi24-linux.zip";
-        darwin = "https://web.archive.org/web/20260318193855/https://www.un4seen.com/files/bassmidi24-osx.zip";
+        linux = "https://web.archive.org/web/20260801181155/https://www.un4seen.com/files/bassmidi24-linux.zip";
+        darwin = "https://web.archive.org/web/20260801180948/https://www.un4seen.com/files/bassmidi24-osx.zip";
       };
       hash = {
-        linux = "sha256-HrF1chhGk32bKN3jwal44Tz/ENGe/zORsrLPeGAv1OE=";
-        darwin = "sha256-Sqr83pSEv6hGGxgzEBLSg56sLR2QiPLazp0cmKz1vis=";
+        linux = "sha256-qNzY7ciG2Ld1n+hamcd6MOvuzOvmIIzVMbNLnmyd6HI=";
+        darwin = "sha256-gBVVtfmDxJ+bOylYIJLtwyEwKwD1u4YkN96HoBUot/c=";
       };
       buildInputs = [ libbass ];
     };


### PR DESCRIPTION
added better info about internet archive usage to the package update instructions and updated the one library that there's a newer version for

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
