### PR TITLE
test/pnpm: fix fixup-state-db test by storing SQL dump

### DIFF
--- a/pkgs/test/pnpm/pnpm-fixup-state-db/default.nix
+++ b/pkgs/test/pnpm/pnpm-fixup-state-db/default.nix
@@ -16,8 +16,8 @@ testers.runCommand {
 
     pnpm-fixup-state-db ./store
 
-    cp ./store/index.db $out
+    sqlite3 ./store/index.db .dump > $out
   '';
 
-  hash = "sha256-P3PDQAziwUxl2pfYV+QyPVwNpq90Jg46bawTvrT0NOQ=";
+  hash = "sha256-PEzcJgGRo+dK5X9TBcx3A+BOIsvJ7gFmzV8vanTuGCo=";
 }


### PR DESCRIPTION
Fixup-state-db is effectively only used in fetchPnpmDeps.
We previously included the SQLite database in the FOD, it was first
problematic as it produced different hashes on linux and darwin, but
SQLite version updates have a higher chance of changing the DB format
and break our hashes, that just happened with the 3.53.1 -> 3.53.3 bump.

Nowadays fetchPnpmDeps relies on the SQL dump of the database which is
more stable, but in the past hashes were broken once.

The point is, we no longer rely on the raw DB, but only it's dump, so
it's safe to assert for that in this test.

Fixes https://hydra.nixos.org/build/338832983.

These bytes caused the hash change (context of the output is truncated):

```console
nixpkgs ❯ diffoscope /nix/store/k514p150nmg6sjr53nyv8i2b1cnx2572-pnpm-fixup-state-db-test-salted-rs1cl4kr0xh8 /nix/store/j8zpn1zvx4fbn0h5d5hdk0zjrhyb3m2x-pnpm-fixup-state-db-test-salted-cdg65xd8y3xw
--- /nix/store/k514p150nmg6sjr53nyv8i2b1cnx2572-pnpm-fixup-state-db-test-salted-rs1cl4kr0xh8
+++ /nix/store/j8zpn1zvx4fbn0h5d5hdk0zjrhyb3m2x-pnpm-fixup-state-db-test-salted-cdg65xd8y3xw
@@ -1,14 +1,14 @@
 00000000: 5351 4c69 7465 2066 6f72 6d61 7420 3300  SQLite format 3.
 00000010: 1000 0202 0040 2020 0000 0004 0000 000f  .....@  ........
 00000020: 0000 0000 0000 0000 0000 0003 0000 0004  ................
 00000030: 0000 0000 0000 0000 0000 0001 0000 0000  ................
 00000040: 0000 0000 0000 0000 0000 0000 0000 0000  ................
 00000050: 0000 0000 0000 0000 0000 0000 0000 0004  ................
-00000060: 002e 95c9 0d00 0000 020f 1100 0f5e 0f11  .............^..
+00000060: 002e 95cb 0d00 0000 020f 1100 0f5e 0f11  .............^..
```

The first path was produced by checking out **a** (not "the", I choose this with git bisect before a long staging build) bad commit, b7620ae184e5bf4020e5dfebec3dd33a1508beac and building the test, the second (good) path was produced by reverting 703a55ddf48d1ebb4ace62665dfec573e7cbe933 on the bad commit.

It doesn't really matter what those bytes are, since the SQL dump didn't change this time.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
