### PR TITLE
bootmac: init at 0.7.1

### DIFF
--- a/pkgs/by-name/bo/bootmac/package.nix
+++ b/pkgs/by-name/bo/bootmac/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  meson,
+  ninja,
+  makeWrapper,
+  gawk,
+  bluez,
+  util-linux,
+  gnugrep,
+  gnused,
+  coreutils,
+  iproute2,
+  udevCheckHook,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  name = "bootmac";
+  version = "0.7.1";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitLab {
+    domain = "gitlab.postmarketos.org";
+    owner = "postmarketOS";
+    repo = "bootmac";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-GWvZUC8LKPpOWt1oCr93JHg5+W+0CCiYT63VhpSH1ko=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    makeWrapper
+    udevCheckHook
+  ];
+
+  mesonFlags = [ "-Dsystemd_units=true" ];
+
+  postInstall = ''
+     wrapProgram $out/bin/bootmac \
+       --prefix PATH : ${
+         lib.makeBinPath [
+           gawk
+           bluez
+           util-linux
+           gnugrep
+           gnused
+           coreutils
+           iproute2
+         ]
+       }
+
+    substituteInPlace \
+      $out/lib/systemd/system/bootmac@.service \
+      $out/lib/udev/rules.d/90-bootmac-{bluetooth,wifi}.rules \
+      --replace-fail /usr/bin/bootmac $out/bin/bootmac
+  '';
+
+  meta = {
+    description = "Configure the MAC addresses of WLAN and Bluetooth interfaces at boot";
+    mainProgram = "bootmac";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ matthewcroughan ];
+    platforms = bluez.meta.platforms;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Upstreaming bootmac, largely copied from https://github.com/vanilla-mobile-nixos/vanilla-mobile-nixos/blob/main/pkgs/bootmac/default.nix

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
