### PR TITLE
isabelle: cleanup and properly fix vscodium

### DIFF
--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -70,6 +70,8 @@
   useVSCodeRipgrep ? false,
   hasVsceSign ? false,
   patchVSCodePath ? true,
+  appDir ? "app",
+  installExecutable ? true,
 
   # Populate passthru.tests
   tests,
@@ -326,22 +328,27 @@ stdenv.mkDerivation (
     + (
       if stdenv.hostPlatform.isDarwin then
         ''
-          mkdir -p "$out/Applications/${longName}.app" "$out/bin"
+          mkdir -p "$out/Applications/${longName}.app"
           cp -r ./* "$out/Applications/${longName}.app"
-          ln -s "$out/Applications/${longName}.app/Contents/Resources/app/bin/${sourceExecutableName}" "$out/bin/${executableName}"
+        ''
+        + lib.optionalString installExecutable ''
+          mkdir -p "$out/bin"
+          ln -s "$out/Applications/${longName}.app/Contents/Resources/${appDir}/bin/${sourceExecutableName}" "$out/bin/${executableName}"
         ''
       else
         (
           ''
-            mkdir -p "$out/lib/${libraryName}" "$out/bin"
+            mkdir -p "$out/lib/${libraryName}"
             cp -r ./* "$out/lib/${libraryName}"
-
+          ''
+          + lib.optionalString installExecutable ''
+            mkdir -p "$out/bin"
             ln -s "$out/lib/${libraryName}/bin/${sourceExecutableName}" "$out/bin/${executableName}"
           ''
           # These are named vscode.png, vscode-insiders.png, etc to match the name in upstream *.deb packages.
           + ''
             mkdir -p "$out/share/pixmaps"
-            icon_file="$out/lib/${libraryName}/resources/app/resources/linux/code.png"
+            icon_file="$out/lib/${libraryName}/resources/${appDir}/resources/linux/code.png"
             cp "$icon_file" "$out/share/pixmaps/${iconName}.png"
 
             # Dynamically determine size of icon and place in appropriate directory
@@ -360,8 +367,8 @@ stdenv.mkDerivation (
         # in the first place.
         # Also remove prebuilt Copilot binaries that seemingly have been added by accident.
         + ''
-          rm -rf $out/lib/${libraryName}/resources/app/node_modules/vscode-encrypt
-          rm -rf $out/lib/${libraryName}/resources/app/node_modules/@github/copilot-linuxmusl*
+          rm -rf $out/lib/${libraryName}/resources/${appDir}/node_modules/vscode-encrypt
+          rm -rf $out/lib/${libraryName}/resources/${appDir}/node_modules/@github/copilot-linuxmusl*
         ''
     )
     + ''
@@ -406,13 +413,13 @@ stdenv.mkDerivation (
         # disable update checks
         ''
           tmpProductJson="$(mktemp)"
-          jq 'del(.updateUrl, .backupUpdateUrl)' resources/app/product.json > "$tmpProductJson"
-          mv "$tmpProductJson" resources/app/product.json
+          jq 'del(.updateUrl, .backupUpdateUrl)' resources/${appDir}/product.json > "$tmpProductJson"
+          mv "$tmpProductJson" resources/${appDir}/product.json
         ''
         # this is a fix for "save as root" functionality
         + ''
-          packed="resources/app/node_modules.asar"
-          unpacked="resources/app/node_modules"
+          packed="resources/${appDir}/node_modules.asar"
+          unpacked="resources/${appDir}/node_modules"
           asar extract "$packed" "$unpacked"
           substituteInPlace $unpacked/@vscode/sudo-prompt/index.js \
             --replace-fail "/usr/bin/pkexec" "/run/wrappers/bin/pkexec" \
@@ -434,13 +441,13 @@ stdenv.mkDerivation (
               # 1.129 moved node_modules back into app.asar, shipping native
               # binaries in the asar.unpacked directory like before 1.94
               if lib.versionAtLeast vscodeVersion "1.129.0" then
-                "Contents/Resources/app/node_modules.asar.unpacked"
+                "Contents/Resources/${appDir}/node_modules.asar.unpacked"
               else if lib.versionAtLeast vscodeVersion "1.94.0" then
-                "Contents/Resources/app/node_modules"
+                "Contents/Resources/${appDir}/node_modules"
               else
-                "Contents/Resources/app/node_modules.asar.unpacked"
+                "Contents/Resources/${appDir}/node_modules.asar.unpacked"
             else
-              "resources/app/node_modules";
+              "resources/${appDir}/node_modules";
 
           # see https://www.npmjs.com/package/@vscode/ripgrep-universal?activeTab=code
           ripgrepSystem =
@@ -487,11 +494,11 @@ stdenv.mkDerivation (
       ''
       # restore original vsce-sign, which has integrity checks
       + (lib.optionalString hasVsceSign ''
-        cp -r ./resources/app/node_modules/@vscode/vsce-sign/bin/vsce-sign "$out/lib/vscode/resources/app/node_modules/@vscode/vsce-sign/bin/vsce-sign"
+        cp -r ./resources/${appDir}/node_modules/@vscode/vsce-sign/bin/vsce-sign "$out/lib/vscode/resources/${appDir}/node_modules/@vscode/vsce-sign/bin/vsce-sign"
         patchelf \
           --add-needed ${lib.getLib openssl}/lib/libssl.so.3 \
-          $out/lib/vscode/resources/app/node_modules/@vscode/vsce-sign/bin/vsce-sign
-        chmod +x $out/lib/vscode/resources/app/node_modules/@vscode/vsce-sign/bin/vsce-sign
+          $out/lib/vscode/resources/${appDir}/node_modules/@vscode/vsce-sign/bin/vsce-sign
+        chmod +x $out/lib/vscode/resources/${appDir}/node_modules/@vscode/vsce-sign/bin/vsce-sign
       '')
     );
 

--- a/pkgs/by-name/is/isabelle/package.nix
+++ b/pkgs/by-name/is/isabelle/package.nix
@@ -25,7 +25,8 @@
   isabelle-components,
   symlinkJoin,
   fetchhg,
-  electron,
+  callPackage,
+  writeTextFile,
   writableTmpDirAsHomeHook,
 }:
 
@@ -136,6 +137,27 @@ let
         };
       };
 
+  # Isabelle requires it's own version of vscodium, patched with support
+  # for it's unique charsets
+  vscodium = callPackage ./vscodium.nix { };
+
+  vscodium-settings = writeTextFile {
+    name = "vscodium-settings";
+    text =
+      if stdenv.hostPlatform.isDarwin then
+        ''
+          ISABELLE_VSCODIUM_HOME="${vscodium}/Applications"
+          ISABELLE_VSCODIUM_ELECTRON="$ISABELLE_VSCODIUM_HOME/VSCodium.app/Contents/MacOS/Electron"
+          ISABELLE_VSCODIUM_RESOURCES="$ISABELLE_VSCODIUM_HOME/VSCodium.app/Contents/Resources"
+        ''
+      else
+        ''
+          ISABELLE_VSCODIUM_HOME="${vscodium}/lib/vscode"
+          ISABELLE_VSCODIUM_ELECTRON="$ISABELLE_VSCODIUM_HOME/electron"
+          ISABELLE_VSCODIUM_RESOURCES="$ISABELLE_VSCODIUM_HOME/resources"
+        '';
+    destination = "/etc/settings";
+  };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "isabelle";
@@ -251,6 +273,10 @@ stdenv.mkDerivation (finalAttrs: {
     done
     rm -rf contrib/*/src
 
+    substituteInPlace etc/components \
+      --replace-fail 'contrib/vscodium-1.105.17075' '${vscodium-settings}'
+    rm -rf contrib/vscodium-*
+
     substituteInPlace lib/Tools/env \
       --replace-fail /usr/bin/env ${coreutils}/bin/env
 
@@ -272,10 +298,6 @@ stdenv.mkDerivation (finalAttrs: {
       patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) "$f"${lib.optionalString stdenv.hostPlatform.isAarch64 " || true"}
     done
     patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) contrib/bash_process-*/${platform}/bash_process
-
-    ln -sf ${electron}/bin/electron contrib/vscodium-*/*/electron
-    rm contrib/vscodium-*/*/*.so{,.*}
-    rm contrib/vscodium-*/*/chrome*
 
     for d in contrib/kodkodi-*/jni/${platform}; do
       patchelf --set-rpath "${
@@ -351,10 +373,22 @@ stdenv.mkDerivation (finalAttrs: {
         "Math"
       ];
     })
+    (makeDesktopItem {
+      name = "isabelle_vscodium";
+      exec = "isabelle vscode";
+      icon = "isabelle";
+      desktopName = "Isabelle (VSCodium)";
+      comment = finalAttrs.meta.description;
+      categories = [
+        "Education"
+        "Science"
+        "Math"
+      ];
+    })
   ];
 
   passthru = {
-    inherit platform;
+    inherit vscodium platform;
     vampire = vampire';
     polyml = polyml';
     cvc5 = cvc5';

--- a/pkgs/by-name/is/isabelle/package.nix
+++ b/pkgs/by-name/is/isabelle/package.nix
@@ -20,14 +20,25 @@
   perl,
   procps,
   makeDesktopItem,
+  copyDesktopItems,
+  desktopToDarwinBundle,
   isabelle-components,
   symlinkJoin,
   fetchhg,
   electron,
+  writableTmpDirAsHomeHook,
 }:
 
 let
   java = openjdk21;
