### PR TITLE
podman-desktop: 1.28.2 -> 1.29.1

### DIFF
--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -3,9 +3,9 @@
   stdenv,
   fetchFromGitHub,
   makeBinaryWrapper,
-  electron_42,
-  nodejs-slim_24,
-  pnpm_10,
+  electron_43,
+  nodejs-slim_26,
+  pnpm_11,
   fetchPnpmDeps,
   pnpmConfigHook,
   darwin,
@@ -21,14 +21,14 @@
 }:
 
 let
-  nodejs-slim = nodejs-slim_24;
-  pnpm = pnpm_10.override { inherit nodejs-slim; };
-  electron = electron_42;
+  nodejs-slim = nodejs-slim_26;
+  pnpm = pnpm_11.override { inherit nodejs-slim; };
+  electron = electron_43;
   appName = "Podman Desktop";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "podman-desktop";
-  version = "1.28.2";
+  version = "1.29.1";
 
   passthru.updateScript = _experimental-update-script-combinators.sequence [
     (nix-update-script { })
@@ -68,14 +68,14 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "podman-desktop";
     repo = "podman-desktop";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-8pp1lxWduKZuxDXmq3GQQ7w10PUC9wR667gO6u9OhSI=";
+    hash = "sha256-yAGwXY1MxjIS4ChK/YUHSjysFFKlsPmdxysTW7y7DlA=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     inherit pnpm;
-    fetcherVersion = 3;
-    hash = "sha256-llkgy+JDJRxTZXxXHxza3RKdACU/Yd9xiGJ5CyptXpY=";
+    fetcherVersion = 4;
+    hash = "sha256-W5Hl/6sMfpHsf6OZ+u9nP0FN1U0Mv3c30j5cABWBS9A=";
   };
 
   patches = [


### PR DESCRIPTION
Updated to 1.29.1
changelog: https://github.com/podman-desktop/podman-desktop/releases

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
