### PR TITLE
nixos/geoclue2: RFC 42 compliance

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -113,6 +113,11 @@
 
 - `buildFHSEnvChroot` has been removed after deprecation in 23.05.
 
+- `services.geoclue2` has been refactored into structured INI settings rather
+  than ad-hoc options.  Most of the options have been renamed and must now be
+  set manually in `services.geoclue2.settings`.  The options in
+  `services.geoclue2.appConfig` have also been renamed.
+
 - `leafnode` has been removed, as it was an unmaintained alpha-release of leafnode 2 and has a dependency on the EOL PRCE-library. Consider using `leafnode1` instead, which is still maintained.
 
 - `gh-actions-cache` has been removed since its functionality has been integrated directly into `gh` (`gh cache`). See [upstream readme](https://github.com/actions/gh-actions-cache).

--- a/nixos/modules/programs/mepo.nix
+++ b/nixos/modules/programs/mepo.nix
@@ -41,8 +41,8 @@ in
     services.geoclue2 = lib.mkIf cfg.locationBackends.geoclue {
       enable = true;
       appConfig.where-am-i = {
-        isAllowed = true;
-        isSystem = false;
+        allowed = true;
+        system = false;
       };
     };
 

--- a/nixos/modules/services/desktop-managers/cosmic.nix
+++ b/nixos/modules/services/desktop-managers/cosmic.nix
@@ -156,10 +156,10 @@ in
     # We _do_ use the demo agent in the `cosmic-settings-daemon` package,
     # but this option also creates a systemd service that conflicts with the
     # `cosmic-settings-daemon` package's geoclue2 agent. Therefore, disable it.
-    services.geoclue2.enableDemoAgent = false;
+    services.geoclue2.demoAgent.enable = false;
     # As mentioned above, we do use the demo agent. And it needs to be
     # whitelisted, otherwise it doesn't run.
-    services.geoclue2.whitelistedAgents = [ "geoclue-demo-agent" ]; # whitelist our own geoclue2 agent o
+    services.geoclue2.settings.agent.whitelist = [ "geoclue-demo-agent" ]; # whitelist our own geoclue2 agent o
 
     # Good to have defaults
     hardware.bluetooth.enable = lib.mkDefault true;

--- a/nixos/modules/services/desktop-managers/gnome.nix
+++ b/nixos/modules/services/desktop-managers/gnome.nix
@@ -409,19 +409,19 @@ in
       services.avahi.enable = mkDefault true;
 
       services.geoclue2.enable = mkDefault true;
-      services.geoclue2.enableDemoAgent = false; # GNOME has its own geoclue agent
+      services.geoclue2.demoAgent.enable = false; # GNOME has its own geoclue agent
 
       services.geoclue2.appConfig.gnome-datetime-panel = {
-        isAllowed = true;
-        isSystem = true;
+        allowed = true;
+        system = true;
       };
       services.geoclue2.appConfig.gnome-color-panel = {
-        isAllowed = true;
-        isSystem = true;
+        allowed = true;
+        system = true;
       };
       services.geoclue2.appConfig."org.gnome.Shell" = {
-        isAllowed = true;
-        isSystem = true;
+        allowed = true;
+        system = true;
       };
 
       services.orca.enable = notExcluded pkgs.orca;

--- a/nixos/modules/services/desktop-managers/pantheon.nix
+++ b/nixos/modules/services/desktop-managers/pantheon.nix
@@ -179,10 +179,10 @@ in
       services.zeitgeist.enable = mkDefault true;
       services.geoclue2.enable = mkDefault true;
       # pantheon has pantheon-agent-geoclue2
-      services.geoclue2.enableDemoAgent = false;
+      services.geoclue2.demoAgent.enable = false;
       services.geoclue2.appConfig."io.elementary.desktop.agent-geoclue2" = {
-        isAllowed = true;
-        isSystem = true;
+        allowed = true;
+        system = true;
       };
       services.udev.packages = [
         pkgs.pantheon.gnome-settings-daemon

--- a/nixos/modules/services/desktops/geoclue2.nix
+++ b/nixos/modules/services/desktops/geoclue2.nix
@@ -7,64 +7,93 @@
 }:
 let
   cfg = config.services.geoclue2;
-
-  appConfigModule = lib.types.submodule (
-    { name, ... }:
-    {
-      options = {
-        desktopID = lib.mkOption {
-          type = lib.types.str;
-          description = "Desktop ID of the application.";
-        };
-
-        isAllowed = lib.mkOption {
-          type = lib.types.bool;
-          description = ''
-            Whether the application will be allowed access to location information.
-          '';
-        };
-
-        isSystem = lib.mkOption {
-          type = lib.types.bool;
-          description = ''
-            Whether the application is a system component or not.
-          '';
-        };
-
-        users = lib.mkOption {
-          type = lib.types.listOf lib.types.str;
-          default = [ ];
-          description = ''
-            List of UIDs of all users for which this application is allowed location
-            info access, Defaults to an empty string to allow it for all users.
-          '';
-        };
+  ini = pkgs.formats.ini { listToValue = lib.concatStringsSep ";"; };
+  appConfig' = lib.mapAttrs' (name: x: {
+    name = x.desktopID or name;
+    value =
+      removeAttrs x [
+        "desktopID"
+        "isAllowed"
+        "isSystem"
+      ]
+      // {
+        allowed = if x.allowed != null then x.allowed else x.isAllowed or null;
+        system = if x.system != null then x.system else x.isSystem or null;
       };
-
-      config.desktopID = lib.mkDefault name;
-    }
-  );
-
-  appConfigToINICompatible =
-    _:
-    {
-      desktopID,
-      isAllowed,
-      isSystem,
-      users,
-      ...
-    }:
-    {
-      name = desktopID;
-      value = {
-        allowed = isAllowed;
-        system = isSystem;
-        users = lib.concatStringsSep ";" users;
-      };
-    };
-
+  }) cfg.appConfig;
 in
 {
+
+  imports =
+    let
+      inherit (lib) mkRenamedOptionModule;
+    in
+    [
+      (mkRenamedOptionModule
+        [ "services" "geoclue2" "whitelistedAgents" ]
+        [ "services" "geoclue2" "settings" "agent" "whitelist" ]
+      )
+      (mkRenamedOptionModule
+        [ "services" "geoclue2" "enable3G" ]
+        [ "services" "geoclue2" "settings" "3g" "enable" ]
+      )
+      (mkRenamedOptionModule
+        [ "services" "geoclue2" "enableCDMA" ]
+        [ "services" "geoclue2" "settings" "cdma" "enable" ]
+      )
+      (mkRenamedOptionModule
+        [ "services" "geoclue2" "enableModemGPS" ]
+        [ "services" "geoclue2" "settings" "modem-gps" "enable" ]
+      )
+      (mkRenamedOptionModule
+        [ "services" "geoclue2" "enableNmea" ]
+        [ "services" "geoclue2" "settings" "network-nmea" "enable" ]
+      )
+      (mkRenamedOptionModule
+        [ "services" "geoclue2" "enableWifi" ]
+        [ "services" "geoclue2" "settings" "wifi" "enable" ]
+      )
+      (mkRenamedOptionModule
+        [ "services" "geoclue2" "geoProviderUrl" ]
+        [ "services" "geoclue2" "settings" "wifi" "url" ]
+      )
+      (mkRenamedOptionModule
+        [ "services" "geoclue2" "submitData" ]
+        [ "services" "geoclue2" "settings" "wifi" "submit-data" ]
+      )
+      (mkRenamedOptionModule
+        [ "services" "geoclue2" "submissionUrl" ]
+        [ "services" "geoclue2" "settings" "wifi" "submission-url" ]
+      )
+      (mkRenamedOptionModule
+        [ "services" "geoclue2" "submissionNick" ]
+        [ "services" "geoclue2" "settings" "wifi" "submission-nick" ]
+      )
+      (mkRenamedOptionModule
+        [ "services" "geoclue2" "enableStatic" ]
+        [ "services" "geoclue2" "settings" "static-source" "enable" ]
+      )
+      (mkRenamedOptionModule
+        [ "services" "geoclue2" "staticLatitude" ]
+        [ "services" "geoclue2" "staticLocation" "latitude" ]
+      )
+      (mkRenamedOptionModule
+        [ "services" "geoclue2" "staticLongitude" ]
+        [ "services" "geoclue2" "staticLocation" "longitude" ]
+      )
+      (mkRenamedOptionModule
+        [ "services" "geoclue2" "staticAltitude" ]
+        [ "services" "geoclue2" "staticLocation" "altitude" ]
+      )
+      (mkRenamedOptionModule
+        [ "services" "geoclue2" "staticAccuracy" ]
+        [ "services" "geoclue2" "staticLocation" "accuracy" ]
+      )
+      (mkRenamedOptionModule
+        [ "services" "geoclue2" "enableDemoAgent" ]
+        [ "services" "geoclue2" "demoAgent" "enable" ]
+      )
+    ];
 
   ###### interface
 
@@ -72,177 +101,247 @@ in
 
     services.geoclue2 = {
 
-      enable = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
+      enable = lib.mkEnableOption "GeoClue 2 daemon";
+
+      settings = lib.mkOption {
         description = ''
-          Whether to enable GeoClue 2 daemon, a DBus service
-          that provides location information for accessing.
+          Configuration settings for GeoClue 2.  See {manpage}`geoclue(5)` for
+          details.
         '';
+        type = lib.types.submodule {
+          freeformType = ini.type;
+          options = {
+
+            agent.whitelist = lib.mkOption {
+              type = lib.types.nullOr (lib.types.listOf lib.types.str);
+              default = [
+                "gnome-shell"
+                "io.elementary.desktop.agent-geoclue2"
+              ]
+              ++ lib.optionals cfg.demoAgent.enable [
+                "geoclue-demo-agent"
+              ];
+              defaultText = lib.literalExpression ''
+                [
+                  "gnome-shell"
+                  "io.elementary.desktop.agent-geoclue2"
+                ]
+                ++ lib.optionals config.geoclue2.demoAgent.enable [
+                  "geoclue-demo-agent"
+                ]
+              '';
+              description = ''
+                Desktop IDs (without the .desktop extension) of whitelisted
+                agents.
+              '';
+              apply = lib.unique;
+            };
+            ip = {
+              enable = lib.mkOption {
+                type = lib.types.nullOr lib.types.bool;
+                default = !cfg.settings.static-source.enable;
+                defaultText = lib.literalExpression "!config.services.geoclue2.static-source.enable";
+                description = ''
+                  Enable the GeoIP source.
+                '';
+              };
+              method = lib.mkOption {
+                type = lib.types.nullOr lib.types.str;
+                default = "ichnaea";
+                description = ''
+                  Method (backend) to use for IP location.  See
+                  {manpage}`geoclue(5)` for available methods.
+                '';
+              };
+            };
+            network-nmea.enable = lib.mkOption {
+              type = lib.types.nullOr lib.types.bool;
+              default = !cfg.settings.static-source.enable;
+              defaultText = lib.literalExpression "!config.services.geoclue2.static-source.enable";
+              description = ''
+                Fetch location from NMEA sources on local network.  Sources are
+                automatically discovered using avahi (domain `_nmea-0183._tcp`).
+              '';
+            };
+            "3g".enable = lib.mkOption {
+              type = lib.types.nullOr lib.types.bool;
+              default = !cfg.settings.static-source.enable;
+              defaultText = lib.literalExpression "!config.services.geoclue2.static-source.enable";
+              description = ''
+                Enable 3G source.  The 3G source uses the wireless geolocation
+                service URL defined for WiFi.
+              '';
+            };
+            cdma.enable = lib.mkOption {
+              type = lib.types.nullOr lib.types.bool;
+              default = !cfg.settings.static-source.enable;
+              defaultText = lib.literalExpression "!config.services.geoclue2.static-source.enable";
+              description = ''
+                Enable CDMA source.
+              '';
+            };
+            modem-gps.enable = lib.mkOption {
+              type = lib.types.nullOr lib.types.bool;
+              default = !cfg.settings.static-source.enable;
+              defaultText = lib.literalExpression "!config.services.geoclue2.static-source.enable";
+              description = ''
+                Enable Modem-GPS source.
+              '';
+            };
+            wifi = {
+              enable = lib.mkOption {
+                type = lib.types.nullOr lib.types.bool;
+                default = !cfg.settings.static-source.enable;
+                defaultText = lib.literalExpression "!config.services.geoclue2.static-source.enable";
+                description = ''
+                  Enable WiFi source.
+                '';
+              };
+              submit-data = lib.mkOption {
+                type = lib.types.nullOr lib.types.bool;
+                default = false;
+                description = ''
+                  Submit data to a wireless geolocation service.
+                '';
+              };
+              submission-nick = lib.mkOption {
+                type = lib.types.nullOr lib.types.str;
+                default = "geoclue";
+                description = ''
+                  A nickname to submit network data with.  If set to an empty
+                  string, omitted from the submission.  Otherwise, must be 2 to
+                  32 characters long.
+                '';
+              };
+            };
+            compass.enable = lib.mkOption {
+              type = lib.types.nullOr lib.types.bool;
+              default = !cfg.settings.static-source.enable;
+              defaultText = lib.literalExpression "!config.services.geoclue2.static-source.enable";
+              description = ''
+                Enable Compass.
+              '';
+            };
+            static-source.enable = lib.mkOption {
+              type = lib.types.nullOr lib.types.bool;
+              default = cfg.staticLocation != null;
+              defaultText = lib.literalExpression "config.geoclue2.staticLocation != null";
+              description = ''
+                Enable the static source.  If you make use of this source, you
+                probably should disable other location sources so they won't
+                override the configured static location.
+              '';
+            };
+
+          };
+        };
       };
-      whitelistedAgents = lib.mkOption {
-        type = lib.types.listOf lib.types.str;
-        default = [
-          "gnome-shell"
-          "io.elementary.desktop.agent-geoclue2"
-        ];
+
+      appConfig = lib.mkOption {
         description = ''
-          Desktop IDs (without the .desktop extension) of whitelisted agents.
+          Specify extra settings per application.  Appended to configuration
+          file after settings.
+        '';
+        type = lib.types.attrsOf (
+          lib.types.submodule {
+            freeformType = ini.lib.types.section;
+            options = {
+              allowed = lib.mkOption {
+                type = lib.types.nullOr lib.types.bool;
+                default = null;
+                description = ''
+                  Allowed access to location information.
+                '';
+              };
+              system = lib.mkOption {
+                type = lib.types.nullOr lib.types.bool;
+                default = null;
+                description = ''
+                  Is application a system component.
+                '';
+              };
+              users = lib.mkOption {
+                type = lib.types.nullOr (lib.types.listOf lib.types.str);
+                default = [ ];
+                description = ''
+                  List of UIDs of all users for which this application is allowed
+                  location info access.  Keep empty to allow for all users.
+                '';
+              };
+            };
+          }
+        );
+        defaultText = lib.literalExpression ''
+          {
+            "epiphany" = {
+              allowed = true;
+              system = false;
+            };
+            "firefox" = {
+              allowed = true;
+              system = false;
+            };
+          }
         '';
       };
 
-      enableDemoAgent = lib.mkOption {
+      staticLocation = lib.mkOption {
+        type = lib.types.nullOr (
+          lib.types.submodule {
+            options = {
+              latitude = lib.mkOption {
+                type = lib.types.number;
+                default = config.location.latitude;
+                defaultText = lib.literalExpression "config.location.latitude";
+                description = ''
+                  Latitude to be used by `static-source`.
+                '';
+              };
+              longitude = lib.mkOption {
+                type = lib.types.number;
+                default = config.location.longitude;
+                defaultText = lib.literalExpression "config.location.longitude";
+                description = ''
+                  Longitude to be used by `static-source`.
+                '';
+              };
+              altitude = lib.mkOption {
+                type = lib.types.number;
+                description = ''
+                  Altitude in meters to be used by `static-source`.
+                '';
+              };
+              accuracy = lib.mkOption {
+                type = lib.types.number;
+                description = ''
+                  Accuracy radius in meters to be used by `static-source`.
+                '';
+              };
+            };
+          }
+        );
+        default = null;
+        description = ''
+          Static location to be used to be used by `static-source`.
+        '';
+      };
+
+      demoAgent.enable = lib.mkOption {
         type = lib.types.bool;
         default = true;
         description = ''
-          Whether to use the GeoClue demo agent. This should be
-          overridden by desktop environments that provide their own
-          agent.
+          Whether to use the GeoClue demo agent.  This should be overridden by
+          desktop environments that provide their own agent.
         '';
       };
 
-      enableNmea = lib.mkOption {
-        type = lib.types.bool;
-        default = true;
-        description = ''
-          Whether to fetch location from NMEA sources on local network.
-        '';
-      };
-
-      enable3G = lib.mkOption {
-        type = lib.types.bool;
-        default = true;
-        description = ''
-          Whether to enable 3G source.
-        '';
-      };
-
-      enableCDMA = lib.mkOption {
-        type = lib.types.bool;
-        default = true;
-        description = ''
-          Whether to enable CDMA source.
-        '';
-      };
-
-      enableModemGPS = lib.mkOption {
-        type = lib.types.bool;
-        default = true;
-        description = ''
-          Whether to enable Modem-GPS source.
-        '';
-      };
-
-      enableWifi = lib.mkOption {
-        type = lib.types.bool;
-        default = true;
-        description = ''
-          Whether to enable WiFi source.
-        '';
-      };
-
-      enableStatic = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = ''
-          Whether to enable the static source. This source defines a fixed
-          location using the `staticLatitude`, `staticLongitude`,
-          `staticAltitude`, and `staticAccuracy` options.
-
-          Setting `enableStatic` to true will disable all other sources, to
-          prevent conflicts. Use `lib.mkForce true` when enabling other sources
-          if for some reason you want to override this.
-        '';
-      };
-
-      staticLatitude = lib.mkOption {
-        type = lib.types.numbers.between (-90) 90;
-        description = ''
-          Latitude to use for the static source. Defaults to `location.latitude`.
-        '';
-      };
-
-      staticLongitude = lib.mkOption {
-        type = lib.types.numbers.between (-180) 180;
-        description = ''
-          Longitude to use for the static source. Defaults to `location.longitude`.
-        '';
-      };
-
-      staticAltitude = lib.mkOption {
-        type = lib.types.number;
-        description = ''
-          Altitude in meters to use for the static source.
-        '';
-      };
-
-      staticAccuracy = lib.mkOption {
-        type = lib.types.numbers.positive;
-        description = ''
-          Accuracy radius in meters to use for the static source.
-        '';
-      };
-
-      geoProviderUrl = lib.mkOption {
-        type = lib.types.str;
-        default = "https://api.beacondb.net/v1/geolocate";
-        example = "https://www.googleapis.com/geolocation/v1/geolocate?key=YOUR_KEY";
-        description = ''
-          The url to the wifi GeoLocation Service.
-        '';
-      };
-
-      package = lib.mkOption {
-        type = lib.types.package;
-        default = pkgs.geoclue2;
-        defaultText = lib.literalExpression "pkgs.geoclue2";
+      package = lib.mkPackageOption pkgs "geoclue2" { } // {
         apply =
           pkg:
           pkg.override {
             # the demo agent isn't built by default, but we need it here
-            withDemoAgent = cfg.enableDemoAgent;
+            withDemoAgent = cfg.demoAgent.enable;
           };
-        description = "The geoclue2 package to use";
-      };
-
-      submitData = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = ''
-          Whether to submit data to a GeoLocation Service.
-        '';
-      };
-
-      submissionUrl = lib.mkOption {
-        type = lib.types.str;
-        default = "https://api.beacondb.net/v2/geosubmit";
-        description = ''
-          The url to submit data to a GeoLocation Service.
-        '';
-      };
-
-      submissionNick = lib.mkOption {
-        type = lib.types.str;
-        default = "geoclue";
-        description = ''
-          A nickname to submit network data with.
-          Must be 2-32 characters long.
-        '';
-      };
-
-      appConfig = lib.mkOption {
-        type = lib.types.attrsOf appConfigModule;
-        default = { };
-        example = lib.literalExpression ''
-          "com.github.app" = {
-            isAllowed = true;
-            isSystem = true;
-            users = [ "300" ];
-          };
-        '';
-        description = ''
-          Specify extra settings per application.
-        '';
       };
 
     };
@@ -251,6 +350,54 @@ in
 
   ###### implementation
   config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = lib.intersectAttrs cfg.settings appConfig' == { };
+        message = "Overlap between `services.geoclue2.settings' and `services.geoclue2.appConfig'. Cannot have an application with the same desktop ID as a settings section.";
+      }
+    ];
+
+    warnings = lib.concatMap ({ cond, msg }: lib.optional cond msg) [
+      {
+        cond = lib.any (x: x ? desktopID) (lib.attrValues cfg.appConfig);
+        msg = "Obsolete option `services.geoclue2.appConfig.<name>.desktopID' is used. It is now obtained from the <name> itself.";
+      }
+      {
+        cond = lib.any (x: x ? isAllowed) (lib.attrValues cfg.appConfig);
+        msg = "Obsolete option `services.geoclue2.appConfig.<name>.isAllowed' is used. It was renamed to `services.geoclue2.appConfig.<name>.allowed'.";
+      }
+      {
+        cond = lib.any (x: x ? isSystem) (lib.attrValues cfg.appConfig);
+        msg = "Obsolete option `services.geoclue2.appConfig.<name>.isSystem' is used. It was renamed to `services.geoclue2.appConfig.<name>.system'.";
+      }
+    ];
+
+    services.geoclue2.appConfig = lib.mkDefault {
+      "gnome-datetime-panel" = {
+        allowed = true;
+        system = true;
+      };
+      "gnome-color-panel" = {
+        allowed = true;
+        system = true;
+      };
+      "org.gnome.Shell" = {
+        allowed = true;
+        system = true;
+      };
+      "io.elementary.desktop.agent-geoclue2" = {
+        allowed = true;
+        system = true;
+      };
+      "epiphany" = {
+        allowed = true;
+        system = false;
+      };
+      "firefox" = {
+        allowed = true;
+        system = false;
+      };
+    };
 
     environment.systemPackages = [ cfg.package ];
 
