### PR TITLE
python3Packages.pysbd: modernize, enable tests

### DIFF
--- a/pkgs/development/python-modules/pysbd/default.nix
+++ b/pkgs/development/python-modules/pysbd/default.nix
@@ -2,29 +2,36 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
   tqdm,
   spacy,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pysbd";
   version = "0.3.4";
-  format = "setuptools";
+  pyproject = true;
+
+  __structuredAttrs = true;
 
   # provides no sdist on pypi
   src = fetchFromGitHub {
     owner = "nipunsadvilkar";
     repo = "pySBD";
-    rev = "v${version}";
-    sha256 = "12p7qm237z56hw4zr03n8rycgfymhki2m9c4w3ib0mvqq122a5dp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-txUlRMB4V7Di4ISlKuKE1bvHfEZ2gPwJh6b8M0TF54o=";
   };
 
-  nativeCheckInputs = [
-    tqdm
-    spacy
+  build-system = [
+    setuptools
   ];
 
-  doCheck = false; # requires pyconll and blingfire
+  nativeCheckInputs = [
+    pytestCheckHook
+    spacy
+    tqdm
+  ];
 
   pythonImportsCheck = [ "pysbd" ];
 
@@ -34,4 +41,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     teams = [ lib.teams.tts ];
   };
-}
+})

--- a/pkgs/development/python-modules/pysbd/default.nix
+++ b/pkgs/development/python-modules/pysbd/default.nix
@@ -38,6 +38,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Pysbd (Python Sentence Boundary Disambiguation) is a rule-based sentence boundary detection that works out-of-the-box across many languages";
     homepage = "https://github.com/nipunsadvilkar/pySBD";
+    changelog = "https://github.com/nipunsadvilkar/pySBD/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     teams = [ lib.teams.tts ];
   };


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
