### PR TITLE
[26.05] filebrowser: 2.63.18 -> 2.63.23

### DIFF
--- a/pkgs/by-name/fi/filebrowser/package.nix
+++ b/pkgs/by-name/fi/filebrowser/package.nix
@@ -12,13 +12,13 @@
 }:
 
 let
-  version = "2.63.18";
+  version = "2.63.23";
 
   src = fetchFromGitHub {
     owner = "filebrowser";
     repo = "filebrowser";
     rev = "v${version}";
-    hash = "sha256-0j0i6bKKbyUi4O0wBT+xYjvywjRzAGd0/13Yh/dG5GA=";
+    hash = "sha256-G0TIQE+Rru4JWBJIi8kdxSaP0CDPo2DyWLmcU2AX7Fs=";
   };
 
   frontend = buildNpmPackage rec {
@@ -41,7 +41,7 @@ let
         ;
       fetcherVersion = 3;
       pnpm = pnpm_10;
-      hash = "sha256-UwTA7Eogp2GrvmXDbdfGBTJS3DuOTJ42e6fHlQxSHoA=";
+      hash = "sha256-XZdHaXnIfjA1wO6KQihj6PwXQ5LEcMrLRe2Md65nQ38=";
     };
 
     installPhase = ''
@@ -59,7 +59,7 @@ buildGoModule {
   pname = "filebrowser";
   inherit version src;
 
-  vendorHash = "sha256-BXw+fURCh1qNlwWo49aXIpSM339bV3Gwn9Ov8HLEVF0=";
+  vendorHash = "sha256-CuYi2PfR0F0lppFiRFzFj0yLms7VFNxzKpzlmEaCWWs=";
 
   excludedPackages = [ "tools" ];
 


### PR DESCRIPTION
Bumps `filebrowser` on `release-26.05` to **2.63.23**, the final upstream release.

Upstream's [release notes for v2.63.23](https://github.com/filebrowser/filebrowser/releases/tag/v2.63.23) state:

> File Browser is winding down and this is the last planned release. The repository is archived on **2026-09-01**. After that date there will be no further releases, bug fixes, or security fixes. Existing releases and Docker images stay online and will not be withdrawn.

Since 26.05 users will not receive anything further from upstream, this gets the release branch to the last version that will ever exist. It is a patch-level bump with no option or config changes.

Changelog for the range: [2.63.18...2.63.23](https://github.com/filebrowser/filebrowser/compare/v2.63.18...v2.63.23)

### Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. (`nixosTests.filebrowser` passes)
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

The upstream Go test suite also runs as part of the build and passes.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
