### PR TITLE
copilot-language-server: trim bundled platform artifacts

### DIFF
--- a/pkgs/by-name/co/copilot-language-server/package.nix
+++ b/pkgs/by-name/co/copilot-language-server/package.nix
@@ -77,6 +77,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       shortName = "GitHub Copilot License";
       url = "https://github.com/customer-terms/github-copilot-product-specific-terms";
     };
+    sourceProvenance = with lib.sourceTypes; [
+      binaryNativeCode # prebuild directory
+      binaryBytecode # WASM files
+      obfuscatedCode # minified JavaScript
+    ];
     mainProgram = "copilot-language-server";
     platforms = [
       "x86_64-linux"

--- a/pkgs/by-name/co/copilot-language-server/package.nix
+++ b/pkgs/by-name/co/copilot-language-server/package.nix
@@ -5,8 +5,8 @@
   fetchzip,
   nix-update-script,
   nodejs-slim,
-
-  testers,
+  writableTmpDirAsHomeHook,
+  versionCheckHook,
 }:
 let
   inherit (stdenvNoCC.hostPlatform.node) arch platform;
@@ -54,9 +54,16 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    writableTmpDirAsHomeHook
+    versionCheckHook
+  ];
+  # uv_os_homedir returned ENOENT (no such file or directory)
+  versionCheckKeepEnvironment = lib.optionals stdenvNoCC.hostPlatform.isDarwin [ "HOME" ];
+
   passthru = {
     updateScript = nix-update-script { };
-    tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
   };
 
   meta = {

--- a/pkgs/by-name/co/copilot-language-server/package.nix
+++ b/pkgs/by-name/co/copilot-language-server/package.nix
@@ -4,10 +4,13 @@
   makeWrapper,
   fetchzip,
   nix-update-script,
-  nodejs,
+  nodejs-slim,
 
   testers,
 }:
+let
+  inherit (stdenvNoCC.hostPlatform.node) arch platform;
+in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "copilot-language-server";
   version = "1.527.1";
@@ -23,16 +26,29 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    nodejs
+    nodejs-slim
   ];
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/share/copilot-language-server
-    cp -r ./* $out/share/copilot-language-server/
+    server=$out/share/copilot-language-server
 
-    makeWrapper ${lib.getExe nodejs} $out/bin/copilot-language-server \
+    mkdir -p $server
+    cp -r ./* $server/
+
+    find "$server/node_modules/@github" -mindepth 1 -maxdepth 1 \
+      \( -name 'copilot-linux-*' -o -name 'copilot-darwin-*' -o -name 'copilot-win32-*' \) \
+      ! -name "copilot-${platform}-${arch}" -exec rm -rf {} +
+
+    find "$server/bin" "$server/compiled" -mindepth 1 -maxdepth 1 ! -name "${platform}" -exec rm -rf {} +
+    find "$server/bin/${platform}" "$server/compiled/${platform}" -mindepth 1 -maxdepth 1 ! -name "${arch}" -exec rm -rf {} +
+
+    find "$server/policy-templates" -mindepth 1 -maxdepth 1 ! -name "${platform}" -exec rm -rf {} +
+
+    find "$server" -name '*.map' -delete
+
+    makeWrapper ${lib.getExe nodejs-slim} $out/bin/copilot-language-server \
       --add-flags $out/share/copilot-language-server/main.js
 
     runHook postInstall


### PR DESCRIPTION
Before: 
```
➜ nix path-info ./result --size --human-readable --closure-size
/nix/store/1kgj2xwwa1arrynw2n0qiwny182da1g3-copilot-language-server-1.527.1      532.5 MiB       785.5 MiB
```

After:
```
➜ nix path-info ./result --size --human-readable --closure-size
/nix/store/9f11pqg9wqp4z8j5zr06b4bzmhwxsk4x-copilot-language-server-1.527.1      159.6 MiB       388.0 MiB
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
