### PR TITLE
autoconf: enable strictDeps, enable structuredAttrs, modernize

### DIFF
--- a/pkgs/development/tools/misc/autoconf/2.69.nix
+++ b/pkgs/development/tools/misc/autoconf/2.69.nix
@@ -6,12 +6,12 @@
   perl,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "autoconf";
   version = "2.69";
 
   src = fetchurl {
-    url = "mirror://gnu/autoconf/autoconf-${version}.tar.xz";
+    url = "mirror://gnu/autoconf/autoconf-${finalAttrs.version}.tar.xz";
     sha256 = "113nlmidxy9kjr45kg9x3ngar4951mvag1js2a3j8nxcz34wxsv4";
   };
 
@@ -41,6 +41,8 @@ stdenv.mkDerivation rec {
 
   doInstallCheck = false; # fails
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://www.gnu.org/software/autoconf/";
     description = "Part of the GNU Build System";
@@ -59,4 +61,4 @@ stdenv.mkDerivation rec {
 
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/development/tools/misc/autoconf/2.69.nix
+++ b/pkgs/development/tools/misc/autoconf/2.69.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   buildInputs = [ m4 ];
 
+  strictDeps = true;
+
   # Work around a known issue in Cygwin.  See
   # http://thread.gmane.org/gmane.comp.sysutils.autoconf.bugs/6822 for
   # details.

--- a/pkgs/development/tools/misc/autoconf/2.69.nix
+++ b/pkgs/development/tools/misc/autoconf/2.69.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnu/autoconf/autoconf-${finalAttrs.version}.tar.xz";
-    sha256 = "113nlmidxy9kjr45kg9x3ngar4951mvag1js2a3j8nxcz34wxsv4";
+    hash = "sha256-ZOvOyfisWySHElqGp3YNJZGsnh09vVlIljP53mKldoQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/misc/autoconf/default.nix
+++ b/pkgs/development/tools/misc/autoconf/default.nix
@@ -12,7 +12,7 @@
 # cgit) that are needed here should be included directly in Nixpkgs as
 # files.
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "autoconf";
   version = "2.73";
   outputs = [
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   ];
 
   src = fetchurl {
-    url = "mirror://gnu/autoconf/autoconf-${version}.tar.xz";
+    url = "mirror://gnu/autoconf/autoconf-${finalAttrs.version}.tar.xz";
     hash = "sha256-n9ZyschCX6wvpn+gR3uZCYcmi5D/NtXwFtrle+DWtS4=";
   };
 
@@ -57,6 +57,8 @@ stdenv.mkDerivation rec {
     export TESTSUITEFLAGS="-j$NIX_BUILD_CORES"
   '';
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://www.gnu.org/software/autoconf/";
     description = "Part of the GNU Build System";
@@ -75,4 +77,4 @@ stdenv.mkDerivation rec {
 
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
~~Tested on top of master as part of https://github.com/NixOS/nixpkgs/compare/master...SFrijters:nixpkgs:lowlevel-structuredattrs with~~

~~`nixpkgs-review rev lowlevel-structuredattrs --package pkgsi686Linux.tests.stdenv --package gccgo --package pkgsi686Linux.gccgo --package tests.stdenv --package pkgsMusl.tests.stdenv`~~

Split off from https://github.com/NixOS/nixpkgs/pull/551108

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
