### PR TITLE
freesmlauncher: init at 2.2.2

### DIFF
--- a/pkgs/by-name/fr/freesmlauncher-unwrapped/package.nix
+++ b/pkgs/by-name/fr/freesmlauncher-unwrapped/package.nix
@@ -1,0 +1,113 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  cmark,
+  gamemode,
+  jdk17,
+  kdePackages,
+  libarchive,
+  ninja,
+  nix-update-script,
+  qrencode,
+  stripJavaArchivesHook,
+  tomlplusplus,
+  vulkan-headers,
+  zlib,
+  msaClientID ? null,
+}:
+let
+  libnbtplusplus = fetchFromGitHub {
+    owner = "FreesmTeam";
+    repo = "libnbtplusplus";
+    rev = "687e43031df0dc641984b4256bcca50d5b3f7de3";
+    hash = "sha256-7itkptyjoRcXfGLwg1/jxajetZ3a4mDc66+w4X6yW8s=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "freesmlauncher-unwrapped";
+  version = "2.2.2";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "FreesmTeam";
+    repo = "FreesmLauncher";
+    tag = finalAttrs.version;
+    hash = "sha256-FPBifWh/1hOhUpEl+eoB685T9lP5lSA9FQHQeFBJu24=";
+  };
+
+  postUnpack = ''
+    rm -rf source/libraries/libnbtplusplus
+    ln -s ${libnbtplusplus} source/libraries/libnbtplusplus
+  '';
+
+  # Ensure that instance shortcuts point to our final wrapper, rather than this unwrapped version
+  postPatch = ''
+    substituteInPlace launcher/minecraft/ShortcutUtils.cpp \
+      --replace-fail 'QApplication::applicationFilePath()' 'QProcessEnvironment::systemEnvironment().value("NIX_LAUNCHER_WRAPPER", "${placeholder "out"}/bin/freesmlauncher")'
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    ninja
+    kdePackages.extra-cmake-modules
+    jdk17
+    stripJavaArchivesHook
+  ];
+
+  buildInputs = [
+    cmark
+    kdePackages.extra-cmake-modules
+    kdePackages.qtbase
+    kdePackages.qtnetworkauth
+    libarchive
+    qrencode
+    tomlplusplus
+    vulkan-headers
+    zlib
+  ]
+  ++ lib.optional stdenv.hostPlatform.isLinux gamemode;
+
+  cmakeFlags = [
+    # downstream branding
+    (lib.cmakeFeature "Launcher_BUILD_PLATFORM" "nixpkgs")
+  ]
+  ++ lib.optionals (msaClientID != null) [
+    (lib.cmakeFeature "Launcher_MSA_CLIENT_ID" (toString msaClientID))
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # we wrap our binary manually
+    (lib.cmakeFeature "INSTALL_BUNDLE" "nodeps")
+    # disable built-in updater
+    (lib.cmakeFeature "MACOSX_SPARKLE_UPDATE_FEED_URL" "''")
+    (lib.cmakeFeature "CMAKE_INSTALL_PREFIX" "${placeholder "out"}/Applications/")
+  ];
+
+  doCheck = true;
+
+  dontWrapQtApps = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Prism Launcher fork aimed to provide a free way to play Minecraft";
+    longDescription = ''
+      Freesm Launcher is a custom launcher for Minecraft that allows you
+      to easily manage multiple installations of Minecraft at once and login
+      with offline account without any restrictions.
+    '';
+    homepage = "https://freesmlauncher.org/";
+    changelog = "https://github.com/FreesmTeam/FreesmLauncher/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ mio ];
+    mainProgram = "freesmlauncher";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})

