### PR TITLE
Revert "matcha-gtk-theme: remove"

### DIFF
--- a/pkgs/by-name/ma/matcha-gtk-theme/package.nix
+++ b/pkgs/by-name/ma/matcha-gtk-theme/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  gdk-pixbuf,
+  gtk-engine-murrine,
+  jdupes,
+  librsvg,
+  gitUpdater,
+  colorVariants ? [ ], # default: all
+  themeVariants ? [ ], # default: blue
+}:
+
+let
+  pname = "matcha-gtk-theme";
+
+in
+lib.checkListOfEnum "${pname}: color variants" [ "standard" "light" "dark" ] colorVariants
+  lib.checkListOfEnum
+  "${pname}: theme variants"
+  [ "aliz" "azul" "sea" "pueril" "all" ]
+  themeVariants
+
+  stdenvNoCC.mkDerivation
+  rec {
+    inherit pname;
+    version = "2025-04-11";
+
+    src = fetchFromGitHub {
+      owner = "vinceliuice";
+      repo = "matcha-gtk-theme";
+      rev = version;
+      sha256 = "sha256-vPAGEa3anWAynEg2AYme4qpHJdLDKk2CmL5iQ1mBYgM=";
+    };
+
+    nativeBuildInputs = [
+      jdupes
+    ];
+
+    buildInputs = [
+      gdk-pixbuf
+      librsvg
+    ];
+
+    propagatedUserEnvPkgs = [
+      gtk-engine-murrine
+    ];
+
+    postPatch = ''
+      patchShebangs install.sh
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/share/themes
+
+      name= ./install.sh \
+        ${lib.optionalString (colorVariants != [ ]) "--color " + toString colorVariants} \
+        ${lib.optionalString (themeVariants != [ ]) "--theme " + toString themeVariants} \
+        --dest $out/share/themes
+
+      mkdir -p $out/share/doc/matcha-gtk-theme
+      cp -a src/extra/firefox $out/share/doc/matcha-gtk-theme
+
+      jdupes --quiet --link-soft --recurse $out/share
+
+      runHook postInstall
+    '';
+
+    passthru.updateScript = gitUpdater { };
+
+    meta = {
+      description = "Stylish flat Design theme for GTK based desktop environments";
+      homepage = "https://vinceliuice.github.io/theme-matcha";
+      license = lib.licenses.gpl3Only;
+      platforms = lib.platforms.unix;
+      maintainers = [ lib.maintainers.romildo ];
+    };
+  }

--- a/pkgs/by-name/ma/matcha-gtk-theme/package.nix
+++ b/pkgs/by-name/ma/matcha-gtk-theme/package.nix
@@ -3,7 +3,6 @@
   stdenvNoCC,
   fetchFromGitHub,
   gdk-pixbuf,
-  gtk-engine-murrine,
   jdupes,
   librsvg,
   gitUpdater,
@@ -40,10 +39,6 @@ lib.checkListOfEnum "${pname}: color variants" [ "standard" "light" "dark" ] col
     buildInputs = [
       gdk-pixbuf
       librsvg
-    ];
-
-    propagatedUserEnvPkgs = [
-      gtk-engine-murrine
     ];
 
     postPatch = ''

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1563,7 +1563,6 @@ mapAliases {
   marwaita-yellow = throw "'marwaita-yellow' has been removed because it depended on 'gtk-engine-murrine', which was removed because it was unmaintained upstream and depended on GTK 2."; # Added 2026-07-22
   massif-visualizer = throw "'massif-visualizer' has been removed due to outdated KF5 dependencies."; # Added 2026-05-01
   mastodon-bot = throw "'mastodon-bot' has been removed because it was archived by upstream in 2021."; # Added 2025-11-07
-  matcha-gtk-theme = throw "'matcha-gtk-theme' has been removed because it depended on 'gtk-engine-murrine', which was removed because it was unmaintained upstream and depended on GTK 2."; # Added 2026-07-22
   materia-theme = throw "'materia-theme' has been removed because it depended on 'gtk-engine-murrine', which was removed because it was unmaintained upstream and depended on GTK 2."; # Added 2026-07-22
   material-kwin-decoration = throw "'material-kwin-decoration' has been removed, as it is only compatible with Plasma 5, which is EOL"; # Added 2025-08-20
   matheria-theme-transparent = throw "'matheria-theme-transparent' has been removed because it depended on 'gtk-engine-murrine', which was removed because it was unmaintained upstream and depended on GTK 2."; # Added 2026-07-22


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Revert the removal in https://github.com/NixOS/nixpkgs/pull/544598 and remove gtk-engine-murrine, similar to https://github.com/NixOS/nixpkgs/pull/548594

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
