### PR TITLE
gettext: enable structuredAttrs, use finalAttrs

### DIFF
--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -12,12 +12,12 @@
 # cgit) that are needed here should be included directly in Nixpkgs as
 # files.
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gettext";
   version = "1.0";
 
   src = fetchurl {
-    url = "mirror://gnu/gettext/${pname}-${version}.tar.gz";
+    url = "mirror://gnu/gettext/gettext-${finalAttrs.version}.tar.gz";
     hash = "sha256-hdmbecmBpASHTALgNCF2z3XHaY4rUf5BAxz2Um2XTxo=";
   };
   patches = [
@@ -103,6 +103,8 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
   enableParallelChecking = false; # fails sometimes
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Well integrated set of translation tools and documentation";
 
@@ -135,4 +137,4 @@ stdenv.mkDerivation rec {
 
 // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
   makeFlags = [ "CFLAGS=-D_FORTIFY_SOURCE=0" ];
-}
+})

--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -45,6 +45,10 @@ stdenv.mkDerivation (finalAttrs: {
     "gl_cv_func_wcwidth_works=yes"
   ];
 
+  makeFlags = lib.optionals stdenv.hostPlatform.isDarwin [
+    "CFLAGS=-D_FORTIFY_SOURCE=0"
+  ];
+
   postPatch = ''
     # Older versions of gettext come with a copy of `extern-inline.m4` that is not compatible with clang 18.
     # When a project uses gettext + autoreconfPhase, autoreconfPhase will invoke `autopoint -f`, which will
@@ -133,8 +137,4 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.all;
   };
-}
-
-// lib.optionalAttrs stdenv.hostPlatform.isDarwin {
-  makeFlags = [ "CFLAGS=-D_FORTIFY_SOURCE=0" ];
 })


### PR DESCRIPTION
Tested on top of master as part of https://github.com/NixOS/nixpkgs/compare/master...SFrijters:nixpkgs:lowlevel-structuredattrs with 

`nixpkgs-review rev lowlevel-structuredattrs --package pkgsi686Linux.tests.stdenv --package gccgo --package pkgsi686Linux.gccgo --package tests.stdenv --package pkgsMusl.tests.stdenv`
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
