### PR TITLE
nixos/image/amend-repart-definitions: appease ruff

### DIFF
--- a/nixos/modules/image/amend-repart-definitions.py
+++ b/nixos/modules/image/amend-repart-definitions.py
@@ -13,8 +13,8 @@ files using the same mechanism.
 """
 
 import json
-import sys
 import shutil
+import sys
 from pathlib import Path
 
 

--- a/nixos/modules/image/repart-image.nix
+++ b/nixos/modules/image/repart-image.nix
@@ -86,7 +86,6 @@ let
         depsBuildBuild = [ ruff ];
         nativeBuildInputs = [
           python3
-          black
           mypy
         ];
       }
@@ -94,8 +93,8 @@ let
         install ${./amend-repart-definitions.py} $out
         patchShebangs --build $out
 
-        black --check --diff $out
-        ruff check --line-length 88 $out
+        ruff format --check $out
+        ruff check $out
         mypy --strict $out
       '';
 


### PR DESCRIPTION
Ruff seems to have enabled more lints by default. We need to appease the linter lords.

Also removed dependency on black while I was there.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
