### PR TITLE
speedtest-exporter: 1.0.0 -> 1.1.0

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters/speedtest.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/speedtest.nix
@@ -34,6 +34,14 @@ in
         If the configured serverID is unavailable, fall back to the closest available server.
       '';
     };
+
+    timeout = mkOption {
+      type = types.ints.positive;
+      default = 60;
+      description = ''
+        Request timeout in seconds for the execution of the speedtest.
+      '';
+    };
   };
 
   serviceOpts = {
@@ -43,6 +51,7 @@ in
           -listen-address ${cfg.listenAddress} \
           -port ${toString cfg.port} \
           -server_id ${toString cfg.serverID} \
+          -timeout ${toString cfg.timeout} \
           ${optionalString cfg.serverFallback "-server_fallback"} \
           ${concatStringsSep " \\\n  " cfg.extraFlags}
       '';

--- a/pkgs/by-name/pr/prometheus-speedtest-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-speedtest-exporter/package.nix
@@ -7,13 +7,13 @@
 buildGoModule (finalAttrs: {
   __structuredAttrs = true;
   pname = "prometheus-speedtest-exporter";
-  version = "1.0.0";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "podocarp";
     repo = "speedtest_exporter";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-n9eunZRssS13mTOeFeZ/PpfSj430DKf3ZRS10hY4Ps8=";
+    hash = "sha256-xXTyxwECGlYv9bBco09zvlOpF4GcHeT3yZMNUQTPPoo=";
   };
 
   vendorHash = "sha256-HBg44D0CUc4HYCBwGrswnrqG5o5ltA6UT8L0oWetlIc=";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Version bump, fixes quite a major OOM bug.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
