### PR TITLE
makeSetupHook: support `__structuredAttrs`

### DIFF
--- a/doc/build-helpers/special/makesetuphook.section.md
+++ b/doc/build-helpers/special/makesetuphook.section.md
@@ -51,10 +51,30 @@ pkgs.makeSetupHook
 
 ## Attributes {#sec-pkgs.makeSetupHook-attributes}
 
-* `name` Set the name of the hook.
-* `propagatedBuildInputs` Runtime dependencies (such as binaries) of the hook.
-* `depsTargetTargetPropagated` Non-binary dependencies.
-* `meta`
-* `passthru`
-* `substitutions` Mapping of key to substitution value. Each `@key@` in the script is replaced by the corresponding value.
-* `__structuredAttrs` Whether to enable `__structuredAttrs` for the hook derivation itself (not for its consumers, which are unaffected either way).
+`name`
+
+: Set the name of the hook.
+
+`propagatedBuildInputs`
+
+: Runtime dependencies (such as binaries) of the hook.
+
+`depsTargetTargetPropagated`
+
+: Non-binary dependencies.
+
+`meta`
+
+: Package metadata, see [](#chap-meta).
+
+`passthru`
+
+: Extra attributes, see [](#chap-passthru).
+
+`substitutions`
+
+: Mapping of key to substitution value. Each `@key@` in the script is replaced by the corresponding value.
+
+`__structuredAttrs`
+
+: Whether to enable `__structuredAttrs` for the hook derivation itself (not for its consumers, which are unaffected either way).

--- a/doc/build-helpers/special/makesetuphook.section.md
+++ b/doc/build-helpers/special/makesetuphook.section.md
@@ -45,6 +45,10 @@ pkgs.makeSetupHook
   )
 ```
 
+## Default substitutions {#sec-pkgs.makeSetupHook-default-substitutions}
+
+`@name@`, `@pname@`, `@version@` and `@system@` are always substituted, without being listed in `substitutions`. Everything else must be declared explicitly.
+
 ## Attributes {#sec-pkgs.makeSetupHook-attributes}
 
 * `name` Set the name of the hook.
@@ -52,4 +56,5 @@ pkgs.makeSetupHook
 * `depsTargetTargetPropagated` Non-binary dependencies.
 * `meta`
 * `passthru`
-* `substitutions` Variables for `substituteAll`
+* `substitutions` Mapping of key to substitution value. Each `@key@` in the script is replaced by the corresponding value.
+* `__structuredAttrs` Whether to enable `__structuredAttrs` for the hook derivation itself (not for its consumers, which are unaffected either way).

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -2360,6 +2360,9 @@
   "sec-pkgs.makeSetupHook-usage-example": [
     "index.html#sec-pkgs.makeSetupHook-usage-example"
   ],
+  "sec-pkgs.makeSetupHook-default-substitutions": [
+    "index.html#sec-pkgs.makeSetupHook-default-substitutions"
+  ],
   "sec-pkgs.makeSetupHook-attributes": [
     "index.html#sec-pkgs.makeSetupHook-attributes"
   ],

--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -136,6 +136,8 @@
   [pnpm `fetcherVersion` section](#javascript-pnpm-fetcherVersion) of the manual
   for details.
 
+- `pkgs.makeSetupHook` does no longer allow you to rely on substitutions outside those listed in the `substitutions` argument (see [](#sec-pkgs.makeSetupHook) for usage details).
+
 - `rebuilderd` has been updated to 0.27.0 introducing breaking changes. See upstream changelog for details: [0.26.0](https://github.com/kpcyrd/rebuilderd/releases/tag/v0.26.0), [0.27.0](https://github.com/kpcyrd/rebuilderd/releases/tag/v0.27.0)
 
 - Starting with v14, `flameshot` will primarily utilise xdg-desktop-portal calls for screenshotting. This will directly affect users on X11 window managers due to the lack of a compatible portal with Screenshot feature. See [upstream changelog](https://github.com/flameshot-org/flameshot/releases/tag/v14.0.0) or [NixOS Flameshot](https://wiki.nixos.org/wiki/Flameshot) wiki page for workarounds.
@@ -162,6 +164,8 @@
   Maintainers using `fetchurl` for `drv.src` are urged to adapt their `drv.meta.identifiers.purlParts` for proper identification.
 
 - The fwts efi-runtime kernel module was removed.
+
+- `pkgs.makeSetupHook` now allows for hook derivations to be created with `__structuredAttrs` enabled. Note that this does not affect the consumers of the hook.
 
 - Emacs loads the `early-default` library after `early-init.el`.
   Users can add `early-init.el` via `emacs.pkgs.withPackages`

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -740,14 +740,11 @@ rec {
     script:
     runCommand name
       (
-        substitutions
+        (if __structuredAttrs then { inherit substitutions; } else substitutions)
         // {
           # Make the position of the derivation accurate.
           # Since not having `name` is deprecated, this should be fairly accurate.
           pos = lib.unsafeGetAttrPos "name" args;
-          # TODO(@Artturin:) substitutions should be inside the env attrset
-          # but users are likely passing non-substitution arguments through substitutions
-          # turn off __structuredAttrs to unbreak substituteAll
           inherit __structuredAttrs;
           pname = name;
           version = "26.05pre-git";
@@ -764,16 +761,25 @@ rec {
             );
         }
       )
-      (
-        ''
-          mkdir -p $out/nix-support
-          cp ${script} $out/nix-support/setup-hook
-          recordPropagatedDependencies
-        ''
-        + lib.optionalString (substitutions != { }) ''
-          substituteAll ${script} $out/nix-support/setup-hook
-        ''
-      );
+
+      ''
+        mkdir -p $out/nix-support
+        cp ${script} $out/nix-support/setup-hook
+        recordPropagatedDependencies
+
+        declare -a setupHookSubstArgs=(
+          --subst-var name
+          --subst-var pname
+          --subst-var version
+          --subst-var system
+        )
+        declare setupHookSubstKey
+        ${lib.optionalString (!__structuredAttrs) (lib.toShellVar "substitutions" substitutions)}
+        for setupHookSubstKey in "''${!substitutions[@]}"; do
+          setupHookSubstArgs+=(--subst-var-by "$setupHookSubstKey" "''${substitutions["$setupHookSubstKey"]}")
+        done
+        substitute ${script} $out/nix-support/setup-hook "''${setupHookSubstArgs[@]}"
+      '';
 
   # Docs in doc/build-helpers/trivial-build-helpers.chapter.md
   # See https://nixos.org/manual/nixpkgs/unstable/#trivial-builder-writeClosure

--- a/pkgs/by-name/ud/udevCheckHook/package.nix
+++ b/pkgs/by-name/ud/udevCheckHook/package.nix
@@ -18,6 +18,7 @@ makeSetupHook {
   substitutions = {
     udevadm = if applyHook then lib.getExe' systemdMinimal "udevadm" else "";
   };
+  __structuredAttrs = true;
   meta = {
     description = "Check validity of udev rules in outputs";
     maintainers = with lib.maintainers; [ grimmauld ];

--- a/pkgs/by-name/ve/versionCheckHook/package.nix
+++ b/pkgs/by-name/ve/versionCheckHook/package.nix
@@ -10,6 +10,7 @@ makeSetupHook {
     storeDir = builtins.storeDir;
     envCommand = lib.getExe' coreutils "env"; # Cannot call it env, because it isn't an attrset of environment variables!
   };
+  __structuredAttrs = true;
   meta = {
     description = "Lookup for $version in the output of --help and --version";
     maintainers = with lib.maintainers; [ doronbehar ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add support for `__structuredAttrs` in `makeSetupHook`.

Despite what the existing TODO suggested, I thought it might be better to build the argument list of substitutions for `substitute` directly from `substitutions`, limiting substitutions not to rely on anything from `env`.

Note that I added `name`, `pname`, `version` and `system` to the list to make the behaviour similar to `substituteAll`. However I'm not sure that the reasoning behind this list of defaults makes sense anymore. If someone is going to manually go over and edit the hooks to enable `__structuredAttrs` anyway, it might be good to decide whether these substitutions should be explicitly listed or not before anyone starts doing those edits. Here's the comment in `_allFlags` for context:

https://github.com/NixOS/nixpkgs/blob/85fb1d96d97bd43a6ff288dc3d2e913743152b7b/pkgs/stdenv/generic/setup.sh#L1131-L1139

I enabled `__structuredAttrs` for `versionCheckHook` and `udevCheckHook` just to make sure it works as expected.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux (built `versionCheckHook` and `udevCheckHook`)
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
