### PR TITLE
secp256k1-jdk: add nix-update-script

### DIFF
--- a/pkgs/by-name/se/secp256k1-jdk/package.nix
+++ b/pkgs/by-name/se/secp256k1-jdk/package.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   maven,
   jdk25,
+  nix-update-script,
 }:
 
 maven.buildMavenPackage (finalAttrs: {
@@ -12,7 +13,7 @@ maven.buildMavenPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "bitcoinj";
     repo = "secp256k1-jdk";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-F2e4NDPEU7ZAu4+fvEd4BRbE2JwCvUiMeXHTMDXbIJE=";
   };
 
@@ -43,6 +44,8 @@ maven.buildMavenPackage (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     changelog = "https://github.com/bitcoinj/secp256k1-jdk/blob/master/CHANGELOG.adoc";


### PR DESCRIPTION
Add nix-update-script, so the next update can be generated by @r-ryantm.

Also change `rev` to `tag` in `fetchFromGitHub`.

## Things done

I have verified the update works correctly by reverting to `v0.3` and running:

```
nix-shell -p nix-update --run "nix-update --build secp256k1-jdk"
```

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
