### PR TITLE
gnugrep: enable strictDeps, enable structuredAttrs, modernize

### DIFF
--- a/pkgs/by-name/gn/gnugrep/package.nix
+++ b/pkgs/by-name/gn/gnugrep/package.nix
@@ -15,16 +15,12 @@
 # cgit) that are needed here should be included directly in Nixpkgs as
 # files.
 
-let
-  version = "3.12";
-in
-
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gnugrep";
-  inherit version;
+  version = "3.12";
 
   src = fetchurl {
-    url = "mirror://gnu/grep/grep-${version}.tar.xz";
+    url = "mirror://gnu/grep/grep-${finalAttrs.version}.tar.xz";
     hash = "sha256-JkmyfA6Q5jLq3NdXvgbG6aT0jZQd5R58D4P/dkCKB7k=";
   };
 
@@ -39,13 +35,9 @@ stdenv.mkDerivation {
   # - on Musl: https://github.com/NixOS/nixpkgs/pull/228714
   # - on x86_64-darwin: https://github.com/NixOS/nixpkgs/pull/228714#issuecomment-1576826330
   # - when building on Darwin (cross-compilation): test-nl_langinfo-mt fails
-  postPatch =
-    if stdenv.hostPlatform.isMusl || stdenv.buildPlatform.isDarwin then
-      ''
-        sed -i 's:gnulib-tests::g' Makefile.in
-      ''
-    else
-      null;
+  postPatch = lib.optionalString (stdenv.hostPlatform.isMusl || stdenv.buildPlatform.isDarwin) ''
+    substituteInPlace Makefile.in --replace-fail "gnulib-tests" ""
+  '';
 
   nativeCheckInputs = [
     perl
@@ -120,7 +112,7 @@ stdenv.mkDerivation {
     teams = [ lib.teams.security-review ];
     platforms = lib.platforms.all;
     mainProgram = "grep";
-    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnu" version // {
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnu" finalAttrs.version // {
       product = "grep";
     };
   };
@@ -128,4 +120,4 @@ stdenv.mkDerivation {
   passthru = {
     inherit pcre2;
   };
-}
+})

--- a/pkgs/by-name/gn/gnugrep/package.nix
+++ b/pkgs/by-name/gn/gnugrep/package.nix
@@ -63,6 +63,8 @@ stdenv.mkDerivation {
   ]
   ++ lib.optional (!stdenv.hostPlatform.isWindows) runtimeShellPackage;
 
+  strictDeps = true;
+
   # cygwin: FAIL: multibyte-white-space
   # freebsd: FAIL mb-non-UTF8-performance
   # x86_64-darwin: fails 'stack-overflow' tests on Rosetta 2 emulator

--- a/pkgs/by-name/gn/gnugrep/package.nix
+++ b/pkgs/by-name/gn/gnugrep/package.nix
@@ -99,6 +99,8 @@ stdenv.mkDerivation {
     NIX_CFLAGS_COMPILE = "-Wno-error=format-security";
   };
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://www.gnu.org/software/grep/";
     description = "GNU implementation of the Unix grep command";


### PR DESCRIPTION
Tested on top of master as part of https://github.com/NixOS/nixpkgs/compare/master...SFrijters:nixpkgs:lowlevel-structuredattrs with 

`nixpkgs-review rev lowlevel-structuredattrs --package pkgsi686Linux.tests.stdenv --package gccgo --package pkgsi686Linux.gccgo --package tests.stdenv --package pkgsMusl.tests.stdenv`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
