### PR TITLE
uhk-agent: fix startup EACCES on smart-macro docs copy

### DIFF
--- a/pkgs/by-name/uh/uhk-agent/package.nix
+++ b/pkgs/by-name/uh/uhk-agent/package.nix
@@ -69,6 +69,30 @@ stdenvNoCC.mkDerivation {
     runHook postInstall
   '';
 
+  # SmartMacroCopy fs.cp's bundled docs out of the nix store (dirs mode 0555)
+  # into ~/.config/uhk-agent/smart-macro-docs, preserving source modes. Inside
+  # the minified SmartMacroCopy (Mi) the sequence is:
+  #   1. fs.cp(firmware/doc -> dest)               # creates dest as 0555
+  #   2. fs.cp(firmware/doc-dev -> dest/doc-dev)   # needs write on dest
+  #   3. (later) chmod -R +w smart-macro-docs
+  # Step 2 fails with EACCES on first launch; step 1's force-unlink fails on
+  # every subsequent launch against the leftover 0555 tree. The unhandled
+  # rejection aborts createWindow, leaving a live process with no window.
+  #
+  # Upstream fix: https://github.com/UltimateHackingKeyboard/agent/pull/3024
+  # (Vi is the existing makeFolderWriteableToUserOnLinux helper, hoisted).
+  # Drop this postFixup once a release containing that fix is packaged.
+  postFixup = ''
+    substituteInPlace $out/opt/${pname}/app.asar.unpacked/electron-main.js \
+      --replace-fail \
+        'await(0,Pi.cp)(s,i,{force:!0,recursive:!0});const a=g().join(e.tmpDirectory,"doc-dev"),c=g().join(i,"doc-dev");await(0,Pi.cp)(a,c,{force:!0,recursive:!0}),t.misc("[SmartMacroCopy] done")' \
+        'await Vi(i).catch(()=>{}),await(0,Pi.cp)(s,i,{force:!0,recursive:!0}),await Vi(i);const a=g().join(e.tmpDirectory,"doc-dev"),c=g().join(i,"doc-dev");await(0,Pi.cp)(a,c,{force:!0,recursive:!0}),t.misc("[SmartMacroCopy] done")'
+    wrapProgram $out/bin/${pname} --run '
+      docs="''${XDG_CONFIG_HOME:-$HOME/.config}/uhk-agent/smart-macro-docs"
+      [ -d "$docs" ] && chmod -R u+w "$docs" || true
+    '
+  '';
+
   meta = {
     description = "Configuration application of the Ultimate Hacking Keyboard";
     homepage = "https://github.com/UltimateHackingKeyboard/agent";


### PR DESCRIPTION
## Problem

`uhk-agent`'s `SmartMacroCopy` uses Node `fs.cp({ force, recursive })` to copy bundled smart-macro docs from `$out/opt/uhk-agent/packages/firmware/doc` (a nix store path — directories mode `0555`) into `~/.config/uhk-agent/smart-macro-docs/...`, preserving source modes.

Sequence inside the minified `SmartMacroCopy` (function `Mi`):

1. `fs.cp(doc → dest)` — creates `dest` as `dr-xr-xr-x`
2. `fs.cp(doc-dev → dest/doc-dev)` — needs write on `dest` → **EACCES mkdir**
3. Later: `chmod -R +w` on the smart-macro root

Step 3 never runs when step 2 throws. On the next launch, step 1's force-unlink hits the leftover `0555` tree → **EACCES unlink**. Either way the rejection escapes `createWindow`, so the main `BrowserWindow` is never constructed: live process, no window.

```
[SmartMacroService] can't be started on undefined
Error: EACCES: permission denied, unlink '.../smart-macro-docs/.../v17.2.0/bootstrap.min.css'
(node:PID) UnhandledPromiseRejectionWarning: ...
```

Confirmed: after `chmod -R u+w ~/.config/uhk-agent/smart-macro-docs`, startup completes and the window appears. A one-shot chmod is not durable — a future Agent release that bundles a new doc version (`v17.2.0` → `v18.x`) creates a fresh `0555` directory and the failure returns on the launch after that.

## Fix

1. **Patch** the minified `SmartMacroCopy` so the existing `Vi` helper (`chmod -R +w`, already present and hoisted) runs before the first `cp` when the dest exists, and between the two `cp`s. Matches [UltimateHackingKeyboard/agent#3024](https://github.com/UltimateHackingKeyboard/agent/pull/3024).
2. **Wrap** `$out/bin/uhk-agent` to `chmod -R u+w` the docs tree on every launch as defense in depth.

Drop the `postFixup` once a uhk-agent release containing the upstream fix is packaged.

## Upstream

- https://github.com/UltimateHackingKeyboard/agent/issues/2652
- https://github.com/UltimateHackingKeyboard/agent/issues/2679
- https://github.com/UltimateHackingKeyboard/agent/pull/2680 (closed; same between-cp idea)
- https://github.com/UltimateHackingKeyboard/agent/pull/3024 (source fix)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [`nix.conf` manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [ ] NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - [ ] [macOS](https://git.lix.systems/lix-project/nixpkgs/blob/master/pkgs/README.md#darwin-specifics) binaries through `rosetta` on `aarch64-darwin`
  - [ ] Package tests under a non-Nix based OS using `nix-shell -p ...` and then `./result/bin/...`
  - [ ] Package tests under a Nix based OS using `nix-shell -I nixpkgs=$PWD -p ...` and then `./result/bin/...`
  - [ ] NixOS non-reproducible VM test via `nixosTests.installed-tests` or similar
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` (or a comparable approach)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] [Nixpkgs Manual](https://nixos.org/manual/nixpkgs/unstable/) relevant sections were checked for best practices
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)

## Extra verification

Against 10.1.0 with Xvfb and isolated `$HOME`:

| Binary | Config state | Result |
|--------|--------------|--------|
| unpatched | fresh | `EACCES mkdir .../doc-dev` |
| unpatched | `chmod a-w` leftover | `EACCES unlink ...` |
| **patched** | fresh | `[SmartMacroCopy] done` / `SmartMacroService started` |
| **patched** | `chmod a-w` leftover | same success |
| **patched** | second `chmod a-w` relaunch | idempotent success |

Wrapper still execs electron with `app.asar.unpacked`, keeps `ELECTRON_IS_DEV=0` and `NIXOS_OZONE_WL` handling.