### PR TITLE
services.chrony: new option `keyFile`

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -324,6 +324,10 @@
   Migrating sites to Grav 2 is a [manual process](https://learn.getgrav.org/20/migration/manual-migration) with this package since the migration plugin cannot modify the Nix store.
   The [`services.grav.package`](#opt-services.grav.package) option defaults to `pkgs.grav_2` if [`system.stateVersion`](#opt-system.stateVersion) >=26.11.
 
+- `services.chrony` now offers an option to control the location of the file containing symmetric packet authentication keys, [`services.chrony.keyFile`](#opt-services.chrony.keyFile).  By default, symmetric packet authentication is turned off (public NTP pools do not use this feature of the protocol) and regardless of how the option is set, the module will no longer create an empty keyfile.
+   If you manually added keys to the empty file that older versions of this module would create, you will need to set the option, or the keys will not be used.  You should also move the file to a more suitable location, and verify it has appropriate permissions; for security reasons, it’s not supposed to be inside the chrony state directory, and the chrony service user is not supposed to be able to modify it.
+   If the file [`${services.chrony.directory}`](#opt-services.chrony.directory)`/chrony.keys` (usually `/var/lib/chrony/chrony.keys`) exists and is empty, it is safe to delete it after the upgrade.
+
 - `services.plausible` can now again seed an initial admin user declaratively via [`services.plausible.adminUser.email`](#opt-services.plausible.adminUser.email).
   This makes fully declarative deployments safer: Otherwise the user needed to either accept Plausible's unauthenticated "first launch" setup wizard, which lets anyone reaching the instance create the first admin account, or do more work (deploying with NixOS's default binding to `localhost` without exposing it publicly, going through the wizard, and then deploying Plausible exposed to the Internet).
   This option was previously removed with NixOS 25.05 due to an upstream Plausible change making declarative admin creation more difficult, but this change re-implements the admin creation directly.

--- a/nixos/modules/services/networking/ntp/chrony.nix
+++ b/nixos/modules/services/networking/ntp/chrony.nix
@@ -11,7 +11,6 @@ let
 
   stateDir = cfg.directory;
   driftFile = "${stateDir}/chrony.drift";
-  keyFile = "${stateDir}/chrony.keys";
   rtcFile = "${stateDir}/chrony.rtc";
 
   configFile = pkgs.writeText "chrony.conf" ''
@@ -31,7 +30,7 @@ let
     ${lib.optionalString cfg.makestep.enable "makestep ${toString cfg.makestep.threshold} ${toString cfg.makestep.limit}"}
 
     driftfile ${driftFile}
-    keyfile ${keyFile}
+    ${lib.optionalString (cfg.keyFile != null && cfg.keyFile != "") "keyfile ${cfg.keyFile}"}
     ${lib.optionalString (cfg.enableRTCTrimming) "rtcfile ${rtcFile}"}
     ${lib.optionalString (cfg.enableNTS) "ntsdumpdir ${stateDir}"}
 
@@ -149,6 +148,26 @@ in
         description = ''
           Whether to enable Network Time Security authentication.
           Make sure it is supported by your selected NTP server(s).
+        '';
+      };
+
+      keyFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          Absolute pathname of a file containing NTP packet authentication keys.
+
+          Because these keys are shared secrets, chronyd requires this file to be owned by
+          root (*not* the chrony user), writable only by root, and readable only by root
+          and the chrony group.  Also, it should *not* be stored within chrony's state
+          directory ([](#opt-services.chrony.directory)), because the chrony user can
+          clobber any file in this directory, regardless of ownership.
+
+          ::: {.note}
+          Packet authentication keys have to be shared with all configured NTP servers.
+          If you're not running your own private NTP pool, you probably want the
+          [](#opt-services.chrony.enableNTS) option instead.
+          :::
         '';
       };
 
@@ -271,7 +290,6 @@ in
     systemd.tmpfiles.rules = [
       "d ${stateDir} 0750 chrony chrony - -"
       "f ${driftFile} 0640 chrony chrony - -"
-      "f ${keyFile} 0640 root chrony - -"
     ]
     ++ lib.optionals cfg.enableRTCTrimming [
       "f ${rtcFile} 0640 chrony chrony - -"


### PR DESCRIPTION
For people who actually need it, this makes chrony’s symmetric packet authentication feature usable.  For everyone else, it eliminates an annoying warning message from chronyd on every boot.

Fixes #445035; see that issue for details.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
