### PR TITLE
jibri: 8.0-183-g7b406bf -> 8.0-205-g206e038

### DIFF
--- a/pkgs/by-name/ji/jibri/package.nix
+++ b/pkgs/by-name/ji/jibri/package.nix
@@ -24,10 +24,10 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "jibri";
-  version = "8.0-183-g7b406bf";
+  version = "8.0-205-g206e038";
   src = fetchurl {
     url = "https://download.jitsi.org/stable/jibri_${finalAttrs.version}-1_all.deb";
-    sha256 = "QF7BkLizAsEzjC6PdTyPFAFf82AzukTnxHxLHyz5Kco=";
+    sha256 = "DJyBNjCgesg0P1SSU8mi3vVN9TK5sU/eLS1PLzEsIRE=";
   };
 
   dontBuild = true;


### PR DESCRIPTION
Changes: https://github.com/jitsi/jibri/compare/7b406bf...206e038

switched jdk11 -> jre_headless, since the updated jar requires Java 17+

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].