### PR TITLE
gmsh: 4.15.0 -> 4.15.2, adopt

### DIFF
--- a/pkgs/by-name/gm/gmsh/package.nix
+++ b/pkgs/by-name/gm/gmsh/package.nix
@@ -33,11 +33,11 @@ assert (!blas.isILP64) && (!lapack.isILP64);
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gmsh";
-  version = "4.15.0";
+  version = "4.15.2";
 
   src = fetchurl {
     url = "https://gmsh.info/src/gmsh-${finalAttrs.version}-source.tgz";
-    hash = "sha256-q7JjJxW9fQEw3tcUT9YmNjXNfeqIO432G6TaWM5qHf4=";
+    hash = "sha256-vj9m8iXSe6n6AU8H6DFpKF2ooFGw6KtxA9iAZrOb3T4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gm/gmsh/package.nix
+++ b/pkgs/by-name/gm/gmsh/package.nix
@@ -121,6 +121,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://gmsh.info/";
     changelog = "https://gitlab.onelab.info/gmsh/gmsh/-/releases/gmsh_${lib.concatStringsSep "_" (lib.versions.splitVersion finalAttrs.version)}#changelog";
     license = lib.licenses.gpl2Plus;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.magicquark ];
   };
 })


### PR DESCRIPTION
### Update from 4.15.0 to 4.15.2
Releases:
- https://gitlab.onelab.info/gmsh/gmsh/-/releases/gmsh_4_15_1
- https://gitlab.onelab.info/gmsh/gmsh/-/releases/gmsh_4_15_2

I have also adopted this orphaned package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
