### PR TITLE
buildGoModule: do not use the build drv's build inputs in the FOD

### DIFF
--- a/pkgs/build-support/go/module.nix
+++ b/pkgs/build-support/go/module.nix
@@ -93,7 +93,7 @@ lib.extendMkDerivation {
               in
               "${prefix}go-modules${suffix}";
 
-            nativeBuildInputs = (finalAttrs.nativeBuildInputs or [ ]) ++ [
+            nativeBuildInputs = args.modNativeBuildInputs or [ ] ++ [
               go
               gitMinimal
               cacert
@@ -109,7 +109,7 @@ lib.extendMkDerivation {
             patches = finalAttrs.patches or [ ];
             patchFlags = finalAttrs.patchFlags or [ ];
             postPatch = finalAttrs.postPatch or "";
-            preBuild = finalAttrs.preBuild or "";
+            preBuild = finalAttrs.modPreBuild or "";
             postBuild = finalAttrs.modPostBuild or "";
             sourceRoot = finalAttrs.sourceRoot or "";
             setSourceRoot = finalAttrs.setSourceRoot or "";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Currently, the `goModule` FOD takes in `finalAttrs.nativeBuildInputs`. In my opinion this does not make much sense. 

For this to be useful, the user must also add on something with the phases. It is also a bad idea IMO since FODs should not do anything except cache downloads. 

This also breaks `setupHook` modularity because now everytime someone adds a setupHook to their Go module, it is also added to the FOD. This is pretty unexpected as no other drv builders do this (afaik), and can lead to issue where:

1. Developer tests that the program builds fine
2. Developer adds the setupHook to their Go program
3. Developer runs build with the setupHook. It builds fine.
4. Developer pushes their change, then pulls it to another computer
5. Developer builds on their new computer
6. Build fails!

This is because of step 1: The FOD is built, and since the hash is already fixed, it will never be built again on that computer (unless they do a gc run). But on their other computer, or when they do update the FOD later (if this FOD is cached), the build may fail.

The same story with `preBuild`. There is not really any reason that the build drv and the FOD drv should have the same `preBuild` as they are building very different things. If a user really wants to, they can set it explicitly. It is also unified with `modPostBuild` and such. 

Looking around, are a good amount of workarounds to this in-tree that look similar to this:
https://github.com/NixOS/nixpkgs/blob/643809054d65fdd466a63e3155b8c498cb483c04/pkgs/by-name/re/readeck/package.nix#L56-L58

Since the FOD hash makes it so that things are not rebuilt, it is a bit hard to get the full downstream effects. Some rg I've done:
* `rg '(modConfigurePhase|modBuildPhase|modInstallPhase)'`
Only match: https://github.com/NixOS/nixpkgs/blob/643809054d65fdd466a63e3155b8c498cb483c04/pkgs/by-name/lo/local-ai/package.nix#L429-L432
* `rg -F 'overrideModAttrs' --files-with-matches pkgs | count` = 40
  Not all need to be fixed-up, but many do
* List generated with `rg 'overrideModAttrs' --after-context 10 pkgs --null --no-context-separator | cut -d "$(printf '\000')" -f 1 | uniq | sed 's|^|* [ ] |'`
  - [ ] helm
  - [ ] satisfactorymodmanager
  - [ ] dcp
  - [ ] gitea
  - [ ] go-hass-agent
  - [ ] golink
  - [ ] godns
  - [ ] drasl
  - [ ] yubihsm-connector
  - [ ] puredns
  - [ ] grafana
  - [ ] dnote
  - [ ] talosctl
  - [ ] evcc
  - [ ] legitify
  - [ ] karma
  - [ ] glauth
  - [ ] proton-cli
  - [ ] authentik
  - [ ] scion-apps
  - [ ] forgejo
  - [ ] netbird
  - [ ] readeck
  - [ ] navidrome
  - [ ] aaaaxy
  - [ ] mattermost
  - [ ] exatorrent
  - [ ] perses
  - [ ] immich-kiosk
  - [ ] sshwifty
  - [ ] homebox
  - [ ] sesh
  - [ ] searchix
  - [ ] ollama
  - [ ] spotifalc
  - [ ] coredns
  - [ ] coroot

Lots of `overrideModAttrs.preBuild = ""` and filtering out hooks. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
