### PR TITLE
unicode-*: update license

### DIFF
--- a/pkgs/by-name/un/unicode-character-database/package.nix
+++ b/pkgs/by-name/un/unicode-character-database/package.nix
@@ -33,7 +33,7 @@ stdenvNoCC.mkDerivation rec {
   meta = {
     description = "Unicode Character Database";
     homepage = "https://www.unicode.org/";
-    license = lib.licenses.unicode-dfs-2016;
+    license = lib.licenses.unicode-30;
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/un/unicode-emoji/package.nix
+++ b/pkgs/by-name/un/unicode-emoji/package.nix
@@ -59,7 +59,7 @@ symlinkJoin {
   meta = {
     description = "Unicode Emoji Data Files";
     homepage = "https://home.unicode.org/emoji/";
-    license = lib.licenses.unicode-dfs-2016;
+    license = lib.licenses.unicode-30;
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/un/unicode-idna/package.nix
+++ b/pkgs/by-name/un/unicode-idna/package.nix
@@ -27,7 +27,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   meta = {
     description = "Unicode IDNA compatible processing data";
     homepage = "http://www.unicode.org/reports/tr46/";
-    license = lib.licenses.unicode-dfs-2016;
+    license = lib.licenses.unicode-30;
     maintainers = with lib.maintainers; [ jopejoe1 ];
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/un/unihan-database/package.nix
+++ b/pkgs/by-name/un/unihan-database/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Unicode Han Database";
     homepage = "https://www.unicode.org/";
-    license = lib.licenses.unicode-dfs-2016;
+    license = lib.licenses.unicode-30;
     platforms = lib.platforms.all;
   };
 })


### PR DESCRIPTION
Unicode changed their license a few years ago. Update our packages to reflect that change.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
