### PR TITLE
python3Packages.verilogae: 24.0.0mob-unstable-2025-07-21 -> 24.0.0mob-unstable-2026-08-01

### DIFF
--- a/pkgs/development/python-modules/verilogae/default.nix
+++ b/pkgs/development/python-modules/verilogae/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonAtLeast,
   nix-update-script,
   setuptools-rust,
   rustPlatform,
@@ -17,27 +16,32 @@
 
 buildPythonPackage.override { stdenv = llvmPackages.stdenv; } rec {
   pname = "verilogae";
-  version = "24.0.0mob-unstable-2025-07-21";
+  version = "24.0.0mob-unstable-2026-08-01";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "OpenVAF";
     repo = "OpenVAF-Reloaded";
-    rev = "d878f5519b1767b64c6ebeb4d67e29e7cd46e60b";
-    hash = "sha256-TDE2Ewokhm2KSKe+sunUbV8KD3kaTSd5dB3CLCWGJ9U=";
+    rev = "3369a83f9c626f6d298f9f881379f561ce432e27";
+    hash = "sha256-+7Ni75QPkgHm1jh7ppiP0oRtDhmzV3OpNqpPWtGhVF4=";
   };
 
-  # segfault in pythonImportsCheckPhase
-  disabled = pythonAtLeast "3.14";
+  # upstream's ./configure is an LLVM auto-detection script, not autotools
+  dontConfigure = true;
 
   postPatch = ''
     substituteInPlace openvaf/osdi/build.rs \
       --replace-fail "-fPIC" ""
+
+    # upstream no longer defaults to an LLVM version; select the one we build with
+    substituteInPlace setup.py \
+      --replace-fail "binding=Binding.NoBinding," \
+        'binding=Binding.NoBinding, features=["llvm${lib.versions.major llvmPackages.llvm.version}"],'
   '';
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-5SLrVL3h6+tptHv3GV7r8HUTrYQC9VdF68O2/Uct3xA=";
+    hash = "sha256-+jvaiBCmjd3RrlES+Sc1SskEMOtO1ykOdInMTH/Gazo=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Updates verilogae to the latest upstream revision. Upstream moved to pyo3-ffi 0.29, which supports Python 3.14. This fixes the import segfault, so the package is enabled for 3.14 again.

Upstream also removed the default LLVM version and added a `configure` script for LLVM detection. That script is not autotools, so the expression skips it and selects the LLVM feature from `llvmPackages` instead.

Resolves #547634

Note: `python314Packages.dmt-core` still fails. Its dependency `scikit-rf` 1.9.0 fails two of its own tests on Python 3.14. That failure is present on master and is separate from this change (related NGI tracking: ngi-nix/projects#47).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested, as applicable: `pythonImportsCheck` passes for python313Packages.verilogae and python314Packages.verilogae
- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review rev HEAD`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)
