### PR TITLE
bootdev-cli: 1.29.6 -> 1.31.1

### DIFF
--- a/pkgs/by-name/bo/bootdev-cli/package.nix
+++ b/pkgs/by-name/bo/bootdev-cli/package.nix
@@ -7,17 +7,18 @@
   nix-update-script,
   versionCheckHook,
   writableTmpDirAsHomeHook,
+  coreutils,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "bootdev-cli";
-  version = "1.29.6";
+  version = "1.31.1";
 
   src = fetchFromGitHub {
     owner = "bootdotdev";
     repo = "bootdev";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-uoFnhcJvvY+lb8VLv0kPI8hp4H8XfQOY5R83Rj17gfw=";
+    hash = "sha256-0koZYMQxCHPtB44OYhiD9+nYAyHWXbyQd2xhdqnOqEw=";
   };
 
   vendorHash = "sha256-ZDioEU5uPCkd+kC83cLlpgzyOsnpj2S7N+lQgsQb8uY=";
@@ -32,6 +33,14 @@ buildGoModule (finalAttrs: {
     writableTmpDirAsHomeHook
   ];
 
+  # TestGetLatestVersionHasOverallTimeout writes a fake go helper that runs
+  # /bin/sleep; that path is missing in the Nix sandbox, and the test also
+  # resets PATH so a bare "sleep" would not help. Point at store sleep.
+  postPatch = ''
+    substituteInPlace version/version_test.go \
+      --replace-fail 'exec /bin/sleep 5' 'exec ${lib.getExe' coreutils "sleep"} 5'
+  '';
+
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     for shell in bash fish zsh; do
       installShellCompletion --cmd bootdev --"$shell" <($out/bin/bootdev completion "$shell")
@@ -41,6 +50,9 @@ buildGoModule (finalAttrs: {
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgram = "${placeholder "out"}/bin/bootdev";
   doInstallCheck = true;
+
+  # checks tests use httptest.NewServer (bind localhost)
+  __darwinAllowLocalNetworking = true;
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
Update `bootdev-cli` from 1.29.6 to 1.31.1.

Changelog: https://github.com/bootdotdev/bootdev/releases/tag/v1.31.1

`TestGetLatestVersionHasOverallTimeout` writes a fake `go` helper that runs
`/bin/sleep` and resets `PATH` to only that helper. `/bin/sleep` is unavailable
in the Nix sandbox, so the test is patched to use `sleep` from `coreutils`.

The test suite also uses `httptest.NewServer`, so Darwin builds require
`__darwinAllowLocalNetworking = true`.

Assisted-by: OpenAI Codex (GPT-5.6-sol).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test