### PR TITLE
memgraph: init at 3.12.0 

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -74,6 +74,8 @@
 
 - [Entropy](https://github.com/ergohaven/entropy), a configurator for programmable keyboards and input devices running Vial-QMK/RMK firmware. Available as [programs.entropy](#opt-programs.entropy.enable).
 
+- [Memgraph](https://memgraph.com/), a high performance, in-memory, transactional graph database. Available as [services.memgraph](#opt-services.memgraph.enable).
+
 ## Backward Incompatibilities {#sec-release-26.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -548,6 +548,7 @@
   ./services/databases/influxdb.nix
   ./services/databases/lldap.nix
   ./services/databases/memcached.nix
+  ./services/databases/memgraph.nix
   ./services/databases/monetdb.nix
   ./services/databases/mongodb.nix
   ./services/databases/mysql.nix

--- a/nixos/modules/services/databases/memgraph.nix
+++ b/nixos/modules/services/databases/memgraph.nix
@@ -1,0 +1,170 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.memgraph;
+
+in
+{
+  options.services.memgraph = {
+    enable = lib.mkEnableOption "High-performance open-source in-memory graph database";
+    package = lib.mkPackageOption pkgs "memgraph" { };
+
+    settings = lib.mkOption {
+      description = ''
+        See <https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags>
+      '';
+      type = lib.types.submodule {
+        freeformType = lib.types.attrsOf (
+          lib.types.oneOf [
+            lib.types.str
+            lib.types.int
+            lib.types.path
+            lib.types.bool
+          ]
+        );
+        options = {
+          bolt-address = lib.mkOption {
+            description = "IP address on which the Bolt server should listen";
+            type = lib.types.str;
+            default = "0.0.0.0";
+          };
+          bolt-port = lib.mkOption {
+            description = "Port on which the Bolt server should listen";
+            type = lib.types.port;
+            default = 7687;
+          };
+
+          metrics-address = lib.mkOption {
+            description = "Host for HTTP server for exposing metrics";
+            type = lib.types.str;
+            default = "0.0.0.0";
+          };
+          metrics-port = lib.mkOption {
+            description = "Port for HTTP server for exposing metrics";
+            type = lib.types.port;
+            default = 9091;
+          };
+
+          monitoring-address = lib.mkOption {
+            description = "IP address where the Memgraph's monitoring WebSocket server should listen";
+            type = lib.types.str;
+            default = "0.0.0.0";
+          };
+          monitoring-port = lib.mkOption {
+            description = "Port on which the Memgraph's monitoring WebSocket server should listen";
+            type = lib.types.port;
+            default = 7444;
+          };
+
+          data-directory = lib.mkOption {
+            description = "Path to directory in which to save all permanent data";
+            type = lib.types.path;
+            default = "/var/lib/memgraph";
+            readOnly = true;
+          };
+        };
+      };
+      default = { };
+      example = lib.literalExpression ''
+        {
+          telemetry-enabled = false;
+          init-file = ./create_users.cypherl;
+        }
+      '';
+    };
+
+    environmentFile = lib.mkOption {
+      description = ''
+        Path to environment file containing secrets like MEMGRAPH_USER or MEMGRAPH_PASSWORD.
+        {option}`services.memgraph.settings` take precedence over these
+
+        See <https://memgraph.com/docs/database-management/configuration#environment-variables>
+      '';
+      type = lib.types.nullOr lib.types.path;
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    networking.firewall.allowedTCPPorts = [
+      cfg.settings.bolt-port
+      cfg.settings.metrics-port
+      cfg.settings.monitoring-port
+    ];
+    environment.systemPackages = [ cfg.package ];
+    systemd.services.memgraph = {
+      description = "Memgraph: High performance, in-memory, transactional graph database";
+      documentation = [ "https://memgraph.com/docs" ];
+
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${lib.getExe cfg.package} ${
+          lib.escapeShellArgs (
+            builtins.map (
+              { name, value }:
+              "--${name}=${if builtins.isBool value then lib.boolToString value else toString value}"
+            ) (lib.attrsToList cfg.settings)
+          )
+        }";
+        EnvironmentFile = lib.mkIf (cfg.environmentFile != null) cfg.environmentFile;
+        DynamicUser = true;
+        StateDirectory = "memgraph";
+        WorkingDirectory = "/var/lib/memgraph";
+        StateDirectoryMode = "1700";
+
+        CapabilityBoundingSet = [ "" ];
+        DeviceAllow = [ "" ];
+        KeyringMode = "private";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProcSubset = "all"; # Required to check on vm.max_map_count
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        ReadWritePaths = [ "/var/lib/memgraph" ];
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+          "~@resources"
+        ];
+        SystemCallErrorNumber = "EPERM";
+      };
+    };
+
+    services.logrotate.settings.memgraph = lib.mkIf (cfg.settings.audit-enabled or false) {
+      files = "/var/lib/memgraph/audit/audit.log";
+      frequency = "daily";
+      rotate = 365;
+      postrotate = "${lib.getExe pkgs.killall} -s SIGUSR2 memgraph";
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ kip93 ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1033,6 +1033,7 @@ in
   };
   meilisearch = runTest ./meilisearch.nix;
   memcached = runTest ./memcached.nix;
+  memgraph = runTest ./memgraph.nix;
   merecat = runTest ./merecat.nix;
   meshtasticd = runTest ./networking/meshtasticd.nix;
   metabase = runTest ./metabase.nix;

--- a/nixos/tests/memgraph.nix
+++ b/nixos/tests/memgraph.nix
@@ -1,0 +1,68 @@
+{ lib, ... }: {
+  name = "memgraph";
+  containers.machine.services.memgraph.enable = true;
+  testScript = { containers, ... }: ''
+    import csv
+    from shlex import quote
+
+    def mgconsole(cmd: str):
+      return list(csv.reader(machine.succeed(f"""
+        printf '%s\\n' {quote(cmd)} | tee /dev/stderr \
+        | mgconsole --output_format=csv | tee /dev/stderr
+      """).splitlines()))
+
+    machine.wait_for_unit("memgraph.service")
+    machine.wait_for_open_port(7687)
+
+    assert mgconsole("""
+      SHOW VERSION;
+    """) == [
+      ["version"],
+      ['"${containers.machine.services.memgraph.package.version}"'],
+    ]
+    assert mgconsole("""
+      CREATE INDEX ON :Person(name);
+    """) == []
+    assert mgconsole("""
+      SHOW INDEX INFO;
+    """) == [
+      ["index type",       "label",    "property", "count"],
+      ['"label+property"', '"Person"', '["name"]', "0"],
+    ]
+    assert mgconsole("""
+      CREATE CONSTRAINT ON (p:Person)
+      ASSERT EXISTS (p.name);
+      CREATE CONSTRAINT ON (p:Person)
+      ASSERT p.name IS TYPED STRING;
+    """) == []
+    assert mgconsole("""
+      SHOW CONSTRAINT INFO;
+    """) == [
+      ["constraint type", "label",    "properties", "data_type"],
+      ['"exists"',        '"Person"', '"name"',     '""'],
+      ['"data_type"',     '"Person"', '"name"',     '"STRING"'],
+    ]
+    assert mgconsole("""
+      CREATE
+        (alice:Person {name: "alice"}),
+        (bob:Person {name: "bob"}),
+        (alice)-[:KNOWS]->(bob),
+        (bob)-[:KNOWS]->(alice);
+    """) == []
+    assert mgconsole("""
+      MATCH (n:Person) RETURN count(n) AS people;
+    """) == [
+      ["people"],
+      ["2"],
+    ]
+    assert mgconsole("""
+      MATCH (:Person)-[r:KNOWS]->(:Person)
+      RETURN count(r) AS knows;
+    """) == [
+      ["knows"],
+      ["2"],
+    ]
+  '';
+
+  meta.maintainers = with lib.maintainers; [ kip93 ];
+}

--- a/pkgs/by-name/me/memgraph/package.nix
+++ b/pkgs/by-name/me/memgraph/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  dpkg,
+  libseccomp,
+  libuuid,
+  openssl,
+  python313,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "memgraph";
+  version = "3.12.0";
+  src = fetchurl {
+    url = "https://download.memgraph.com/memgraph/v${finalAttrs.version}/debian-13${lib.optionalString stdenv.hostPlatform.isAarch64 "-aarch64"}/memgraph_${finalAttrs.version}-1_${
+      {
+        "x86_64-linux" = "amd64";
+        "aarch64-linux" = "arm64";
+      }
+      .${stdenv.hostPlatform.system}
+    }.deb";
+    hash =
+      {
+        "x86_64-linux" = "sha256-4GGp2A8X9FZcW71hZ9SAlI8c/ulJrH94TKhRbDAYOpU=";
+        "aarch64-linux" = "sha256-JQ6pnKNdK1nIxIG4SP2m6/AHcY6ln73xwYfkP6czHt8=";
+      }
+      .${stdenv.hostPlatform.system} or lib.fakeHash;
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+  ];
+  buildInputs = [
+    (lib.getLib stdenv.cc.cc)
+    libseccomp
+    libuuid
+    openssl
+    python313
+  ];
+
+  unpackPhase = ''
+    dpkg -X $src .
+  '';
+  dontConfigure = true;
+  dontBuild = true;
+  installPhase = ''
+    mkdir -p $out
+
+    mv ./etc $out/etc
+    mv ./usr/bin $out/bin
+    mv ./usr/include $out/include
+    mv ./usr/lib $out/lib
+    mv ./usr/share $out/share
+
+    ln -sf ../lib/memgraph/memgraph $out/bin
+  '';
+
+  meta = with lib; {
+    description = "High-performance open-source in-memory graph database";
+    homepage = "https://memgraph.com/";
+    changelog = "https://memgraph.com/docs/release-notes";
+    mainProgram = "memgraph";
+    license = licenses.bsl11;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    maintainers = with maintainers; [ kip93 ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/me/memgraph/package.nix
+++ b/pkgs/by-name/me/memgraph/package.nix
@@ -8,6 +8,7 @@
   libuuid,
   openssl,
   python313,
+  nixosTests,
 }:
 stdenv.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
@@ -59,6 +60,10 @@ stdenv.mkDerivation (finalAttrs: {
 
     ln -sf ../lib/memgraph/memgraph $out/bin
   '';
+
+  passthru.tests = {
+    inherit (nixosTests) memgraph;
+  };
 
   meta = with lib; {
     description = "High-performance open-source in-memory graph database";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Memgraph is a high performance, in-memory, transactional graph database; with compatibility with Neo4j's Cypher language.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
