### PR TITLE
mate-themes: Revert removal and remove GTK2

### DIFF
--- a/pkgs/by-name/ma/mate-themes/package.nix
+++ b/pkgs/by-name/ma/mate-themes/package.nix
@@ -1,0 +1,71 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  gettext,
+  mate-icon-theme,
+  gtk3,
+  gdk-pixbuf,
+  librsvg,
+  gitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mate-themes";
+  version = "3.22.26-unstable-2026-06-25";
+
+  src = fetchFromGitHub {
+    owner = "mate-desktop";
+    repo = "mate-themes";
+    # For `build: add --enable-gtk2 configure flag`
+    # nixpkgs-update: no auto update
+    rev = "3eba5d520b9ae1c64ef6c42ac442a7a97d38f7c7";
+    hash = "sha256-IZc1LxjHnwmvUOqGGnfzFdNI8dfyB3juOgY28xrXf1c=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    gettext
+    gtk3
+  ];
+
+  buildInputs = [
+    mate-icon-theme
+    gdk-pixbuf
+    librsvg
+  ];
+
+  configureFlags = [
+    "--disable-gtk2"
+  ];
+
+  dontDropIconThemeCache = true;
+
+  postInstall = ''
+    gtk-update-icon-cache "$out"/share/icons/ContrastHigh
+  '';
+
+  enableParallelBuilding = true;
+
+  passthru.updateScript = gitUpdater {
+    odd-unstable = true;
+    rev-prefix = "v";
+  };
+
+  meta = {
+    description = "Set of themes from MATE";
+    homepage = "https://mate-desktop.org";
+    license = with lib.licenses; [
+      lgpl21Plus
+      lgpl3Only
+      gpl3Plus
+    ];
+    platforms = lib.platforms.unix;
+    teams = [ lib.teams.mate ];
+  };
+})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1562,7 +1562,6 @@ mapAliases {
   massif-visualizer = throw "'massif-visualizer' has been removed due to outdated KF5 dependencies."; # Added 2026-05-01
   mastodon-bot = throw "'mastodon-bot' has been removed because it was archived by upstream in 2021."; # Added 2025-11-07
   matcha-gtk-theme = throw "'matcha-gtk-theme' has been removed because it depended on 'gtk-engine-murrine', which was removed because it was unmaintained upstream and depended on GTK 2."; # Added 2026-07-22
-  mate-themes = throw "'mate-themes' has been removed because it depended on 'gtk-engine-murrine', which was removed because it was unmaintained upstream and depended on GTK 2."; # Added 2026-07-22
   materia-theme = throw "'materia-theme' has been removed because it depended on 'gtk-engine-murrine', which was removed because it was unmaintained upstream and depended on GTK 2."; # Added 2026-07-22
   material-kwin-decoration = throw "'material-kwin-decoration' has been removed, as it is only compatible with Plasma 5, which is EOL"; # Added 2025-08-20
   matheria-theme-transparent = throw "'matheria-theme-transparent' has been removed because it depended on 'gtk-engine-murrine', which was removed because it was unmaintained upstream and depended on GTK 2."; # Added 2026-07-22


### PR DESCRIPTION
This mostly reverts commit 55776f4f39d94cc3b9f5e2499cee63b7b4f575a0.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
