### PR TITLE
gh-stack: distribute the agent skill

### DIFF
--- a/pkgs/by-name/gh/gh-stack/package.nix
+++ b/pkgs/by-name/gh/gh-stack/package.nix
@@ -30,6 +30,10 @@ buildGoModule (finalAttrs: {
     "-X=github.com/github/gh-stack/cmd.Version=${finalAttrs.version}"
   ];
 
+  postInstall = ''
+    install -Dm444 skills/gh-stack/SKILL.md $out/share/skills/gh-stack/gh-stack/SKILL.md
+  '';
+
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
 


### PR DESCRIPTION
The gh-stack source includes an agent skill alongside the CLI, but the package currently installs only the executable. Users must fetch the skill separately, which can leave it out of sync with the packaged CLI version.

Install the upstream `SKILL.md` at `$out/share/gh-stack/skills/gh-stack`. This makes the version-matched skill available to Home Manager and other agent configurations. The layout follows the direction being discussed in #547426.

Verification:

- `nix build .#gh-stack --no-link` on aarch64-darwin, after the review change.
- `nixpkgs-review pr 548750 --no-shell` on the previous revision: one package built (`gh-stack`).
- The upstream Go test suite passes.
- `gh-stack --version` and `gh-stack --help` work.
- The output contains `share/gh-stack/skills/gh-stack/SKILL.md`.

Assisted-by: OpenAI Codex (GPT-5)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
