### PR TITLE
python3Packages.pyfakefs: remove pandas from nativeCheckInputs by default, modernize

### DIFF
--- a/pkgs/development/python-modules/pyfakefs/default.nix
+++ b/pkgs/development/python-modules/pyfakefs/default.nix
@@ -16,13 +16,13 @@
   xlrd,
 }:
 let
-  self = buildPythonPackage rec {
+  self = buildPythonPackage (finalAttrs: {
     pname = "pyfakefs";
     version = "6.2.0";
     pyproject = true;
 
     src = fetchPypi {
-      inherit pname version;
+      inherit (finalAttrs) pname version;
       hash = "sha256-5Zo220R79QnOnJerPRUQwIzFGJXFMRMlpWCl5bXcGUA=";
     };
 
@@ -56,13 +56,15 @@ let
       ];
     });
 
+    __structuredAttrs = true;
+
     meta = {
       description = "Fake file system that mocks the Python file system modules";
       homepage = "https://pyfakefs.org/";
-      changelog = "https://github.com/jmcgeheeiv/pyfakefs/blob/v${version}/CHANGES.md";
+      changelog = "https://github.com/jmcgeheeiv/pyfakefs/blob/v${finalAttrs.version}/CHANGES.md";
       license = lib.licenses.asl20;
       maintainers = [ ];
     };
-  };
+  });
 in
 self

--- a/pkgs/development/python-modules/pyfakefs/default.nix
+++ b/pkgs/development/python-modules/pyfakefs/default.nix
@@ -8,46 +8,61 @@
   setuptools,
 
   # tests
-  pandas,
   pytestCheckHook,
+
+  # extra tests
+  openpyxl,
+  pandas,
+  xlrd,
 }:
+let
+  self = buildPythonPackage rec {
+    pname = "pyfakefs";
+    version = "6.2.0";
+    pyproject = true;
 
-buildPythonPackage rec {
-  pname = "pyfakefs";
-  version = "6.2.0";
-  pyproject = true;
+    src = fetchPypi {
+      inherit pname version;
+      hash = "sha256-5Zo220R79QnOnJerPRUQwIzFGJXFMRMlpWCl5bXcGUA=";
+    };
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-5Zo220R79QnOnJerPRUQwIzFGJXFMRMlpWCl5bXcGUA=";
+    build-system = [ setuptools ];
+
+    pythonImportsCheck = [ "pyfakefs" ];
+
+    nativeCheckInputs = [
+      pytestCheckHook
+    ];
+
+    enabledTestPaths = [
+      "pyfakefs/tests"
+    ];
+
+    disabledTests = [
+      "test_expand_root"
+    ]
+    ++ (lib.optionals stdenv.hostPlatform.isDarwin [
+      # this test fails on darwin due to case-insensitive file system
+      "test_rename_dir_to_existing_dir"
+    ]);
+
+    # Keep the big pandas 'extra' dependency outside the standard build: providing it enables only two additional tests
+    # The other two members of the 'extra' group (xlrd and openpyxl) enable two more tests
+    passthru.tests.extra = self.overridePythonAttrs (prevPythonAttrs: {
+      nativeCheckInputs = prevPythonAttrs.nativeCheckInputs ++ [
+        pandas
+        xlrd
+        openpyxl
+      ];
+    });
+
+    meta = {
+      description = "Fake file system that mocks the Python file system modules";
+      homepage = "https://pyfakefs.org/";
+      changelog = "https://github.com/jmcgeheeiv/pyfakefs/blob/v${version}/CHANGES.md";
+      license = lib.licenses.asl20;
+      maintainers = [ ];
+    };
   };
-
-  build-system = [ setuptools ];
-
-  pythonImportsCheck = [ "pyfakefs" ];
-
-  nativeCheckInputs = [
-    pandas
-    pytestCheckHook
-  ];
-
-  enabledTestPaths = [
-    "pyfakefs/tests"
-  ];
-
-  disabledTests = [
-    "test_expand_root"
-  ]
-  ++ (lib.optionals stdenv.hostPlatform.isDarwin [
-    # this test fails on darwin due to case-insensitive file system
-    "test_rename_dir_to_existing_dir"
-  ]);
-
-  meta = {
-    description = "Fake file system that mocks the Python file system modules";
-    homepage = "https://pyfakefs.org/";
-    changelog = "https://github.com/jmcgeheeiv/pyfakefs/blob/v${version}/CHANGES.md";
-    license = lib.licenses.asl20;
-    maintainers = [ ];
-  };
-}
+in
+self


### PR DESCRIPTION
pandas is a rather big dependency to pull in for only two tests (especially since this package is in the closure of distutils).
Also, the dependency-group 'extra' defined in pyproject.toml also contains xlrd and openpyxl, which each add one test.
    
So, both reduce the standard build closure and make the new passthru test more complete.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
