### PR TITLE
meson: 1.10.2 -> 1.12.0, modernize

### DIFF
--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -91,6 +91,12 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   nativeBuildInputs = [ installShellFiles ];
 
+  optional-dependencies = {
+    ninja = [ python3.pkgs.ninja ];
+    progress = [ python3.pkgs.tqdm ];
+    typing = [ python3.pkgs.mypy ];
+  };
+
   nativeCheckInputs = [
     ninja
     pkg-config

--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -3,18 +3,43 @@
   stdenv,
   fetchFromGitHub,
   installShellFiles,
+  cargo,
+  cmake,
+  cups,
   coreutils,
+  gfortran,
+  gitMinimal,
+  glib,
+  gobject-introspection,
+  hdf5-fortran,
+  jdk,
   libblocksruntime,
   llvmPackages,
+  meson,
+  nasm,
+  netcdf,
   ninja,
   pkg-config,
   python3,
+  ncurses,
+  libxml2,
+  qt6,
   replaceVars,
+  rustc,
   writableTmpDirAsHomeHook,
   writeShellScriptBin,
   zlib,
+  # This field is intended for internal nixpkgs use (to break dependency cycles).
+  # It is a positive integer specifying the level of additional tests to run.
+  # 0 is the default.
+  # At the moment, 1 is more tests (and a larger closure),
+  # 2 is even more (including LLVM/clang/rustc in the closure).
+  _extraTests ? 0,
 }:
 
+let
+  boost' = python3.pkgs.boost.override { enableStatic = true; };
+in
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "meson";
   version = "1.11.2";
@@ -93,6 +118,10 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     typing = [ python3.pkgs.mypy ];
   };
 
