### PR TITLE
python3Packages.faust-cchardet: 2.1.20 -> 2.2.1

### DIFF
--- a/pkgs/development/python-modules/faust-cchardet/default.nix
+++ b/pkgs/development/python-modules/faust-cchardet/default.nix
@@ -3,16 +3,14 @@
   buildPythonPackage,
   fetchFromGitHub,
   cython,
-  packaging,
-  pkgconfig,
-  setuptools,
+  meson-python,
   pytestCheckHook,
   python,
 }:
 
 buildPythonPackage rec {
   pname = "faust-cchardet";
-  version = "2.1.20";
+  version = "2.2.1";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -20,19 +18,12 @@ buildPythonPackage rec {
     repo = "cChardet";
     tag = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-MeRX/g38c+q2jiTtEhUpaGYf+5tkhexRGuIG0PdUGvI=";
+    hash = "sha256-m/wa41dhLFmRg20iAn1YkXVCIubp5bT4PI+YuUIK3Wc=";
   };
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail "packaging<26" packaging
-  '';
 
   build-system = [
     cython
-    packaging
-    pkgconfig
-    setuptools
+    meson-python
   ];
 
   postFixup = ''


### PR DESCRIPTION
Diff: https://github.com/faust-streaming/cChardet/compare/v2.1.20...v2.2.1

Changelog: https://github.com/faust-streaming/cChardet/blob/v2.2.1/CHANGES.rst


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
