### PR TITLE
reka: init at 0-unstable-2026-04-19

### DIFF
--- a/pkgs/by-name/fi/filebrowser/package.nix
+++ b/pkgs/by-name/fi/filebrowser/package.nix
@@ -15,13 +15,13 @@
 }:
 
 let
-  version = "2.63.20";
+  version = "2.63.23";
 
   src = fetchFromGitHub {
     owner = "filebrowser";
     repo = "filebrowser";
     tag = "v${version}";
-    hash = "sha256-TyCd3AAfc/qMSG1mYZ9OF5kiHTrSRuJ8EzBM5fNzqnA=";
+    hash = "sha256-G0TIQE+Rru4JWBJIi8kdxSaP0CDPo2DyWLmcU2AX7Fs=";
   };
 
   frontend = stdenvNoCC.mkDerivation (finalAttrs: {
@@ -46,7 +46,7 @@ let
         ;
       fetcherVersion = 3;
       pnpm = pnpm_10;
-      hash = "sha256-UwTA7Eogp2GrvmXDbdfGBTJS3DuOTJ42e6fHlQxSHoA=";
+      hash = "sha256-XZdHaXnIfjA1wO6KQihj6PwXQ5LEcMrLRe2Md65nQ38=";
     };
 
     installPhase = ''
@@ -64,7 +64,7 @@ buildGoModule {
   pname = "filebrowser";
   inherit version src;
 
-  vendorHash = "sha256-BXw+fURCh1qNlwWo49aXIpSM339bV3Gwn9Ov8HLEVF0=";
+  vendorHash = "sha256-CuYi2PfR0F0lppFiRFzFj0yLms7VFNxzKpzlmEaCWWs=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/re/reka/package.nix
+++ b/pkgs/by-name/re/reka/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  rustPlatform,
+  fetchgit,
+  pkg-config,
+  libxkbcommon,
+  stdenvNoCC,
+  wayland,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "reka";
+  version = "0-unstable-2026-04-19";
+  __structuredAttrs = true;
+
+  src = fetchgit {
+    url = "https://code.tvl.fyi/depot.git:/tools/emacs-pkgs/reka.git";
+    rev = "90e89c2f51240e3d0a10d98e0cc61732bd86334e";
+    sha256 = "sha256-w25BZpbKMAACFweRqNEtGDvw/sNNJUfsVJQCXh41Y6w=";
+  };
+
+  cargoHash = "sha256-h5FTiU6zR0+w0KVnrjjaeQkSXOuCrQOXbZinJMLrNiY=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libxkbcommon
+  ]
+  ++ lib.optionals stdenvNoCC.isLinux [ wayland ];
+
+  postInstall = ''
+    install -Dm644 lisp/*.el \
+      --target-directory="$out"/share/emacs/site-lisp
+    ln -s "$out"/lib/libreka.so "$_"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Emacs-based window manager for river";
+    homepage = "https://code.tvl.fyi/about/tools/emacs-pkgs/reka";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ yiyu ];
+    badPlatforms = lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
