### PR TITLE
wiff: init at 0.1.0

### DIFF
--- a/pkgs/by-name/wi/wiff/package.nix
+++ b/pkgs/by-name/wi/wiff/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  git,
+  cacert,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "wiff";
+  version = "0.1.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "wez";
+    repo = "wiff";
+    rev = "6e76b0afad17987ef4aafc0c375b69cf83a5f51d";
+    hash = "sha256-PdyixXuob6RoiAUTHO+FJ4GJj6njuZqMTuAwOmsnh4Q=";
+  };
+
+  cargoHash = "sha256-m0gCmZ8ozVjQkuffTaMHmOcaoJAx0aJW5cgKTTi+U6g=";
+
+  nativeCheckInputs = [
+    git
+  ];
+
+  env.SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+
+  meta = {
+    description = "Terminal-centric diff and code-review utility";
+    longDescription = ''
+      wiff captures a diff and lets you browse and annotate it with syntax
+      highlighting from the comfort of your terminal. Reviews are persisted as
+      local sessions that both a human (through the TUI) and an agent (through
+      the CLI and a skill) can read and write at the same time. It works
+      entirely offline on your local working tree, index or history, and can
+      also mirror a GitHub pull request into a local session and publish the
+      review back to the forge.
+    '';
+    homepage = "https://github.com/wez/wiff";
+    changelog = "https://github.com/wez/wiff/commits/main";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      philocalyst
+    ];
+    mainProgram = "wiff";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- Built


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
<img width="1134" height="738" alt="Screenshot 2026-08-02 at 14 14 16" src="https://github.com/user-attachments/assets/89b3d65a-5b50-4b8a-ac13-3f46a69eeffd" />
