### PR TITLE
jigasi: 1.1-395-g3bb4143 -> 1.1-412-ge9a3acc

### DIFF
--- a/pkgs/by-name/ji/jigasi/package.nix
+++ b/pkgs/by-name/ji/jigasi/package.nix
@@ -9,10 +9,10 @@
 
 let
   pname = "jigasi";
-  version = "1.1-395-g3bb4143";
+  version = "1.1-412-ge9a3acc";
   src = fetchurl {
     url = "https://download.jitsi.org/stable/jigasi_${version}-1_all.deb";
-    hash = "sha256-kBUo9TZZs3/OUrV1t813jk8Pf2vNrKEP7hZL2L2oMNE=";
+    hash = "sha256-NlJxfUyUGUqyk8rQAtykZhyAhMapmTvca42HaG1MRJU=";
   };
 in
 stdenv.mkDerivation {
@@ -37,6 +37,8 @@ stdenv.mkDerivation {
   passthru.tests = {
     single-node-smoke-test = nixosTests.jitsi-meet;
   };
+
+  passthru.updateScript = ./update.sh;
 
   meta = {
     description = "Server-side application that allows regular SIP clients to join Jitsi Meet conferences";

--- a/pkgs/by-name/ji/jigasi/update.sh
+++ b/pkgs/by-name/ji/jigasi/update.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl pup common-updater-scripts
+
+set -eu -o pipefail
+
+version="$(curl https://download.jitsi.org/stable/ | \
+    pup 'a[href] text{}' | \
+    awk -F'[_-]' '/jigasi_/ {printf $2"-"$3"-"$4"\n"}' | \
+    sort -Vu | \
+    tail -n 1)"
+
+update-source-version jigasi "$version"


### PR DESCRIPTION
Changes: https://github.com/jitsi/jigasi/compare/3bb4143...e9a3acc

switched jdk11 -> jre_headless, since the updated jar requires Java 17+

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
