### PR TITLE
python3Packages.alpha-vantage: patch version

### DIFF
--- a/pkgs/development/python-modules/alpha-vantage/default.nix
+++ b/pkgs/development/python-modules/alpha-vantage/default.nix
@@ -24,6 +24,9 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail "version='2.3.1'," "version='${version}',"
+
     # Files are only linked
     rm alpha_vantage/async_support/*
     cp alpha_vantage/{cryptocurrencies.py,foreignexchange.py,techindicators.py,timeseries.py} alpha_vantage/async_support/

--- a/pkgs/development/python-modules/alpha-vantage/default.nix
+++ b/pkgs/development/python-modules/alpha-vantage/default.nix
@@ -11,7 +11,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "alpha-vantage";
   version = "3.0.0";
   pyproject = true;
@@ -19,13 +19,13 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "RomelTorres";
     repo = "alpha_vantage";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Ae9WqEsAjJcD62NZOPh6a49g1wY4KMswzixDAZEtWkw=";
   };
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace-fail "version='2.3.1'," "version='${version}',"
+      --replace-fail "version='2.3.1'," "version='${finalAttrs.version}',"
 
     # Files are only linked
     rm alpha_vantage/async_support/*
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     requests-mock
     pytestCheckHook
   ]
-  ++ lib.concatAttrValues optional-dependencies;
+  ++ lib.flatten (builtins.attrValues finalAttrs.passthru.optional-dependencies);
 
   # Starting with 3.0.0 most tests require an API key
   doCheck = false;
@@ -60,8 +60,8 @@ buildPythonPackage rec {
   meta = {
     description = "Python module for the Alpha Vantage API";
     homepage = "https://github.com/RomelTorres/alpha_vantage";
-    changelog = "https://github.com/RomelTorres/alpha_vantage/releases/tag/${version}";
+    changelog = "https://github.com/RomelTorres/alpha_vantage/releases/tag/v${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
