### PR TITLE
angie: mark as vulnerable due to insufficient nixpkgs maintainer attention

### DIFF
--- a/pkgs/servers/http/angie/default.nix
+++ b/pkgs/servers/http/angie/default.nix
@@ -43,5 +43,8 @@ callPackage ../nginx/generic.nix args rec {
     license = lib.licenses.bsd2;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ izorkin ];
+    knownVulnerabilities = [
+      "angie is insufficiently maintained in nixpkgs. Security updates are frequently delayed. Please consider stepping up as maintainer or switching to an alternative."
+    ];
   };
 }


### PR DESCRIPTION
My impression is that currently angie doesn't recveive the attention within nixpkgs it actually should get if there are active users.

The only currently listed maintainer @Izorkin has has done some review work of angie in the not to distant past but it doesn't seem to be enough. I fully sympathize with not always having time for everything. So definitly no blame here. My intention with this PR is simply to protect the users of this package.

For example the latest (bot based) version bump was opened about 3 weeks ago. Since then another version was tagged which addreesses three CVEs:

- #542017

Also in the past backports to the stable branch haven't really happened until i looked into it (but i'm actually not a user of that package so that isn't sustainable):

- #526997

Given that it's an nginx fork and recent experiences with nginx vulnerabilities it kinda does seem irresponsible to offer an unpatched nginx fork without a warning to it's users.

So my proposal would be to add a `knownVulnerabilities` entry to it. If there is active maintainer interest and for example an additional maintainer keeping an eye on it this can easily be removed again.
Otherwise the value proposition of an under maintained nginx fork within nixpkgs doesn't seem justified to me given the human (and monetary) costs attached to every single package.

I hope my reasoning for opening this PR is understandable.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
