### PR TITLE
oscar: fix packaging and desktop integration

### DIFF
--- a/pkgs/by-name/os/oscar/package.nix
+++ b/pkgs/by-name/os/oscar/package.nix
@@ -1,11 +1,12 @@
 {
   lib,
   stdenv,
-  qt6,
   fetchFromGitLab,
   libGLU,
   nix-update-script,
+  qt6,
 }:
+
 stdenv.mkDerivation (finalAttrs: {
   pname = "oscar";
   version = "2.0.1";
@@ -13,18 +14,20 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitLab {
     owner = "CrimsonNape";
     repo = "oscar-sql";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ivOEAP7/pc5yS6mhc/6ButbSjfFmOP4PM7c/S23oyYw=";
   };
 
-  buildInputs = [
-    qt6.qtbase
-    qt6.qttools
-    libGLU
-  ];
   nativeBuildInputs = [
-    qt6.wrapQtAppsHook
     qt6.qmake
+    qt6.qtserialport
+    qt6.qttools
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    libGLU
+    qt6.qtbase
     qt6.qtserialport
   ];
 
@@ -34,21 +37,25 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     substituteInPlace oscar/oscar.pro \
       --replace-fail "/bin/bash" "${stdenv.shell}" \
-      --replace-fail "\$\$[QT_INSTALL_BINS]/lrelease" "${qt6.qttools}/bin/lrelease"
+      --replace-fail "\$\$[QT_INSTALL_BINS]/lrelease" "lrelease"
+    substituteInPlace oscar/SleepLib/common.cpp \
+      --replace-fail 'QString( "/usr/share/" )' 'QString( "${placeholder "out"}/share/" )'
+    substituteInPlace Building/Linux/OSCAR20.desktop \
+      --replace-fail "Icon=/usr/share/icons/hicolor/48x48/apps/OSCAR20.png" "Icon=OSCAR20"
   '';
 
   qmakeFlags = [ "OSCAR_QT.pro" ];
 
   installPhase = ''
     runHook preInstall
-    install -D oscar/OSCAR20 -t $out/bin
+    install -Dm755 oscar/OSCAR20 -t "$out/bin"
     # help browser was removed 'temporarily' in https://gitlab.com/pholy/OSCAR-code/-/commit/57c3e4c33ccdd2d0eddedbc24c0e4f2969da3841
-    # install -D oscar/Help/* -t $out/share/OSCAR/Help
-    install -D oscar/Html/* -t $out/share/OSCAR/Html
-    install -D oscar/Translations/* -t $out/share/OSCAR/Translations
-    install -D Building/Linux/OSCAR.png -t $out/share/icons/hicolor/48x48/apps
-    install -D Building/Linux/OSCAR.svg -t $out/share/icons/hicolor/scalable/apps
-    install -D Building/Linux/OSCAR.desktop -t $out/share/applications
+    # install -Dm644 oscar/Help/* -t "$out/share/OSCAR20/Help"
+    install -Dm644 oscar/Html/* -t "$out/share/OSCAR20/Html"
+    install -Dm644 oscar/Translations/* -t "$out/share/OSCAR20/Translations"
+    install -Dm644 Building/Linux/OSCAR20.png -t "$out/share/icons/hicolor/48x48/apps"
+    install -Dm644 Building/Linux/OSCAR20.svg -t "$out/share/icons/hicolor/scalable/apps"
+    install -Dm644 Building/Linux/OSCAR20.desktop -t "$out/share/applications"
     runHook postInstall
   '';
 
@@ -61,6 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://www.sleepfiles.com/OSCAR/";
+    changelog = "https://gitlab.com/CrimsonNape/oscar-sql/-/raw/${finalAttrs.src.tag}/Htmldocs/release_notes.html";
     description = "Software for reviewing and exploring data produced by CPAP and related machines used in the treatment of sleep apnea";
     mainProgram = "OSCAR20";
     license = lib.licenses.gpl3Only;


### PR DESCRIPTION
- Prefer `fetchFromGitLab.tag` instead of `rev`.
- Explicitly add `qt6.qtserialport` as a needed library to preserve cross-compilation compatibility.
- Resolve `lrelease` through build environment's `PATH` to preserve cross-compilation compatibility.
- Patch OSCAR to find HTML and translation resources in the Nix store.
- Install resources under the expected `share/OSCAR20` directory.
- Install only the matching OSCAR20 desktop entry and icons.
- Use icon lookup instead of an invalid absolute `/usr/share` icon path.
- Set executable bit only to the binary and read-only permissions to resources.
- Add `meta.changelog`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
