### PR TITLE
mk-kde-derivation: clean up licenses

### DIFF
--- a/lib/licenses/licenses.nix
+++ b/lib/licenses/licenses.nix
@@ -1657,6 +1657,11 @@ lib.mapAttrs mkLicense (
       fullName = "W3C Software Notice and License (1998-07-20)";
     };
 
+    w3c-20150513 = {
+      spdxId = "W3C-20150513";
+      fullName = "W3C Software Notice and Document License (2015-05-13)";
+    };
+
     wadalab = {
       fullName = "Wadalab Font License";
       url = "https://fedoraproject.org/wiki/Licensing:Wadalab?rd=Licensing/Wadalab";

--- a/lib/licenses/licenses.nix
+++ b/lib/licenses/licenses.nix
@@ -1370,6 +1370,11 @@ lib.mapAttrs mkLicense (
       fullName = "Q Public License 1.0";
     };
 
+    qtGplException10 = {
+      spdxId = "Qt-GPL-exception-1.0";
+      fullName = "Qt GPL exception 1.0";
+    };
+
     qwtException = {
       spdxId = "Qwt-exception-1.0";
       fullName = "Qwt exception 1.0";

--- a/lib/licenses/licenses.nix
+++ b/lib/licenses/licenses.nix
@@ -699,6 +699,11 @@ lib.mapAttrs mkLicense (
       url = "https://geant4.web.cern.ch/geant4/license/LICENSE.html";
     };
 
+    gccException31 = {
+      spdxId = "GCC-exception-3.1";
+      fullName = "GCC Runtime Library exception 3.1";
+    };
+
     geogebra = {
       fullName = "GeoGebra Non-Commercial License Agreement";
       url = "https://www.geogebra.org/license";

--- a/lib/licenses/licenses.nix
+++ b/lib/licenses/licenses.nix
@@ -1375,6 +1375,11 @@ lib.mapAttrs mkLicense (
       fullName = "Qt GPL exception 1.0";
     };
 
+    qtLgplException11 = {
+      spdxId = "Qt-LGPL-exception-1.1";
+      fullName = "Qt LPL exception 1.1";
+    };
+
     qwtException = {
       spdxId = "Qwt-exception-1.0";
       fullName = "Qwt exception 1.0";

--- a/lib/licenses/licenses.nix
+++ b/lib/licenses/licenses.nix
@@ -178,6 +178,11 @@ lib.mapAttrs mkLicense (
       fullName = "Baekmuk License";
     };
 
+    bisonException22 = {
+      spdxId = "Bison-exception-2.2";
+      fullName = "Bison exception 2.2";
+    };
+
     bitstreamCharter = {
       spdxId = "Bitstream-Charter";
       fullName = "Bitstream Charter Font License";

--- a/lib/licenses/licenses.nix
+++ b/lib/licenses/licenses.nix
@@ -940,6 +940,11 @@ lib.mapAttrs mkLicense (
       fullName = "FSF All Permissive License";
     };
 
+    fsfullr = {
+      spdxId = "FSFULLR";
+      fullName = "FSF Unlimited License (with License Retention)";
+    };
+
     hl3 = {
       fullName = "Hippocratic License v3.0";
       url = "https://firstdonoharm.dev/version/3/0/core.txt";

--- a/pkgs/kde/lib/mk-kde-derivation.nix
+++ b/pkgs/kde/lib/mk-kde-derivation.nix
@@ -35,25 +35,8 @@ let
       # https://invent.kde.org/kdevelop/kdevelop/-/blob/master/LICENSES/LicenseRef-MIT-KDevelop-Ideal.txt
       "LicenseRef-MIT-KDevelop-Ideal" = lib.licenses.mit;
 
-      "FSFULLR" = {
-        spdxId = "FSFULLR";
-        fullName = "FSF Unlimited License (with License Retention)";
-      };
-
-      "W3C-20150513" = {
-        spdxId = "W3C-20150513";
-        fullName = "W3C Software Notice and Document License (2015-05-13)";
-      };
-
-      "LGPL" = lib.licenses.lgpl2Plus;
-
-      # Technically not exact
-      "bzip2-1.0.6" = lib.licenses.bsdOriginal;
-
       # FIXME: typo lol
       "ICS" = lib.licenses.isc;
-      "BSD-2-Clauses" = lib.licenses.bsd2;
-      "BSD-3-clause" = lib.licenses.bsd3;
       "BSD-3-Clauses" = lib.licenses.bsd3;
 
       # These are only relevant to Qt commercial users
@@ -62,13 +45,8 @@ let
       "LicenseRef-Qt-Commercial-exception-1.0" = null;
 
       # FIXME: ???
-      "Qt-GPL-exception-1.0" = null;
       "LicenseRef-Qt-LGPL-exception-1.0" = null;
-      "Qt-LGPL-exception-1.1" = null;
       "LicenseRef-Qt-exception" = null;
-      "GCC-exception-3.1" = null;
-      "Bison-exception-2.2" = null;
-      "Font-exception-2.0" = null;
       None = null;
     };
 


### PR DESCRIPTION
These licenses all have an SPDX ID, so let's move them to `lib.licenses`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
