### PR TITLE
python3Packages.gitpython: 3.1.51 -> 3.1.57

### DIFF
--- a/pkgs/development/python-modules/gitpython/default.nix
+++ b/pkgs/development/python-modules/gitpython/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "gitpython";
-  version = "3.1.51";
+  version = "3.1.57";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "gitpython-developers";
     repo = "GitPython";
     tag = finalAttrs.version;
-    hash = "sha256-c8tjBvWjVR7krR59Tfx5jKoJc/fcLWVt5D4xk15DvP4=";
+    hash = "sha256-pCGDKwIefGqx/UJaVqrsofc0t+ntqZRPMhsdbK2XBB0=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Updates GitPython from 3.1.51 to 3.1.57. This update includes fixes for the following security advisories:

- GHSA-rwj8-pgh3-r573
- GHSA-3rp5-jjmw-4wv2
- GHSA-r9mr-m37c-5fr3
- GHSA-6p8h-3wgx-97gf
- GHSA-fjr4-x663-mwxc
- GHSA-94p4-4cq8-9g67
- GHSA-p538-c434-8v24
- GHSA-3f7w-8rr8-f37f
- GHSA-539m-9xh6-q6rr

See the [3.1.57 changelog](https://redirect.github.com/gitpython-developers/GitPython/blob/3.1.57/doc/source/changes.rst).

Addresses #548546 and #549105.

Validation on x86_64-linux:

- Built `python313Packages.gitpython` and `python314Packages.gitpython`.
- Ran 15 targeted upstream security regression tests with both Python 3.13 and Python 3.14.
- Ran targeted checks for the advisory-related input-validation paths against both built packages, including the explicit `allow_unsafe_options=True` behavior.

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
