### PR TITLE
catgirldownloader: init at 0.5

### DIFF
--- a/pkgs/by-name/ca/catgirldownloader/package.nix
+++ b/pkgs/by-name/ca/catgirldownloader/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  gtk4,
+  libadwaita,
+  gobject-introspection,
+  wrapGAppsHook4,
+  meson,
+  ninja,
+  pkg-config,
+  gettext,
+  desktop-file-utils,
+}:
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "catgirldownloader";
+  version = "0.5";
+
+  __structuredAttrs = true;
+  pyproject = false;
+
+  src = fetchFromGitHub {
+    owner = "NyarchLinux";
+    repo = "CatgirlDownloader";
+    tag = finalAttrs.version;
+    hash = "sha256-+RyQOgqPZN3AnVdd5mtgppQ/z51VIEeEsiW2RFTnVbk=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    desktop-file-utils
+    gettext
+    gobject-introspection
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    gtk4
+    libadwaita
+  ];
+
+  dependencies = with python3Packages; [
+    pygobject3
+    requests
+  ];
+
+  meta = {
+    description = "A GTK4 application that downloads images of catgirl and waifus from multiple sources";
+    homepage = "https://github.com/NyarchLinux/CatgirlDownloader";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ yarn ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
https://github.com/NyarchLinux/CatgirlDownloader

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
