### PR TITLE
msm-modem: init at 13

### DIFF
--- a/pkgs/by-name/ms/msm-modem/package.nix
+++ b/pkgs/by-name/ms/msm-modem/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  meson,
+  ninja,
+  nix-update-script,
+  makeWrapper,
+  gnugrep,
+  gawk,
+  libqmi,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "msm-modem";
+  version = "13";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitLab {
+    domain = "gitlab.postmarketos.org";
+    owner = "postmarketOS";
+    repo = "msm-modem";
+    tag = finalAttrs.version;
+    hash = "sha256-kKDqYrd7yI3beS7kMVN+xqTBfNC4NTUgch2t/rDM9LE=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    makeWrapper
+  ];
+
+  mesonFlags = [
+    "-Ddownstream=false"
+    "-Dopenrc=false"
+  ];
+
+  postInstall = ''
+    wrapProgram $out/libexec/msm-modem-uim-selection \
+        --prefix PATH : ${
+          lib.makeBinPath [
+            libqmi
+            gawk
+            gnugrep
+          ]
+        }
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Common support for Qualcomm MSM modems";
+    homepage = "https://gitlab.postmarketos.org/postmarketOS/msm-modem";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ matthewcroughan ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Upstreaming msm-modem, largely copied from https://github.com/vanilla-mobile-nixos/vanilla-mobile-nixos/blob/main/pkgs/msm-modem/default.nix
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
