### PR TITLE
nixos/systemd-initrd: disambiguate doc for root="gpt-auto"

### DIFF
--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -229,7 +229,7 @@ in
         KExecWatchdogSec = "5min";
       };
       description = ''
-        Options for the global systemd service manager used in initrd. See {manpage}`systemd-system.conf(5)` man page
+        Options for the global systemd service manager used in initrd. See {manpage}`systemd-system.conf(5)`
         for available options.
       '';
     };
@@ -311,10 +311,19 @@ in
       example = "gpt-auto";
       description = ''
         Controls how systemd will interpret the root FS in initrd. See
-        {manpage}`kernel-command-line(7)`. NixOS currently does not
-        allow specifying the root file system itself this
-        way. Instead, the `fstab` value is used in order to interpret
-        the root file system specified with the `fileSystems` option.
+        the description of the `root=` argument in {manpage}`kernel-command-line(7)`.
+
+        When set to "gpt-auto", {manpage}`systemd-gpt-auto-generator(8)`
+        automatically discovers and mounts the root, EFI System (ESP),
+        swap, and various other partitions based on their partition
+        type, allowing them to be effectively omitted from
+        {option}`fileSystems.<name>`.
+        Note however that {option}`boot.initrd.supportedFilesystems`
+        will not be inferred for partitions without an explicit
+        {option}`fileSystems.<name>.fsType`, therefore the filesystem
+        names of all partitions mounted through "gpt-auto" must be
+        manually appended to `supportedFilesystems`.
+
         If root shall be omitted, set this option to `null`.
       '';
     };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
The current documentation string for `boot.initrd.systemd.root` is ambiguous in the way it is written.

1. > NixOS currently does not allow specifying the root file system itself this way.

   could be interpreted as _"gpt-auto is not supported in NixOS for the root partition"_.

   This is however entirely supported since NixOS 24.05, judging by the module's code (and my personal experience rocking this configuration).

1. > the `fstab` value is used in order to interpret the root file system specified with the `fileSystems` option.

   could be interpreted as _"the root partition must be declared via fileSystems even though gpt-auto is selected"_.

   This is incorrect and ill-advised. Declaring `fileSystems."/"` suppresses the effect of "gpt-auto" for that partition, which may not be what the user wants or expects.

   > Note that this generator [...] will also not create mount point configuration [...] if the mount point is explicitly configured in fstab(5).
   > -- [systemd-gpt-auto-generator(8)](https://www.freedesktop.org/software/systemd/man/latest/systemd-gpt-auto-generator.html)

I'm leaving the relevant bits of my boot configuration here for reference:

```nix
boot.initrd = {
  systemd.root = "gpt-auto";
  supportedFilesystems = [ "ext4" ]; # root partition, SD_GPT_ROOT_X86_64
};

fileSystems = {};
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
