### PR TITLE
work-louder-input: init at 0.18.0

### DIFF
--- a/pkgs/by-name/wo/work-louder-input/package.nix
+++ b/pkgs/by-name/wo/work-louder-input/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  _7zz,
+  re-plistbuddy,
+  versionCheckHook,
+  writeShellScript,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "work-louder-input";
+  version = "0.18.0";
+
+  src = fetchurl {
+    url = "https://github.com/worklouder/input-releases/releases/download/v${finalAttrs.version}/input-${finalAttrs.version}-arm64.dmg";
+    hash = "sha512-wWqOccCNrV84/kedxHBZrvZ9nndWVHuzNaEAGEyOO/iCVMOkh1gixtAPexlZb/KVGjOsMwBX74lTH2vOaevJHQ==";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [ _7zz ];
+
+  sourceRoot = ".";
+
+  unpackCmd = "7zz x -snld -xr'!*:com.apple.*' $curSrc";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications"
+    cp -R input.app "$out/Applications"
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = writeShellScript "version-check" ''
+    ${lib.getExe' re-plistbuddy "PlistBuddy"} -c "Print :CFBundleShortVersionString" "$1"
+  '';
+  versionCheckProgramArg = [
+    "${placeholder "out"}/Applications/input.app/Contents/Info.plist"
+  ];
+  doInstallCheck = true;
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Keyboard configurator for Work Louder devices";
+    homepage = "https://worklouder.cc/input";
+    changelog = "https://github.com/worklouder/input-releases/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ pradyuman ];
+    platforms = [ "aarch64-darwin" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/wo/work-louder-input/update.sh
+++ b/pkgs/by-name/wo/work-louder-input/update.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env nix
+#!nix shell -f ``<nixpkgs>`` common-updater-scripts curl jq yq-go -c bash
+
+set -euo pipefail
+
+manifest="$(
+  curl -fsSL https://github.com/worklouder/input-releases/releases/latest/download/latest-mac.yml \
+    | yq -o=json
+)"
+version="$(jq -r '.version' <<<"$manifest")"
+hash="$(
+  jq -r \
+    --arg filename "input-${version}-arm64.dmg" \
+    '.files[] | select(.url == $filename) | "sha512-\(.sha512)"' \
+    <<<"$manifest"
+)"
+
+update-source-version work-louder-input "$version" "$hash"


### PR DESCRIPTION
Adding [Input](https://worklouder.cc/input), a keyboard configurator for Work Louder devices. There is a community-driven Linux version, but it isn't officially supported so I'm not including it in this package.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
