### PR TITLE
trzsz-ssh: 0.1.24 -> 0.1.26

### DIFF
--- a/pkgs/by-name/tr/trzsz-ssh/package.nix
+++ b/pkgs/by-name/tr/trzsz-ssh/package.nix
@@ -8,21 +8,31 @@
 
 buildGoModule (finalAttrs: {
   pname = "trzsz-ssh";
-  version = "0.1.24";
+  version = "0.1.26";
 
   src = fetchFromGitHub {
     owner = "trzsz";
     repo = "trzsz-ssh";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-mcGsCPW8YHKCm5c+OWlKMp6k+J7ibvd6zN/76Ws5eUE=";
+    hash = "sha256-96xISHU0/C473Ohi3obsO1ihkxa0Q7Z39JIKzt5R7iM=";
   };
 
-  vendorHash = "sha256-RhmWoULbJZdYYFxLlj+ekca4u8+DQTH3QmZlpnUeZ2Y=";
+  vendorHash = "sha256-t/uJ+YyemTsDbuO+7VlOjFY8DvizkSZCE6uloA4mNqY=";
 
   ldflags = [
     "-s"
     "-w"
   ];
+
+  checkFlags =
+    let
+      skippedTests = [
+        # Failing test - Expected output is a table in plain text, but got ANSI color codes for the table's border
+        # Reported upstream: https://github.com/trzsz/trzsz-ssh/issues/277
+        "TestTableExample"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   nativeCheckInputs = [
     versionCheckHook


### PR DESCRIPTION
Bump `trzsz-ssh` from 0.1.24 to 0.1.26

Added `checkFlags` to skip a failing test.

The comment I added is hard to explain without actually looking at the test itself.

`
Running phase: checkPhase
--- FAIL: TestTableExample (0.00s)
    table_test.go:117: expected:
        
        ┌──────────┬───────────────────────────────┬─────────────────┐
        │ LANGUAGE │            FORMAL             │    INFORMAL     │
        ├──────────┼───────────────────────────────┼─────────────────┤
        │ Chinese  │ 您好                          │ 你好            │
        │ Japanese │ こんにちは                    │ やあ            │
        │ Russian  │ Здравствуйте                  │ Привет          │
        │ Spanish  │ Hola                          │ ¿Qué tal?       │
        │ English  │ You look absolutely fabulous. │ How's it going? │
        └──────────┴───────────────────────────────┴─────────────────┘
        
        got:  (color is unable to be rendered but it will show the borders as purple)
        
        ┌──────────┬───────────────────────────────┬─────────────────┐
        │ LANGUAGE │            FORMAL             │    INFORMAL     │
        ├──────────┼───────────────────────────────┼─────────────────┤
        │ Chinese  │ 您好                          │ 你好            │
        │ Japanese │ こんにちは                    │ やあ            │
        │ Russian  │ Здравствуйте                  │ Привет          │
        │ Spanish  │ Hola                          │ ¿Qué tal?       │
        │ English  │ You look absolutely fabulous. │ How's it going? │
        └──────────┴───────────────────────────────┴─────────────────┘
FAIL
FAIL    github.com/trzsz/trzsz-ssh/internal/table       0.029s
`

Recommended in a terminal that supports color to run `nix-build -A trzsz-ssh` without the `checkFlags` to actually see the colored border.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
