### PR TITLE
faiss: 1.14.3 -> 1.15.0

### DIFF
--- a/pkgs/by-name/fa/faiss/package.nix
+++ b/pkgs/by-name/fa/faiss/package.nix
@@ -42,7 +42,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "faiss";
-  version = "1.14.3";
+  version = "1.15.0";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -53,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "facebookresearch";
     repo = "faiss";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-lIyb+T3tvCqfIqUJ6KtubnLWYTlOt5Cz51mZmDW+AYo=";
+    hash = "sha256-cP13HRNa17KL5ZE6if8QmoyKQBLf8ckAa0bOaioEOgE=";
   };
 
   nativeBuildInputs = [
@@ -83,6 +83,11 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "FAISS_ENABLE_GPU" cudaSupport)
     (lib.cmakeBool "FAISS_ENABLE_PYTHON" pythonSupport)
     (lib.cmakeFeature "FAISS_OPT_LEVEL" optLevel)
+
+    # NOTE The `metal` command-line utility used to build the Metal kernels is not open-source.
+    # To build mlx with Metal support in Nix, you'd need to use one of the sandbox escape
+    # hatches which let you interact with a native install of Xcode, such as `composeXcodeWrapper`
+    (lib.cmakeBool "FAISS_ENABLE_METAL" false)
   ]
   ++ lib.optionals cudaSupport [
     (lib.cmakeFeature "CMAKE_CUDA_ARCHITECTURES" flags.cmakeCudaArchitecturesString)

--- a/pkgs/development/python-modules/autofaiss/default.nix
+++ b/pkgs/development/python-modules/autofaiss/default.nix
@@ -14,18 +14,20 @@
   numpy,
   pyarrow,
 
+  # tests
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "autofaiss";
   version = "2.18.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "criteo";
     repo = "autofaiss";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-XuubpTxmyKdV9nWqLTljp5cNyIwLt2BKJYcBzwPNzD8=";
   };
 
@@ -40,12 +42,10 @@ buildPythonPackage rec {
   ];
 
   pythonRelaxDeps = [
+    "pandas"
     # As of v2.15.4, autofaiss asks for fire<0.5 but we have fire v0.5.0 in
     # nixpkgs at the time of writing (2022-12-25).
     "fire"
-    # As of v2.15.3, autofaiss asks for pyarrow<8 but we have pyarrow v9.0.0 in
-    # nixpkgs at the time of writing (2022-12-15).
-    "pyarrow"
 
     # No official numpy2 support yet
     "numpy"
@@ -60,7 +60,9 @@ buildPythonPackage rec {
     pyarrow
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
 
   disabledTests = [
     # Attempts to spin up a Spark cluster and talk to it which doesn't work in
@@ -81,8 +83,8 @@ buildPythonPackage rec {
     description = "Automatically create Faiss knn indices with the most optimal similarity search parameters";
     mainProgram = "autofaiss";
     homepage = "https://github.com/criteo/autofaiss";
-    changelog = "https://github.com/criteo/autofaiss/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/criteo/autofaiss/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ samuela ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/facebookresearch/faiss/compare/v1.14.2...v1.15.0
Changelog: https://github.com/facebookresearch/faiss/blob/v1.15.0/CHANGELOG.md

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
