### PR TITLE
sparrow: 2.4.2 -> 2.5.3, fix native library loading, fix cross compilation

### DIFF
--- a/pkgs/by-name/sp/sparrow/package.nix
+++ b/pkgs/by-name/sp/sparrow/package.nix
@@ -180,6 +180,9 @@ let
       gnugrep
       openjdk
       autoPatchelfHook
+    ];
+
+    buildInputs = [
       (lib.getLib stdenv.cc.cc)
       zlib
       libusb1

--- a/pkgs/by-name/sp/sparrow/package.nix
+++ b/pkgs/by-name/sp/sparrow/package.nix
@@ -24,7 +24,6 @@
 }:
 
 let
-  pname = "sparrow";
   version = "2.5.3";
 
   openjdk = zulu25.override { enableJavaFX = true; };
@@ -51,7 +50,7 @@ let
     ."${stdenvNoCC.hostPlatform.system}";
 
   src = fetchurl {
-    url = "https://github.com/sparrowwallet/${pname}/releases/download/${version}/sparrowwallet-${version}-${sparrowArch}.tar.gz";
+    url = "https://github.com/sparrowwallet/sparrow/releases/download/${version}/sparrowwallet-${version}-${sparrowArch}.tar.gz";
     hash =
       {
         x86_64-linux = "sha256-xRtMh8nYHzjMyb8zSPQZNIbcfQIuKk4izfPW/PLK2zg=";
@@ -85,12 +84,12 @@ let
   };
 
   manifest = fetchurl {
-    url = "https://github.com/sparrowwallet/${pname}/releases/download/${version}/${pname}-${version}-manifest.txt";
+    url = "https://github.com/sparrowwallet/sparrow/releases/download/${version}/sparrow-${version}-manifest.txt";
     hash = "sha256-oVR5lJOWHTyEe+fBbxa+ZPh9GERHlZbZMPmaGImmdhg=";
   };
 
   manifestSignature = fetchurl {
-    url = "https://github.com/sparrowwallet/${pname}/releases/download/${version}/${pname}-${version}-manifest.txt.asc";
+    url = "https://github.com/sparrowwallet/sparrow/releases/download/${version}/sparrow-${version}-manifest.txt.asc";
     hash = "sha256-9ohRv/3rcOr78Mr0Bfny9zn+SqpLFaf0hn9G2LMAc8Q=";
   };
 
@@ -141,7 +140,7 @@ let
 
     XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS \
     LD_LIBRARY_PATH=@nativeLibs@''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH} \
-    ${openjdk}/bin/java ''${params[@]} $@
+    ${openjdk}/bin/java "''${params[@]}" "$@"
   '';
 
   torWrapper = writeScript "tor-wrapper" ''
@@ -199,41 +198,23 @@ let
 
       # Delete unneeded native libs.
 
