### PR TITLE
anthy: 9100h -> 1.0.0.20260213

### DIFF
--- a/pkgs/by-name/an/anthy/package.nix
+++ b/pkgs/by-name/an/anthy/package.nix
@@ -1,39 +1,16 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  buildPackages,
+  fetchFromGitHub,
+  autoconf,
+  automake,
+  libtool,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "anthy";
-  version = "9100h";
-
-  postPatch = lib.optionalString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
-    # for cross builds, copy build tools from the native package
-    cp -r "${buildPackages.anthy.dev}"/lib/internals/{mkdepgraph,.libs} depgraph/
-    cp -r "${buildPackages.anthy.dev}"/lib/internals/{mkworddic,.libs} mkworddic/
-    cp -r "${buildPackages.anthy.dev}"/lib/internals/{calctrans,.libs} calctrans/
-    cp -r "${buildPackages.anthy.dev}"/lib/internals/{mkfiledic,.libs} mkanthydic/
-    substituteInPlace mkworddic/Makefile.in \
-      --replace-fail 'anthy.wdic : mkworddic' 'anthy.wdic : ' \
-      --replace-fail 'all: ' 'all: anthy.wdic #'
-    substituteInPlace calctrans/Makefile.in \
-      --replace-fail '$(dict_source_files): $(srcdir)/corpus_info $(srcdir)/weak_words calctrans' \
-                     '$(dict_source_files): $(srcdir)/corpus_info $(srcdir)/weak_words' \
-      --replace-fail 'all-am: Makefile $(PROGRAMS) $(DATA)' 'all-am: $(DATA)'
-    substituteInPlace depgraph/Makefile.in \
-      --replace-fail 'anthy.dep : mkdepgraph' 'anthy.dep : ' \
-      --replace-fail 'all-am: Makefile $(PROGRAMS) $(DATA)' 'all-am: $(DATA)'
-    substituteInPlace mkanthydic/Makefile.in \
-      --replace-fail 'anthy.dic : mkfiledic' 'anthy.dic : ' \
-      --replace-fail 'all-am: Makefile $(PROGRAMS) $(SCRIPTS) $(DATA)' 'all-am: $(DATA)'
-  '';
-
-  outputs = [
-    "out"
-    "dev"
-  ];
+  version = "1.0.0.20260213";
+  __stucturedAttrs = true;
 
   meta = {
     description = "Hiragana text to Kana Kanji mixed text Japanese input method";
@@ -43,14 +20,20 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.unix;
   };
 
-  postFixup = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
-    # not relevant for installed package
-    mkdir "$dev/lib/internals"
-    cp -r depgraph/{mkdepgraph,.libs} mkworddic/{mkworddic,.libs} calctrans/{calctrans,.libs} mkanthydic/{mkfiledic,.libs} "$dev/lib/internals"
-  '';
-
-  src = fetchurl {
-    url = "mirror://osdn/anthy/37536/anthy-${finalAttrs.version}.tar.gz";
-    sha256 = "0ism4zibcsa5nl77wwi12vdsfjys3waxcphn1p5s7d0qy1sz0mnj";
+  src = fetchFromGitHub {
+    owner = "fujiwarat";
+    repo = "anthy-unicode";
+    rev = finalAttrs.version;
+    hash = "sha256-lyd6cvuddQa535ZXhng6iQbP9cwfPXWXBEsqOEsjkHI=";
   };
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    libtool
+  ];
+
+  configurePhase = ''
+    ./autogen.sh --prefix="$out"
+  '';
 })


### PR DESCRIPTION
This commit switched anthy to a maintained fork. This is an attempt to fix #117562, but many things seem to have changed in the project, and I'm not sure how to properly test this locally? Like what's the best way to rebuild a package and all the package depending on it locally?

Fixes: #117562

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
