### PR TITLE
xdg-desktop-portal-generic: init at 0.5.0

### DIFF
--- a/pkgs/by-name/xd/xdg-desktop-portal-generic/package.nix
+++ b/pkgs/by-name/xd/xdg-desktop-portal-generic/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  pipewire,
+  wayland,
+  libxkbcommon,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "xdg-desktop-portal-generic";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "lamco-admin";
+    repo = "xdg-desktop-portal-generic";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-Owx4GnsVzu16Md0ARQLwkjFN5bCurhS216nguA95EDg=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  postPatch = ''
+    substituteInPlace data/org.freedesktop.impl.portal.desktop.generic.service \
+      --replace-fail '/usr/libexec/' '${placeholder "out"}/libexec/'
+
+    substituteInPlace data/xdg-desktop-portal-generic.service \
+      --replace-fail '/usr/libexec/' '${placeholder "out"}/libexec/'
+  '';
+
+  cargoHash = "sha256-m/OdKQNX4ufUBIBg5+dZyr46X9ovgKXMLa5AvdbOQ5Q=";
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    pipewire
+    wayland
+    libxkbcommon
+  ];
+
+  postInstall = ''
+    install -Dm644 data/generic.portal -t $out/share/xdg-desktop-portal/portals
+    install -Dm644 data/org.freedesktop.impl.portal.desktop.generic.service -t $out/share/dbus-1/services
+    install -Dm644 data/xdg-desktop-portal-generic.service -t $out/share/systemd/user
+
+    mkdir -p $out/libexec
+    mv $out/bin/xdg-desktop-portal-generic $out/libexec/
+    rmdir $out/bin
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Generic XDG Desktop Portal backend for Wayland compositors";
+    homepage = "https://github.com/lamco-admin/xdg-desktop-portal-generic";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    maintainers = with lib.maintainers; [ johnrtitor ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
https://github.com/lamco-admin/xdg-desktop-portal-generic

A generic XDG Desktop Portal backend for Wayland compositors. Targeted at any compositor that implements ext- or wlr- Wayland protocols, ie. Niri, Jay, COSMIC.

Implements RemoteDesktop, ScreenCast, Clipboard, Settings, Screenshot portal backends.


## Things done


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