-      rm -fR com.sparrowwallet.merged.module/com/sun/jna/freebsd-x86-64
-      rm -fR com.sparrowwallet.merged.module/com/sun/jna/dragonflybsd-x86-64
-      rm -fR com.sparrowwallet.merged.module/com/sun/jna/freebsd-aarch64
-      rm -fR com.sparrowwallet.merged.module/com/sun/jna/freebsd-x86
-      rm -fR com.sparrowwallet.merged.module/com/sun/jna/linux-arm
-      rm -fR com.sparrowwallet.merged.module/com/sun/jna/linux-armel
-      rm -fR com.sparrowwallet.merged.module/com/sun/jna/linux-mips64el
-      rm -fR com.sparrowwallet.merged.module/com/sun/jna/linux-ppc
-      rm -fR com.sparrowwallet.merged.module/com/sun/jna/linux-ppc64le
-      rm -fR com.sparrowwallet.merged.module/com/sun/jna/linux-s390x
-      rm -fR com.sparrowwallet.merged.module/com/sun/jna/linux-x86
-      rm -fR com.sparrowwallet.merged.module/com/sun/jna/openbsd-x86-64
-      rm -fR com.sparrowwallet.merged.module/com/sun/jna/openbsd-x86
-      rm -fR com.sparrowwallet.merged.module/com/sun/jna/sunos-sparc
-      rm -fR com.sparrowwallet.merged.module/com/sun/jna/sunos-sparcv9
-      rm -fR com.sparrowwallet.merged.module/com/sun/jna/sunos-x86-64
-      rm -fR com.sparrowwallet.merged.module/com/sun/jna/sunos-x86
-      rm -fR com.github.sarxos.webcam.capture/com/github/sarxos/webcam/ds/buildin/lib/linux_armel
-      rm -fR com.github.sarxos.webcam.capture/com/github/sarxos/webcam/ds/buildin/lib/linux_armhf
-      rm -fR com.github.sarxos.webcam.capture/com/github/sarxos/webcam/ds/buildin/lib/linux_x86
-      rm -fR openpnp.capture.java/darwin-aarch64
-      rm -fR openpnp.capture.java/darwin-x86-64
-      rm -fR openpnp.capture.java/win32-x86-64
-      rm -fR com.nativelibs4java.bridj/org/bridj/lib/linux_arm32_armel
-      rm -fR com.nativelibs4java.bridj/org/bridj/lib/linux_armel
-      rm -fR com.nativelibs4java.bridj/org/bridj/lib/linux_armhf
-      rm -fR com.nativelibs4java.bridj/org/bridj/lib/linux_x86
-      rm -fR com.nativelibs4java.bridj/org/bridj/lib/sunos_x64
-      rm -fR com.nativelibs4java.bridj/org/bridj/lib/sunos_x86
-      rm -fR com.sparrowwallet.merged.module/linux-arm
-      rm -fR com.sparrowwallet.merged.module/linux-x86
-      rm -fR com.fazecast.jSerialComm/FreeBSD
-      rm -fR com.fazecast.jSerialComm/OpenBSD
-      rm -fR com.fazecast.jSerialComm/Android
-      rm -fR com.fazecast.jSerialComm/Solaris
+      rm -R com.sparrowwallet.merged.module/com/sun/jna/win32
+      rm -R com.fazecast.jSerialComm/FreeBSD
+      rm -R com.fazecast.jSerialComm/OpenBSD
+      rm -R com.fazecast.jSerialComm/Android
+      rm -R com.fazecast.jSerialComm/Solaris
+      rm -R com.fazecast.jSerialComm/OSX
+      rm -R com.fazecast.jSerialComm/Windows
+      rm -R com.fazecast.jSerialComm/Linux/armv5
+      rm -R com.fazecast.jSerialComm/Linux/armv6hf
+      rm -R com.fazecast.jSerialComm/Linux/armv7hf
+      rm -R com.fazecast.jSerialComm/Linux/armv8_32
+      rm -R com.fazecast.jSerialComm/Linux/ppc64le
+      rm -R com.fazecast.jSerialComm/Linux/x86
+
+      echo "--- Remaining native libraries in modules ---"
+      find . -name "*.so" -o -name "*.dll" -o -name "*.dylib" -o -name "*.jnilib" -o -name "*.a"
+      echo "--------------------------------------------"
 
       ls | xargs -d " " -- echo > ../manifest.txt
       find . | grep "\.so$" | xargs -- chmod ugo+x
