### PR TITLE
stcgal: init 1.10

### DIFF
--- a/pkgs/by-name/st/stcgal/stcgal.nix
+++ b/pkgs/by-name/st/stcgal/stcgal.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "stcgal";
+  version = "1.10";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "grigorig";
+    repo = "stcgal";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-SM2wtpJ1F6sfBwfX+2124fLfTtVNjwa5NqsWrhORGhI=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = with python3Packages; [
+    pyserial
+    tqdm
+    pyusb
+  ];
+
+  doCheck = false;
+
+  pythonImportsCheck = [ "stcgal" ];
+
+  meta = {
+    description = "Command line flash programming tool for STC 8051 microcontrollers";
+    homepage = "https://github.com/grigorig/stcgal";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ Wu-XR ];
+    mainProgram = "stcgal";
+  };
+})


### PR DESCRIPTION
Chinese network environment can't provide the fork update way through Git,  please forgive me.

------

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
