### PR TITLE
nixosTests.opencloud: fix LDAPS and aarch64 WebDriver setup

### DIFF
--- a/nixos/tests/opencloud.nix
+++ b/nixos/tests/opencloud.nix
@@ -21,12 +21,14 @@ let
         from selenium.webdriver.common.by import By
         from selenium.webdriver import Firefox
         from selenium.webdriver.firefox.options import Options
+        from selenium.webdriver.firefox.service import Service
         from selenium.webdriver.support.ui import WebDriverWait
         from selenium.webdriver.support import expected_conditions as EC
 
         options = Options()
         options.add_argument('--headless')
-        driver = Firefox(options=options)
+        service = Service(executable_path="${lib.getExe pkgs.geckodriver}")
+        driver = Firefox(options=options, service=service)
 
         host = sys.argv[1]
         user = sys.argv[2]
@@ -71,6 +73,7 @@ in
       environment = {
         ADMIN_PASSWORD = adminPassword;
         IDM_CREATE_DEMO_USERS = "true";
+        IDM_LDAPS_ADDR = "127.0.0.1:9235";
         IDM_LDAPS_CERT = "${certs.${domain}.cert}";
         IDM_LDAPS_KEY = "${certs.${domain}.key}";
         OC_INSECURE = "false";


### PR DESCRIPTION
OpenCloud 7.2 changed the IDM default listener from LDAPS on port 9235 to loopback LDAP on port 9236. This test still configures its clients to use LDAPS, so enable the LDAPS listener explicitly.

Pass the packaged geckodriver to Selenium instead of invoking Selenium Manager, which does not support aarch64-linux.

`nixosTests.opencloud` passes on aarch64-linux with OpenCloud 7.3.0, including the admin and demo-user browser login checks.

Assisted-by: OpenAI Codex (GPT-5)

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
