### PR TITLE
lib60870: 2.3.6 -> 2.4.1

### DIFF
--- a/pkgs/by-name/li/lib60870/package.nix
+++ b/pkgs/by-name/li/lib60870/package.nix
@@ -9,20 +9,21 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lib60870";
-  version = "2.3.6";
+  version = "2.4.1";
 
   src = fetchFromGitHub {
     owner = "mz-automation";
     repo = "lib60870";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-9VqLl1pDmi8TauBA8uCyymzsYd3w4b5AKtqH7XW80N4=";
+    hash = "sha256-WXEe+G7ib9XNAZSsNl/RZcFHXpIbCMKNfPLnxZzz09E=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/lib60870-C";
 
   postPatch = ''
+    # Keep system mbedTLS support enabled without vendored mbedTLS sources.
     substituteInPlace CMakeLists.txt \
-      --replace-fail "cmake_minimum_required(VERSION 3.0)" "cmake_minimum_required(VERSION 3.10)"
+      --replace-fail "if(MBEDTLS_DIR)" "if(MBEDTLS_DIR OR WITH_MBEDTLS3)"
   ''
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace src/CMakeLists.txt \


### PR DESCRIPTION
Updates lib60870 to 2.4.1, fixing CVE-2026-61893 and CVE-2026-63033. The release adds payload-size validation for declared ASDU elements and bounds-aware information-object decoding.

Release notes: https://redirect.github.com/mz-automation/lib60870/releases/tag/v2.4.1

The existing system-mbedTLS integration is retained despite upstream's new vendored-source detection.

Addresses #547732

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
