### PR TITLE
ucx: fix build for gcc 16

### DIFF
--- a/pkgs/by-name/uc/ucx/deprecated-openmp-pragma.patch
+++ b/pkgs/by-name/uc/ucx/deprecated-openmp-pragma.patch
@@ -1,0 +1,17 @@
+diff --git a/src/tools/perf/perftest.c b/src/tools/perf/perftest.c
+index 52a1682f85..87e0511807 100644
+--- a/src/tools/perf/perftest.c
++++ b/src/tools/perf/perftest.c
+@@ -243,7 +243,11 @@
+ {
+ #if _OPENMP
+ #  pragma omp barrier
+-#  pragma omp master
++#  if _OPENMP >= 202011
++#    pragma omp masked
++#  else
++#    pragma omp master
++#  endif
+ #endif
+   {
+     sock_rte_group_t *group = rte_group;

--- a/pkgs/by-name/uc/ucx/package.nix
+++ b/pkgs/by-name/uc/ucx/package.nix
@@ -54,6 +54,14 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Td6L5wXDadIbHfk251bj6k9J3kIjqCYVx5lDso/u76M=";
   };
 
+  # UCX uses the `#pragma omp master` declaration which is deprecated since
+  # OpenMP 5.1. Since UCX builds with -Werror by default, this causes build
+  # failures in GCC 16 which introduced the `deprecated-openmp` warning.
+  # Accordingly, we replace it with the new `#pragma omp masked` version in
+  # compilers which support OpenMP 5.1.
+  # https://github.com/openucx/ucx/pull/11697
+  patches = [ ./deprecated-openmp-pragma.patch ];
+
   postPatch = ''
     patchShebangs config/nvcc_wrap.sh
   '';


### PR DESCRIPTION
UCX uses the `#pragma omp master` declaration which is deprecated since OpenMP 5.1. Since UCX builds with -Werror by default, this causes build failures in GCC 16 which introduced the `deprecated-openmp` warning. Accordingly, we replace it with the new `#pragma omp masked` version in compilers which support OpenMP 5.1. This has been PRed upstream (https://github.com/openucx/ucx/pull/11697), but not yet accepted, and so it is vendored here.

We elected to vendor a patch instead of just suppressing the warning or `substituteInPlace`ing the pragma as some older compiler versions do not support the new `#pragma omp masked` (this failed a *lot* with a blind replacement in the upstream PR CI) and older versions of GCC do not like the `deprecated-openmp` name. This seems the least fragile way to take this fix.

failing build logs: https://hydra.nixos.org/build/339234842/log
working towards #537781

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