@@ -337,10 +318,11 @@ stdenvNoCC.mkDerivation rec {
 
     mkdir -p $out/bin $out
     ln -s ${sparrow-modules}/modules $out/lib
-    install -D -m 777 ${launcher} $out/bin/sparrow-desktop
+    install -D -m 555 ${launcher} $out/bin/sparrow-desktop
     substituteAllInPlace $out/bin/sparrow-desktop
-    substituteInPlace $out/bin/sparrow-desktop --subst-var-by jdkModules ${jdk-modules}
-    substituteInPlace $out/bin/sparrow-desktop --subst-var-by nativeLibs ${sparrow-modules}/native-libs
+    substituteInPlace $out/bin/sparrow-desktop \
+      --subst-var-by jdkModules ${jdk-modules} \
+      --subst-var-by nativeLibs ${sparrow-modules}/native-libs
 
     mkdir -p $out/share/icons
     ln -s ${sparrow-icons}/hicolor $out/share/icons

--- a/pkgs/by-name/sp/sparrow/package.nix
+++ b/pkgs/by-name/sp/sparrow/package.nix
@@ -110,11 +110,11 @@ let
       --add-opens=javafx.controls/javafx.scene.control.cell=com.sparrowwallet.sparrow
       --add-opens=org.controlsfx.controls/impl.org.controlsfx.skin=com.sparrowwallet.sparrow
       --add-opens=org.controlsfx.controls/impl.org.controlsfx.skin=javafx.fxml
-      --add-opens=javafx.graphics/com.sun.javafx.tk=centerdevice.nsmenufx
-      --add-opens=javafx.graphics/com.sun.javafx.tk.quantum=centerdevice.nsmenufx
-      --add-opens=javafx.graphics/com.sun.glass.ui=centerdevice.nsmenufx
-      --add-opens=javafx.controls/com.sun.javafx.scene.control=centerdevice.nsmenufx
-      --add-opens=javafx.graphics/com.sun.javafx.menu=centerdevice.nsmenufx
+      --add-opens=javafx.graphics/com.sun.javafx.tk=nsmenufx
+      --add-opens=javafx.graphics/com.sun.javafx.tk.quantum=nsmenufx
+      --add-opens=javafx.graphics/com.sun.glass.ui=nsmenufx
+      --add-opens=javafx.controls/com.sun.javafx.scene.control=nsmenufx
+      --add-opens=javafx.graphics/com.sun.javafx.menu=nsmenufx
       --add-opens=javafx.graphics/com.sun.glass.ui=com.sparrowwallet.sparrow
       --add-opens=javafx.graphics/javafx.scene.input=com.sparrowwallet.sparrow
       --add-opens=javafx.graphics/com.sun.javafx.application=com.sparrowwallet.sparrow

--- a/pkgs/by-name/sp/sparrow/package.nix
+++ b/pkgs/by-name/sp/sparrow/package.nix
@@ -25,7 +25,7 @@
 
 let
   pname = "sparrow";
-  version = "2.4.2";
+  version = "2.5.3";
 
   openjdk = zulu25.override { enableJavaFX = true; };
 
@@ -40,8 +40,8 @@ let
     url = "https://github.com/sparrowwallet/${pname}/releases/download/${version}/sparrowwallet-${version}-${sparrowArch}.tar.gz";
     hash =
       {
-        x86_64-linux = "sha256-BvtQZ+b+Hj+9eBdLg/KfYUeRQth0LWwwbZUQMfyTayE=";
-        aarch64-linux = "sha256-SMVO07kuTo1Yfj+8QfPOvkLR4551tQadJPoIMdT9GFE=";
+        x86_64-linux = "sha256-xRtMh8nYHzjMyb8zSPQZNIbcfQIuKk4izfPW/PLK2zg=";
+        aarch64-linux = "sha256-Kl4SV5MSIfCszUI2uN9/eLK+25gkSWkRHoSf8X837VM=";
       }
       ."${stdenvNoCC.hostPlatform.system}";
 
@@ -72,12 +72,12 @@ let
 
   manifest = fetchurl {
     url = "https://github.com/sparrowwallet/${pname}/releases/download/${version}/${pname}-${version}-manifest.txt";
-    hash = "sha256-cv/bkUZArASgWjgEphdWc6p8R9uOOkT+Idc53sjEOQ0=";
+    hash = "sha256-oVR5lJOWHTyEe+fBbxa+ZPh9GERHlZbZMPmaGImmdhg=";
   };
 
   manifestSignature = fetchurl {
     url = "https://github.com/sparrowwallet/${pname}/releases/download/${version}/${pname}-${version}-manifest.txt.asc";
-    hash = "sha256-lIamtUX45HVTrUJKbiGsFkRanM17KaZS0NwlTAoptEE=";
+    hash = "sha256-9ohRv/3rcOr78Mr0Bfny9zn+SqpLFaf0hn9G2LMAc8Q=";
   };
 
   publicKey = ./publickey.asc;

--- a/pkgs/by-name/sp/sparrow/package.nix
+++ b/pkgs/by-name/sp/sparrow/package.nix
@@ -36,6 +36,20 @@ let
     }
     ."${stdenvNoCC.hostPlatform.system}";
 
