### PR TITLE
gnomeExtensions.auto-accent-colour: fix gjs runtime path

### DIFF
--- a/pkgs/desktops/gnome/extensions/extensionOverrides.nix
+++ b/pkgs/desktops/gnome/extensions/extensionOverrides.nix
@@ -65,6 +65,14 @@ lib.trivial.pipe super [
     ];
   }))
 
+  (patchExtension "auto-accent-colour@Wartybix" (old: {
+    patches = [
+      (replaceVars ./extensionOverridesPatches/auto-accent-colour_at_Wartybix.patch {
+        inherit gjs;
+      })
+    ];
+  }))
+
   (patchExtension "caffeine@patapon.info" (old: {
     meta.maintainers = with lib.maintainers; [ eperuffo ];
   }))

--- a/pkgs/desktops/gnome/extensions/extensionOverridesPatches/auto-accent-colour_at_Wartybix.patch
+++ b/pkgs/desktops/gnome/extensions/extensionOverridesPatches/auto-accent-colour_at_Wartybix.patch
@@ -1,0 +1,10 @@
+--- a/extension.js
++++ b/extension.js
+@@ -163,7 +163,7 @@ async function runColorThief(imagePath, extensionPath) {
+     try {
+         const resultStr = await execCommand(
+-            ['gjs', '-m', `${extensionPath}/color-thief/run-color-thief.js`, imagePath]
++            ['@gjs@/bin/gjs', '-m', `${extensionPath}/color-thief/run-color-thief.js`, imagePath]
+         )
+ 
+         const palette = resultStr.split(';')


### PR DESCRIPTION
Auto Accent Colour spawns a `gjs` subprocess to run its `color-thief` helper when extracting colors from the current wallpaper.

Right now it invokes plain `gjs`, which fails on NixOS because `gjs` is stored in the Nix store rather than on a global search path.

As a result, changing the wallpaper can fail with:

```
GLib.SpawnError: Failed to execute child process "gjs" (No such file or directory)
```

and the extension falls back to `(0, 0, 0)` instead of updating the accent color from the wallpaper palette.

This patches the runtime invocation to use the `gjs` path from the derivation via `replaceVars`.

Fixes #547995 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
