### PR TITLE
deno: fix find expression in preInstall, move libdenort.so to its own output

### DIFF
--- a/pkgs/by-name/de/deno/package.nix
+++ b/pkgs/by-name/de/deno/package.nix
@@ -43,6 +43,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   outputs = [
     "out"
     "denort"
+    "libdenort"
   ];
 
   src = fetchFromGitHub {
@@ -244,6 +245,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   postInstall = ''
     moveToOutput "bin/denort" "$denort"
+    moveToOutput "lib/libdenort${stdenv.hostPlatform.extensions.sharedLibrary}" "$libdenort"
 
     # Remove non-essential binaries like test_server
     find $out/bin/* -not -name "deno" -delete

--- a/pkgs/by-name/de/deno/package.nix
+++ b/pkgs/by-name/de/deno/package.nix
@@ -236,9 +236,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   preInstall = ''
     # Delete generated shared libraries that aren't needed in the final package
     find ./target \
-      -name "libswc_common${stdenv.hostPlatform.extensions.sharedLibrary}" -o \
+      \( -name "libswc_common${stdenv.hostPlatform.extensions.sharedLibrary}" -o \
       -name "libtest_ffi${stdenv.hostPlatform.extensions.sharedLibrary}" -o \
-      -name "libtest_napi${stdenv.hostPlatform.extensions.sharedLibrary}" \
+      -name "libtest_napi${stdenv.hostPlatform.extensions.sharedLibrary}" \) \
       -delete
   '';
 


### PR DESCRIPTION
- Fix find expression in preInstall
   `-delete` only applied to the last -name branch, so libtest_ffi and
   libswc_common stayed in the package. Parenthesize the -o chain.
- Move libdenort.so to its own output
   Move it out of $out into a dedicated libdenort output to reduce the deno
   closure size, like denort already is (5e8a08a2a8c8).
   libdenort.so is large (~112M) and not linked by the deno CLI. It is the
   base for `deno desktop`, and upstream ships it as a separate artifact.

Before:
```
$ du -sh /nix/store/1w42p7jj0dmw525pnnlsj9496fsb30fc-deno-2.9.4/*/*  
138M	/nix/store/1w42p7jj0dmw525pnnlsj9496fsb30fc-deno-2.9.4/bin/deno
16K	/nix/store/1w42p7jj0dmw525pnnlsj9496fsb30fc-deno-2.9.4/bin/dx
112M	/nix/store/1w42p7jj0dmw525pnnlsj9496fsb30fc-deno-2.9.4/lib/libdenort.so
440K	/nix/store/1w42p7jj0dmw525pnnlsj9496fsb30fc-deno-2.9.4/lib/libtest_ffi.so
368K	/nix/store/1w42p7jj0dmw525pnnlsj9496fsb30fc-deno-2.9.4/share/bash-completion
484K	/nix/store/1w42p7jj0dmw525pnnlsj9496fsb30fc-deno-2.9.4/share/fish
360K	/nix/store/1w42p7jj0dmw525pnnlsj9496fsb30fc-deno-2.9.4/share/zsh
```

After:
```
$ du -sh /nix/store/2xg5nni7hdqbrl7vk2dbql6k9y875bh2-deno-2.9.4/*/*  
138M	/nix/store/2xg5nni7hdqbrl7vk2dbql6k9y875bh2-deno-2.9.4/bin/deno
16K	/nix/store/2xg5nni7hdqbrl7vk2dbql6k9y875bh2-deno-2.9.4/bin/dx
368K	/nix/store/2xg5nni7hdqbrl7vk2dbql6k9y875bh2-deno-2.9.4/share/bash-completion
484K	/nix/store/2xg5nni7hdqbrl7vk2dbql6k9y875bh2-deno-2.9.4/share/fish
360K	/nix/store/2xg5nni7hdqbrl7vk2dbql6k9y875bh2-deno-2.9.4/share/zsh
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
