### PR TITLE
kdenlive-bin: init at 26.04.3

### DIFF
--- a/pkgs/by-name/kd/kdenlive-bin/package.nix
+++ b/pkgs/by-name/kd/kdenlive-bin/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  makeBinaryWrapper,
+  undmg,
+  kdePackages,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "kdenlive-bin";
+  version = "26.04.3";
+
+  src = fetchurl {
+    url = "mirror://kde/stable/kdenlive/${lib.versions.majorMinor finalAttrs.version}/macOS/kdenlive-${finalAttrs.version}-arm64.dmg";
+    hash = "sha256-6oLNi4F4lFXJh9n7DUerR/6UlaYyuy1JXDGyfhmZKAI=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    undmg
+  ];
+
+  # Make sure to not break dmg code signature
+  dontFixup = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    cp -R kdenlive.app $out/Applications/
+
+    makeWrapper $out/Applications/kdenlive.app/Contents/MacOS/kdenlive $out/bin/kdenlive
+    makeWrapper $out/Applications/kdenlive.app/Contents/MacOS/kdenlive_render $out/bin/kdenlive_render
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = ./update.py;
+
+  meta = {
+    inherit (kdePackages.kdenlive.meta) description license;
+    homepage = "https://kdenlive.org";
+    downloadPage = "https://kdenlive.org/en/download/";
+    changelog = "https://kdenlive.org/en/releases/";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ BatteredBunny ];
+    mainProgram = "kdenlive";
+    platforms = lib.platforms.darwin;
+  };
+})

--- a/pkgs/by-name/kd/kdenlive-bin/update.py
+++ b/pkgs/by-name/kd/kdenlive-bin/update.py
@@ -1,0 +1,40 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i python3 -p python3 common-updater-scripts
+
+import re
+import subprocess
+import urllib.request
+
+# Git tags include betas in the same version scheme which seems error prone to filter out
+# Easier to get the info from here
+BASE = "https://download.kde.org/stable/kdenlive"
+
+# e.g "26.04/"
+SERIES = re.compile(r'href="(\d+\.\d+)/"')
+
+# Ignore variant artifacts, e.g "kdenlive-26.04.0-A-arm64.dmg"
+IMAGE = re.compile(r"kdenlive-(\d+(?:\.\d+)*)-arm64\.dmg")
+
+
+def fetch(url):
+    with urllib.request.urlopen(url) as response:
+        return response.read().decode()
+
+
+def newest(pattern, url, what):
+    found = set(pattern.findall(fetch(url)))
+    if not found:
+        raise SystemExit(f"found no {what} at {url}")
+    return max(found, key=lambda v: tuple(int(n) for n in v.split(".")))
+
+
+def main():
+    series = newest(SERIES, f"{BASE}/", "release series")
+    macos = f"{BASE}/{series}/macOS/"
+    version = newest(IMAGE, macos, "macOS disk image")
+    subprocess.run(["update-source-version", "kdenlive-bin", version],
+                   check=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Created this package as the normal `kdePackages.kdenlive` is missing darwin support. It seemed too messy to add it support for darwin. I looked briefly into it and it would involve patching kde frameworks since none of it seems to have darwin support. (for example most things were always pulling in linux-only deps)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
