### PR TITLE
python3Packages.dictdiffer: 0.9.0 -> 0.10.0

### DIFF
--- a/pkgs/development/python-modules/dictdiffer/default.nix
+++ b/pkgs/development/python-modules/dictdiffer/default.nix
@@ -2,39 +2,46 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  hatch-vcs,
+  hatchling,
+  pytest-cov-stub,
   pytestCheckHook,
-  setuptools-scm,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "dictdiffer";
-  version = "0.9.0";
-  format = "setuptools";
+  version = "0.10.0";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "inveniosoftware";
     repo = "dictdiffer";
-    rev = "v${version}";
-    hash = "sha256-lQyPs3lQWtsvNPuvvwJUTDzrFaOX5uwGuRHe3yWUheU=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5jYfkqyU3LrYDy+U9+McOYXyutp8gZSeCmx99NsLYgo=";
   };
 
-  nativeBuildInputs = [ setuptools-scm ];
-
-  nativeCheckInputs = [ pytestCheckHook ];
-
   postPatch = ''
-    substituteInPlace setup.py \
-      --replace "'pytest-runner>=2.7'," ""
-    substituteInPlace pytest.ini \
-      --replace ' --isort --pydocstyle --pycodestyle --doctest-glob="*.rst" --doctest-modules --cov=dictdiffer --cov-report=term-missing' ""
+    substituteInPlace pyproject.toml \
+      --replace-fail "--isort --pydocstyle" ""
   '';
+
+  nativeBuildInputs = [
+    hatch-vcs
+    hatchling
+  ];
+
+  nativeCheckInputs = [
+    pytest-cov-stub
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [ "dictdiffer" ];
 
   meta = {
     description = "Module to diff and patch dictionaries";
     homepage = "https://github.com/inveniosoftware/dictdiffer";
+    changelog = "https://github.com/inveniosoftware/dictdiffer/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/inveniosoftware/dictdiffer/compare/v0.9.0...v0.10.0

Changelog: https://github.com/inveniosoftware/dictdiffer/releases/tag/v0.10.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
