### PR TITLE
maintainers: cvengler → cve

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5958,7 +5958,7 @@
     name = "Serg Nesterov";
     keys = [ { fingerprint = "6E7D BA30 DB5D BA60 693C  3BE3 1512 F6EB 84AE CC8C"; } ];
   };
-  cvengler = {
+  cve = {
     name = "Clara Engler";
     github = "cvengler";
     githubId = 12272949;

--- a/pkgs/by-name/ki/kiesel/package.nix
+++ b/pkgs/by-name/ki/kiesel/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "JavaScript engine written in Zig";
     license = lib.licenses.mit;
     homepage = "https://kiesel.dev";
-    maintainers = with lib.maintainers; [ cvengler ];
+    maintainers = with lib.maintainers; [ cve ];
     platforms = lib.platforms.all;
     mainProgram = "kiesel";
   };

--- a/pkgs/by-name/op/openbgpd/package.nix
+++ b/pkgs/by-name/op/openbgpd/package.nix
@@ -24,7 +24,7 @@ clangStdenv.mkDerivation (finalAttrs: {
     description = "Free implementation of the Border Gateway Protocol, Version 4. It allows ordinary machines to be used as routers exchanging routes with other systems speaking the BGP protocol";
     license = lib.licenses.isc;
     homepage = "http://www.openbgpd.org/";
-    maintainers = with lib.maintainers; [ cvengler ];
+    maintainers = with lib.maintainers; [ cve ];
     platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
This commit changes my maintainer handle from `cvengler` to `cve`.

The reason for this is, that I feel more comfortable with this handle and generally go as `cve` everywhere online, with my GitHub username being the notable exception, due to `cve` already being taken there.

Unfortunately, I was not aware of this when I created this handle, as I thought it had to be equal to the GitHub username.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