@@ -271,19 +418,9 @@ in
       groups.geoclue = { };
     };
 
-    services.geoclue2 = {
-      enable3G = lib.mkIf cfg.enableStatic false;
-      enableCDMA = lib.mkIf cfg.enableStatic false;
-      enableModemGPS = lib.mkIf cfg.enableStatic false;
-      enableNmea = lib.mkIf cfg.enableStatic false;
-      enableWifi = lib.mkIf cfg.enableStatic false;
-      staticLatitude = lib.mkDefault config.location.latitude;
-      staticLongitude = lib.mkDefault config.location.longitude;
-    };
-
     systemd.services.geoclue = {
-      wants = lib.optionals cfg.enableWifi [ "network-online.target" ];
-      after = lib.optionals cfg.enableWifi [ "network-online.target" ];
+      wants = lib.optionals cfg.settings.wifi.enable [ "network-online.target" ];
+      after = lib.optionals cfg.settings.wifi.enable [ "network-online.target" ];
       # restart geoclue service when the configuration changes
       restartTriggers = [
         config.environment.etc."geoclue/geoclue.conf".source
@@ -293,15 +430,15 @@ in
 
     # this needs to run as a user service, since it's associated with the
     # user who is making the requests
-    systemd.user.services = lib.mkIf cfg.enableDemoAgent {
+    systemd.user.services = lib.mkIf cfg.demoAgent.enable {
       geoclue-agent = {
         description = "Geoclue agent";
         # this should really be `partOf = [ "geoclue.service" ]`, but
         # we can't be part of a system service, and the agent should
         # be okay with the main service coming and going
         wantedBy = [ "default.target" ];
-        wants = lib.optionals cfg.enableWifi [ "network-online.target" ];
-        after = lib.optionals cfg.enableWifi [ "network-online.target" ];
+        wants = lib.optionals cfg.settings.wifi.enable [ "network-online.target" ];
+        after = lib.optionals cfg.settings.wifi.enable [ "network-online.target" ];
         unitConfig.ConditionUser = "!@system";
         serviceConfig = {
           Type = "exec";
@@ -312,63 +449,19 @@ in
       };
     };
 
-    services.geoclue2.appConfig.epiphany = {
-      isAllowed = true;
-      isSystem = false;
-    };
+    environment.etc = {
+      "geoclue/geoclue.conf".source = ini.generate "geoclue.conf" (cfg.settings // appConfig');
 
-    services.geoclue2.appConfig.firefox = {
-      isAllowed = true;
-      isSystem = false;
-    };
-
-    environment.etc."geoclue/geoclue.conf".text = lib.generators.toINI { } (
-      {
-        agent = {
-          whitelist = lib.concatStringsSep ";" (
-            lib.lists.unique (
-              cfg.whitelistedAgents
-              ++ lib.optionals config.services.geoclue2.enableDemoAgent [ "geoclue-demo-agent" ]
-            )
-          );
-        };
-        network-nmea = {
-          enable = cfg.enableNmea;
-        };
-        "3g" = {
-          enable = cfg.enable3G;
-        };
-        cdma = {
-          enable = cfg.enableCDMA;
-        };
-        modem-gps = {
-          enable = cfg.enableModemGPS;
-        };
-        wifi = {
-          enable = cfg.enableWifi;
-        }
-        // lib.optionalAttrs cfg.enableWifi {
-          url = cfg.geoProviderUrl;
-          submit-data = lib.boolToString cfg.submitData;
-          submission-url = cfg.submissionUrl;
-          submission-nick = cfg.submissionNick;
-        };
-        static-source = {
-          enable = cfg.enableStatic;
-        };
-      }
-      // lib.mapAttrs' appConfigToINICompatible cfg.appConfig
-    );
-
-    environment.etc.geolocation = lib.mkIf cfg.enableStatic {
-      mode = "0440";
-      group = "geoclue";
-      text = ''
-        ${toString cfg.staticLatitude}
-        ${toString cfg.staticLongitude}
-        ${toString cfg.staticAltitude}
-        ${toString cfg.staticAccuracy}
-      '';
+      "geolocation" = lib.mkIf (cfg.staticLocation != null) {
+        mode = "0440";
+        group = "geoclue";
+        text = ''
+          ${toString cfg.staticLocation.latitude}
+          ${toString cfg.staticLocation.longitude}
+          ${toString cfg.staticLocation.altitude}
+          ${toString cfg.staticLocation.accuracy}
+        '';
+      };
     };
   };
 

--- a/nixos/modules/services/system/automatic-timezoned.nix
+++ b/nixos/modules/services/system/automatic-timezoned.nix
@@ -46,8 +46,8 @@ in
     services.geoclue2 = {
       enable = true;
       appConfig.automatic-timezoned = {
-        isAllowed = true;
-        isSystem = true;
+        allowed = true;
+        system = true;
         users = [ (toString config.ids.uids.automatic-timezoned) ];
       };
     };

--- a/nixos/modules/services/system/localtimed.nix
+++ b/nixos/modules/services/system/localtimed.nix
@@ -37,8 +37,8 @@ in
     time.timeZone = null;
 
     services.geoclue2.appConfig.localtimed = {
-      isAllowed = true;
-      isSystem = true;
+      allowed = true;
+      system = true;
       users = [ (toString config.ids.uids.localtimed) ];
     };
 

--- a/nixos/modules/services/x11/clight.nix
+++ b/nixos/modules/services/x11/clight.nix
@@ -140,8 +140,8 @@ in
     });
 
     services.geoclue2.appConfig.clightc = {
-      isAllowed = true;
-      isSystem = true;
+      allowed = true;
+      system = true;
     };
 
     systemd.services.clightd = {

--- a/nixos/modules/services/x11/redshift.nix
+++ b/nixos/modules/services/x11/redshift.nix
@@ -117,8 +117,8 @@ in
     environment.systemPackages = [ cfg.package ];
 
     services.geoclue2.appConfig.redshift = {
-      isAllowed = true;
-      isSystem = true;
+      allowed = true;
+      system = true;
     };
 
     systemd.user.services.redshift =

--- a/nixos/tests/geoclue2.nix
+++ b/nixos/tests/geoclue2.nix
@@ -15,10 +15,12 @@
 
     services.geoclue2 = {
       enable = true;
-      enableDemoAgent = true;
-      enableStatic = true;
-      staticAltitude = 123.45;
-      staticAccuracy = 1000;
+      demoAgent.enable = true;
+      settings.static-source.enable = true;
+      staticLocation = {
+        altitude = 123.45;
+        accuracy = 1000;
+      };
     };
   };
 

--- a/nixos/tests/installed-tests/xdg-desktop-portal.nix
+++ b/nixos/tests/installed-tests/xdg-desktop-portal.nix
@@ -26,7 +26,7 @@ makeInstalledTest {
     ];
     services.geoclue2 = {
       enable = true;
-      enableDemoAgent = true;
+      demoAgent.enable = true;
     };
     location.provider = "geoclue2";
   };

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -300,7 +300,10 @@ optionalAttrs allowAliases aliases
           {
 
             type = attrsOf (iniSection atom);
-            lib.types.atom = atom;
+            lib.types = {
+              inherit atom;
+              section = iniSection atom;
+            };
 
             generate =
               name: value:


### PR DESCRIPTION
Major refactor of the geoclue2 nixos module for improved maintainability and forwards-compatibility.  Specifically caused by the introduction of the new `[ip]` section in the config.

Closes https://github.com/NixOS/nixpkgs/pull/254060, closes https://github.com/NixOS/nixpkgs/pull/555644.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
