### PR TITLE
python3Packages.pyinputevent: fix version scheme

### DIFF
--- a/pkgs/development/python-modules/pyinputevent/default.nix
+++ b/pkgs/development/python-modules/pyinputevent/default.nix
@@ -2,12 +2,14 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
 }:
 
 buildPythonPackage {
   pname = "pyinputevent";
   version = "0.1-unstable-2015-10-18";
-  format = "setuptools";
+
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ntzrmtthihu777";
@@ -15,6 +17,8 @@ buildPythonPackage {
     rev = "d2075fa5db5d8a402735fe788bb33cf9fe272a5b";
     sha256 = "0rkis0xp8f9jc00x7jb9kbvhdla24z1vl30djqa6wy6fx0cr6sib";
   };
+
+  build-system = [ setuptools ];
 
   meta = {
     homepage = "https://github.com/ntzrmtthihu777/pyinputevent";

--- a/pkgs/development/python-modules/pyinputevent/default.nix
+++ b/pkgs/development/python-modules/pyinputevent/default.nix
@@ -6,7 +6,7 @@
 
 buildPythonPackage {
   pname = "pyinputevent";
-  version = "2016-10-18";
+  version = "0.1-unstable-2015-10-18";
   format = "setuptools";
 
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/pyinputevent/default.nix
+++ b/pkgs/development/python-modules/pyinputevent/default.nix
@@ -9,13 +9,14 @@ buildPythonPackage {
   pname = "pyinputevent";
   version = "0.1-unstable-2015-10-18";
 
+  __structuredAttrs = true;
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ntzrmtthihu777";
     repo = "pyinputevent";
     rev = "d2075fa5db5d8a402735fe788bb33cf9fe272a5b";
-    sha256 = "0rkis0xp8f9jc00x7jb9kbvhdla24z1vl30djqa6wy6fx0cr6sib";
+    hash = "sha256-K2qTGejOeG4Ulg0MusMnQtEG95ppydMBYDI5dDvQcWY=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- #515974

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
