### PR TITLE
handheld-daemon-ui: update license

### DIFF
--- a/pkgs/by-name/ha/handheld-daemon-ui/package.nix
+++ b/pkgs/by-name/ha/handheld-daemon-ui/package.nix
@@ -33,7 +33,7 @@ appimageTools.wrapType2 {
   meta = {
     description = "UI for the Handheld Daemon";
     homepage = "https://github.com/hhd-dev/hhd-ui";
-    license = lib.licenses.gpl3Only;
+    license = lib.licenses.lgpl21Plus;
     maintainers = with lib.maintainers; [ toast ];
     mainProgram = "hhd-ui";
     platforms = [ "x86_64-linux" ];


### PR DESCRIPTION
License changed in v3.4.2 from GPL to LGPL.

https://github.com/hhd-dev/hhd-ui/commit/2428d0c36ece7a6819626141eb2a18527bc31ca9
https://github.com/hhd-dev/hhd-ui/commit/115ebf84388c63492629237b016390d7a0323e04

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
