### PR TITLE
python3Packages.pyimpfuzzy: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/pyimpfuzzy/default.nix
+++ b/pkgs/development/python-modules/pyimpfuzzy/default.nix
@@ -4,20 +4,23 @@
   fetchPypi,
   ssdeep,
   pefile,
+  setuptools,
 }:
 buildPythonPackage rec {
   pname = "pyimpfuzzy";
   version = "0.5";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "da9796df302db4b04a197128637f84988f1882f1e08fdd69bbf9fdc6cfbaf349";
   };
 
+  build-system = [ setuptools ];
+
   buildInputs = [ ssdeep ];
 
-  propagatedBuildInputs = [ pefile ];
+  dependencies = [ pefile ];
 
   # no tests
   doCheck = false;

--- a/pkgs/development/python-modules/pyimpfuzzy/default.nix
+++ b/pkgs/development/python-modules/pyimpfuzzy/default.nix
@@ -6,14 +6,17 @@
   pefile,
   setuptools,
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pyimpfuzzy";
   version = "0.5";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "da9796df302db4b04a197128637f84988f1882f1e08fdd69bbf9fdc6cfbaf349";
+    pname = "pyimpfuzzy";
+    inherit (finalAttrs) version;
+    hash = "sha256-2peW3zAttLBKGXEoY3+EmI8YgvHgj91pu/n9xs+680k=";
   };
 
   build-system = [ setuptools ];
@@ -33,4 +36,4 @@ buildPythonPackage rec {
     license = lib.licenses.gpl2Only;
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- #515974

<!-- magic comment :p -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
