### PR TITLE
bison: enable strictDeps, enable structuredAttrs

### DIFF
--- a/pkgs/by-name/bi/bison/package.nix
+++ b/pkgs/by-name/bi/bison/package.nix
@@ -50,6 +50,8 @@ stdenv.mkDerivation (finalAttrs: {
   # TODO: enable doInstallCheck unconditionally when fixed upstream.
   doInstallCheck = !stdenv.cc.isClang;
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://www.gnu.org/software/bison/";
     description = "Yacc-compatible parser generator";

--- a/pkgs/by-name/bi/bison/package.nix
+++ b/pkgs/by-name/bi/bison/package.nix
@@ -28,10 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
     "host"
   ];
 
-  # there's a /bin/sh shebang in bin/yacc which when no strictDeps is patched with the build stdenv shell
-  # however when cross-compiling it would still be patched with the build stdenv shell which would be wrong
-  # cannot add bash to buildInputs due to infinite recursion
-  strictDeps = stdenv.hostPlatform != stdenv.buildPlatform;
+  strictDeps = true;
 
   nativeBuildInputs = [
     m4
@@ -39,6 +36,13 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optional stdenv.hostPlatform.isSunOS help2man;
   propagatedBuildInputs = [ m4 ];
+
+  # there's a /bin/sh shebang in bin/yacc which when no strictDeps is patched with the build stdenv shell
+  # however when cross-compiling it would still be patched with the build stdenv shell which would be wrong
+  # cannot add bash to buildInputs due to infinite recursion
+  postFixup = lib.optionalString (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) ''
+    patchShebangs --build $out/bin/yacc
+  '';
 
   enableParallelBuilding = true;
   # tests are flaky / timing sensitive on FreeBSD


### PR DESCRIPTION
~~Tested on top of master as part of https://github.com/NixOS/nixpkgs/compare/master...SFrijters:nixpkgs:lowlevel-structuredattrs with~~

~~`nixpkgs-review rev lowlevel-structuredattrs --package pkgsi686Linux.tests.stdenv --package gccgo --package pkgsi686Linux.gccgo --package tests.stdenv --package pkgsMusl.tests.stdenv`~~

Split off from https://github.com/NixOS/nixpkgs/pull/551108

Tested via https://github.com/NixOS/nixpkgs/pull/551108#issuecomment-5244248102

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
