### PR TITLE
intel-npu-driver: 1.28.0 -> 1.35.0

### DIFF
--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -206,10 +206,10 @@ sub pciCheck {
          $device eq "0x4222" || $device eq "0x4227");
 
     # Intel NPU driver
-    # list taken from linux(v6.18): drivers/accel/ivpu/ivpu_drv.h
+    # list taken from linux(v7.1): drivers/accel/ivpu/ivpu_drv.h
     if ($vendor eq "0x8086" &&
-        ($device eq "0xfd3e" || $device eq "0x7d1d" || $device eq "0xad1d" ||
-         $device eq "0x643e" || $device eq "0xb03e"))
+        ($device eq "0x7d1d" || $device eq "0xad1d" || $device eq "0x643e" ||
+         $device eq "0xb03e" || $device eq "0xfd3e" || $device eq "0xd71d"))
     {
         push @attrs, "hardware.cpu.intel.npu.enable = true;";
     }

--- a/pkgs/by-name/in/intel-npu-driver/package.nix
+++ b/pkgs/by-name/in/intel-npu-driver/package.nix
@@ -7,19 +7,20 @@
   cmake,
   git,
   level-zero,
+  pkg-config,
   fetchFromGitHub,
 }:
 
 stdenv.mkDerivation rec {
   pname = "intel-npu-driver";
-  version = "1.28.0";
+  version = "1.35.0";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "linux-npu-driver";
     tag = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-aH7npJompKYlyq2RPXHn/lflQ1C/yYcTp2K+6kX/L0w=";
+    hash = "sha256-n23yb6ZEJ7bfLactFixBQTcRlSIsVMOJ1QESoHLIhPg=";
   };
 
   buildInputs = [
@@ -31,7 +32,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
+    pkg-config
   ];
+
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=missing-field-initializers";
 
   outputs = [
     "out"
@@ -40,9 +44,7 @@ stdenv.mkDerivation rec {
   ];
 
   postPatch = ''
-    rm -rf third_party/level-zero
     rm third_party/cmake/level-zero.cmake
-    rm third_party/cmake/FindLevelZero.cmake
 
     substituteInPlace third_party/yaml-cpp/CMakeLists.txt --replace-fail \
       "cmake_minimum_required" \
@@ -50,7 +52,8 @@ stdenv.mkDerivation rec {
 
     substituteInPlace third_party/CMakeLists.txt --replace-fail \
       "include(cmake/level-zero.cmake)" \
-      ""
+      "include(cmake/FindLevelZero.cmake)"
+
     substituteInPlace third_party/level-zero-npu-extensions/ze_graph_ext.h --replace-fail \
     "#include \"ze_api.h\"" \
     "#include <level_zero/ze_api.h>"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Update intel npu driver to [v1.35.0](https://github.com/intel/linux-npu-driver/releases/tag/v1.35.0)
- Fix the intel npu driver build, there are massive CMake changes in v1.30.0 release https://github.com/intel/linux-npu-driver/commit/3897263520820dd8d552f8e430139fc721f32491
- Update Intel NPU PCI IDs from [linux@v7.1/drivers/accel/ivpu/ivpu_drv.h](https://github.com/torvalds/linux/blob/v7.1/drivers/accel/ivpu/ivpu_drv.h#L31) in nixos-generate-config,pl

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
