### PR TITLE
gmp: enable structuredAttrs, use finalAttrs

### DIFF
--- a/pkgs/development/libraries/gmp/6.x.nix
+++ b/pkgs/development/libraries/gmp/6.x.nix
@@ -14,19 +14,19 @@
 # files.
 
 let
-  inherit (lib) optional;
+  inherit (lib) optionals;
 in
 
 let
-  self = stdenv.mkDerivation rec {
+  self = stdenv.mkDerivation (finalAttrs: {
     pname = "gmp${lib.optionalString cxx "-with-cxx"}";
     version = "6.3.0";
 
     src = fetchurl {
       # we need to use bz2, others aren't in bootstrapping stdenv
       urls = [
-        "mirror://gnu/gmp/gmp-${version}.tar.bz2"
-        "ftp://ftp.gmplib.org/pub/gmp-${version}/gmp-${version}.tar.bz2"
+        "mirror://gnu/gmp/gmp-${finalAttrs.version}.tar.bz2"
+        "ftp://ftp.gmplib.org/pub/gmp-${finalAttrs.version}/gmp-${finalAttrs.version}.tar.bz2"
       ];
       hash = "sha256-rCghGnz7YJuuLiyNYFjWbI/pZDT3QM9v4uR7AA0cIMs=";
     };
@@ -65,17 +65,26 @@ let
       # broken on multicore CPUs). Avoid this impurity.
       "--build=${stdenv.buildPlatform.config}"
     ]
-    ++ optional (cxx && stdenv.hostPlatform.isDarwin) "CPPFLAGS=-fexceptions"
-    ++ optional (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.is64bit) "ABI=64"
+    ++ optionals (cxx && stdenv.hostPlatform.isDarwin) [
+      "CPPFLAGS=-fexceptions"
+    ]
+    ++ optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.is64bit) [
+      "ABI=64"
+    ]
     # to build a .dll on windows, we need --disable-static + --enable-shared
     # see https://gmplib.org/manual/Notes-for-Particular-Systems.html
-    ++ optional (!withStatic && stdenv.hostPlatform.isPE) "--disable-static --enable-shared";
+    ++ optionals (!withStatic && stdenv.hostPlatform.isPE) [
+      "--disable-static"
+      "--enable-shared"
+    ];
 
     doCheck = true; # not cross;
 
     dontDisableStatic = withStatic;
 
     enableParallelBuilding = true;
+
+    __structuredAttrs = true;
 
     meta = {
       homepage = "https://gmplib.org/";
@@ -112,6 +121,6 @@ let
       platforms = lib.platforms.all;
       maintainers = with lib.maintainers; [ coolcuber ];
     };
-  };
+  });
 in
 self


### PR DESCRIPTION
The flags "--disable-static --enable-shared" must be split for structuredAttrs, the other changes to configureFlags are cosmetic (but consistent).


Tested on top of master as part of https://github.com/NixOS/nixpkgs/compare/master...SFrijters:nixpkgs:lowlevel-structuredattrs with 

`nixpkgs-review rev lowlevel-structuredattrs --package pkgsi686Linux.tests.stdenv --package gccgo --package pkgsi686Linux.gccgo --package tests.stdenv --package pkgsMusl.tests.stdenv`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
