### PR TITLE
nixos/lk-jwt-service: update configuration options to align with upst…

### DIFF
--- a/nixos/modules/services/matrix/lk-jwt-service.nix
+++ b/nixos/modules/services/matrix/lk-jwt-service.nix
@@ -4,40 +4,157 @@
   pkgs,
   ...
 }:
+
 let
   cfg = config.services.lk-jwt-service;
+
+  # Environment variables that point to a file and should be routed through systemd's LoadCredential= mechanism.
+  credentialVars = [
+    "LIVEKIT_KEY_FILE"
+    "LIVEKIT_KEY_FROM_FILE"
+    "LIVEKIT_SECRET_FROM_FILE"
+  ];
+
+  # Returns the credentialVars that have actually been set
+  activeCredentialVars = lib.filter (name: cfg.environment.${name} != null) credentialVars;
+
+  # Create a mapping of credentials for systemd to load
+  LoadCredential = map (name: "${name}:${cfg.environment.${name}}") activeCredentialVars;
+
+  # Replace old attributes with prefixed credentials paths
+  environment =
+    (removeAttrs cfg.environment credentialVars)
+    // lib.genAttrs activeCredentialVars (name: "%d/${name}");
 in
 {
   meta.maintainers = [ lib.maintainers.quadradical ];
+
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "services" "lk-jwt-service" "port" ]
+      [ "services" "lk-jwt-service" "environment" "LIVEKIT_JWT_PORT" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "lk-jwt-service" "keyFile" ]
+      [ "services" "lk-jwt-service" "environment" "LIVEKIT_KEY_FILE" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "lk-jwt-service" "livekitUrl" ]
+      [ "services" "lk-jwt-service" "environment" "LIVEKIT_URL" ]
+    )
+  ];
+
   options.services.lk-jwt-service = {
     enable = lib.mkEnableOption "lk-jwt-service";
+
     package = lib.mkPackageOption pkgs "lk-jwt-service" { };
 
-    livekitUrl = lib.mkOption {
-      type = lib.types.strMatching "^wss?://.*";
-      example = "wss://example.com/livekit/sfu";
+    environment = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = lib.types.attrsOf lib.types.str;
+        options = {
+          LIVEKIT_URL = lib.mkOption {
+            type = lib.types.strMatching "^wss?://.*";
+            example = "wss://example.com/livekit/sfu";
+            description = ''
+              The public websocket URL for LiveKit.
+
+              The scheme must be either `wss://` (recommended) or `ws://` (insecure).
+            '';
+          };
+          LIVEKIT_KEY_FILE = lib.mkOption {
+            type = lib.types.nullOr lib.types.path;
+            default = null;
+            example = "/run/secrets/lk-jwt-service.key";
+            description = ''
+              Path to a file containing the LiveKit key/secret pair in
+              `key: secret` form.
+
+              When set, the file is passed to the service via systemd's
+              `LoadCredential=` mechanism, so the path does not need to be
+              readable by the service's dynamic user directly.
+            '';
+          };
+          LIVEKIT_KEY_FROM_FILE = lib.mkOption {
+            type = lib.types.nullOr lib.types.path;
+            default = null;
+            example = "/run/secrets/lk-jwt-service.key-id";
+            description = ''
+              Path to a file containing only the LiveKit API key.
+
+              When set, the file is passed to the service via systemd's
+              `LoadCredential=` mechanism.
+            '';
+          };
+          LIVEKIT_SECRET_FROM_FILE = lib.mkOption {
+            type = lib.types.nullOr lib.types.path;
+            default = null;
+            example = "/run/secrets/lk-jwt-service.secret";
+            description = ''
+              Path to a file containing only the LiveKit API secret.
+
+              When set, the file is passed to the service via systemd's
+              `LoadCredential=` mechanism.
+            '';
+          };
+          LIVEKIT_JWT_BIND = lib.mkOption {
+            type = lib.types.strMatching ".*:[0-9]+";
+            default = ":8080";
+            example = "127.0.0.1:8080";
+            description = ''
+              Address to bind the server to, in `host:port` form.
+
+              The host part may be omitted to bind on all interfaces (for example, `:8080`).
+
+              This replaces the upstream `LIVEKIT_JWT_PORT` variable, which has been deprecated.
+            '';
+          };
+          LIVEKIT_FULL_ACCESS_HOMESERVERS = lib.mkOption {
+            type = lib.types.either (lib.types.enum [ "*" ]) (lib.types.listOf lib.types.str);
+
+            default = "*";
+            apply = value: if builtins.isList value then lib.concatStringsSep "," value else value;
+
+            example = [
+              "example.com"
+              "matrix.org"
+            ];
+
+            description = ''
+              Homeservers whose users are allowed full access to the LiveKit JWT
+              service.
+
+              Set to `"*"` (the default) to allow all homeservers, or provide a
+              list of homeserver names to restrict access.
+            '';
+          };
+        };
+      };
+      default = { };
       description = ''
-        The public websocket URL for livekit.
-        The proto needs to be either  `wss://` (recommended) or `ws://` (insecure).
+        Environment variables for configuring lk-jwt-service.
+        This field will end up public in /nix/store, for secret values (such as `LIVEKIT_KEY` and `LIVEKIT_SECRET`) use `environmentFile`.
+
+        See <https://github.com/element-hq/lk-jwt-service#%EF%B8%8F-configuration> for available options.
       '';
     };
 
