### PR TITLE
libgphoto2: fix darwin build

### DIFF
--- a/pkgs/by-name/li/libgphoto2/package.nix
+++ b/pkgs/by-name/li/libgphoto2/package.nix
@@ -43,6 +43,9 @@ stdenv.mkDerivation rec {
     curl
     libxml2
     gd
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    gettext
   ];
 
   doInstallCheck = true;


### PR DESCRIPTION
Hi,

Originally caught this while building darktable on aarch64-darwin (which has a dependency on libgphoto2)
libgphoto2 fails to build on Darwin with linker errors due to missing _libintl_dgettext symbols. Logs below: 

```
error: Cannot build '/nix/store/w65rxjfygfgqrp3svnnkbhg61k4hyjjy-libgphoto2-2.5.34.drv'.
       Reason: builder failed with exit code 2.
       Output paths:
         /nix/store/8bxlsx24xb0ycc77h3i6hdc5zbwx12hk-libgphoto2-2.5.34
       Last 25 log lines:
       >   CC       ax203/la-library.lo
       >   CC       ax203/la-ax203.lo
       >   CC       ax203/la-ax203_decode_yuv.lo
       >   CC       ax203/la-ax203_decode_yuv_delta.lo
       >   CC       ax203/la-ax203_compress_jpeg.lo
       >   CC       ax203/la-jpeg_memsrcdest.lo
       >   CC       ax203/la-tinyjpeg.lo
       >   CC       ax203/la-jidctflt.lo
       >   CCLD     ax203.la
       > Undefined symbols for architecture arm64:
       >   "_libintl_dgettext", referenced from:
       >       _camera_summary in la-library.o
       >       _camera_manual in la-library.o
       >       _camera_about in la-library.o
       >       _camera_get_config in la-library.o
       >       _camera_set_config in la-library.o
       > ld: symbol(s) not found for architecture arm64
       > clang: error: linker command failed with exit code 1 (use -v to see invocation)
       > make[3]: *** [Makefile:2214: ax203.la] Error 1
       > make[3]: Leaving directory '/nix/var/nix/builds/nix-38571-1052516044/source/camlibs'
       > make[2]: *** [Makefile:4944: all-recursive] Error 1
       > make[2]: Leaving directory '/nix/var/nix/builds/nix-38571-1052516044/source/camlibs'
       > make[1]: *** [Makefile:778: all-recursive] Error 1
       > make[1]: Leaving directory '/nix/var/nix/builds/nix-38571-1052516044/source'
       > make: *** [Makefile:602: all] Error 2
       For full logs, run:
         nix-store -l /nix/store/w65rxjfygfgqrp3svnnkbhg61k4hyjjy-libgphoto2-2.5.34.drv
```

Fixed by adding `gettext` to `buildInputs` when building for Darwin hosts. It should not affect any other platforms.
Tested manually by building both `libgphoto2` and the downstream package `darktable`. They build and function as expected.

Hope this helps,
Thanks!
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
