### PR TITLE
pcre2: remove withJitSealloc

### DIFF
--- a/nixos/modules/services/audio/mympd.nix
+++ b/nixos/modules/services/audio/mympd.nix
@@ -108,7 +108,7 @@ in
         DynamicUser = true;
         ExecStart = lib.getExe cfg.package;
         LockPersonality = true;
-        MemoryDenyWriteExecute = true;
+        MemoryDenyWriteExecute = false; # pcre2 jit
         PrivateDevices = true;
         ProtectClock = true;
         ProtectControlGroups = true;

--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -752,7 +752,7 @@ in
             "AF_INET6"
           ];
           LockPersonality = true;
-          MemoryDenyWriteExecute = true;
+          MemoryDenyWriteExecute = false; # pcre2 jit
           RestrictRealtime = true;
           RestrictSUIDSGID = true;
           PrivateMounts = true;

--- a/nixos/modules/services/mail/cyrus-imap.nix
+++ b/nixos/modules/services/mail/cyrus-imap.nix
@@ -355,7 +355,7 @@ in
         PrivateDevices = true;
         ProtectSystem = "full";
         CapabilityBoundingSet = [ "~CAP_NET_ADMIN CAP_SYS_ADMIN CAP_SYS_BOOT CAP_SYS_MODULE" ];
-        MemoryDenyWriteExecute = true;
+        MemoryDenyWriteExecute = false; # pcre2 jit
         ProtectKernelModules = true;
         ProtectKernelTunables = true;
         ProtectControlGroups = true;

--- a/nixos/modules/services/mail/dovecot.nix
+++ b/nixos/modules/services/mail/dovecot.nix
@@ -1061,7 +1061,7 @@ in
           "CAP_SYS_RESOURCE"
         ];
         LockPersonality = true;
-        MemoryDenyWriteExecute = true;
+        MemoryDenyWriteExecute = false; # pcre2 jit
         NoNewPrivileges = false; # e.g for sendmail
         OOMPolicy = "continue";
         PrivateTmp = true;

--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -1011,7 +1011,7 @@ in
             PrivateDevices = true;
             ProtectSystem = "full";
             CapabilityBoundingSet = [ "~CAP_NET_ADMIN CAP_SYS_ADMIN CAP_SYS_BOOT CAP_SYS_MODULE" ];
-            MemoryDenyWriteExecute = true;
+            MemoryDenyWriteExecute = false; # pcre2 jit
             ProtectKernelModules = true;
             ProtectKernelTunables = true;
             ProtectControlGroups = true;

--- a/nixos/modules/services/misc/forgejo.nix
+++ b/nixos/modules/services/misc/forgejo.nix
@@ -777,7 +777,7 @@ in
         ];
         RestrictNamespaces = true;
         LockPersonality = true;
-        MemoryDenyWriteExecute = true;
+        MemoryDenyWriteExecute = false; # pcre2 jit
         RestrictRealtime = true;
         RestrictSUIDSGID = true;
         RemoveIPC = true;

--- a/nixos/modules/services/misc/gitea.nix
+++ b/nixos/modules/services/misc/gitea.nix
@@ -953,7 +953,7 @@ in
         ++ lib.optional (useSendmail && config.services.postfix.enable) "AF_NETLINK";
         RestrictNamespaces = true;
         LockPersonality = true;
-        MemoryDenyWriteExecute = true;
+        MemoryDenyWriteExecute = false; # pcre2 jit
         RestrictRealtime = true;
         RestrictSUIDSGID = true;
         RemoveIPC = true;

--- a/nixos/modules/services/networking/suricata/default.nix
+++ b/nixos/modules/services/networking/suricata/default.nix
@@ -270,7 +270,7 @@ in
               ProtectSystem = "strict";
               DevicePolicy = "closed";
               LockPersonality = true;
-              MemoryDenyWriteExecute = true;
+              MemoryDenyWriteExecute = false; # pcre2 jit
               ProtectHostname = true;
               ProtectProc = true;
               ProtectKernelLogs = true;

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -1614,11 +1614,7 @@ in
           ];
           RestrictNamespaces = true;
           LockPersonality = true;
