### PR TITLE
python3Packages.testrepository: 0.0.21 -> 0.0.22

### DIFF
--- a/pkgs/development/python-modules/testrepository/default.nix
+++ b/pkgs/development/python-modules/testrepository/default.nix
@@ -1,32 +1,40 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
-  testtools,
-  testresources,
-  pbr,
-  python-subunit,
+  fetchFromGitHub,
   fixtures,
+  hatch-vcs,
+  hatchling,
+  python-subunit,
   python,
+  testresources,
+  testtools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "testrepository";
-  version = "0.0.21";
-  format = "setuptools";
+  version = "0.0.22";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-Nor89+CQs8aIvddUol9kvDFOUSuBb4xxufn8F9w3o9k=";
+  src = fetchFromGitHub {
+    owner = "testing-cabal";
+    repo = "testrepository";
+    tag = finalAttrs.version;
+    hash = "sha256-t5cTVMtzYIu4AIQVUVz3odvj+qFeYyUxIroB3yb0bFQ=";
   };
 
-  nativeCheckInputs = [ testresources ];
-  buildInputs = [ pbr ];
-  propagatedBuildInputs = [
+  build-system = [
+    hatch-vcs
+    hatchling
+  ];
+
+  dependencies = [
     fixtures
     python-subunit
     testtools
   ];
+
+  nativeCheckInputs = [ testresources ];
 
   checkPhase = ''
     ${python.interpreter} ./testr
@@ -34,8 +42,10 @@ buildPythonPackage rec {
 
   meta = {
     description = "Database of test results which can be used as part of developer workflow";
-    mainProgram = "testr";
-    homepage = "https://pypi.org/project/testrepository/";
+    homepage = "https://github.com/testing-cabal/testrepository";
+    changelog = "https://github.com/testing-cabal/testrepository/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd2;
+    maintainers = [ ];
+    mainProgram = "testr";
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/testing-cabal/testrepository/compare/0.0.21...0.0.22

Changelog: https://github.com/testing-cabal/testrepository/releases/tag/0.0.22


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
