### PR TITLE
firefox: use ffmpeg 8 for browsers that support it

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -12,6 +12,7 @@
 
   ## various stuff that can be plugged in
   ffmpeg_7,
+  ffmpeg_8,
   libxxf86vm,
   libxxf86dga,
   libxt,
@@ -88,6 +89,11 @@ let
 
     let
       ffmpegSupport = browser.ffmpegSupport or false;
+      # Firefox dlopens libavcodec by hardcoded soname, so each ffmpeg major needs
+      # explicit browser support; keep versioned pins here (never the ffmpeg alias)
+      # and add a tier when a release gains the next ABI. 146 added libavcodec 62
+      # (https://bugzilla.mozilla.org/show_bug.cgi?id=1962139), not uplifted to ESR 140.
+      ffmpegPackage = if lib.versionAtLeast browser.version "146" then ffmpeg_8 else ffmpeg_7;
       gssSupport = browser.gssSupport or false;
       alsaSupport = browser.alsaSupport or false;
       pipewireSupport = browser.pipewireSupport or false;
@@ -113,7 +119,7 @@ let
           ++ lib.optional (cfg.speechSynthesisSupport or true) speechd-minimal
         )
         ++ lib.optional pipewireSupport pipewire
-        ++ lib.optional ffmpegSupport ffmpeg_7
+        ++ lib.optional ffmpegSupport ffmpegPackage
         ++ lib.optional gssSupport libkrb5
         ++ lib.optional useGlvnd libglvnd
         ++ lib.optionals (cfg.enableQuakeLive or false) [


### PR DESCRIPTION
Firefox was pinned to ffmpeg 7 in #460904 because ffmpeg 8 broke software decode for h264/hevc/aac. The upstream fix ([bug 1962139](https://bugzilla.mozilla.org/show_bug.cgi?id=1962139)) shipped in Firefox 146; it was **not** uplifted to ESR 140 (flagged wontfix), so a plain unpin would break media decode there.

This selects the wrapper's ffmpeg based on `lib.versionAtLeast browser.version "146"`, which resolves correctly for every current consumer of `wrapFirefox`:

| package | version | ffmpeg in wrapper |
|---|---|---|
| firefox / firefox-bin / firefox-beta / firefox-devedition | 153.x | 8.1.2 |
| firefox-esr-153 | 153.0esr | 8.1.2 |
| librewolf / librewolf-bin | 153.x | 8.1.2 |
| thunderbird-latest | 153.0.1 | 8.1.2 |
| firefox-esr-140 / thunderbird-esr | 140.13.0esr | 7.1.5 (unchanged) |
| floorp-bin (ESR 140 based) | 12.15.2 | 7.1.5 (unchanged) |

Browsers with independent versioning fall below the gate and keep the status quo, which is correct since they are ESR-based. Verified the table above by eval; built `firefox`, `firefox-esr`, and `firefox-bin`, confirmed the expected ffmpeg in each wrapper's `LD_LIBRARY_PATH`, and launched each binary.

Besides dropping a duplicate ffmpeg closure for most users, this fixes live breakage. Firefox 153 shipped Vulkan video decode (off by default, `media.hardware-video-decoding-vulkan.enabled`). Under the blanket `ffmpeg_7` pin, enabling it on the current firefox (153.0.1) breaks VP9 hardware decode outright: VP9-over-Vulkan requires libavcodec 62 (FFmpeg 8), and 153/154 lack the guard that would fall back to VA-API on older libavcodec ([bug 2057693](https://bugzilla.mozilla.org/show_bug.cgi?id=2057693), fixed in 155 only, no uplift).

It also prepares the next transition. FFmpeg 9 is imminent: `release/9.0` was branched on 2026-06-26 ([original schedule](https://www.mail-archive.com/ffmpeg-devel@ffmpeg.org/msg188172.html) targeted June), and Firefox 155 (current Nightly) just landed FFmpeg 9 / libavcodec 63 support ([mozilla-firefox/firefox@df4c67d](https://github.com/mozilla-firefox/firefox/commit/df4c67dc9015)). The Vulkan zero-copy "direct export" mode requires libavcodec 63 — 155 + FFmpeg 9 will be the first pairing where it works, and users will want this when 155 ships. When 9.0 lands in nixpkgs, this gate naturally gains a one-line third tier (155 → `ffmpeg_9`).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage).
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.

---

Diff and PR text written with Claude Code (Claude Fable 5), reviewed by me.