+  javaArch =
+    {
+      x86_64-linux = "x64";
+      aarch64-linux = "aarch64";
+    }
+    ."${stdenvNoCC.hostPlatform.system}";
+
+  jnaArch =
+    {
+      x86_64-linux = "x86-64";
+      aarch64-linux = "aarch64";
+    }
+    ."${stdenvNoCC.hostPlatform.system}";
+
   src = fetchurl {
     url = "https://github.com/sparrowwallet/${pname}/releases/download/${version}/sparrowwallet-${version}-${sparrowArch}.tar.gz";
     hash =
@@ -117,10 +131,17 @@ let
       --add-reads=com.sparrowwallet.merged.module=com.fasterxml.jackson.core
       --add-reads=com.sparrowwallet.merged.module=co.nstant.in.cbor
       --add-reads=kotlin.stdlib=kotlinx.coroutines.core
+      --enable-native-access=com.sparrowwallet.drongo
+      --enable-native-access=com.sparrowwallet.merged.module
+      --enable-native-access=javafx.graphics
+      --enable-native-access=com.fazecast.jSerialComm
+      --enable-native-access=org.usb4java
       -m com.sparrowwallet.sparrow
     )
 
-    XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS ${openjdk}/bin/java ''${params[@]} $@
+    XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS \
+    LD_LIBRARY_PATH=@nativeLibs@''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH} \
+    ${openjdk}/bin/java ''${params[@]} $@
   '';
 
   torWrapper = writeScript "tor-wrapper" ''
@@ -215,6 +236,40 @@ let
       find . | grep "\.so$" | xargs -- chmod ugo+x
       popd
 
