### PR TITLE
python3Packages.emsutil: 0.8.3 -> 0.8.3-unstable-2026-08-03

### DIFF
--- a/pkgs/development/python-modules/emsutil/default.nix
+++ b/pkgs/development/python-modules/emsutil/default.nix
@@ -18,15 +18,15 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "emsutil";
-  version = "0.8.3";
+  version = "0.8.3-unstable-2026-08-03";
   pyproject = true;
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "FennisRobert";
     repo = "emsutil";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-Ca+nhaa9pMMsNy5p9Yg17bVJgFPPTnBFgz8vTFLCjVU=";
+    rev = "18449659ca374ba84f02709a0d245b6bebb8ddb6";
+    hash = "sha256-9kyEBNKKP9Dz6s1svzq6C3ow27jV+zwz2M82gJndZsg=";
   };
 
   build-system = [
@@ -54,12 +54,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Utilities for the EMerge software suite";
     homepage = "https://github.com/FennisRobert/emsutil";
-    license =
-      with lib.licenses;
-      AND [
-        cc0 # src/emsutil/lib.py
-        unfree # FIXME: https://github.com/FennisRobert/emsutil/issues/1
-      ];
+    license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ eljamm ];
     teams = with lib.teams; [ ngi ];
   };


### PR DESCRIPTION
Upstream added a license to the project, so we're updating to unstable until they make a new release.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
