### PR TITLE
jicofo: 1.0-1153 -> 1.0-1183

### DIFF
--- a/pkgs/by-name/ji/jicofo/package.nix
+++ b/pkgs/by-name/ji/jicofo/package.nix
@@ -9,10 +9,10 @@
 
 let
   pname = "jicofo";
-  version = "1.0-1153";
+  version = "1.0-1183";
   src = fetchurl {
     url = "https://download.jitsi.org/stable/jicofo_${version}-1_all.deb";
-    sha256 = "tBvaXyRqNg8VeIy3aI1HbrZNlelsYowLOVlsXyap+gA=";
+    sha256 = "72MSkZYShvKwGtOWr21cd6W17WjootOcC6aA+QPIdOk=";
   };
 in
 stdenv.mkDerivation {


### PR DESCRIPTION
Update jicofo from 1.0-1153 to 1.0-1183.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].