### PR TITLE
wonderbrushed: init at 0.45-beta.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -31719,6 +31719,12 @@
     githubId = 3449926;
     name = "David Costa";
   };
+  ZariTen = {
+    email = "ZaritenProt@proton.me";
+    github = "ZariTen";
+    githubId = 48529745;
+    name = "ZariTen";
+  };
   zatm8 = {
     email = "maxis1191@gmail.com";
     github = "mourogurt";

--- a/pkgs/by-name/wo/wonderbrushed/package.nix
+++ b/pkgs/by-name/wo/wonderbrushed/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "wonderbrushed";
+  version = "0.45-beta.1";
+
+  src = fetchFromGitHub {
+    owner = "Bhavneeth-Games";
+    repo = "Wonderbrushed";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-jyXeGFvNxov7NAY9jQp+gnhxBGFUI2dHX0tizlSTCAU=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/icons/Wonderbrushed
+    cp -r * $out/share/icons/Wonderbrushed/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "KDE icon pack featuring colorful, chalky icons";
+    homepage = "https://github.com/Bhavneeth-Games/Wonderbrushed";
+    license = lib.licenses.cc-by-sa-40;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ ZariTen ];
+  };
+})


### PR DESCRIPTION
Adds `wonderbrushed`, KDE icon pack aimed at making the desktop a less boring and sterile place with chalky icons that look almost edible.

- **Homepage:** https://github.com/Bhavneeth-Games/Wonderbrushed
- **License:** CC BY-SA 4.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].