### PR TITLE
siesta: 5.4.1 -> 5.4.2

### DIFF
--- a/pkgs/by-name/si/siesta/package.nix
+++ b/pkgs/by-name/si/siesta/package.nix
@@ -8,6 +8,7 @@
   useMpi ? false,
   mpi,
   fetchFromGitLab,
+  fetchpatch,
   cmake,
   pkg-config,
   readline,
@@ -18,15 +19,24 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "siesta";
-  version = "5.4.1";
+  version = "5.4.2";
 
   src = fetchFromGitLab {
     owner = "siesta-project";
     repo = "siesta";
     tag = finalAttrs.version;
-    hash = "sha256-pud8RlJAT+0TwyPRsbf5D/8FfLjZvPYPf84Xb7UH6os=";
+    hash = "sha256-J6cR8h6wMaofNLcTVyH9cr59FN533GhkviOQ4/5whIM=";
     fetchSubmodules = true;
   };
+
+  patches = [
+    # upstream patch, remove with next upgrade
+    (fetchpatch {
+      name = "gcc-bug-125383";
+      url = "https://gitlab.com/siesta-project/siesta/-/commit/bb6d7f5493c19078ecc236cf36b8672eeaf228c8.patch";
+      hash = "sha256-p7jE5m055m0XW/lJHtyHYmGIJ3Dz+5sLy0jcG/zyAqg=";
+    })
+  ];
 
   passthru = {
     inherit mpi;
@@ -59,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-DCMAKE_INSTALL_LIBDIR=lib"
   ];
 
-  enableParallelBuilding = false; # Started making trouble with gcc-11
+  enableParallelBuilding = true;
 
   preBuild =
     if useMpi then


### PR DESCRIPTION
Unbreak build and update.

Changelog: https://siesta-project.org/siesta/Documentation/Release_Notes/SIESTA-5.4.2_release_notes.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
