### PR TITLE
vscode-extensions.leanprover.lean4: build from source, bundle elan

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/leanprover.lean4/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/leanprover.lean4/default.nix
@@ -1,14 +1,117 @@
 {
   lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  clang_20,
+  elan,
+  libsecret,
+  nix-update-script,
+  nodejs,
+  npmHooks,
+  pkg-config,
+  replaceVars,
+  strip-nondeterminism,
   vscode-utils,
 }:
 
-vscode-utils.buildVscodeMarketplaceExtension {
-  mktplcRef = {
-    name = "lean4";
-    publisher = "leanprover";
+let
+  vsix = stdenv.mkDerivation (finalAttrs: {
+    name = "leanprover-lean4-${finalAttrs.version}.vsix";
+    pname = "leanprover-lean4-vsix";
     version = "0.0.239";
-    hash = "sha256-6XqjmClUzmyz1nkp/bLv5+F9cj7ZCp4+uAGIJgLDi+o=";
+
+    src = fetchFromGitHub {
+      owner = "leanprover";
+      repo = "vscode-lean4";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-aa3AFcxGpJMiKcoZbb5bhRglFpA2cXeUMjg/yWRyg94=";
+    };
+
+    npmDeps = fetchNpmDeps {
+      name = "${finalAttrs.pname}-npm-deps";
+      inherit (finalAttrs) src;
+      # `npmConfigHook` diffs the lockfile in the unpacked source against the one
+      # recorded here, so any patch that touches the lockfile has to be applied
+      # on both sides.
+      patches = [ ./sync-glob-version-with-lockfile.patch ];
+      fetcherVersion = 2;
+      hash = "sha256-wjimqeiqeXpHFsfarxdb2KRMAeS7X3VrXEpjb3HJv/A=";
+    };
+
+    buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ libsecret ];
+
+    nativeBuildInputs = [
+      nodejs
+      nodejs.python
+      npmHooks.npmConfigHook
+      strip-nondeterminism
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ pkg-config ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      clang_20 # clang_21 breaks @vscode/vsce's optional dependency keytar
+    ];
+
+    patches = [
+      # Upstream's package-lock.json pins `glob` 11.0.1 in the `vscode-lean4`
+      # workspace while its package.json asks for `^10.4.5`. `npm ci` tries to
+      # resolve the range against the registry, and the offline cache only holds
+      # the versions the lockfile mentions, so the build fails. Make the manifest
+      # agree with the lockfile so that no resolution is needed.
+      #
+      # Identical to the upstream fix; drop this, along with the copy in
+      # `npmDeps.patches`, once a release containing it is packaged here.
+      # TODO: link the upstream pull request.
+      ./sync-glob-version-with-lockfile.patch
+
+      # Opening a Lean file with no `lean` on the PATH makes the extension offer
+      # to download and install Lean's version manager Elan itself. Teach it to
+      # fall back to an Elan supplied at build time instead, so that no
+      # out-of-band installation is needed.
+      (replaceVars ./use-builtin-elan.patch { elan = lib.getBin elan; })
+    ];
+
+    strictDeps = true;
+
+    env.NX_DAEMON = "false";
+
+    buildPhase = ''
+      runHook preBuild
+
+      npm run build
+      # `vsce package` must run from the extension's own workspace, not the
+      # repository root.
+      (cd vscode-lean4 && npx vsce package --out $out)
+      # `vsce` stamps every zip entry with the current time, so the vsix is not
+      # reproducible as it comes out.
+      strip-nondeterminism --type zip $out
+
+      runHook postBuild
+    '';
+  });
+in
+vscode-utils.buildVscodeExtension (finalAttrs: {
+  pname = "leanprover-lean4";
+  inherit (finalAttrs.src) version;
+
+  vscodeExtPublisher = "leanprover";
+  vscodeExtName = "lean4";
+  vscodeExtUniqueId = "${finalAttrs.vscodeExtPublisher}.${finalAttrs.vscodeExtName}";
+
+  src = vsix;
+
+  # The `elan` path that `use-builtin-elan.patch` bakes into the bundle only
+  # survives as a registered store reference if `elan` is also an input of this
+  # derivation: Nix records references to the derivation's own inputs, and the
+  # inner vsix derivation cannot register it either because the string is
+  # compressed inside the zip where the scanner will not find it.
+  buildInputs = [ elan ];
+
+  passthru = {
+    vsix = finalAttrs.src;
+    updateScript = nix-update-script {
+      attrPath = "vscode-extensions.leanprover.lean4.vsix";
+    };
   };
 
   meta = {
@@ -18,4 +121,4 @@ vscode-utils.buildVscodeMarketplaceExtension {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ alexstaeding ];
   };
-}
+})

