### PR TITLE
widelands: add an explicit libX11 dependency

### DIFF
--- a/pkgs/by-name/wi/widelands/package.nix
+++ b/pkgs/by-name/wi/widelands/package.nix
@@ -26,6 +26,7 @@
   libsm,
   libice,
   libxext,
+  libX11,
 }:
 
 stdenv.mkDerivation rec {
@@ -80,7 +81,10 @@ stdenv.mkDerivation rec {
     libsm # XXX: these should be propagated by SDL2?
     libice
   ]
-  ++ lib.optional stdenv.hostPlatform.isLinux libxext;
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    libxext
+    libX11
+  ];
 
   postInstall =
     lib.optionalString stdenv.hostPlatform.isLinux ''


### PR DESCRIPTION
Seems to fix running it on Linux.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
