### PR TITLE
dispatcharr: init at 0.28.2

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -1643,6 +1643,15 @@
   "module-services-emacs-man-pages": [
     "index.html#module-services-emacs-man-pages"
   ],
+  "module-services-dispatcharr": [
+    "index.html#module-services-dispatcharr"
+  ],
+  "module-services-dispatcharr-basic-usage": [
+    "index.html#module-services-dispatcharr-basic-usage"
+  ],
+  "module-services-dispatcharr-reverse-proxy": [
+    "index.html#module-services-dispatcharr-reverse-proxy"
+  ],
   "module-services-ente": [
     "index.html#module-services-ente"
   ],

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -26,6 +26,8 @@
 
 - [tranquil](https://tangled.org/tranquil.farm/tranquil-pds) is an ATProto PDS (personal data server) implementation in Rust. A featureful, spec conscious and community driven alternative to the Bluesky reference implementation PDS. Available as [services.tranquil-pds](#opt-services.tranquil-pds.enable).
 
+- [Dispatcharr](https://github.com/Dispatcharr/Dispatcharr), an IPTV stream, M3U/EPG, and HDHomeRun management companion. Available as [services.dispatcharr](#opt-services.dispatcharr.enable).
+
 - [Moonlight Qt](https://moonlight-stream.org/), a client for playing your PC games on almost any device. Available as [programs.moonlight-qt](#opt-programs.moonlight-qt.enable).
 
 - [scx_loader](https://github.com/sched-ext/scx-loader), a system daemon and DBus-based loader for sched_ext schedulers. `scxctl` is the command-line client for interacting with the loader, allowing users to switch schedulers, modes, and arguments dynamically. Available as [services.scx-loader](#opt-services.scx-loader.enable)

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1664,6 +1664,7 @@
   ./services/web-apps/dependency-track.nix
   ./services/web-apps/dex.nix
   ./services/web-apps/discourse.nix
+  ./services/web-apps/dispatcharr.nix
   ./services/web-apps/documize.nix
   ./services/web-apps/docuseal.nix
   ./services/web-apps/dokuwiki.nix

--- a/nixos/modules/services/web-apps/dispatcharr.md
+++ b/nixos/modules/services/web-apps/dispatcharr.md
@@ -1,0 +1,33 @@
+# Dispatcharr {#module-services-dispatcharr}
+
+Dispatcharr is a web-based IPTV stream, M3U/EPG, and HDHomeRun management companion.
+
+## Basic usage {#module-services-dispatcharr-basic-usage}
+
+A minimal working configuration looks like this:
+
+```nix
+{ pkgs, ... }:
+{
+  services.dispatcharr = {
+    enable = true;
+    secretKeyFile = "/run/secrets/dispatcharr-secret-key";
+  };
+
+  # Create the secret file before the service starts. In a real deployment you
+  # would use a secret management tool such as sops-nix or agenix.
+  systemd.services.dispatcharr-migrations.serviceConfig.EnvironmentFile =
+    pkgs.writeText "dispatcharr-secret-key" ''
+      DJANGO_SECRET_KEY=change-me-to-a-long-random-string
+    '';
+}
+```
+
+The module automatically provisions a local PostgreSQL database and a local
+Redis server for Dispatcharr.
+
+## Reverse proxy {#module-services-dispatcharr-reverse-proxy}
+
+The module does not serve static files itself. In production, place Dispatcharr
+behind a reverse proxy such as nginx and serve the static files collected under
+`''${config.services.dispatcharr.dataDir}/static/` from the `/static/` path.

--- a/nixos/modules/services/web-apps/dispatcharr.nix
+++ b/nixos/modules/services/web-apps/dispatcharr.nix
@@ -1,0 +1,276 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.dispatcharr;
+
+  python = cfg.package.python;
+  pythonSitePackages = python.sitePackages;
+
+  # Dispatcharr hard-codes BASE_DIR to the read-only site-packages directory in
+  # its upstream settings.py, which breaks static/media/backup paths at runtime.
+  # Load a tiny shim after the upstream settings so all mutable paths live under
+  # the NixOS state directory.
+  nixosSettingsFile = pkgs.writeTextFile {
+    name = "dispatcharr-nixos-settings.py";
+    text = ''
+      from dispatcharr.settings import *
+      import os
+      from pathlib import Path
+
+      BASE_DIR = Path(os.environ.get("DISPATCHARR_STATE_DIRECTORY", "${cfg.dataDir}"))
+      STATIC_ROOT = BASE_DIR / "static"
+      MEDIA_ROOT = BASE_DIR / "media"
+      BACKUP_ROOT = BASE_DIR / "backups"
+      DATA_DIR = os.environ.get("DISPATCHARR_DATA_DIRECTORY", str(BASE_DIR / "data"))
+      BACKUP_DATA_DIRS = [
+          os.path.join(DATA_DIR, "logos"),
+          os.path.join(DATA_DIR, "uploads"),
+          os.path.join(DATA_DIR, "plugins"),
+      ]
+    '';
+  };
+
+  nixosSettingsPackage = pkgs.runCommand "dispatcharr-nixos-settings" { } ''
+    install -Dm644 ${nixosSettingsFile} $out/${pythonSitePackages}/dispatcharr_nixos_settings.py
+  '';
+
+  pythonPath = lib.concatStringsSep ":" [
+    cfg.package.pythonPath
+    "${nixosSettingsPackage}/${pythonSitePackages}"
+  ];
+
+  envVars = {
+    DJANGO_SETTINGS_MODULE = "dispatcharr_nixos_settings";
+    PYTHONPATH = lib.concatStringsSep ":" [
+      pythonPath
+      "${cfg.package}/${cfg.package.python.sitePackages}"
+    ];
+    DISPATCHARR_STATE_DIRECTORY = cfg.dataDir;
+    DISPATCHARR_DATA_DIRECTORY = "${cfg.dataDir}/data";
+    DISPATCHARR_PLUGINS_DIR = "${cfg.dataDir}/data/plugins";
+    # Redis settings are read from environment variables by upstream.
+    REDIS_HOST = "localhost";
+    REDIS_PORT = toString config.services.redis.servers.dispatcharr.port;
+    REDIS_DB = "0";
+    # PostgreSQL settings are read from environment variables by upstream.
+    DB_ENGINE = "postgresql";
+    POSTGRES_DB = "dispatcharr";
+    POSTGRES_USER = "dispatcharr";
+    POSTGRES_HOST = "/run/postgresql";
+    POSTGRES_PORT = "5432";
+  };
+
+  manage = "${cfg.package}/bin/dispatcharr-manage";
+in
+{
+  options.services.dispatcharr = {
+    enable = lib.mkEnableOption "Dispatcharr, an IPTV stream management companion";
+
+    package = lib.mkPackageOption pkgs "dispatcharr" { };
+
+    dataDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/dispatcharr";
+      description = "Directory where Dispatcharr stores mutable data.";
+    };
+
+    secretKeyFile = lib.mkOption {
+      type = lib.types.path;
+      example = "/run/secrets/dispatcharr-secret-key";
+      description = ''
+        Path to a file containing the Django secret key.
+
+        This file is loaded as a systemd EnvironmentFile and should contain a
+        single line of the form `DJANGO_SECRET_KEY=your-secret-key`.
+      '';
+    };
+
+    listenAddress = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      description = "Address the Dispatcharr web interface will listen on.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 8000;
+      description = "Port the Dispatcharr web interface will listen on.";
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Open ports in the firewall for the Dispatcharr web interface.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.secretKeyFile != null;
+        message = "services.dispatcharr.secretKeyFile must be set.";
+      }
+    ];
+
+    services.postgresql = {
+      enable = true;
+      ensureDatabases = [ "dispatcharr" ];
+      ensureUsers = [
+        {
+          name = "dispatcharr";
+          ensureDBOwnership = true;
+        }
+      ];
+    };
+
+    services.redis.servers.dispatcharr = {
+      enable = true;
+      bind = "127.0.0.1";
+      port = 6379;
+    };
+
+    systemd.tmpfiles.settings."10-dispatcharr".${cfg.dataDir} = {
+      d = {
+        user = "dispatcharr";
+        group = "dispatcharr";
+        mode = "0750";
+      };
+    };
+
+    systemd.services.dispatcharr-migrations = {
+      description = "Dispatcharr database migrations";
+      wantedBy = [ "dispatcharr.target" ];
+      after = [
+        "network-online.target"
+        "postgresql.service"
+        "redis-dispatcharr.service"
+      ];
+      requires = [
+        "postgresql.service"
+        "redis-dispatcharr.service"
+      ];
+      environment = envVars;
+      serviceConfig = {
+        Type = "oneshot";
+        User = "dispatcharr";
+        Group = "dispatcharr";
+        EnvironmentFile = cfg.secretKeyFile;
+        StateDirectory = "dispatcharr";
+        StateDirectoryMode = "0750";
+        WorkingDirectory = cfg.dataDir;
+        ExecStart = manage + " migrate --no-input";
+      };
+    };
+
+    systemd.services.dispatcharr-collectstatic = {
+      description = "Dispatcharr collectstatic";
+      wantedBy = [ "dispatcharr.target" ];
+      after = [ "dispatcharr-migrations.service" ];
+      environment = envVars;
+      serviceConfig = {
+        Type = "oneshot";
+        User = "dispatcharr";
+        Group = "dispatcharr";
+        EnvironmentFile = cfg.secretKeyFile;
+        StateDirectory = "dispatcharr";
+        StateDirectoryMode = "0750";
+        WorkingDirectory = cfg.dataDir;
+        ExecStart = manage + " collectstatic --no-input";
+      };
+    };
+
+    systemd.services.dispatcharr = {
+      description = "Dispatcharr web interface";
+      wantedBy = [ "dispatcharr.target" ];
+      after = [
+        "network-online.target"
+        "dispatcharr-migrations.service"
+        "dispatcharr-collectstatic.service"
+      ];
+      environment = envVars;
+      serviceConfig = {
+        Type = "simple";
+        User = "dispatcharr";
+        Group = "dispatcharr";
+        EnvironmentFile = cfg.secretKeyFile;
+        StateDirectory = "dispatcharr";
+        StateDirectoryMode = "0750";
+        WorkingDirectory = cfg.dataDir;
+        ExecStart = "${python.pkgs.daphne}/bin/daphne -b ${cfg.listenAddress} -p ${toString cfg.port} dispatcharr.asgi:application";
+        Restart = "on-failure";
+      };
+    };
+
+    systemd.services.dispatcharr-worker = {
+      description = "Dispatcharr Celery worker";
+      wantedBy = [ "dispatcharr.target" ];
+      after = [
+        "network-online.target"
+        "dispatcharr-migrations.service"
+        "dispatcharr.service"
+      ];
+      environment = envVars;
+      serviceConfig = {
+        Type = "simple";
+        User = "dispatcharr";
+        Group = "dispatcharr";
+        EnvironmentFile = cfg.secretKeyFile;
+        StateDirectory = "dispatcharr";
+        StateDirectoryMode = "0750";
+        WorkingDirectory = cfg.dataDir;
+        ExecStart = "${python.pkgs.celery}/bin/celery -A dispatcharr worker --loglevel=info";
+        Restart = "on-failure";
+      };
+    };
+
+    systemd.services.dispatcharr-beat = {
+      description = "Dispatcharr Celery beat scheduler";
+      wantedBy = [ "dispatcharr.target" ];
+      after = [
+        "network-online.target"
+        "dispatcharr-migrations.service"
+        "dispatcharr.service"
+      ];
+      environment = envVars;
+      serviceConfig = {
+        Type = "simple";
+        User = "dispatcharr";
+        Group = "dispatcharr";
+        EnvironmentFile = cfg.secretKeyFile;
+        StateDirectory = "dispatcharr";
+        StateDirectoryMode = "0750";
+        WorkingDirectory = cfg.dataDir;
+        ExecStart = "${python.pkgs.celery}/bin/celery -A dispatcharr beat --loglevel=info --scheduler django_celery_beat.schedulers:DatabaseScheduler";
+        Restart = "on-failure";
+      };
+    };
+
+    systemd.targets.dispatcharr = {
+      description = "Target for all Dispatcharr services";
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+    };
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.port ];
+    };
+
+    users.users.dispatcharr = {
+      isSystemUser = true;
+      group = "dispatcharr";
+      home = cfg.dataDir;
+    };
+    users.groups.dispatcharr = { };
+  };
+
+  meta = {
+    doc = ./dispatcharr.md;
+    maintainers = with lib.maintainers; [ staticdev ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -491,6 +491,7 @@ in
     imports = [ ./discourse.nix ];
     _module.args.package = pkgs.discourseAllPlugins;
   };
+  dispatcharr = runTest ./dispatcharr.nix;
   dnscrypt-proxy = runTestOn [ "x86_64-linux" ] ./dnscrypt-proxy.nix;
   dnsdist = import ./dnsdist.nix { inherit pkgs runTest; };
   doas = runTest ./doas.nix;

--- a/nixos/tests/dispatcharr.nix
+++ b/nixos/tests/dispatcharr.nix
@@ -1,0 +1,27 @@
+{ lib, pkgs, ... }:
+{
+  name = "dispatcharr";
+
+  meta = {
+    maintainers = with lib.maintainers; [ staticdev ];
+  };
+
+  nodes.machine =
+    { ... }:
+    {
+      services.dispatcharr = {
+        enable = true;
+        secretKeyFile = pkgs.writeText "dispatcharr-secret-key" ''
+          DJANGO_SECRET_KEY=django-test-secret-key-keep-it-long-and-random
+        '';
+        port = 8000;
+      };
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("dispatcharr.target")
+    machine.wait_for_open_port(8000)
+    machine.succeed("curl -sSf http://127.0.0.1:8000/ | grep -i dispatcharr")
+  '';
+}

--- a/pkgs/by-name/di/dispatcharr/package.nix
+++ b/pkgs/by-name/di/dispatcharr/package.nix
@@ -7,6 +7,7 @@
   moreutils,
   nodejs,
   npmHooks,
+  nixosTests,
   python3Packages,
   ffmpeg,
   streamlink,
@@ -22,6 +23,38 @@ let
     };
   };
   pythonPackages = python.pkgs;
