### PR TITLE
check-meta: targeted performance cleanups

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -160,32 +160,40 @@ let
   isMarkedInsecure =
     attrs: attrs ? meta.knownVulnerabilities && attrs.meta.knownVulnerabilities != [ ];
 
-  # Allow granular checks to allow only some unfree packages
+  # Check whether unfree packages are allowed and if not, whether the
+  # package has an unfree license and is not explicitly allowed by the
+  # `allowUnfreePredicate` function.
+  #
   # Example:
   # {pkgs, ...}:
   # {
   #   allowUnfree = false;
   #   allowUnfreePredicate = (x: pkgs.lib.hasPrefix "vscode" x.name);
+  #   allowUnfreePackages = [ "steam" ];
   # }
-  # Defaults to allow all names defined in config.allowUnfreePackages
-  allowUnfreePredicate =
-    let
-      listPredicate = pkg: elem (getName pkg) (config.allowUnfreePackages or [ ]);
-
-      # Be robust against misconfigured allowUnfreePredicate values such as null
-      explicitPredicate =
-        let
-          raw = config.allowUnfreePredicate or null;
-        in
-        if isFunction raw then raw else (_: false);
-    in
-    pkg: (listPredicate pkg) || (explicitPredicate pkg);
-
-  # Check whether unfree packages are allowed and if not, whether the
-  # package has an unfree license and is not explicitly allowed by the
-  # `allowUnfreePredicate` function.
+  # Defaults to allow all names defined in config.allowUnfreePackages, and all
+  # packages that match the unfree predicate function
   hasDeniedUnfreeLicense =
-    if allowUnfree then _: false else attrs: hasUnfreeLicense attrs && !allowUnfreePredicate attrs;
+    if allowUnfree then
+      _: false
+    else
+      let
+        listPredicate = pkg: elem (getName pkg) config.allowUnfreePackages;
+        definedListPredicate = config.allowUnfreePackages or [ ] != [ ];
+
+        explicitPredicate = config.allowUnfreePredicate;
+        # Be robust against misconfigured allowUnfreePredicate values such as null
+        definedExplicitPredicate = isFunction (config.allowUnfreePredicate or null);
+      in
+      if definedListPredicate then
+        if definedExplicitPredicate then
+          attrs: hasUnfreeLicense attrs && !(listPredicate attrs || explicitPredicate attrs)
+        else
+          attrs: hasUnfreeLicense attrs && !listPredicate attrs
+      else if definedExplicitPredicate then
+        attrs: hasUnfreeLicense attrs && !explicitPredicate attrs
+      else
+        hasUnfreeLicense;
 
   allowInsecure = getEnv "NIXPKGS_ALLOW_INSECURE" == "1";
 

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -69,7 +69,9 @@ let
     if envVar != "" then envVar != "0" else config.allowNonSource or true;
 
   allowlist = config.allowlistedLicenses or config.whitelistedLicenses or [ ];
+  nonEmptyAllowList = allowlist != [ ];
   blocklist = config.blocklistedLicenses or config.blacklistedLicenses or [ ];
+  nonEmptyBlocklist = blocklist != [ ];
 
   areLicenseListsValid =
     if mutuallyExclusive allowlist blocklist then
@@ -427,13 +429,13 @@ let
       }
 
     # --- Put checks that can be ignored here ---
-    else if hasDeniedUnfreeLicense attrs && !(allowlist != [ ] && hasAllowlistedLicense attrs) then
+    else if hasDeniedUnfreeLicense attrs && !(nonEmptyAllowList && hasAllowlistedLicense attrs) then
       {
         reason = "unfree";
         msg = "has an unfree license (‘${showLicense attrs.meta.license}’)";
         remediation = remediate_allowlist "Unfree" (remediate_predicate "allowUnfreePredicate" attrs);
       }
