### PR TITLE
python3Packages.pygtrie: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/pygtrie/default.nix
+++ b/pkgs/development/python-modules/pygtrie/default.nix
@@ -2,15 +2,21 @@
   lib,
   fetchPypi,
   buildPythonPackage,
+  setuptools,
 }:
 buildPythonPackage rec {
   pname = "pygtrie";
   version = "2.5.0";
-  format = "setuptools";
+
+  pyproject = true;
+
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-IDUUrYJutAPasdLi3dA04NFTS75NvgITuwWT9mvrpOI=";
   };
+
+  build-system = [ setuptools ];
+
   meta = {
     homepage = "https://github.com/mina86/pygtrie";
     description = "Trie data structure implementation";

--- a/pkgs/development/python-modules/pygtrie/default.nix
+++ b/pkgs/development/python-modules/pygtrie/default.nix
@@ -4,14 +4,16 @@
   buildPythonPackage,
   setuptools,
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pygtrie";
   version = "2.5.0";
 
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchPypi {
-    inherit pname version;
+    pname = "pygtrie";
+    inherit (finalAttrs) version;
     hash = "sha256-IDUUrYJutAPasdLi3dA04NFTS75NvgITuwWT9mvrpOI=";
   };
 
@@ -23,4 +25,4 @@ buildPythonPackage rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ kmein ];
   };
-}
+})

--- a/pkgs/development/python-modules/pygtrie/default.nix
+++ b/pkgs/development/python-modules/pygtrie/default.nix
@@ -27,6 +27,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     homepage = "https://github.com/mina86/pygtrie";
     description = "Trie data structure implementation";
+    changelog = "https://github.com/mina86/pygtrie/blob/v${finalAttrs.version}/version-history.rst";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ kmein ];
   };

--- a/pkgs/development/python-modules/pygtrie/default.nix
+++ b/pkgs/development/python-modules/pygtrie/default.nix
@@ -3,6 +3,7 @@
   fetchPypi,
   buildPythonPackage,
   setuptools,
+  pytestCheckHook,
 }:
 buildPythonPackage (finalAttrs: {
   pname = "pygtrie";
@@ -18,6 +19,10 @@ buildPythonPackage (finalAttrs: {
   };
 
   build-system = [ setuptools ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  enabledTestPaths = [ "test.py" ];
 
   meta = {
     homepage = "https://github.com/mina86/pygtrie";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- https://github.com/NixOS/nixpkgs/issues/515974

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
