### PR TITLE
lib.licenses: Introduce FSFAP license

### DIFF
--- a/lib/licenses/licenses.nix
+++ b/lib/licenses/licenses.nix
@@ -925,6 +925,11 @@ lib.mapAttrs mkLicense (
       redistributable = true;
     };
 
+    fsfap = {
+      spdxId = "FSFAP";
+      fullName = "FSF All Permissive License";
+    };
+
     hl3 = {
       fullName = "Hippocratic License v3.0";
       url = "https://firstdonoharm.dev/version/3/0/core.txt";

--- a/pkgs/by-name/ka/karp/package.nix
+++ b/pkgs/by-name/ka/karp/package.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation {
       bsd3
       cc-by-sa-40
       cc0
-      # FSFAP
+      fsfap
       gpl2Only
       gpl3Only
       lgpl2Plus

--- a/pkgs/kde/lib/mk-kde-derivation.nix
+++ b/pkgs/kde/lib/mk-kde-derivation.nix
@@ -35,11 +35,6 @@ let
       # https://invent.kde.org/kdevelop/kdevelop/-/blob/master/LICENSES/LicenseRef-MIT-KDevelop-Ideal.txt
       "LicenseRef-MIT-KDevelop-Ideal" = lib.licenses.mit;
 
-      "FSFAP" = {
-        spdxId = "FSFAP";
-        fullName = "FSF All Permissive License";
-      };
-
       "FSFULLR" = {
         spdxId = "FSFULLR";
         fullName = "FSF Unlimited License (with License Retention)";

--- a/pkgs/kde/misc/klevernotes/default.nix
+++ b/pkgs/kde/misc/klevernotes/default.nix
@@ -27,7 +27,7 @@ mkKdeDerivation rec {
     bsd3
     cc-by-sa-40
     cc0
-    # TODO: add FSFAP license
+    fsfap
     gpl2Plus
     gpl3Only
     gpl3Plus


### PR DESCRIPTION
Introduces the [FSFAP](https://spdx.org/licenses/FSFAP.html) license used by some packages (mainly KDE's).
Also updates some references I could find which were previously not filled in or used placeholders.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
