### PR TITLE
jitsi-meet: 1.0.8792 -> 1.0.9367

### DIFF
--- a/pkgs/by-name/ji/jitsi-meet/package.nix
+++ b/pkgs/by-name/ji/jitsi-meet/package.nix
@@ -15,21 +15,23 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "jitsi-meet";
-  version = "1.0.8792";
+  version = "1.0.9367";
 
   src = fetchFromGitHub {
     owner = "jitsi";
     repo = "jitsi-meet";
     tag = lib.last (lib.splitVersion finalAttrs.version);
-    hash = "sha256-K4Xrse1kpNqlUChbQnAjP5lRCRuDfJKiN/022tCmMVQ=";
+    hash = "sha256-ohajOdZ4VKpX9PW9VUriqBgmUv0LnpinhAhZXi3TjFk=";
   };
 
   env = {
     makeFlags = "source-package";
     makeCacheWritable = true;
+    forceGitDeps = true;
     npmDeps = fetchNpmDeps {
       inherit (finalAttrs) src;
-      hash = "sha256-2NPfr3gskHz9zSGs//uzyCCuE+CZ295hhitDPlS9xuY=";
+      hash = "sha256-5fGaX8VFCCMkTeQuhFPwd9W7cBNVML/bVYLODq07s5w=";
+      forceGitDeps = true;
     };
   };
 


### PR DESCRIPTION
Changes: https://github.com/jitsi/jitsi-meet/compare/8792...9367

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].