### PR TITLE
frei0r: 2.5.1 -> 3.2.1 add new dep gavl && gavl: init at 2.0.1

### DIFF
--- a/pkgs/by-name/fr/frei0r/package.nix
+++ b/pkgs/by-name/fr/frei0r/package.nix
@@ -1,26 +1,30 @@
 {
-  lib,
-  config,
-  stdenv,
-  fetchFromGitHub,
   cairo,
   cmake,
+  config,
+  fetchFromGitHub,
+  gavl,
+  lib,
   opencv,
   pkg-config,
-  cudaSupport ? config.cudaSupport,
+  stdenv,
   cudaPackages,
+  cudaSupport ? config.cudaSupport,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "frei0r-plugins";
-  version = "2.5.1";
+  version = "3.2.1";
 
   src = fetchFromGitHub {
     owner = "dyne";
     repo = "frei0r";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-3gUWvO5izOrJt+XwcNBNiLfu+iMqo4nuPbx++TYzao0=";
+    hash = "sha256-eBaaEE+4mKYr5VCXUnoS/4aE6EV8DnXFJLFYsrk3gs0=";
   };
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   nativeBuildInputs = [
     cmake
@@ -28,6 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   buildInputs = [
     cairo
+    gavl
     opencv
   ]
   ++ lib.optionals cudaSupport [
@@ -42,10 +47,12 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "https://frei0r.dyne.org";
     description = "Minimalist, cross-platform, shared video plugins";
+    homepage = "https://frei0r.dyne.org";
     license = lib.licenses.gpl2Plus;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      nick-linux
+    ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/ga/gavl/package.nix
+++ b/pkgs/by-name/ga/gavl/package.nix
@@ -1,0 +1,56 @@
+{
+  autoreconfHook,
+  doxygen,
+  fetchFromGitHub,
+  gnutls,
+  lib,
+  libdrm,
+  libGL,
+  libGLU,
+  libpng,
+  nettle,
+  pkg-config,
+  stdenv,
+  zlib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gavl";
+  version = "2.0.1";
+
+  src = fetchFromGitHub {
+    owner = "bplaum";
+    repo = "gavl";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-nvgBsUiSF6+voMzo5XRWHig2Iq8DD2hVV5hWodGxgQo=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    doxygen
+    pkg-config
+  ];
+
+  buildInputs = [
+    gnutls
+    libdrm
+    libGL
+    libGLU
+    libpng
+    nettle
+    zlib
+  ];
+
+  meta = {
+    description = "Low level library for handling uncompressed audio and video data";
+    homepage = "https://github.com/bplaum/gavl";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [
+      nick-linux
+    ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
## Summary
Version bump of Frei0r from an old release which now requires `Gavl` which did not exist in nixpkgs therefore we will add the package here

This is also to work on #548583 @BatteredBunny 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
