### PR TITLE
vscode-extensions.reditorsupport.r: prefer R from PATH

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/reditorsupport.r/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/reditorsupport.r/default.nix
@@ -1,15 +1,28 @@
 {
   lib,
+  writeShellScript,
   vscode-utils,
   jq,
   moreutils,
   languageserver ? rPackages.languageserver,
-  R,
+  rWrapper,
   radian,
-
   rPackages,
 }:
 
+let
+  rWithLanguageServer = rWrapper.override { packages = [ languageserver ]; };
+  preferPath =
+    name: fallback:
+    writeShellScript "${name}-path-first" ''
+      if command -v ${name} > /dev/null 2>&1; then
+        exec ${name} "$@"
+      fi
+      exec ${fallback} "$@"
+    '';
+  rPathFirst = preferPath "R" (lib.getExe' rWithLanguageServer "R");
+  radianPathFirst = preferPath "radian" (lib.getExe radian);
+in
 vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "r";
@@ -23,11 +36,10 @@ vscode-utils.buildVscodeMarketplaceExtension {
   ];
   postInstall = ''
     cd "$out/$installPrefix"
-    jq '.contributes.configuration.properties."r.rpath.mac".default = "${lib.getExe' R "R"}"' package.json | sponge package.json
-    jq '.contributes.configuration.properties."r.rpath.linux".default = "${lib.getExe' R "R"}"' package.json | sponge package.json
-    jq '.contributes.configuration.properties."r.rterm.mac".default = "${lib.getExe radian}"' package.json | sponge package.json
-    jq '.contributes.configuration.properties."r.rterm.linux".default = "${lib.getExe radian}"' package.json | sponge package.json
-    jq '.contributes.configuration.properties."r.libPaths".default = [ "${languageserver}/library" ]' package.json | sponge package.json
+    jq '.contributes.configuration.properties."r.rpath.mac".default = "${rPathFirst}"' package.json | sponge package.json
+    jq '.contributes.configuration.properties."r.rpath.linux".default = "${rPathFirst}"' package.json | sponge package.json
+    jq '.contributes.configuration.properties."r.rterm.mac".default = "${radianPathFirst}"' package.json | sponge package.json
+    jq '.contributes.configuration.properties."r.rterm.linux".default = "${radianPathFirst}"' package.json | sponge package.json
   '';
   meta = {
     changelog = "https://marketplace.visualstudio.com/items/REditorSupport.r/changelog";


### PR DESCRIPTION
This PR addresses #548951 for the `reditorsupport.r` VS Code extension by wrapping binaries in a shell script that first checks to see if that binary is available on `PATH`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
