### PR TITLE
rufin: 0.9.0 -> 0.12.0

### DIFF
--- a/pkgs/by-name/ru/rufin/package.nix
+++ b/pkgs/by-name/ru/rufin/package.nix
@@ -14,7 +14,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rufin";
-  version = "0.9.0";
+  version = "0.12.0";
 
   __structuredAttrs = true;
 
@@ -22,10 +22,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "screwys";
     repo = "Rufin";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-VYuM0SAAvoQ/H4dufgoPFNIYwwEjpctqiElrKPi5D+E=";
+    hash = "sha256-1kxZthQ8A+cNJSc/BO8V06bwbLOdTQT/cYqxMVZg5Yw=";
   };
 
-  cargoHash = "sha256-a0VPqbw2rjOzRjYpk8NoI2mq9LxFd6BBJ/AmE3tyVR4=";
+  cargoHash = "sha256-S+Jt95zPBjymhp5wnx6EIsTgHkKwOb6KklsT9dBhdDA=";
 
   strictDeps = true;
 
@@ -57,6 +57,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   doCheck = false;
 
   postInstall = ''
+    install -Dm644 data/japanese-readings.dic \
+      "$out/share/rufin/japanese-readings.dic"
+    install -Dm644 data/japanese-readings.LICENSE \
+      "$out/share/licenses/rufin/japanese-readings.LICENSE"
     install -Dm644 data/io.github.screwys.Rufin.desktop \
       "$out/share/applications/io.github.screwys.Rufin.desktop"
     substituteInPlace "$out/share/applications/io.github.screwys.Rufin.desktop" \
@@ -92,7 +96,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   meta = {
-    description = "Native GTK music client for Jellyfin";
+    description = "Native GTK4/libadwaita music client for Jellyfin, Subsonic, Navidrome and local libraries written in Rust";
     homepage = "https://github.com/screwys/Rufin";
     changelog = "https://github.com/screwys/Rufin/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;


### PR DESCRIPTION
A manual update since I needed to bundle Japanese dictionary, and additionally update the description.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

