### PR TITLE
mdk-sdk: support aarch64-darwin; 0.35.1 -> 0.37.0

### DIFF
--- a/pkgs/by-name/md/mdk-sdk/package.nix
+++ b/pkgs/by-name/md/mdk-sdk/package.nix
@@ -12,6 +12,7 @@
   libglvnd,
   libpulseaudio,
   libxcb,
+  lz4,
   wayland,
   xz,
   zlib,
@@ -31,16 +32,16 @@ let
     }
     .${stdenv.hostPlatform.system} or "";
 
-  version = "0.35.1";
+  version = "0.37.0";
 
   linux = {
     url = "https://github.com/wang-bin/mdk-sdk/releases/download/v${version}/mdk-sdk-linux.tar.xz";
-    hash = "sha256-qdsYWu0bRRhPTbOEeGBFhPdk3S2JpqroOz+gd3KMDts=";
+    hash = "sha256-bBneSsNHfMH2MoDddT1cOtnyWjRNYHo0UTqnjrLpk4Q=";
   };
 
   darwin = {
     url = "https://github.com/wang-bin/mdk-sdk/releases/download/v${version}/mdk-sdk-apple.tar.xz";
-    hash = "sha256-u70LG4SiQnP9Fh0MEo7DHX1ISAvq37A9D0FMIOU/aAY=";
+    hash = "sha256-KGKzwy/unzkCUoh/dGjk0BVEUgDdMx5jy1Qt5C357DQ=";
   };
 
   sources = {
@@ -72,6 +73,7 @@ stdenv.mkDerivation {
     libglvnd
     libpulseaudio
     libxcb
+    lz4
     wayland
     xz
     zlib

--- a/pkgs/by-name/md/mdk-sdk/package.nix
+++ b/pkgs/by-name/md/mdk-sdk/package.nix
@@ -29,20 +29,40 @@ let
       aarch64-linux = "arm64";
       x86_64-linux = "amd64";
     }
-    .${stdenv.hostPlatform.system};
-in
-stdenv.mkDerivation rec {
-  pname = "mdk-sdk";
+    .${stdenv.hostPlatform.system} or "";
+
   version = "0.35.1";
 
-  src = fetchurl {
+  linux = {
     url = "https://github.com/wang-bin/mdk-sdk/releases/download/v${version}/mdk-sdk-linux.tar.xz";
     hash = "sha256-qdsYWu0bRRhPTbOEeGBFhPdk3S2JpqroOz+gd3KMDts=";
   };
 
-  nativeBuildInputs = [ autoPatchelfHook ];
+  darwin = {
+    url = "https://github.com/wang-bin/mdk-sdk/releases/download/v${version}/mdk-sdk-apple.tar.xz";
+    hash = "sha256-u70LG4SiQnP9Fh0MEo7DHX1ISAvq37A9D0FMIOU/aAY=";
+  };
 
-  buildInputs = [
+  sources = {
+    aarch64-linux = linux;
+    x86_64-linux = linux;
+    aarch64-darwin = darwin;
+  };
+
+  source =
+    sources.${stdenv.hostPlatform.system} or (throw "Unsupported system ${stdenv.hostPlatform.system}");
+in
+stdenv.mkDerivation {
+  pname = "mdk-sdk";
+  inherit version;
+
+  src = fetchurl { inherit (source) url hash; };
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+
+  dontStrip = stdenv.hostPlatform.isDarwin;
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     alsa-lib
     gcc-unwrapped
     libx11
@@ -61,34 +81,49 @@ stdenv.mkDerivation rec {
     fribidi
   ];
 
-  appendRunpaths = lib.makeLibraryPath [
-    libva
-    libvdpau
-    addDriverRunpath.driverLink
+  appendRunpaths = lib.optionalString stdenv.hostPlatform.isLinux (
+    lib.makeLibraryPath [
+      libva
+      libvdpau
+      addDriverRunpath.driverLink
+    ]
+  );
+
+  autoPatchelfIgnoreMissingDeps = lib.optionals stdenv.hostPlatform.isLinux [
+    "librockchip_mpp.so.1"
   ];
 
-  autoPatchelfIgnoreMissingDeps = [ "librockchip_mpp.so.1" ];
+  installPhase =
+    if stdenv.hostPlatform.isDarwin then
+      ''
+        runHook preInstall
 
-  installPhase = ''
-    runHook preInstall
+        mkdir -p $out/lib $out/Frameworks
+        cp -a lib/mdk.xcframework/macos-arm64_x86_64/mdk.framework $out/lib/
+        cp -a lib/cmake $out/lib/cmake
+        ln -s ../lib/mdk.framework $out/Frameworks/mdk.framework
+        cp -a include $out/include
 
-    mkdir $out
-    cp -r include $out/include
-    cp -r lib/${arch} $out/lib
-    cp -r lib/cmake $out/lib/cmake
-    ln -s . $out/lib/${arch}
+        runHook postInstall
+      ''
+    else
+      ''
+        runHook preInstall
 
-    runHook postInstall
-  '';
+        mkdir $out
+        cp -r include $out/include
+        cp -r lib/${arch} $out/lib
+        cp -r lib/cmake $out/lib/cmake
+        ln -s . $out/lib/${arch}
+
+        runHook postInstall
+      '';
 
   meta = {
     description = "Multimedia development kit";
     homepage = "https://github.com/wang-bin/mdk-sdk";
     license = lib.licenses.unfree;
     maintainers = [ ];
-    platforms = [
-      "x86_64-linux"
-      "aarch64-linux"
-    ];
+    platforms = builtins.attrNames sources;
   };
 }


### PR DESCRIPTION
Add it support for aarch64-darwin and bump to latest version.
Cherry-picked from https://github.com/NixOS/nixpkgs/pull/548433

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
