### PR TITLE
home-assistant-custom-components.blueprints-updater: 2.10.1 -> 2.11.1

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/blueprints-updater/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/blueprints-updater/package.nix
@@ -2,24 +2,25 @@
   lib,
   buildHomeAssistantComponent,
   fetchFromGitHub,
-  httpx,
   home-assistant,
+  httpx,
+  pytest-asyncio,
   pytest-cov-stub,
   pytest-homeassistant-custom-component,
-  pytest-asyncio,
+  pytest-xdist,
   pytestCheckHook,
 }:
 
 buildHomeAssistantComponent rec {
   owner = "luuquangvu";
   domain = "blueprints_updater";
-  version = "2.10.1";
+  version = "2.11.1";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "blueprints-updater";
     tag = version;
-    hash = "sha256-MhhdWvSV+oyDxYGGj0IcqP5bymCjNCVTNIzvHdRKesU=";
+    hash = "sha256-hFBOmjbhw8HECJLj/MmgCzCb1rVlh7k/oI9v20HuYlI=";
   };
 
   patches = [
@@ -41,6 +42,7 @@ buildHomeAssistantComponent rec {
     pytest-asyncio
     pytest-cov-stub
     pytest-homeassistant-custom-component
+    pytest-xdist
     pytestCheckHook
   ];
 


### PR DESCRIPTION
Diff: https://github.com/luuquangvu/blueprints-updater/compare/2.10.1...2.11.1

Changelog: https://github.com/luuquangvu/blueprints-updater/releases/tag/2.11.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
