### PR TITLE
libfprint: libfprint-1.94.10 -> libfprint-1.94.100

### DIFF
--- a/pkgs/by-name/li/libfprint/package.nix
+++ b/pkgs/by-name/li/libfprint/package.nix
@@ -22,7 +22,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libfprint";
-  version = "1.94.10";
+  version = "1.94.100";
   outputs = [
     "out"
     "devdoc"
@@ -33,37 +33,8 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "libfprint";
     repo = "libfprint";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-aNBUIKY3PP5A07UNg3N0qq+2cwb6Fk67oKQcXgr2G/4=";
+    hash = "sha256-JwD8U6CjVH+huvVFIxRWRrsWbLOEeqOd1lCMdWgPtrA=";
   };
-
-  patches = [
-    # New hardware support since 1.94.10, just new USB Product IDs
-    (fetchpatch {
-      name = "realtek-3274-9003.patch";
-      url = "https://gitlab.freedesktop.org/libfprint/libfprint/-/commit/a25f71cf97820c51edc4c32f84686fcdc608d9d1.patch";
-      sha256 = "sha256-T9rvT53Ij+5gtiVOp+xfzQwiVkyF0m6lZAUCXWmaugg=";
-    })
-    (fetchpatch {
-      name = "elan-0c58.patch";
-      url = "https://gitlab.freedesktop.org/libfprint/libfprint/-/commit/4610f2285e6373c2fe4ead0dff4ebf8dabe4e532.patch";
-      sha256 = "sha256-VR96V+7FvSa8sE6JpcCx/slZ0MaK9HLuNuAay2P9C6M=";
-    })
-    (fetchpatch {
-      name = "elan-04F3-0C9C.patch";
-      url = "https://gitlab.freedesktop.org/libfprint/libfprint/-/commit/2bdc2b7ca6d8bedc675054934fbc8f8b6a21deac.patch";
-      sha256 = "sha256-LFMip9Mq55uDRgHkW+XeI+j0mILOb7DIHscHjyKe4yE=";
-    })
-    (fetchpatch {
-      name = "focal-077a-079a.patch";
-      url = "https://gitlab.freedesktop.org/libfprint/libfprint/-/commit/2c7842c905147a2d127c1b168b2e9d432b8c91a4.patch";
-      sha256 = "sha256-PuISGITn0/6AWY0WVUfViZtdcQFh+0s+4OLIszqdLUs=";
-    })
-    (fetchpatch {
-      name = "focal-a97a.patch";
-      url = "https://gitlab.freedesktop.org/libfprint/libfprint/-/commit/0dc384b90ed8cd78b3e8d7c0d30a953bd088b98c.patch";
-      sha256 = "sha256-X/wl4MpxfQ7sLlFTkkiDQGyRFQ6lC9pdcy3XPrSeOZw=";
-    })
-  ];
 
   postPatch = ''
     patchShebangs \


### PR DESCRIPTION
https://gitlab.freedesktop.org/libfprint/libfprint/-/releases/v1.94.100

Add support for a lot new hardware. I had previously added them in patches.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
