### PR TITLE
jitsi-meet-electron: 2026.5.0 -> 2026.7.0

### DIFF
--- a/pkgs/by-name/ji/jitsi-meet-electron/package.nix
+++ b/pkgs/by-name/ji/jitsi-meet-electron/package.nix
@@ -17,6 +17,7 @@
   zlib,
 
   electron_41,
+  nix-update-script,
 }:
 
 let
@@ -24,13 +25,13 @@ let
 in
 buildNpmPackage rec {
   pname = "jitsi-meet-electron";
-  version = "2026.5.0";
+  version = "2026.7.0";
 
   src = fetchFromGitHub {
     owner = "jitsi";
     repo = "jitsi-meet-electron";
     rev = "v${version}";
-    hash = "sha256-yeYDft2d2RHNXYrmnHlBzsZ43bvBgwwsqxQr/Q+/AuQ=";
+    hash = "sha256-l0vnnIJpG5Ttt9lgWx9tsS8Vne53sGW/50CsnwPFhUQ=";
   };
 
   nativeBuildInputs = [
@@ -52,7 +53,7 @@ buildNpmPackage rec {
     zlib
   ];
 
-  npmDepsHash = "sha256-5y7q6SnA9s85+HFOhqif1N8XRO7ekGJ4nfVbWZ/diuI=";
+  npmDepsHash = "sha256-m2+knAWSSraNGNGjMFoMC9+MlOhs+XyXs90GcMx9ulw=";
 
   makeCacheWritable = true;
 
@@ -131,6 +132,8 @@ buildNpmPackage rec {
       terminal = false;
     })
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     changelog = "https://github.com/jitsi/jitsi-meet-electron/releases/tag/${src.rev}";


### PR DESCRIPTION
Changes: https://github.com/jitsi/jitsi-meet-electron/compare/v2026.5.0...v2026.7.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].