### PR TITLE
nixos/flarum: manage `config.php` declaratively, guard reinstall with marker file

### DIFF
--- a/nixos/modules/services/web-apps/flarum.nix
+++ b/nixos/modules/services/web-apps/flarum.nix
@@ -12,17 +12,19 @@ let
 
   # Only placeholders reach the world-readable Nix store; the install
   # script substitutes the real secrets at runtime.
+  dbConfig =
+    cfg.database
+    // optionalAttrs (cfg.databasePasswordFile != null) {
+      password = "@databasePassword@";
+    };
+
   flarumInstallConfig = pkgs.writeText "config.json" (
     builtins.toJSON {
       debug = false;
       offline = false;
 
       baseUrl = cfg.baseUrl;
-      databaseConfiguration =
-        cfg.database
-        // optionalAttrs (cfg.databasePasswordFile != null) {
-          password = "@databasePassword@";
-        };
+      databaseConfiguration = dbConfig;
       adminUser = {
         username = cfg.adminUser;
         password =
@@ -34,6 +36,25 @@ let
       };
     }
   );
+
+  phpFormat = pkgs.formats.php { };
+
+  configPhpFile = phpFormat.generate "flarum-config.php" {
+    debug = false;
+    database = dbConfig;
+    url = cfg.baseUrl;
+    paths = {
+      api = "api";
+      admin = "admin";
+    };
+    headers = {
+      poweredByHeader = true;
+      referrerPolicy = "same-origin";
+    };
+    queue = {
+      driver = "sync";
+    };
+  };
 in
 {
   options.services.flarum = {
@@ -268,26 +289,31 @@ in
         ln -sf ${cfg.package}/share/php/flarum/public/index.php public/
       ''
       + optionalString (cfg.createDatabaseLocally && cfg.database.driver == "mysql") ''
-        if [ ! -f config.php ]; then
-          install -m 0600 ${flarumInstallConfig} /tmp/flarum-install.json
-          ${optionalString (cfg.initialAdminPasswordFile != null) ''
-            ${pkgs.replace-secret}/bin/replace-secret '@adminPassword@' \
-              ${escapeShellArg cfg.initialAdminPasswordFile} /tmp/flarum-install.json
-          ''}
-          ${optionalString (cfg.databasePasswordFile != null) ''
-            ${pkgs.replace-secret}/bin/replace-secret '@databasePassword@' \
-              ${escapeShellArg cfg.databasePasswordFile} /tmp/flarum-install.json
-          ''}
-          php flarum install --file=/tmp/flarum-install.json
-          # config.php contains the database password; stateDir is world-readable
-          chmod 600 config.php
+        if [ ! -f .flarum-installed ]; then
+          if [ ! -f config.php ]; then
+            install -m 0600 ${flarumInstallConfig} /tmp/flarum-install.json
+            ${optionalString (cfg.initialAdminPasswordFile != null) ''
+              ${pkgs.replace-secret}/bin/replace-secret '@adminPassword@' \
+                ${escapeShellArg cfg.initialAdminPasswordFile} /tmp/flarum-install.json
+            ''}
+            ${optionalString (cfg.databasePasswordFile != null) ''
+              ${pkgs.replace-secret}/bin/replace-secret '@databasePassword@' \
+                ${escapeShellArg cfg.databasePasswordFile} /tmp/flarum-install.json
+            ''}
+            php flarum install --file=/tmp/flarum-install.json
+          fi
+          touch .flarum-installed
         fi
       ''
       + ''
-        if [ -f config.php ]; then
-          php flarum migrate
-          php flarum cache:clear
-        fi
+        install -m 0600 ${configPhpFile} config.php
+        ${optionalString (cfg.databasePasswordFile != null) ''
+          ${pkgs.replace-secret}/bin/replace-secret '@databasePassword@' \
+            ${escapeShellArg cfg.databasePasswordFile} config.php
+        ''}
+
+        php flarum migrate
+        php flarum cache:clear
       '';
     };
   };

--- a/nixos/tests/flarum.nix
+++ b/nixos/tests/flarum.nix
@@ -69,5 +69,17 @@
     # not be world-readable.
     machine.succeed("grep -q 'flarum-db-password' /var/lib/flarum/config.php")
     machine.succeed("[ $(stat -c %a /var/lib/flarum/config.php) = 600 ]")
+
+    # `flarum install` must not rerun on later activations, or it errors out
+    # since the database already exists.
+    machine.succeed(
+        "echo 'create table nixos_test_marker (id int); insert into nixos_test_marker values (1);' "
+        + "| sudo -u flarum mysql -u flarum flarum"
+    )
+    machine.succeed("systemctl restart flarum-install.service")
+    machine.succeed(
+        "echo 'select id from nixos_test_marker;' | sudo -u flarum mysql -u flarum flarum -N | grep -q 1"
+    )
+    machine.succeed("[ -f /var/lib/flarum/.flarum-installed ]")
   '';
 }


### PR DESCRIPTION
Regenerate `config.php`declaratively from module options on every activation instead of leaving it as a one-time installer artifact, guarded by a new `.flarum-installed` marker file so reinstalling never reruns against an existing database. This is prep for Flarum 2, which will support multiple database.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
