### PR TITLE
deluge: fix generic launcher without setuptools

### DIFF
--- a/pkgs/applications/networking/p2p/deluge/default.nix
+++ b/pkgs/applications/networking/p2p/deluge/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  fetchpatch,
   fetchurl,
   intltool,
   libtorrent-rasterbar,
@@ -32,11 +31,8 @@ let
       };
 
       patches = [
-        (fetchpatch {
-          name = "deluge-use-importlib-for-ui-entrypoints.patch";
-          url = "https://github.com/deluge-torrent/deluge/commit/1a031d00094d4613667bcaadae57b548b7e1413b.patch";
-          hash = "sha256-KfACbRs1yVr5PsRrXLp/RD8YT3Ow71bvuPZyKMDRmOA=";
-        })
+        # https://github.com/deluge-torrent/deluge/pull/501
+        ./use-importlib-for-ui-entrypoints.patch
       ];
 
       propagatedBuildInputs =

--- a/pkgs/applications/networking/p2p/deluge/default.nix
+++ b/pkgs/applications/networking/p2p/deluge/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  fetchpatch,
   fetchurl,
   intltool,
   libtorrent-rasterbar,
@@ -29,6 +30,14 @@ let
         url = "http://download.deluge-torrent.org/source/${lib.versions.majorMinor version}/deluge-${version}.tar.xz";
         hash = "sha256-ubonK1ukKq8caU5sKWKKuBbMGnAKN7rAiqy1JXFgas0=";
       };
+
+      patches = [
+        (fetchpatch {
+          name = "deluge-use-importlib-for-ui-entrypoints.patch";
+          url = "https://github.com/deluge-torrent/deluge/commit/1a031d00094d4613667bcaadae57b548b7e1413b.patch";
+          hash = "sha256-KfACbRs1yVr5PsRrXLp/RD8YT3Ow71bvuPZyKMDRmOA=";
+        })
+      ];
 
       propagatedBuildInputs =
         with pypkgs;

--- a/pkgs/applications/networking/p2p/deluge/use-importlib-for-ui-entrypoints.patch
+++ b/pkgs/applications/networking/p2p/deluge/use-importlib-for-ui-entrypoints.patch
@@ -1,0 +1,45 @@
+--- a/deluge/common.py
++++ b/deluge/common.py
+@@ -25,6 +25,7 @@
+ from contextlib import closing
+ from datetime import datetime
+ from importlib import resources
++from importlib.metadata import distribution
+ from io import BytesIO
+ from pathlib import Path
+ from urllib.parse import unquote_plus, urljoin
+@@ -33,12 +34,6 @@
+ from deluge.decorators import deprecated
+ from deluge.error import InvalidPathError
+
+-try:
+-    from importlib.metadata import distribution
+-except ImportError:
+-    from pkg_resources import get_distribution as distribution
+-
+-
+ try:
+     import chardet
+ except ImportError:
+--- a/deluge/ui/ui_entry.py
++++ b/deluge/ui/ui_entry.py
+@@ -16,8 +16,7 @@
+ import logging
+ import os
+ import sys
+-
+-import pkg_resources
++from importlib.metadata import entry_points
+
+ import deluge.common
+ import deluge.configmanager
+@@ -32,7 +31,8 @@
+ def get_ui_entrypoints():
+     """Return a dict of loaded deluge.ui entry points, keyed by name."""
+     ui_entrypoints = {}
+-    for entrypoint in pkg_resources.iter_entry_points('deluge.ui'):
++    eps = entry_points(group='deluge.ui')
++    for entrypoint in eps.select():
+         try:
+             ui_entrypoints[entrypoint.name] = entrypoint.load()
+         except ImportError:


### PR DESCRIPTION
Upstream change: https://github.com/deluge-torrent/deluge/pull/501

Deluge’s generic `deluge` launcher uses `pkg_resources` to discover UI entry points. Although `standard-pkg-resources` provides the `pkg_resources` module, resolving those entry points also checks Deluge’s package metadata and fails because the `setuptools` distribution is unavailable at runtime.

Backport the upstream change to use `importlib.metadata` for UI entry-point discovery. Keep `standard-pkg-resources` because Deluge’s plugin manager still uses `pkg_resources`.

The failure can be reproduced on the unmodified base revision:

```console
$ nix shell 'github:NixOS/nixpkgs/19a567c178bebc336d60d8da5dedea44bbe4f730#deluge-gtk' \
    --command deluge --version
...
pkg_resources.DistributionNotFound: The 'setuptools' distribution was not found and is required by the application
```

With this change, the generic launcher works:

```console
$ nix shell .#deluge-gtk --command deluge --version
.deluge-wrapped 2.2.0
...
```

Assisted by OpenAI Codex (gpt-5.6-sol-xhigh).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Both affected packages build, and all five launchers handle `--version` successfully:

```console
$ nix build .#deluged .#deluge-gtk
$ nix run .#deluged -- --version
$ nix run .#deluge-gtk -- --version
$ nix shell .#deluge-gtk --command deluge --version
$ nix shell .#deluge-gtk --command deluge-web --version
$ nix shell .#deluge-gtk --command deluge-console --version
```

`nixpkgs-review` successfully built both affected packages:

```console
$ nixpkgs-review rev HEAD \
    --branch 19a567c178bebc336d60d8da5dedea44bbe4f730 \
    --package deluged \
    --package deluge-gtk \
    --no-shell
--------- Report for 'x86_64-linux' ---------
2 packages built:
deluge-gtk deluged
```

The existing integration test was also attempted:

```console
$ nix build .#deluged.tests.deluge
```

It fails independently during daemon startup because PyOpenSSL 26 removed `OpenSSL.crypto.X509Req`:

```console
Unable to start deluged: module 'OpenSSL.crypto' has no attribute 'X509Req'
```

That failure is addressed separately by https://github.com/NixOS/nixpkgs/pull/548035. The NixOS and package-test checkboxes are therefore left unchecked here.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test