### PR TITLE
xadi: init at 0-unstable-2025-06-07

### DIFF
--- a/pkgs/by-name/xa/xadi/dub-lock.json
+++ b/pkgs/by-name/xa/xadi/dub-lock.json
@@ -1,0 +1,52 @@
+{
+  "dependencies": {
+    "automem": {
+      "version": "0.6.11",
+      "sha256": "0l3cbkji47p9myhdpmm83s4j8rjvdwkyln1hinlw1kzph4dgb5wn"
+    },
+    "cachetools": {
+      "version": "0.4.2",
+      "sha256": "0l24y3pwnwxdf1zkx7nxgiscf2ycyj4a4cqhy2qn9syvmdgy6rd4"
+    },
+    "dxml": {
+      "version": "0.4.4",
+      "sha256": "0p5vmkw29ksh5wdxz1ijms1wblq288pv15vnbl93z7q2vgnq995w"
+    },
+    "dynamic-loader": {
+      "version": "9202b389affa6be0740e7295dea8f0146537a784",
+      "repository": "https://github.com/Dadoum/dynamicloader.git",
+      "sha256": "0l2d7pd5r3crkvgi9i8fbcmcbzkw12syf1i7pnics75w1gk5f717"
+    },
+    "plist": {
+      "version": "a425458e2c3d8195c6a9ad68e643f2d823850693",
+      "repository": "https://github.com/Dadoum/plist.git",
+      "sha256": "0174dpkkf8l235f8p0d1ql26646xd8y869ckz1xmg6rjc71vlvnc"
+    },
+    "plist-d": {
+      "version": "6fdaa60d62bbf7c55044069e8f03cbe74401c444",
+      "repository": "https://github.com/Dadoum/libplist-d.git",
+      "sha256": "00v556i9ky3r8dixa53dmy3dfbq19mih6fd7a38cjwpk6pvc1is2"
+    },
+    "provision": {
+      "version": "6b899c20a26aba8d2640188c75d184267e57fc06",
+      "repository": "https://github.com/Dadoum/Provision.git",
+      "sha256": "0v843rkza1m03mcac1hzxv112vs220ing32pppb4yn5r3r98jc80"
+    },
+    "requests": {
+      "version": "2.1.3",
+      "sha256": "0j7jz1n5g21cj6kw389raj60hpq7rkak17y84ny7yqv2i3pqwvc5"
+    },
+    "slf4d": {
+      "version": "2.4.3",
+      "sha256": "1745wzkial5yk0900649wh8f73nwf7wja0xyawvh5gx4zwssw04a"
+    },
+    "test_allocator": {
+      "version": "0.3.4",
+      "sha256": "1xpjz6smxwgm4walrv3xbzi46cddc80q5n4gs7j9gm2yx11sf7gj"
+    },
+    "unit-threaded": {
+      "version": "2.2.3",
+      "sha256": "070qlnr33miyg6w6q8yvry8nnxng23vdklvbr94dmjrbplxb9fy8"
+    }
+  }
+}

--- a/pkgs/by-name/xa/xadi/package.nix
+++ b/pkgs/by-name/xa/xadi/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildDubPackage,
+  fetchFromGitHub,
+  stdenv,
+}:
+
+buildDubPackage (finalAttrs: {
+  pname = "xadi";
+  version = "0-unstable-2025-06-07";
+
+  src = fetchFromGitHub {
+    owner = "xtool-org";
+    repo = "xadi";
+    rev = "61c02708c9cb046100f500878863fd2122b0d7e3";
+    hash = "sha256-mKHZE5Al2RK0kDLq3gDzHp1+GmqMFo4R8SItrmY5tcE=";
+  };
+
+  dubLock = ./dub-lock.json;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 -t $out/lib bin/libxadi${stdenv.hostPlatform.extensions.sharedLibrary}
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "CoreADI wrapper based on libprovision";
+    homepage = "https://github.com/xtool-org/xadi";
+    license = lib.licenses.lgpl21Only;
+    maintainers = with lib.maintainers; [ anish ];
+  };
+})


### PR DESCRIPTION
Adds `xadi`, a CoreADI wrapper based on libprovision.

The intended consumer is [xtool](https://github.com/xtool-org/xtool), which links xadi on Linux to generate anisette data for Apple ID login. xtool needs the Swift 6.3 toolchain (#343210), so it can't be packaged yet.

`dub-lock.json` is generated by `dub-to-nix`, it depends on #548514 to regenerate correctly.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
