### PR TITLE
{python3Package,}padne: init at 0.3

### DIFF
--- a/pkgs/by-name/pa/padne/package.nix
+++ b/pkgs/by-name/pa/padne/package.nix
@@ -1,0 +1,3 @@
+{ python3Packages }:
+
+python3Packages.toPythonApplication python3Packages.padne

--- a/pkgs/development/python-modules/padne/default.nix
+++ b/pkgs/development/python-modules/padne/default.nix
@@ -1,0 +1,156 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  kicad,
+
+  # build-time
+  cmake,
+  ninja,
+  pkg-config,
+  python,
+
+  # run-time
+  boost,
+  gmp,
+  mpfr,
+
+  # build-system
+  nanobind,
+  scikit-build-core,
+  setuptools,
+  setuptools-scm,
+  wheel,
+
+  # dependencies
+  lxml,
+  numpy,
+  pygerber,
+  pyopengl,
+  pyside6,
+  scipy,
+  sexpdata,
+  shapely,
+
+  # tests
+  pytestCheckHook,
+  typeguard,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "padne";
+  version = "0.3";
+  pyproject = true;
+  dontUseCmakeConfigure = true; # handled by python
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "atx";
+    repo = "padne";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-eFrBjmLZQnfMG7nl9gHPb0Qr8MCAdhjzRIp5n1IzguM=";
+    fetchSubmodules = true;
+  };
+
+  postPatch = ''
+    # `padne` tries to import `pcbnew` directly from `KiCad`, falling back to
+    # `kigadgets` if that fails.
+    # However, `kigadgets` only supports KiCad v5-v9, whereas Nixpkgs is on
+    # v10, so drop it as a dependency to avoid a broken fallback.
+    sed -i '/kigadgets/d' pyproject.toml
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    boost
+    gmp
+    mpfr
+    nanobind
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "nanobind_DIR" "${nanobind}/${python.sitePackages}/nanobind/cmake")
+  ];
+
+  build-system = [
+    nanobind
+    scikit-build-core
+    setuptools
+    setuptools-scm
+    wheel
+  ];
+
+  dependencies = [
+    kicad
+    lxml
+    numpy
+    finalAttrs.passthru.pygerber
+    pyopengl
+    pyside6
+    scipy
+    sexpdata
+    shapely
+  ];
+
+  pythonImportsCheck = [
+    "padne"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    typeguard
+  ];
+
+  preCheck = ''
+    # remove src module, so tests use the installed module, instead
+    mv padne _padne
+  '';
+
+  disabledTests = lib.optionals stdenv.hostPlatform.isAarch64 [
+    # AssertionError: Center distance 4.8999999999999995 not ~5.0
+    "test_basic_rectangle_distance_map"
+  ];
+
+  passthru = {
+    # Padne needs a more recent version of `pygerber` than the one in Nixpkgs,
+    # which is currently the 2.4.3 stable release.
+    pygerber = pygerber.overrideAttrs {
+      version = "2.4.3-unstable-2026-03-20";
+      src = fetchFromGitHub {
+        owner = "Argmaster";
+        repo = "pygerber";
+        rev = "5446d44d424897e1b1a68c48c160ed9b4e828f44";
+        hash = "sha256-AhLIBh1dAmmOLBw6XaJIeYhUAh1BSv/ALVc4qOfD7g4=";
+      };
+      # TODO:
+      # 46 failed, 592 passed, 1 xfailed, 61 warnings, 96 errors in 16.52s
+      dontUsePytestCheck = true;
+    };
+  };
+
+  meta = {
+    description = "KiCad-focused Power Delivery Network Simulator";
+    longDescription = ''
+      Padne is a KiCad-native power delivery network analysis tool.
+
+      It uses the finite element method in order to simulate the voltage drop
+      induced by DC currents on printed circuit boards.
+
+      This allows easy identification of resistive bottlenecks, design of high
+      current distribution networks or implementing complex heating elements.
+    '';
+    homepage = "https://github.com/atx/padne";
+    changelog = "https://github.com/atx/padne/releases/tag/${finalAttrs.src.tag}";
+    mainProgram = "padne";
+    license = with lib.licenses; [ gpl3Plus ];
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12741,6 +12741,8 @@ self: super: with self; {
 
   paddlex = callPackage ../development/python-modules/paddlex { };
 
+  padne = callPackage ../development/python-modules/padne { };
+
   pagelabels = callPackage ../development/python-modules/pagelabels { };
 
   paginate = callPackage ../development/python-modules/paginate { };


### PR DESCRIPTION
[Padne](https://github.com/atx/padne) is a KiCad-native tool for power delivery network analysis using the finite element method.

> [!NOTE]
> Work done as part of the [Nix@NGI](https://nixos.org/community/teams/ngi/) packaging effort

Closes: https://github.com/ngi-nix/projects/issues/2145
Assisted-by: nix-init

<img width="1880" height="1008" alt="image" src="https://github.com/user-attachments/assets/5c65d961-4fc6-42ce-82a8-e5ff5be58c80" />


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
