### PR TITLE
pentect: init at 0.0.16

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7878,6 +7878,11 @@
     githubId = 63052937;
     name = "Connor Alecks";
   };
+  edamame_x = {
+    name = "EdamAmex";
+    github = "EdamAme-x";
+    githubId = 121654029;
+  };
   edanaher = {
     email = "nixos@edanaher.net";
     github = "edanaher";

--- a/pkgs/by-name/pe/pentect/package.nix
+++ b/pkgs/by-name/pe/pentect/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  rustc,
+  stdenv,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "pentect";
+  version = "0.0.16";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "EdamAme-x";
+    repo = "pentect";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rmULftKFwMdVlZAQsGI8a37PpnYNjjCvB5DmRo1ydro=";
+  };
+
+  cargoHash = "sha256-pO2ZoyGOsfikyznFw9y3O2gR9oxZkWxN26Pkau9C+E8=";
+
+  cargoBuildFlags = [
+    "-p"
+    "pentect-cli"
+  ];
+  cargoTestFlags = [
+    "-p"
+    "pentect-cli"
+  ];
+
+  postPatch = lib.optionalString (stdenv.isx86_64 && lib.versionOlder rustc.llvm.version "22") ''
+    # LLVM 21 has an incompatible signature for the AVX-512 VNNI intrinsic used by
+    # rten-gemm. Disable that optional dispatch path and retain its AVX2 fallback.
+    substituteInPlace "$cargoDepsCopy/source-registry-0/rten-gemm-0.24.0/src/i8dot.rs" \
+      --replace-fail 'if !is_x86_feature_detected!("avx512vnni") {' 'if true {' \
+      --replace-fail '_mm512_dpbusd_epi32(acc.0, a.0, b.0).into()' 'unreachable!("AVX-512 VNNI is disabled for LLVM 21")'
+  '';
+
+  preCheck = ''
+    export HOME="$TMPDIR/home"
+    export XDG_CACHE_HOME="$TMPDIR/cache"
+    export XDG_CONFIG_HOME="$TMPDIR/config"
+    export XDG_DATA_HOME="$TMPDIR/data"
+    export XDG_STATE_HOME="$TMPDIR/state"
+    mkdir -p "$HOME" "$XDG_CACHE_HOME" "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_STATE_HOME"
+  '';
+
+  postInstall = ''
+    cat > "$out/bin/.pentect-managed-install.json" <<'JSON'
+    {"version":1,"manager":"nix","update":"nix profile upgrade pentect","uninstall":"nix profile remove pentect"}
+    JSON
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    test "$($out/bin/pentect version)" = "pentect ${finalAttrs.version}"
+    runHook postInstallCheck
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Local secret masking boundary for AI agents";
+    homepage = "https://github.com/EdamAme-x/pentect";
+    changelog = "https://github.com/EdamAme-x/pentect/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ edamame_x ];
+    mainProgram = "pentect";
+  };
+})


### PR DESCRIPTION
Adds Pentect 0.0.16, a local secret-masking boundary for AI agents.

Homepage: https://github.com/EdamAme-x/pentect

The package is built from the tagged source release with the Rust platform. It installs the `pentect` CLI and includes an install check for `pentect version`.

Validation performed locally:
- Parsed and evaluated the package expression with Nix.
- Prefetched and verified both the source and Cargo dependency hashes.
- Full compilation was delegated to Nixpkgs CI because the default OCR feature is expensive to compile; ofborg passed `pentect` on x86_64-linux and aarch64-linux.

Automation disclosure: OpenAI Codex (GPT-5) assisted with the package expression and PR text. I reviewed the resulting diff, package structure, fixed-output hashes, and evaluation output before submission.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and core functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