--- a/pkgs/by-name/fr/freesmlauncher/package.nix
+++ b/pkgs/by-name/fr/freesmlauncher/package.nix
@@ -1,0 +1,165 @@
+{
+  addDriverRunpath,
+  alsa-lib,
+  flite,
+  gamemode,
+  glfw3-minecraft,
+  jdk17,
+  jdk21,
+  jdk25,
+  jdk8,
+  kdePackages,
+  lib,
+  libGL,
+  libx11,
+  libxcursor,
+  libxext,
+  libxrandr,
+  libxxf86vm,
+  libjack2,
+  libpulseaudio,
+  libusb1,
+  openal,
+  pciutils,
+  pipewire,
+  freesmlauncher-unwrapped,
+  stdenv,
+  symlinkJoin,
+  udev,
+  vulkan-loader,
+  wayland,
+  wrapGAppsHook3,
+  xrandr,
+
+  additionalLibs ? [ ],
+  additionalPrograms ? [ ],
+  controllerSupport ? stdenv.hostPlatform.isLinux,
+  gamemodeSupport ? stdenv.hostPlatform.isLinux,
+  jdks ? [
+    jdk25
+    jdk21
+    jdk17
+    jdk8
+  ],
+  msaClientID ? null,
+  textToSpeechSupport ? stdenv.hostPlatform.isLinux,
+}:
+
+assert lib.assertMsg (
+  controllerSupport -> stdenv.hostPlatform.isLinux
+) "controllerSupport only has an effect on Linux.";
+
+assert lib.assertMsg (
+  textToSpeechSupport -> stdenv.hostPlatform.isLinux
+) "textToSpeechSupport only has an effect on Linux.";
+
+let
+  freesmlauncher' = freesmlauncher-unwrapped.override { inherit msaClientID; };
+in
+
+symlinkJoin {
+  pname = "freesmlauncher";
+  inherit (freesmlauncher') version;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  paths = [ freesmlauncher' ];
+
+  nativeBuildInputs = [
+    kdePackages.wrapQtAppsHook
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    kdePackages.qtbase
+    kdePackages.qtimageformats
+    kdePackages.qtsvg
+  ]
+  ++ lib.optional stdenv.hostPlatform.isLinux kdePackages.qtwayland;
+
+  postBuild = ''
+    # Required for org.gtk.Settings.FileChooser
+    gappsWrapperArgsHook
+    qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -p $out/bin
+    ln -s $out/Applications/FreesmLauncher.app/Contents/MacOS/freesmlauncher $out/bin/freesmlauncher
+  ''
+  + ''
+
+    wrapQtAppsHook
+  '';
+
+  qtWrapperArgs =
+    let
+      runtimeLibs = [
+        (lib.getLib stdenv.cc.cc)
+        ## native versions
+        glfw3-minecraft
+        openal
+
+        ## openal
+        alsa-lib
+        libjack2
+        libpulseaudio
+        pipewire
+
+        ## glfw
+        libGL
+        libx11
+        libxcursor
+        libxext
+        libxrandr
+        libxxf86vm
+        wayland
+
+        udev # oshi
+
+        vulkan-loader # VulkanMod's lwjgl
+      ]
+      ++ lib.optional textToSpeechSupport flite
+      ++ lib.optional gamemodeSupport gamemode.lib
+      ++ lib.optional controllerSupport libusb1
+      ++ additionalLibs;
+
+      runtimePrograms = [
+        pciutils # need lspci
+        xrandr # needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
+      ]
+      ++ additionalPrograms;
+
+    in
+    [
+      "--set"
+      "NIX_LAUNCHER_WRAPPER"
+      "${placeholder "out"}/bin/freesmlauncher"
+      "--prefix"
+      "FREESMLAUNCHER_JAVA_PATHS"
+      ":"
+      "${lib.makeSearchPath "bin/java" jdks}"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      "--set"
+      "LD_LIBRARY_PATH"
+      "${addDriverRunpath.driverLink}/lib:${lib.makeLibraryPath runtimeLibs}"
+      "--prefix"
+      "PATH"
+      ":"
+      "${lib.makeBinPath runtimePrograms}"
+    ];
+
+  meta = {
+    inherit (freesmlauncher'.meta)
+      description
+      longDescription
+      homepage
+      changelog
+      license
+      maintainers
+      mainProgram
+      platforms
+      ;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
