### PR TITLE
makeBinaryWrapper: reject prefix/suffix with an empty path segment

### DIFF
--- a/pkgs/by-name/ma/makeBinaryWrapper/make-binary-wrapper.sh
+++ b/pkgs/by-name/ma/makeBinaryWrapper/make-binary-wrapper.sh
@@ -263,6 +263,7 @@ setEnvPrefix() {
     val=$(escapeStringLiteral "$3")
     printf '%s' "set_env_prefix(\"$env\", \"$sep\", \"$val\");"
     assertValidEnvName "$1"
+    assertNoEmptySegment "--prefix" "$1" "$2" "$3"
 }
 
 # suffix ENV SEP VAL
@@ -273,6 +274,7 @@ setEnvSuffix() {
     val=$(escapeStringLiteral "$3")
     printf '%s' "set_env_suffix(\"$env\", \"$sep\", \"$val\");"
     assertValidEnvName "$1"
+    assertNoEmptySegment "--suffix" "$1" "$2" "$3"
 }
 
 # setEnv KEY VALUE
@@ -323,6 +325,14 @@ assertValidEnvName() {
         *=*) printf '\n%s\n' "#error Illegal environment variable name \`$1\` (cannot contain \`=\`)";;
         "")  printf '\n%s\n' "#error Environment variable name can't be empty.";;
     esac
+}
+
+assertNoEmptySegment() {
+    local flag="$1" env="$2" sep="$3" val="$4"
+    [ -n "$sep" ] || return 0
+    if [[ "$sep$val$sep" == *"$sep$sep"* ]]; then
+        printf '\n%s\n' "#error $flag $env would introduce an empty PATH-like segment (empty, or a leading/trailing/doubled \`$sep\`). This is interpreted as \"search the current directory\" by shells, execvp() and the dynamic linker, see https://github.com/NixOS/nixpkgs/security/advisories/GHSA-p7v3-pr2c-8584. Guard the value with e.g. lib.optionalString (list != [])."
+    fi
 }
 
 setSepSurroundCheck() {


### PR DESCRIPTION
Preferred to reject explictly the value instead of silently sanitizing it. It's closer to what we do for the invalid env name and it will allow us to spot derivation that were impacted by the issue that has not yet been fixed.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
