### PR TITLE
pkgs/nixos-render-docs: add xhtml unit test

### DIFF
--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/manual.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/manual.py
@@ -387,6 +387,7 @@ class ManualHTMLRenderer(RendererMixin, HTMLRenderer):
             //]]>
         """
         intersection_observer_js = """
+//<![CDATA[
 function createObserver() {
   const content = document.querySelector(".content");
   const headings = content.querySelectorAll("h1, h2, h3, h4, h5, h6");
@@ -442,6 +443,7 @@ function createObserver() {
 }
 
 document.addEventListener("DOMContentLoaded", createObserver);
+//]]>
         """
 
         header_content = ""

--- a/pkgs/by-name/ni/nixos-render-docs/src/tests/test_manual.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/tests/test_manual.py
@@ -1,6 +1,26 @@
+import xml.parsers.expat as expat
+from html.entities import name2codepoint
 from pathlib import Path
 
 from nixos_render_docs.manual import HTMLConverter, HTMLParameters
+
+
+def _parse_xhtml(text: str) -> None:
+    parser = expat.ParserCreate()
+    # Use offline html entity definitions
+    # and enble to use them (XML_PARAM_ENTITY_PARSING_ALWAYS)
+    parser.UseForeignDTD(True)
+    parser.SetParamEntityParsing(expat.XML_PARAM_ENTITY_PARSING_ALWAYS)
+
+    def external_entity_ref(context: str | None, base: str | None,
+                            system_id: str | None, public_id: str | None) -> int:
+        sub = parser.ExternalEntityParserCreate(context)
+        sub.Parse("".join(f'<!ENTITY {name} "&#{cp};">'
+                          for name, cp in name2codepoint.items()), True)
+        return 1
+
+    parser.ExternalEntityRefHandler = external_entity_ref
+    parser.Parse(text, True)
 
 
 def _build(tmp_path: Path, sidebar_depth: int = 2, sidebar_open: frozenset[str] = frozenset()) -> str:
@@ -122,3 +142,30 @@ def test_chunked_pages_carry_the_sidebar(tmp_path: Path) -> None:
     assert '<h4 id="sub-a" class="title"' in chunk
     assert chunk.count("<h1") <= 1
     assert "Table of Contents" not in chunk
+
+
+def test_output_is_well_formed_xhtml(tmp_path: Path) -> None:
+    (tmp_path / "chapter.md").write_text(
+        "# Fixed-point arguments {#chap-fpa}\n\n"
+        "Intro.\n\n"
+        "## First section {#sec-first}\n\n"
+        "Body.\n"
+    )
+    (tmp_path / "index.md").write_text(
+        "# Test manual {#book-test}\n\n"
+        "## Version 1\n\n"
+        "```{=include=} chapters html:into-file=//chapter.html\nchapter.md\n```\n"
+    )
+    out = tmp_path / "out"
+    out.mkdir(exist_ok=True)
+    conv = HTMLConverter(
+        "1.0.0",
+        HTMLParameters("test-gen", [], [], 3, Path("media")),
+        {},
+    )
+    conv.convert(tmp_path / "index.md", out / "index.html")
+    pages = sorted(out.glob("*.html"))
+    # Test that pages produced orderly with into-file
+    assert {p.name for p in pages} == {"index.html", "chapter.html"}
+    for page in pages:
+        _parse_xhtml(page.read_text())


### PR DESCRIPTION
Add a unit test after regression fixed in #542970

Officially xhtml was never stable (since there was no test).

I have more changes queued for nixos-render-docs; adding a test now to prevent further regressions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
