### PR TITLE
rio: 0.4.7 -> 0.5.9

### DIFF
--- a/pkgs/by-name/ri/rio/package.nix
+++ b/pkgs/by-name/ri/rio/package.nix
@@ -51,24 +51,16 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rio";
-  version = "0.4.7";
+  version = "0.5.9";
 
   src = fetchFromGitHub {
     owner = "raphamorim";
     repo = "rio";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-vlNt8hBb1fhO5tEAID5WXMc7I0k9vn6/L45nkTXS6Qg=";
+    hash = "sha256-gZW7qPGDxM9+ZKHBJssGH3xvdpStXAzazwNQK/FaIfk=";
   };
 
-  cargoHash = "sha256-8qVS9wINEBLKKWbylG3sHO+oqnLvsa1wgN0OOHFzOBM=";
-
-  # The 0.4.7 "update to rust 1.96" bump (raphamorim/rio@6a11aa33c7) only made
-  # clippy-style refactors that build on older rustc; the MSRV pin is cosmetic.
-  # Lower it so nixpkgs' rustc (1.95) can build rio.
-  postPatch = ''
-    substituteInPlace Cargo.toml \
-      --replace-fail 'rust-version = "1.96.0"' 'rust-version = "1.95.0"'
-  '';
+  cargoHash = "sha256-a3JO5CQ8nGucXEWdO5jZD4xPOs9SQlHvI9kjd94nGNc=";
 
   nativeBuildInputs = [
     rustPlatform.bindgenHook
@@ -100,8 +92,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
   buildFeatures = [ ] ++ lib.optional withX11 "x11" ++ lib.optional withWayland "wayland";
 
   checkFlags = [
-    # Fail to run in sandbox environment.
-    "--skip=sys::unix::eventedfd::EventedFd"
+    # These build "dead" contexts, which carry the placeholder shell PID 1.
+    # Dropping one sends SIGHUP to that PID, and the builder is PID 1 inside the
+    # sandbox, so the tests kill the build. Workaround until
+    # https://github.com/raphamorim/rio/pull/1812 is merged.
+    "--skip=context::test::"
+    "--skip=context::title::test::test_update_title"
   ];
 
   postInstall = ''
@@ -109,8 +105,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     install -D -m 644 misc/logo.svg \
                       $out/share/icons/hicolor/scalable/apps/rio.svg
 
-    install -dm 755 "$terminfo/share/terminfo/r/"
-    tic -xe rio,rio-direct -o "$terminfo/share/terminfo" misc/rio.terminfo
+    install -dm 755 "$terminfo/share/terminfo"
+    tic -xe xterm-rio,rio -o "$terminfo/share/terminfo" misc/rio.terminfo
     mkdir -p $out/nix-support
     echo "$terminfo" >> $out/nix-support/propagated-user-env-packages
 


### PR DESCRIPTION
https://github.com/raphamorim/rio/releases/tag/v0.5.9


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