+
+  dependencies = with pythonPackages; [
+    celery
+    channels
+    channels-redis
+    daphne
+    django
+    django-celery-beat
+    django-cors-headers
+    django-db-geventpool
+    django-filter
+    django-redis
+    djangorestframework
+    djangorestframework-simplejwt
+    drf-spectacular
+    gevent
+    lxml
+    m3u8
+    packaging
+    pillow
+    psutil
+    psycopg
+    python-vlc
+    pytz
+    rapidfuzz
+    regex
+    requests
+    sentence-transformers
+    torch
+    tzlocal
+    yt-dlp
+  ];
 in
 
 pythonPackages.buildPythonApplication (finalAttrs: {
@@ -29,6 +62,8 @@ pythonPackages.buildPythonApplication (finalAttrs: {
   version = "0.28.2";
   pyproject = true;
   __structuredAttrs = true;
+
+  inherit dependencies;
 
   src = fetchFromGitHub {
     owner = "Dispatcharr";
@@ -87,38 +122,6 @@ pythonPackages.buildPythonApplication (finalAttrs: {
     hatchling
   ];
 
-  dependencies = with pythonPackages; [
-    celery
-    channels
-    channels-redis
-    daphne
-    django
-    django-celery-beat
-    django-cors-headers
-    django-db-geventpool
-    django-filter
-    django-redis
-    djangorestframework
-    djangorestframework-simplejwt
-    drf-spectacular
-    gevent
-    lxml
-    m3u8
-    packaging
-    pillow
-    psutil
-    psycopg
-    python-vlc
-    pytz
-    rapidfuzz
-    regex
-    requests
-    sentence-transformers
-    torch
-    tzlocal
-    yt-dlp
-  ];
-
   pythonRemoveDeps = [
     # streamlink and uwsgi are runtime command-line tools, not Python imports
     "streamlink"
@@ -173,6 +176,14 @@ pythonPackages.buildPythonApplication (finalAttrs: {
     "apps"
     "core"
   ];
+
+  passthru = {
+    inherit python;
+    pythonPath = pythonPackages.makePythonPath dependencies;
+    tests = {
+      inherit (nixosTests) dispatcharr;
+    };
+  };
 
   meta = {
     description = "IPTV stream, M3U/EPG, and HDHomeRun management companion";

--- a/pkgs/by-name/di/dispatcharr/package.nix
+++ b/pkgs/by-name/di/dispatcharr/package.nix
@@ -1,0 +1,188 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  jq,
+  makeWrapper,
+  moreutils,
+  nodejs,
+  npmHooks,
+  python3Packages,
+  ffmpeg,
+  streamlink,
+  uwsgi,
+  vlc,
+}:
+
+let
+  python = python3Packages.python.override {
+    self = python;
+    packageOverrides = final: prev: {
+      django = prev.django_6;
+    };
+  };
+  pythonPackages = python.pkgs;
+in
+
+pythonPackages.buildPythonApplication (finalAttrs: {
+  pname = "dispatcharr";
+  version = "0.28.2";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Dispatcharr";
+    repo = "Dispatcharr";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rO3ZltWG29/fxFNiWzZP18yAMSUewm43mThQireTbtI=";
+  };
+
+  npmRoot = "frontend";
+
+  # mpegts.js depends on webworkify-webpack through a GitHub shorthand
+  # (`github:xqq/webworkify-webpack`). fetchNpmDeps cannot correctly handle git
+  # deps without a lockfile, so replace the lockfile entry with the equivalent
+  # GitHub tarball before the npm deps are fetched.
+  postPatch = ''
+    lockfile=frontend/package-lock.json
+    if [ ! -f "$lockfile" ]; then
+      lockfile=package-lock.json
+    fi
+    ${lib.getExe jq} '
+      .packages["node_modules/webworkify-webpack"] |= {
+        version: "2.1.5",
+        resolved: "https://codeload.github.com/xqq/webworkify-webpack/tar.gz/24d1e719b4a6cac37a518b2bb10fe124527ef4ef",
+        integrity: "sha512-DPqNW8CSRNB+5wfoia6e63A04AuOnkFPsBZMtEB2TMbQbBDcmrsBgwmppiCZZlvl1ve9i2p6f9ivCMtkz8q87A==",
+        license: "MIT"
+      }
+      | .packages["node_modules/mpegts.js"].dependencies["webworkify-webpack"] = "2.1.5"
+    ' "$lockfile" | sponge "$lockfile"
+  '';
+
+  npmDeps = fetchNpmDeps {
+    inherit (finalAttrs) src postPatch;
+    sourceRoot = "${finalAttrs.src.name}/${finalAttrs.npmRoot}";
+    fetcherVersion = 2;
+    nativeBuildInputs = [ moreutils ];
+    hash = "sha256-cg/85fmhjSKk9j5LiQXGiK9hJpNfFVygxi3gBTu501Y=";
+  };
+
+  makeCacheWritable = true;
+
+  nativeBuildInputs = [
+    jq
+    makeWrapper
+    moreutils
+    nodejs
+    npmHooks.npmConfigHook
+  ];
+
+  preBuild = ''
+    pushd frontend
+    npm run build
+    popd
+  '';
+
+  build-system = with pythonPackages; [
+    hatchling
+  ];
+
+  dependencies = with pythonPackages; [
+    celery
+    channels
+    channels-redis
+    daphne
+    django
+    django-celery-beat
+    django-cors-headers
+    django-db-geventpool
+    django-filter
+    django-redis
+    djangorestframework
+    djangorestframework-simplejwt
+    drf-spectacular
+    gevent
+    lxml
+    m3u8
+    packaging
+    pillow
+    psutil
+    psycopg
+    python-vlc
+    pytz
+    rapidfuzz
+    regex
+    requests
+    sentence-transformers
+    torch
+    tzlocal
+    yt-dlp
+  ];
+
+  pythonRemoveDeps = [
+    # streamlink and uwsgi are runtime command-line tools, not Python imports
+    "streamlink"
+    "uwsgi"
+  ];
+
+  pythonRelaxDeps = [
+    "channels"
+    "channels-redis"
+    "django"
+    "django-celery-beat"
+    "django-cors-headers"
+    "djangorestframework-simplejwt"
+    "drf-spectacular"
+    "gevent"
+    "lxml"
+    "psutil"
+    "rapidfuzz"
+    "requests"
+    "sentence-transformers"
+    "torch"
+  ];
+
+  postInstall = ''
+    # The frontend dist is served by Django from BASE_DIR / "frontend/dist".
+    # BASE_DIR resolves to the site-packages directory that holds dispatcharr/,
+    # apps/, and core/, so install the built assets next to them.
+    mkdir -p $out/${pythonPackages.python.sitePackages}/frontend
+    cp -r frontend/dist $out/${pythonPackages.python.sitePackages}/frontend/
+
+    # manage.py and version.py live at the repo root and are not included in
+    # the wheel. Install them at the site-packages root so they can be found at
+    # runtime and so running manage.py does not put dispatcharr/ on sys.path.
+    cp manage.py version.py $out/${pythonPackages.python.sitePackages}/
+    chmod +x $out/${pythonPackages.python.sitePackages}/manage.py
+
+    # Provide a manage.py wrapper that exposes the runtime command-line tools.
+    makeWrapper $out/${pythonPackages.python.sitePackages}/manage.py $out/bin/dispatcharr-manage \
+      --prefix PATH : "$out/bin:${
+        lib.makeBinPath [
+          ffmpeg
+          streamlink
+          uwsgi
+          vlc
+        ]
+      }" \
+      --prefix PYTHONPATH : "$PYTHONPATH"
+  '';
+
+  pythonImportsCheck = [
+    "dispatcharr"
+    "apps"
+    "core"
+  ];
+
+  meta = {
+    description = "IPTV stream, M3U/EPG, and HDHomeRun management companion";
+    homepage = "https://github.com/Dispatcharr/Dispatcharr";
+    changelog = "https://github.com/Dispatcharr/Dispatcharr/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [
+      diogotcorreia
+      staticdev
+    ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/development/python-modules/django-db-geventpool/default.nix
+++ b/pkgs/development/python-modules/django-db-geventpool/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  hatchling,
+  django,
+  psycopg,
+  gevent,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "django-db-geventpool";
+  version = "4.0.8";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "django_db_geventpool";
+    inherit (finalAttrs) version;
+    hash = "sha256-jqEA5IFRUnL3bHf03zuzQBzoOMl1SXgtDTD6+ZDQy/Q=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    django
+    psycopg
+    gevent
+  ];
+
+  pythonImportsCheck = [ "django_db_geventpool" ];
+
+  meta = {
+    description = "Another DB pool using gevent for PostgreSQL DB";
+    homepage = "https://github.com/jneight/django-db-geventpool";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ staticdev ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4543,6 +4543,8 @@ self: super: with self; {
 
   django-currentuser = callPackage ../development/python-modules/django-currentuser { };
 
+  django-db-geventpool = callPackage ../development/python-modules/django-db-geventpool { };
+
   django-dbbackup = callPackage ../development/python-modules/django-dbbackup { };
 
   django-debug-toolbar = callPackage ../development/python-modules/django-debug-toolbar { };


### PR DESCRIPTION
This PR packages Dispatcharr 0.28.2 in nixpkgs.
Superseeds https://github.com/NixOS/nixpkgs/pull/497011

Dispatcharr is an IPTV stream, M3U/EPG, and HDHomeRun management
companion (https://github.com/Dispatcharr/Dispatcharr).

Changes:
- python3Packages.django-db-geventpool: init at 4.0.8
  Required PostgreSQL connection-pool dependency for Dispatcharr.
- dispatcharr: init at 0.28.2
  - Builds the Vite/React frontend inside the derivation.
  - Patches the npm lockfile so the webworkify-webpack GitHub
    shorthand is resolved from the npm registry.
  - Uses Django 6 via python3Packages.django_6.
  - Provides a dispatcharr-manage wrapper that exposes the
    runtime tools (ffmpeg, streamlink, uwsgi, vlc) on PATH.
  - Installs repo-root manage.py and version.py next to the
    site-packages so Django can find them at runtime.
  - Exposes `passthru.python` and `passthru.pythonPath` so the
    NixOS module can reuse the same Python environment.
- nixos/dispatcharr: init module
  - Minimal NixOS module that provisions PostgreSQL and Redis.
  - Runs migrations and collectstatic automatically.
  - Starts Daphne (web UI) plus Celery worker and beat.
  - Redirects mutable paths (static, media, backups, plugins) to
    the configured state directory instead of the Nix store.
  - Includes a NixOS VM test.

Tested:
- nix-build -A dispatcharr
- ./result/bin/dispatcharr-manage --version
- ./result/bin/dispatcharr-manage check (with sqlite/Redis disabled)
- nix-build -A nixosTests.dispatcharr
- ./ci/nixpkgs-vet.sh master

This PR was prepared with assistance from an AI coding assistant. I reviewed and tested all changes.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