-          MemoryDenyWriteExecute =
-            !(
-              (builtins.any (mod: (mod.allowMemoryWriteExecute or false)) cfg.package.modules)
-              || (lib.getName cfg.package == "openresty")
-            );
+          MemoryDenyWriteExecute = false; # for pcre2 & several plugins
           RestrictRealtime = true;
           RestrictSUIDSGID = true;
           RemoveIPC = true;

--- a/nixos/modules/services/web-servers/unit/default.nix
+++ b/nixos/modules/services/web-servers/unit/default.nix
@@ -139,7 +139,7 @@ in
           "AF_INET6"
         ];
         LockPersonality = true;
-        MemoryDenyWriteExecute = true;
+        MemoryDenyWriteExecute = false; # pcre2 jit
         RestrictRealtime = true;
         RestrictSUIDSGID = true;
         PrivateMounts = true;

--- a/pkgs/by-name/pc/pcre2/package.nix
+++ b/pkgs/by-name/pc/pcre2/package.nix
@@ -3,9 +3,6 @@
   stdenv,
   fetchurl,
   updateAutotoolsGnuConfigScriptsHook,
-  # Causes consistent segfaults on ELFv1 PPC64 when trying to use Perl regex in gnugrep
-  # https://github.com/PCRE2Project/pcre2/issues/762
-  withJitSealloc ? !(stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isAbiElfv1),
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -28,9 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--enable-pcre2-32"
     # only enable jit on supported platforms which excludes Apple Silicon, see https://github.com/zherczeg/sljit/issues/51
     "--enable-jit=${if stdenv.hostPlatform.isS390x then "no" else "auto"}"
-  ]
-  # fix pcre jit in systemd units that set MemoryDenyWriteExecute=true like gitea
-  ++ lib.optional withJitSealloc "--enable-jit-sealloc";
+  ];
 
   outputs = [
     "bin"

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -12,9 +12,6 @@ let
     let
       base = callPackage ./generic.nix {
         stdenv = if stdenv.cc.isClang then llvmPackages.stdenv else stdenv;
-        pcre2 = pcre2.override {
-          withJitSealloc = false; # See https://bugs.php.net/bug.php?id=78927 and https://bugs.php.net/bug.php?id=78630
-        };
         inherit version hash;
       };
     in

--- a/pkgs/servers/http/nginx/modules/lua-upstream/package.nix
+++ b/pkgs/servers/http/nginx/modules/lua-upstream/package.nix
@@ -19,8 +19,6 @@ mkNginxPlugin (finalAttrs: {
 
   buildInputs = [ luajit_openresty ];
 
-  allowMemoryWriteExecute = true;
-
   meta = {
     description = "Expose Lua API to ngx_lua for Nginx upstreams";
     homepage = "https://github.com/openresty/lua-upstream-nginx-module";

--- a/pkgs/servers/http/nginx/modules/lua/package.nix
+++ b/pkgs/servers/http/nginx/modules/lua/package.nix
@@ -23,8 +23,6 @@ mkNginxPlugin (finalAttrs: {
     export LUAJIT_INC="$(realpath ${luajit_openresty}/include/luajit-*)"
   '';
 
-  allowMemoryWriteExecute = true;
-
   meta = {
     description = "Embed the Power of Lua";
     homepage = "https://github.com/openresty/lua-nginx-module";


### PR DESCRIPTION
Replaces https://github.com/NixOS/nixpkgs/pull/384302 as discussed in there.
It seems however like pcre2 doesn't reliable avoid using JIT: https://github.com/NixOS/nixpkgs/pull/179444

So my approach was to remove MemoryDenyWriteExecute where appropriate and await feedback from the respective maintainers if any.

Note on automation: my approach was relatively primitive: I built some dumb mapping of module files that contained `MemoryDenyWriteExecute` to packages (and fixed up things that didn't match any per hand). Packages where I removed this are the ones where the derivation directly referenced pcre2 which seemed like a reasonable heuristic to me.

If somebody has a better proposal for treewide changes like this to improve the list of hits, I'd be very open for suggestions.

Tested via php85, postfix & dovecot VM-test.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
