### PR TITLE
python3Packages.pyatspi: 2.58.1 -> 2.58.2

### DIFF
--- a/pkgs/development/python-modules/pyatspi/default.nix
+++ b/pkgs/development/python-modules/pyatspi/default.nix
@@ -13,13 +13,13 @@
 
 buildPythonPackage rec {
   pname = "pyatspi";
-  version = "2.58.1";
+  version = "2.58.2";
 
   pyproject = false;
 
   src = fetchurl {
     url = "mirror://gnome/sources/pyatspi/${lib.versions.majorMinor version}/pyatspi-${version}.tar.xz";
-    sha256 = "Px8HmTX5JlhDMQJcdTGFjetCJFyZO2USH09LAeawRTY=";
+    hash = "sha256-JFkOW2D+yN+1n80n0qkN5wNAYL4xjKP3dw4PmE8flOI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/pyatspi/default.nix
+++ b/pkgs/development/python-modules/pyatspi/default.nix
@@ -48,6 +48,7 @@ buildPythonPackage rec {
     homepage = "https://gitlab.gnome.org/GNOME/pyatspi2";
     license = lib.licenses.lgpl2Only;
     maintainers = with lib.maintainers; [ jtojnar ];
+    teams = [ lib.teams.gnome ];
     platforms = with lib.platforms; unix;
   };
 }


### PR DESCRIPTION
Was part of GNOME 50.1.
Release notes: https://gitlab.gnome.org/GNOME/pyatspi2/-/blob/master/NEWS?ref_type=heads

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