--- a/pkgs/applications/editors/vscode/extensions/leanprover.lean4/sync-glob-version-with-lockfile.patch
+++ b/pkgs/applications/editors/vscode/extensions/leanprover.lean4/sync-glob-version-with-lockfile.patch
@@ -1,0 +1,35 @@
+diff --git a/package-lock.json b/package-lock.json
+index 1f93e8db..5159d4df 100644
+--- a/package-lock.json
++++ b/package-lock.json
+@@ -11794,7 +11794,7 @@
+         },
+         "vscode-lean4": {
+             "name": "lean4",
+-            "version": "0.0.238",
++            "version": "0.0.239",
+             "license": "Apache-2.0",
+             "dependencies": {
+                 "@leanprover/infoview": "~0.13.0",
+@@ -11820,7 +11820,7 @@
+                 "@vscode/vsce": "^2.21.1",
+                 "concurrently": "^8.2.2",
+                 "copy-webpack-plugin": "^12.0.2",
+-                "glob": "^10.4.5",
++                "glob": "^11.0.1",
+                 "mocha": "^10.3.0",
+                 "ovsx": "^0.9.1",
+                 "source-map-loader": "^5.0.0",
+diff --git a/vscode-lean4/package.json b/vscode-lean4/package.json
+index 9261ebb6..8a93a8f5 100644
+--- a/vscode-lean4/package.json
++++ b/vscode-lean4/package.json
+@@ -1885,7 +1885,7 @@
+         "typescript": "^5.4.5",
+         "webpack": "^5.90.3",
+         "webpack-cli": "^5.1.4",
+-        "glob": "^10.4.5"
++        "glob": "^11.0.1"
+     },
+     "icon": "images/lean_logo.png",
+     "license": "Apache-2.0",

--- a/pkgs/applications/editors/vscode/extensions/leanprover.lean4/use-builtin-elan.patch
+++ b/pkgs/applications/editors/vscode/extensions/leanprover.lean4/use-builtin-elan.patch
@@ -1,0 +1,29 @@
+diff --git a/vscode-lean4/src/extension.ts b/vscode-lean4/src/extension.ts
+index bb4d3909..2ba7369d 100644
+--- a/vscode-lean4/src/extension.ts
++++ b/vscode-lean4/src/extension.ts
+@@ -16,7 +16,7 @@ import { LeanTaskGutter } from './taskgutter'
+ import { LeanClientProvider } from './utils/clientProvider'
+ import { depInstallationLocations, DepInstaller } from './utils/depInstaller'
+ import { ElanCommandProvider } from './utils/elanCommands'
+-import { addToProcessEnvPATH } from './utils/envPath'
++import { addToProcessEnvPATH, PATH, setProcessEnvPATH } from './utils/envPath'
+ import { combine, onEventWhile, withoutReentrancy } from './utils/events'
+ import { ExtUri, extUriToCwdUri, FileUri, toExtUri } from './utils/exturi'
+ import { FullInstaller } from './utils/fullInstaller'
+@@ -118,6 +118,15 @@ async function copyModuleName(uri: Uri | undefined) {
+ 
+ function addElanPathToPATH() {
+     addToProcessEnvPATH(path.join(os.homedir(), '.elan', 'bin'))
++    // Fall back to the Elan that was built into this extension, so that Lean
++    // works out of the box without the extension having to offer to download
++    // and install Elan itself. This is appended rather than prepended so that
++    // any Lean toolchain that is already on the PATH stays in charge.
++    const builtinElanBin = '@elan@/bin'
++    const currentPATH = PATH.ofProcessEnv()
++    if (!currentPATH.includes(builtinElanBin)) {
++        setProcessEnvPATH(currentPATH.join(new PATH([builtinElanBin])))
++    }
+ }
+ 
+ /**


### PR DESCRIPTION
Still a draft PR because I haven't fully reviewed the whole diff yet.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
