### PR TITLE
[release-26.05] python3Packages.gradio-client: 2.5.0 -> 2.6.0

### DIFF
--- a/pkgs/development/python-modules/gradio/client.nix
+++ b/pkgs/development/python-modules/gradio/client.nix
@@ -134,6 +134,7 @@ buildPythonPackage (finalAttrs: {
       disabledTests = [ ];
       pythonImportsCheck = null;
       dontCheckRuntimeDeps = true;
+      dontCheckPythonMetadata = true; # broken due to changed pname
     });
 
     inherit (gradio) updateScript;

--- a/pkgs/development/python-modules/gradio/client.nix
+++ b/pkgs/development/python-modules/gradio/client.nix
@@ -31,7 +31,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "gradio-client";
-  version = "2.5.0";
+  version = "2.6.0";
   pyproject = true;
 
   # no tests on pypi

--- a/pkgs/development/python-modules/gradio/default.nix
+++ b/pkgs/development/python-modules/gradio/default.nix
@@ -82,7 +82,7 @@ let
 in
 buildPythonPackage (finalAttrs: {
   pname = "gradio";
-  version = "6.20.0"; # please always backport gradio changes
+  version = "6.22.0"; # please always backport gradio changes
   pyproject = true;
   __structuredAttrs = true;
 
@@ -90,7 +90,7 @@ buildPythonPackage (finalAttrs: {
     owner = "gradio-app";
     repo = "gradio";
     tag = "gradio@${finalAttrs.version}";
-    hash = "sha256-q5OoMguG/f0A3c6X+zotafc3kRRuebxMBPUIlrlcNFI=";
+    hash = "sha256-9FcGnZ/yktKM8sTGpgTv3QLIe2IoGbSw10rLWgj1zSU=";
   };
 
   patches = [
@@ -107,7 +107,7 @@ buildPythonPackage (finalAttrs: {
     inherit (finalAttrs) version src;
     inherit pnpm;
     fetcherVersion = 4;
-    hash = "sha256-xCxr/jnp9emeB6THGt4cumvApw6fSZQwG2NGOcvR0yQ=";
+    hash = "sha256-TX4sLAfka/j002OsUKqxqi5B6Fb+DXSGdeL+w6V9XuM=";
   };
 
   env = {

--- a/pkgs/development/python-modules/gradio/default.nix
+++ b/pkgs/development/python-modules/gradio/default.nix
@@ -49,6 +49,7 @@
   typer,
   typing-extensions,
   uvicorn,
+  urllib3,
 
   # oauth
   authlib,
@@ -157,6 +158,7 @@ buildPythonPackage (finalAttrs: {
     typer
     typing-extensions
     uvicorn
+    urllib3
   ]
   ++ lib.optionals (pythonAtLeast "3.13") [
     audioop-lts
@@ -195,6 +197,10 @@ buildPythonPackage (finalAttrs: {
   ]
   ++ finalAttrs.passthru.optional-dependencies.oauth
   ++ pydantic.optional-dependencies.email;
+
+  pythonRelaxDeps = [
+    "tomlkit" # pre-emptive upper bound
+  ];
 
   preBuild = ''
     pnpm build
@@ -440,6 +446,7 @@ buildPythonPackage (finalAttrs: {
           '';
           pythonImportsCheck = null;
           dontCheckRuntimeDeps = true;
+          dontCheckPythonMetadata = true; # broken due to changed pname
         });
 
     # We can't use gitUpdater, because we need to update the pnpm hash.

--- a/pkgs/development/python-modules/huggingface-hub/default.nix
+++ b/pkgs/development/python-modules/huggingface-hub/default.nix
@@ -7,7 +7,6 @@
   setuptools,
 
   # dependencies
-  click,
   filelock,
   fsspec,
   hf-xet,
@@ -15,6 +14,7 @@
   packaging,
   pyyaml,
   tqdm,
+  typer,
   typing-extensions,
 
   # optional-dependencies
@@ -41,20 +41,19 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "huggingface-hub";
-  version = "1.23.0";
+  version = "1.16.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "huggingface";
     repo = "huggingface_hub";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Xl9girALcJw7aeLjFd4d/xITS8bTz9xlmziEQwrOdQ0=";
+    hash = "sha256-GuTsoz7ow3A/PJyU3L/xLp56r3RVx5O1YH3nr3T4u7U=";
   };
 
   build-system = [ setuptools ];
 
   dependencies = [
-    click
     filelock
     fsspec
     hf-xet
@@ -62,6 +61,7 @@ buildPythonPackage (finalAttrs: {
     packaging
     pyyaml
     tqdm
+    typer
     typing-extensions
   ];
 

--- a/pkgs/development/python-modules/huggingface-hub/default.nix
+++ b/pkgs/development/python-modules/huggingface-hub/default.nix
@@ -7,6 +7,7 @@
   setuptools,
 
   # dependencies
+  click,
   filelock,
   fsspec,
   hf-xet,
@@ -14,7 +15,6 @@
   packaging,
   pyyaml,
   tqdm,
-  typer,
   typing-extensions,
 
   # optional-dependencies
@@ -28,6 +28,10 @@
   # gradio
   gradio,
   requests,
+  # oauth
+  authlib,
+  fastapi,
+  itsdangerous,
   # mcp
   mcp,
 
@@ -37,19 +41,20 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "huggingface-hub";
-  version = "1.10.2";
+  version = "1.23.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "huggingface";
     repo = "huggingface_hub";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Q9N0QnxV8oJcxUsJzv4wX8Z6FkNdEfUH5BEVoZolsRY=";
+    hash = "sha256-Xl9girALcJw7aeLjFd4d/xITS8bTz9xlmziEQwrOdQ0=";
   };
 
   build-system = [ setuptools ];
 
   dependencies = [
+    click
     filelock
     fsspec
     hf-xet
@@ -57,7 +62,6 @@ buildPythonPackage (finalAttrs: {
     packaging
     pyyaml
     tqdm
-    typer
     typing-extensions
   ];
 
@@ -65,11 +69,6 @@ buildPythonPackage (finalAttrs: {
     all = [
 
     ];
-    torch = [
-      torch
-      safetensors
-    ]
-    ++ safetensors.optional-dependencies.torch;
     fastai = [
       toml
       fastai
@@ -85,6 +84,17 @@ buildPythonPackage (finalAttrs: {
     mcp = [
       mcp
     ];
+    oauth = [
+      authlib
+      fastapi
+      httpx
+      itsdangerous
+    ];
+    torch = [
+      torch
+      safetensors
+    ]
+    ++ safetensors.optional-dependencies.torch;
   };
 
   nativeCheckInputs = [


### PR DESCRIPTION
- **python3Packages.huggingface-hub: 1.10.2 -> 1.23.0**
- **python3Packages.huggingface-hub: 1.23.0 -> 1.16.0**
- **python3Packages.gradio{,-client}: unbreak**
- **python3Packages.gradio-client: 2.5.0 -> 2.6.0**

closes https://github.com/NixOS/nixpkgs/pull/548391

----

this is a partial backport of 4 PRs

* https://github.com/nixos/nixpkgs/commit/18a55b8b13448feb8610adbb83157af673d4b686 from https://github.com/NixOS/nixpkgs/pull/541370
* https://github.com/nixos/nixpkgs/commit/1b19e5e19615fcc2fab31c038c0a345c29b8aff9 from https://github.com/NixOS/nixpkgs/pull/541843
* https://github.com/NixOS/nixpkgs/commit/4fa87fa204aaaf6dd2208aa1095f3c4b4e28b95f from https://github.com/NixOS/nixpkgs/pull/546324
* https://github.com/NixOS/nixpkgs/commit/5e900f31fe3c5f96d9dd17de0c81a2a1d7a7e8a4 from https://github.com/NixOS/nixpkgs/pull/548276

All in order to keep gradio on stable in sync with unstable

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