+  ${if _extraTests > 0 then "dontUseCmakeConfigure" else null} = true;
+  ${if _extraTests > 1 then "dontUseQmakeConfigure" else null} = true;
+  ${if _extraTests > 1 then "dontWrapQtApps" else null} = true;
+
   nativeCheckInputs = [
     ninja
     pkg-config
@@ -101,16 +130,55 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   ++ lib.optionals python3.isPyPy [
     # Several tests hardcode python3.
     (writeShellScriptBin "python3" ''exec pypy3 "$@"'')
+  ]
+  ++ lib.optionals (_extraTests > 0) [
+    cmake
+    gfortran
+    gitMinimal
+    glib # glib-compile-resources
+    nasm
+    python3.pkgs.cython
+  ]
+  ++ lib.optionals (_extraTests > 1) [
+    cargo
+    gobject-introspection # g-ir-scanner
+    jdk
+    llvmPackages.clang
+    llvmPackages.llvm
+    qt6.qmake
+    qt6.qtbase
+    qt6.qtdeclarative
+    qt6.qttools
+    rustc
   ];
 
   checkInputs = [
     zlib
   ]
-  ++ lib.optionals (stdenv.cc.isClang && !stdenv.hostPlatform.isDarwin) [
-    # https://github.com/mesonbuild/meson/blob/bd3f1b2e0e70ef16dfa4f441686003212440a09b/test%20cases/common/184%20openmp/meson.build
-    llvmPackages.openmp
+  ++ lib.optionals (_extraTests > 0) [
+    boost'
+    boost'.dev
+    glib
+    hdf5-fortran
+    netcdf
+    python3 # required by "test cases/python3/3 cython/meson.build"
+  ]
+  ++ lib.optionals (_extraTests > 1) [
+    cups.dev
+    cups.lib
+    libxml2
+    libxml2.dev
+    llvmPackages.llvm.dev
+    llvmPackages.llvm.lib
+    ncurses
+    ncurses.dev
+  ]
+  ++ lib.optionals (_extraTests > 1 && stdenv.cc.isClang) [
     # https://github.com/mesonbuild/meson/blob/1670fca36fcb1a4fe4780e96731e954515501a35/test%20cases/frameworks/29%20blocks/meson.build
     libblocksruntime
+    # https://github.com/mesonbuild/meson/blob/bd3f1b2e0e70ef16dfa4f441686003212440a09b/test%20cases/common/184%20openmp/meson.build
+    llvmPackages.openmp
+    llvmPackages.openmp.dev
   ];
 
   checkPhase = lib.concatStringsSep "\n" (
@@ -126,24 +194,48 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
           --replace-fail "multiprocessing.cpu_count()" "int(os.environ['NIX_BUILD_CORES'])"
       ''
     ]
+    ++ lib.optionals (_extraTests > 1) [
+      # For some reason, this variable is TRUE and not ON.
+      ''
+        substituteInPlace 'test cases/common/211 dependency get_variable method/meson.build' \
+          --replace-fail \
+            "dep_cm.get_variable(cmake : 'LLVM_ENABLE_RTTI') == 'ON')" \
+            "dep_cm.get_variable(cmake : 'LLVM_ENABLE_RTTI') == 'TRUE')"
+        substituteInPlace "test cases/python3/3 cython/meson.build" \
+          --replace-fail \
+            "find_program('cython3'" \
+            "find_program('${python3.pkgs.cython.meta.mainProgram}'"
+      ''
+    ]
     # Remove problematic tests
     ++ (map (f: ''rm -vr "${f}";'') (
       [
+        # Nixpkgs cctools does not have bitcode support.
+        "test cases/osx/7 bitcode"
+        # This test tries to compile with flags `-D_FORTIFY_SOURCE=2 -U_FORTIFY_SOURCE -O0`.
+        # It fails because cc-wrapper adds `-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3`
+        # after the provided args (to ensure that fortify cannot be disabled without
+        # being allowed by the package definition)
+        "test cases/common/282 -D_FORTIFY_SOURCE=2 and -O0"
+        # requires static zlib, see #66461
+        "test cases/linuxlike/14 static dynamic linkage"
+      ]
+      ++ lib.optionals (_extraTests < 1) [
         # requires git, creating cyclic dependency
         "test cases/common/66 vcstag"
         # requires glib, creating cyclic dependency
         "test cases/linuxlike/6 subdir include order"
         "test cases/linuxlike/9 compiler checks with dependencies"
-        # requires static zlib, see #66461
-        "test cases/linuxlike/14 static dynamic linkage"
-        # Nixpkgs cctools does not have bitcode support.
-        "test cases/osx/7 bitcode"
-        # Fails because "_FORTIFY_SOURCE requires compiling with optimization (-O)"
-        "test cases/common/282 -D_FORTIFY_SOURCE=2 and -O0"
       ]
-      ++ lib.optionals stdenv.hostPlatform.isDarwin [
-        # requires llvmPackages.openmp, creating cyclic dependency
+      ++ lib.optionals (stdenv.cc.isClang) [
+        # _extraTests < 2: needs llvmPackages.openmp
+        # _extraTests >= 2: seems to require both headers from llvmPackages.openmp.dev (for C/C++) and gfortran.
         "test cases/common/184 openmp"
+      ]
+      ++ lib.optionals (stdenv.hostPlatform.isDarwin && _extraTests > 1) [
+        # These expect libraries to be .so files, not .dylib files.
+        "test cases/frameworks/12 multiple gir"
+        "test cases/frameworks/34 gir static lib"
       ]
       ++ lib.optionals stdenv.hostPlatform.isFreeBSD [
         # pch doesn't work quite right on FreeBSD, I think
@@ -185,6 +277,10 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   setupHook = ./setup-hook.sh;
   env.hostPlatform = stdenv.targetPlatform.system;
+  passthru.tests = {
+    extraTests1 = meson.override { _extraTests = 1; };
+    extraTests2 = meson.override { _extraTests = 2; };
+  };
 
   meta = {
     homepage = "https://mesonbuild.com";

--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -10,6 +10,7 @@
   pkg-config,
   python3,
   replaceVars,
+  writableTmpDirAsHomeHook,
   writeShellScriptBin,
   zlib,
 }:
@@ -92,6 +93,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   nativeCheckInputs = [
     ninja
     pkg-config
+    writableTmpDirAsHomeHook
   ]
   ++ lib.optionals python3.isPyPy [
     # Several tests hardcode python3.
@@ -150,9 +152,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
       ]
     ))
     ++ [
-      ''HOME="$TMPDIR" ${
-        if python3.isPyPy then python3.interpreter else "python"
-      } ./run_project_tests.py''
+      "${if python3.isPyPy then python3.interpreter else "python"} ./run_project_tests.py"
       "runHook postCheck"
     ]
   );

--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -14,7 +14,7 @@
   zlib,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "meson";
   version = "1.11.2";
   format = "setuptools";
@@ -22,7 +22,7 @@ python3.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "mesonbuild";
     repo = "meson";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-HGXNrw39TfNio64BH0DhSAj8zz6XLwuG0RhOfCxT2PU=";
   };
 
@@ -195,5 +195,4 @@ python3.pkgs.buildPythonApplication rec {
     maintainers = with lib.maintainers; [ qyliss ];
     inherit (python3.meta) platforms;
   };
-}
-# TODO: a more Nixpkgs-tailoired test suite
+})

--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -121,7 +121,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
         substituteInPlace \
           'test cases/native/8 external program shebang parsing/script.int.in' \
           'test cases/common/274 customtarget exe for test/generate.py' \
