### PR TITLE
python3Packages.textualeffects: fix meta.changelog url

### DIFF
--- a/pkgs/development/python-modules/textualeffects/default.nix
+++ b/pkgs/development/python-modules/textualeffects/default.nix
@@ -10,6 +10,7 @@ buildPythonPackage rec {
   pname = "textualeffects";
   version = "0.2.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/textualeffects/default.nix
+++ b/pkgs/development/python-modules/textualeffects/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   meta = {
     description = "Visual effects for Textual, a TerminalTextEffects wrapper";
     homepage = "https://github.com/ggozad/textualeffects";
-    changelog = "https://github.com/ggozad/textualeffects/blob/v${version}/CHANGES.txt";
+    changelog = "https://github.com/ggozad/textualeffects/releases/tag/${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ gaelj ];
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixed the changelog url and added `__structuredAttrs = true`

Tracking: https://github.com/NixOS/nixpkgs/issues/514132

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
