### PR TITLE
clonehero: 1.1.0.6085 -> 1.1.0.6142, modernize & update script

### DIFF
--- a/pkgs/by-name/cl/clonehero/package.nix
+++ b/pkgs/by-name/cl/clonehero/package.nix
@@ -26,11 +26,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "clonehero";
-  version = "1.1.0.6085";
+  version = "1.1.0.6142";
 
   src = fetchurl {
     url = "https://github.com/clonehero-game/releases/releases/download/v${finalAttrs.version}-final/Linux.x86_64-Standalone.tar";
-    hash = "sha256-xy7/3SDNgKw67ikA7CtRVK2gNrfjqx4cTDeRUkkSBKo=";
+    hash = "sha256-Vylx2TCSKDxdDVIAaia1Krjo+xKNz7QqNJbeJsiqIx0=";
   };
 
   __structuredAttrs = true;

--- a/pkgs/by-name/cl/clonehero/package.nix
+++ b/pkgs/by-name/cl/clonehero/package.nix
@@ -3,6 +3,9 @@
   stdenv,
   fetchurl,
   autoPatchelfHook,
+  copyDesktopItems,
+  makeDesktopItem,
+  nix-update-script,
   gtk3,
   zlib,
   alsa-lib,
@@ -19,7 +22,6 @@
   udev,
   vulkan-loader, # (not used by default, enable in settings menu)
   wayland, # (not used by default, enable with SDL_VIDEODRIVER=wayland - doesn't support HiDPI)
-  makeDesktopItem,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -31,7 +33,13 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-xy7/3SDNgKw67ikA7CtRVK2gNrfjqx4cTDeRUkkSBKo=";
   };
 
-  nativeBuildInputs = [ autoPatchelfHook ];
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    copyDesktopItems
+  ];
 
   buildInputs = [
     # Load-time libraries (loaded from DT_NEEDED section in ELF binary)
@@ -56,14 +64,16 @@ stdenv.mkDerivation (finalAttrs: {
     wayland
   ];
 
-  desktopItem = makeDesktopItem {
-    name = "clonehero";
-    desktopName = "Clone Hero";
-    comment = finalAttrs.meta.description;
-    icon = "clonehero";
-    exec = "clonehero";
-    categories = [ "Game" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "clonehero";
+      desktopName = "Clone Hero";
+      comment = finalAttrs.meta.description;
+      icon = "clonehero";
+      exec = "clonehero";
+      categories = [ "Game" ];
+    })
+  ];
 
   installPhase = ''
     runHook preInstall
@@ -74,7 +84,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     mkdir -p "$out/share"
     cp -r clonehero_Data "$out/share/clonehero"
-    install -Dm644 "$desktopItem/share/applications/clonehero.desktop" "$out/share/applications/clonehero.desktop"
 
     mkdir -p "$out/bin" "$out/share/icons/hicolor/128x128/apps"
     ln -s "$out/libexec/clonehero/clonehero" "$out/bin/clonehero"
@@ -115,10 +124,18 @@ stdenv.mkDerivation (finalAttrs: {
       "$out/lib/clonehero/UnityPlayer.so"
   '';
 
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^v([0-9.]+)-final$"
+    ];
+  };
+
   meta = {
     description = "Clone of Guitar Hero and Rockband-style games";
     homepage = "https://clonehero.net";
     license = lib.licenses.unfree;
+    mainProgram = "clonehero";
     maintainers = with lib.maintainers; [
       kira-bruneau
       syboxez


### PR DESCRIPTION
Changelog: https://github.com/clonehero-game/releases/releases/tag/v1.1.0.6142-final

- Bumped to latest version
- Modernized the expression: `strictDeps`, `__structuredAttrs`, `meta.mainProgram`
- Added `nix-update-script` config. [Bot is failing on its own](https://nixpkgs-update-logs.nix-community.org/clonehero/) and this should fix it
- Changed the desktop item install to use `copyDesktopItems` hook

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
