### PR TITLE
[backport release-26.05] llvmPackages_git: 23.0.0-unstable-2026-07-12 -> 24.0.0-unstable-2026-07-26

### DIFF
--- a/pkgs/development/compilers/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/default.nix
@@ -36,9 +36,9 @@ let
       name = "23";
     };
     "24.0.0-git".gitRelease = {
-      rev = "a64f7412551ae63a49dd8617f93ab89878288879";
-      rev-version = "24.0.0-unstable-2026-07-19";
-      sha256 = "sha256-51tlsUW4cObqyCGsrvzFoisNtN9S8Qk7iCDbg6/awVI=";
+      rev = "43a704b657423a0eead02e64911b413c4afca73f";
+      rev-version = "24.0.0-unstable-2026-07-26";
+      sha256 = "sha256-wXhYrz3g5F7iwVqgIVryfRtkQ+3lKIKRDd9D8X18dEE=";
     };
   }
   // llvmVersions;

--- a/pkgs/development/compilers/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/default.nix
@@ -35,6 +35,11 @@ let
       };
       name = "23";
     };
+    "24.0.0-git".gitRelease = {
+      rev = "a64f7412551ae63a49dd8617f93ab89878288879";
+      rev-version = "24.0.0-unstable-2026-07-19";
+      sha256 = "sha256-51tlsUW4cObqyCGsrvzFoisNtN9S8Qk7iCDbg6/awVI=";
+    };
   }
   // llvmVersions;
 

--- a/pkgs/development/compilers/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/default.nix
@@ -27,10 +27,13 @@ let
     "20.1.8".officialRelease.sha256 = "sha256-ysyB/EYxi2qE9fD5x/F2zI4vjn8UDoo1Z9ukiIrjFGw=";
     "21.1.8".officialRelease.sha256 = "sha256-pgd8g9Yfvp7abjCCKSmIn1smAROjqtfZaJkaUkBSKW0=";
     "22.1.5".officialRelease.sha256 = "sha256-eunfMOH+HVpefZJ+CG7hXDoM+pi6iYvHpD3DoSAsjoE=";
-    "23.1.0-rc1".gitRelease = {
-      rev = "acdf320b78fcf075ddcf660b51cf18d5c0af755b";
-      rev-version = "23.1.0-rc1";
-      sha256 = "sha256-kSfy7IRgF/2HX5Fr3OS5LTXx7xm/iUx7tWb27e4wO+s=";
+    "23.1.0-rc1" = {
+      gitRelease = {
+        rev = "acdf320b78fcf075ddcf660b51cf18d5c0af755b";
+        rev-version = "23.1.0-rc1";
+        sha256 = "sha256-kSfy7IRgF/2HX5Fr3OS5LTXx7xm/iUx7tWb27e4wO+s=";
+      };
+      name = "23";
     };
   }
   // llvmVersions;

--- a/pkgs/development/compilers/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/default.nix
@@ -27,10 +27,10 @@ let
     "20.1.8".officialRelease.sha256 = "sha256-ysyB/EYxi2qE9fD5x/F2zI4vjn8UDoo1Z9ukiIrjFGw=";
     "21.1.8".officialRelease.sha256 = "sha256-pgd8g9Yfvp7abjCCKSmIn1smAROjqtfZaJkaUkBSKW0=";
     "22.1.5".officialRelease.sha256 = "sha256-eunfMOH+HVpefZJ+CG7hXDoM+pi6iYvHpD3DoSAsjoE=";
-    "23.0.0-git".gitRelease = {
-      rev = "7d24dfa5f29e1794e452aadaa27f994f15568763";
-      rev-version = "23.0.0-unstable-2026-07-12";
-      sha256 = "sha256-mHiwOqEvqXyG6OoiVLRrhzb2MK7FqjQm9ez329ngbYw=";
+    "23.1.0-rc1".gitRelease = {
+      rev = "acdf320b78fcf075ddcf660b51cf18d5c0af755b";
+      rev-version = "23.1.0-rc1";
+      sha256 = "sha256-kSfy7IRgF/2HX5Fr3OS5LTXx7xm/iUx7tWb27e4wO+s=";
     };
   }
   // llvmVersions;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4179,6 +4179,8 @@ with pkgs;
       bolt_22 = llvmPackages_22.bolt;
       flang_22 = llvmPackages_22.flang;
 
+      llvmPackages_23 = llvmPackagesSet."23";
+
       mkLLVMPackages = llvmPackagesSet.mkPackage;
     })
     llvmPackages_18
@@ -4213,6 +4215,7 @@ with pkgs;
     llvm_22
     bolt_22
     flang_22
+    llvmPackages_23
     mkLLVMPackages
     ;
 


### PR DESCRIPTION
(cherry picked from commit 90c2cde)<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
