### PR TITLE
[26.05] python3Packages.datamodel-code-generator: 0.55.0 -> 0.71.0

### DIFF
--- a/pkgs/development/python-modules/datamodel-code-generator/default.nix
+++ b/pkgs/development/python-modules/datamodel-code-generator/default.nix
@@ -36,14 +36,14 @@
 
 buildPythonPackage rec {
   pname = "datamodel-code-generator";
-  version = "0.68.1";
+  version = "0.71.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "koxudaxi";
     repo = "datamodel-code-generator";
     tag = version;
-    hash = "sha256-fYnI7S4FJ927qZXyAsWQzxhLTrcpscYqJunmcSt/gkk=";
+    hash = "sha256-0vh/iynZzmMzvdUXNScb+JWANdSrzPLT1qt+jyKleg4=";
   };
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/datamodel-code-generator/default.nix
+++ b/pkgs/development/python-modules/datamodel-code-generator/default.nix
@@ -3,15 +3,21 @@
   argcomplete,
   black,
   buildPythonPackage,
+  email-validator,
   fetchFromGitHub,
   genson,
   graphql-core,
+  grpcio-tools,
   hatch-vcs,
   hatchling,
   httpx,
+  hypothesis,
+  hypothesis-jsonschema,
   inflect,
   inline-snapshot,
   isort,
+  jsonschema,
+  msgspec,
   jinja2,
   openapi-spec-validator,
   packaging,
@@ -20,6 +26,8 @@
   pydantic,
   pysnooper,
   pytest-mock,
+  pytest-timeout,
+  pytest-xdist,
   pytestCheckHook,
   pyyaml,
   time-machine,
@@ -28,14 +36,14 @@
 
 buildPythonPackage rec {
   pname = "datamodel-code-generator";
-  version = "0.55.0";
+  version = "0.68.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "koxudaxi";
     repo = "datamodel-code-generator";
     tag = version;
-    hash = "sha256-zsLJv7gKhmnEIS/AUvnBzm+07QFQoMdiFo/PkfRyHek=";
+    hash = "sha256-fYnI7S4FJ927qZXyAsWQzxhLTrcpscYqJunmcSt/gkk=";
   };
 
   pythonRelaxDeps = [
@@ -65,6 +73,7 @@ buildPythonPackage rec {
     debug = [ pysnooper ];
     graphql = [ graphql-core ];
     http = [ httpx ];
+    protobuf = [ grpcio-tools ];
     ruff = [ ruff ];
     validation = [
       openapi-spec-validator
@@ -76,19 +85,30 @@ buildPythonPackage rec {
   };
 
   nativeCheckInputs = [
+    email-validator
     inline-snapshot
+    hypothesis
+    hypothesis-jsonschema
+    jsonschema
+    msgspec
     pytest-mock
+    pytest-timeout
+    pytest-xdist
     pytestCheckHook
     time-machine
   ]
   ++ optional-dependencies.all;
 
-  pythonImportsCheck = [ "datamodel_code_generator" ];
+  pytestFlags = [
+    "--maxfail=2"
+  ];
 
   disabledTests = [
     # remote testing, name resolution failure.
     "test_openapi_parser_parse_remote_ref"
   ];
+
+  pythonImportsCheck = [ "datamodel_code_generator" ];
 
   meta = {
     description = "Pydantic model and dataclasses.dataclass generator for easy conversion of JSON, OpenAPI, JSON Schema, and YAML data sources";

--- a/pkgs/development/python-modules/hypothesis-jsonschema/default.nix
+++ b/pkgs/development/python-modules/hypothesis-jsonschema/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  hypothesis,
+  jsonschema,
+  pytest-cov-stub,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "hypothesis-jsonschema";
+  version = "0.23.1";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  # no git tags
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-9KwDICQ0KkFJoQJTmE9aVza4Kz/ir7CIjzg0oxFT8hU=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    hypothesis
+    jsonschema
+  ];
+
+  doCheck = false; # sdist does not include everything to run the tests
+
+  nativeCheckInputs = [
+    pytest-cov-stub
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "hypothesis_jsonschema"
+  ];
+
+  meta = {
+    description = "Generate test data from JSON schemata with Hypothesis";
+    homepage = "https://github.com/Zac-HD/hypothesis-jsonschema";
+    license = lib.licenses.mpl20;
+  };
+})

--- a/pkgs/development/python-modules/inline-snapshot/default.nix
+++ b/pkgs/development/python-modules/inline-snapshot/default.nix
@@ -21,14 +21,14 @@
 
 buildPythonPackage rec {
   pname = "inline-snapshot";
-  version = "0.32.5";
+  version = "0.34.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "15r10nk";
     repo = "inline-snapshot";
     tag = version;
-    hash = "sha256-xnooMIm0UiNOWrZ4JZwbpFzliGsTF7b1DAXi1fxMb30=";
+    hash = "sha256-4Uvc925/6RxJRHjP3SZaB7T+gqky5KlL9agHy/14Jd0=";
   };
 
   build-system = [ hatchling ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7415,6 +7415,8 @@ self: super: with self; {
 
   hypothesis-auto = callPackage ../development/python-modules/hypothesis-auto { };
 
+  hypothesis-jsonschema = callPackage ../development/python-modules/hypothesis-jsonschema { };
+
   hypothesis_6_136 = callPackage ../development/python-modules/hypothesis/hypothesis_6_136.nix { };
 
   hypothesmith = callPackage ../development/python-modules/hypothesmith { };


### PR DESCRIPTION
Backports #546325 to `staging-26.05`.

The release branch still packaged datamodel-code-generator 0.55.0, so the security update could not be cherry-picked directly. This backport first applies the already-merged test dependency updates for `inline-snapshot` and `hypothesis-jsonschema` and the intervening datamodel-code-generator 0.68.1 update, then applies the 0.71.0 security update unchanged.

Version 0.71.0 rejects unsafe schema-controlled `customBasePath` values before generating Python imports, fixing CVE-2026-63720.

Changelog: https://github.com/koxudaxi/datamodel-code-generator/blob/0.71.0/CHANGELOG.md

Addresses #546268

Verification:

- The complete four-patch form built on release-26.05 commit `878b6bec4c350230083f54fbc6e4d9f89a60b02d`: `inline-snapshot` reported 1300 passed / 112 skipped and datamodel-code-generator reported 5951 passed / 25 skipped.
- Malicious scalar and nested-list `customBasePath` fixtures were rejected without creating output; a valid dotted base path generated the expected import.
- The final branch is a signed, patch-equivalent replay of the four upstream commits onto the current `staging-26.05` head; `nixfmt --check` and `git diff --check` pass.
- Official `ci.eval` reports 1767 Linux and 1544 Darwin rebuilds, confirming `staging-26.05` as the required route.

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
