### PR TITLE
[26.05] python3Packages.general-sam: 1.0.3 -> 1.0.5

### DIFF
--- a/pkgs/development/python-modules/general-sam/default.nix
+++ b/pkgs/development/python-modules/general-sam/default.nix
@@ -10,19 +10,19 @@
 
 buildPythonPackage rec {
   pname = "general-sam";
-  version = "1.0.4.post0";
+  version = "1.0.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ModelTC";
     repo = "general-sam-py";
     rev = "v${version}";
-    hash = "sha256-bpJL6kpcpMWNNUOSLUnRLsAi7yp3fl0WKzvfXiGwYeE=";
+    hash = "sha256-/hfq14oFNPhPrhjlIDCyjMfdCuhMdKZ5DBc/nlEQKno=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-kmc1sGlSTQHdLaW7fDk0AmkEDmttEEljVEsc6inLRuw=";
+    hash = "sha256-8uUCe/isN1qos8cBml16NOzUYHfr94G/GzllQt/5vWg=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/general-sam/default.nix
+++ b/pkgs/development/python-modules/general-sam/default.nix
@@ -10,19 +10,19 @@
 
 buildPythonPackage rec {
   pname = "general-sam";
-  version = "1.0.3";
+  version = "1.0.4.post0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ModelTC";
     repo = "general-sam-py";
     rev = "v${version}";
-    hash = "sha256-++6Z9Ocee4QFN1u0nK/g9uGdmB1UYnfHhhJj74zboCE=";
+    hash = "sha256-bpJL6kpcpMWNNUOSLUnRLsAi7yp3fl0WKzvfXiGwYeE=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-8HHIM1Abz5KxnVphFFNJp6L3D6iPeoB7qVmxy11CUZs=";
+    hash = "sha256-kmc1sGlSTQHdLaW7fDk0AmkEDmttEEljVEsc6inLRuw=";
   };
 
   build-system = [


### PR DESCRIPTION
Backports general-sam 1.0.3 -> 1.0.5

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
