### PR TITLE
nixos/nextcloud: add test verifying that bind-mounts and special places of /var/lib/nextcloud are OK

### DIFF
--- a/nixos/tests/nextcloud/default.nix
+++ b/nixos/tests/nextcloud/default.nix
@@ -136,6 +136,8 @@ let
     map callNextcloudTest (
       [
         ./basic.nix
+        ./home-bindmount.nix
+        ./home-mount.nix
         ./with-declarative-redis-and-secrets.nix
         ./with-mysql-and-memcached.nix
         ./with-postgresql-and-redis.nix

--- a/nixos/tests/nextcloud/home-bindmount.nix
+++ b/nixos/tests/nextcloud/home-bindmount.nix
@@ -1,0 +1,68 @@
+{
+  name,
+  pkgs,
+  testBase,
+  system,
+  ...
+}:
+
+with import ../../lib/testing-python.nix { inherit system pkgs; };
+runTest (
+  { lib, ... }:
+  {
+    inherit name;
+    meta.maintainers = lib.teams.nextcloud.members;
+
+    imports = [ testBase ];
+
+    nodes.nextcloud = { pkgs, ... }: {
+      # Make sure that inside our tmpfs mount an actual directory for Nextcloud exists.
+      boot.initrd.systemd.tmpfiles.settings."nextcloud"."/sysroot/mnt/nextcloud".d = { };
+
+      boot.initrd.systemd.mounts = [
+        # Create a mocked /mnt/nextcloud. Only a tmpfs here, but in reality this could e.g.
+        # be the mount of a larger disk.
+        {
+          unitConfig.DefaultDependencies = "no";
+          conflicts = [ "umount.target" ];
+          wantedBy = [ "initrd.target" ];
+          before = [ "systemd-tmpfiles-setup-sysroot.service" ];
+          options = "x-initrd.mount";
+          where = "/sysroot/mnt";
+          what = "tmpfs";
+          type = "tmpfs";
+        }
+        # Bind some directory to /var/lib/nextcloud, the place that the Nextcloud module expects
+        # by default.
+        {
+          conflicts = [ "umount.target" ];
+          wantedBy = [ "initrd.target" ];
+          before = [ "systemd-tmpfiles-setup-sysroot.service" ];
+          options = "x-initrd.mount,bind";
+          where = "/sysroot/var/lib/nextcloud";
+          what = "/sysroot/mnt/nextcloud";
+          type = "none";
+        }
+      ];
+      environment.systemPackages = [
+        pkgs.util-linux
+      ];
+      services.nextcloud = {
+        config.dbtype = "sqlite";
+      };
+    };
+
+    test-helpers.init = ''
+      import json
+      mnts = json.loads(nextcloud.succeed("findmnt /var/lib/nextcloud -J"))["filesystems"]
+      t.assertEqual(1, len(mnts))
+      mnt = mnts[0]
+      t.assertEqual("tmpfs[/nextcloud]", mnt["source"])
+      t.assertEqual("/var/lib/nextcloud", mnt["target"])
+    '';
+
+    test-helpers.extraTests = ''
+      nextcloud.succeed("test -d /mnt/nextcloud/data/root")
+    '';
+  }
+)

--- a/nixos/tests/nextcloud/home-mount.nix
+++ b/nixos/tests/nextcloud/home-mount.nix
@@ -1,0 +1,32 @@
+{
+  name,
+  pkgs,
+  testBase,
+  system,
+  ...
+}:
+
+with import ../../lib/testing-python.nix { inherit system pkgs; };
+runTest (
+  { config, lib, ... }:
+  {
+    inherit name;
+    meta.maintainers = lib.teams.nextcloud.members;
+
+    imports = [ testBase ];
+
+    nodes.nextcloud = { pkgs, ... }: {
+      system.activationScripts.nc-mock-mount = {
+        deps = [ "users" ];
+        text = ''
+          ${pkgs.coreutils}/bin/mkdir -p /mnt
+          ${pkgs.util-linux}/bin/mount -t tmpfs tmpfs /mnt
+        '';
+      };
+      services.nextcloud = {
+        config.dbtype = "sqlite";
+        home = "/mnt/nextcloud";
+      };
+    };
+  }
+)


### PR DESCRIPTION

This is a regular source for confusion and had no test-coverage so far, so adding two tests that

* Make sure Nextcloud running in a different location (tmpfs mount here as mock for the mount of a different disk).

* A bind-mount of Nextcloud from a disk-mount to /var/lib/nextcloud can be created.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
