### PR TITLE
zxing-cpp: enable old and new writers, 3.0.2 -> 3.1.1

### DIFF
--- a/pkgs/by-name/zx/zxing-cpp/package.nix
+++ b/pkgs/by-name/zx/zxing-cpp/package.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "zxing-cpp";
-  version = "3.0.2";
+  version = "3.1.1";
 
   src = fetchFromGitHub {
     owner = "zxing-cpp";
     repo = "zxing-cpp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ZtjvHBnuPJkc9kU998jH7IPlX3jF/RGtLNWDzsb0v4A=";
+    hash = "sha256-dCqn2qYQGHY/nmwwkgd4uGoKp0YeQxWiHpS0Hhsm+UE=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/zx/zxing-cpp/package.nix
+++ b/pkgs/by-name/zx/zxing-cpp/package.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-DZXING_DEPENDENCIES=LOCAL"
     "-DZXING_EXAMPLES=OFF"
     "-DZXING_USE_BUNDLED_ZINT=OFF"
+    (lib.cmakeFeature "ZXING_WRITERS" "BOTH")
   ];
 
   passthru = {

--- a/pkgs/development/python-modules/zxing-cpp/default.nix
+++ b/pkgs/development/python-modules/zxing-cpp/default.nix
@@ -1,14 +1,16 @@
 {
+  lib,
   buildPythonPackage,
   cmake,
-  setuptools-scm,
+  ninja,
+  scikit-build-core,
   numpy,
   pillow,
-  pybind11,
+  nanobind,
   libzxing-cpp,
-  pyprojectVersionPatchHook,
   pytestCheckHook,
   libzint,
+  python,
 }:
 
 buildPythonPackage {
@@ -18,32 +20,31 @@ buildPythonPackage {
 
   sourceRoot = "${libzxing-cpp.src.name}/wrappers/python";
 
-  # we don't need pybind11 in the root environment
-  # https://pybind11.readthedocs.io/en/stable/installing.html#include-with-pypi
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail "pybind11[global]" "pybind11"
-
-    substituteInPlace setup.py \
-      --replace-fail "cfg = 'Debug' if self.debug else 'Release'" "cfg = 'Release'" \
-      --replace-fail "f'-DPython_EXECUTABLE={sys.executable}'," "f'-DPython_EXECUTABLE={sys.executable}', '-DZXING_DEPENDENCIES=LOCAL', '-DZXING_USE_BUNDLED_ZINT=OFF',"
-  '';
-
   dontUseCmakeConfigure = true;
 
+  env = {
+    nanobind_DIR = "${nanobind}/${python.sitePackages}/nanobind/cmake";
+  };
+
+  cmakeFlags = [
+    (lib.cmakeBool "ZXING_USE_BUNDLED_ZINT" false)
+  ];
+
   build-system = [
-    setuptools-scm
-    pybind11
+    scikit-build-core
+    nanobind
   ];
 
   dependencies = [ numpy ];
 
   nativeBuildInputs = [
     cmake
-    pyprojectVersionPatchHook
+    ninja
   ];
 
-  buildInputs = [ libzint ];
+  buildInputs = [
+    libzint
+  ];
 
   nativeCheckInputs = [
     pillow


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
See https://github.com/zxing-cpp/zxing-cpp/releases/tag/v3.0.1
> It is generally advised for package maintainers to use the BOTH config option during the 3.0 release cycle to allow client applications (like e.g. LibreOffice) to work until they switch to the new API.

This broke `liblinphone`'s build.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
