### PR TITLE
yarn-zpm: 6.0.0-rc.18 -> 6.0.0-rc.19, add simple package test

### DIFF
--- a/pkgs/by-name/ya/yarn-zpm/package.nix
+++ b/pkgs/by-name/ya/yarn-zpm/package.nix
@@ -1,7 +1,10 @@
 {
   lib,
   fetchFromGitHub,
+  git,
+  jq,
   nix-update-script,
+  runCommand,
   rustPlatform,
   versionCheckHook,
 }:
@@ -33,6 +36,35 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   passthru = {
     updateScript = nix-update-script { };
+    tests = {
+      simple-test =
+        runCommand "yarn-zpm-simple-test"
+          {
+            nativeBuildInputs = [
+              jq
+              git
+              finalAttrs.finalPackage
+            ];
+          }
+          ''
+            export HOME=$(mktemp -d)
+            git config --global user.name nixbld
+            git config --global user.email nixbld@localhost
+            cat > .yarnrc.yml <<EOF
+            nodeLinker: node-modules
+            EOF
+            yarn init
+            jq -e '.packageManager == "yarn@${finalAttrs.finalPackage.version}.local"' package.json
+            jq '. + {workspaces: ["workspace-test"]}' package.json > package.json.tmp
+            mv package.json.tmp package.json
+            mkdir workspace-test
+            jq -n '{name: "workspace-test"}' > workspace-test/package.json
+            yarn install
+            jq -e '.name == "workspace-test"' node_modules/workspace-test/package.json
+            jq -e '.workspaces | has("workspace-test")' yarn.lock
+            touch $out
+          '';
+    };
   };
 
   meta = {

--- a/pkgs/by-name/ya/yarn-zpm/package.nix
+++ b/pkgs/by-name/ya/yarn-zpm/package.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "yarn-zpm";
-  version = "6.0.0-rc.18";
+  version = "6.0.0-rc.19";
 
   src = fetchFromGitHub {
     owner = "yarnpkg";
     repo = "zpm";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-eiI20hptKhQegh/BRKgDwd6ztQ7XsupV3vtGpdxTrdA=";
+    hash = "sha256-I7iMmTcz+NfZfSebOTNDTe1YTwqGCU3zC+5pRhkYgsQ=";
   };
 
-  cargoHash = "sha256-mcTlUwnr02pmiQhgkLHOUHoxBxWB8rwuOgjEEqdW0wE=";
+  cargoHash = "sha256-6TPis4c/2uLGfG3NppY72x8YPo8WyAGRXt4urIwIGt0=";
 
   cargoBuildFlags = [ "--package=zpm" ];
   cargoTestFlags = [ "--package=zpm" ];


### PR DESCRIPTION
## Things done


Update https://github.com/yarnpkg/zpm/releases/tag/v6.0.0-rc.19

Added simple package test

Tested fetching manually on `aarch64-darwin`:

```console
$ nix-build -A yarn-zpm
/nix/store/spng0rv66chyaffgi8l736vkzhamq7va-yarn-zpm-6.0.0-rc.19
$ cd /tmp
$ mkdir test-package
$ cd test-package
$ /nix/store/spng0rv66chyaffgi8l736vkzhamq7va-yarn-zpm-6.0.0-rc.19/bin/yarn -v
6.0.0-rc.19.local
$ /nix/store/spng0rv66chyaffgi8l736vkzhamq7va-yarn-zpm-6.0.0-rc.19/bin/yarn init
➤ · Yarn 6.0.0-rc.19.local
$ /nix/store/spng0rv66chyaffgi8l736vkzhamq7va-yarn-zpm-6.0.0-rc.19/bin/yarn add express
➤ · Yarn 6.0.0-rc.19.local
➤ ┌ Installing packages
➤ │ Resolved 85 packages, fetched 69 packages (2.16 MiB)
➤ └ Completed in 780ms
$ nix shell nixpkgs#nodejs --command /nix/store/spng0rv66chyaffgi8l736vkzhamq7va-yarn-zpm-6.0.0-rc.19/bin/yarn node -p "require('express/package.json').version"
5.2.1
$ cat package.json 
{
  "dependencies": {
    "express": "^5.2.1"
  },
  "name": "test-package",
  "packageManager": "yarn@6.0.0-rc.19.local",
  "type": "module"
}
$ mv yarn.lock yarn-lock.json
$ nix shell nixpkgs#nodejs --command /nix/store/spng0rv66chyaffgi8l736vkzhamq7va-yarn-zpm-6.0.0-rc.19/bin/yarn node -p "require('./yarn-lock.json').__metadata"
{ version: 9 }
$ nix shell nixpkgs#nodejs --command /nix/store/spng0rv66chyaffgi8l736vkzhamq7va-yarn-zpm-6.0.0-rc.19/bin/yarn node -p "Object.keys(require('./yarn-lock.json').entries).find(i => i.includes('express'))"
express@npm:^5.2.1
```

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
