### PR TITLE
kpx: init at 1.13.0

### DIFF
--- a/pkgs/by-name/kp/kpx/package.nix
+++ b/pkgs/by-name/kp/kpx/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "kpx";
+  version = "1.13.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "momiji";
+    repo = "kpx";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-D5SfWE/58L9G2miwx+hmcGCTCq6kHMOEnZ/4z0bMVzs=";
+  };
+
+  vendorHash = null;
+
+  subPackages = [ "cli" ];
+
+  ldflags = [
+    "-s"
+    "-X=github.com/momiji/kpx.AppVersion=${finalAttrs.version}"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  doInstallCheck = true;
+
+  # Tests are container-based
+  doCheck = false;
+
+  postInstall = ''
+    mv $out/bin/cli $out/bin/kpx
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Kerberos proxy with dynamic proxy selection";
+    homepage = "https://github.com/momiji/kpx";
+    changelog = "https://github.com/momiji/kpx/blob/${finalAttrs.src.rev}/CHANGELOG_old.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "kpx";
+  };
+})


### PR DESCRIPTION
Kerberos proxy with dynamic proxy selection

https://github.com/momiji/kpx


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
