### PR TITLE
python3Packages.fastapi: 0.139.0 -> 0.141.1

### DIFF
--- a/pkgs/development/python-modules/fastapi/default.nix
+++ b/pkgs/development/python-modules/fastapi/default.nix
@@ -41,7 +41,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "fastapi";
-  version = "0.139.0";
+  version = "0.141.1";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -49,7 +49,7 @@ buildPythonPackage (finalAttrs: {
     owner = "tiangolo";
     repo = "fastapi";
     tag = finalAttrs.version;
-    hash = "sha256-c4balkkmBv7zKRQnYRpRohVjP23m0HvtdiVrJtgNKYo=";
+    hash = "sha256-5P9aDMS7gLti2CBlrucvjgl4Od1mti9ityPdqxI1RIM=";
   };
 
   build-system = [ pdm-backend ];


### PR DESCRIPTION
Split out of #547607 per review discussion: the bump causes ~1300 rebuilds, so it targets `staging` instead of riding along with the romm init PR.

Commit authored by @gaelj, who found that fastapi 0.139.0 breaks romm at startup; 0.141.1 fixes it. Changelog: https://github.com/fastapi/fastapi/releases

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable: exercised via romm on the branch of #547607
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)