### PR TITLE
sstorytime: init at 0-unstable-2026-08-12

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -54,6 +54,8 @@
 
 - [P2Pool](https://github.com/SChernykh/p2pool), a decentralized mining pool for Monero. Available as [services.p2pool](#opt-services.p2pool.enable).
 
+- [SSTorytime](https://github.com/markburgess/SSTorytime), graph knowledge base on PostgreSQL with an N4L CLI and a small HTTP UI. Available as [services.sstorytime](#opt-services.sstorytime.enable).
+
 - [Freescout](https://freescout.net/), a free, open source Helpdesk and shared mailbox. Available as [services.freescout](#opt-services.freescout.enable).
 
 - [Lix TOML remote builders](https://docs.lix.systems/manual/lix/stable/advanced-topics/distributed-builds.html#using-a-toml-configuration), remote builder configuration using lix's TOML format. Available as [lix.buildMachines](#opt-lix.buildMachines). Note: incompatible with `nix.buildMachines`.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1826,6 +1826,7 @@
   ./services/web-apps/sogo.nix
   ./services/web-apps/speedtest-tracker.nix
   ./services/web-apps/sshwifty.nix
+  ./services/web-apps/sstorytime.nix
   ./services/web-apps/stash.nix
   ./services/web-apps/stirling-pdf.nix
   ./services/web-apps/strfry.nix

--- a/nixos/modules/services/web-apps/sstorytime.nix
+++ b/nixos/modules/services/web-apps/sstorytime.nix
@@ -1,0 +1,284 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    mkIf
+    mkDefault
+    mkMerge
+    types
+    ;
+
+  cfg = config.services.sstorytime;
+  dbName = "sstoryline";
+  configPath = "/etc/sstorytime";
+  stateDir = "/var/lib/sstorytime";
+
+  defaultDatabaseUri = "postgresql://${dbName}@/${dbName}?host=/run/postgresql";
+
+  commonServiceConfig = {
+    User = dbName;
+    Group = dbName;
+    StateDirectory = "sstorytime";
+    WorkingDirectory = "%S/sstorytime";
+    EnvironmentFile = lib.optional (cfg.environmentFile != null) cfg.environmentFile;
+  };
+
+  # linkding-manage / lasuite-*-manage: same user/state/env as the long-running unit.
+  systemdRunArgs = lib.escapeShellArgs (
+    [
+      "--quiet"
+      "--collect"
+      "--pipe"
+      "--wait"
+      "--service-type=exec"
+      "--uid=${commonServiceConfig.User}"
+      "--gid=${commonServiceConfig.Group}"
+      "--working-directory=${stateDir}"
+      "--property=StateDirectory=${commonServiceConfig.StateDirectory}"
+    ]
+    ++ lib.optional (cfg.environmentFile != null) "--property=EnvironmentFile=${cfg.environmentFile}"
+    ++ lib.mapAttrsToList (name: value: "--setenv=${name}=${value}") (
+      cfg.settings
+      // {
+        PATH = lib.makeBinPath [ cfg.package ];
+      }
+    )
+    ++ [ "--" ]
+  );
+
+  sstorytime-run = pkgs.writeShellApplication {
+    name = "sstorytime-run";
+    text = ''
+      exec ${lib.getExe' config.systemd.package "systemd-run"} \
+        ${systemdRunArgs} \
+        "$@"
+    '';
+  };
+in
+{
+  meta.maintainers = lib.teams.ngi.members;
+
+  options.services.sstorytime = {
+    enable = mkEnableOption "SSTorytime, a unified graph process for mapping knowledge";
+
+    package = mkPackageOption pkgs "sstorytime" { };
+
+    openFirewall = mkEnableOption "opening the SSTorytime ports in the firewall";
+
+    httpPort = mkOption {
+      type = types.port;
+      default = 8080;
+      description = "HTTP listen port (redirects to HTTPS).";
+    };
+
+    httpsPort = mkOption {
+      type = types.port;
+      default = 8443;
+      description = "HTTPS listen port for the web UI and API.";
+    };
+
+    configDir = mkOption {
+      type = types.path;
+      default = "${cfg.package}/share/SSTconfig";
+      defaultText = lib.literalExpression ''"''${config.services.sstorytime.package}/share/SSTconfig"'';
+      description = ''
+        Directory that contains configuration files to be installed under
+        {file}`${configPath}`.
+      '';
+    };
+
+    settings = mkOption {
+      type = types.submodule {
+        freeformType = types.attrsOf (types.nullOr types.str);
+        options = {
+          POSTGRESQL_URI = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            example = "postgresql://sstoryline@/sstoryline?host=/run/postgresql";
+            description = ''
+              PostgreSQL connection URI. When
+              {option}`database.createLocally` is true, defaults to a peer-auth
+              socket URI. For remote databases prefer
+              {option}`environmentFile` if the URI contains secrets.
+            '';
+          };
+
+          SST_CONFIG_PATH = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            example = configPath;
+            description = ''
+              Directory of SSTconfig ontology files (arrows, closures, …).
+              Defaults to {file}`${configPath}` when the service is enabled.
+            '';
+          };
+        };
+      };
+      default = { };
+      apply = lib.filterAttrs (_: v: v != null);
+      example = {
+        POSTGRESQL_URI = "postgresql://sstoryline@/sstoryline?host=/run/postgresql";
+      };
+      description = ''
+        Environment for the service and {command}`sstorytime-run`.
+        Null values are omitted. Extra freeform keys are passed through as
+        additional environment variables.
+      '';
+    };
+
+    environmentFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/run/secrets/sstorytime.env";
+      description = ''
+        Optional EnvironmentFile (e.g. secrets for `POSTGRESQL_URI` via sops).
+        Used by the service and by {command}`sstorytime-run`.
+      '';
+    };
+
+    database = {
+      createLocally = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Local PostgreSQL role/database `sstoryline` and default
+          {option}`settings.POSTGRESQL_URI` using the Unix socket at
+          {file}`/run/postgresql` (peer auth as user `sstoryline`).
+        '';
+      };
+    };
+
+    finalPackage = mkOption {
+      type = types.package;
+      visible = false;
+      readOnly = true;
+      default = sstorytime-run;
+      defaultText = lib.literalExpression "sstorytime-run (systemd-run wrapper)";
+      description = ''
+        Runs tools in a transient unit with the same user, state directory,
+        and environment as {option}`systemd.services.sstorytime`.
+        Example: {command}`sstorytime-run N4L -u notes.n4l`.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion =
+          cfg.database.createLocally || cfg.settings ? POSTGRESQL_URI || cfg.environmentFile != null;
+        message = ''
+          services.sstorytime: when database.createLocally is false, set
+          settings.POSTGRESQL_URI or environmentFile (e.g. sops) so the service
+          can reach PostgreSQL.
+        '';
+      }
+    ];
+
+    # `/*` makes etc a directory of links so nested entries can extend it.
+    environment.etc.sstorytime.source = "${cfg.configDir}/*";
+
+    environment.systemPackages = [
+      cfg.package
+      cfg.finalPackage
+    ];
+
+    users.users.${dbName} = {
+      isSystemUser = true;
+      group = dbName;
+      description = "SSTorytime service and database user";
+    };
+    users.groups.${dbName} = { };
+
+    services.sstorytime.settings = mkMerge [
+      {
+        SST_CONFIG_PATH = mkDefault configPath;
+      }
+      (mkIf cfg.database.createLocally {
+        POSTGRESQL_URI = mkDefault defaultDatabaseUri;
+      })
+    ];
+
+    systemd.services.sstorytime = {
+      description = "SSTorytime Server";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ] ++ lib.optionals cfg.database.createLocally [ "postgresql.target" ];
+      path = [ pkgs.openssl ];
+      environment = cfg.settings;
+      unitConfig = {
+        StartLimitBurst = 5;
+        StartLimitIntervalSec = 100;
+      };
+      preStart = ''
+        mkdir -p cacheroot
+        if [ ! -f cert.pem ] || [ ! -f key.pem ]; then
+          openssl req -x509 -newkey rsa:4096 \
+            -keyout key.pem -out cert.pem \
+            -days 365 -nodes \
+            -subj "/CN=localhost"
+        fi
+      '';
+      serviceConfig = commonServiceConfig // {
+        Restart = "on-failure";
+        RestartSec = 5;
+        ExecStart = lib.escapeShellArgs [
+          (lib.getExe' cfg.package "http_server")
+          "-http"
+          ":${toString cfg.httpPort}"
+          "-https"
+          ":${toString cfg.httpsPort}"
+          "-cert"
+          "cert.pem"
+          "-key"
+          "key.pem"
+        ];
+
+        # MemoryDenyWriteExecute breaks Go.
+        CapabilityBoundingSet = "";
+        LockPersonality = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectSystem = "strict";
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        SystemCallArchitectures = "native";
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = lib.optionals cfg.openFirewall [
+      cfg.httpPort
+      cfg.httpsPort
+    ];
+
+    services.postgresql = mkIf cfg.database.createLocally {
+      enable = true;
+      ensureUsers = [
+        {
+          name = dbName;
+          ensureDBOwnership = true;
+        }
+      ];
+      ensureDatabases = [ dbName ];
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1605,6 +1605,7 @@ in
   sslh = handleTest ./sslh.nix { };
   sssd-ldap = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./sssd-ldap.nix { };
   sssd-legacy-config = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./sssd-legacy-config.nix { };
+  sstorytime = runTest ./sstorytime.nix;
   stalwart = runTest ./stalwart/stalwart.nix;
   stardust-xr-atmosphere = runTest ./stardust-xr/atmosphere.nix;
   stardust-xr-flatland = runTest ./stardust-xr/flatland.nix;

--- a/nixos/tests/sstorytime.nix
+++ b/nixos/tests/sstorytime.nix
@@ -1,0 +1,53 @@
+{ lib, ... }:
+{
+  name = "sstorytime";
+
+  meta = {
+    maintainers = lib.teams.ngi.members;
+  };
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.sstorytime = {
+        enable = true;
+        httpPort = 18080;
+        httpsPort = 18443;
+        database.createLocally = true;
+      };
+
+      environment.etc."sstorytime/test".source = pkgs.writeText "sstorytime-test" "extra-config-ok\n";
+    };
+
+  testScript =
+    { nodes, ... }:
+    let
+      inherit (nodes.machine.services.sstorytime) package httpPort httpsPort;
+    in
+    ''
+      start_all()
+
+      machine.wait_for_unit("sstorytime.service")
+      machine.wait_for_open_port(${toString httpPort})
+      machine.wait_for_open_port(${toString httpsPort})
+
+      machine.succeed("test -d /etc/sstorytime")
+      machine.succeed("test -f /etc/sstorytime/arrows-LT-1.sst")
+      machine.succeed("test -f /etc/sstorytime/closures.sst")
+      machine.succeed("test -f /etc/sstorytime/test")
+      machine.succeed("grep -q extra-config-ok /etc/sstorytime/test")
+
+      machine.succeed("ln -s ${package.examples}/share/examples /tmp/examples")
+
+      machine.succeed("sstorytime-run N4L -v -u /tmp/examples/SSTorytime.n4l")
+
+      output = machine.succeed("sstorytime-run searchN4L -v SSTorytime")
+      assert "notes about SSTorytime in N4L" in output, "Failed to search for term in graph."
+
+      output = machine.succeed('sstorytime-run N4L -s -adj="pe" /tmp/examples/chinese.n4l')
+      assert "Incidence summary of raw declarations" in output, "Failed to get relation sub-graph."
+
+      output = machine.succeed('sstorytime-run N4L -s -adj="" /tmp/examples/Mary.n4l')
+      assert "Incidence summary of raw declarations" in output, "Failed to summarize graph."
+    '';
+}

--- a/pkgs/by-name/ss/sstorytime/package.nix
+++ b/pkgs/by-name/ss/sstorytime/package.nix
@@ -1,0 +1,138 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  makeWrapper,
+  postgresql,
+  postgresqlTestHook,
+  writableTmpDirAsHomeHook,
+  nix-update-script,
+  nixosTests,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "sstorytime";
+  version = "0-unstable-2026-08-12";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "markburgess";
+    repo = "SSTorytime";
+    rev = "9085a82bd2357e914d862879224bc9d807f7e049";
+    hash = "sha256-ZA3qN//bkCU+yl7uych8Pz7J4AbtlBwRxqV/d/GkEZg=";
+  };
+
+  vendorHash = "sha256-lei5IG02QYSigHmLArlE7huDFVGoVMkw8DTEQeJWFX0=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  excludedPackages = [
+    "API_EXAMPLE"
+    "demo_pocs"
+  ];
+
+  outputs = [
+    "out"
+    "examples"
+  ];
+
+  # Prefer installCheck so a cd into tests/ cannot clobber install.
+  # postgresqlTestHook only registers preCheck/postCheck hooks, so start/stop explicitly.
+  doCheck = false;
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [
+    postgresql
+    postgresqlTestHook
+    writableTmpDirAsHomeHook
+  ];
+
+  # Peer on the hook's Unix socket: role = build user. SUPERUSER for schema setup.
+  env = {
+    PGUSER = "nixbld";
+    PGDATABASE = "sstoryline";
+    postgresqlTestUserOptions = "LOGIN SUPERUSER";
+  };
+
+  postInstall = ''
+    # cmd/server installs as "server"; upstream Makefile calls it http_server.
+    mv $out/bin/server $out/bin/http_server
+
+    mkdir -p $examples/share
+    cp -a examples $examples/share/
+    install -Dm644 SSTconfig/* -t $out/share/SSTconfig
+  '';
+
+  postFixup = ''
+    for bin in $out/bin/*; do
+      wrapProgram "$bin" \
+        --set-default SST_CONFIG_PATH "$out/share/SSTconfig"
+    done
+  '';
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    postgresqlStart
+    export POSTGRESQL_URI="postgresql://$PGUSER@/$PGDATABASE?host=$PGHOST"
+
+    failed=0
+    bin=$out/bin/N4L
+
+    for f in tests/pass_*.in; do
+      if "$bin" -adj=all "$f" >/dev/null; then
+        echo "ok $f"
+      else
+        echo "FAIL $f"
+        failed=1
+      fi
+    done
+
+    for f in tests/fail_*.in; do
+      if "$bin" "$f" >/dev/null 2>&1; then
+        echo "FAIL $f (expected non-zero exit)"
+        failed=1
+      else
+        echo "ok $f"
+      fi
+    done
+
+    if "$bin" -u examples/doors.n4l >/dev/null; then
+      echo "ok N4L -u doors.n4l"
+    else
+      echo "FAIL N4L -u doors.n4l"
+      failed=1
+    fi
+
+    postgresqlStop
+
+    if [ "$failed" -ne 0 ]; then
+      exit 1
+    fi
+
+    runHook postInstallCheck
+  '';
+
+  passthru = {
+    tests = { inherit (nixosTests) sstorytime; };
+    updateScript = nix-update-script {
+      extraArgs = [ "--version=branch" ];
+    };
+  };
+
+  meta = {
+    description = "Unified graph process for mapping knowledge";
+    homepage = "https://github.com/markburgess/SSTorytime";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    teams = [ lib.teams.ngi ];
+    maintainers = [ lib.maintainers.lucasew ];
+    mainProgram = "N4L";
+  };
+})


### PR DESCRIPTION
## Summary

Add [SSTorytime](https://github.com/markburgess/SSTorytime) (NLnet SmartSemanticDataLookup) from ngipkgs.

Tracking: https://github.com/ngi-nix/projects/issues/1381

- Package `sstorytime` at `0-unstable-2026-08-11` (`markburgess/SSTorytime` @ `98de5c19`)
  - Multi-binary: `N4L`, `http_server`, `searchN4L`, …
  - `examples` output for sample N4L graphs; `SSTconfig` on `out`
  - `listen-flags.patch` adds `-http`/`-https`/`-cert`/`-key` (defaults unchanged)
  - installCheck with `postgresqlTestHook` over the Unix socket (peer as `nixbld`)
  - `passthru.updateScript` via `nix-update-script --version=branch`
- NixOS module `services.sstorytime`
  - RFC 0042-style freeform `settings` (`POSTGRESQL_URI`, `SST_CONFIG_PATH`)
  - `httpPort` / `httpsPort` passed as `http_server` flags
  - SSTconfig under `/etc/sstorytime` via `environment.etc` glob (`/*`)
  - Local PostgreSQL over `/run/postgresql` with peer auth as `sstoryline`
  - `sstorytime-run` admin wrapper (`systemd-run`, same user/state/env)
- NixOS test: etc layout, ingest/search, non-default ports 18080/18443

## Things done

- [x] Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy).

Assisted by Grok Build (xAI Grok 4.6). Commits include `Assisted-by:` trailers.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md