### PR TITLE
adapta-gtk-theme: revert removal and remove gtk2

### DIFF
--- a/pkgs/by-name/ad/adapta-gtk-theme/disable-gtk2.patch
+++ b/pkgs/by-name/ad/adapta-gtk-theme/disable-gtk2.patch
@@ -1,0 +1,89 @@
+diff --git a/configure.ac b/configure.ac
+index e59085f6..908a38bc 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -24,6 +24,7 @@ AC_PREFIX_DEFAULT(/usr/local)
+ AM_SILENT_RULES([yes])
+ 
+ ADAPTA_OPTION([PARALLEL],     [parallel],     [parallel-build],      [disable])
++ADAPTA_OPTION([GTK_2],        [gtk_2],        [Gtk-2.0],             [disable])
+ ADAPTA_OPTION([GTK_NEXT],     [gtk_next],     [Gtk-4.0],             [disable])
+ ADAPTA_OPTION([GNOME],        [gnome],        [Gnome-Shell],         [enable])
+ ADAPTA_OPTION([CINNAMON],     [cinnamon],     [Cinnamon],            [enable])
+@@ -106,7 +107,7 @@ AC_MSG_RESULT([
+         | Supported Gtk+ Version
+         -----------------------------------------------------------------
+ 
+-         Gtk+ 2.0:               always
++         Gtk+ 2.0:               $ENABLE_GTK_2 (default: no)
+          Gtk+ 3.20:              always
+          Gtk+ 3.22:              always
+          Gtk+ 3.24:              always
+diff --git a/gtk/Makefile.am b/gtk/Makefile.am
+index d3291a40..349d18ed 100644
+--- a/gtk/Makefile.am
++++ b/gtk/Makefile.am
+@@ -528,7 +528,10 @@ all:
+ 	$(MKDIR_P) $(srcdir)/asset/assets-gtk2/Toolbar && \
+ 	$(MKDIR_P) $(srcdir)/asset/assets-gtk3
+ 
++if ENABLE_GTK_2
+ 	cd $(srcdir)/gtk-2.0 && ./recolor-gtk2.sh
++endif
++
+ if ENABLE_PARALLEL
+ 	cd $(srcdir)/sass && $(PARALLEL) $(parallel_option) ::: \
+ 		"$(SASSC) $(sassc_option) 3.20/gtk.scss ../gtk-3.20/gtk-contained.css" \
+@@ -593,12 +596,11 @@ if ENABLE_XFCE
+ endif
+ 
+ if ENABLE_PARALLEL
++if ENABLE_GTK_2
+ 	cd $(srcdir)/asset/assets-gtk2-scripts && \
+ 		./recolor-assets-gtk2.sh
+ 	cd $(srcdir)/asset/assets-gtk2-scripts && \
+ 		./clone-assets-gtk2.sh
+-	cd $(srcdir)/asset/assets-gtk3-scripts && \
+-		./recolor-assets-gtk3.sh
+ 	cd $(srcdir)/asset/assets-gtk2-scripts && \
+ 	$(PARALLEL) $(parallel_option) ./render-assets-gtk2.sh ::: \
+ 		arrow \
+@@ -611,6 +613,9 @@ if ENABLE_PARALLEL
+ 		range \
+ 		scrollbar \
+ 		spin
++endif
++	cd $(srcdir)/asset/assets-gtk3-scripts && \
++		./recolor-assets-gtk3.sh
+ 	cd $(srcdir)/asset/assets-gtk3-scripts && \
+ 	$(PARALLEL) $(parallel_option) ./render-assets-gtk3.sh ::: \
+ 		checkbox \
+@@ -623,10 +628,12 @@ if ENABLE_PARALLEL
+ 		window-maximize \
+ 		window-unmaximize
+ else
++if ENABLE_GTK_2
+ 	cd $(srcdir)/asset/assets-gtk2-scripts && \
+ 		./recolor-assets-gtk2.sh && \
+ 		./clone-assets-gtk2.sh && \
+ 		./render-assets-gtk2.sh all
++endif
+ 	cd $(srcdir)/asset/assets-gtk3-scripts && \
+ 		./recolor-assets-gtk3.sh && \
+ 		./render-assets-gtk3.sh all
+@@ -686,6 +693,7 @@ install-data-local:
+ 	$(MKDIR_P) $(noktoetadir)/gtk-3.24
+ 	cp -Rv $(gtk324noktoeta_file) $(noktoetadir)/gtk-3.24
+ 
++if ENABLE_GTK_2
+ 	$(MKDIR_P) $(adaptadir)/gtk-2.0
+ 	$(MKDIR_P) $(adaptadir)/gtk-2.0/Arrows
+ 	$(MKDIR_P) $(adaptadir)/gtk-2.0/Buttons
+@@ -813,6 +821,7 @@ install-data-local:
+ 	cp -Rv $(gtk2_nokto_shadow_file) $(noktoetadir)/gtk-2.0/Shadows
+ 	cp -Rv $(gtk2_nokto_spin_file) $(noktoetadir)/gtk-2.0/Spin
+ 	cp -Rv $(gtk2_nokto_toolbar_file) $(noktoetadir)/gtk-2.0/Toolbar
++endif
+ 
+ if ENABLE_GTK_NEXT
+ 	$(MKDIR_P) $(adaptadir)/gtk-4.0

--- a/pkgs/by-name/ad/adapta-gtk-theme/package.nix
+++ b/pkgs/by-name/ad/adapta-gtk-theme/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  parallel,
+  sassc,
+  inkscape,
+  libxml2,
+  glib,
+  gdk-pixbuf,
+  librsvg,
+  gtk-engine-murrine,
+  gnome-shell,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "adapta-gtk-theme";
+  version = "3.95.0.11";
+
+  src = fetchFromGitHub {
+    owner = "adapta-project";
+    repo = "adapta-gtk-theme";
+    tag = finalAttrs.version;
+    sha256 = "19skrhp10xx07hbd0lr3d619vj2im35d8p9rmb4v4zacci804q04";
+  };
+
+  preferLocalBuild = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    parallel
+    sassc
+    inkscape
+    libxml2
+    glib.dev
+    gnome-shell
+  ];
+
+  buildInputs = [
+    gdk-pixbuf
+    librsvg
+  ];
+
+  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+  postPatch = "patchShebangs .";
+
+  configureFlags = [
+    "--disable-gtk_legacy"
+    "--disable-gtk_next"
+    "--disable-unity"
+  ];
+
+  meta = {
+    description = "Adaptive GTK theme based on Material Design Guidelines";
+    homepage = "https://github.com/adapta-project/adapta-gtk-theme";
+    license = with lib.licenses; [
+      gpl2
+      cc-by-sa-30
+    ];
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ romildo ];
+  };
+})

