### PR TITLE
doc/rl-2611: move sing-box naïveproxy to other notable changes

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -16,8 +16,6 @@
   +nixpkgs.url = "https://channels.nixos.org/nixos-26.05/nixexprs.tar.zst";
   ```
 
-- `sing-box` now supports NaïveProxy outbounds.
-
 ## Backward Incompatibilities {#sec-nixpkgs-release-26.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
@@ -162,6 +160,8 @@
   by packaging `early-init.el` into a library named `early-default`.
   To prevent loading the `early-default` library,
   set `inhibit-early-default-init` in `early-init.el`.
+
+- `sing-box` now supports NaïveProxy outbounds.
 
 - `services.ceph` enabled the generation of Ceph log files at `/var/log/ceph/`.
   They were missing before because Ceph omitted logs when this directory was missing.

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -18,8 +18,6 @@
   +nixpkgs.url = "https://channels.nixos.org/nixos-26.05/nixexprs.tar.zst";
   ```
 
-- `sing-box` now supports NaïveProxy outbounds.
-
 ## New Modules {#sec-release-26.11-new-modules}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
@@ -156,6 +154,8 @@
 - `programs.regreet` has been renamed to `services.displayManager.regreet`.
 
 - `komodo` has been updated to the v2 release line (2.x). See the [upstream v1 → v2 upgrade guide](https://github.com/moghtech/komodo/releases/tag/v2.0.0).
+
+- `sing-box` now supports NaïveProxy outbounds.
 
 - `temporal` has been updated to the 1.31 release line. Always consult the [upstream upgrade
   notes](https://docs.temporal.io/self-hosted-guide/upgrade-server) before upgrading between versions.


### PR DESCRIPTION
see https://github.com/NixOS/nixpkgs/pull/495515#discussion_r3700274254. we don't feel super strongly here, so feel free to just close this if you disagree, but this sing-box change doesn't seem to meet the relevance that is typically used for "Highlights" as opposed to just "Other Notable Changes" (which we've moved it to).

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
