### PR TITLE
harlequin: 2.5.2 -> 2.6.0

### DIFF
--- a/pkgs/by-name/ha/harlequin/package.nix
+++ b/pkgs/by-name/ha/harlequin/package.nix
@@ -29,14 +29,14 @@ let
 in
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "harlequin";
-  version = "2.5.2";
+  version = "2.6.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tconbeer";
     repo = "harlequin";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ea8fR+tsur/tIQwfUS88HvjCADv8VgEjHD7JnR44Twk=";
+    hash = "sha256-jZGQ6t6djiKK9B+R8TYMPwXKkLPk7Z+dXuUcVQuZMfU=";
   };
 
   pythonRelaxDeps = [
@@ -90,6 +90,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   nativeCheckInputs = with python3Packages; [
     pytest-asyncio
+    pytest-xdist
     pytestCheckHook
     versionCheckHook
     writableTmpDirAsHomeHook
@@ -117,7 +118,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   meta = {
     description = "SQL IDE for Your Terminal";
     homepage = "https://harlequin.sh";
-    changelog = "https://github.com/tconbeer/harlequin/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/tconbeer/harlequin/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     mainProgram = "harlequin";
     maintainers = with lib.maintainers; [ pcboy ];

--- a/pkgs/development/python-modules/sqlfmt/default.nix
+++ b/pkgs/development/python-modules/sqlfmt/default.nix
@@ -26,19 +26,18 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "sqlfmt";
-  version = "0.30.0";
+  version = "0.31.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "tconbeer";
     repo = "sqlfmt";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/8BTH2nuqO+du6PsTPB59L21HvvAIZKDcG1kV9XHxsg=";
+    hash = "sha256-nbgLzeMOXgiXtvV/XHu1I0LkwwaTrzj8ga6EtoZuvRk=";
   };
 
   build-system = [ hatchling ];
-
-  pythonRelaxDeps = [ "click" ];
 
   dependencies = [
     click
@@ -61,13 +60,10 @@ buildPythonPackage (finalAttrs: {
     versionCheckHook
     writableTmpDirAsHomeHook
   ]
-  ++ lib.flatten (builtins.attrValues finalAttrs.passthru.optional-dependencies);
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
 
-  disabledTestPaths = [
-    # TypeError: CliRunner.__init__() got an unexpected keyword argument 'mix_stderr'
-    "tests/functional_tests/test_end_to_end.py"
-    "tests/unit_tests/test_cli.py"
-  ];
+  # importlib.metadata.PackageNotFoundError: No package metadata was found for sqlfmt
+  dontCheckPythonMetadata = true;
 
   meta = {
     description = "Formatter for dbt SQL files";


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- **python3Packages.sqlfmt: 0.30.0 -> 0.31.0** ([Diff](https://github.com/tconbeer/sqlfmt/compare/v0.30.0...v0.31.0), [Changelog](https://github.com/tconbeer/sqlfmt/blob/v0.31.0/CHANGELOG.md))
- **harlequin: 2.5.2 -> 2.6.0** ([Diff](https://github.com/tconbeer/harlequin/compare/v2.5.2...v2.6.0), [Changelog](https://github.com/tconbeer/harlequin/releases/tag/v2.6.0))

cc @pcboy

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
