### PR TITLE
mpvScripts.videoclip: 0.2-unstable-2026-07-07 -> 26.7.30.0

### DIFF
--- a/pkgs/by-name/mp/mpv/scripts/videoclip.nix
+++ b/pkgs/by-name/mp/mpv/scripts/videoclip.nix
@@ -1,38 +1,37 @@
 {
   lib,
-  fetchFromGitHub,
-  curl,
-  xclip,
-  wl-clipboard,
-  stdenv,
   buildLua,
-  unstableGitUpdater,
+  fetchFromGitHub,
+  gitUpdater,
+  stdenv,
+  curl,
+  wl-clipboard,
+  xclip,
 }:
-buildLua {
+buildLua (finalAttrs: {
   pname = "videoclip";
-  version = "0.2-unstable-2026-07-07";
+  version = "26.7.30.0";
 
   src = fetchFromGitHub {
     owner = "Ajatt-Tools";
     repo = "videoclip";
-    rev = "979bae398da7ccd70cb2fb305c371b7af9259b10";
-    hash = "sha256-k3fxSeAjRZg4J5x5IQhKGYtUqfBE4heR1KNurGTElGs=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-4ptnF3/L3U0CDucYcd8/O5EN1mUtnor+iXLRXbiC7os=";
   };
 
-  patchPhase = ''
-    substituteInPlace platform.lua \
-    --replace \'curl\' \'${lib.getExe curl}\' \
+  postPatch = ''
+    substituteInPlace videoclip/platform.lua \
+      --replace-fail "'curl'" "'${lib.getExe curl}'"
   ''
   + lib.optionalString stdenv.hostPlatform.isLinux ''
-    --replace xclip ${lib.getExe xclip} \
-    --replace wl-copy ${lib.getExe' wl-clipboard "wl-copy"}
+    substituteInPlace videoclip/platform.lua \
+      --replace-fail '"wl-copy' '"${lib.getExe' wl-clipboard "wl-copy"}' \
+      --replace-fail '"xclip' '"${lib.getExe xclip}'
   '';
 
-  scriptPath = ".";
-  passthru.scriptName = "videoclip";
-  passthru.updateScript = unstableGitUpdater {
-    tagPrefix = "v";
-  };
+  scriptPath = "videoclip";
+
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 
   meta = {
     description = "Easily create videoclips with mpv";
@@ -41,4 +40,4 @@ buildLua {
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ BatteredBunny ];
   };
-}
+})


### PR DESCRIPTION
https://github.com/Ajatt-Tools/videoclip/releases/tag/v26.7.30.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
