### PR TITLE
hyperscan: cleanup, fix build; babeldoc: cleanup, fix

### DIFF
--- a/pkgs/by-name/ba/babeldoc/package.nix
+++ b/pkgs/by-name/ba/babeldoc/package.nix
@@ -12,6 +12,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pname = "babeldoc";
   version = "0.6.4";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "funstory-ai";

--- a/pkgs/by-name/ba/babeldoc/package.nix
+++ b/pkgs/by-name/ba/babeldoc/package.nix
@@ -1,33 +1,28 @@
 {
   lib,
-  python3Packages,
+  python313Packages,
   fetchFromGitHub,
-  fetchpatch2,
-  writableTmpDirAsHomeHook,
   versionCheckHook,
 }:
 
+let
+  python3Packages = python313Packages;
+in
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "babeldoc";
-  version = "0.5.22";
+  version = "0.6.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "funstory-ai";
     repo = "BabelDOC";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ArLTv5AjpUdbsN8bQs03ATwg5ugXetld2FmHhicU8OE=";
+    hash = "sha256-eYCIXMYOJPGReDFkFdxgrhpkAG/pA14v3Si+5unfXz4=";
   };
 
-  patches = [
-    (fetchpatch2 {
-      name = "rename-python-levenshtein-to-levenshtein";
-      url = "https://github.com/funstory-ai/BabelDOC/pull/542.patch?full_index=1";
-      hash = "sha256-rjXhKVFivkJo54WdYiihqB3lrlu4YEwVZZkE4WBatWs=";
-    })
+  build-system = with python3Packages; [
+    hatchling
   ];
-
-  build-system = with python3Packages; [ hatchling ];
 
   dependencies =
     with python3Packages;
@@ -72,12 +67,10 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   pythonImportsCheck = [ "babeldoc" ];
 
+  # Upstream dropped its test suite in 0.6.0
   nativeCheckInputs = [
-    writableTmpDirAsHomeHook
-    python3Packages.pytestCheckHook
     versionCheckHook
   ];
-  versionCheckKeepEnvironment = "HOME";
 
   meta = {
     description = "PDF scientific paper translation and bilingual comparison library";

--- a/pkgs/by-name/ba/babeldoc/package.nix
+++ b/pkgs/by-name/ba/babeldoc/package.nix
@@ -28,39 +28,39 @@ python3Packages.buildPythonApplication (finalAttrs: {
     with python3Packages;
     [
       bitstring
+      chardet
+      charset-normalizer
       configargparse
+      cryptography
+      freetype-py
       httpx
       huggingface-hub
+      hyperscan
+      levenshtein
+      msgpack
       numpy
       onnx
       onnxruntime
       openai
+      opencv-python-headless
       orjson
-      charset-normalizer
-      cryptography
       peewee
       psutil
+      pydantic
       pymupdf
+      pyzstd
+      rapidocr-onnxruntime
       rich
+      rtree
+      scikit-image
+      scikit-learn
+      scipy
+      tenacity
+      tiktoken
       toml
       tqdm
-      xsdata
-      msgpack
-      pydantic
-      tenacity
-      scikit-image
-      freetype-py
-      tiktoken
-      levenshtein
-      opencv-python-headless
-      rapidocr-onnxruntime
-      pyzstd
-      hyperscan
-      rtree
-      chardet
-      scipy
       uharfbuzz
-      scikit-learn
+      xsdata
     ]
     ++ httpx.optional-dependencies.socks
     ++ (with xsdata.optional-dependencies; cli ++ lxml ++ soap);

--- a/pkgs/by-name/hy/hyperscan/package.nix
+++ b/pkgs/by-name/hy/hyperscan/package.nix
@@ -16,6 +16,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "hyperscan";
   version = "5.4.2";
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   src = fetchFromGitHub {
     owner = "intel";
     repo = "hyperscan";

--- a/pkgs/by-name/hy/hyperscan/package.nix
+++ b/pkgs/by-name/hy/hyperscan/package.nix
@@ -8,7 +8,7 @@
   util-linux,
   pkg-config,
   boost,
-  pcre2,
+  pcre,
   withStatic ? false, # build only shared libs by default, build static+shared if true
 }:
 
@@ -78,10 +78,11 @@ stdenv.mkDerivation (finalAttrs: {
   # hyperscan CMake is completely broken for chimera builds when pcre is compiled
   # the only option to make it build - building from source
   # In case pcre is built from source, chimera build is turned on by default
+  # NOTE: chimera requires PCRE1 (>= 8.41), it is not compatible with pcre2.
   preConfigure = lib.optionalString withStatic (
     ''
       mkdir -p pcre
-      tar xvf ${pcre2.src} --strip-components 1 -C pcre
+      tar xvf ${pcre.src} --strip-components 1 -C pcre
     ''
     # - CMake 4 dropped support of versions lower than 3.5, versions lower than 3.10 are deprecated.
     #   https://github.com/NixOS/nixpkgs/issues/445447

--- a/pkgs/development/python-modules/hyperscan/default.nix
+++ b/pkgs/development/python-modules/hyperscan/default.nix
@@ -21,19 +21,23 @@ let
     ];
   };
 in
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "hyperscan";
-  version = "0.8.0";
+  version = "0.8.2";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "darvid";
     repo = "python-hyperscan";
-    tag = "v${version}";
-    hash = "sha256-on++eSNaVY2Q6yT/O+unvE0x/Pt/SsIQFQblIqii2sM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jIDUfl6ReWvypfWecM8hReux6YxzXSsLCFU3AO97xUY=";
   };
 
-  env.CMAKE_ARGS = "-DHS_SRC_ROOT=${pkgs.hyperscan.src} -DHS_BUILD_LIB_ROOT=${lib-deps}/lib";
+  env.CMAKE_ARGS = lib.toString [
+    (lib.cmakeFeature "HS_SRC_ROOT" pkgs.hyperscan.src.outPath)
+    (lib.cmakeFeature "HS_BUILD_LIB_ROOT" "${lib-deps}/lib")
+  ];
 
   dontUseCmakeConfigure = true;
 
@@ -56,11 +60,11 @@ buildPythonPackage rec {
   meta = {
     description = "CPython extension for the Hyperscan regular expression matching library";
     homepage = "https://github.com/darvid/python-hyperscan";
-    changelog = "https://github.com/darvid/python-hyperscan/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/darvid/python-hyperscan/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     platforms = [
       "x86_64-linux"
     ];
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
## Things done

- **hyperscan: enable __structuredAttrs and strictDeps**
- **hyperscan: fix build by switching from pcre2 to pcre**
- **python3Packages.hyperscan: 0.8.0 -> 0.8.2** ([Diff](https://github.com/darvid/python-hyperscan/compare/v0.8.0...v0.8.2), [Changelog](https://github.com/darvid/python-hyperscan/blob/v0.8.2/CHANGELOG.md))
- **babeldoc: 0.5.22 -> 0.6.4** ([Diff](https://github.com/funstory-ai/BabelDOC/compare/v0.5.22...v0.6.4), [Changelog](https://github.com/funstory-ai/BabelDOC/releases/tag/v0.6.4))
- **babeldoc: sort dependencies**
- **babeldoc: enable __structuredAttrs**

---

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
