### PR TITLE
python3Packages.st7789: init at 1.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5283,6 +5283,12 @@
     name = "Christian Kruse";
     keys = [ { fingerprint = "BC5D 9F4E F7FB 4382 6056  E834 B8E0 F342 A99A 9D73"; } ];
   };
+  cktiel = {
+    email = "tiel@tuta.io";
+    github = "cktiel";
+    githubId = 310042450;
+    name = "Artur Cierocki";
+  };
   clacke = {
     email = "claes.wallin@greatsinodevelopment.com";
     github = "clacke";

--- a/pkgs/development/python-modules/st7789/default.nix
+++ b/pkgs/development/python-modules/st7789/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  fetchPypi,
+  buildPythonPackage,
+  hatchling,
+  hatch-fancy-pypi-readme,
+  gpiod,
+  spidev,
+  numpy,
+  gpiodevice,
+}:
+
+buildPythonPackage rec {
+  pname = "st7789";
+  version = "1.0.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit version;
+    pname = "st7789";
+    sha256 = "sha256-8gSYPRnTXiZlBFWsfim9eybUItRw8JOZRAP2347N3Bs=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    hatch-fancy-pypi-readme
+    gpiod
+    spidev
+    numpy
+    gpiodevice
+  ];
+
+  doCheck = false;
+
+  pythonImportsCheck = [ "st7789" ];
+
+  meta = {
+    homepage = "https://github.com/pimoroni/st7789-python";
+    description = "Python library to control an ST7789 240x240 1.3\" TFT LCD display.";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ cktiel ];
+  };
+}


### PR DESCRIPTION
Added pimoroni's st7789 driver module.
https://github.com/pimoroni/st7789-python
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
