### PR TITLE
koboldcpp: fix runtime failure

### DIFF
--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -97,19 +97,19 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p "$out/bin"
+    mkdir -p "$out/bin/embd_res"
 
     install -Dm755 koboldcpp.py "$out/bin/koboldcpp.unwrapped"
     cp *.so "$out/bin"
-    cp embd_res/*.embd "$out/bin"
+    cp -r embd_res/* "$out/bin/embd_res/"
 
     ${lib.optionalString metalSupport ''
       cp *.metal "$out/bin"
     ''}
 
     ${lib.optionalString (!koboldLiteSupport) ''
-      rm "$out/bin/kcpp_docs.embd"
-      rm "$out/bin/klite.embd"
+      rm "$out/bin/embd_res/kcpp_docs.embd"
+      rm "$out/bin/embd_res/klite.embd"
     ''}
 
     runHook postInstall


### PR DESCRIPTION
## Summary

Hello,

Current `installPhase` logic moves `.embd` files from `bin/embd_res` to `bin/`. However, `koboldcpp` still looks up  `bin/embd_res` for .embd files. This disparity causes a runtime error (see below). This PR fixes it by preserving `bin/embd_res` folder structure.

I've built and tested this after with **Steps to reproduce** below, and koboldcpp embd lookup works.

Hope this helps,
Cheers!

### Steps to reproduce (how I came across the issue)
1. [Download starter pack config - originally mentioned in the koboldcpp wiki ](https://huggingface.co/api/resolve-cache/models/koboldcpp/kcppt/c5ac26476c0de1d9a1d855bec241e80d5503827e/starter-pack-v2.kcppt?%2Fkoboldcpp%2Fkcppt%2Fresolve%2Fmain%2Fstarter-pack-v2.kcppt=&etag=%22968da090bcd6e591ac75bb3a06f739b3e6c392ea%22)
2. Run `koboldcpp --config ~/Downloads/starter-pack-v2.kcppt`
3. Following error should occur 
```
libc++abi: terminating due to uncaught exception of type std::runtime_error: 
Failed to open file: /nix/store/...-koboldcpp-1.110/bin/embd_res/qwen2_merges_utf8_c_str.embd
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
