### PR TITLE
calculix-ccx: 2.22 -> 2.23, adopt, update meta.hompage

### DIFF
--- a/pkgs/by-name/ca/calculix-ccx/calculix-ccx.patch
+++ b/pkgs/by-name/ca/calculix-ccx/calculix-ccx.patch
@@ -1,5 +1,5 @@
---- old/ccx_2.22/src/Makefile	2024-08-06 01:13:21.031704000 +0800
-+++ new/ccx_2.22/src/Makefile	2024-12-19 00:27:06.848862592 +0800
+--- old/ccx_2.23/src/Makefile	2024-08-06 01:13:21.031704000 +0800
++++ new/ccx_2.23/src/Makefile	2024-12-19 00:27:06.848862592 +0800
 @@ -18,15 +18,10 @@
  OCCXC = $(SCCXC:.c=.o)
  OCCXMAIN = $(SCCXMAIN:.c=.o)
@@ -12,10 +12,10 @@
 -	../../../ARPACK/libarpack_INTEL.a \
 -       -lpthread -lm -lc
 -
--ccx_2.22: $(OCCXMAIN) ccx_2.22.a  $(LIBS)
--	./date.pl; $(CC) $(CFLAGS) -c ccx_2.22.c; $(FC)  -Wall -O2 -o $@ $(OCCXMAIN) ccx_2.22.a $(LIBS) -fopenmp
-+ccx_2.22: $(OCCXMAIN) ccx_2.22.a
-+	$(CC) $(CFLAGS) -c ccx_2.22.c; $(FC)  -Wall -O2 -o $@ $(OCCXMAIN) ccx_2.22.a $(LIBS) -fopenmp
+-ccx_2.23: $(OCCXMAIN) ccx_2.23.a  $(LIBS)
+-	./date.pl; $(CC) $(CFLAGS) -c ccx_2.23.c; $(FC)  -Wall -O2 -o $@ $(OCCXMAIN) ccx_2.23.a $(LIBS) -fopenmp
++ccx_2.23: $(OCCXMAIN) ccx_2.23.a
++	$(CC) $(CFLAGS) -c ccx_2.23.c; $(FC)  -Wall -O2 -o $@ $(OCCXMAIN) ccx_2.23.a $(LIBS) -fopenmp
  
  ccx_2.22.a: $(OCCXF) $(OCCXC)
  	ar vr $@ $?

--- a/pkgs/by-name/ca/calculix-ccx/package.nix
+++ b/pkgs/by-name/ca/calculix-ccx/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "http://www.calculix.de";
+    homepage = "https://www.calculix.de";
     description = "Three-dimensional structural finite element program";
     mainProgram = "ccx";
     license = lib.licenses.gpl2Plus;

--- a/pkgs/by-name/ca/calculix-ccx/package.nix
+++ b/pkgs/by-name/ca/calculix-ccx/package.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Three-dimensional structural finite element program";
     mainProgram = "ccx";
     license = lib.licenses.gpl2Plus;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.magicquark ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/ca/calculix-ccx/package.nix
+++ b/pkgs/by-name/ca/calculix-ccx/package.nix
@@ -13,11 +13,11 @@ assert (blas.isILP64 == lapack.isILP64 && blas.isILP64 == arpack.isILP64 && !bla
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "calculix-ccx";
-  version = "2.22";
+  version = "2.23";
 
   src = fetchurl {
     url = "https://www.dhondt.de/ccx_${finalAttrs.version}.src.tar.bz2";
-    hash = "sha256-OpTcx3WjH1cCKXNLNB1rBjAevcdZhj35Aci5vxhUwLw=";
+    hash = "sha256-nIg4XBD7BPXcbE6YAnpRvr3YruOSDgUZDWwd0INX1uc=";
   };
 
   nativeBuildInputs = [ gfortran ];
@@ -32,6 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   env.NIX_CFLAGS_COMPILE = toString [
     "-I${spooles}/include/spooles"
     "-std=legacy"
+    "-Wno-return-mismatch"
   ];
 
   patches = [


### PR DESCRIPTION
### Update from version 2.22 to 2.23

Changes: https://www.dhondt.de/new_calc.htm

Tested against an upstream reference test solution `truss2`.

I have adopted this unmaintained package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
