### PR TITLE
nxv: 0.6.0 -> 0.7.0

### DIFF
--- a/pkgs/by-name/nx/nxv/package.nix
+++ b/pkgs/by-name/nx/nxv/package.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nxv";
-  version = "0.6.0";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "utensils";
     repo = "nxv";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Ym30QiImry+3Io933SFQw5q6Lyl5p8nuidQhrXHSv54=";
+    hash = "sha256-tjVhLHn2FH4QQ5ynLEiB2nJTmpu4viho2Sf+mc7YWX8=";
   };
 
-  cargoHash = "sha256-syAlYsXPxMUIyPNankujiVD3lXaAgGmr5v585ysxIWI=";
+  cargoHash = "sha256-Gx45+hiRByQc/OcHlJ7L4G+xh/IZHWipslQ3Xv5+fHE=";
 
   # Tests use mockito which needs to bind to localhost
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
Adds the new `nxv run` subcommand (opens a shell with resolved package versions). No dependency or packaging changes — only version + hashes.

Diff: https://github.com/utensils/nxv/compare/v0.6.0...v0.7.0
Changelog: https://github.com/utensils/nxv/blob/v0.7.0/CHANGELOG.md

Supersedes #514996 (r-ryantm, targets 0.6.1 against a pre-0.6.0 base — it would reintroduce the `fetchSubmodules = true` dropped in 0.6.0). I also closed my own #546738 (0.6.1) in favour of going straight to 0.7.0.

cc @yzhou216 (co-maintainer) — and @pbsds, who merged the last nxv bump (#544893), in case you have a moment for this one.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html#conf-sandbox))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [x] Package tests, including when applicable:
    - [x] Tests exercised by the build (`checkPhase`) and `versionCheckHook`
- [x] Tested basic functionality of all binary files, usually in `./result/bin/` (`nxv --version`, `nxv run --help`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs as applicable.

This PR was made with AI assistance (Claude Code); the commit carries an `Assisted-by:` trailer and I reviewed it.