### PR TITLE
python3Packages.flash-linear-attention: 0.5.1 -> 0.5.2

### DIFF
--- a/pkgs/development/python-modules/flash-linear-attention/default.nix
+++ b/pkgs/development/python-modules/flash-linear-attention/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonOlder,
 
   # build-system
   setuptools,
@@ -13,42 +12,52 @@
   transformers,
 
   # optional-dependencies
+  tilelang,
   causal-conv1d,
+  pandas,
+  pytest-xdist,
   matplotlib,
   datasets,
   pytest,
+  triton,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "flash-linear-attention";
-  version = "0.5.1";
+  version = "0.5.2";
   pyproject = true;
 
-  disabled = pythonOlder "3.10";
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "fla-org";
     repo = "flash-linear-attention";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-vxNbZ+FkxJh2E0TF09Z7ghkm8eas7Q96heeSXwgV4uU=";
+    hash = "sha256-Z4TEy8ycUA9NNw/yA4uIJHooqsmXUF2EIG0Lo454NXg=";
   };
 
   build-system = [ setuptools ];
 
   dependencies = [
     einops
-    torch
+    torch # Requires torch to function
     transformers
   ];
 
   optional-dependencies = {
-    # tilelang = [ tilelang ];
+    cuda = [ triton ];
+    cpu = [ triton ];
+    tilelang = [ tilelang ];
     conv1d = [ causal-conv1d ];
     benchmark = [
       matplotlib
+      pandas
       datasets
     ];
-    test = [ pytest ];
+    test = [
+      pytest
+      pytest-xdist
+    ];
   };
 
   # Tests require a GPU


### PR DESCRIPTION
https://github.com/fla-org/flash-linear-attention/releases/tag/v0.5.2
https://github.com/fla-org/flash-linear-attention/compare/v0.5.1...v0.5.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
