### PR TITLE
python3Packages.pystrich: init at 0.20

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19342,6 +19342,12 @@
     githubId = 708570;
     name = "Manuel Mendez";
   };
+  mmulqueen = {
+    email = "michael@mulqueen.me.uk";
+    github = "mmulqueen";
+    githubId = 6616321;
+    name = "Michael Mulqueen";
+  };
   mmusnjak = {
     email = "marko.musnjak@gmail.com";
     github = "mmusnjak";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18926,6 +18926,12 @@
     githubId = 708570;
     name = "Manuel Mendez";
   };
+  mmulqueen = {
+    email = "michael@mulqueen.me.uk";
+    github = "mmulqueen";
+    githubId = 6616321;
+    name = "Michael Mulqueen";
+  };
   mmusnjak = {
     email = "marko.musnjak@gmail.com";
     github = "mmusnjak";

--- a/pkgs/development/python-modules/pystrich/default.nix
+++ b/pkgs/development/python-modules/pystrich/default.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  pillow,
+  typing-extensions,
+  pytestCheckHook,
+  ezdxf,
+  fonttools,
+  hypothesis,
+  zxing-cpp,
+  dmtx-utils,
+  librsvg,
+  ghostscript,
+  nix-update-script,
+}:
+
+buildPythonPackage rec {
+  pname = "pystrich";
+  version = "0.20";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mmulqueen";
+    repo = "pyStrich";
+    tag = version;
+    hash = "sha256-08IKFJfcK0I+phUejUY7FHh2a7efR+UKrj+tsKEwSJ4=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    pillow
+    typing-extensions
+  ];
+
+  optional-dependencies = {
+    png = [ pillow ];
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    ezdxf
+    fonttools
+    hypothesis
+    zxing-cpp
+    dmtx-utils
+    librsvg
+    ghostscript
+  ];
+
+  pythonImportsCheck = [ "pystrich" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Pure-Python module to generate 1D and 2D barcodes";
+    homepage = "https://github.com/mmulqueen/pyStrich";
+    changelog = "https://github.com/mmulqueen/pyStrich/releases/tag/${version}";
+    license = lib.licenses.asl20;
+    mainProgram = "pystrich";
+    maintainers = with lib.maintainers; [ mmulqueen ];
+  };
+}

--- a/pkgs/development/python-modules/pystrich/default.nix
+++ b/pkgs/development/python-modules/pystrich/default.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  pillow,
+  typing-extensions,
+  pytestCheckHook,
+  ezdxf,
+  fonttools,
+  hypothesis,
+  zxing-cpp,
+  dmtx-utils,
+  librsvg,
+  ghostscript,
+  nix-update-script,
+}:
+
+buildPythonPackage rec {
+  pname = "pystrich";
+  version = "0.19";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mmulqueen";
+    repo = "pyStrich";
+    tag = version;
+    hash = "sha256-pdh41B/eGcyO4fZRRyNc0ZBvTmZqWq4Wao4K19/e4Dk=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    pillow
+    typing-extensions
+  ];
+
+  optional-dependencies = {
+    png = [ pillow ];
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    ezdxf
+    fonttools
+    hypothesis
+    zxing-cpp
+    dmtx-utils
+    librsvg
+    ghostscript
+  ];
+
+  pythonImportsCheck = [ "pystrich" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Pure-Python module to generate 1D and 2D barcodes";
+    homepage = "https://github.com/mmulqueen/pyStrich";
+    changelog = "https://github.com/mmulqueen/pyStrich/releases/tag/${version}";
+    license = lib.licenses.asl20;
+    mainProgram = "pystrich";
+    maintainers = with lib.maintainers; [ mmulqueen ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16284,6 +16284,10 @@ self: super: with self; {
 
   pystray = callPackage ../development/python-modules/pystray { };
 
+  pystrich = callPackage ../development/python-modules/pystrich {
+    inherit (pkgs) ghostscript;
+  };
+
   pysubs2 = callPackage ../development/python-modules/pysubs2 { };
 
   pysuezv2 = callPackage ../development/python-modules/pysuezv2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15971,6 +15971,10 @@ self: super: with self; {
 
   pystray = callPackage ../development/python-modules/pystray { };
 
+  pystrich = callPackage ../development/python-modules/pystrich {
+    inherit (pkgs) ghostscript;
+  };
+
   pysubs2 = callPackage ../development/python-modules/pysubs2 { };
 
   pysuezv2 = callPackage ../development/python-modules/pysuezv2 { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

New package for inclusion in nixpkgs. pyStrich is an established Python library for generating 1D and 2D barcodes. It also provides a CLI for ad-hoc use.

Repo: https://github.com/mmulqueen/pyStrich
Docs: https://www.method-b.uk/pyStrich/docs/index.html
PyPI: https://pypi.org/project/pyStrich/

I am the upstream maintainer and intend to keep the nix definition in sync.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
