### PR TITLE
jitsi-excalidraw: 21 -> 2026.3.0

### DIFF
--- a/pkgs/by-name/ji/jitsi-excalidraw/package.nix
+++ b/pkgs/by-name/ji/jitsi-excalidraw/package.nix
@@ -9,16 +9,16 @@
 
 buildNpmPackage rec {
   pname = "jitsi-excalidraw-backend";
-  version = "21";
+  version = "2026.3.0";
 
   src = fetchFromGitHub {
     owner = "jitsi";
     repo = "excalidraw-backend";
-    rev = "x${version}";
-    hash = "sha256-52LU5I2pNjSb9+nJjiczp/dLWRTwQDC+thyGXBvkBBA=";
+    rev = version;
+    hash = "sha256-ji5qSnT/FNHEDm6v8Fw9SW3N9RzEr2AbeQq+PNehZGo=";
   };
 
-  npmDepsHash = "sha256-BJqjaqTeg5i+ECGMuiBYVToK2i2XCOVP9yeDFz6nP4k=";
+  npmDepsHash = "sha256-lOytyKRu7kh3UcUkbEEErntqb7aUzULK1SfQrCvvIBw=";
 
   nativeBuildInputs = [ python3 ];
 


### PR DESCRIPTION
Changes: https://github.com/jitsi/excalidraw-backend/compare/x22...2026.3.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].