### PR TITLE
lix: boost is required to build against lix/libutil

### DIFF
--- a/pkgs/tools/package-management/lix/common-lix.nix
+++ b/pkgs/tools/package-management/lix/common-lix.nix
@@ -311,6 +311,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   propagatedBuildInputs = [
     boehmgc
+    boost
     nlohmann_json
   ];
 


### PR DESCRIPTION
This fixes compilation errors like:
```
In file included from /nix/store/1p6r4w8943g0cklmsdmsm4pdvvldw8ja-lix-2.95.2-dev/include/lix/libutil/error-trace.hh:11,
                 from /nix/store/1p6r4w8943g0cklmsdmsm4pdvvldw8ja-lix-2.95.2-dev/include/lix/libutil/error.hh:18,
                 from /nix/store/1p6r4w8943g0cklmsdmsm4pdvvldw8ja-lix-2.95.2-dev/include/lix/libutil/async.hh:4,
                 from /nix/store/1p6r4w8943g0cklmsdmsm4pdvvldw8ja-lix-2.95.2-dev/include/lix/libutil/async-io.hh:4,
                 from /nix/store/1p6r4w8943g0cklmsdmsm4pdvvldw8ja-lix-2.95.2-dev/include/lix/libutil/archive.hh:4,
                 from /nix/store/1p6r4w8943g0cklmsdmsm4pdvvldw8ja-lix-2.95.2-dev/include/lix/libutil/hash.hh:6,
                 from /nix/store/1p6r4w8943g0cklmsdmsm4pdvvldw8ja-lix-2.95.2-dev/include/lix/libstore/realisation.hh:6,
                 from /nix/store/1p6r4w8943g0cklmsdmsm4pdvvldw8ja-lix-2.95.2-dev/include/lix/libstore/build-result.hh:4,
                 from ../src/plugin.cc:3:
/nix/store/1p6r4w8943g0cklmsdmsm4pdvvldw8ja-lix-2.95.2-dev/include/lix/libutil/fmt.hh:6:10: fatal error: boost/format.hpp: No such file or directory
    6 | #include <boost/format.hpp>
      |          ^~~~~~~~~~~~~~~~~~
compilation terminated.
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
