### PR TITLE
darling: re init at unstable-2026-06-09

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -200,6 +200,7 @@
   ./programs/corefreq.nix
   ./programs/cpu-energy-meter.nix
   ./programs/criu.nix
+  ./programs/darling.nix
   ./programs/dconf.nix
   ./programs/digitalbitbox/default.nix
   ./programs/direnv.nix

--- a/nixos/modules/programs/darling.nix
+++ b/nixos/modules/programs/darling.nix
@@ -1,0 +1,27 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.darling;
+in
+{
+  options = {
+    programs.darling = {
+      enable = lib.mkEnableOption "Darling, a Darwin/macOS compatibility layer for Linux";
+      package = lib.mkPackageOption pkgs "darling" { };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    security.wrappers.darling = {
+      source = lib.getExe cfg.package;
+      owner = "root";
+      group = "root";
+      setuid = true;
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -467,6 +467,7 @@ in
   custom-ca = import ./custom-ca.nix { inherit pkgs runTest; };
   cyrus-imap = runTest ./cyrus-imap.nix;
   dae = runTest ./dae.nix;
+  darling = handleTest ./darling.nix { };
   darling-dmg = runTest ./darling-dmg.nix;
   dashy = runTest ./web-apps/dashy.nix;
   davis = runTest ./davis.nix;

--- a/nixos/tests/darling.nix
+++ b/nixos/tests/darling.nix
@@ -1,0 +1,52 @@
+import ./make-test-python.nix (
+  { pkgs, lib, ... }:
+
+  let
+    # Well, we _can_ cross-compile from Linux :)
+    hello =
+      pkgs.runCommand "hello"
+        {
+          sdk = "${pkgs.darling.sdk}/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk";
+          nativeBuildInputs = with pkgs.llvmPackages_18; [
+            clang-unwrapped
+            lld
+          ];
+          src = pkgs.writeText "hello.c" ''
+            #include <stdio.h>
+            int main() {
+              printf("Hello, Darling!\n");
+              return 0;
+            }
+          '';
+        }
+        ''
+          clang \
+            -target x86_64-apple-darwin \
+            -fuse-ld=lld \
+            -nostdinc -nostdlib \
+            -mmacosx-version-min=10.15 \
+            --sysroot $sdk \
+            -isystem $sdk/usr/include \
+            -L $sdk/usr/lib -lSystem \
+            $src -o $out
+        '';
+  in
+  {
+    name = "darling";
+
+    meta.maintainers = with lib.maintainers; [ zhaofengli ];
+
+    nodes.machine = {
+      programs.darling.enable = true;
+    };
+
+    testScript = ''
+      start_all()
+
+      # Darling holds stdout until the server is shutdown
+      machine.succeed("darling ${hello} >hello.out")
+      machine.succeed("grep Hello hello.out")
+      machine.succeed("darling shutdown")
+    '';
+  }
+)

--- a/pkgs/by-name/da/darling/package.nix
+++ b/pkgs/by-name/da/darling/package.nix
@@ -1,0 +1,307 @@
+{
+  clangStdenv,
+  lib,
+  runCommandWith,
+  writeShellScript,
+  fetchFromGitHub,
+  fetchpatch,
+  nixosTests,
+
+  freetype,
+  libjpeg,
+  libpng,
+  libtiff,
+  giflib,
+  libX11,
+  libXext,
+  libXrandr,
+  libXcursor,
+  libxkbfile,
+  cairo,
+  libglvnd,
+  fontconfig,
+  dbus,
+  libGLU,
+  fuse,
+  ffmpeg,
+  pulseaudio,
+
+  makeWrapper,
+  python3,
+  cmake,
+  ninja,
+  pkg-config,
+  bison,
+  flex,
+
+  libbsd,
+  openssl,
+
+  xdg-user-dirs,
+
+  addDriverRunpath,
+}:
+let
+  stdenv = clangStdenv;
+
+  # The build system invokes clang to compile Darwin executables.
+  # In this case, our cc-wrapper must not be used.
+  ccWrapperBypass =
+    runCommandWith
+      {
+        inherit stdenv;
+        name = "cc-wrapper-bypass";
+        runLocal = false;
+        derivationArgs = {
+          template = writeShellScript "template" ''
+            for (( i=1; i<=$#; i++)); do
+              j=$((i+1))
+              if [[ "''${!i}" == "-target" && "''${!j}" == *"darwin"* ]]; then
+                # their flags must take precedence
+                exec @unwrapped@ "$@" $NIX_CFLAGS_COMPILE
+              fi
+            done
+            exec @wrapped@ "$@"
+          '';
+        };
+      }
+      ''
+        unwrapped_bin=${stdenv.cc.cc}/bin
+        wrapped_bin=${stdenv.cc}/bin
+
+        mkdir -p $out/bin
+
+        unwrapped=$unwrapped_bin/$CC wrapped=$wrapped_bin/$CC \
+          substituteAll $template $out/bin/$CC
+        unwrapped=$unwrapped_bin/$CXX wrapped=$wrapped_bin/$CXX \
+          substituteAll $template $out/bin/$CXX
+
+        chmod +x $out/bin/$CC $out/bin/$CXX
+      '';
+
+  wrappedLibs = [
+    # To find all of them: rg -w wrap_elf
+
+    # src/native/CMakeLists.txt
+    freetype
+    libjpeg
+    libpng
+    libtiff
+    giflib
+    libX11
+    libXext
+    libXrandr
+    libXcursor
+    libxkbfile
+    cairo
+    libglvnd
+    fontconfig
+    dbus
+    libGLU
+
+    # src/external/darling-dmg/CMakeLists.txt
+    fuse
+
+    # src/CoreAudio/CMakeLists.txt
+    ffmpeg
+    pulseaudio
+  ];
+in
+stdenv.mkDerivation {
+  pname = "darling";
+  version = "unstable-2024-02-03";
+
+  src = fetchFromGitHub {
+    owner = "darlinghq";
+    repo = "darling";
+    rev = "25afbc76428c39c3909e9efcf5caef1140425211";
+    fetchSubmodules = true;
+    hash = "sha256-z9IMgc5hH2Upn8wHl1OgP42q9HTSkeHnxB3N812A+Kc=";
+    # Remove 500MB of dependency test files to get under Hydra output limit
+    postFetch = ''
+      rm -r $out/src/external/openjdk/test
+      rm -r $out/src/external/libmalloc/tests
+      rm -r $out/src/external/libarchive/libarchive/tar/test
+    '';
+  };
+
+  outputs = [
+    "out"
+    "sdk"
+  ];
+
+  patches = [
+    # Fix 'clang: error: no such file or directory: .../signal/mach_excUser.c'
+    # https://github.com/darlinghq/darling/issues/1511
+    # https://github.com/darlinghq/darling/commit/f46eb721c11d32addd807f092f4b3a6ea515bb6d
+    (fetchpatch {
+      url = "https://github.com/darlinghq/darling/commit/f46eb721c11d32addd807f092f4b3a6ea515bb6d.patch?full_index=1";
+      hash = "sha256-FnLcHnK4cNto+E3OQSxE3iK+FHSU8y459FcpMvrzd6o=";
+    })
+
+    # Fix compatibility with ffmpeg_7
+    # https://github.com/darlinghq/darling/pull/1537
+    # https://github.com/darlinghq/darling/commit/9655d5598c87dcb22c54a83cc7741b77cb47a1b0
+    (fetchpatch {
+      url = "https://github.com/darlinghq/darling/commit/9655d5598c87dcb22c54a83cc7741b77cb47a1b0.patch?full_index=1";
+      hash = "sha256-ogMo4SRRwiOhaVJ+OS8BVolGDa7vGKyR9bdGiOiCuRc=";
+    })
+  ];
+
+  postPatch = ''
+    # We have to be careful - Patching everything indiscriminately
+    # would affect Darwin scripts as well
+    chmod +x src/external/bootstrap_cmds/migcom.tproj/mig.sh
+    patchShebangs \
+      src/external/bootstrap_cmds/migcom.tproj/mig.sh \
+      src/external/darlingserver/scripts \
+      src/external/openssl_certificates/scripts
+
+    substituteInPlace src/startup/CMakeLists.txt --replace SETUID ""
+    substituteInPlace src/external/basic_cmds/CMakeLists.txt --replace SETGID ""
+
+    # Fix compiler error: read of non-constexpr variable 'lastSlash' is not allowed in a constant expression (VLA error in templates)
+    substituteInPlace src/external/cctools-port/cctools/ld64/src/ld/HeaderAndLoadCommands.hpp \
+      --replace-fail "char frameworkName[strlen(lastSlash)+20];" "char* frameworkName = (char*)__builtin_alloca(strlen(lastSlash)+20);"
+
+    # Fix compiler error: no member named 'clone' in 'Security::BlobCore'
+    substituteInPlace src/external/cctools-port/cctools/ld64/src/ld/code-sign-blobs/blob.h \
+      --replace-fail "void length(size_t size)			{ mLength = size; }" "void length(size_t size)			{ mLength = size; }
+	BlobCore *clone() const;"
+
+    substituteInPlace src/external/cctools-port/cctools/ld64/src/ld/code-sign-blobs/blob.cpp \
+      --replace-fail "BlobWrapper *BlobWrapper::alloc(const void *data, size_t length, Magic magic /* = _magic */)
+{
+	BlobWrapper *w = alloc(length, magic);
+	memcpy(w->data(), data, w->length());
+	return w;
+}" "BlobWrapper *BlobWrapper::alloc(const void *data, size_t length, Magic magic /* = _magic */)
+{
+	BlobWrapper *w = alloc(length, magic);
+	memcpy(w->data(), data, w->length());
+	return w;
+}
+
+BlobCore *BlobCore::clone() const
+{
+	size_t len = this->length();
+	BlobCore *copy = (BlobCore *)malloc(len);
+	if (copy) {
+		memcpy(copy, this, len);
+	}
+	return copy;
+}"
+
+    # Fix compiler error: use of undeclared identifier 'avcodec_close' (removed in ffmpeg 7)
+    substituteInPlace src/CoreAudio/AudioToolbox/AudioConverterImpl.cpp \
+      --replace-fail '	if (m_decoder)
+		avcodec_close(m_decoder);' '	avcodec_free_context(&m_decoder);' \
+      --replace-fail '	if (m_encoder)
+		avcodec_close(m_encoder);' '	avcodec_free_context(&m_encoder);'
+  '';
+
+  nativeBuildInputs = [
+    bison
+    ccWrapperBypass
+    cmake
+    flex
+    makeWrapper
+    ninja
+    pkg-config
+    python3
+  ];
+  buildInputs = wrappedLibs ++ [
+    libbsd
+    openssl
+    stdenv.cc.libc.linuxHeaders
+  ];
+
+  # Breaks valid paths like
+  # Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include
+  dontFixCmake = true;
+
+  # src/external/objc4 forces OBJC_IS_DEBUG_BUILD=1, which conflicts with NDEBUG
+  # TODO: Fix in a better way
+  cmakeBuildType = " ";
+
+  cmakeFlags = [
+    "-DTARGET_i386=OFF"
+    "-DCOMPILE_PY2_BYTECODE=OFF"
+    "-DDARLINGSERVER_XDG_USER_DIR_CMD=${xdg-user-dirs}/bin/xdg-user-dir"
+    "-DCMAKE_C_LINKER_DEPFILE_SUPPORTED=OFF"
+    "-DCMAKE_CXX_LINKER_DEPFILE_SUPPORTED=OFF"
+  ];
+
+  env.NIX_CFLAGS_COMPILE = "-Wno-macro-redefined -Wno-unused-command-line-argument -fno-aligned-allocation";
+
+  # Linux .so's are dlopen'd by wrapgen during the build
+  env.LD_LIBRARY_PATH = lib.makeLibraryPath wrappedLibs;
+
+  # Breaks shebangs of Darwin scripts
+  dontPatchShebangs = true;
+
+  # Disable broken symlink checks as Darling intentionally bundles dangling symlinks for its simulated macOS root prefix
+  dontCheckForBrokenSymlinks = true;
+
+  postInstall = ''
+    # Install the SDK as a separate output
+    mkdir -p $sdk
+
+    sdkDir=$(readlink -f ../Developer)
+
+    while read -r path; do
+      dst="$sdk/Developer/''${path#$sdkDir}"
+
+      if [[ -L "$path" ]]; then
+        target=$(readlink -m "$path")
+        if [[ -e "$target" && "$target" == "$NIX_BUILD_TOP"* && "$target" != "$sdkDir"* ]]; then
+          # dereference
+          cp -r -L "$path" "$dst"
+        elif [[ -e "$target" ]]; then
+          # preserve symlink
+          cp -d "$path" "$dst"
+        else
+          # ignore symlink
+          >&2 echo "Ignoring symlink $path -> $target"
+        fi
+      elif [[ -f $path ]]; then
+        cp "$path" "$dst"
+      elif [[ -d $path ]]; then
+        mkdir -p "$dst"
+      fi
+    done < <(find $sdkDir)
+
+    mkdir -p $sdk/bin
+    cp src/external/cctools-port/cctools/ld64/src/*-ld $sdk/bin
+    cp src/external/cctools-port/cctools/ar/*-{ar,ranlib} $sdk/bin
+  '';
+
+  postFixup = ''
+    echo "Checking for references to $NIX_STORE in Darling root..."
+
+    set +e
+    grep -r --exclude=mldr "$NIX_STORE" $out/libexec/darling
+    ret=$?
+    set -e
+
+    if [[ $ret == 0 ]]; then
+      echo "Found references to $NIX_STORE in Darling root (see above)"
+      exit 1
+    fi
+
+    patchelf --add-rpath "${lib.makeLibraryPath wrappedLibs}:${addDriverRunpath.driverLink}/lib" \
+      $out/libexec/darling/usr/libexec/darling/mldr
+  '';
+
+  passthru.tests.nixos = nixosTests.darling;
+
+  meta = with lib; {
+    description = "Open-source Darwin/macOS emulation layer for Linux";
+    homepage = "https://www.darlinghq.org";
+    changelog = "https://github.com/darlinghq/darling/releases";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ zhaofengli ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "darling";
+  };
+}

--- a/pkgs/by-name/da/darling/package.nix
+++ b/pkgs/by-name/da/darling/package.nix
@@ -109,14 +109,14 @@ let
 in
 stdenv.mkDerivation {
   pname = "darling";
-  version = "unstable-2024-02-03";
+  version = "unstable-2026-06-09";
 
   src = fetchFromGitHub {
     owner = "darlinghq";
     repo = "darling";
-    rev = "25afbc76428c39c3909e9efcf5caef1140425211";
+    rev = "e947f0d5a3c6bba27e3631d9bf0da2a9840e6894";
     fetchSubmodules = true;
-    hash = "sha256-z9IMgc5hH2Upn8wHl1OgP42q9HTSkeHnxB3N812A+Kc=";
+    hash = "sha256-ZPq433Bg3H6OJnMTcLOqZJ2vpSYdGyo/q6qGMbXKuYk=";
     # Remove 500MB of dependency test files to get under Hydra output limit
     postFetch = ''
       rm -r $out/src/external/openjdk/test
@@ -130,23 +130,7 @@ stdenv.mkDerivation {
     "sdk"
   ];
 
-  patches = [
-    # Fix 'clang: error: no such file or directory: .../signal/mach_excUser.c'
-    # https://github.com/darlinghq/darling/issues/1511
-    # https://github.com/darlinghq/darling/commit/f46eb721c11d32addd807f092f4b3a6ea515bb6d
-    (fetchpatch {
-      url = "https://github.com/darlinghq/darling/commit/f46eb721c11d32addd807f092f4b3a6ea515bb6d.patch?full_index=1";
-      hash = "sha256-FnLcHnK4cNto+E3OQSxE3iK+FHSU8y459FcpMvrzd6o=";
-    })
-
-    # Fix compatibility with ffmpeg_7
-    # https://github.com/darlinghq/darling/pull/1537
-    # https://github.com/darlinghq/darling/commit/9655d5598c87dcb22c54a83cc7741b77cb47a1b0
-    (fetchpatch {
-      url = "https://github.com/darlinghq/darling/commit/9655d5598c87dcb22c54a83cc7741b77cb47a1b0.patch?full_index=1";
-      hash = "sha256-ogMo4SRRwiOhaVJ+OS8BVolGDa7vGKyR9bdGiOiCuRc=";
-    })
-  ];
+  patches = [ ];
 
   postPatch = ''
     # We have to be careful - Patching everything indiscriminately
@@ -191,13 +175,6 @@ BlobCore *BlobCore::clone() const
 	}
 	return copy;
 }"
-
-    # Fix compiler error: use of undeclared identifier 'avcodec_close' (removed in ffmpeg 7)
-    substituteInPlace src/CoreAudio/AudioToolbox/AudioConverterImpl.cpp \
-      --replace-fail '	if (m_decoder)
-		avcodec_close(m_decoder);' '	avcodec_free_context(&m_decoder);' \
-      --replace-fail '	if (m_encoder)
-		avcodec_close(m_encoder);' '	avcodec_free_context(&m_encoder);'
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/da/darling/package.nix
+++ b/pkgs/by-name/da/darling/package.nix
@@ -157,8 +157,8 @@ stdenv.mkDerivation {
       src/external/darlingserver/scripts \
       src/external/openssl_certificates/scripts
 
-    substituteInPlace src/startup/CMakeLists.txt --replace SETUID ""
-    substituteInPlace src/external/basic_cmds/CMakeLists.txt --replace SETGID ""
+    substituteInPlace src/startup/CMakeLists.txt --replace-fail SETUID ""
+    substituteInPlace src/external/basic_cmds/CMakeLists.txt --replace-fail SETGID ""
 
     # Fix compiler error: read of non-constexpr variable 'lastSlash' is not allowed in a constant expression (VLA error in templates)
     substituteInPlace src/external/cctools-port/cctools/ld64/src/ld/HeaderAndLoadCommands.hpp \

--- a/pkgs/by-name/da/darling/package.nix
+++ b/pkgs/by-name/da/darling/package.nix
@@ -4,7 +4,6 @@
   runCommandWith,
   writeShellScript,
   fetchFromGitHub,
-  fetchpatch,
   nixosTests,
 
   freetype,
@@ -12,10 +11,10 @@
   libpng,
   libtiff,
   giflib,
-  libX11,
-  libXext,
-  libXrandr,
-  libXcursor,
+  libx11,
+  libxext,
+  libxrandr,
+  libxcursor,
   libxkbfile,
   cairo,
   libglvnd,
@@ -33,6 +32,8 @@
   pkg-config,
   bison,
   flex,
+  # Provides setcap, which the build looks for with find_package(Setcap REQUIRED)
+  libcap,
 
   libbsd,
   openssl,
@@ -88,10 +89,10 @@ let
     libpng
     libtiff
     giflib
-    libX11
-    libXext
-    libXrandr
-    libXcursor
+    libx11
+    libxext
+    libxrandr
+    libxcursor
     libxkbfile
     cairo
     libglvnd
@@ -130,8 +131,6 @@ stdenv.mkDerivation {
     "sdk"
   ];
 
-  patches = [ ];
-
   postPatch = ''
     # We have to be careful - Patching everything indiscriminately
     # would affect Darwin scripts as well
@@ -149,41 +148,39 @@ stdenv.mkDerivation {
       --replace-fail "char frameworkName[strlen(lastSlash)+20];" "char* frameworkName = (char*)__builtin_alloca(strlen(lastSlash)+20);"
 
     # Fix compiler error: no member named 'clone' in 'Security::BlobCore'
+    # The anchors avoid the tab-indented lines around them, as .nix files must not contain tabs
     substituteInPlace src/external/cctools-port/cctools/ld64/src/ld/code-sign-blobs/blob.h \
-      --replace-fail "void length(size_t size)			{ mLength = size; }" "void length(size_t size)			{ mLength = size; }
-	BlobCore *clone() const;"
+      --replace-fail "template <class BlobType>" "BlobCore *clone() const;
+
+      template <class BlobType>"
 
     substituteInPlace src/external/cctools-port/cctools/ld64/src/ld/code-sign-blobs/blob.cpp \
-      --replace-fail "BlobWrapper *BlobWrapper::alloc(const void *data, size_t length, Magic magic /* = _magic */)
-{
-	BlobWrapper *w = alloc(length, magic);
-	memcpy(w->data(), data, w->length());
-	return w;
-}" "BlobWrapper *BlobWrapper::alloc(const void *data, size_t length, Magic magic /* = _magic */)
-{
-	BlobWrapper *w = alloc(length, magic);
-	memcpy(w->data(), data, w->length());
-	return w;
-}
+      --replace-fail "BlobWrapper *BlobWrapper::alloc(const void *data, size_t length, Magic magic /* = _magic */)" "BlobCore *BlobCore::clone() const
+      {
+        size_t len = this->length();
+        BlobCore *copy = (BlobCore *)malloc(len);
+        if (copy) {
+          memcpy(copy, this, len);
+        }
+        return copy;
+      }
 
-BlobCore *BlobCore::clone() const
-{
-	size_t len = this->length();
-	BlobCore *copy = (BlobCore *)malloc(len);
-	if (copy) {
-		memcpy(copy, this, len);
-	}
-	return copy;
-}"
+      BlobWrapper *BlobWrapper::alloc(const void *data, size_t length, Magic magic /* = _magic */)"
   '';
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   nativeBuildInputs = [
     bison
     ccWrapperBypass
     cmake
     flex
+    libcap
     makeWrapper
     ninja
+    # Also a buildInput; the CA bundle is hashed with the openssl CLI at build time
+    openssl
     pkg-config
     python3
   ];


### PR DESCRIPTION
mostly is revert of https://github.com/NixOS/nixpkgs/pull/405727 with update to latest version
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
