### PR TITLE
python313Packages.pandera: 0.30.1 -> 0.32.1

### DIFF
--- a/pkgs/development/python-modules/pandera/default.nix
+++ b/pkgs/development/python-modules/pandera/default.nix
@@ -9,7 +9,6 @@
   setuptools-scm,
 
   # dependencies
-  numpy,
   packaging,
   pandas,
   pydantic,
@@ -26,11 +25,14 @@
   geopandas,
   hypothesis,
   ibis-framework,
+  narwhals,
+  numpy,
   pandas-stubs,
   polars,
   pyyaml,
   scipy,
   shapely,
+  xarray,
 
   # tests
   joblib,
@@ -44,14 +46,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pandera";
-  version = "0.30.1";
+  version = "0.32.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "unionai-oss";
     repo = "pandera";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-JmD8p0Syt/Tgf9LiMWeug1dSPp4cyd7BtBfo6yi08xg=";
+    hash = "sha256-6xLrLPFjU3BMw/G8T4O48S8Ntx8EN29OQvSv2pCjIJg=";
   };
 
   build-system = [
@@ -103,11 +105,16 @@ buildPythonPackage (finalAttrs: {
           ibis-framework
           duckdb
         ];
+        narwhals = [ narwhals ];
         pandas = [
           numpy
           pandas
         ];
         polars = [ polars ];
+        xarray = [
+          xarray
+          numpy
+        ];
       };
     in
     extras // { all = lib.concatLists (lib.attrValues extras); };
@@ -127,15 +134,19 @@ buildPythonPackage (finalAttrs: {
     "tests/pandas/test_docs_setting_column_widths.py" # tests doc generation, requires sphinx
     "tests/modin" # requires modin, not in nixpkgs
     "tests/mypy/test_pandas_static_type_checking.py" # some typing failures
-    "tests/pyspark" # requires spark
+    "tests/pyspark" # requires pyspark, not in nixpkgs
 
     # KeyError: 'dask'
     "tests/dask/test_dask.py::test_series_schema"
     "tests/dask/test_dask_accessor.py::test_dataframe_series_add_schema"
-
-    # TypeError: memtable() got an unexpected keyword argument 'name'
-    # https://github.com/unionai-oss/pandera/issues/2154
-    "tests/ibis/test_ibis_container.py"
+    # mypy tests
+    "tests/mypy/"
+    # Very time-consuming tests
+    "tests/strategies/test_strategies.py"
+    # Narwhals backend issues
+    "tests/narwhals/"
+    # Schema issues
+    "tests/strategies/test_no_filter_chain.py"
   ];
 
   disabledTests = [
@@ -143,6 +154,11 @@ buildPythonPackage (finalAttrs: {
     "test_schema_model"
     "test_schema_from_dataframe"
     "test_schema_no_geometry"
+    # Tests requires pyspark
+    "test_pyspark_pandas_does_not_route_to_pyspark_sql"
+    # Assertion error due to None vs. NaN
+    "test_ibis_backend_is_narwhals"
+    "test_ibis_custom_check"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # OOM error on ofborg:


### PR DESCRIPTION
Changelog: https://github.com/unionai-oss/pandera/releases/tag/v0.32.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