-    else if blocklist != [ ] && hasBlocklistedLicense attrs then
+    else if nonEmptyBlocklist && hasBlocklistedLicense attrs then
       {
         reason = "blocklisted";
         msg = "has a blocklisted license (‘${showLicense attrs.meta.license}’)";

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -8,38 +8,48 @@
 
 let
   inherit (lib)
-    all
     attrValues
+    concatMap
     concatMapStrings
     concatStrings
+    concatStringsSep
     filter
     findFirst
+    foldl'
     getName
+    isAttrs
+    isFunction
+    isString
     length
-    concatMap
     mutuallyExclusive
     optional
-    isAttrs
-    isString
+    optionalString
+    seq
+    unsafeGetAttrPos
     warn
-    foldl'
+    all
     ;
 
   inherit (lib.lists)
     any
-    toList
-    isList
     elem
+    isList
+    toList
     unique
     ;
 
   inherit (lib.meta)
-    platformMatch
     cpeFullVersionWithVendor
+    platformMatch
     ;
 
   inherit (lib.generators)
     toPretty
+    ;
+
+  inherit (lib.licenses)
+    containsLicenses
+    isFree
     ;
 
   inherit (builtins)
@@ -83,7 +93,7 @@ let
     assert areLicenseListsValid;
     list:
     let
-      containsListLicenses = lib.licenses.containsLicenses list;
+      containsListLicenses = containsLicenses list;
     in
     attrs:
     attrs ? meta.license
@@ -106,7 +116,7 @@ let
   isUnfree =
     licenses:
     if isAttrs licenses && licenses ? "licenseType" then
-      !(lib.licenses.isFree licenses)
+      !(isFree licenses)
     else if isAttrs licenses then
       !(licenses.free or true)
     # TODO: Returning false in the case of a string is a bug that should be fixed.
@@ -152,14 +162,14 @@ let
   # Defaults to allow all names defined in config.allowUnfreePackages
   allowUnfreePredicate =
     let
-      listPredicate = pkg: builtins.elem (lib.getName pkg) (config.allowUnfreePackages or [ ]);
+      listPredicate = pkg: elem (getName pkg) (config.allowUnfreePackages or [ ]);
 
       # Be robust against misconfigured allowUnfreePredicate values such as null
       explicitPredicate =
         let
           raw = config.allowUnfreePredicate or null;
         in
-        if builtins.isFunction raw then raw else (_: false);
+        if isFunction raw then raw else (_: false);
     in
     pkg: (listPredicate pkg) || (explicitPredicate pkg);
 
@@ -306,9 +316,9 @@ let
       missingOutputs = filter (output: !elem output actualOutputs) expectedOutputs;
     in
     ''
-      The package ${getNameWithVersion attrs} has set meta.outputsToInstall to: ${builtins.concatStringsSep ", " expectedOutputs}
+      The package ${getNameWithVersion attrs} has set meta.outputsToInstall to: ${concatStringsSep ", " expectedOutputs}
 
-      however ${getNameWithVersion attrs} only has the outputs: ${builtins.concatStringsSep ", " actualOutputs}
+      however ${getNameWithVersion attrs} only has the outputs: ${concatStringsSep ", " actualOutputs}
 
       and is missing the following outputs:
 
@@ -536,9 +546,9 @@ let
     }:
     let
       outputs = attrs.outputs or [ "out" ];