+      # Provide native libs for LD_LIBRARY_PATH
+      mkdir native-libs
+      cp lib/runtime/lib/libargon2.so \
+         lib/runtime/lib/libbwt_jni.so \
+         lib/runtime/lib/libopenpnp-capture.so \
+         lib/runtime/lib/libzbar.so \
+         native-libs/
+      chmod ugo+x native-libs/*.so
+
+      # secp256k1 explicitly looks in java.home/lib or inside the module jar
+      mkdir -p modules/com.sparrowwallet.drongo/native/linux/${javaArch}
+      cp lib/runtime/lib/libsecp256k1.so modules/com.sparrowwallet.drongo/native/linux/${javaArch}/
+
+      # JNA extracts from resource path
+      mkdir -p modules/com.sparrowwallet.merged.module/com/sun/jna/linux-${jnaArch}
+      cp lib/runtime/lib/libjnidispatch.so modules/com.sparrowwallet.merged.module/com/sun/jna/linux-${jnaArch}/
+
+      # hidapi extracts from resource path via JNA
+      mkdir -p modules/com.sparrowwallet.merged.module/linux-${jnaArch}
+      cp lib/runtime/lib/libhidapi.so modules/com.sparrowwallet.merged.module/linux-${jnaArch}/
+      cp lib/runtime/lib/libhidapi-libusb.so modules/com.sparrowwallet.merged.module/linux-${jnaArch}/
+
+      # usb4java extracts from resource path
+      mkdir -p modules/org.usb4java/org/usb4java/linux-${jnaArch}
+      cp lib/runtime/lib/libusb4java.so modules/org.usb4java/org/usb4java/linux-${jnaArch}/
+
+      # jzbar extracts from resource path
+      mkdir -p modules/io.github.doblon8.jzbar/native/linux/${javaArch}
+      cp lib/runtime/lib/libzbar.so modules/io.github.doblon8.jzbar/native/linux/${javaArch}/
+
+      # openpnp extracts from resource path
+      mkdir -p modules/io.github.doblon8.openpnp.capture/native/linux/${javaArch}
+      cp lib/runtime/lib/libopenpnp-capture.so modules/io.github.doblon8.openpnp.capture/native/linux/${javaArch}/
+
       # Replace the embedded Tor binary (which is in a Tar archive)
       # with one from Nixpkgs.
       gzip -c ${torWrapper}  > tor.gz
@@ -225,6 +280,7 @@ let
       mkdir -p $out
       cp manifest.txt $out/
       cp -r modules/ $out/
+      cp -r native-libs/ $out/
     '';
   };
 in
@@ -281,6 +337,7 @@ stdenvNoCC.mkDerivation rec {
     install -D -m 777 ${launcher} $out/bin/sparrow-desktop
     substituteAllInPlace $out/bin/sparrow-desktop
     substituteInPlace $out/bin/sparrow-desktop --subst-var-by jdkModules ${jdk-modules}
+    substituteInPlace $out/bin/sparrow-desktop --subst-var-by nativeLibs ${sparrow-modules}/native-libs
 
     mkdir -p $out/share/icons
     ln -s ${sparrow-icons}/hicolor $out/share/icons

--- a/pkgs/by-name/sp/sparrow/package.nix
+++ b/pkgs/by-name/sp/sparrow/package.nix
@@ -313,6 +313,7 @@ stdenvNoCC.mkDerivation rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       msgilligan
+      eymeric
     ];
     platforms = [
       "x86_64-linux"


### PR DESCRIPTION
This supersedes #524622

- Update Sparrow to the latest version
- Add myself as maintainer
- Fix missing library warnings
- Split the nativeBuildInputs and the buildInputs, which causes cross-compilation to fail.

<details>

<summary>Logs before the fix</summary>

```log
nix run .#sparrow
WARNING: Unknown module: centerdevice.nsmenufx specified to --add-opens
WARNING: Unknown module: centerdevice.nsmenufx specified to --add-opens
WARNING: Unknown module: centerdevice.nsmenufx specified to --add-opens
WARNING: Unknown module: centerdevice.nsmenufx specified to --add-opens
WARNING: Unknown module: centerdevice.nsmenufx specified to --add-opens
2026-06-16 11:34:59,547 ERROR Error loading libsecp256k1 library
java.io.FileNotFoundException: File /native/linux/x64/libsecp256k1.so was not found inside JAR.
        at com.sparrowwallet.drongo/com.sparrowwallet.drongo.NativeUtils.loadLibraryFromJar(Unknown Source)
        at com.sparrowwallet.drongo/org.bitcoin.Secp256k1Context.loadLibrary(Unknown Source)
        at com.sparrowwallet.drongo/org.bitcoin.Secp256k1Context.<clinit>(Unknown Source)
        at com.sparrowwallet.drongo/com.sparrowwallet.drongo.crypto.ECKey.publicPointFromPrivate(Unknown Source)
        at com.sparrowwallet.drongo/com.sparrowwallet.drongo.crypto.ECKey.fromPrivate(Unknown Source)
        at com.sparrowwallet.drongo/com.sparrowwallet.drongo.crypto.ECKey.fromPrivate(Unknown Source)
        at com.sparrowwallet.drongo/com.sparrowwallet.drongo.crypto.ECKey.fromPrivate(Unknown Source)
        at com.sparrowwallet.sparrow/com.sparrowwallet.sparrow.io.Storage.<clinit>(Unknown Source)
        at com.sparrowwallet.sparrow/com.sparrowwallet.sparrow.SparrowWallet.main(Unknown Source)
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by com.sun.glass.utils.NativeLibLoader in module javafx.graphics (jrt:/javafx.graphics)
WARNING: Use --enable-native-access=javafx.graphics to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled


(java:172247): Gdk-WARNING **: 11:35:02.319: XSetErrorHandler() called with a GDK error trap pushed. Don't do that.
2026-06-16 11:35:02,381 ERROR Error enumerating USB devices
org.hid4java.HidException: Hidapi did not initialise: Native library (com/sun/jna/linux-x86-64/libjnidispatch.so) not found in resource path ()
        at org.hid4java@0.8.1/org.hid4java.HidDeviceManager.<init>(Unknown Source)
        at org.hid4java@0.8.1/org.hid4java.HidServices.<init>(Unknown Source)
        at org.hid4java@0.8.1/org.hid4java.HidManager.getHidServices(Unknown Source)
        at com.sparrowwallet.lark/com.sparrowwallet.lark.Lark.enumerateHidClients(Unknown Source)
        at com.sparrowwallet.lark/com.sparrowwallet.lark.Lark.enumerate(Unknown Source)
        at com.sparrowwallet.lark/com.sparrowwallet.lark.Lark.enumerate(Unknown Source)
        at com.sparrowwallet.lark/com.sparrowwallet.lark.Lark.enumerate(Unknown Source)
        at com.sparrowwallet.sparrow/com.sparrowwallet.sparrow.io.Hwi.enumerateUsb(Unknown Source)
        at com.sparrowwallet.sparrow/com.sparrowwallet.sparrow.io.Hwi.enumerate(Unknown Source)
        at com.sparrowwallet.sparrow/com.sparrowwallet.sparrow.io.Hwi$ScheduledEnumerateService$1.call(Unknown Source)
        at com.sparrowwallet.sparrow/com.sparrowwallet.sparrow.io.Hwi$ScheduledEnumerateService$1.call(Unknown Source)
        at javafx.graphics/javafx.concurrent.Task$TaskCallable.call(Task.java:1407)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:328)
        at javafx.graphics/javafx.concurrent.Service.lambda$executeTask$4(Service.java:714)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
        at java.base/java.lang.Thread.run(Thread.java:1474)
Caused by: java.lang.UnsatisfiedLinkError: Native library (com/sun/jna/linux-x86-64/libjnidispatch.so) not found in resource path ()
        at com.sparrowwallet.merged.module@2.5.2/com.sun.jna.Native.loadNativeDispatchLibraryFromClasspath(Unknown Source)
        at com.sparrowwallet.merged.module@2.5.2/com.sun.jna.Native.loadNativeDispatchLibrary(Unknown Source)
        at com.sparrowwallet.merged.module@2.5.2/com.sun.jna.Native.<clinit>(Unknown Source)
        at org.hid4java@0.8.1/org.hid4java.jna.HidrawHidApiLibrary.<clinit>(Unknown Source)
        at org.hid4java@0.8.1/org.hid4java.jna.HidApi.init(Unknown Source)
        ... 17 common frames omitted
```
</details> 

The error in the logs was because upstream's jpackage build ships these as loose .so files in lib/runtime/lib/ (implicitly on java.home for the bundled JVM).
So to fix:
- I copy the loose native libs out of lib/runtime/lib/ into a  native-libs output, added to LD_LIBRARY_PATH in the launcher.
- For libsecp256k1/libjnidispatch/libhidapi*/libusb4java, which check  java.home + jar-resource extraction only (ignoring LD_LIBRARY_PATH/java.library.path), inject the file directly at the module resource path each loader expects
- Restore --enable-native-access for the relevant modules   (com.sparrowwallet.drongo, com.sparrowwallet.merged.module,  javafx.graphics, com.fazecast.jSerialComm, org.usb4java), matching upstream's build.gradle

I tested to open Sparrow and view my wallet. But I cannot do a transaction as my cold wallet is not with me, so if someone else could confirm that it works as expected, it would be welcome.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
