### PR TITLE
renovate: 43.214.1 -> 44.13.1

### DIFF
--- a/pkgs/by-name/re/renovate/package.nix
+++ b/pkgs/by-name/re/renovate/package.nix
@@ -24,6 +24,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "renovate";
   version = "44.13.1";
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   src = fetchFromGitHub {
     owner = "renovatebot";
     repo = "renovate";

--- a/pkgs/by-name/re/renovate/package.nix
+++ b/pkgs/by-name/re/renovate/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   makeWrapper,
   nodejs_24,
-  pnpm_10,
+  pnpm_11,
   fetchPnpmDeps,
   pnpmConfigHook,
   python3,
@@ -15,18 +15,20 @@
   yq-go,
   cctools,
 }:
+
 let
   nodejs = nodejs_24;
+  pnpm = pnpm_11;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "renovate";
-  version = "43.214.1";
+  version = "44.13.1";
 
   src = fetchFromGitHub {
     owner = "renovatebot";
     repo = "renovate";
     tag = finalAttrs.version;
-    hash = "sha256-S5ixP4Dp/YDv23kE5lvmp/Px6GrF9B6/wwSiKUwVWhA=";
+    hash = "sha256-2N+dQnuQwQNt7SZlIYq0CT2dRMiOF947MJZZ8BhZpcI=";
   };
 
   postPatch = ''
@@ -38,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper
     nodejs
     pnpmConfigHook
-    pnpm_10
+    pnpm
     python3
     yq-go
   ]
@@ -49,9 +51,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_10;
-    fetcherVersion = 3;
-    hash = "sha256-A8aL5ZF0tFKi0uCXxOQMzxByAIVyt76wnLvolFVYKuI=";
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = "sha256-xm4H+PIpVcisw8wKz77+v6iCcwEpkpLZ6awtwXPNBc8=";
   };
 
   env.COREPACK_ENABLE_STRICT = 0;
@@ -61,25 +63,17 @@ stdenv.mkDerivation (finalAttrs: {
 
     # relax nodejs version
     yq '.engines.node = "${nodejs.version}"' -i package.json
+  ''
+  # pnpm install gets run with --ignore-scripts so we need to manually build native dependencies (e.g. re2)
+  # Keep https://github.com/renovatebot/renovate/blob/main/pnpm-workspace.yaml#L9 in mind when updating,
+  # new native dependencies could bloat up binary size.
+  + ''
+    pnpm rebuild
+    rm -rf node_modules/.pnpm/re2*/node_modules/re2/build/Release/{obj.target,.deps} \
+      node_modules/.pnpm/re2*/node_modules/re2/vendor
 
     pnpm build
-    find -name 'node_modules' -type d -exec rm -rf {} \; || true
-    pnpm install --offline --prod --ignore-scripts
-  ''
-  # The optional dependencies re2 and better-sqlite3 are not built by pnpm and need to be built manually.
-  # If re2 is not built, you will get an annoying warning when you run renovate.
-  # better-sqlite3 is required.
-  + ''
-    pushd node_modules/.pnpm/re2*/node_modules/re2
-
-    mkdir -p $HOME/.node-gyp/${nodejs.version}
-    echo 9 > $HOME/.node-gyp/${nodejs.version}/installVersion
-    ln -sfv ${nodejs}/include $HOME/.node-gyp/${nodejs.version}
-    export npm_config_nodedir=${nodejs}
-    npm run rebuild
-    rm -rf build/Release/{obj.target,.deps} vendor
-
-    popd
+    pnpm prune --prod --ignore-scripts
 
     runHook postBuild
   '';


### PR DESCRIPTION
- **renovate: 43.214.1 -> 44.13.1**
- **renovate: enable structuredAttrs, strictDeps**

No breaking changes here, [as announced](https://github.com/renovatebot/renovate/discussions/44952), but I thought it might be nice to have it updated as it has been almost 1.5 months since the last bump. This required some moving around as re2 is now neccesary for the Husky prepare script to run. I also bumped pnpm to version 11 as [that is what they use now upstream](https://github.com/renovatebot/renovate/blob/e765c6fcdee3c1d16a775f6c7511ecd567570deb/package.json#L353), and the fetcher version to 4 as well. Tested basic functionality, will run on my Forge right now in order to test. Not listing all of the changelogs as there are a lot of them.

Diff: https://github.com/renovatebot/renovate/compare/43.214.1...44.13.1

Changelog: https://github.com/renovatebot/renovate/releases/tag/44.13.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
