### PR TITLE
rocqPackages.unicoq: init at 1.6-9.1

### DIFF
--- a/pkgs/development/rocq-modules/unicoq/default.nix
+++ b/pkgs/development/rocq-modules/unicoq/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  mkRocqDerivation,
+  rocq-core,
+  version ? null,
+}:
+
+mkRocqDerivation {
+  pname = "unicoq";
+  owner = "unicoq";
+  inherit version;
+  defaultVersion =
+    let
+      case = case: out: { inherit case out; };
+    in
+    with lib.versions;
+    lib.switch rocq-core.version [
+      (case (range "9.1" "9.1") "1.6-9.1")
+      (case (range "8.20" "9.0") "1.6-8.20")
+      (case (range "8.19" "8.19") "1.6-8.19")
+    ] null;
+  release."1.6-9.1".hash = "sha256-RMLXIuubfUCzww8leMF40z9I+lPpo7Y0oIeDDavpgVo=";
+  release."1.6-8.20".hash = "sha256-zne9LB0lGdqUfrBe8cDK8fwuxfBDFU4PqNlt9nl7rNI=";
+  release."1.6-8.19".hash = "sha256-fDk60B8AzJwiemxHGgWjNu6PTu6NcJoI9uK7Ww2AT14=";
+  releaseRev = v: "v${v}";
+  mlPlugin = true;
+  meta = {
+    description = "Enhanced unification algorithm for Coq";
+    license = lib.licenses.mit;
+  };
+  preBuild = ''
+    rocq makefile -f _CoqProject -o Makefile
+  '';
+}

--- a/pkgs/top-level/rocq-packages.nix
+++ b/pkgs/top-level/rocq-packages.nix
@@ -65,6 +65,7 @@ let
       rocqnavi = callPackage ../development/rocq-modules/rocqnavi { };
       stdlib = callPackage ../development/rocq-modules/stdlib { };
       stdpp = callPackage ../development/rocq-modules/stdpp { };
+      unicoq = callPackage ../development/rocq-modules/unicoq { };
       vsrocq-language-server = callPackage ../development/rocq-modules/vsrocq-language-server { };
 
       filterPackages = doesFilter: if doesFilter then filterRocqPackages self else self;


### PR DESCRIPTION
Cloned the file from coqPackages.unicoq to rocqPackages

Should the package be renamed to unirocq like with coq-elpi and rocq-elpi ? (and who decides of this)


- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
