### PR TITLE
jpmml-evaluator: fix build

### DIFF
--- a/pkgs/by-name/jp/jpmml-evaluator/package.nix
+++ b/pkgs/by-name/jp/jpmml-evaluator/package.nix
@@ -7,23 +7,37 @@
   nix-update-script,
 }:
 
-let
+maven.buildMavenPackage (finalAttrs: {
   pname = "jpmml-evaluator";
   version = "1.7.7";
-in
-maven.buildMavenPackage {
-  inherit pname version;
+
   strictDeps = true;
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "jpmml";
     repo = "jpmml-evaluator";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-DtI/cHmiKVH0IAp3mWJr2sDDjAzM5d9/cBx4KJm74WM=";
   };
 
-  mvnHash = "sha256-PBkRDMPF/btYROGs4bl71wl2em05N6T2Klf1qFZLHDI=";
+  # Upstream's pom.xml declares commons-math3 and guava as open Maven version
+  # ranges ("[3.1, 3.6.1]", "[19.0, 33.5.0-jre]"), which forces Maven to
+  # query Central's maven-metadata.xml at resolve time to pick the highest
+  # matching version — a live network lookup that produces different results
+  # across machines/times, causing mvnHash drift. Pin them to the exact
+  # upper-bound versions the ranges resolve to today.
+  postPatch = ''
+    substituteInPlace pom.xml \
+      --replace-fail \
+        '<commons-math3.version>[3.1, 3.6.1]</commons-math3.version>' \
+        '<commons-math3.version>3.6.1</commons-math3.version>' \
+      --replace-fail \
+        '<guava.version>[19.0, 33.5.0-jre]</guava.version>' \
+        '<guava.version>33.5.0-jre</guava.version>'
+  '';
+
+  mvnHash = "sha256-xnFwQGjLEX59zeYKX+R7+F9hRRmRXtkP6Xw2hRi6Jbc=";
 
   nativeBuildInputs = [
     makeBinaryWrapper
@@ -35,7 +49,7 @@ maven.buildMavenPackage {
     mkdir -p $out/share/java $out/bin
     cp pmml-evaluator-example/target/pmml-evaluator-example-executable-*.jar $out/share/java/jpmml-evaluator.jar
 
-    makeBinaryWrapper ${jre_headless}/bin/java $out/bin/jpmml-evaluator \
+    makeBinaryWrapper ${lib.getExe jre_headless} $out/bin/jpmml-evaluator \
       --add-flags "-jar $out/share/java/jpmml-evaluator.jar"
 
     runHook postInstall
@@ -43,14 +57,14 @@ maven.buildMavenPackage {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = {
+  meta = with lib; {
     description = "Java Evaluator API for PMML";
     homepage = "https://github.com/jpmml/jpmml-evaluator";
-    changelog = "https://github.com/jpmml/jpmml-evaluator/releases/tag/${version}";
-    license = lib.licenses.agpl3Only;
-    maintainers = [ lib.maintainers.b-rodrigues ];
+    changelog = "https://github.com/jpmml/jpmml-evaluator/releases/tag/${finalAttrs.version}";
+    license = licenses.agpl3Only;
+    maintainers = [ maintainers.b-rodrigues ];
     mainProgram = "jpmml-evaluator";
-    platforms = lib.platforms.all;
-    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    platforms = platforms.all;
+    sourceProvenance = with sourceTypes; [ fromSource ];
   };
-}
+})


### PR DESCRIPTION
jpmml-evaluator  experienced periodic  mvnHash  drift across builds.

Upstream's root pom.xml declares `commons-math3` and `guava` using version ranges ( [3.1, 3.6.1]  and  [19.0, 33.5.0-jre]). At resolution time, Maven queries Central's `maven-metadata.xml` to pick the highest available version in those ranges which resulted in non-deterministic dependency resolution and hash drift.

## Things done

Added `postPatch`  to substitute version ranges in  pom.xml with exact, fixed upper-bound versions ( 3.6.1 and 33.5.0-jre ) and refactored `package.nix`  to use `finalAttrs`  pattern.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
