### PR TITLE
python3Packages.marisa: fix pythonMetadataCheckPhase

### DIFF
--- a/pkgs/development/python-modules/marisa/default.nix
+++ b/pkgs/development/python-modules/marisa/default.nix
@@ -13,6 +13,13 @@ buildPythonPackage {
 
   patches = marisa.patches or [ ];
 
+  # fix The 'marisa' derivation has version '0.3.1' but .dist-info/METADATA specifies version '0.0.0'.
+  postPatch = ''
+    substituteInPlace bindings/python/setup.py --replace-fail \
+      'setup(name = "marisa",' \
+      'setup(name = "marisa", version = "${marisa.version}"',
+  '';
+
   build-system = [ setuptools ];
 
   nativeBuildInputs = [ swig ];


### PR DESCRIPTION
fix https://hydra.nixos.org/build/340365939:
```
Executing pythonMetadataCheckPhase
The 'marisa' derivation has version '0.3.1' but .dist-info/METADATA specifies version '0.0.0'.
This usually means that the wrong version is hardcoded in pyproject.toml or setup.{py,cfg}.
Use the pyprojectVersionPatchHook or patch the version manually so that the project metadata matches the derivation's version.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
