### PR TITLE
python3Packages.datafusion: 53.0.0 -> 54.0.0; rerun: 0.35.0 -> 0.36.0

### DIFF
--- a/pkgs/by-name/re/rerun/package.nix
+++ b/pkgs/by-name/re/rerun/package.nix
@@ -40,7 +40,7 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rerun";
-  version = "0.35.0";
+  version = "0.36.0";
 
   __structuredAttrs = true;
 
@@ -53,7 +53,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "rerun-io";
     repo = "rerun";
     tag = finalAttrs.version;
-    hash = "sha256-PPur5of8zoStXl+3Eq/sgDZ0E9ADUnks6nJ55mzJTuI=";
+    hash = "sha256-t/OvWxMFfkTKrTYvaw7xcmL6oDyNaKoyW0sa/n5yVMs=";
   };
 
   # The path in `build.rs` is wrong for some reason, so we patch it to make the passthru tests work
@@ -62,7 +62,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace-fail '"rerun_sdk/rerun_cli/rerun"' '"rerun_sdk/rerun"'
   '';
 
-  cargoHash = "sha256-yapmDUOCCqvxmFFe/nQjeBWytTEnMw2opd/U7aXI4jQ=";
+  cargoHash = "sha256-VXKMEilmgHLHAq6Y7gDvKNJywRIV4fv/XHmNFCMjJws=";
 
   cargoBuildFlags = [
     "--package"

--- a/pkgs/development/python-modules/datafusion/default.nix
+++ b/pkgs/development/python-modules/datafusion/default.nix
@@ -4,6 +4,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   rustPlatform,
+  pythonOlder,
 
   # nativeBuildInputs
   protoc,
@@ -12,6 +13,7 @@
   protobuf,
 
   # dependencies
+  cloudpickle,
   pyarrow,
   typing-extensions,
 
@@ -26,7 +28,7 @@
 buildPythonPackage (finalAttrs: {
   pname = "datafusion";
   # WARNING: Ensure rerun-sdk is compatible with this version of datafusion
-  version = "53.0.0";
+  version = "54.0.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -37,12 +39,12 @@ buildPythonPackage (finalAttrs: {
     tag = finalAttrs.version;
     # Fetch arrow-testing and parquet-testing (tests assets)
     fetchSubmodules = true;
-    hash = "sha256-3plgAJuh2rrnvzkQVy3gUgEoHHT4FSjDp5DZx1keD+g=";
+    hash = "sha256-Kh8w8L3AJCs9a3KA9RHaA0btbJEBdYZge1VK7AX0lX0=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname src version;
-    hash = "sha256-kHGlUaPNSs1Nh3HCU+yUVQq/IXp9PUwpDmfAon8eRBk=";
+    hash = "sha256-s4+Y2axZKL7wKiw8Z6c12eWAnf1zGPAFFvWS45vFrlo=";
   };
 
   nativeBuildInputs = with rustPlatform; [
@@ -56,7 +58,10 @@ buildPythonPackage (finalAttrs: {
   ];
 
   dependencies = [
+    cloudpickle
     pyarrow
+  ]
+  ++ lib.optionals (pythonOlder "3.13") [
     typing-extensions
   ];
 

--- a/pkgs/development/python-modules/rerun-notebook/default.nix
+++ b/pkgs/development/python-modules/rerun-notebook/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage (finalAttrs: {
     inherit (finalAttrs) version;
     format = "wheel";
     python = "py2.py3";
-    hash = "sha256-PMhHz/rTB3yIOg80g/dt/ktq4pHZ6hNrCYdlp70dcOI=";
+    hash = "sha256-2w2Jvoz/L5VPx4dGcYyQkdcitoPO+NJCzuAxeJR9JHM=";
   };
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/rerun-sdk/default.nix
+++ b/pkgs/development/python-modules/rerun-sdk/default.nix
@@ -12,10 +12,9 @@
   # dependencies
   attrs,
   numpy,
-  opencv4,
   pillow,
+  psutil,
   pyarrow,
-  semver,
   typing-extensions,
 
   # tests
@@ -23,9 +22,10 @@
   datafusion,
   inline-snapshot,
   polars,
-  pytest-snapshot,
   pytestCheckHook,
   rerun-notebook,
+  semver,
+  syrupy,
   tomli,
   torch,
   torchvision,
@@ -67,7 +67,7 @@ buildPythonPackage {
     # dependencies), so they are never codegen'd and runtime dispatch falls back to the equivalent
     # AVX2 / scalar kernels.
     + ''
-      lanceDistance="$cargoDepsCopy/source-registry-0/lance-linalg-8.0.0/src/distance"
+      lanceDistance="$cargoDepsCopy/source-registry-0/lance-linalg-9.0.0/src/distance"
 
       substituteInPlace "$lanceDistance/dot_u8.rs" \
         --replace-fail "return |a, b| unsafe { x86::dot_u8_avx512_vnni(a, b) };" ""
@@ -89,10 +89,9 @@ buildPythonPackage {
   dependencies = [
     attrs
     numpy
-    opencv4
     pillow
+    psutil
     pyarrow
-    semver
     typing-extensions
   ];
 
@@ -115,9 +114,10 @@ buildPythonPackage {
     datafusion
     inline-snapshot
     polars
-    pytest-snapshot
     pytestCheckHook
     rerun-notebook
+    semver
+    syrupy
     tomli
     torch
     torchvision
@@ -126,11 +126,15 @@ buildPythonPackage {
   inherit (rerun) addDlopenRunpaths addDlopenRunpathsPhase;
   postPhases = lib.optionals stdenv.hostPlatform.isLinux [ "addDlopenRunpathsPhase" ];
 
+  pytestFlags = [
+    # Some checked-in `.ambr` entries belong to tests skipped below (and to tests upstream has since
+    # removed). syrupy fails the whole session over unused snapshots by default.
+    "--snapshot-warn-unused"
+  ];
+
   disabledTests = [
     # RuntimeError: MP4 error: MP4 demux: MP4 error: file contains a box with a larger size than it
-    "test_allow_b_frames_opts_in_to_b_frame_inputs"
     "test_asset_mode_timeline_type_timestamp_applies_to_index_chunk"
-    "test_b_frames_in_stream_mode_raise"
     "test_custom_entity_path_applies_to_every_chunk"
     "test_default_mode_produces_video_stream_chunks"
     "test_output_codec_same_as_source_stays_on_the_direct_path"
@@ -153,14 +157,6 @@ buildPythonPackage {
     "test_server_with_dataset_prefix"
     "test_server_with_multiple_datasets"
     "test_viewer_dies_on_client_close"
-
-    # TypeError: 'Snapshot' object is not callable
-    "test_chunk_record_batch"
-    "test_schema_recording"
-
-    # pytest_snapshot mismatch: serialized schema/summary output drifted in 0.32.0
-    "test_schema"
-    "test_summary_format"
 
     # AttributeError: 'datetime.datetime' object has no attribute 'value'
     "test_lenses_time_extraction"
@@ -188,6 +184,10 @@ buildPythonPackage {
     # real binaries (rerun.src is fetched without fetchLFS).
     "rerun_py/tests/integration/test_hdf5_reader.py"
 
+    # ModuleNotFoundError: No module named 'mdlint'. It sits next to the test file, which is
+    # not on `sys.path` as `scripts/ci` has no `__init__.py`.
+    "scripts/ci/mdlint_test.py"
+
     # "fixture 'benchmark' not found"
     "tests/python/log_benchmark/test_log_benchmark.py"
     "tests/python/log_benchmark/test_micro_benchmark.py"
@@ -198,7 +198,8 @@ buildPythonPackage {
     # ConnectionError: Connection: connecting to server: transport error
     "rerun_py/tests/api_sandbox/"
 
-    # RuntimeError: Failed to load URDF file: No elements found
+    # RuntimeError: Failed to load URDF file: No elements found. `so100.urdf` is a Git LFS
+    # pointer file, not the real model (rerun.src is fetched without fetchLFS).
     "rerun_py/tests/unit/test_urdf_tree.py"
   ];
 


### PR DESCRIPTION
- **python3Packages.datafusion: 53.0.0 -> 54.0.0** ([Diff](https://github.com/apache/datafusion-python/compare/53.0.0...54.0.0), [Changelog](https://github.com/apache/datafusion-python/blob/54.0.0/CHANGELOG.md))
- **rerun: 0.35.0 -> 0.36.0** ([Diff](https://github.com/rerun-io/rerun/compare/0.35.0...0.36.0), [Changelog](https://github.com/rerun-io/rerun/blob/0.36.0/CHANGELOG.md))

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
