### PR TITLE
qmplay2: 26.06.27 -> 26.08.02

### DIFF
--- a/pkgs/by-name/qm/qmplay2/package.nix
+++ b/pkgs/by-name/qm/qmplay2/package.nix
@@ -39,9 +39,6 @@
 
 let
   sources = callPackage ./sources.nix { };
-  vulkan-headers-qmplay2 = vulkan-headers.overrideAttrs (oldAttrs: {
-    inherit (sources.vulkan-headers-qmplay2) version src;
-  });
 in
 assert lib.elem qtVersion [
   "5"
@@ -82,7 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
     libva
     libxcb
     taglib
-    vulkan-headers-qmplay2
+    vulkan-headers
     vulkan-tools
     deno
     expat

--- a/pkgs/by-name/qm/qmplay2/sources.nix
+++ b/pkgs/by-name/qm/qmplay2/sources.nix
@@ -5,13 +5,13 @@
     let
       self = {
         pname = "qmplay2";
-        version = "26.06.27";
+        version = "26.08.02";
 
         src = fetchFromGitHub {
           owner = "zaps166";
           repo = "QMPlay2";
           tag = self.version;
-          hash = "sha256-8PY6s74unLgwDFlyiHHCWrsatdI05obbREOICZoI+lU=";
+          hash = "sha256-5y39RylYa+dvgAtxg1fh4y8UOJwPoKRfmrc0gGwL7vk=";
         };
       };
     in
@@ -21,13 +21,13 @@
     let
       self = {
         pname = "vulkan-headers";
-        version = "1.4.350";
+        version = "1.4.358";
 
         src = fetchFromGitHub {
           owner = "KhronosGroup";
           repo = "Vulkan-Headers";
           tag = "v${self.version}";
-          hash = "sha256-RcUVurC+Rc0MyWpQLaLVmdn7FZO1GWWzTZZAOwvKwb4=";
+          hash = "sha256-SrfDWSp7DmGHT+fM09gry9L4x6BDWxoUi3Qtbi1qg2I=";
         };
       };
     in

--- a/pkgs/by-name/qm/qmplay2/sources.nix
+++ b/pkgs/by-name/qm/qmplay2/sources.nix
@@ -17,22 +17,6 @@
     in
     self;
 
-  vulkan-headers-qmplay2 =
-    let
-      self = {
-        pname = "vulkan-headers";
-        version = "1.4.358";
-
-        src = fetchFromGitHub {
-          owner = "KhronosGroup";
-          repo = "Vulkan-Headers";
-          tag = "v${self.version}";
-          hash = "sha256-SrfDWSp7DmGHT+fM09gry9L4x6BDWxoUi3Qtbi1qg2I=";
-        };
-      };
-    in
-    self;
-
   qmvk = {
     pname = "qmvk";
     version = "0-unstable-2026-06-21";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Diff: https://github.com/zaps166/QMPlay2/compare/26.06.27...26.08.02
## Things done
Changed hashes for qmplay2 and vulkan-headers. Basic test passed
Migrating to use vulkan-headers from nixpkgs
Fixes #548478 
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
