### PR TITLE
python3Packages.python-crontab: modernize

### DIFF
--- a/pkgs/development/python-modules/celery-redbeat/default.nix
+++ b/pkgs/development/python-modules/celery-redbeat/default.nix
@@ -2,64 +2,52 @@
   lib,
   buildPythonPackage,
   celery,
-  cron-descriptor,
-  django-timezone-field,
-  django,
   fakeredis,
   fetchFromGitHub,
-  mock,
   pytestCheckHook,
-  python-crontab,
   python-dateutil,
+  pbr,
+  redis,
   pytz,
-  setuptools,
+  tenacity,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "celery-redbeat";
-  version = "2.9.0";
+  version = "2.4.2";
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "celery";
-    repo = "django-celery-beat";
-    tag = "v${version}";
-    hash = "sha256-UGKMSXB+Hg865sAk5ePc/noO3eNTr7b3pp7tvNvn1T8=";
+    owner = "sibson";
+    repo = "redbeat";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dva4th7CAvVKA8UeIQdFsDd5xOFxsluVYDzvn5Y5Pi4=";
   };
 
-  postPatch = ''
-    # Hack the custom dependency resolution in setup.py to avoid pulling in pip
-    substituteInPlace setup.py \
-      --replace-fail "install_requires=reqs('default.txt') + reqs('runtime.txt')," "install_requires=[],"
-  '';
+  build-system = [ pbr ];
 
-  build-system = [ setuptools ];
+  env.PBR_VERSION = finalAttrs.version;
 
   dependencies = [
     celery
-    cron-descriptor
-    django
-    django-timezone-field
-    python-crontab
     python-dateutil
+    redis
+    tenacity
   ];
 
   nativeCheckInputs = [
-    mock
+    fakeredis
     pytestCheckHook
     pytz
   ];
 
-  pythonImportsCheck = [ "django_celery_beat" ];
-
-  # Tests require additional work
-  doCheck = false;
+  pythonImportsCheck = [ "redbeat" ];
 
   meta = {
     description = "Database-backed Periodic Tasks";
-    homepage = "https://github.com/celery/django-celery-beat";
-    changelog = "https://github.com/celery/django-celery-beat/releases/tag/${src.tag}";
+    homepage = "https://github.com/sibson/redbeat";
+    changelog = "https://github.com/sibson/redbeat/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ onny ];
   };
-}
+})

--- a/pkgs/development/python-modules/crontab/default.nix
+++ b/pkgs/development/python-modules/crontab/default.nix
@@ -1,39 +1,46 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitLab,
+  fetchFromGitHub,
+  nix-update-script,
   pytestCheckHook,
   python-dateutil,
   pytz,
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "crontab";
-  version = "3.3.0";
+  version = "1.0.5";
   pyproject = true;
 
-  src = fetchFromGitLab {
-    owner = "doctormo";
-    repo = "python-crontab";
-    tag = "v${version}";
-    hash = "sha256-eJXtvTRwokbewWrTArHJ2FXGDLvlkGA/5ZZR01koMW8=";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "josiahcarlson";
+    repo = "parse-crontab";
+    tag = finalAttrs.version;
+    hash = "sha256-iZS4vkfp93BK5wp1S3qCg0bC7NcT7o5/nNMRI+SXTws=";
   };
 
   build-system = [ setuptools ];
 
-  nativeCheckInputs = [
-    pytestCheckHook
+  dependencies = [
     python-dateutil
     pytz
   ];
 
+  nativeCheckInputs = [ pytestCheckHook ];
+
   pythonImportsCheck = [ "crontab" ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Parse and use crontab schedules in Python";
-    homepage = "https://gitlab.com/doctormo/python-crontab/";
+    homepage = "https://github.com/josiahcarlson/parse-crontab";
+    changelog = "https://github.com/josiahcarlson/parse-crontab/blob/${finalAttrs.src.rev}/changelog.txt";
     license = lib.licenses.lgpl21Only;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/development/python-modules/python-crontab/default.nix
+++ b/pkgs/development/python-modules/python-crontab/default.nix
@@ -1,21 +1,24 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitLab,
   python-dateutil,
   pytestCheckHook,
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "python-crontab";
   version = "3.3.0";
   pyproject = true;
 
-  src = fetchPypi {
-    pname = "python_crontab";
-    inherit version;
-    hash = "sha256-AHyK7mjd3z4E7E3OD6wSS5O9aL50cPyV0qlhehXeKRs=";
+  __structuredAttrs = true;
+
+  src = fetchFromGitLab {
+    owner = "doctormo";
+    repo = "python-crontab";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-eJXtvTRwokbewWrTArHJ2FXGDLvlkGA/5ZZR01koMW8=";
   };
 
   build-system = [ setuptools ];
@@ -23,15 +26,6 @@ buildPythonPackage rec {
   dependencies = [ python-dateutil ];
 
   nativeCheckInputs = [ pytestCheckHook ];
-
-  disabledTests = [
-    "test_07_non_posix_shell"
-    # doctest that assumes /tmp is writeable, awkward to patch
-    "test_03_usage"
-    # Test is assuming $CURRENT_YEAR is not a leap year
-    "test_19_frequency_at_month"
-    "test_20_frequency_at_year"
-  ];
 
   pythonImportsCheck = [ "crontab" ];
 
@@ -42,7 +36,10 @@ buildPythonPackage rec {
       and accessing the system cron automatically and simply using a direct API.
     '';
     homepage = "https://gitlab.com/doctormo/python-crontab/";
-    license = lib.licenses.lgpl3Plus;
-    maintainers = with lib.maintainers; [ kfollesdal ];
+    license = lib.licenses.lgpl21Only;
+    maintainers = with lib.maintainers; [
+      fab
+      kfollesdal
+    ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
