### PR TITLE
evil-winrm: 3.7 -> 3.9

### DIFF
--- a/pkgs/by-name/ev/evil-winrm/Gemfile
+++ b/pkgs/by-name/ev/evil-winrm/Gemfile
@@ -1,7 +1,10 @@
 source 'https://rubygems.org'
 
+gem 'benchmark'
+gem 'csv'
+gem 'fileutils'
+gem 'logger'
+gem 'stringio'
+gem 'syslog'
 gem 'winrm'
 gem 'winrm-fs'
-gem 'stringio'
-gem 'logger'
-gem 'fileutils'

--- a/pkgs/by-name/ev/evil-winrm/Gemfile.lock
+++ b/pkgs/by-name/ev/evil-winrm/Gemfile.lock
@@ -2,11 +2,13 @@ GEM
   remote: https://rubygems.org/
   specs:
     base64 (0.3.0)
-    bigdecimal (3.3.1)
+    benchmark (0.5.0)
+    bigdecimal (4.1.2)
     builder (3.3.0)
+    csv (3.3.6)
     erubi (1.13.1)
-    ffi (1.17.2)
-    fileutils (1.7.3)
+    ffi (1.17.4)
+    fileutils (1.8.0)
     gssapi (1.3.1)
       ffi (>= 1.0.1)
     gyoku (1.4.0)
@@ -19,15 +21,18 @@ GEM
     logging (2.4.0)
       little-plugger (~> 1.1)
       multi_json (~> 1.14)
-    multi_json (1.17.0)
+    multi_json (1.21.1)
     mutex_m (0.3.0)
-    nori (2.7.1)
+    nori (2.9.1)
       bigdecimal
+      stringio
     rexml (3.4.4)
     rubyntlm (0.6.5)
       base64
     rubyzip (2.4.1)
-    stringio (3.1.7)
+    stringio (3.2.0)
+    syslog (0.4.0)
+      logger
     winrm (2.3.9)
       builder (>= 2.1.2)
       erubi (~> 1.8)
@@ -48,11 +53,14 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  benchmark
+  csv
   fileutils
   logger
   stringio
+  syslog
   winrm
   winrm-fs
 
 BUNDLED WITH
-   2.7.1
+   2.7.2

--- a/pkgs/by-name/ev/evil-winrm/gemset.nix
+++ b/pkgs/by-name/ev/evil-winrm/gemset.nix
@@ -9,15 +9,25 @@
     };
     version = "0.3.0";
   };
+  benchmark = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0v1337j39w1z7x9zs4q7ag0nfv4vs4xlsjx2la0wpv8s6hig2pa6";
+      type = "gem";
+    };
+    version = "0.5.0";
+  };
   bigdecimal = {
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0612spks81fvpv2zrrv3371lbs6mwd7w6g5zafglyk75ici1x87a";
+      sha256 = "1g9zi8c4i7g8zz0c3hxrw6mblrjvgn7akys60clb9si7c1k1gljk";
       type = "gem";
     };
-    version = "3.3.1";
+    version = "4.1.2";
   };
   builder = {
     groups = [ "default" ];
@@ -28,6 +38,16 @@
       type = "gem";
     };
     version = "3.3.0";
+  };
+  csv = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0mj4kq4wwpc7c8ll52q30hsir1jrcd5kq7yb8lyz0rksa1z1x9mb";
+      type = "gem";
+    };
+    version = "3.3.6";
   };
   erubi = {
     groups = [ "default" ];
@@ -44,20 +64,20 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "19kdyjg3kv7x0ad4xsd4swy5izsbb1vl1rpb6qqcqisr5s23awi9";
+      sha256 = "1kqasqvy8d7r09ri4n6bkdwbk63j7afd9ilsw34nzlgh0qp69ldw";
       type = "gem";
     };
-    version = "1.17.2";
+    version = "1.17.4";
   };
   fileutils = {
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1nmmbvqxssmn9cav5x5sxcw9ab3vqpskdy3nbmsqfjk99f2iw9sp";
+      sha256 = "00kf7icj8r5w9cwlsaymp9qallw8yy5g0n4jyfrbsh159vsisswc";
       type = "gem";
     };
-    version = "1.7.3";
+    version = "1.8.0";
   };
   gssapi = {
     dependencies = [ "ffi" ];
@@ -134,10 +154,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "06sabsvnw0x1aqdcswc6bqrqz6705548bfd8z22jxgxfjrn1yn3n";
+      sha256 = "1040lr5y2phn7avdyam6zw6ikprlmk77biw3yhclsfwfh0qnl4p6";
       type = "gem";
     };
-    version = "1.17.0";
+    version = "1.21.1";
   };
   mutex_m = {
     groups = [ "default" ];
@@ -150,15 +170,18 @@
     version = "0.3.0";
   };
   nori = {
-    dependencies = [ "bigdecimal" ];
+    dependencies = [
+      "bigdecimal"
+      "stringio"
+    ];
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0qb84bbi74q0zgs09sdkq750jf2ri3lblbry0xi4g1ard4rwsrk1";
+      sha256 = "01p6ns6fxrjba8q8yj624pjqmh0wmgcf9hk64k1n4gyb1i115pbj";
       type = "gem";
     };
-    version = "2.7.1";
+    version = "2.9.1";
   };
   rexml = {
     groups = [ "default" ];
@@ -196,10 +219,21 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1yh78pg6lm28c3k0pfd2ipskii1fsraq46m6zjs5yc9a4k5vfy2v";
+      sha256 = "1q92y9627yisykyscv0bdsrrgyaajc2qr56dwlzx7ysgigjv4z63";
       type = "gem";
     };
-    version = "3.1.7";
+    version = "3.2.0";
+  };
+  syslog = {
+    dependencies = [ "logger" ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0wklh86rhpiff34ja0hda5pwdfywybjvb50hqhz90wpyhblqmhy4";
+      type = "gem";
+    };
+    version = "0.4.0";
   };
   winrm = {
     dependencies = [

--- a/pkgs/by-name/ev/evil-winrm/package.nix
+++ b/pkgs/by-name/ev/evil-winrm/package.nix
@@ -35,13 +35,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "evil-winrm";
-  version = "3.7";
+  version = "3.9";
 
   src = fetchFromGitHub {
     owner = "Hackplayers";
     repo = "evil-winrm";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-jr8glS732UvSt+qFkhhLFZUB7OIRpRj3SzXm6mVikrE=";
+    hash = "sha256-z6dFtyro4inG3uAJ1gkALmlkqKY6eGH7h/sGJknY7Uk=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Update evil-winrm from 3.7 to 3.9.

## Things done

- Built on platform:
  - [x] x86_64-linux
- [x] Tested basic functionality of the binary.
- [x] Fits CONTRIBUTING.md and pkgs/README.md.
