### PR TITLE
huggingface: update

### DIFF
--- a/pkgs/development/python-modules/huggingface-hub/default.nix
+++ b/pkgs/development/python-modules/huggingface-hub/default.nix
@@ -41,7 +41,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "huggingface-hub";
-  version = "1.27.0";
+  version = "1.28.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -49,7 +49,7 @@ buildPythonPackage (finalAttrs: {
     owner = "huggingface";
     repo = "huggingface_hub";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-AJglCIJZPeabIjgx+qeEpKM2HhX2hr4xx4SWpghDrhE=";
+    hash = "sha256-nUdBUBLM2NivmQiumY36GfUYREl+4hRszlJEM6ryj1w=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/sentence-transformers/default.nix
+++ b/pkgs/development/python-modules/sentence-transformers/default.nix
@@ -34,7 +34,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "sentence-transformers";
-  version = "5.7.0";
+  version = "6.0.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -42,7 +42,7 @@ buildPythonPackage (finalAttrs: {
     owner = "huggingface";
     repo = "sentence-transformers";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-0H/sgSxEcDnZkDEtAroSV9zVLfLF04AsjSV0m0Csyk0=";
+    hash = "sha256-uT/3TxhKJKeTz/xBho/YjJJPk9BdCM4PPPNiHruHg/U=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/tokenizers/default.nix
+++ b/pkgs/development/python-modules/tokenizers/default.nix
@@ -74,29 +74,30 @@ let
     };
   };
 in
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "tokenizers";
-  version = "0.22.2";
+  version = "0.23.1";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "huggingface";
     repo = "tokenizers";
-    tag = "v${version}";
-    hash = "sha256-krc+FUA5H3J7L4D1xyjyFMpjXMU8TEfwdfRT4+uvti8=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-tY1pzbcCRQVxk3Qxd4FjFZTQJicm7Iwa0qRgjUrR+rk=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit
+    inherit (finalAttrs)
       pname
       version
       src
       sourceRoot
       ;
-    hash = "sha256-anYZ7M5OvLOOHDy+sLuZlHQ/cNTk6xHksBHSHa75iY4=";
+    hash = "sha256-JUhjjDyWsl9+hsRYIfNMX68b1GU+F++KS1tHEl6OzHA=";
   };
 
-  sourceRoot = "${src.name}/bindings/python";
+  sourceRoot = "${finalAttrs.src.name}/bindings/python";
 
   nativeBuildInputs = [
     cargo
@@ -136,9 +137,10 @@ buildPythonPackage rec {
 
   disabledTests = [
     # Downloads data using the datasets module
+    "TestTrainFromIterators"
+    "TestUnigram"
     "test_encode_special_tokens"
     "test_splitting"
-    "TestTrainFromIterators"
 
     # Require downloading from huggingface
     # huggingface_hub.errors.LocalEntryNotFoundError
@@ -171,9 +173,9 @@ buildPythonPackage rec {
   meta = {
     description = "Fast State-of-the-Art Tokenizers optimized for Research and Production";
     homepage = "https://github.com/huggingface/tokenizers";
-    changelog = "https://github.com/huggingface/tokenizers/releases/tag/v${version}";
+    changelog = "https://github.com/huggingface/tokenizers/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ GaetanLepage ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/development/python-modules/transformers/default.nix
+++ b/pkgs/development/python-modules/transformers/default.nix
@@ -79,7 +79,6 @@
   mistral-common,
   # chat_template
   jinja2,
-  jmespath,
   # quality
   ruff,
   gitpython,
@@ -94,7 +93,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "transformers";
-  version = "5.15.0";
+  version = "5.16.1";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -102,7 +101,7 @@ buildPythonPackage (finalAttrs: {
     owner = "huggingface";
     repo = "transformers";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-DAQrsE2onVc2/MWJlGmlXFBzai5/ysAxpPEFMxDo7wI=";
+    hash = "sha256-VgBgaj4Qh2NVmJoqlrdb3hED/n1otIqDawXcALBpb2c=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
## Things done

- **python3Packages.tokenizers: 0.22.2 -> 0.23.1** ([Diff](https://github.com/huggingface/tokenizers/compare/v0.22.2...v0.23.1), [Changelog](https://github.com/huggingface/tokenizers/releases/tag/v0.23.1))
- **python3Packages.sentence-transformers: 5.7.0 -> 6.0.0** ([Diff](https://github.com/huggingface/sentence-transformers/compare/v5.7.0...v6.0.0), [Changelog](https://github.com/huggingface/sentence-transformers/releases/tag/v6.0.0))
- **python3Packages.huggingface-hub: 1.27.0 -> 1.28.0** ([Diff](https://github.com/huggingface/huggingface_hub/compare/v1.27.0...v1.28.0), [Changelog](https://github.com/huggingface/huggingface_hub/releases/tag/v1.28.0))
- **python3Packages.transformers: 5.15.0 -> 5.16.1** ([Diff](https://github.com/huggingface/transformers/compare/v5.15.0...v5.16.1), [Changelog](https://github.com/huggingface/transformers/releases/tag/v5.16.1))

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

