### PR TITLE
goshs: 2.1.4 -> 2.1.5, fix security issues

### DIFF
--- a/pkgs/by-name/go/goshs/CVE-2026-5160.patch
+++ b/pkgs/by-name/go/goshs/CVE-2026-5160.patch
@@ -1,0 +1,14 @@
+diff --git a/go.mod b/go.mod
+index fe507b4678693915f275648ff052c2d2d859f4cc..aeb7e04795d9527edd1c4c100a870b38f4de538c 100644
+--- a/go.mod
++++ b/go.mod
+@@ -104 +104 @@ require (
+-	github.com/yuin/goldmark v1.7.13 // indirect
++	github.com/yuin/goldmark v1.7.17 // indirect
+diff --git a/go.sum b/go.sum
+index 1c56fd543ca070281c9c23e83a3387b16cf3dac3..9cc1bcb4a0fac0eb2e366a9b438da16d6cd13428 100644
+--- a/go.sum
++++ b/go.sum
+@@ -217,0 +218,2 @@ github.com/yuin/goldmark v1.7.13/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Br
++github.com/yuin/goldmark v1.7.17 h1:p36OVWwRb246iHxA/U4p8OPEpOTESm4n+g+8t0EE5uA=
++github.com/yuin/goldmark v1.7.17/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=

--- a/pkgs/by-name/go/goshs/package.nix
+++ b/pkgs/by-name/go/goshs/package.nix
@@ -17,7 +17,12 @@ buildGoModule (finalAttrs: {
     hash = "sha256-mVgBY1QhQ+tDQnfangqylNeCbBJTSJaM0y7vZ95BU3Y=";
   };
 
-  vendorHash = "sha256-lwZ+F/DaP5pYiaihMxFAo1DokKm6itreX7yG1CNCdWM=";
+  vendorHash = "sha256-LLYgb0DIFx97+ZXOlQc4yVdjjiw7ebXx76hADfWnlkw=";
+
+  patches = [
+    # No upstream fix yet; remove when updating to a release that uses goldmark 1.7.17 or later.
+    ./CVE-2026-5160.patch
+  ];
 
   ldflags = [ "-s" ];
 

--- a/pkgs/by-name/go/goshs/package.nix
+++ b/pkgs/by-name/go/goshs/package.nix
@@ -3,31 +3,21 @@
   stdenv,
   buildGoModule,
   fetchFromGitHub,
-  fetchpatch2,
   versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "goshs";
-  version = "2.1.4";
+  version = "2.1.5";
 
   src = fetchFromGitHub {
     owner = "goshs-labs";
     repo = "goshs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-8xSYdLO+2AB044sV3JJw0RXB0RuLQ7eIzWvwgoJdp5k=";
+    hash = "sha256-mVgBY1QhQ+tDQnfangqylNeCbBJTSJaM0y7vZ95BU3Y=";
   };
 
-  vendorHash = "sha256-yKNJHs6A7Du9NvGOpwaDmABz6SBMPVzJNoQb7W32IfA=";
-
-  patches = [
-    # Remove when updating to 2.1.5 or later.
-    (fetchpatch2 {
-      name = "CVE-2026-66063+CVE-2026-66064.patch";
-      url = "https://github.com/goshs-labs/goshs/commit/f3ef599e409151d1380866e47de8b1afb0bb54fa.patch?full_index=1";
-      hash = "sha256-fIKeqWKraaLcocp7aaWE58ffkA1/2NVwR7KMmJfXL5g=";
-    })
-  ];
+  vendorHash = "sha256-lwZ+F/DaP5pYiaihMxFAo1DokKm6itreX7yG1CNCdWM=";
 
   ldflags = [ "-s" ];
 
@@ -53,7 +43,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Simple, yet feature-rich web server written in Go";
     homepage = "https://goshs.de";
-    changelog = "https://github.com/goshs-labs/goshs/releases/tag/${finalAttrs.src.rev}";
+    changelog = "https://github.com/goshs-labs/goshs/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       fab


### PR DESCRIPTION
Updates goshs to the security-focused v2.1.5 release. It includes the existing fixes for CVE-2026-66063 and CVE-2026-66064 and fixes six additional advisories across its HTTP, WebDAV, FTP, and SFTP surfaces.

Upstream v2.1.5 still selects `github.com/yuin/goldmark` 1.7.13. A local patch updates it to 1.7.17, the first version fixing CVE-2026-5160. The patch is marked for removal once an upstream goshs release includes the fixed dependency.

`govulncheck` reproduces CVE-2026-5160 on the unpatched v2.1.5 binary and reports no reachable vulnerabilities for the patched, unstripped binary. The enabled upstream test suite and the targeted security regression tests pass.

Changelog: https://redirect.github.com/goshs-labs/goshs/releases/tag/v2.1.5

Addresses #547000
Addresses #547003

After this PR is merged, its final commits need to be backported to `release-26.05`.

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
