### PR TITLE
dub-to-nix: fetch submodules for git dependencies

### DIFF
--- a/pkgs/build-support/dlang/builddubpackage/import-dub-lock.nix
+++ b/pkgs/build-support/dlang/builddubpackage/import-dub-lock.nix
@@ -41,6 +41,7 @@ let
       src = fetchgit {
         url = repository;
         rev = version;
+        fetchSubmodules = true; # this is the default, but let's be explicit
         inherit sha256;
       };
     };

--- a/pkgs/build-support/dlang/dub-to-nix/dub-to-nix.py
+++ b/pkgs/build-support/dlang/dub-to-nix/dub-to-nix.py
@@ -57,7 +57,7 @@ for pname in depsDict:
         repository = depDict["repository"]
         strippedRepo = repository[4:]
         eprint(f"Fetching {pname}@{version} ({strippedRepo})")
-        command = ["nix-prefetch-git", strippedRepo, version]
+        command = ["nix-prefetch-git", "--fetch-submodules", strippedRepo, version]
         rawRes = subprocess.run(command, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL).stdout
         sha256 = json.loads(rawRes)["sha256"]
         lockedDepsDict[pname] = {"version": version, "repository": strippedRepo, "sha256": sha256}


### PR DESCRIPTION
`dub-to-nix` records hashes for `git+` dependencies by running `nix-prefetch-git` without `--fetch-submodules`. The consumer, `importDubLock`, fetches those same dependencies with `fetchgit`, whose `fetchSubmodules` argument defaults to `true`. This makes the generated hashes disagree.

This should be backwards-compatible because for git dependencies without submodules, `--fetch-submodules` should fetch nothing extra and yield the same NAR hash.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