+
+  platforms = {
+    x86_64-linux = "x86_64-linux";
+    aarch64-linux = "arm64-linux";
+    aarch64-darwin = "arm64-darwin";
+  };
+
+  platform = platforms."${stdenv.hostPlatform.system}";
 
   # There have been issues with proofs failing on NixOS in the past,
   # so we pin polyml to the exact commit that upstream isabelle uses
@@ -149,7 +160,14 @@ stdenv.mkDerivation (finalAttrs: {
         hash = "sha256-ZQqWabSgh2da+zQpTYLe0vBwTUfVgN2e1FzdyfF2S90=";
       };
 
-  nativeBuildInputs = [ java ];
+  nativeBuildInputs = [
+    java
+    copyDesktopItems
+    writableTmpDirAsHomeHook
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    desktopToDarwinBundle
+  ];
 
   buildInputs = [
     polyml'
@@ -250,19 +268,16 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail 'ISABELLE_APPLE_PLATFORM64=arm64-darwin' ""
   ''
   + lib.optionalString stdenv.hostPlatform.isLinux ''
-    arch=${
-      if stdenv.hostPlatform.system == "aarch64-linux" then "arm64-linux" else stdenv.hostPlatform.system
-    }
-    for f in contrib/*/$arch/{z3,nunchaku,SPASS,zipperposition}; do
+    for f in contrib/*/${platform}/{z3,nunchaku,SPASS,zipperposition}; do
       patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) "$f"${lib.optionalString stdenv.hostPlatform.isAarch64 " || true"}
     done
-    patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) contrib/bash_process-*/$arch/bash_process
+    patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) contrib/bash_process-*/${platform}/bash_process
 
     ln -sf ${electron}/bin/electron contrib/vscodium-*/*/electron
     rm contrib/vscodium-*/*/*.so{,.*}
     rm contrib/vscodium-*/*/chrome*
 
