### PR TITLE
formats: use AST-based approach for codegen

### DIFF
--- a/nixos/doc/manual/development/settings-options.section.md
+++ b/nixos/doc/manual/development/settings-options.section.md
@@ -395,7 +395,7 @@ have a predefined type and string generator already declared under
 
     `mkRaw pythonCode`
 
-    :   Outputs the given string as raw Python code
+    :   Outputs the given string as raw Python code. Note that the final result will be stripped of any comments.
 
     `_imports`
 

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -967,36 +967,44 @@ optionalAttrs allowAliases aliases
               # otherwise removeAttrs will fail.
               value = removeAttrs value [ "_imports" ];
               pythonGen = pkgs.writeText "pythonGen" ''
+                import ast
                 import json
                 import os
 
-                def recursive_repr(value: any) -> str:
+                def gen_ast_node(value: any) -> ast.expr:
                     if type(value) is list:
-                        return '\n'.join([
-                            "[",
-                            *[recursive_repr(x) + "," for x in value],
-                            "]",
-                        ])
-                    elif type(value) is dict and value.get("_type") == "raw":
-                        return value.get("value")
+                        return ast.List(elts=[gen_ast_node(x) for x in value])
                     elif type(value) is dict:
-                        return '\n'.join([
-                            "{",
-                            *[f"'{k.replace('\''', '\\\''')}': {recursive_repr(v)}," for k, v in value.items()],
-                            "}",
-                        ])
+                        if value.get("_type") == "raw":
+                            return ast.parse(value["value"], mode="eval").body
+                        else:
+                            return ast.Dict(
+                                keys=[ast.Constant(k) for k in value],
+                                values=[gen_ast_node(v) for v in value.values()],
+                            )
                     else:
-                        return repr(value)
+                        return ast.Constant(value)
+
+
+                tree = ast.Module(body=[], type_ignores=[])
 
                 with open(os.environ["NIX_ATTRS_JSON_FILE"], "r") as f:
                     attrs = json.load(f)
+
                     if attrs["imports"] is not None:
                         for i in attrs["imports"]:
-                            print(f"import {i}")
-                        print()
+                            tree.body.append(ast.parse(f"import {i}").body[0])
 
-                    for key, value in attrs["value"].items():
-                        print(f"{key} = {recursive_repr(value)}")
+                    for key, val in attrs["value"].items():
+                        tree.body.append(ast.Assign(
+                            targets=[ast.Name(id=key, ctx=ast.Store())],
+                            value=gen_ast_node(val),
+                        ))
+
+                ast.fix_missing_locations(tree)
+
+                print(ast.unparse(tree))
+
               '';
               preferLocalBuild = true;
               __structuredAttrs = true;

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -1145,21 +1145,12 @@ runBuildTests {
         import re
         import a.b.c
 
-        attrs = {
-            "conditional": 1 if True else 2,
-            "foo": None,
-        }
+        attrs = {"conditional": 1 if True else 2, "foo": None}
         bool = True
         float = 3.141
-        func = re.findall(r"\bf[a-z]*", "which foot or hand fell fastest")
+        func = re.findall("\\bf[a-z]*", "which foot or hand fell fastest")
         int = 10
-        list = [
-            None,
-            1,
-            "str",
-            True,
-            1 if True else 2,
-        ]
+        list = [None, 1, "str", True, 1 if True else 2]
         null = None
         str = "foo"
         str_special = "foo\ntesthello''''"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR switches the codegen implementation of `formats.pythonVars` from recursively calling `repr` on all items to building an AST with python stdlib's `ast` library, and rendering it to code.

This has the side effect that we can now syntax validate anything that is passed with `mkRaw`.

# Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [X] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
