### PR TITLE
nixos/dnscrypt-proxy: fix `.settings` type

### DIFF
--- a/nixos/modules/services/networking/dnscrypt-proxy.nix
+++ b/nixos/modules/services/networking/dnscrypt-proxy.nix
@@ -8,6 +8,7 @@
 let
 
   cfg = config.services.dnscrypt-proxy;
+  settingsFormat = pkgs.formats.toml { };
 
 in
 
@@ -36,7 +37,7 @@ in
           };
         }
       '';
-      type = lib.types.attrs;
+      type = settingsFormat.type;
       default = { };
     };
 

--- a/nixos/tests/dnscrypt-proxy.nix
+++ b/nixos/tests/dnscrypt-proxy.nix
@@ -1,6 +1,7 @@
 { lib, ... }:
 let
   localProxyPort = 43;
+  localProxyExtraPort = 44;
 in
 {
   name = "dnscrypt-proxy";
@@ -12,11 +13,21 @@ in
     client =
       { ... }:
       {
-        security.apparmor.enable = true;
+        imports = [
+          # Tests if dnscrypt-proxy settings correctly deep-merge across modules,
+          # and that the resulting config works.
+          # See https://github.com/NixOS/nixpkgs/issues/523152
+          {
+            services.dnscrypt-proxy.settings.listen_addresses = [ "127.0.0.1:${toString localProxyPort}" ];
+          }
+          {
+            services.dnscrypt-proxy.settings.listen_addresses = [ "127.0.0.1:${toString localProxyExtraPort}" ];
+          }
+        ];
 
+        security.apparmor.enable = true;
         services.dnscrypt-proxy.enable = true;
         services.dnscrypt-proxy.settings = {
-          listen_addresses = [ "127.0.0.1:${toString localProxyPort}" ];
           sources.public-resolvers = {
             urls = [ "https://download.dnscrypt.info/resolvers-list/v2/public-resolvers.md" ];
             cache_file = "public-resolvers.md";
@@ -26,7 +37,10 @@ in
         };
 
         services.dnsmasq.enable = true;
-        services.dnsmasq.settings.server = [ "127.0.0.1#${toString localProxyPort}" ];
+        services.dnsmasq.settings.server = [
+          "127.0.0.1#${toString localProxyPort}"
+          "127.0.0.1#${toString localProxyExtraPort}"
+        ];
       };
   };
 
@@ -34,5 +48,6 @@ in
     client.wait_for_unit("dnsmasq")
     client.wait_for_unit("dnscrypt-proxy")
     client.wait_until_succeeds("ss --numeric --udp --listening | grep -q ${toString localProxyPort}")
+    client.wait_until_succeeds("ss --numeric --udp --listening | grep -q ${toString localProxyExtraPort}")
   '';
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This pull request improves the configuration handling and testing for the `dnscrypt-proxy` NixOS module, focusing on better support for TOML settings and ensuring deep-merge behavior across modules. The main changes involve switching to a TOML-based settings format and enhancing the integration test to verify correct merging and multiple listen addresses.

**Improvements to settings format:**

* Switched the `services.dnscrypt-proxy.settings` option type from a generic attribute set to a TOML-based format (`settingsFormat.type`), ensuring stricter validation and compatibility with TOML configuration files. [[1]](diffhunk://#diff-8afea4ecc597a06e928bd615d3889d1d9eb279ad6d72d17f5d7cf726f3bb9a10R11) [[2]](diffhunk://#diff-8afea4ecc597a06e928bd615d3889d1d9eb279ad6d72d17f5d7cf726f3bb9a10L39-R40)

**Enhancements to integration testing:**

* Updated the test in `nixos/tests/dnscrypt-proxy.nix` to:
  * Define two listen addresses on different ports via multiple module imports, verifying that settings deep-merge as expected. [[1]](diffhunk://#diff-c4f5776bd247be125ee0e5996cb5d59f35f034a2dcfc377b0df92ab06e1e742cR4) [[2]](diffhunk://#diff-c4f5776bd247be125ee0e5996cb5d59f35f034a2dcfc377b0df92ab06e1e742cL15-L19)
  * Adjust the `dnsmasq` configuration to use both ports, and extend the test script to check that both UDP ports are listening, ensuring the merged configuration works at runtime.

These changes help prevent configuration errors and make sure multi-module setups for `dnscrypt-proxy` are robust and well-tested.

Fixes #523152

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
