### PR TITLE
python3Packages.pydantic-settings: 2.12.0 -> 2.14.2

### DIFF
--- a/pkgs/development/python-modules/pydantic-settings/default.nix
+++ b/pkgs/development/python-modules/pydantic-settings/default.nix
@@ -5,7 +5,7 @@
   hatchling,
   pydantic,
   python-dotenv,
-  pytestCheckHook,
+  pytest9_0CheckHook,
   pytest-examples,
   pytest-mock,
 }:
@@ -13,14 +13,14 @@
 let
   self = buildPythonPackage rec {
     pname = "pydantic-settings";
-    version = "2.12.0";
+    version = "2.14.2";
     pyproject = true;
 
     src = fetchFromGitHub {
       owner = "pydantic";
       repo = "pydantic-settings";
       tag = "v${version}";
-      hash = "sha256-5SfF5Wfs/iLThd5xL/5C+qOQfg8s/9WUCSc5qag7CY0=";
+      hash = "sha256-7h0Jr/0qGJmve6fav9hKR1npDz29zD6Cci8h1TmuK4M=";
     };
 
     build-system = [ hatchling ];
@@ -33,14 +33,15 @@ let
     pythonImportsCheck = [ "pydantic_settings" ];
 
     nativeCheckInputs = [
-      pytestCheckHook
+      pytest9_0CheckHook
       pytest-examples
       pytest-mock
     ];
 
-    disabledTests = [
-      # expected to fail
-      "test_docs_examples[docs/index.md:212-246]"
+    disabledTestPaths = [
+      # fail with our version of ruff, can be removed once we have
+      # https://github.com/pydantic/pydantic-settings/pull/924
+      "tests/test_docs.py::test_docs_examples"
     ];
 
     preCheck = ''


### PR DESCRIPTION
Diff: https://github.com/pydantic/pydantic-settings/compare/v2.12.0...v2.14.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
