### PR TITLE
mkbrr: 1.22.0 -> 1.24.1

### DIFF
--- a/pkgs/by-name/mk/mkbrr/package.nix
+++ b/pkgs/by-name/mk/mkbrr/package.nix
@@ -7,16 +7,19 @@
 
 buildGoModule (finalAttrs: {
   pname = "mkbrr";
-  version = "1.22.0";
+  version = "1.24.1";
 
   src = fetchFromGitHub {
     owner = "autobrr";
     repo = "mkbrr";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-M4lulMYb6jomS2sZ4E5nA6rP1KmuGiMjQEyuXqyl2vQ=";
+    hash = "sha256-O2zN/qdsIQqT+NieOW/XEKlVqPpacQwCbEQK1EYgSfE=";
   };
 
-  vendorHash = "sha256-BNswyeGBhm0CY6D9HcJHTDKIGCJ5QotiwRnr22HltMo=";
+  vendorHash = "sha256-Ow8dQKBmFZj8QsAVqjLrYndklOrwcKOfhtZBdhyjXQs=";
+
+  # From v1.23.0, a separate Go module (GUI) was introduced into the repo. Build only the cli tool.
+  subPackages = [ "." ];
 
   ldflags = [
     "-s"
@@ -38,6 +41,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Tool to create, modify and inspect torrent files";
     homepage = "https://github.com/autobrr/mkbrr";
+    changelog = "https://github.com/autobrr/mkbrr/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ ambroisie ];
     mainProgram = "mkbrr";


### PR DESCRIPTION
From 1.23.0 the repo adds in a separate GUI Go module. Added `subPackages` to only build root CLI package. 
Added `changelog` to `meta` attrs.

The new module is out-of-scope.
Since a new module has been introduced, a new package called `mkbrr-gui` or whatever is preferrable can be introduced.  


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
