### PR TITLE
viber: fix libxshmfence library

### DIFF
--- a/pkgs/by-name/vi/viber/package.nix
+++ b/pkgs/by-name/vi/viber/package.nix
@@ -62,6 +62,7 @@
   libxcb-image,
   libxtst,
   libxscrnsaver,
+  libxshmfence,
   libxrender,
   libxrandr,
   libxi,
@@ -163,6 +164,7 @@ stdenv.mkDerivation (finalAttrs: {
     libxrandr
     libxrender
     libxscrnsaver
+    libxshmfence
     libxtst
     libxcb
     libxcb-image


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add missing library

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
  - [x] Built and ran `viber` locally on NixOS x86_64-linux (confirmed it now launches without missing library errors).