### PR TITLE
{binutils, libbfd, libopcodes}{,_2_38}: enable structuredAttrs

### DIFF
--- a/pkgs/development/tools/misc/binutils/2.38/default.nix
+++ b/pkgs/development/tools/misc/binutils/2.38/default.nix
@@ -263,6 +263,8 @@ stdenv.mkDerivation {
     isGNU = true;
   };
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Tools for manipulating binaries (linker, assembler, etc.)";
     longDescription = ''

--- a/pkgs/development/tools/misc/binutils/2.38/libbfd.nix
+++ b/pkgs/development/tools/misc/binutils/2.38/libbfd.nix
@@ -66,6 +66,8 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Library for manipulating containers of machine code";
     longDescription = ''

--- a/pkgs/development/tools/misc/binutils/2.38/libopcodes.nix
+++ b/pkgs/development/tools/misc/binutils/2.38/libopcodes.nix
@@ -50,6 +50,8 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Library from binutils for manipulating machine code";
     homepage = "https://www.gnu.org/software/binutils/";

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -278,7 +278,7 @@ stdenv.mkDerivation (finalAttrs: {
     for target in ${lib.escapeShellArgs allGasTargets}; do
       mkdir "$NIX_BUILD_TOP/build-$target"
       env -C "$NIX_BUILD_TOP/build-$target" \
-        "$configureScript" $configureFlags "''${configureFlagsArray[@]}" \
+        "$configureScript" "''${configureFlags[@]}" \
         --enable-gas --program-prefix "$target-"  --target "$target"
     done
   '';
@@ -293,7 +293,7 @@ stdenv.mkDerivation (finalAttrs: {
   postBuild = lib.optionalString withAllTargets ''
     for target in ${lib.escapeShellArgs allGasTargets}; do
       make -C "$NIX_BUILD_TOP/build-$target" -j"$NIX_BUILD_CORES" \
-        $makeFlags "''${makeFlagsArray[@]}" $buildFlags "''${buildFlagsArray[@]}" \
+        "''${makeFlags[@]}" "''${buildFlags[@]}" \
         TARGET-gas=as-new all-gas
     done
   '';
@@ -328,7 +328,7 @@ stdenv.mkDerivation (finalAttrs: {
     + lib.optionalString withAllTargets ''
       for target in ${lib.escapeShellArgs allGasTargets}; do
         make -C "$NIX_BUILD_TOP/build-$target/gas" -j"$NIX_BUILD_CORES" \
-          $makeFlags "''${makeFlagsArray[@]}" $installFlags "''${installFlagsArray[@]}" \
+          "''${makeFlags[@]}" "''${installFlags[@]}" \
           install-exec-bindir
       done
     ''
@@ -353,6 +353,8 @@ stdenv.mkDerivation (finalAttrs: {
         --wildcards '*'/include/plugin-api.h
     '';
   };
+
+  __structuredAttrs = true;
 
   meta = {
     description = "Tools for manipulating binaries (linker, assembler, etc.)";

--- a/pkgs/development/tools/misc/binutils/libbfd.nix
+++ b/pkgs/development/tools/misc/binutils/libbfd.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation {
     inherit (binutils-unwrapped-all-targets) src dev plugin-api-header;
   };
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Library for manipulating containers of machine code";
     longDescription = ''

--- a/pkgs/development/tools/misc/binutils/libopcodes.nix
+++ b/pkgs/development/tools/misc/binutils/libopcodes.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation {
     inherit (binutils-unwrapped-all-targets) dev;
   };
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Library from binutils for manipulating machine code";
     homepage = "https://www.gnu.org/software/binutils/";


### PR DESCRIPTION
~~Tested on top of master as part of https://github.com/NixOS/nixpkgs/compare/master...SFrijters:nixpkgs:lowlevel-structuredattrs with~~

~~`nixpkgs-review rev lowlevel-structuredattrs --package pkgsi686Linux.tests.stdenv --package gccgo --package pkgsi686Linux.gccgo --package tests.stdenv --package pkgsMusl.tests.stdenv`~~

Split off from https://github.com/NixOS/nixpkgs/pull/551108

Tested via https://github.com/NixOS/nixpkgs/pull/551108#issuecomment-5244248102

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
