### PR TITLE
papis: fix isbn importer by upstream patch

### DIFF
--- a/pkgs/development/python-modules/papis/default.nix
+++ b/pkgs/development/python-modules/papis/default.nix
@@ -139,6 +139,11 @@ buildPythonPackage (finalAttrs: {
       url = "https://github.com/papis/papis/commit/15cae5986ae9dec75c7d103757adbd73c39feb89.patch?full_index=1";
       hash = "sha256-kuVZdOd+H99TinM7yAs7NJrfw7rOPyxDlSaT0P2NeC4=";
     })
+    # Commit ae77020: feat: show error instead of raising when missing isbnlib
+    (fetchpatch2 {
+      url = "https://github.com/papis/papis/commit/ae77020dcb3d44613f66c69e3ba86d55e2f2cb3e.patch?full_index=1";
+      hash = "sha256-BewySBqLoV8ID62vmT4lgRxrQVVXBIUgwpbEaTUy+X8=";
+    })
   ];
 
   meta = {


### PR DESCRIPTION
Although papis tests pass with no failures (since we included commit 15cae59 that conditionally skips them), the importer itself doesn't function as it should be. 

```sh
$ papis add ~/paper.pdf
[INFO] config: Registering the only library as the default.
[INFO] importer.bibtex: Reading input file or string: '/<HOME>/paper.pdf'.
[ERROR] importer.bibtex: Error reading BibTeX file or string: '/<HOME>/vrst26a-sub1381-i5.pdf'. (Caught exception 'UnicodeDecodeError: 'utf-8' codec can't decode byte 0xbf in...'. Use `--log DEBUG` to see traceback)
Traceback (most recent call last):
  File "/nix/store/wl4vs3ph8ckqad6vgaigqm68rn07akgl-python3.14-papis-0.15.0/bin/.papis-wrapped", line 9, in <module>
    sys.exit(run())
             ~~~^^
  File "/nix/store/g7d1j2jd853b4msxkp1ia5vaam8lcv7h-python3.14-click-8.3.3/lib/python3.14/site-packages/click/core.py", line 1514, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/nix/store/g7d1j2jd853b4msxkp1ia5vaam8lcv7h-python3.14-click-8.3.3/lib/python3.14/site-packages/click/core.py", line 1435, in main
    rv = self.invoke(ctx)
  File "/nix/store/g7d1j2jd853b4msxkp1ia5vaam8lcv7h-python3.14-click-8.3.3/lib/python3.14/site-packages/click/core.py", line 1902, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/nix/store/g7d1j2jd853b4msxkp1ia5vaam8lcv7h-python3.14-click-8.3.3/lib/python3.14/site-packages/click/core.py", line 1298, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/g7d1j2jd853b4msxkp1ia5vaam8lcv7h-python3.14-click-8.3.3/lib/python3.14/site-packages/click/core.py", line 853, in invoke
    return callback(*args, **kwargs)
  File "/nix/store/wl4vs3ph8ckqad6vgaigqm68rn07akgl-python3.14-papis-0.15.0/lib/python3.14/site-packages/papis/commands/add.py", line 507, in cli
    importers = list(
        chain.from_iterable(
            get_matching_importers_by_uri(f, include_downloaders=True)
            for f in files))
  File "/nix/store/wl4vs3ph8ckqad6vgaigqm68rn07akgl-python3.14-papis-0.15.0/lib/python3.14/site-packages/papis/commands/add.py", line 509, in <genexpr>
    get_matching_importers_by_uri(f, include_downloaders=True)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/wl4vs3ph8ckqad6vgaigqm68rn07akgl-python3.14-papis-0.15.0/lib/python3.14/site-packages/papis/importer/__init__.py", line 286, in get_matching_importers_by_uri
    result = match(IMPORTER_NAMESPACE_NAME)
  File "/nix/store/wl4vs3ph8ckqad6vgaigqm68rn07akgl-python3.14-papis-0.15.0/lib/python3.14/site-packages/papis/importer/__init__.py", line 269, in match
    importer = cls.match(uri)
  File "/nix/store/wl4vs3ph8ckqad6vgaigqm68rn07akgl-python3.14-papis-0.15.0/lib/python3.14/site-packages/papis/importer/isbn.py", line 14, in match
    from isbnlib import notisbn
ModuleNotFoundError: No module named 'isbnlib'
```

Cherry-picking commit `ae77020` from upstream fixes the issue.

This commit should have been included in the previous PR #547844.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] ~Package update: when the change is major or breaking.~
- NixOS Release Notes
  - [x] ~Module addition: when adding a new NixOS module.~
  - [x] ~Module update: when the change is significant.~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
