### PR TITLE
lycheeslicer: register lycheeslicer URI scheme

### DIFF
--- a/pkgs/by-name/ly/lycheeslicer/package.nix
+++ b/pkgs/by-name/ly/lycheeslicer/package.nix
@@ -24,7 +24,10 @@ let
     noDisplay = false;
     exec = "lycheeslicer";
     terminal = false;
-    mimeTypes = [ "model/stl" ];
+    mimeTypes = [
+      "model/stl"
+      "x-scheme-handler/lycheeslicer"
+    ];
     categories = [ "Graphics" ];
     keywords = [
       "STL"


### PR DESCRIPTION
## Description

Register the `lycheeslicer://` URI scheme in the desktop entry.

Lychee Slicer uses browser-based authentication and returns to
the desktop application via a `lycheeslicer://` callback. The
desktop file currently only registers `model/stl`, so desktop
environments are unable to dispatch the callback to the
application.

Adding the missing `x-scheme-handler/lycheeslicer` MIME type
allows authentication to complete successfully.

## Testing

- Built and installed the package.
- Verified browser login opens normally.
- Before this change, GNOME reported that no application was
  available to handle `lycheeslicer://` links and login could
  not complete.
- After adding the URI handler, authentication completes and
  returns successfully to Lychee Slicer.