-      hasOutput = out: builtins.elem out outputs;
-      maintainersPosition = builtins.unsafeGetAttrPos "maintainers" (attrs.meta or { });
-      teamsPosition = builtins.unsafeGetAttrPos "teams" (attrs.meta or { });
+      hasOutput = out: elem out outputs;
+      maintainersPosition = unsafeGetAttrPos "maintainers" (attrs.meta or { });
+      teamsPosition = unsafeGetAttrPos "teams" (attrs.meta or { });
     in
     {
       # `name` derivation attribute includes cross-compilation cruft,
@@ -691,7 +701,7 @@ let
           let
             msg =
               "Refusing to evaluate package '${getNameWithVersion attrs}' in ${pos_str meta} because it ${error.msg}"
-              + lib.optionalString (!inHydra && error.remediation != "") "\n${error.remediation}";
+              + optionalString (!inHydra && error.remediation != "") "\n${error.remediation}";
           in
           if config ? handleEvalIssue then
             if error.reason == "problem" then
@@ -706,12 +716,12 @@ let
         let
           msg =
             "Package '${getNameWithVersion attrs}' in ${pos_str meta} ${warning.msg}"
-            + lib.optionalString (!inHydra && warning.remediation != "") " ${warning.remediation}";
+            + optionalString (!inHydra && warning.remediation != "") " ${warning.remediation}";
         in
         warn msg acc;
     in
     # Give all warnings first, then error if any
-    builtins.seq (foldl' giveWarning null warnings) withError;
+    seq (foldl' giveWarning null warnings) withError;
 
   assertValidity =
     hostPlatform:

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -127,7 +127,8 @@ let
     else if isString licenses then
       false
     else
-      any (l: !(l.free or true)) licenses;
+      # on a list, check if any of the licenses weren't free (boolean AND)
+      any (l: !l.free or false) licenses;
 
   hasUnfreeLicense = attrs: attrs ? meta.license && isUnfree attrs.meta.license;
 

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -124,17 +124,20 @@ let
 
   # Logical inversion of meta.availableOn for hostPlatform
   hasUnsupportedPlatform =
-    hostPlatform:
-    let
-      inherit (hostPlatform) system;
-      # in almost all cases, meta.platforms is a simple list of strings, and we
-      # can just check if it contains the current system. we only run the more
-      # intensive platformMatch if necessary
-      anyHostPlatform = list: elem system list || any (platformMatch hostPlatform) list;
-    in
-    pkg:
-    pkg ? meta.platforms && !(anyHostPlatform pkg.meta.platforms)
-    || pkg ? meta.badPlatforms && anyHostPlatform pkg.meta.badPlatforms;
+    if allowUnsupportedSystem then
+      _: _: false
+    else
+      hostPlatform:
+      let
+        inherit (hostPlatform) system;
+        # in almost all cases, meta.platforms is a simple list of strings, and we
+        # can just check if it contains the current system. we only run the more
+        # intensive platformMatch if necessary
+        anyHostPlatform = list: elem system list || any (platformMatch hostPlatform) list;
+      in
+      pkg:
+      pkg ? meta.platforms && !(anyHostPlatform pkg.meta.platforms)
+      || pkg ? meta.badPlatforms && anyHostPlatform pkg.meta.badPlatforms;
 
   isMarkedInsecure = attrs: (attrs.meta.knownVulnerabilities or [ ]) != [ ];
 
@@ -447,7 +450,7 @@ let
         msg = "contains elements not built from source (‘${showSourceType attrs.meta.sourceProvenance}’)";
         remediation = remediate_allowlist "NonSource" (remediate_predicate "allowNonSourcePredicate" attrs);
       }
-    else if hasUnsupportedPlatform' attrs && !allowUnsupportedSystem then
+    else if hasUnsupportedPlatform' attrs then
       let
         toPretty' = toPretty {
           allowPrettyValues = true;

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -166,7 +166,7 @@ let
   # package has an unfree license and is not explicitly allowed by the
   # `allowUnfreePredicate` function.
   hasDeniedUnfreeLicense =
-    attrs: hasUnfreeLicense attrs && !allowUnfree && !allowUnfreePredicate attrs;
+    if allowUnfree then _: false else attrs: hasUnfreeLicense attrs && !allowUnfreePredicate attrs;
 
   allowInsecureDefaultPredicate =
     x: elem (getNameWithVersion x) (config.permittedInsecurePackages or [ ]);

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -168,14 +168,24 @@ let
   hasDeniedUnfreeLicense =
     if allowUnfree then _: false else attrs: hasUnfreeLicense attrs && !allowUnfreePredicate attrs;
 
-  allowInsecureDefaultPredicate =
-    x: elem (getNameWithVersion x) (config.permittedInsecurePackages or [ ]);
-  allowInsecurePredicate = config.allowInsecurePredicate or allowInsecureDefaultPredicate;
-
   allowInsecure = getEnv "NIXPKGS_ALLOW_INSECURE" == "1";
 
   hasDisallowedInsecure =
-    attrs: isMarkedInsecure attrs && !allowInsecure && !allowInsecurePredicate attrs;
+    if allowInsecure then
+      _: false
+    else if config ? allowInsecurePredicate then
+      let
+        inherit (config) allowInsecurePredicate;
+      in
+      attrs: isMarkedInsecure attrs && !allowInsecurePredicate attrs
+    else if config ? permittedInsecurePackages then
+      let
+        inherit (config) permittedInsecurePackages;
+        allowInsecurePredicate = x: elem (getNameWithVersion x) permittedInsecurePackages;
+      in
+      attrs: isMarkedInsecure attrs && !allowInsecurePredicate attrs
+    else
+      isMarkedInsecure;
 
   # Allow granular checks to allow only some non-source-built packages
   # Example:

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -115,7 +115,8 @@ let
 
   isUnfree =
     licenses:
-    if isAttrs licenses && licenses ? "licenseType" then
+    # ? is non-strict in its type, so it doubles as performing an isAttrs check
+    if licenses ? licenseType then
       !(isFree licenses)
     else if isAttrs licenses then
       !(licenses.free or true)

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -139,7 +139,8 @@ let
       pkg ? meta.platforms && !(anyHostPlatform pkg.meta.platforms)
       || pkg ? meta.badPlatforms && anyHostPlatform pkg.meta.badPlatforms;
 
-  isMarkedInsecure = attrs: (attrs.meta.knownVulnerabilities or [ ]) != [ ];
+  isMarkedInsecure =
+    attrs: attrs ? meta.knownVulnerabilities && attrs.meta.knownVulnerabilities != [ ];
 
   # Allow granular checks to allow only some unfree packages
   # Example:

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -141,15 +141,21 @@ let
     else
       hostPlatform:
       let
-        inherit (hostPlatform) system;
-        # in almost all cases, meta.platforms is a simple list of strings, and we
-        # can just check if it contains the current system. we only run the more
-        # intensive platformMatch if necessary
-        anyHostPlatform = list: elem system list || any (platformMatch hostPlatform) list;
+        containsHostSystem = elem hostPlatform.system;
+        matchesHostPlatform = any (platformMatch hostPlatform);
       in
       pkg:
-      pkg ? meta.platforms && !(anyHostPlatform pkg.meta.platforms)
-      || pkg ? meta.badPlatforms && anyHostPlatform pkg.meta.badPlatforms;
+      # in almost all cases, platforms are a simple list of strings, and we
+      # can just check if they contains the current system. we only run the more
+      # intensive platformMatch if necessary
+      (
+        pkg ? meta.platforms
+        && !(containsHostSystem pkg.meta.platforms || matchesHostPlatform pkg.meta.platforms)
+      )
+      || (
+        pkg ? meta.badPlatforms
+        && (containsHostSystem pkg.meta.badPlatforms || matchesHostPlatform pkg.meta.badPlatforms)
+      );
 
   isMarkedInsecure =
     attrs: attrs ? meta.knownVulnerabilities && attrs.meta.knownVulnerabilities != [ ];


### PR DESCRIPTION
I've done similar work on this file in the past - just continuing it.

There's a lot of places where we know info ahead-of-time based on `config`, and can avoid doing more expensive checks if so. The most impactful change from this is likely to be the third commit - anyone with `config.allowUnfree = true` should see a nice performance improvement, as they no longer have to check whether packages are unfree at all.

Stats diff on `pkgs.firefox` _without_ `allowUnfree = true`:
```json
{
  "attrset": {
    "lookups": "-3.48%",
    "merges": "+0.02%",
    "mergeCopies": "+0%"
  },
  "list": {
    "concats": "+0.01%"
  },
  "parser": {
    "expressions": "+0.02%"
  },
  "memoryBytes": {
    "envs": "-0.92%",
    "list": "+0.01%",
    "sets": "+0%",
    "symbols": "+0.01%",
    "values": "+0.01%",
    "total": "-0.06%"
  },
  "speed": {
    "primops": "-0.7%",
    "functionCalls": "-1.68%",
    "thunksMade": "+0.03%",
    "thunksAvoided": "-1.24%"
  }
}
```
And here's _with_ `allowUnfree = true` (set before and after, so we can see what difference the optimization makes):
```json
{
  "attrset": {
    "lookups": "-6.81%",
    "merges": "-0.2%",
    "mergeCopies": "-0.05%"
  },
  "list": {
    "concats": "-0.01%"
  },
  "parser": {
    "expressions": "-0.52%"
  },
  "memoryBytes": {
    "envs": "-1.5%",
    "list": "-0.19%",
    "sets": "-0.08%",
    "symbols": "-0.34%",
    "values": "-0.17%",
    "total": "-0.21%"
  },
  "speed": {
    "primops": "-1.09%",
    "functionCalls": "-2.58%",
    "thunksMade": "-0.28%",
    "thunksAvoided": "-1.6%"
  }
}
```
Also included is a bunch of cleanups to lower the number of function calls where possible. Something like this (toy example):
```nix
  allowUnfreePredicate = config.allowUnfreePredicate or (_: true):
  hasDeniedUnfreeLicenses = attrs: hasUnfreeLicense attrs && allowUnfreePredicate attrs
```
Can be simplified to a single function call when `allowUnfreePredicate` isn't defined:
```nix
	hasUnfreeLicense =
	  if config ? allowUnfreePredicate then
	    attrs: hasUnfreeLicense attrs && config.allowUnfreePredicate attrs
	  else
	    hasUnfreeLicense;
```
Optimizations like this were applied to several cases where predicates were relevant.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
