### PR TITLE
app2unit: 1.4.2 -> 1.4.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5398,6 +5398,12 @@
     githubId = 718298;
     name = "Michael Livshin";
   };
+  cnst = {
+    name = "cnst";
+    email = "mail@cnst.dev";
+    github = "cnsta";
+    githubId = 61944575;
+  };
   CnTeng = {
     name = "CnTeng";
     email = "me@snakepi.xyz";

--- a/pkgs/by-name/ap/app2unit/package.nix
+++ b/pkgs/by-name/ap/app2unit/package.nix
@@ -11,13 +11,13 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "app2unit";
-  version = "1.4.2";
+  version = "1.4.4";
 
   src = fetchFromGitHub {
     owner = "Vladimir-csp";
     repo = "app2unit";
     tag = "v${finalAttrs.version}";
-    sha256 = "sha256-jUAjcpR4IszvmqWAIjZo0rWZt9yydCe3xH4X+mJ5O8k=";
+    sha256 = "sha256-TIY+/9ekGub+10uyqXy5aYU+2NLysMtaQnD1PIjBCFA=";
   };
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/ap/app2unit/package.nix
+++ b/pkgs/by-name/ap/app2unit/package.nix
@@ -63,7 +63,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://github.com/Vladimir-csp/app2unit";
     license = lib.licenses.gpl3;
     mainProgram = "app2unit";
-    maintainers = with lib.maintainers; [ fazzi ];
+    maintainers = with lib.maintainers; [
+      fazzi
+      cnst
+    ];
     platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
Upstream release: https://github.com/Vladimir-csp/app2unit/releases/tag/v1.4.4

Fixes the build, which currently fails in `buildPhase` since scdoc was bumped to 1.11.5:
    `Error at 70:17: Cannot nest inline formatting (began with _ at 69:43)`
    
Also adding myself as a maintainer at @fxzzi's suggestion (see review comment).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

<details>
<summary><code>nixpkgs-review rev HEAD</code></summary>
--------- Impacted packages on 'x86_64-linux' ---------
1 package updated:
app2unit (1.4.2 → 1.4.4)

--------- Report for 'x86_64-linux' ---------
1 package built:
app2unit
</details>

<details>
<summary>Functional testing</summary>

```console
$ head -3 result/bin/app2unit
#!/nix/store/jbiq23y1hv48nckmb15iixs7rfz421y0-dash-0.5.13.5/bin/dash

A2U__TERMINAL_HANDLER=/nix/store/d9fl4p387n0jdmbrm5a5hbvzrhm1fpcs-xdg-terminal-exec-0.14.2/bin/xdg-terminal-exec

$ result/bin/app2unit --test foot.desktop
Command and arguments:
  >systemd-run
  >--user
  >--scope
  >--same-dir
  >--property=After=graphical-session.target
  >--property=PartOf=graphical-session.target
  >--property=SourcePath=/run/current-system/sw/share/applications/./foot.desktop
  >--slice=app.slice
  >--unit=app-Hyprland-foot-66e938a4.scope
  >--description=Foot - Terminal
  >--quiet
  >--collect
  >--
  >foot
```

`man app2unit` renders correctly; `installManPage` picked up the generated page (`gzipping man pages under …/share/man/`) and all six symlinks are present.
</details>

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
