### PR TITLE
python3Packages.pyinstaller-versionfile: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/pyinstaller-versionfile/default.nix
+++ b/pkgs/development/python-modules/pyinstaller-versionfile/default.nix
@@ -33,6 +33,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Create a windows version-file from a simple YAML file that can be used by PyInstaller";
     mainProgram = "create-version-file";
+    changelog = "https://github.com/DudeNr33/pyinstaller-versionfile/blob/v${finalAttrs.version}/CHANGELOG.md";
     homepage = "https://pypi.org/project/pyinstaller-versionfile/";
     license = lib.licenses.mit;
     maintainers = [ ];

--- a/pkgs/development/python-modules/pyinstaller-versionfile/default.nix
+++ b/pkgs/development/python-modules/pyinstaller-versionfile/default.nix
@@ -8,16 +8,17 @@
   poetry-core,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pyinstaller-versionfile";
   version = "3.1.0";
 
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "DudeNr33";
     repo = "pyinstaller-versionfile";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-L94MrZjCOw2Cxj0kF+F35TixVNJUi1sK99FG9+CzaIg=";
   };
 
@@ -36,4 +37,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/pyinstaller-versionfile/default.nix
+++ b/pkgs/development/python-modules/pyinstaller-versionfile/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "pyinstaller-versionfile";
-  version = "3.0.1";
+  version = "3.1.0";
 
   pyproject = true;
 
@@ -18,12 +18,8 @@ buildPythonPackage rec {
     owner = "DudeNr33";
     repo = "pyinstaller-versionfile";
     tag = "v${version}";
-    hash = "sha256-UNrXP5strO6LIkIM3etBo1+Vm+1lR5wF0VfKtZYRoYc=";
+    hash = "sha256-L94MrZjCOw2Cxj0kF+F35TixVNJUi1sK99FG9+CzaIg=";
   };
-
-  preBuild = ''
-    touch requirements.txt
-  '';
 
   build-system = [ poetry-core ];
 

--- a/pkgs/development/python-modules/pyinstaller-versionfile/default.nix
+++ b/pkgs/development/python-modules/pyinstaller-versionfile/default.nix
@@ -5,13 +5,14 @@
   packaging,
   jinja2,
   pyyaml,
+  poetry-core,
 }:
 
 buildPythonPackage rec {
   pname = "pyinstaller-versionfile";
   version = "3.0.1";
 
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "DudeNr33";
@@ -24,7 +25,9 @@ buildPythonPackage rec {
     touch requirements.txt
   '';
 
-  propagatedBuildInputs = [
+  build-system = [ poetry-core ];
+
+  dependencies = [
     packaging
     jinja2
     pyyaml


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- #515974

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
