### PR TITLE
xdg-desktop-portal: apply patch to fix graphical-session.target regression

### DIFF
--- a/pkgs/by-name/xd/xdg-desktop-portal/allow-no-graphical-session-target.patch
+++ b/pkgs/by-name/xd/xdg-desktop-portal/allow-no-graphical-session-target.patch
@@ -1,0 +1,36 @@
+From 77e837f0034d1b9237e09244fb17fed81c9c9e45 Mon Sep 17 00:00:00 2001
+From: Alessandro Astone <alessandro.astone@canonical.com>
+Date: Sun, 29 Mar 2026 23:10:03 +0200
+Subject: [PATCH] Allow service's start even if graphical-session is not
+ reached
+
+While this is not ideal, we need to support desktop environments that do not
+bind to graphical-session.target, at least as a temporary measure.
+
+We keep the After=graphical-session.target stanza, since 'After' will only
+affect the ordering of start operations if both are queued up to start, while
+it is a no-op if graphical-session.target is not pending start.
+
+This partially reverts commit 4d284de29d1d0740c9b80b634631a8f253287680.
+
+Resolves: https://github.com/flatpak/xdg-desktop-portal/issues/1983
+Bug-Fedora: https://bugzilla.redhat.com/show_bug.cgi?id=2481764
+Bug-Ubuntu: https://launchpad.net/bugs/2144855
+---
+ desktop-portal/xdg-desktop-portal.service.in | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/xdg-desktop-portal.service.in b/src/xdg-desktop-portal.service.in
+index 1029f5901..d7a9e8b55 100644
+--- a/src/xdg-desktop-portal.service.in
++++ b/src/xdg-desktop-portal.service.in
+@@ -4,7 +4,8 @@
+ [Unit]
+ Description=Portal service
+ PartOf=graphical-session.target
+-Requisite=graphical-session.target
++Requires=dbus.service
++After=dbus.service
+ After=graphical-session.target
+ 
+ [Service]

--- a/pkgs/by-name/xd/xdg-desktop-portal/package.nix
+++ b/pkgs/by-name/xd/xdg-desktop-portal/package.nix
@@ -81,6 +81,9 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Allow installing installed tests to a separate output.
     ./installed-tests-path.patch
+
+    # See https://github.com/flatpak/xdg-desktop-portal/issues/1983#issuecomment-4651275776
+    ./allow-no-graphical-session-target.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
`xdg-desktop-portal.service` doesn't start anymore on desktops which do not use `graphical-session.target`.
See https://github.com/flatpak/xdg-desktop-portal/issues/1983#issuecomment-4651275776

Tested with `nixosTests.mate-wayland.driverInteractive`.
`xdg-desktop-portal.service` failed to start before this patch, starts successfully afterwards.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
