### PR TITLE
mailutils: fix build with libtool 2.6.2

### DIFF
--- a/pkgs/by-name/ma/mailutils/fix-linking-with-libtool-2.6.2.patch
+++ b/pkgs/by-name/ma/mailutils/fix-linking-with-libtool-2.6.2.patch
@@ -1,0 +1,24 @@
+diff --git a/libmu_sieve/extensions/Makefile.am b/libmu_sieve/extensions/Makefile.am
+--- a/libmu_sieve/extensions/Makefile.am
++++ b/libmu_sieve/extensions/Makefile.am
+@@ -25,7 +25,7 @@ mod_LTLIBRARIES =\
+  vacation.la
+ AM_CPPFLAGS = $(MU_APP_COMMON_INCLUDES)
+ AM_LDFLAGS = -module -avoid-version -no-undefined -rpath '$(moddir)'
+-LIBS = ../libmu_sieve.la
++LIBS = ../libmu_sieve.la $(MU_LIB_MAILUTILS)
+ 
+ if MU_COND_DBM
+   mod_LTLIBRARIES += uidnew.la
+diff --git a/examples/Makefile.am b/examples/Makefile.am
+--- a/examples/Makefile.am
++++ b/examples/Makefile.am
+@@ -60,7 +60,7 @@ LDADD = \
+  $(MU_COMMON_LIBRARIES)
+ 
+ numaddr_la_SOURCES = numaddr.c
+-numaddr_la_LIBADD = $(MU_LIB_SIEVE)
++numaddr_la_LIBADD = $(MU_LIB_SIEVE) $(MU_LIB_MAILUTILS)
+ numaddr_la_LDFLAGS = -module -avoid-version -no-undefined -rpath '$(moddir)'
+ 
+ msg_send_LDADD =\

--- a/pkgs/by-name/ma/mailutils/package.nix
+++ b/pkgs/by-name/ma/mailutils/package.nix
@@ -75,6 +75,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./fix-build-mb-len-max.patch
+    # Fix linking loadable modules with Libtool 2.6.2
+    # https://savannah.gnu.org/bugs/?68588
+    ./fix-linking-with-libtool-2.6.2.patch
     ./path-to-cat.patch
     # Fix cross-compilation
     # https://lists.gnu.org/archive/html/bug-mailutils/2020-11/msg00038.html


### PR DESCRIPTION
Mailutils 3.21 fails to build on `aarch64-darwin` with Libtool 2.6.2 because several loadable modules use symbols from `libmailutils` without linking against it directly.

This patch adds the missing direct dependency to the Sieve modules and `examples/numaddr.la`. I tested this locally and confirmed that the full package builds and installs successfully with the patch, but didn’t run the test suite because Mailutils disables it on Darwin.

For reference, this is the upstream bug report: https://savannah.gnu.org/bugs/?68588

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
