### PR TITLE
home-assistant-custom-components.mass-queue: 0.10.2 -> 0.10.3

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/mass-queue/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/mass-queue/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  aiocache,
   fetchFromGitHub,
   buildHomeAssistantComponent,
   music-assistant-client,
@@ -8,16 +9,17 @@
 buildHomeAssistantComponent rec {
   owner = "droans";
   domain = "mass_queue";
-  version = "0.10.2";
+  version = "0.10.3";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "mass_queue";
     tag = version;
-    hash = "sha256-kr3XV/C7TGffDX8U/81UnjN7HSZnsAd+k/ALls/QALc=";
+    hash = "sha256-x64R6h66nXUdaI14W57QRMkR8Xid1oqQ6WFrdWuwR7Y=";
   };
 
   dependencies = [
+    aiocache
     music-assistant-client
   ];
 


### PR DESCRIPTION
Diff: https://github.com/droans/mass_queue/compare/0.10.2...0.10.3

Changelog: https://github.com/droans/mass_queue/releases/tag/0.10.3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