-    for d in contrib/kodkodi-*/jni/$arch; do
+    for d in contrib/kodkodi-*/jni/${platform}; do
       patchelf --set-rpath "${
         lib.concatStringsSep ":" [
           "${java}/lib/openjdk/lib/server"
@@ -272,11 +287,12 @@ stdenv.mkDerivation (finalAttrs: {
     done
   ''
   + lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux") ''
-    patchelf --set-rpath "${lib.getLib stdenv.cc.cc}/lib" contrib/z3-*/$arch/z3
+    patchelf --set-rpath "${lib.getLib stdenv.cc.cc}/lib" contrib/z3-*/${platform}/z3
   '';
 
   buildPhase = ''
-    export HOME=$TMP # The build fails if home is not set
+    runHook preBuild
+
     setup_name=$(basename contrib/isabelle_setup*)
 
     # Stop Isabelle trying to use `/tmp`.
@@ -303,9 +319,13 @@ stdenv.mkDerivation (finalAttrs: {
     echo "Building HOL heap"
     ln -s ${polyml'}/bin ./contrib/polyml-*/
     bin/isabelle build -v -o system_heaps -b HOL
+
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin
     mv $TMP/$dirname $out
     cd $out/$dirname
@@ -315,52 +335,26 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p "$out/share/icons/hicolor/isabelle/apps"
     cp "$out/Isabelle${finalAttrs.version}/lib/icons/isabelle.xpm" "$out/share/icons/hicolor/isabelle/apps/"
 
-    # desktop item
-    mkdir -p "$out/share"
-    cp -r "${finalAttrs.desktopItem}/share/applications" "$out/share/applications"
+    runHook postInstall
   '';
 
-  desktopItem = makeDesktopItem {
-    name = "isabelle";
-    exec = "isabelle jedit";
-    icon = "isabelle";
-    desktopName = "Isabelle";
-    comment = finalAttrs.meta.description;
-    categories = [
-      "Education"
-      "Science"
-      "Math"
-    ];
-  };
-
-  meta = {
-    description = "Generic proof assistant";
-    longDescription = ''
-      Isabelle is a generic proof assistant.  It allows mathematical formulas
-      to be expressed in a formal language and provides tools for proving those
-      formulas in a logical calculus.
-    '';
-    homepage = "https://isabelle.in.tum.de/";
-    sourceProvenance = with lib.sourceTypes; [
-      fromSource
-      binaryNativeCode # source bundles binary dependencies
-    ];
-    license = lib.licenses.bsd3;
-    maintainers = [
-      lib.maintainers.jvanbruegge
-      lib.maintainers.sempiternal-aurora
-    ];
-    # need to compile the heaps for host on build
-    # which requires us to use the host polyml toolchain
-    broken = !(stdenv.buildPlatform.canExecute stdenv.hostPlatform);
-    platforms = [
-      "x86_64-linux"
-      "aarch64-linux"
-      "aarch64-darwin"
-    ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "isabelle";
+      exec = "isabelle jedit";
+      icon = "isabelle";
+      desktopName = "Isabelle";
+      comment = finalAttrs.meta.description;
+      categories = [
+        "Education"
+        "Science"
+        "Math"
+      ];
+    })
+  ];
 
   passthru = {
+    inherit platform;
     vampire = vampire';
     polyml = polyml';
     cvc5 = cvc5';
@@ -393,5 +387,29 @@ stdenv.mkDerivation (finalAttrs: {
           echo contrib/${c.pname}-${c.version} >> ${base}/etc/components
         '') components;
       };
+  };
+
+  meta = {
+    description = "Generic proof assistant";
+    longDescription = ''
+      Isabelle is a generic proof assistant.  It allows mathematical formulas
+      to be expressed in a formal language and provides tools for proving those
+      formulas in a logical calculus.
+    '';
+    homepage = "https://isabelle.in.tum.de/";
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryNativeCode # source bundles binary dependencies
+      binaryBytecode # contains many jars
+    ];
+    license = lib.licenses.bsd3;
+    maintainers = [
+      lib.maintainers.jvanbruegge
+      lib.maintainers.sempiternal-aurora
+    ];
+    # need to compile the heaps for host on build
+    # which requires us to use the host polyml toolchain
+    broken = !(stdenv.buildPlatform.canExecute stdenv.hostPlatform);
+    platforms = lib.attrNames platforms;
   };
 })

--- a/pkgs/by-name/is/isabelle/package.nix
+++ b/pkgs/by-name/is/isabelle/package.nix
@@ -211,7 +211,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   sourceRoot = "${finalAttrs.dirname}${lib.optionalString stdenv.hostPlatform.isDarwin ".app"}";
 
-  doCheck = stdenv.hostPlatform.system != "aarch64-linux";
+  # The z3 version isabelle uses is only built for x86_64
+  # even though it can work on apple-silicon with rosetta, leave this up to the user
+  doCheck = stdenv.hostPlatform.isx86_64;
   checkPhase = "bin/isabelle build -v HOL-SMT_Examples";
 
   postUnpack = lib.optionalString stdenv.hostPlatform.isDarwin ''

--- a/pkgs/by-name/is/isabelle/vscodium.nix
+++ b/pkgs/by-name/is/isabelle/vscodium.nix
@@ -1,0 +1,49 @@
+{
+  buildVscode,
+  fetchurl,
+  stdenv,
+  lib,
+  isabelle,
+}:
+
+buildVscode rec {
+  version = "1.105.17075";
+  vscodeVersion = "1.105.1";
+  pname = "vscodium";
+
+  executableName = "electron";
+  longName = "VSCodium";
+  shortName = "vscodium";
+
+  src = fetchurl {
+    url = "https://isabelle.in.tum.de/components/vscodium-${version}.tar.gz";
+    hash = "sha256-sKMUOZP8C0kHcKtH5J4+JaBDAM1kL7DXn+sak6kE8fk=";
+  };
+  sourceRoot =
+    "vscodium-${version}/${isabelle.platform}"
+    + lib.optionalString stdenv.hostPlatform.isDarwin "/VSCodium.app";
+
+  tests = { };
+  commandLineArgs = "";
+  useVSCodeRipgrep = stdenv.hostPlatform.isDarwin;
+  patchVSCodePath = false;
+  updateScript = null;
+  hasVsceSign = false;
+  # isabelle vscodium doesn't properly wrap it's electron, so can't be called directly
+  # instead it is executed through `isabelle vscode`, which calls electron with the proper arguments
+  installExecutable = false;
+  appDir = "vscodium";
+
+  dontFixup = stdenv.hostPlatform.isDarwin;
+
+  meta = {
+    description = "Patched version of vscodium with support for Isabelle specific charsets";
+    homepage = "https://isabelle.in.tum.de/";
+    license = lib.licenses.mit;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    maintainers = [ lib.maintainers.sempiternal-aurora ];
+    inherit (isabelle.meta) platforms;
+    # requires libc.so.6 and other glibc specifics
+    broken = stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isGnu;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds a bunch of quality of life fixes to isabelle, including properly fixing the bundled vscodium. The generic `buildVscode` mostly worked, but needed a small patch or two to deal with the quirks of the bundled vscodium (specifically, that it doesn't properly wrap electron and uses a different directory under resources for it's code).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
