### PR TITLE
jitsi-videobridge: 2.3-249-g9a2123ad4 -> 2.3-295-g8d5c0037b

### DIFF
--- a/pkgs/by-name/ji/jitsi-videobridge/package.nix
+++ b/pkgs/by-name/ji/jitsi-videobridge/package.nix
@@ -11,10 +11,10 @@
 
 let
   pname = "jitsi-videobridge2";
-  version = "2.3-249-g9a2123ad4";
+  version = "2.3-295-g8d5c0037b";
   src = fetchurl {
     url = "https://download.jitsi.org/stable/jitsi-videobridge2_${version}-1_all.deb";
-    sha256 = "b8hYuDyweRLAagaehHMzC2/XjZHNlxMchM8za8zPtj4=";
+    sha256 = "+9h3hlPUlMO8+nTz6sA8MnDXo64cSI+mjK2aGwbWt9I=";
   };
 in
 stdenv.mkDerivation {


### PR DESCRIPTION
Changes: https://github.com/jitsi/jitsi-videobridge/compare/9a2123ad4...8d5c0037b

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].