### PR TITLE
git-metrics: 0.2.6 -> 0.2.7

### DIFF
--- a/pkgs/by-name/gi/git-metrics/package.nix
+++ b/pkgs/by-name/gi/git-metrics/package.nix
@@ -5,20 +5,22 @@
   gitMinimal,
   rustPlatform,
   openssl,
+  versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "git-metrics";
-  version = "0.2.6";
+  version = "0.2.7";
 
   src = fetchFromGitHub {
     owner = "jdrouet";
     repo = "git-metrics";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-SdA/FpdrbC36Ny7aBpTUvFldbYXyajSqWGheaDPHYoE=";
+    hash = "sha256-z34yzKHoTskIDPWl9LHy9dsXeNxwlI6kD73EzeSUrN0=";
   };
 
-  cargoHash = "sha256-e4CdpwoFl8leV5HJWkWBpvPrVrk+7vq49yTPkpeQ2Ng=";
+  cargoHash = "sha256-7/1Jf3GJmEydTDVL3oGIKIkCHAMKJ8BE6PUmpWH0xcQ=";
 
   buildInputs = [
     openssl
@@ -38,10 +40,17 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--skip=tests::display_diff::execute"
     "--skip=tests::simple_use_case::execute::with_command_backend"
     "--skip=tests::simple_use_case::execute::with_git2_backend"
+    "--skip=tests::config_override"
   ];
+
+  passthru.updateScript = nix-update-script { };
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     homepage = "https://github.com/jdrouet/git-metrics";
+    changelog = "https://github.com/jdrouet/git-metrics/releases/tag/v${finalAttrs.version}";
     description = "Git extension to be able to track metrics about your project, within the git repository";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [


### PR DESCRIPTION
Bump `git-metrics` from 0.2.6 to 0.2.7

Added to `checkFlags` - `config_override` test introduced in `0.2.7` to skip Added `versionCheckHook`, `updateScript` and `changelog` attrs to `meta`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
