### PR TITLE
automake: enable structuredAttrs, modernize

### DIFF
--- a/pkgs/development/tools/misc/automake/automake-1.16.x.nix
+++ b/pkgs/development/tools/misc/automake/automake-1.16.x.nix
@@ -7,12 +7,12 @@
   updateAutotoolsGnuConfigScriptsHook,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "automake";
   version = "1.16.5";
 
   src = fetchurl {
-    url = "mirror://gnu/automake/automake-${version}.tar.xz";
+    url = "mirror://gnu/automake/automake-${finalAttrs.version}.tar.xz";
     sha256 = "0sdl32qxdy7m06iggmkkvf7j520rmmgbsjzbm7fgnxwxdp6mh7gh";
   };
 
@@ -36,6 +36,8 @@ stdenv.mkDerivation rec {
   # "fixed" path in generated files!
   dontPatchShebangs = true;
 
+  __structuredAttrs = true;
+
   meta = {
     branch = "1.16";
     homepage = "https://www.gnu.org/software/automake/";
@@ -48,4 +50,4 @@ stdenv.mkDerivation rec {
     '';
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/development/tools/misc/automake/automake-1.16.x.nix
+++ b/pkgs/development/tools/misc/automake/automake-1.16.x.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnu/automake/automake-${finalAttrs.version}.tar.xz";
-    sha256 = "0sdl32qxdy7m06iggmkkvf7j520rmmgbsjzbm7fgnxwxdp6mh7gh";
+    hash = "sha256-8B1YzW2dd/vcqetLvV6tGYgij9tz1veiAfX41rEYtGk=";
   };
 
   strictDeps = true;

--- a/pkgs/development/tools/misc/automake/automake-1.18.x.nix
+++ b/pkgs/development/tools/misc/automake/automake-1.18.x.nix
@@ -7,12 +7,12 @@
   updateAutotoolsGnuConfigScriptsHook,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "automake";
   version = "1.18.1";
 
   src = fetchurl {
-    url = "mirror://gnu/automake/automake-${version}.tar.xz";
+    url = "mirror://gnu/automake/automake-${finalAttrs.version}.tar.xz";
     hash = "sha256-FoqjYyeDUbia9WaERI9SWlvOUHnQtoQr2RD90/FkaIc=";
   };
 
@@ -36,6 +36,8 @@ stdenv.mkDerivation rec {
   # "fixed" path in generated files!
   dontPatchShebangs = true;
 
+  __structuredAttrs = true;
+
   meta = {
     branch = "1.18";
     homepage = "https://www.gnu.org/software/automake/";
@@ -48,4 +50,4 @@ stdenv.mkDerivation rec {
     '';
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
~~Tested on top of master as part of https://github.com/NixOS/nixpkgs/compare/master...SFrijters:nixpkgs:lowlevel-structuredattrs with~~

~~`nixpkgs-review rev lowlevel-structuredattrs --package pkgsi686Linux.tests.stdenv --package gccgo --package pkgsi686Linux.gccgo --package tests.stdenv --package pkgsMusl.tests.stdenv`~~

Split off from https://github.com/NixOS/nixpkgs/pull/551108

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
