### PR TITLE
qman: better darwin support, respect /etc/xdg/qman/qman.conf

### DIFF
--- a/pkgs/by-name/qm/qman/package.nix
+++ b/pkgs/by-name/qm/qman/package.nix
@@ -2,13 +2,12 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  man-db,
+  man,
   groff,
   xdg-utils,
   meson,
   ninja,
   pkg-config,
-  cmake,
   python3Packages,
   ncurses,
   zlib,
@@ -17,7 +16,49 @@
   cunit,
   nix-update-script,
   versionCheckHook,
+  writeShellScript,
 }:
+
+let
+  # On darwin, skip xdg-utils and just use /usr/bin/open
+  utils =
+    if stdenv.hostPlatform.isDarwin then
+      {
+        open = "/usr/bin/open";
+        email = writeShellScript "open-mailto" ''
+          uris=()
+          while (( $# )); do
+            uris+=mailto:"$1"
+            shift
+          done
+          /usr/bin/open "''${uris[@]}"
+        '';
+      }
+    else
+      {
+        open = lib.getExe' xdg-utils "xdg-open";
+        email = lib.getExe' xdg-utils "xdg-email";
+      };
+  /*
+    We substitute some paths into the manpage.  Sticking a full store
+    path with hash in there causes layout problems so we get rid of
+    the hash.
+  */
+  escapedPathForMan =
+    path:
+    lib.escapeShellArg (
+      /*
+        I don't know manpage syntax, but the existing paths in there
+        escape hyphens so we will too.
+      */
+      lib.replaceString "-" "\\-" (
+        let
+          result = builtins.match "${lib.escapeRegex builtins.storeDir}/[a-z0-9]{32}-(.*)" (toString path);
+        in
+        if result == null then toString path else "${builtins.storeDir}/…-${builtins.head result}"
+      )
+    );
+in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "qman";
@@ -34,20 +75,28 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     patchShebangs --build src/qman_tests_list.sh
+
     substituteInPlace src/config_def.py \
-      --replace-fail "/usr/bin/man" ${man-db}/bin/man \
-      --replace-fail "/usr/bin/groff" ${groff}/bin/groff \
-      --replace-fail "/usr/bin/whatis" ${man-db}/bin/whatis \
-      --replace-fail "/usr/bin/apropos" ${man-db}/bin/apropos \
-      --replace-fail "/usr/bin/xdg-open" ${xdg-utils}/bin/xdg-open \
-      --replace-fail "/usr/bin/xdg-email" ${xdg-utils}/bin/xdg-email
+      --replace-fail /usr/bin/man ${lib.getExe man} \
+      --replace-fail /usr/bin/groff ${lib.getExe' groff "groff"} \
+      --replace-fail /usr/bin/whatis ${lib.getExe' man "whatis"} \
+      --replace-fail /usr/bin/apropos ${lib.getExe' man "apropos"} \
+      --replace-fail /usr/bin/xdg-open ${utils.open} \
+      --replace-fail /usr/bin/xdg-email ${utils.email}
+
+    substituteInPlace man/qman.1 \
+      --replace-fail /usr/bin/man ${escapedPathForMan (lib.getExe man)} \
+      --replace-fail /usr/bin/groff ${escapedPathForMan (lib.getExe' groff "groff")} \
+      --replace-fail /usr/bin/whatis ${escapedPathForMan (lib.getExe' man "whatis")} \
+      --replace-fail /usr/bin/apropos ${escapedPathForMan (lib.getExe' man "apropos")} \
+      --replace-fail '/usr/bin/xdg\-open' ${escapedPathForMan utils.open} \
+      --replace-fail '/usr/bin/xdg\-email' ${escapedPathForMan utils.email}
   '';
 
   nativeBuildInputs = [
     meson
     ninja
     pkg-config
-    cmake
     python3Packages.cogapp
   ];
 
@@ -56,14 +105,27 @@ stdenv.mkDerivation (finalAttrs: {
     zlib
     bzip2
     xz
-    cunit
   ];
 
   mesonFlags = [
-    "-Dconfigdir=${placeholder "out"}/etc/xdg/qman"
+    (lib.mesonEnable "tests" finalAttrs.doCheck)
+    # Change installation config dir, themes and sample config go here.
+    # Also see postInstall where we delete the sample config.
+    (lib.mesonOption "configdir" "${placeholder "out"}/etc/xdg/qman")
   ];
 
+  # Delete the sample config that we installed so that way qman will go ahead and check
+  # /etc/xdg/qman/qman.conf and /etc/qman/qman.conf for configs as documented, and so initial
+  # behavior will match documentation.
+  postInstall = ''
+    rm $out/etc/xdg/qman/qman.conf
+  '';
+
+  doCheck = true;
+  checkInputs = [ cunit ];
+
   doInstallCheck = true;
+  # qman crashes if the TERM env var isn't present
   versionCheckKeepEnvironment = [
     "TERM"
   ];
@@ -75,9 +137,22 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "A more modern man page viewer for our terminals";
+    description = "Modern man page viewer";
+    longDescription = ''
+      Unix manual pages are lovely.  They are concise, well-written,
+      complete, and downright useful.  However, the standard way of
+      accessing them from the command-line hasn't changed since the
+      early days.
+
+      Qman aims to change that.  It's a modern, full-featured manual
+      page viewer featuring hyperlinks, web browser like navigation, a
+      table of contents for each page, incremental search, on-line
+      help, and more.  It also strives to be fast and tiny, so that it
+      can be used everywhere.  For this reason, it's been written in
+      plain C and has only minimal dependencies.
+    '';
     homepage = "https://github.com/plp13/qman";
-    changelog = "https://github.com/plp13/qman/releases/tag/${finalAttrs.src.tag}";
+    changelog = "https://github.com/plp13/qman/tree/${finalAttrs.src.tag}#new-in-this-version";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ pborzenkov ];
     mainProgram = "qman";


### PR DESCRIPTION
This updates the qman package to match the package definition from #434438. This supports darwin better (using `/usr/bin/open` for URLs and email addresses instead of `xdg-utils`), allows for disabling tests, updates the manpage, and removes the copy of the sample config file so that way qman will respect any config at `/etc/xdg/qman/qman.conf`.

The resulting package definition is equivalent to that from #434438 but some code was moved around to minimize the diff, and I left the maintainer list alone.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
