### PR TITLE
vscode-extensions.chrischinchilla.vscode-pandoc: build from source

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/chrischinchilla.vscode-pandoc/add-pandoc-to-path.patch
+++ b/pkgs/applications/editors/vscode/extensions/chrischinchilla.vscode-pandoc/add-pandoc-to-path.patch
@@ -1,0 +1,13 @@
+diff --git a/src/extension.ts b/src/extension.ts
+index 49637fa..c48c655 100644
+--- a/src/extension.ts
++++ b/src/extension.ts
+@@ -375,7 +375,7 @@ function renderDoc(
+   execFile(
+     command,
+     args,
+-    { cwd: filePath },
++    { cwd: filePath, env: { ...process.env, PATH: process.env.PATH ? `${process.env.PATH}${path.delimiter}@pandocBin@` : "@pandocBin@" } },
+     function (error, stdout, stderr) {
+       if (stdout !== null) {
+         pandocOutputChannel.append(stdout.toString() + "\n");

--- a/pkgs/applications/editors/vscode/extensions/chrischinchilla.vscode-pandoc/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/chrischinchilla.vscode-pandoc/default.nix
@@ -1,30 +1,70 @@
 {
   lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  nix-update-script,
+  nodejs,
+  npmHooks,
+  replaceVars,
+  vsce,
   vscode-utils,
-  jq,
-  moreutils,
   pandoc,
 }:
 
-vscode-utils.buildVscodeMarketplaceExtension {
-  mktplcRef = {
-    name = "vscode-pandoc";
-    publisher = "chrischinchilla";
-    version = "0.7.3";
-    hash = "sha256-TGkNYA96mzFtUoM+XPKXJ/AM+hbiLc6Lvk5YDxFUwcI=";
+let
+  version = "0.7.3";
+  src = stdenvNoCC.mkDerivation (finalAttrs: {
+    sourceName = "chrischinchilla-vscode-pandoc";
+    name = "${finalAttrs.sourceName}-${finalAttrs.version}.vsix";
+    pname = "${finalAttrs.sourceName}-vsix";
+    inherit version;
+    src = fetchFromGitHub {
+      owner = "ChrisChinchilla";
+      repo = "vscode-pandoc";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-tn3qQzbwjUnbuZtwCs4kXiGcrR/pTDECoHIirG/0WrU=";
+    };
+    patches = [
+      (replaceVars ./add-pandoc-to-path.patch {
+        pandocBin = lib.makeBinPath [ pandoc ];
+      })
+    ];
+    npmDeps = fetchNpmDeps {
+      inherit (finalAttrs) src;
+      hash = "sha256-1j+bDx2CiViEgLfanyx0dwLRgY1aYV9rQDWP3nDl1Bw=";
+    };
+    nativeBuildInputs = [
+      nodejs
+      npmHooks.npmConfigHook
+      vsce
+    ];
+    strictDeps = true;
+    __structuredAttrs = true;
+    dontConfigure = true;
+    buildPhase = ''
+      runHook preBuild
+      vsce package --no-dependencies --out $out
+      runHook postBuild
+    '';
+    dontInstall = true;
+  });
+in
+vscode-utils.buildVscodeExtension (finalAttrs: {
+  pname = "chrischinchilla-vscode-pandoc";
+  inherit version src;
+  vscodeExtPublisher = "chrischinchilla";
+  vscodeExtName = "vscode-pandoc";
+  vscodeExtUniqueId = "${finalAttrs.vscodeExtPublisher}.${finalAttrs.vscodeExtName}";
+  buildInputs = [ pandoc ]; # The Nix path scanner can't see into the VSIX.
+  passthru.updateScript = nix-update-script {
+    attrPath = "vscode-extensions.chrischinchilla.vscode-pandoc.src";
   };
-  nativeBuildInputs = [
-    jq
-    moreutils
-  ];
-  postInstall = ''
-    jq '.contributes.configuration.properties."pandoc.executable".default = "${lib.getExe pandoc}"' $out/$installPrefix/package.json | sponge $out/$installPrefix/package.json
-  '';
   meta = {
     description = "Converts Markdown files to pdf, docx, or html files using pandoc";
     homepage = "https://github.com/ChrisChinchilla/vscode-pandoc#readme";
-    downloadPage = "https://marketplace.visualstudio.com/items?itemName=yzane.markdown-pdf";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=chrischinchilla.vscode-pandoc";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ pandapip1 ];
   };
-}
+})


### PR DESCRIPTION
This PR addresses #548951 for the `chrischinchilla.vscode-pandoc` VS Code extension by building from source. See `pkgs/applications/editors/vscode/extensions/ms-vscode.js-debug/default.nix` for an existing example of a similar structure.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
