### PR TITLE
[26.05] python3Packages.gitpython: 3.1.50 -> 3.1.58

### DIFF
--- a/pkgs/development/python-modules/gitpython/default.nix
+++ b/pkgs/development/python-modules/gitpython/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "gitpython";
-  version = "3.1.50";
+  version = "3.1.51";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "gitpython-developers";
     repo = "GitPython";
     tag = finalAttrs.version;
-    hash = "sha256-oHJrN/iYaAZUNPgOLS+8Ekr1eLES8APfXynmR4OySwk=";
+    hash = "sha256-c8tjBvWjVR7krR59Tfx5jKoJc/fcLWVt5D4xk15DvP4=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/gitpython/default.nix
+++ b/pkgs/development/python-modules/gitpython/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "gitpython";
-  version = "3.1.57";
+  version = "3.1.58";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "gitpython-developers";
     repo = "GitPython";
     tag = finalAttrs.version;
-    hash = "sha256-pCGDKwIefGqx/UJaVqrsofc0t+ntqZRPMhsdbK2XBB0=";
+    hash = "sha256-C6hrN7SRWngwkD/NYvsoEVQUagdurkxzWbnn42EJOHE=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/gitpython/default.nix
+++ b/pkgs/development/python-modules/gitpython/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "gitpython";
-  version = "3.1.51";
+  version = "3.1.57";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "gitpython-developers";
     repo = "GitPython";
     tag = finalAttrs.version;
-    hash = "sha256-c8tjBvWjVR7krR59Tfx5jKoJc/fcLWVt5D4xk15DvP4=";
+    hash = "sha256-pCGDKwIefGqx/UJaVqrsofc0t+ntqZRPMhsdbK2XBB0=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Backports GitPython 3.1.51, 3.1.57, and 3.1.58 to NixOS 26.05.

Security fixes:

- 3.1.51: CVE-2026-67323, CVE-2026-67324, and CVE-2026-67325 ([changelog](https://redirect.github.com/gitpython-developers/GitPython/blob/3.1.51/doc/source/changes.rst), [#541370](https://redirect.github.com/NixOS/nixpkgs/pull/541370)).
- 3.1.57: nine additional security advisories ([changelog](https://redirect.github.com/gitpython-developers/GitPython/blob/3.1.57/doc/source/changes.rst), [#548847](https://redirect.github.com/NixOS/nixpkgs/pull/548847)).
- 3.1.58: five high- and one medium-severity security advisories ([changelog](https://redirect.github.com/gitpython-developers/GitPython/blob/3.1.58/doc/source/changes.rst), [#549312](https://redirect.github.com/NixOS/nixpkgs/pull/549312)).

Validation on x86_64-linux:

- Built `python313Packages.gitpython` and `python314Packages.gitpython`.
- Security checks for the addressed advisories pass with Python 3.13 and 3.14.
- `nixpkgs-review` builds both packages successfully.
- Evaluation reports 607 Linux and 515 Darwin rebuilds.

Addresses #548546, #548548, and #549105.

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
