### PR TITLE
waypaper-engine: 3.0.0 -> 3.1.1

### DIFF
--- a/pkgs/by-name/wa/waypaper-engine/package.nix
+++ b/pkgs/by-name/wa/waypaper-engine/package.nix
@@ -17,13 +17,13 @@
 let
   pnpm = pnpm_11;
 
-  version = "3.0.0";
+  version = "3.1.1";
 
   src = fetchFromGitHub {
     owner = "0bCdian";
     repo = "Waypaper-Engine";
     tag = "v${version}";
-    hash = "sha256-oee44RABW+0BcirsJbc5WnLVQeyAamXfxj4Q1x4B2JA=";
+    hash = "sha256-MnxxHJ6ff13N2ABqr/29uTxBbgmm1hySROVCwXEYCc0=";
   };
 
   backend = buildGoModule (finalAttrs: {
@@ -42,7 +42,7 @@ let
     buildInputs = [ wayland ];
 
     proxyVendor = true;
-    vendorHash = "sha256-KGyaZhWU5UOPV73MitA5eycy3ugH+rwgNu09r3ALtIo=";
+    vendorHash = "sha256-yKXPQ3Q/dyn/ZHQX/lDRjkYiF+6/lUkDioqnzPlYtN0=";
 
     subPackages = [ "cmd/daemon" ];
 
@@ -70,8 +70,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     inherit pnpm;
-    fetcherVersion = 3;
-    hash = "sha256-m/TtZ1rUXyzSYfxDMuZGW8d0Rl6T7qU+v4kRHAa6PM0=";
+    fetcherVersion = 4;
+    hash = "sha256-8x0qzKW2iGTKIF2VI9KGEgFeSPtnOjURZHtN/azbfSw=";
   };
 
   patchPhase = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
[Changelog](https://github.com/0bCdian/Waypaper-Engine/releases/tag/v3.1.1)

No AI was used. Just a human brain to change the pnpm fetcher version and hashes.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