-    keyFile = lib.mkOption {
-      type = lib.types.path;
+    environmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/run/secrets/lk-jwt-service.env";
       description = ''
-        Path to a file containing the credential mapping (`<keyname>: <secret>`) to access LiveKit.
+        Path to an environment file for lk-jwt-service.
 
-        Example:
-        `lk-jwt-service: f6lQGaHtM5HfgZjIcec3cOCRfiDqIine4CpZZnqdT5cE`
+        Use this file to supply secret configuration such as `LIVEKIT_KEY`
+        and `LIVEKIT_SECRET`. The file must contain lines in the form
+        `KEY=value` and should be managed by a secret store such as
+        sops-nix or agenix, so that its contents do not end up in the
+        Nix store.
 
-        For more information, see <https://github.com/element-hq/lk-jwt-service#configuration>.
+        See <https://github.com/element-hq/lk-jwt-service#%EF%B8%8F-configuration>
+        for available variables.
       '';
-    };
-
-    port = lib.mkOption {
-      type = lib.types.port;
-      default = 8080;
-      description = "Port that lk-jwt-service should listen on.";
     };
   };
 
@@ -48,14 +165,12 @@ in
       wantedBy = [ "multi-user.target" ];
       wants = [ "network-online.target" ];
       after = [ "network-online.target" ];
-      environment = {
-        LIVEKIT_URL = cfg.livekitUrl;
-        LIVEKIT_JWT_BIND = ":${toString cfg.port}";
-        LIVEKIT_KEY_FILE = "/run/credentials/lk-jwt-service.service/livekit-secrets";
-      };
+
+      inherit environment;
 
       serviceConfig = {
-        LoadCredential = [ "livekit-secrets:${cfg.keyFile}" ];
+        EnvironmentFile = cfg.environmentFile;
+        inherit LoadCredential;
         ExecStart = lib.getExe cfg.package;
         DynamicUser = true;
         LockPersonality = true;
@@ -87,5 +202,11 @@ in
         UMask = "077";
       };
     };
+
+    warnings = lib.optional (cfg.environment ? LIVEKIT_JWT_PORT) ''
+      `services.lk-jwt-service.environment.LIVEKIT_JWT_PORT` is set, but this environment variable is deprecated upstream.
+
+      Use `services.lk-jwt-service.environment.LIVEKIT_JWT_BIND` instead.
+    '';
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

My attempt at closing https://github.com/NixOS/nixpkgs/issues/537858. Refer to [upstream documentation](https://github.com/element-hq/lk-jwt-service#%EF%B8%8F-configuration) to see why these changes were necessary.

**AI disclosure:** Claude 4.7 Opus was used to *review and critique* my basic changes in code before submission.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
