### PR TITLE
python3Packages.graph-tool: 2.98 -> 3.6

### DIFF
--- a/pkgs/development/python-modules/graph-tool/default.nix
+++ b/pkgs/development/python-modules/graph-tool/default.nix
@@ -24,6 +24,9 @@
   scipy,
   sparsehash,
   zstandard,
+
+  writableTmpDirAsHomeHook,
+
   gitUpdater,
 }:
 
@@ -43,13 +46,17 @@ let
     inherit python;
   };
 in
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "graph-tool";
   version = "2.98";
   pyproject = false;
 
+  strictDeps = true;
+
+  __structuredAttrs = true;
+
   src = fetchurl {
-    url = "https://downloads.skewed.de/graph-tool/graph-tool-${version}.tar.bz2";
+    url = "https://downloads.skewed.de/graph-tool/graph-tool-${finalAttrs.version}.tar.bz2";
     hash = "sha256-7vGUi5N/XwQ3Se7nX+DG1+jwNlUdlF6dVeN4cLBsxSc=";
   };
 
@@ -109,10 +116,11 @@ buildPythonPackage rec {
 
   propagatedNativeBuildInputs = [ gobject-introspection ];
 
+  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
+
   preInstallCheck =
     # avoid warnings about Matplotlib and Fontconfig configuration issues
     ''
-      export HOME=$(mktemp -d)
       export FONTCONFIG_FILE=${fontconfig.out}/etc/fonts/fonts.conf
     '';
 
@@ -126,8 +134,8 @@ buildPythonPackage rec {
   meta = {
     description = "Python module for manipulation and statistical analysis of graphs";
     homepage = "https://graph-tool.skewed.de";
-    changelog = "https://git.skewed.de/count0/graph-tool/commits/release-${version}";
+    changelog = "https://git.skewed.de/count0/graph-tool/commits/release-${finalAttrs.version}";
     license = lib.licenses.lgpl3Plus;
     maintainers = [ lib.maintainers.mjoerg ];
   };
-}
+})

--- a/pkgs/development/python-modules/graph-tool/default.nix
+++ b/pkgs/development/python-modules/graph-tool/default.nix
@@ -21,7 +21,6 @@
   pygobject3,
   python,
   scipy,
-  sparsehash,
   zstandard,
 
   writableTmpDirAsHomeHook,
@@ -37,7 +36,7 @@ let
 in
 buildPythonPackage (finalAttrs: {
   pname = "graph-tool";
-  version = "2.98";
+  version = "3.6";
   pyproject = false;
 
   strictDeps = true;
@@ -46,7 +45,7 @@ buildPythonPackage (finalAttrs: {
 
   src = fetchurl {
     url = "https://downloads.skewed.de/graph-tool/graph-tool-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-7vGUi5N/XwQ3Se7nX+DG1+jwNlUdlF6dVeN4cLBsxSc=";
+    hash = "sha256-KFKitvz3zFEQAi8hkvIBC0c5QTRmOJRamdV0cyMbejU=";
   };
 
   postPatch =
@@ -71,6 +70,16 @@ buildPythonPackage (finalAttrs: {
       cgal = lib.getDev cgal;
       python-module-path = "$(out)/${python.sitePackages}";
     }
+    ++ [
+      # CXXFLAGS defaults to "-g -O2", if unset.
+      # "-g" produces debugging information, which significantly increases
+      # resource requirements during compilation, but is not necessary as we
+      # subsequently strip the binaries.
+      # "-ftemplate-backtrace-limit=1" reduces the number of template
+      # instantiation notes per warning in order to reduce the log file size.
+      # "-O3" is also used by upstream.
+      "CXXFLAGS=-ftemplate-backtrace-limit=1 -O3"
+    ]
     ++
       lib.optionals stdenv.cc.isGNU
         # enable GCC's link-time optimizer in order to reduce compilation time and memory usage during compilation
@@ -89,7 +98,6 @@ buildPythonPackage (finalAttrs: {
     cgal
     expat
     mpfr
-    sparsehash
   ]
   ++ lib.optionals stdenv.cc.isClang [ llvmPackages.openmp ];
 

--- a/pkgs/development/python-modules/graph-tool/default.nix
+++ b/pkgs/development/python-modules/graph-tool/default.nix
@@ -2,10 +2,9 @@
   buildPythonPackage,
   lib,
   fetchurl,
-  fetchpatch,
   stdenv,
 
-  boost189,
+  boost191,
   cairomm,
   cgal,
   expat,
@@ -31,17 +30,7 @@
 }:
 
 let
-  boost' = boost189.override {
-    patches = [
-      # required to build against Clang >= 21 (https://github.com/boostorg/lexical_cast/pull/87)
-      # TODO: drop when upgrading to Boost >= 1.90
-      (fetchpatch {
-        name = "Reduce-dependency-on-Boost.TypeTraits-now-that-C-11-.patch";
-        url = "https://github.com/boostorg/lexical_cast/commit/8fc8a19931c8cb452400af907959fdacbbdd8ec1.patch";
-        relative = "include";
-        hash = "sha256-OO39ejR+I5ufjqinrMJ6HgjTE7Ph+XBu50PqcIKaIQo=";
-      })
-    ];
+  boost' = boost191.override {
     enablePython = true;
     inherit python;
   };


### PR DESCRIPTION
https://git.skewed.de/count0/graph-tool/-/compare/refs/tags/release-2.98..refs/tags/release-3.6

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test