### PR TITLE
[26.05] tengine: mark as vulnerable

### DIFF
--- a/pkgs/servers/http/tengine/default.nix
+++ b/pkgs/servers/http/tengine/default.nix
@@ -155,5 +155,15 @@ stdenv.mkDerivation rec {
     license = lib.licenses.bsd2;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ izorkin ];
+    knownVulnerabilities = [
+      "CVE-2026-49975 - HPACK/QPACK header decompression bomb in HTTP/1, HTTP/2 and HTTP/3"
+      "CVE-2026-9256 - heap buffer overflow with overlapping captures in ngx_http_rewrite_module"
+      "CVE-2026-42945 - escaping issue and possible buffer overrun in ngx_http_rewrite_module"
+      "CVE-2026-42946 - buffer overread when parsing a split status line in ngx_http_scgi_module and ngx_http_uwsgi_module"
+      "CVE-2026-42934 - buffer overread in recode_from_utf8() of ngx_http_charset_module"
+      "CVE-2026-40701 - use-after-free in the OCSP resolver of ngx_http_ssl_module"
+      "CVE-2026-1642 - a premature plain text response from an SSL backend was parsed before the handshake"
+      "The current version is over 3 years old and contains serious vulnerabilities. It will be dropped in 26.11. Please consider switchiting to another webserver by updating or removing your `services.nginx.package` option."
+    ];
   };
 }


### PR DESCRIPTION
The package has been dropped on master in #548850.

The current version is over 3 years old. There are multiple serious CVEs.

Therefore it also should be marked as vulnerable in 26.05.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
