### PR TITLE
linuxPackages.nvidiaPackages.new_feature: 610.43.03 -> 610.57.04

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -80,12 +80,12 @@ rec {
   };
 
   new_feature = generic {
-    version = "610.43.03";
-    sha256_64bit = "sha256-ReLUwTSiPDXlDyU6SqY+fl6NF+PRhdSgfIpY6WEu05I=";
-    sha256_aarch64 = "sha256-jSdlXo60ilXLKWKvZfgbBnVqVYuw6zhnGuiDgwxYz94=";
-    openSha256 = "sha256-QCXmqo2xNyIwjGv0da2MUC8ex641Mmc5DUI+uRFVwgE=";
-    settingsSha256 = "sha256-z/t+SdEQdVJPwjKIRHO02d264Kt47eWiOwwsaxmh4xQ=";
-    persistencedSha256 = "sha256-sOKUsAFHh0/COH+nNgbH9+7hWgivOzq4YmTuk9MOFfI=";
+    version = "610.57.04";
+    sha256_64bit = "sha256-suk1xmuDuwDAyFe8jg7g/VLekoa0DJzB7sKafOfrEW0=";
+    sha256_aarch64 = "sha256-QCefrMBCmpOwuOyXv1k5Gj0iB2CYlPgnG3JToUw/j54=";
+    openSha256 = "sha256-rQHOOOY4KL92Ww3KDwh+j4eGU7oNAH8LutZC5wmFnPo=";
+    settingsSha256 = "sha256-ZEMo8I8Zc2Tq6RVDNYpAH+f094dUaZiBqO+5f6lIjRI=";
+    persistencedSha256 = "sha256-aXmD2VY1RLlgAnlHhOUMWzvMyhI6JTClcFLm4imF/mA=";
   };
 
   beta = generic {


### PR DESCRIPTION
- Fixed a bug that could cause the X server to crash with GLX indirect rendering.
- Fixed a bug which cased STALKER 2 to crash with VK_DEVICE_LOST Vulkan
- API errors and Xid 31 errors in dmesg with VKD3D_CONFIG=descriptor_heap:
  - https://github.com/HansKristian-Work/vkd3d-proton/issues/3077
- Fixed rendering corruption in Assetto Corsa EVO:
  - https://github.com/HansKristian-Work/vkd3d-proton/issues/3030
- Fixed a crash in Monster Hunter Wilds:
  - https://forums.developer.nvidia.com/t/610-release-feedback-discussion713/371356/26
- Fixed a GPU hang in Forza Horizon 6 with VKD3D_CONFIG=descriptor_heap.
- Fixed a bug that caused Vulkan displays to be enumerated incorrectly when __VK_ENABLE_DEVICE_GROUPS=1 was set.
- Fixed a bug that could cause suspend and resume to fail on systems with runtime D3 (RTD3) power management enabled.
- Fixed hangs or corruption problems in the following games:
  - 007 First Light
  - Assassin's Creed Origins
- Fixed a regression, introduced with the 595 driver series, which led to black screens in Total War: Warhammer III.
- Fixed an issue that could cause application hangs or a black screen in several games, including:
  - Crimson Desert
  - Elden Ring
  - Elden Ring Nightrein
  - ExoDomia
  - Far Far West
  - Grounded 2
  - Incursion Red River
  - John Carpenter's Toxic Commando
  - Paradise Nowhere
  - Screamer
  - Star Rupture
  - Windrose
- Fixed a bug which led to a black screen when console switching on Linux v7.0 and newer when DRM fbdev support is disabled:
  - https://forums.developer.nvidia.com/t/linux-driver-595-71-05-still-tries-to-use-screen-info-struct-which-was-refactored-in-7-0-kernel/370825
- Fixed a bug that could prevent DKMS kernel module builds from succeeding after installing with nvidia-installer.
- Fixed a bug that caused delayed wakeups when multiple threads wait on the same Vulkan semaphore, leading to stutter and reduced performance in some applications
- Fixed a bug that could cause black screens after modesets in X11 applications using the Present extension.
- Fixed an issue where OpenGL buffers allocated with glBufferStorage and no storage flags were allowed to migrate from GPU memory to host memory.
- Fixed a bug that caused corruption in X-Plane on workstation GPUs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