--- a/pkgs/by-name/ad/adapta-gtk-theme/package.nix
+++ b/pkgs/by-name/ad/adapta-gtk-theme/package.nix
@@ -60,10 +60,18 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Adaptive GTK theme based on Material Design Guidelines";
     homepage = "https://github.com/adapta-project/adapta-gtk-theme";
-    license = with lib.licenses; [
-      gpl2
-      cc-by-sa-30
-    ];
+    license =
+      with lib.licenses;
+      # cc-by-sa-40 (svg files) is technically incompatible with gpl2 (everything else),
+      # but cc-by-sa-40 is compatible with gpl3, which this project used to be licensed
+      # under at some point. The intent behind this exact license combination is effectively
+      # lost to time, as more than 700 issues have been made inaccessible even prior to the
+      # repository's archival. At the very least we know it's not `OR [ gpl2 cc-by-sa-40 ]`
+      # based on the README.md and the svg sources (which say cc-by-sa-40 in their xml).
+      AND [
+        gpl2
+        cc-by-sa-40
+      ];
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
       romildo

--- a/pkgs/by-name/ad/adapta-gtk-theme/package.nix
+++ b/pkgs/by-name/ad/adapta-gtk-theme/package.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
         gpl2
         cc-by-sa-40
       ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [
       romildo
       emilylange

--- a/pkgs/by-name/ad/adapta-gtk-theme/package.nix
+++ b/pkgs/by-name/ad/adapta-gtk-theme/package.nix
@@ -25,6 +25,9 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "19skrhp10xx07hbd0lr3d619vj2im35d8p9rmb4v4zacci804q04";
   };
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   patches = [
     ./disable-gtk2.patch
   ];

