### PR TITLE
python3Packages.greenstalk: init at 2.1.1

### DIFF
--- a/pkgs/development/python-modules/greenstalk/default.nix
+++ b/pkgs/development/python-modules/greenstalk/default.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  hatchling,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "greenstalk";
+  version = "2.1.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-6Jt2lN2rvWlWK/4RFA/awa/J/ty+Lt9kZOr3w1VTPvg=";
+  };
+
+  build-system = [ hatchling ];
+
+  doCheck = false;
+
+  dependencies = [
+  ];
+
+  meta = {
+    description = "A Python client for the beanstalkd work queue";
+    homepage = "https://github.com/justinmayhew/greenstalk";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jbcrail ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7173,6 +7173,8 @@ self: super: with self; {
 
   greenplanet-energy-api = callPackage ../development/python-modules/greenplanet-energy-api { };
 
+  greenstalk = callPackage ../development/python-modules/greenstalk { };
+
   gremlinpython = callPackage ../development/python-modules/gremlinpython { };
 
   grep-ast = callPackage ../development/python-modules/grep-ast { };


### PR DESCRIPTION
I added a new package, [greenstalk](https://greenstalk.readthedocs.io/), a Python client for the [beanstalkd](https://beanstalkd.github.io) work queue.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
