### PR TITLE
desync: 1.0.3 -> 1.0.4

### DIFF
--- a/pkgs/by-name/de/desync/package.nix
+++ b/pkgs/by-name/de/desync/package.nix
@@ -8,16 +8,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "desync";
-  version = "1.0.3";
+  version = "1.0.4";
 
   src = fetchFromGitHub {
     owner = "folbricht";
     repo = "desync";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-rdwUoTwN/fG4fsOY4mCcg0bzWMErFaxBe72RtmHohdA=";
+    hash = "sha256-/ojucBo+UOr5WFahVMSz7xJ84dzenwuotZk+5QqODls=";
   };
 
-  vendorHash = "sha256-unwaA+WNyaJbNrOFvjXeMI2YbNTpGBrjwBGXhvOfj0M=";
+  vendorHash = "sha256-PU2EbYei6X/fmA/POaFI6flAZYb2WcBA10E9+rS651U=";
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -34,13 +34,17 @@ buildGoModule (finalAttrs: {
         "TestExtractCommand/extract_with_single_seed,_explicit_data_directory_and_unexpected_seed_options" # block cloning fails on ZFS
         "TestExtractCommand/extract_with_single_seed_and_explicit_data_directory" # block cloning fails on ZFS
         "TestExtractWithNonStaticSeeds" # block cloning fails on ZFS
+        "TestLocalFSDirSetgidWhilePopulated" # cannot setgid in /tmp
         "TestMountIndex" # FUSE does not work in sandbox
         "TestSeed/extract_repetitive_file" # block cloning fails on ZFS
+        "TestTar" # xattr.list: operation not supported
+        "TestUnTarDirMTime" # xattr.list: operation not supported
+        "TestUnTarIntoReadOnlyDir" # xattr.list: operation not supported
+        "TestUnTarNoSamePermissionsOverReadOnlyTree" # xattr.list: operation not supported
       ]
       ++ lib.optionals stdenv.hostPlatform.isDarwin [
-        # sendfile is not permitted in Darwin sandbox
-        "TestS3StoreGetChunk/fail"
-        "TestS3StoreGetChunk/recover"
+        "TestS3StoreGetChunk/fail" # sendfile is not permitted in Darwin sandbox
+        "TestS3StoreGetChunk/recover" # sendfile is not permitted in Darwin sandbox
       ];
     in
     [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];


### PR DESCRIPTION
https://github.com/folbricht/desync/releases/tag/v1.0.4

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
