### PR TITLE
playdate-sdk: 3.1.0 -> 3.1.1

### DIFF
--- a/pkgs/by-name/pl/playdate-sdk/package.nix
+++ b/pkgs/by-name/pl/playdate-sdk/package.nix
@@ -14,11 +14,11 @@
 
 stdenv.mkDerivation rec {
   pname = "playdate-sdk";
-  version = "3.1.0";
+  version = "3.1.1";
 
   src = fetchurl {
     url = "https://download.panic.com/playdate_sdk/Linux/PlaydateSDK-${version}.tar.gz";
-    sha256 = "sha256-yKEl3UpVY3lB9LxAsx0RotTsNHv8WS76ZqpzRi6BSZg=";
+    sha256 = "sha256-K2RXTlZAoT/lZFlE+LUWnrX05MzgQ0gt3B1sRzXhFWs=";
   };
 
   srcScript = ./playdate-simulator-wrapper.sh;


### PR DESCRIPTION
## Things done

Update Playdate SDK from 3.1.0 to 3.1.1

Changelog: https://sdk.play.date/changelog/#_3_1_1

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
