### PR TITLE
calls: 49.1.1 -> 50.0

### DIFF
--- a/pkgs/by-name/ca/calls/package.nix
+++ b/pkgs/by-name/ca/calls/package.nix
@@ -137,6 +137,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://gitlab.gnome.org/GNOME/calls/-/blob/v${finalAttrs.version}/NEWS";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ craigem ];
+    teams = [ lib.teams.gnome ];
     platforms = lib.platforms.linux;
     mainProgram = "gnome-calls";
   };

--- a/pkgs/by-name/ca/calls/package.nix
+++ b/pkgs/by-name/ca/calls/package.nix
@@ -127,6 +127,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Phone dialer and call handler";
     longDescription = "GNOME Calls is a phone dialer and call handler. Setting NixOS option `programs.calls.enable = true` is recommended.";
     homepage = "https://gitlab.gnome.org/GNOME/calls";
+    changelog = "https://gitlab.gnome.org/GNOME/calls/-/blob/v${finalAttrs.version}/NEWS";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ craigem ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/ca/calls/package.nix
+++ b/pkgs/by-name/ca/calls/package.nix
@@ -1,14 +1,16 @@
 {
   lib,
   stdenv,
-  fetchFromGitLab,
+  fetchurl,
   meson,
   mesonEmulatorHook,
   ninja,
   pkg-config,
   libadwaita,
   libsecret,
+  mobile-broadband-provider-info,
   modemmanager,
+  gmobile,
   gtk4,
   gom,
   gsound,
@@ -36,15 +38,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "calls";
-  version = "49.1.1";
+  version = "50.0";
 
-  src = fetchFromGitLab {
-    domain = "gitlab.gnome.org";
-    owner = "GNOME";
-    repo = "calls";
-    rev = "v${finalAttrs.version}";
-    fetchSubmodules = true;
-    hash = "sha256-fqvfzdk1szNFm4aRRGNDaA/AmjJdQjBsMhvEolEetE0=";
+  src = fetchurl {
+    url = "mirror://gnome/sources/calls/${lib.versions.major finalAttrs.version}/calls-${finalAttrs.version}.tar.xz";
+    hash = "sha256-8ozMjm+8UHnnuLXRGlUZabtw2QXl7ZDRsdho8SBFxy8=";
   };
 
   outputs = [
@@ -73,6 +71,8 @@ stdenv.mkDerivation (finalAttrs: {
     modemmanager
     libadwaita
     libsecret
+    mobile-broadband-provider-info
+    gmobile
     evolution-data-server-gtk4 # UI part not needed, using gtk4 variant (over the default of gtk3) to reduce closure.
     folks
     gom

--- a/pkgs/by-name/ca/calls/package.nix
+++ b/pkgs/by-name/ca/calls/package.nix
@@ -11,6 +11,7 @@
   mobile-broadband-provider-info,
   modemmanager,
   gmobile,
+  gnome,
   gtk4,
   gom,
   gsound,
@@ -122,6 +123,12 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postCheck
   '';
+
+  passthru = {
+    updateScript = gnome.updateScript {
+      packageName = "calls";
+    };
+  };
 
   meta = {
     description = "Phone dialer and call handler";

--- a/pkgs/by-name/ca/calls/package.nix
+++ b/pkgs/by-name/ca/calls/package.nix
@@ -17,7 +17,7 @@
   evolution-data-server-gtk4,
   folks,
   desktop-file-utils,
-  appstream-glib,
+  appstream,
   libpeas2,
   dbus,
   vala,
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
     pkg-config
     desktop-file-utils
-    appstream-glib
+    appstream
     vala
     wrapGAppsHook4
     gtk-doc


### PR DESCRIPTION
This was part of GNOME 50.0 (@NixOS/gnome).

Release notes: https://gitlab.gnome.org/GNOME/calls/-/releases/v50.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
