### PR TITLE
msi-ec: 0-unstable-2025-09-17 -> 0-unstable-2026-08-02

### DIFF
--- a/pkgs/os-specific/linux/msi-ec/default.nix
+++ b/pkgs/os-specific/linux/msi-ec/default.nix
@@ -9,13 +9,13 @@
 }:
 stdenv.mkDerivation {
   pname = "msi-ec-kmods";
-  version = "0-unstable-2025-09-17";
+  version = "0-unstable-2026-08-02";
 
   src = fetchFromGitHub {
     owner = "BeardOverflow";
     repo = "msi-ec";
-    rev = "ed92e2eb0005ab815f5492c8cb02495289263738";
-    hash = "sha256-9jynXUvSZT2smyciK8GqojC/4MtxtqfQvJcf5RgPXKY=";
+    rev = "050d4394a6747ebd106ae2f8ddb3a4eebe7c700f";
+    hash = "sha256-b7wwZstjeLPEsxIjmZentDwkQTxdBYbpJfdOR24Ofww=";
   };
 
   dontMakeSourcesWritable = false;

--- a/pkgs/os-specific/linux/msi-ec/patches/makefile.patch
+++ b/pkgs/os-specific/linux/msi-ec/patches/makefile.patch
@@ -1,28 +1,28 @@
 diff --git a/Makefile b/Makefile
-index 9e598ea..0776132 100644
+index db61eb2..dc0be31 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -1,6 +1,7 @@
- VERSION         := 0.12
+@@ -4,6 +4,7 @@ include $(_SRC)/Makefile.vars # AKMOD can be annoying so preventing his silent c
  DKMS_ROOT_PATH  := /usr/src/msi_ec-$(VERSION)
- KERNELRELEASE ?= $(shell uname -r)
+ 
+ KERNELRELEASE := $(shell uname -r)
 +KERNELDIR ?= /lib/modules/$(KERNELRELEASE)/build/
  
- ccflags-y := -std=gnu11 -Wno-declaration-after-statement
+ KMOD_DIR        := /lib/modules/$(KERNELRELEASE)/updates/drivers/platform/x86
  
-@@ -10,11 +11,14 @@ obj-m += msi-ec.o
+@@ -14,10 +15,13 @@ obj-m += $(MODNAME).o
  all: modules
  
  modules:
 -	@$(MAKE) -C /lib/modules/$(KERNELRELEASE)/build M=$(CURDIR) modules
 +	@$(MAKE) -C $(KERNELDIR) M=$(CURDIR) modules
- 
- clean:
- 	@$(MAKE) -C /lib/modules/$(KERNELRELEASE)/build M=$(CURDIR) clean
- 
++
 +modules_install:
 +	@$(MAKE) -C $(KERNELDIR) M=$(CURDIR) modules_install
-+
+ 
+ clean:
+-	@$(MAKE) -C /lib/modules/$(KERNELRELEASE)/build M=$(CURDIR) clean
++	@$(MAKE) -C $(KERNELDIR) M=$(CURDIR) clean
+ 
  load:
  	insmod msi-ec.ko
- 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
