### PR TITLE
indilib: 2.2.0 -> 2.2.4.2; indi-3rdparty: 2.2.0 -> 2.2.4

### DIFF
--- a/pkgs/development/libraries/science/astronomy/indilib/default.nix
+++ b/pkgs/development/libraries/science/astronomy/indilib/default.nix
@@ -4,17 +4,21 @@
   fetchFromGitHub,
   bash,
   cmake,
+  pkg-config,
   cfitsio,
+  curl,
   libusb1,
   kmod,
   zlib,
   boost,
   libev,
   libnova,
-  curl,
+  libtheora,
+  libxisf,
   libjpeg,
   gsl,
   fftw,
+  rtl-sdr-librtlsdr,
   gtest,
   udevCheckHook,
   versionCheckHook,
@@ -23,38 +27,42 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "indilib";
-  version = "2.2.0";
+  version = "2.2.4.2";
 
   src = fetchFromGitHub {
     owner = "indilib";
     repo = "indi";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-XTb+etafMRTP/Arb087s+kZoqFT50RT1fpVDeHaGdmY=";
+    hash = "sha256-DISO8UHrH0cjXe+xTAOdFRce61tOk0SS/CAdsen9cXA=";
   };
 
   nativeBuildInputs = [
     cmake
+    pkg-config
   ];
 
   nativeInstallCheckInputs = [
-    versionCheckHook
     udevCheckHook
   ];
 
   buildInputs = [
-    curl
-    cfitsio
-    libev
-    libusb1
-    zlib
     boost
-    libnova
-    libjpeg
-    gsl
+    cfitsio
+    curl
     fftw
+    gsl
+    libev
+    libjpeg
+    libnova
+    libtheora
+    libusb1
+    libxisf
+    rtl-sdr-librtlsdr
+    zlib
   ];
 
   cmakeFlags = [
+    "-DFIX_WARNINGS=OFF" # disable Werror, which can break the build on newer compilers
     "-DCMAKE_INSTALL_LIBDIR=lib"
     "-DUDEVRULES_INSTALL_DIR=lib/udev/rules.d"
   ]

--- a/pkgs/development/libraries/science/astronomy/indilib/indi-3rdparty.nix
+++ b/pkgs/development/libraries/science/astronomy/indilib/indi-3rdparty.nix
@@ -41,13 +41,13 @@
 }:
 
 let
-  thirdparty_version = "2.2.0";
+  thirdparty_version = "2.2.4";
   fxload = libusb1.override { withExamples = true; };
   src-3rdparty = fetchFromGitHub {
     owner = "indilib";
     repo = "indi-3rdparty";
     rev = "v${thirdparty_version}";
-    hash = "sha256-JGDaRlKYgHADMC3C2kiRmTqoL0dHuJKXiUVAYknQsGA=";
+    hash = "sha256-knmu+ARLvbEQqRfwXYogYkfD8j5QCKy4V8YMIeEjMbU=";
   };
 
   buildIndi3rdParty =


### PR DESCRIPTION
Update to latest release, added a patch to fix compile (also submitted upstream)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
