### PR TITLE
cargo-cooldown: init at 0.3.4

### DIFF
--- a/pkgs/by-name/ca/cargo-cooldown/package.nix
+++ b/pkgs/by-name/ca/cargo-cooldown/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  rustPlatform,
+  fetchCrate,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cargo-cooldown";
+  version = "0.3.4";
+  __structuredAttrs = true;
+
+  src = fetchCrate {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-OpNrly+mSX/cYstewi/IbYOM/H5kQxu4U41Bqtnlu1c=";
+  };
+
+  cargoHash = "sha256-MQUr/twr2vbLgGhPavrVtnBbT4N5O0c2XFwL9+FGdqE=";
+
+  # Integration tests and some unit tests require network access (crates.io registry) which breaks
+  # in the Nix sandbox.
+  cargoTestFlags = [ "--bin=cargo-cooldown" ]; # Focus on binary tests, skip integration tests
+  checkFlags = [ "--skip=lockfile::tests" ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Cargo wrapper that enforces a cooldown window for freshly published registry crates for improved supply chain security";
+    mainProgram = "cargo-cooldown";
+    homepage = "https://github.com/dertin/cargo-cooldown";
+    changelog = "https://github.com/dertin/cargo-cooldown/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license =
+      with lib.licenses;
+      OR [
+        asl20
+        mit
+      ];
+    maintainers = with lib.maintainers; [ bew ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Initialize package for https://github.com/dertin/cargo-cooldown
I use this tool for development on Wezterm and wanted to have it for other projects as well.

AI-disclosure: Claude Sonnet 4.6 helped draft the package, then I iterated to fix the checkPhase errors and manually checked the file.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
