### PR TITLE
codex-security: init at 0.1.5

### DIFF
--- a/pkgs/by-name/co/codex-security/package.nix
+++ b/pkgs/by-name/co/codex-security/package.nix
@@ -1,0 +1,137 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  pnpm_11,
+  nodejs,
+  pnpmConfigHook,
+  makeWrapper,
+  autoPatchelfHook,
+  git,
+  ncurses,
+  python3,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "codex-security";
+  version = "0.1.5";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "openai";
+    repo = "codex-security";
+    tag = "npm-v${finalAttrs.version}";
+    hash = "sha256-WAU/vRpo3k2fIW1xIWoS9ZxopXoV0T80+95m2X/NUDY=";
+  };
+
+  # The npm package lives in the `sdk/typescript` subdirectory of the
+  # repository, so root the whole build there.
+  sourceRoot = "${finalAttrs.src.name}/sdk/typescript";
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      sourceRoot
+      ;
+    pnpm = pnpm_11;
+    fetcherVersion = 4;
+    hash = "sha256-IsqSGb/P9sF2htuHeo7M+lOiq5FdHGxm80g82nc5Diw=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    pnpm_11
+    pnpmConfigHook
+    makeWrapper
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+
+  # The prebuilt @openai/codex binary is a dynamically linked native
+  # executable that autoPatchelfHook needs to fix up on Linux. The bundled
+  # zsh in the codex resources links libtinfo.so.6, which ncurses provides.
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    stdenv.cc.cc.lib
+    ncurses
+  ];
+
+  # The @napi-rs/canvas dependency ships prebuilt binaries for every
+  # platform, including an Android arm64 build that links liblog.so from
+  # the Android NDK. Android arm64 is AArch64, so on aarch64-linux this
+  # binary matches the build target and autoPatchelfHook tries to patch it,
+  # unlike on x86_64-linux where it is skipped for an architecture
+  # mismatch. The binary is never used on any Linux host, so ignore its
+  # otherwise unsatisfiable dependency.
+  autoPatchelfIgnoreMissingDeps = [ "liblog.so" ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm run build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    # Reinstall with only the production dependencies to keep the closure small.
+    rm -rf node_modules
+    pnpm install --force --offline --prod --ignore-scripts --frozen-lockfile
+
+    mkdir -p "$out/lib/codex-security"
+    cp -r bin dist _bundled_plugin node_modules package.json LICENSE README.md \
+      "$out/lib/codex-security/"
+
+    makeWrapper "${lib.getExe nodejs}" "$out/bin/codex-security" \
+      --add-flags "$out/lib/codex-security/bin/codex-security.mjs" \
+      --prefix PATH : "${
+        lib.makeBinPath [
+          git
+          python3
+        ]
+      }"
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "npm-v(.*)"
+    ];
+  };
+
+  meta = {
+    description = "CLI and TypeScript SDK for finding, validating, and fixing security vulnerabilities in your code";
+    homepage = "https://github.com/openai/codex-security";
+    changelog = "https://github.com/openai/codex-security/releases/tag/npm-v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ sheeeng ];
+    mainProgram = "codex-security";
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryNativeCode
+    ];
+  };
+})


### PR DESCRIPTION
Package `@openai/codex-security`, the OpenAI Codex Security command line interface and TypeScript software development kit for finding, validating, and fixing security vulnerabilities in your code. The upstream project publishes the package from the `sdk/typescript` subdirectory, built with pnpm 11 and TypeScript, bundling a plugin and the prebuilt `@openai/codex` native binary.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
