### PR TITLE
vscode-extensions.rocq-prover.vsrocq: build from source, bundle the language server

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -3987,22 +3987,7 @@ let
 
       robocorp.robotframework-lsp = callPackage ./robocorp.robotframework-lsp { };
 
-      rocq-prover.vsrocq = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          publisher = "rocq-prover";
-          name = "vsrocq";
-          # When updating the version here, also update the language server vsrocq-language-server
-          version = "2.4.3";
-          hash = "sha256-o9rsSDCDYRWZQBMDA7DtWay50tBI76kw7H7CivrZpKo=";
-        };
-        meta = {
-          description = "VsRocq is an extension for Visual Studio Code with support for the Rocq Prover";
-          downloadPage = "https://marketplace.visualstudio.com/items?itemName=rocq-prover.vsrocq";
-          homepage = "https://github.com/rocq-prover/vsrocq";
-          license = lib.licenses.mit;
-          maintainers = [ lib.maintainers.Zimmi48 ];
-        };
-      };
+      rocq-prover.vsrocq = callPackage ./rocq-prover.vsrocq { };
 
       roman.ayu-next = buildVscodeMarketplaceExtension {
         mktplcRef = {

--- a/pkgs/applications/editors/vscode/extensions/rocq-prover.vsrocq/avoid-ast-grep-napi.patch
+++ b/pkgs/applications/editors/vscode/extensions/rocq-prover.vsrocq/avoid-ast-grep-napi.patch
@@ -1,0 +1,42 @@
+diff --git a/pp-display/vite.config.ts b/pp-display/vite.config.ts
+index bf097fca..cf12971f 100644
+--- a/pp-display/vite.config.ts
++++ b/pp-display/vite.config.ts
+@@ -1,9 +1,35 @@
+ import { defineConfig } from "vite";
+-import { resolve } from "path";
++import { dirname, relative, resolve } from "path";
+ import dts from 'vite-plugin-dts';
+ import react from "@vitejs/plugin-react";
+ import { externalizeDeps } from 'vite-plugin-externalize-deps';
+-import { libInjectCss} from 'vite-plugin-lib-inject-css';
++
++// Stands in for `vite-plugin-lib-inject-css`, which prepends the same import
++// statements but pulls in `@ast-grep/napi` just to parse the chunk and find a
++// spot for them after any leading directive. The only chunk this build produces
++// has no leading directive, so the front of the chunk is that spot.
++//
++// Unlike the plugin, this does not regenerate the chunk's source map, which is
++// only needed when `build.sourcemap` is set.
++const libInjectCss = () => ({
++  name: "lib-inject-css",
++  apply: "build",
++  enforce: "post",
++  // Without css code splitting there is only one `style.css` and
++  // `chunk.viteMetadata.importedCss` stays empty.
++  config: () => ({ build: { cssCodeSplit: true } }),
++  generateBundle(options, bundle) {
++    for (const chunk of Object.values(bundle)) {
++      if (chunk.type !== "chunk" || !chunk.viteMetadata?.importedCss.size) {
++        continue;
++      }
++      for (const cssFileName of chunk.viteMetadata.importedCss) {
++        const cssFilePath = relative(dirname(chunk.fileName), cssFileName);
++        chunk.code = `import './${cssFilePath}';` + chunk.code;
++      }
++    }
++  },
++});
+ 
+ // https://vitejs.dev/config/
+ export default defineConfig( ({mode}) => ({

--- a/pkgs/applications/editors/vscode/extensions/rocq-prover.vsrocq/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/rocq-prover.vsrocq/default.nix
@@ -1,0 +1,146 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchYarnDeps,
+  nodejs,
+  replaceVars,
+  rocqPackages,
+  strip-nondeterminism,
+  vscode-utils,
+  yarnConfigHook,
+}:
+
+let
+  inherit (rocqPackages) vsrocq-language-server;
+
+  vsix = stdenv.mkDerivation (finalAttrs: {
+    name = "rocq-prover-vsrocq-${finalAttrs.version}.vsix";
+    pname = "rocq-prover-vsrocq-vsix";
+    # When updating the version here, also update the language server
+    # rocqPackages.vsrocq-language-server, whose version the client checks at
+    # startup, and re-prefetch each of the yarn caches below.
+    version = "2.4.3";
+
+    src = fetchFromGitHub {
+      owner = "rocq-prover";
+      repo = "vsrocq";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-R/fpTiYZ9uvtKQcWD4jwUZPvUrcdvHc/wpoTrdkEQoQ=";
+    };
+
+    patches = [
+      # Opening a Rocq file with no `vsrocqtop` on the PATH makes the extension
+      # offer to download and install the VsRocq language server itself. Teach it
+      # to fall back to a language server supplied at build time instead, so that
+      # no out-of-band installation is needed.
+      (replaceVars ./use-builtin-language-server.patch {
+        vsrocqtop = lib.getExe' vsrocq-language-server "vsrocqtop";
+      })
+
+      # `vite-plugin-lib-inject-css` depends on `@ast-grep/napi`, whose prebuilt
+      # `linux-arm64-gnu` binary references an undefined `static_assert` symbol
+      # and so cannot be loaded at all, making the build fail on aarch64-linux.
+      # Do the little that the plugin does for this package without it.
+      ./avoid-ast-grep-napi.patch
+    ];
+
+    sourceRoot = "${finalAttrs.src.name}/client";
+
+    # The three webview UIs and the extension itself are four separate yarn
+    # projects, each with its own lockfile, so each needs its own offline cache.
+    passthru.yarnOfflineCaches = {
+      "." = fetchYarnDeps {
+        name = "${finalAttrs.pname}-yarn-deps";
+        yarnLock = "${finalAttrs.src}/client/yarn.lock";
+        hash = "sha256-XpsAUTu+FTCnVaM/eR00qS5OOraHaQ+X3lO/SCC7TV4=";
+      };
+      "pp-display" = fetchYarnDeps {
+        name = "${finalAttrs.pname}-pp-display-yarn-deps";
+        yarnLock = "${finalAttrs.src}/client/pp-display/yarn.lock";
+        hash = "sha256-57irlPpDci5iv1vWzJMFSy84TPHR/zVb7qGZeXRtboo=";
+      };
+      "goal-view-ui" = fetchYarnDeps {
+        name = "${finalAttrs.pname}-goal-view-ui-yarn-deps";
+        yarnLock = "${finalAttrs.src}/client/goal-view-ui/yarn.lock";
+        hash = "sha256-eNzMWsELyvQDMY6rlSu1IT5Jeuv3qbOx/XOEvgv2gjI=";
+      };
+      "search-ui" = fetchYarnDeps {
+        name = "${finalAttrs.pname}-search-ui-yarn-deps";
+        yarnLock = "${finalAttrs.src}/client/search-ui/yarn.lock";
+        hash = "sha256-sqcbU1wSLOAPTtkBuMXnipFkv4cRxa4leArFpy8zfK4=";
+      };
+    };
+
+    nativeBuildInputs = [
+      nodejs
+      strip-nondeterminism
+      yarnConfigHook
+    ];
+
+    strictDeps = true;
+
+    # `yarnConfigHook` only knows how to populate one project, so run it once per
+    # project instead of letting it fire on its own.
+    dontYarnInstallDeps = true;
+
+    postConfigure = lib.concatLines (
+      lib.mapAttrsToList (dir: cache: ''
+        (cd ${lib.escapeShellArg dir} && offlineCache=${cache} yarnConfigHook)
+      '') finalAttrs.passthru.yarnOfflineCaches
+    );
+
+    buildPhase = ''
+      runHook preBuild
+
+      # The two webview UIs depend on `pp-display` through its package entry
+      # points rather than its sources, so it has to be built first. This is what
+      # the `package` script does, minus the non-production `webpack` run that it
+      # inherits from `build:all`.
+      for project in pp-display goal-view-ui search-ui; do
+        (cd $project && yarn --offline run build)
+      done
+      node_modules/.bin/webpack --mode production --devtool hidden-source-map
+
+      # `vsce package` refuses to run without a `repository` field unless it is
+      # told to go ahead, and would otherwise try to reach the network to prune
+      # dependencies that webpack has already bundled.
+      node_modules/.bin/vsce package --allow-missing-repository --no-dependencies --out $out
+      # `vsce` stamps every zip entry with the current time, so the vsix is not
+      # reproducible as it comes out.
+      strip-nondeterminism --type zip $out
+
+      runHook postBuild
+    '';
+
+    dontInstall = true;
+  });
+in
+vscode-utils.buildVscodeExtension (finalAttrs: {
+  pname = "rocq-prover-vsrocq";
+  inherit (finalAttrs.src) version;
+
+  vscodeExtPublisher = "rocq-prover";
+  vscodeExtName = "vsrocq";
+  vscodeExtUniqueId = "${finalAttrs.vscodeExtPublisher}.${finalAttrs.vscodeExtName}";
+
+  src = vsix;
+
+  # The `vsrocqtop` path that `use-builtin-language-server.patch` bakes into the
+  # bundle only survives as a registered store reference if the language server is
+  # also an input of this derivation: Nix records references to the derivation's
+  # own inputs, and the inner vsix derivation cannot register it either because
+  # the string is compressed inside the zip where the scanner will not find it.
+  buildInputs = [ vsrocq-language-server ];
+
+  passthru.vsix = finalAttrs.src;
+
+  meta = {
+    description = "VsRocq is an extension for Visual Studio Code with support for the Rocq Prover";
+    changelog = "https://github.com/rocq-prover/vsrocq/blob/v${finalAttrs.version}/client/CHANGELOG.md";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=rocq-prover.vsrocq";
+    homepage = "https://github.com/rocq-prover/vsrocq";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.Zimmi48 ];
+  };
+})

--- a/pkgs/applications/editors/vscode/extensions/rocq-prover.vsrocq/use-builtin-language-server.patch
+++ b/pkgs/applications/editors/vscode/extensions/rocq-prover.vsrocq/use-builtin-language-server.patch
@@ -1,0 +1,18 @@
+diff --git a/src/utilities/toolchain.ts b/src/utilities/toolchain.ts
+index 4989f654..2c124806 100644
+--- a/src/utilities/toolchain.ts
++++ b/src/utilities/toolchain.ts
+@@ -96,7 +96,12 @@ export default class VsRocqToolchainManager implements Disposable {
+     }
+ 
+     private async searchForVsrocqtopInPath () : Promise<string> {        
+-        return await which("vsrocqtop", { nothrow: true }) ?? "";
++        // Fall back to the language server that was built into this extension,
++        // so that VsRocq works out of the box without the extension having to
++        // offer to download and install the server itself. This is only
++        // consulted after the PATH, so any `vsrocqtop` the user already has
++        // stays in charge.
++        return await which("vsrocqtop", { nothrow: true }) ?? "@vsrocqtop@";
+     }
+ 
+     // Launch the vsrocqtop -where command with the found exec and provided args


### PR DESCRIPTION
Still a draft PR because I haven't fully reviewed the whole diff yet.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