-            --replace /usr/bin/env ${coreutils}/bin/env
+            --replace-fail /usr/bin/env ${lib.getExe' coreutils "env"}
       ''
     ]
     # Remove problematic tests
@@ -178,7 +178,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     rm $out/nix-support/propagated-build-inputs
 
     substituteInPlace "$out/share/bash-completion/completions/meson" \
-      --replace "python3 -c " "${python3.interpreter} -c "
+      --replace-fail "python3 -c " "${python3.interpreter} -c "
   '';
 
   setupHook = ./setup-hook.sh;

--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -159,8 +159,9 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   );
 
   postInstall = ''
-    installShellCompletion --zsh data/shell-completions/zsh/_meson
-    installShellCompletion --bash data/shell-completions/bash/meson
+    installShellCompletion \
+      --bash data/shell-completions/bash/meson \
+      --zsh data/shell-completions/zsh/_meson
   '';
 
   postFixup = ''

--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -122,6 +122,8 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
           'test cases/native/8 external program shebang parsing/script.int.in' \
           'test cases/common/274 customtarget exe for test/generate.py' \
             --replace-fail /usr/bin/env ${lib.getExe' coreutils "env"}
+        substituteInPlace run_project_tests.py \
+          --replace-fail "multiprocessing.cpu_count()" "int(os.environ['NIX_BUILD_CORES'])"
       ''
     ]
     # Remove problematic tests

--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -70,22 +70,18 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     ./007-freebsd-pkgconfig-path.patch
   ];
 
