### PR TITLE
coreutils: enable strictDeps, structuredAttrs, modernize

### DIFF
--- a/pkgs/by-name/co/coreutils/package.nix
+++ b/pkgs/by-name/co/coreutils/package.nix
@@ -162,6 +162,8 @@ stdenv.mkDerivation (finalAttrs: {
     # TODO(@Ericson2314): Investigate whether Darwin could benefit too
     ++ optional (isCross && stdenv.hostPlatform.libc != "glibc") libiconv;
 
+  strictDeps = true;
+
   hardeningDisable = [ "trivialautovarinit" ];
 
   configureFlags = [

--- a/pkgs/by-name/co/coreutils/package.nix
+++ b/pkgs/by-name/co/coreutils/package.nix
@@ -83,7 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
     # sandbox does not allow setgid
     sed '2i echo Skipping chmod setgid test && exit 77' -i ./tests/chmod/setgid.sh
     substituteInPlace ./tests/install/install-C.sh \
-      --replace 'mode3=2755' 'mode3=1755'
+      --replace-fail 'mode3=2755' 'mode3=1755'
 
     # Fails on systems with a rootfs. Looks like a bug in the test, see
     # https://lists.gnu.org/archive/html/bug-coreutils/2019-12/msg00000.html
@@ -272,6 +272,8 @@ stdenv.mkDerivation (finalAttrs: {
       execer can bin/${if withPrefix then "g" else ""}runcon
     '';
   };
+
+  __structuredAttrs = true;
 
   meta = {
     homepage = "https://www.gnu.org/software/coreutils/";


### PR DESCRIPTION
Tested on top of master as part of https://github.com/NixOS/nixpkgs/compare/master...SFrijters:nixpkgs:lowlevel-structuredattrs with 

`nixpkgs-review rev lowlevel-structuredattrs --package pkgsi686Linux.tests.stdenv --package gccgo --package pkgsi686Linux.gccgo --package tests.stdenv --package pkgsMusl.tests.stdenv`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
