### PR TITLE
python3Packages.typed-argparse: skip broken tests

### DIFF
--- a/pkgs/development/python-modules/typed-argparse/default.nix
+++ b/pkgs/development/python-modules/typed-argparse/default.nix
@@ -30,13 +30,27 @@ buildPythonPackage {
     pytest-cov-stub
   ];
 
+  # The test suite checks for exact output in a way that seems fragile to
+  # cosmetic changes in Python's argparse output, and means some tests fail on
+  # more recent releases.  Disable the affected tests while we're waiting for
+  # upstream fixes.
+  #
   # https://github.com/typed-argparse/typed-argparse/pull/82
-  disabledTests = lib.optionals (pythonAtLeast "3.14") [
-    "test_nargs_with_choices__literal_illegal_default"
-    "test_nargs_with_choices__enum_illegal_default"
-    "test_bindings_check"
-    "test_check_reserved_names"
-  ];
+  # https://github.com/typed-argparse/typed-argparse/issues/84
+  disabledTests =
+    lib.optionals (pythonAtLeast "3.14") [
+      "test_nargs_with_choices__literal_illegal_default"
+      "test_nargs_with_choices__enum_illegal_default"
+      "test_bindings_check"
+      "test_check_reserved_names"
+    ]
+    ++ lib.optionals (pythonAtLeast "3.13") [
+      "test_dynamic_choices"
+      "test_literal__basics"
+      "test_enum__basics[False]"
+      "test_enum__basics[True]"
+      "test_subparsers_common_args__subparser_after_positional"
+    ];
 
   pythonImportsCheck = [ "typed_argparse" ];
 


### PR DESCRIPTION
Fixes #548842

I'd like a better solution than just disabling tests, but given the test failures appear to be cosmetic and we're waiting on an upstream fix, I think that'll do for now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
