### PR TITLE
karakeep: 0.32.0 -> 0.33.0

### DIFF
--- a/pkgs/by-name/ka/karakeep/package.nix
+++ b/pkgs/by-name/ka/karakeep/package.nix
@@ -11,20 +11,20 @@
   python3,
   srcOnly,
   removeReferencesTo,
-  pnpm_9,
+  pnpm_11,
   fetchPnpmDeps,
   pnpmConfigHook,
   versionCheckHook,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "karakeep";
-  version = "0.32.0";
+  version = "0.33.0";
 
   src = fetchFromGitHub {
     owner = "karakeep-app";
     repo = "karakeep";
     tag = "cli/v${finalAttrs.version}";
-    hash = "sha256-P88DQi0T7tmBH7cjs8/Hz77bU0oG7u67XPoLsdePNhI=";
+    hash = "sha256-WL4M2rpbIDUTUUCuw2T5tG4VCMGZaLsWq+BCAQBa2Sc=";
   };
 
   patches = [
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     nodejs
     node-gyp
     pnpmConfigHook
-    pnpm_9
+    pnpm_11
   ];
 
   buildInputs = [
@@ -58,9 +58,9 @@ stdenv.mkDerivation (finalAttrs: {
       src
       patches
       ;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-aT4JPx3iYw4kw8GHXKWMnelSVT0q2S3PK8DgSCQCyKQ=";
+    pnpm = pnpm_11;
+    fetcherVersion = 4;
+    hash = "sha256-JhD1soZj8l6ZVtTOSZc1lMfWfi3R0PU/SsVHEvr50PI=";
   };
   buildPhase = ''
     runHook preBuild

--- a/pkgs/by-name/ka/karakeep/patches/cache-from-env-not-nix-store.patch
+++ b/pkgs/by-name/ka/karakeep/patches/cache-from-env-not-nix-store.patch
@@ -5,10 +5,10 @@ index cba8876..c3d7c43 100644
 @@ -495,7 +495,8 @@ class ImageOptimizerCache {
          ]);
      }
-     constructor({ distDir, nextConfig }){
--        this.cacheDir = (0, _path.join)(distDir, 'cache', 'images');
+     constructor({ distDir, nextConfig, cacheHandler }){
+-        this.cacheDir = (0, _path.join)(/* turbopackIgnore: true */ distDir, 'cache', 'images');
 +        const cacheDir = process.env['NEXT_CACHE_DIR'] || (0, _path.join)(distDir, 'cache');
 +        this.cacheDir = (0, _path.join)(cacheDir, 'images');
          this.nextConfig = nextConfig;
-     }
-     async get(cacheKey) {
+         this.cacheHandler = cacheHandler;
+         // Eagerly start LRU initialization for filesystem cache

--- a/pkgs/by-name/ka/karakeep/patches/dont-lock-pnpm-version.patch
+++ b/pkgs/by-name/ka/karakeep/patches/dont-lock-pnpm-version.patch
@@ -5,6 +5,6 @@ requirement.
 ---
 --- a/package.json
 +++ b/package.json
-@@ -40 +40 @@
--  "packageManager": "pnpm@9.15.9",
-+  "packageManager": "pnpm",
+@@ -41 +41 @@
+-  "packageManager": "pnpm@11.2.1"
++  "packageManager": "pnpm"


### PR DESCRIPTION
Diff: https://github.com/karakeep-app/karakeep/compare/cli/v0.32.0...cli/v0.33.0

Changelog: https://github.com/karakeep-app/karakeep/releases/tag/v0.33.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
