### PR TITLE
python3Packages.probatio: init at 0.11.0

### DIFF
--- a/pkgs/development/python-modules/probatio/default.nix
+++ b/pkgs/development/python-modules/probatio/default.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  hypothesis,
+  mashumaro,
+  nix-update-script,
+  openapi-schema-validator,
+  pyprojectVersionPatchHook,
+  pytest-cov-stub,
+  pytestCheckHook,
+  syrupy,
+  voluptuous-openapi,
+  voluptuous-serialize,
+  voluptuous,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "probatio";
+  version = "0.11.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "frenck";
+    repo = "probatio";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-II9E6t0SoIMgfRbuYyLSHmgjH19x0By185/kZaELEzI=";
+  };
+
+  build-system = [ hatchling ];
+
+  nativeBuildInputs = [ pyprojectVersionPatchHook ];
+
+  nativeCheckInputs = [
+    hypothesis
+    mashumaro
+    openapi-schema-validator
+    pytest-cov-stub
+    pytestCheckHook
+    syrupy
+    voluptuous
+    voluptuous-openapi
+    voluptuous-serialize
+  ];
+
+  pythonImportsCheck = [ "probatio" ];
+
+  disabledTests = [
+    # AssertionError: emitted schema narrows
+    "test_emitted_openapi_never_narrows"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Data validation library for Python";
+    homepage = "https://github.com/frenck/probatio";
+    changelog = "https://github.com/frenck/probatio/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13612,6 +13612,8 @@ self: super: with self; {
 
   prison = callPackage ../development/python-modules/prison { };
 
+  probatio = callPackage ../development/python-modules/probatio { };
+
   probed = callPackage ../development/python-modules/probed { };
 
   process-tests = callPackage ../development/python-modules/process-tests { };


### PR DESCRIPTION
Data validation library for Python

https://github.com/frenck/probatio


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
