### PR TITLE
plasma-applet-appgrid: init at 1.9.3

### DIFF
--- a/pkgs/by-name/pl/plasma-applet-appgrid/package.nix
+++ b/pkgs/by-name/pl/plasma-applet-appgrid/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  fetchFromGitHub,
+  kdePackages,
+}:
+kdePackages.mkKdeDerivation rec {
+  pname = "plasma-applet-appgrid";
+  version = "1.9.3";
+
+  src = fetchFromGitHub {
+    owner = "xarbit";
+    repo = "plasma6-applet-appgrid";
+    rev = "v${version}";
+    hash = "sha256-N5o1fFcnQ074P4MoGWA3rmJOFmFjE+cU2op0EGsOxIg=";
+  };
+
+  __structuredAttrs = true;
+
+  extraBuildInputs = with kdePackages; [
+    plasma-desktop
+    qtdeclarative
+    extra-cmake-modules
+  ];
+
+  meta = with lib; {
+    description = "Grid-centered application launcher";
+    inherit (src.meta) homepage;
+    license = with licenses; [
+      gpl2
+      cc0
+      mit
+    ];
+    maintainers = with maintainers; [ somasis ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

An alternative application launcher widget for Plasma. https://github.com/xarbit/plasma6-applet-appgrid

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
