### PR TITLE
taisei: 1.4.5 -> 1.4.6

### DIFF
--- a/pkgs/by-name/ta/taisei/package.nix
+++ b/pkgs/by-name/ta/taisei/package.nix
@@ -37,13 +37,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "taisei";
-  version = "1.4.5";
+  version = "1.4.6";
 
   src = fetchFromGitHub {
     owner = "taisei-project";
     repo = "taisei";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-xjEfSrtxZBBWUU8nv0fyNAofHSGVTeO3CBR/BhKSGHg=";
+    hash = "sha256-F5fmTY3kl5HW4C/SH5JDZF0vTWescExTANQDYZ2vPmI=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/by-name/ta/taisei/package.nix
+++ b/pkgs/by-name/ta/taisei/package.nix
@@ -73,8 +73,6 @@ stdenv.mkDerivation (finalAttrs: {
     mimalloc
     libogg
     libunibreak
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     glslang
     spirv-cross
   ]
@@ -91,7 +89,6 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonEnable "install_freedesktop" stdenv.hostPlatform.isLinux)
     (lib.mesonEnable "install_macos_bundle" stdenv.hostPlatform.isDarwin)
     (lib.mesonEnable "install_relocatable" stdenv.hostPlatform.isDarwin)
-    (lib.mesonEnable "shader_transpiler" stdenv.hostPlatform.isDarwin)
   ];
 
   preConfigure = ''


### PR DESCRIPTION
Changelog: https://github.com/taisei-project/taisei/releases/tag/v1.4.6
Diff: https://github.com/taisei-project/taisei/compare/v1.4.5...v1.4.6

Good news everyone! The `gles30` and `sdlgpu` now work properly on linux. I removed the `isDarwin` gates so both the linux and darwin builds have support for these backends (linux still defaults to `gl33`).
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
