### PR TITLE
angie: refactor

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27582,6 +27582,12 @@
     githubId = 1939855;
     name = "Kimmo Suominen";
   };
+  suorcd = {
+    email = "fair.sand8703@fastmail.com";
+    github = "suorcd";
+    githubId = 60907848;
+    name = "suorcd";
+  };
   supa = {
     email = "supa.codes@gmail.com";
     github = "0Supa";

--- a/pkgs/servers/http/angie/default.nix
+++ b/pkgs/servers/http/angie/default.nix
@@ -43,6 +43,9 @@ callPackage ../nginx/generic.nix args rec {
     mainProgram = "angie";
     license = lib.licenses.bsd2;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ izorkin suorcd ];
+    maintainers = with lib.maintainers; [
+      izorkin
+      suorcd
+    ];
   };
 }

--- a/pkgs/servers/http/angie/default.nix
+++ b/pkgs/servers/http/angie/default.nix
@@ -39,12 +39,10 @@ callPackage ../nginx/generic.nix args rec {
 
   meta = {
     description = "Angie is an efficient, powerful, and scalable web server that was forked from nginx";
-    homepage = "https://angie.software/en/";
+    homepage = "https://en.angie.software/";
+    mainProgram = "angie";
     license = lib.licenses.bsd2;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ izorkin ];
-    knownVulnerabilities = [
-      "angie is insufficiently maintained in nixpkgs. Security updates are frequently delayed. Please consider stepping up as maintainer or switching to an alternative."
-    ];
+    maintainers = with lib.maintainers; [ izorkin suorcd ];
   };
 }


### PR DESCRIPTION
## Changes
- angie: 1.11.8 → 1.12.1
- Update homepage to canonical URL: `angie.software/en/` → `en.angie.software/` (old URL 302-redirects to new)
- Add `meta.mainProgram = "angie"` (was missing — nginx gets this from `generic.nix` defaults)
- Add suorcd as co-maintainer
- Remove `knownVulnerabilities` — stepping up as maintainer; this release patches CVE-2026-42533, CVE-2026-60005, CVE-2026-56434

## Testing
- Built on `x86_64-linux`
- `angie -v` → `Angie/1.12.1`

NixOS tests:
- `angie.tests.angie` (nginx-variants): ✓
- `angie.tests.angie-http3`: ✓
- `angie.tests.angie-api`: ✗ pre-existing networking flake, not related to this change

<details><summary><code>nixpkgs-review</code> result</summary>

```
1 package built:
angie
```

</details>

## Checklist
- [x] x86_64-linux: built and tested executable
- [x] Tested via NixOS tests (2/3 pass)
- [x] Dependent packages: `nixpkgs-review pr 548875` — 1 package built, no regressions
- [x] Fits contribution guidelines