### PR TITLE
python3Packages.pypaperless: 5.2.3 -> 6.0.0

### DIFF
--- a/pkgs/development/python-modules/pypaperless/default.nix
+++ b/pkgs/development/python-modules/pypaperless/default.nix
@@ -1,27 +1,28 @@
 {
-  aiohttp,
-  aioresponses,
   buildPythonPackage,
   fetchFromGitHub,
   hatchling,
+  httpx,
   lib,
+  pydantic,
+  pydantic-settings,
   pyprojectVersionPatchHook,
   pytest-asyncio,
   pytest-cov-stub,
+  pytest-httpx,
   pytestCheckHook,
-  yarl,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "pypaperless";
-  version = "5.2.3";
+  version = "6.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tb1337";
     repo = "paperless-api";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-G40x/3bb3h49eynwYCoJPeBLmX1Ty+mq3AGQoBAiZOA=";
+    hash = "sha256-TlukfZkoM25XWwWoj5zxjBmglHO8D9TPJPiSN2ea00U=";
   };
 
   nativeBuildInputs = [
@@ -30,17 +31,22 @@ buildPythonPackage (finalAttrs: {
 
   build-system = [ hatchling ];
 
+  pythonRelaxDeps = [
+    "pydantic-settings"
+  ];
+
   dependencies = [
-    aiohttp
-    yarl
+    httpx
+    pydantic
+    pydantic-settings
   ];
 
   pythonImportsCheck = [ "pypaperless" ];
 
   nativeCheckInputs = [
-    aioresponses
     pytest-asyncio
     pytest-cov-stub
+    pytest-httpx
     pytestCheckHook
   ];
 


### PR DESCRIPTION
Diff: https://github.com/tb1337/paperless-api/compare/v5.2.3...v6.0.0

Changelog: https://github.com/tb1337/paperless-api/releases/tag/v6.0.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
