### PR TITLE
eclipse-mat: 1.15.0.20231206 -> 1.17.0.20260601; add darwin and aarch64-linux support

### DIFF
--- a/pkgs/by-name/ec/eclipse-mat/package.nix
+++ b/pkgs/by-name/ec/eclipse-mat/package.nix
@@ -160,7 +160,10 @@ stdenvNoCC.mkDerivation (
       ];
       license = lib.licenses.epl20;
       mainProgram = "eclipse-mat";
-      maintainers = [ lib.maintainers.ktor ];
+      maintainers = with lib.maintainers; [
+        ktor
+        dfjay
+      ];
       platforms = lib.attrNames sources;
     };
   }

--- a/pkgs/by-name/ec/eclipse-mat/package.nix
+++ b/pkgs/by-name/ec/eclipse-mat/package.nix
@@ -1,136 +1,120 @@
 {
+  lib,
+  stdenvNoCC,
+  bintools,
   fetchurl,
-  fontconfig,
-  freetype,
+  copyDesktopItems,
+  makeDesktopItem,
+  makeWrapper,
+  unzip,
+  jdk,
   glib,
   gsettings-desktop-schemas,
   gtk3,
-  jdk21,
-  lib,
-  libx11,
-  libxrender,
   libxtst,
-  makeDesktopItem,
-  makeWrapper,
-  shared-mime-info,
-  stdenv,
-  unzip,
   webkitgtk_4_1,
-  zlib,
 }:
 
