### PR TITLE
shotcut: fix build on darwin

### DIFF
--- a/pkgs/by-name/ml/mlt/package.nix
+++ b/pkgs/by-name/ml/mlt/package.nix
@@ -82,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     gdk-pixbuf
-    (opencv4.override { ffmpeg-headless = ffmpeg; })
+    opencv4
     ffmpeg
     fftw
     fontconfig
@@ -137,6 +137,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "MOD_OPENCV" true)
     (lib.cmakeBool "MOD_QT6" (qtbase != null && lib.versions.major qtbase.version == "6"))
     (lib.cmakeBool "MOD_GLAXNIMATE_QT6" (qtbase != null && lib.versions.major qtbase.version == "6"))
+    (lib.cmakeBool "RELOCATABLE" false)
   ]
   ++ lib.optionals enablePython [
     (lib.cmakeBool "SWIG_PYTHON" true)

--- a/pkgs/by-name/ml/mlt/package.nix
+++ b/pkgs/by-name/ml/mlt/package.nix
@@ -82,11 +82,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     gdk-pixbuf
-    opencv4
+    (opencv4.override { ffmpeg-headless = ffmpeg; })
     ffmpeg
     fftw
     fontconfig
-    frei0r
+    (frei0r.override { opencv = opencv4.override { ffmpeg-headless = ffmpeg; }; })
     libdv
     libebur128
     libexif
@@ -145,7 +145,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   preFixup = ''
     wrapProgram $out/bin/melt \
-      --prefix FREI0R_PATH : ${frei0r}/lib/frei0r-1 \
+      --prefix FREI0R_PATH : ${
+        (frei0r.override { opencv = opencv4.override { ffmpeg-headless = ffmpeg; }; })
+      }/lib/frei0r-1 \
       ${lib.optionalString enableJackrack "--prefix LADSPA_PATH : ${ladspaPlugins}/lib/ladspa"} \
       ${lib.optionalString (qtbase != null) "\${qtWrapperArgs[@]}"}
 

--- a/pkgs/by-name/sh/shotcut/package.nix
+++ b/pkgs/by-name/sh/shotcut/package.nix
@@ -47,8 +47,10 @@ stdenv.mkDerivation (finalAttrs: {
     qt6.qttools
     qt6.qtmultimedia
     qt6.qtcharts
-    qt6.qtwayland
     qt6.qtwebsockets
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    qt6.qtwayland
   ];
 
   env.NIX_CFLAGS_COMPILE = "-DSHOTCUT_NOUPGRADE";

--- a/pkgs/by-name/sh/shotcut/package.nix
+++ b/pkgs/by-name/sh/shotcut/package.nix
@@ -5,6 +5,7 @@
   replaceVars,
   SDL2,
   frei0r,
+  opencv4,
   ladspaPlugins,
   gettext,
   jack1,
@@ -38,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     SDL2
-    frei0r
+    (frei0r.override { opencv = opencv4.override { ffmpeg-headless = ffmpeg; }; })
     ladspaPlugins
     gettext
     qt6Packages.mlt
@@ -67,7 +68,9 @@ stdenv.mkDerivation (finalAttrs: {
   dontWrapGApps = true;
 
   qtWrapperArgs = [
-    "--set FREI0R_PATH ${frei0r}/lib/frei0r-1"
+    "--set FREI0R_PATH ${
+      (frei0r.override { opencv = opencv4.override { ffmpeg-headless = ffmpeg; }; })
+    }/lib/frei0r-1"
     "--set LADSPA_PATH ${ladspaPlugins}/lib/ladspa"
     "--prefix LD_LIBRARY_PATH : ${
       lib.makeLibraryPath ([ SDL2 ] ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [ jack1 ])


### PR DESCRIPTION
This had 2 issues: shotcut would try and use qt wayland module on darwin, and the mlt package would fail to load its plugins, in turn making the application non-functional.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