-  postPatch =
-    if python3.isPyPy then
-      ''
-        substituteInPlace mesonbuild/modules/python.py \
-          --replace-fail "PythonExternalProgram('python3', mesonlib.python_command" \
-                         "PythonExternalProgram('${python3.meta.mainProgram}', mesonlib.python_command"
-        substituteInPlace mesonbuild/modules/python3.py \
-          --replace-fail "state.environment.lookup_binary_entry(mesonlib.MachineChoice.HOST, 'python3'" \
-                         "state.environment.lookup_binary_entry(mesonlib.MachineChoice.HOST, '${python3.meta.mainProgram}'"
-        substituteInPlace "test cases"/*/*/*.py "test cases"/*/*/*/*.py \
-          --replace-quiet '#!/usr/bin/env python3' '#!/usr/bin/env pypy3' \
-          --replace-quiet '#! /usr/bin/env python3' '#!/usr/bin/env pypy3'
-        chmod +x "test cases"/*/*/*.py "test cases"/*/*/*/*.py
-      ''
-    else
-      null;
+  ${if python3.isPyPy then "postPatch" else null} = ''
+    substituteInPlace mesonbuild/modules/python.py \
+      --replace-fail "PythonExternalProgram('python3', mesonlib.python_command" \
+                      "PythonExternalProgram('${python3.meta.mainProgram}', mesonlib.python_command"
+    substituteInPlace mesonbuild/modules/python3.py \
+      --replace-fail "state.environment.lookup_binary_entry(mesonlib.MachineChoice.HOST, 'python3'" \
+                      "state.environment.lookup_binary_entry(mesonlib.MachineChoice.HOST, '${python3.meta.mainProgram}'"
+    substituteInPlace "test cases"/*/*/*.py "test cases"/*/*/*/*.py \
+      --replace-quiet '#!/usr/bin/env python3' '#!/usr/bin/env pypy3' \
+      --replace-quiet '#! /usr/bin/env python3' '#!/usr/bin/env pypy3'
+    chmod +x "test cases"/*/*/*.py "test cases"/*/*/*/*.py
+  '';
 
   build-system = [ python3.pkgs.setuptools ];
 

--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -17,7 +17,7 @@
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "meson";
   version = "1.11.2";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mesonbuild";
@@ -84,6 +84,8 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
       ''
     else
       null;
+
+  build-system = [ python3.pkgs.setuptools ];
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -19,6 +19,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "meson";
   version = "1.11.2";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "mesonbuild";

--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -16,14 +16,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "meson";
-  version = "1.10.2";
+  version = "1.11.2";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "mesonbuild";
     repo = "meson";
     tag = version;
-    hash = "sha256-3Zeavn6aW6920gM7yE73Ms1RPCP2GjX9IUL9YGmISfY=";
+    hash = "sha256-HGXNrw39TfNio64BH0DhSAj8zz6XLwuG0RhOfCxT2PU=";
   };
 
   patches = [
@@ -129,6 +129,8 @@ python3.pkgs.buildPythonApplication rec {
         "test cases/linuxlike/14 static dynamic linkage"
         # Nixpkgs cctools does not have bitcode support.
         "test cases/osx/7 bitcode"
+        # Fails because "_FORTIFY_SOURCE requires compiling with optimization (-O)"
+        "test cases/common/282 -D_FORTIFY_SOURCE=2 and -O0"
       ]
       ++ lib.optionals stdenv.hostPlatform.isDarwin [
         # requires llvmPackages.openmp, creating cyclic dependency

--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -162,8 +162,9 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   );
 
   postInstall = ''
-    installShellCompletion --zsh data/shell-completions/zsh/_meson
-    installShellCompletion --bash data/shell-completions/bash/meson
+    installShellCompletion \
+      --bash data/shell-completions/bash/meson \
+      --zsh data/shell-completions/zsh/_meson
   '';
 
   postFixup = ''

--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -14,7 +14,7 @@
   zlib,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "meson";
   version = "1.12.0";
   format = "setuptools";
@@ -22,7 +22,7 @@ python3.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "mesonbuild";
     repo = "meson";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-lnuySM7aCojPU9bQI7LPKgod8otFa+Spo9yIDFbOJVs=";
   };
 
@@ -198,5 +198,5 @@ python3.pkgs.buildPythonApplication rec {
     maintainers = with lib.maintainers; [ qyliss ];
     inherit (python3.meta) platforms;
   };
-}
+})
 # TODO: a more Nixpkgs-tailoired test suite

--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -10,6 +10,7 @@
   pkg-config,
   python3,
   replaceVars,
+  writableTmpDirAsHomeHook,
   writeShellScriptBin,
   zlib,
 }:
@@ -92,6 +93,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   nativeCheckInputs = [
     ninja
     pkg-config
+    writableTmpDirAsHomeHook
   ]
   ++ lib.optionals python3.isPyPy [
     # Several tests hardcode python3.
@@ -153,9 +155,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
       ]
     ))
     ++ [
-      ''HOME="$TMPDIR" ${
-        if python3.isPyPy then python3.interpreter else "python"
-      } ./run_project_tests.py''
+      "${if python3.isPyPy then python3.interpreter else "python"} ./run_project_tests.py"
       "runHook postCheck"
     ]
   );

--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -121,7 +121,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
         substituteInPlace \
           'test cases/native/8 external program shebang parsing/script.int.in' \
           'test cases/common/274 customtarget exe for test/generate.py' \
-            --replace /usr/bin/env ${coreutils}/bin/env
+            --replace-fail /usr/bin/env ${lib.getExe' coreutils "env"}
       ''
     ]
     # Remove problematic tests
@@ -181,7 +181,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     rm $out/nix-support/propagated-build-inputs
 
     substituteInPlace "$out/share/bash-completion/completions/meson" \
-      --replace "python3 -c " "${python3.interpreter} -c "
+      --replace-fail "python3 -c " "${python3.interpreter} -c "
   '';
 
   setupHook = ./setup-hook.sh;

--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -19,6 +19,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "meson";
   version = "1.12.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "mesonbuild";

--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -16,14 +16,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "meson";
-  version = "1.10.2";
+  version = "1.12.0";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "mesonbuild";
     repo = "meson";
     tag = version;
-    hash = "sha256-3Zeavn6aW6920gM7yE73Ms1RPCP2GjX9IUL9YGmISfY=";
+    hash = "sha256-lnuySM7aCojPU9bQI7LPKgod8otFa+Spo9yIDFbOJVs=";
   };
 
   patches = [
@@ -129,6 +129,11 @@ python3.pkgs.buildPythonApplication rec {
         "test cases/linuxlike/14 static dynamic linkage"
         # Nixpkgs cctools does not have bitcode support.
         "test cases/osx/7 bitcode"
+        # This test tries to compile with flags `-D_FORTIFY_SOURCE=2 -U_FORTIFY_SOURCE -O0`.
+        # It fails because cc-wrapper adds `-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3`
+        # after the provided args (to ensure that fortify cannot be disabled without
+        # being allowed by the package definition)
+        "test cases/common/282 -D_FORTIFY_SOURCE=2 and -O0"
       ]
       ++ lib.optionals stdenv.hostPlatform.isDarwin [
         # requires llvmPackages.openmp, creating cyclic dependency

--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -17,7 +17,7 @@
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "meson";
   version = "1.12.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mesonbuild";
@@ -84,6 +84,8 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
       ''
     else
       null;
+
+  build-system = [ python3.pkgs.setuptools ];
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
Built `meson` and `python3Packages.meson-python` at 9bdf09b40d0fbc77ee4f56a21e68eef898307319 on `x86_64-linux`, `aarch64-linux`, and `aarch64-darwin`.

Closes: #505000

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