--- a/pkgs/by-name/ad/adapta-gtk-theme/package.nix
+++ b/pkgs/by-name/ad/adapta-gtk-theme/package.nix
@@ -11,7 +11,6 @@
   glib,
   gdk-pixbuf,
   librsvg,
-  gtk-engine-murrine,
   gnome-shell,
 }:
 
@@ -25,6 +24,10 @@ stdenv.mkDerivation (finalAttrs: {
     tag = finalAttrs.version;
     sha256 = "19skrhp10xx07hbd0lr3d619vj2im35d8p9rmb4v4zacci804q04";
   };
+
+  patches = [
+    ./disable-gtk2.patch
+  ];
 
   preferLocalBuild = true;
 
@@ -43,8 +46,6 @@ stdenv.mkDerivation (finalAttrs: {
     gdk-pixbuf
     librsvg
   ];
-
-  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
 
   postPatch = "patchShebangs .";
 

--- a/pkgs/by-name/ad/adapta-gtk-theme/package.nix
+++ b/pkgs/by-name/ad/adapta-gtk-theme/package.nix
@@ -53,9 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   configureFlags = [
-    "--disable-gtk_legacy"
     "--disable-gtk_next"
-    "--disable-unity"
     "--enable-parallel"
   ];
 

--- a/pkgs/by-name/ad/adapta-gtk-theme/package.nix
+++ b/pkgs/by-name/ad/adapta-gtk-theme/package.nix
@@ -29,8 +29,6 @@ stdenv.mkDerivation (finalAttrs: {
     ./disable-gtk2.patch
   ];
 
-  preferLocalBuild = true;
-
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
@@ -47,12 +45,18 @@ stdenv.mkDerivation (finalAttrs: {
     librsvg
   ];
 
-  postPatch = "patchShebangs .";
+  postPatch = ''
+    substituteInPlace gtk/Makefile.am \
+      --replace-fail "--jobs 100%" '--jobs ''${NIX_BUILD_CORES}'
+
+    patchShebangs .
+  '';
 
   configureFlags = [
     "--disable-gtk_legacy"
     "--disable-gtk_next"
     "--disable-unity"
+    "--enable-parallel"
   ];
 
   meta = {

--- a/pkgs/by-name/ad/adapta-gtk-theme/package.nix
+++ b/pkgs/by-name/ad/adapta-gtk-theme/package.nix
@@ -65,6 +65,9 @@ stdenv.mkDerivation (finalAttrs: {
       cc-by-sa-30
     ];
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ romildo ];
+    maintainers = with lib.maintainers; [
+      romildo
+      emilylange
+    ];
   };
 })

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -272,7 +272,6 @@ mapAliases {
   abseil-cpp_202301 = throw "abseil-cpp_202301 has been removed as it was unused in tree"; # Added 2025-08-09
   abseil-cpp_202501 = throw "abseil-cpp_202501 has been removed as it was unused in tree"; # Added 2025-09-15
   acd-cli = throw "adc-cli has been removed as it was unmaintained"; # Added 2026-05-02
-  adapta-gtk-theme = throw "'adapta-gtk-theme' has been removed because it depended on 'gtk-engine-murrine', which was removed because it was unmaintained upstream and depended on GTK 2."; # Added 2026-07-22
   adjustor = throw "adjustor has been removed as it part of the 'handheld-daemon' package"; # Added 2025-11-16
   adminer-pematon = throw "'adminer-pematon' has been renamed to/replaced by 'adminneo'"; # Converted to throw 2025-10-27
   adminerneo = throw "'adminerneo' has been renamed to/replaced by 'adminneo'"; # Converted to throw 2025-10-27


### PR DESCRIPTION
Revert the removal of `adapta-gtk-theme` made in #544598 by removing the dependency on `gtk-engine-murrine`.

Similar to #547790 and #547751. 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