-let
-  pVersion = "1.17.0.20260601";
-  pVersionTriple = lib.splitVersion pVersion;
-  majorVersion = lib.elemAt pVersionTriple 0;
-  minorVersion = lib.elemAt pVersionTriple 1;
-  patchVersion = lib.elemAt pVersionTriple 2;
-  baseVersion = "${majorVersion}.${minorVersion}.${patchVersion}";
-  jdk = jdk21;
-in
-stdenv.mkDerivation rec {
-  pname = "eclipse-mat";
-  version = pVersion;
+stdenvNoCC.mkDerivation (
+  finalAttrs:
+  let
+    baseVersion = lib.versions.pad 3 finalAttrs.version;
+  in
+  {
+    pname = "eclipse-mat";
+    version = "1.17.0.20260601";
 
-  src = fetchurl {
-    url = "https://ftp.halifax.rwth-aachen.de/eclipse//mat/${baseVersion}/rcp/MemoryAnalyzer-${version}-linux.gtk.x86_64.zip";
-    sha256 = "sha256-4eqAp5hNQR5MTX37qwktqSVfe3ctaBolamEEm8yIN2c=";
-  };
+    strictDeps = true;
+    __structuredAttrs = true;
 
-  desktopItem = makeDesktopItem {
-    name = "eclipse-mat";
-    exec = "eclipse-mat";
-    icon = "eclipse";
-    comment = "Eclipse Memory Analyzer";
-    desktopName = "Eclipse MAT";
-    genericName = "Java Memory Analyzer";
-    categories = [ "Development" ];
-  };
+    src = fetchurl {
+      urls = [
+        "https://ftp.halifax.rwth-aachen.de/eclipse/mat/${baseVersion}/rcp/MemoryAnalyzer-${finalAttrs.version}-linux.gtk.x86_64.zip"
+        "https://download.eclipse.org/mat/${baseVersion}/rcp/MemoryAnalyzer-${finalAttrs.version}-linux.gtk.x86_64.zip"
+      ];
+      hash = "sha256-4eqAp5hNQR5MTX37qwktqSVfe3ctaBolamEEm8yIN2c=";
+    };
 
-  unpackPhase = ''
-    unzip $src
-  '';
+    sourceRoot = ".";
 
-  buildCommand = ''
-    mkdir -p $out
-    unzip $src
-    mv mat $out
+    nativeBuildInputs = [
+      copyDesktopItems
+      glib
+      makeWrapper
+      unzip
+    ];
 
-    # Patch binaries.
-    interpreter=$(echo ${stdenv.cc.libc}/lib/ld-linux*.so.2)
-    libCairo=$out/eclipse/libcairo-swt.so
-    patchelf --set-interpreter $interpreter $out/mat/MemoryAnalyzer
-    [ -f $libCairo ] && patchelf --set-rpath ${
-      lib.makeLibraryPath [
-        freetype
-        fontconfig
-        libx11
-        libxrender
-        zlib
-      ]
-    } $libCairo
+    buildInputs = [
+      gsettings-desktop-schemas
+      gtk3
+    ];
 
-    # Create wrapper script.  Pass -configuration to store settings in ~/.eclipse-mat/<version>
-    makeWrapper $out/mat/MemoryAnalyzer $out/bin/eclipse-mat \
-      --prefix PATH : ${jdk}/bin \
-      --prefix LD_LIBRARY_PATH : ${
-        lib.makeLibraryPath [
-          glib
-          gtk3
-          libxtst
-          webkitgtk_4_1
-        ]
-      } \
-      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH" \
-      --add-flags "-configuration \$HOME/.eclipse-mat/''${version}/configuration"
+    desktopItems = [
+      (makeDesktopItem {
+        name = "eclipse-mat";
+        exec = "eclipse-mat";
+        icon = "eclipse";
+        comment = "Eclipse Memory Analyzer";
+        desktopName = "Eclipse MAT";
+        genericName = "Java Memory Analyzer";
+        categories = [
+          "Development"
+          "Profiling"
+        ];
+      })
+    ];
 
-    # Create desktop item.
-    mkdir -p $out/share/applications
-    cp ${desktopItem}/share/applications/* $out/share/applications
-    mkdir -p $out/share/pixmaps
-    find $out/mat/plugins -name 'eclipse*.png' -type f -exec cp {} $out/share/pixmaps \;
-    mv $out/share/pixmaps/eclipse64.png $out/share/pixmaps/eclipse.png
-  '';
+    installPhase = ''
+      runHook preInstall
 
-  nativeBuildInputs = [
-    unzip
-    makeWrapper
-  ];
-  buildInputs = [
-    fontconfig
-    freetype
-    glib
-    gsettings-desktop-schemas
-    gtk3
-    jdk
-    libx11
-    libxrender
-    libxtst
-    zlib
-    shared-mime-info
-    webkitgtk_4_1
-  ];
+      mkdir -p $out
+      cp -r mat $out/mat
 
-  dontBuild = true;
-  dontConfigure = true;
+      patchelf --set-interpreter ${bintools.dynamicLinker} $out/mat/MemoryAnalyzer
 
-  meta = {
-    description = "Fast and feature-rich Java heap analyzer";
-    mainProgram = "eclipse-mat";
-    longDescription = ''
-      The Eclipse Memory Analyzer is a tool that helps you find memory
-      leaks and reduce memory consumption. Use the Memory Analyzer to
-      analyze productive heap dumps with hundreds of millions of
-      objects, quickly calculate the retained sizes of objects, see
-      who is preventing the Garbage Collector from collecting objects,
-      run a report to automatically extract leak suspects.
+      # Pass -configuration so that settings are written to ~/.eclipse-mat/<version>
+      # instead of the read-only store path.
+      makeWrapper $out/mat/MemoryAnalyzer $out/bin/eclipse-mat \
+        --prefix PATH : ${lib.makeBinPath [ jdk ]} \
+        --set JAVA_HOME ${jdk.home} \
+        --prefix LD_LIBRARY_PATH : ${
+          lib.makeLibraryPath [
+            glib
+            gtk3
+            libxtst
+            webkitgtk_4_1
+          ]
+        } \
+        --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH" \
+        --add-flags "-configuration \$HOME/.eclipse-mat/${finalAttrs.version}/configuration"
+
+      mkdir -p $out/share/pixmaps
+      find $out/mat/plugins -name 'eclipse*.png' -type f -exec cp {} $out/share/pixmaps \;
+      mv $out/share/pixmaps/eclipse64.png $out/share/pixmaps/eclipse.png
+
+      runHook postInstall
     '';
-    homepage = "https://eclipse.dev/mat/";
-    changelog = "https://eclipse.dev/mat/${baseVersion}/noteworthy.html";
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    license = lib.licenses.epl20;
-    maintainers = [ lib.maintainers.ktor ];
-    platforms = [ "x86_64-linux" ];
-  };
 
-}
+    meta = {
+      description = "Fast and feature-rich Java heap analyzer";
+      longDescription = ''
+        The Eclipse Memory Analyzer is a tool that helps you find memory
+        leaks and reduce memory consumption. Use the Memory Analyzer to
+        analyze productive heap dumps with hundreds of millions of
+        objects, quickly calculate the retained sizes of objects, see
+        who is preventing the Garbage Collector from collecting objects,
+        run a report to automatically extract leak suspects.
+      '';
+      homepage = "https://eclipse.dev/mat/";
+      changelog = "https://eclipse.dev/mat/${baseVersion}/noteworthy.html";
+      sourceProvenance = with lib.sourceTypes; [
+        binaryBytecode
+        binaryNativeCode
+      ];
+      license = lib.licenses.epl20;
+      mainProgram = "eclipse-mat";
+      maintainers = [ lib.maintainers.ktor ];
+      platforms = [ "x86_64-linux" ];
+    };
+  }
+)

--- a/pkgs/by-name/ec/eclipse-mat/package.nix
+++ b/pkgs/by-name/ec/eclipse-mat/package.nix
@@ -19,6 +19,24 @@ stdenvNoCC.mkDerivation (
   finalAttrs:
   let
     baseVersion = lib.versions.pad 3 finalAttrs.version;
+
+    sources = {
+      x86_64-linux = {
+        suffix = "linux.gtk.x86_64";
+        hash = "sha256-4eqAp5hNQR5MTX37qwktqSVfe3ctaBolamEEm8yIN2c=";
+      };
+      aarch64-linux = {
+        suffix = "linux.gtk.aarch64";
+        hash = "sha256-MJUome0KjXjmjROTTnDbSTSnDKiUGHt6LAZY1giXmQ0=";
+      };
+      aarch64-darwin = {
+        suffix = "macosx.cocoa.aarch64";
+        hash = "sha256-Of/BJTaxD6x0+aNDKeod1RVWG86XFBmk8qdbU/p73qQ=";
+      };
+    };
+
+    inherit (stdenvNoCC.hostPlatform) system;
+    source = sources.${system} or (throw "Unsupported system: ${system}");
   in
   {
     pname = "eclipse-mat";
@@ -29,27 +47,36 @@ stdenvNoCC.mkDerivation (
 
     src = fetchurl {
       urls = [
-        "https://ftp.halifax.rwth-aachen.de/eclipse/mat/${baseVersion}/rcp/MemoryAnalyzer-${finalAttrs.version}-linux.gtk.x86_64.zip"
-        "https://download.eclipse.org/mat/${baseVersion}/rcp/MemoryAnalyzer-${finalAttrs.version}-linux.gtk.x86_64.zip"
+        "https://ftp.halifax.rwth-aachen.de/eclipse/mat/${baseVersion}/rcp/MemoryAnalyzer-${finalAttrs.version}-${source.suffix}.zip"
+        "https://download.eclipse.org/mat/${baseVersion}/rcp/MemoryAnalyzer-${finalAttrs.version}-${source.suffix}.zip"
       ];
-      hash = "sha256-4eqAp5hNQR5MTX37qwktqSVfe3ctaBolamEEm8yIN2c=";
+      inherit (source) hash;
     };
 
     sourceRoot = ".";
 
     nativeBuildInputs = [
-      copyDesktopItems
-      glib
       makeWrapper
       unzip
+    ]
+    ++ lib.optionals stdenvNoCC.hostPlatform.isLinux [
+      copyDesktopItems
+      glib
     ];
 
-    buildInputs = [
+    buildInputs = lib.optionals stdenvNoCC.hostPlatform.isLinux [
       gsettings-desktop-schemas
       gtk3
     ];
 
-    desktopItems = [
+    # Keep the .app's notarized upstream signature valid
+    dontPatchShebangs = stdenvNoCC.hostPlatform.isDarwin;
+
+    # The bundle ships JNA natives for every OS, so auditTmpdir finds Linux ELF
+    # objects and calls patchelf, which does not exist on Darwin.
+    noAuditTmpdir = stdenvNoCC.hostPlatform.isDarwin;
+
+    desktopItems = lib.optionals stdenvNoCC.hostPlatform.isLinux [
       (makeDesktopItem {
         name = "eclipse-mat";
         exec = "eclipse-mat";
@@ -64,38 +91,54 @@ stdenvNoCC.mkDerivation (
       })
     ];
 
-    installPhase = ''
-      runHook preInstall
+    installPhase =
+      if stdenvNoCC.hostPlatform.isDarwin then
+        ''
+          runHook preInstall
 
-      mkdir -p $out
-      cp -r mat $out/mat
+          mkdir -p $out/Applications
+          cp -R MemoryAnalyzer.app $out/Applications/
 
-      patchelf --set-interpreter ${bintools.dynamicLinker} $out/mat/MemoryAnalyzer
+          makeWrapper $out/Applications/MemoryAnalyzer.app/Contents/MacOS/MemoryAnalyzer $out/bin/eclipse-mat \
+            --prefix PATH : ${lib.makeBinPath [ jdk ]} \
+            --set JAVA_HOME ${jdk.home} \
+            --add-flags "-configuration \$HOME/.eclipse-mat/${finalAttrs.version}/configuration"
 
-      # Pass -configuration so that settings are written to ~/.eclipse-mat/<version>
-      # instead of the read-only store path.
-      makeWrapper $out/mat/MemoryAnalyzer $out/bin/eclipse-mat \
-        --prefix PATH : ${lib.makeBinPath [ jdk ]} \
-        --set JAVA_HOME ${jdk.home} \
-        --prefix LD_LIBRARY_PATH : ${
-          lib.makeLibraryPath [
-            glib
-            gtk3
-            libxtst
-            webkitgtk_4_1
-          ]
-        } \
-        --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH" \
-        --add-flags "-configuration \$HOME/.eclipse-mat/${finalAttrs.version}/configuration"
+          runHook postInstall
+        ''
+      else
+        ''
+          runHook preInstall
 
-      unzip -j -q mat/plugins/org.eclipse.mat.ui.rcp_*.jar "icons/memory_analyzer_*.png" -d icons
-      for size in 32 48 64 128 256; do
-        install -Dm444 icons/memory_analyzer_$size.png \
-          $out/share/icons/hicolor/''${size}x''${size}/apps/eclipse-mat.png
-      done
+          mkdir -p $out
+          cp -r mat $out/mat
 
-      runHook postInstall
-    '';
+          patchelf --set-interpreter ${bintools.dynamicLinker} $out/mat/MemoryAnalyzer
+
+          # Pass -configuration so that settings are written to ~/.eclipse-mat/<version>
+          # instead of the read-only store path.
+          makeWrapper $out/mat/MemoryAnalyzer $out/bin/eclipse-mat \
+            --prefix PATH : ${lib.makeBinPath [ jdk ]} \
+            --set JAVA_HOME ${jdk.home} \
+            --prefix LD_LIBRARY_PATH : ${
+              lib.makeLibraryPath [
+                glib
+                gtk3
+                libxtst
+                webkitgtk_4_1
+              ]
+            } \
+            --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH" \
+            --add-flags "-configuration \$HOME/.eclipse-mat/${finalAttrs.version}/configuration"
+
+          unzip -j -q mat/plugins/org.eclipse.mat.ui.rcp_*.jar "icons/memory_analyzer_*.png" -d icons
+          for size in 32 48 64 128 256; do
+            install -Dm444 icons/memory_analyzer_$size.png \
+              $out/share/icons/hicolor/''${size}x''${size}/apps/eclipse-mat.png
+          done
+
+          runHook postInstall
+        '';
 
     meta = {
       description = "Fast and feature-rich Java heap analyzer";
@@ -116,7 +159,7 @@ stdenvNoCC.mkDerivation (
       license = lib.licenses.epl20;
       mainProgram = "eclipse-mat";
       maintainers = [ lib.maintainers.ktor ];
-      platforms = [ "x86_64-linux" ];
+      platforms = lib.attrNames sources;
     };
   }
 )

--- a/pkgs/by-name/ec/eclipse-mat/package.nix
+++ b/pkgs/by-name/ec/eclipse-mat/package.nix
@@ -53,7 +53,7 @@ stdenvNoCC.mkDerivation (
       (makeDesktopItem {
         name = "eclipse-mat";
         exec = "eclipse-mat";
-        icon = "eclipse";
+        icon = "eclipse-mat";
         comment = "Eclipse Memory Analyzer";
         desktopName = "Eclipse MAT";
         genericName = "Java Memory Analyzer";
@@ -88,9 +88,11 @@ stdenvNoCC.mkDerivation (
         --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH" \
         --add-flags "-configuration \$HOME/.eclipse-mat/${finalAttrs.version}/configuration"
 
-      mkdir -p $out/share/pixmaps
-      find $out/mat/plugins -name 'eclipse*.png' -type f -exec cp {} $out/share/pixmaps \;
-      mv $out/share/pixmaps/eclipse64.png $out/share/pixmaps/eclipse.png
+      unzip -j -q mat/plugins/org.eclipse.mat.ui.rcp_*.jar "icons/memory_analyzer_*.png" -d icons
+      for size in 32 48 64 128 256; do
+        install -Dm444 icons/memory_analyzer_$size.png \
+          $out/share/icons/hicolor/''${size}x''${size}/apps/eclipse-mat.png
+      done
 
       runHook postInstall
     '';

--- a/pkgs/by-name/ec/eclipse-mat/package.nix
+++ b/pkgs/by-name/ec/eclipse-mat/package.nix
@@ -140,6 +140,8 @@ stdenvNoCC.mkDerivation (
           runHook postInstall
         '';
 
+    passthru.updateScript = ./update.sh;
+
     meta = {
       description = "Fast and feature-rich Java heap analyzer";
       longDescription = ''

--- a/pkgs/by-name/ec/eclipse-mat/package.nix
+++ b/pkgs/by-name/ec/eclipse-mat/package.nix
@@ -5,7 +5,7 @@
   glib,
   gsettings-desktop-schemas,
   gtk3,
-  jdk17,
+  jdk21,
   lib,
   libx11,
   libxrender,
@@ -20,13 +20,13 @@
 }:
 
 let
-  pVersion = "1.15.0.20231206";
+  pVersion = "1.17.0.20260601";
   pVersionTriple = lib.splitVersion pVersion;
   majorVersion = lib.elemAt pVersionTriple 0;
   minorVersion = lib.elemAt pVersionTriple 1;
   patchVersion = lib.elemAt pVersionTriple 2;
   baseVersion = "${majorVersion}.${minorVersion}.${patchVersion}";
-  jdk = jdk17;
+  jdk = jdk21;
 in
 stdenv.mkDerivation rec {
   pname = "eclipse-mat";
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://ftp.halifax.rwth-aachen.de/eclipse//mat/${baseVersion}/rcp/MemoryAnalyzer-${version}-linux.gtk.x86_64.zip";
-    sha256 = "sha256-icmo5zdK0XaH32kXwZUVaQ0VPSGEgvlLr7v7PtdbmCg=";
+    sha256 = "sha256-4eqAp5hNQR5MTX37qwktqSVfe3ctaBolamEEm8yIN2c=";
   };
 
   desktopItem = makeDesktopItem {
@@ -125,7 +125,8 @@ stdenv.mkDerivation rec {
       who is preventing the Garbage Collector from collecting objects,
       run a report to automatically extract leak suspects.
     '';
-    homepage = "https://www.eclipse.org/mat";
+    homepage = "https://eclipse.dev/mat/";
+    changelog = "https://eclipse.dev/mat/${baseVersion}/noteworthy.html";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.epl20;
     maintainers = [ lib.maintainers.ktor ];

--- a/pkgs/by-name/ec/eclipse-mat/update.sh
+++ b/pkgs/by-name/ec/eclipse-mat/update.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=./. -i bash -p bash curl gnused coreutils common-updater-scripts
+
+set -euo pipefail
+
+BASEDIR="$(dirname "$(readlink -f "$0")")/../../../.."
+MIRROR="https://ftp.halifax.rwth-aachen.de/eclipse/mat"
+
+baseVersion=$(curl -sL "$MIRROR/" |
+    sed -n 's/.*href="\([0-9]\+\.[0-9]\+\.[0-9]\+\)\/".*/\1/p' |
+    sort -V | tail -1)
+
+latestVersion=$(curl -sL "$MIRROR/$baseVersion/rcp/" |
+    sed -n 's/.*href="MemoryAnalyzer-\([0-9.]\+\)-linux\.gtk\.x86_64\.zip".*/\1/p' |
+    sort -V | tail -1)
+
+currentVersion=$(nix-instantiate --eval -E "with import $BASEDIR {}; lib.getVersion eclipse-mat" | tr -d '"')
+
+echo "latest  version: $latestVersion"
+echo "current version: $currentVersion"
+
+if [[ -z "$latestVersion" ]]; then
+    echo "could not determine the latest version" >&2
+    exit 1
+fi
+
+if [[ "$latestVersion" == "$currentVersion" ]]; then
+    echo "package is up-to-date"
+    exit 0
+fi
+
+for target in \
+    "x86_64-linux:linux.gtk.x86_64" \
+    "aarch64-linux:linux.gtk.aarch64" \
+    "aarch64-darwin:macosx.cocoa.aarch64"; do
+    nixSystem="${target%%:*}"
+    suffix="${target#*:}"
+
+    prefetch=$(nix-prefetch-url "$MIRROR/$baseVersion/rcp/MemoryAnalyzer-$latestVersion-$suffix.zip")
+    hash=$(nix-hash --type sha256 --to-sri "$prefetch")
+
+    (cd "$BASEDIR" && update-source-version eclipse-mat "$latestVersion" "$hash" --system="$nixSystem" --ignore-same-version)
+done


### PR DESCRIPTION
Changelogs:
https://eclipse.dev/mat/1.16.0/noteworthy.html
https://eclipse.dev/mat/1.17.0/noteworthy.html

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].