### PR TITLE
gtk*,gnome,related: remove 7c6f434c maintainership

### DIFF
--- a/pkgs/by-name/at/at-spi2-core/package.nix
+++ b/pkgs/by-name/at/at-spi2-core/package.nix
@@ -118,7 +118,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Assistive Technology Service Provider Interface protocol definitions and daemon for D-Bus";
     homepage = "https://gitlab.gnome.org/GNOME/at-spi2-core";
     license = lib.licenses.lgpl21Plus;
-    maintainers = with lib.maintainers; [ raskin ];
     teams = [ lib.teams.gnome ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/gl/glib/package.nix
+++ b/pkgs/by-name/gl/glib/package.nix
@@ -370,9 +370,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "C library of programming buildings blocks";
     homepage = "https://gitlab.gnome.org/GNOME/glib";
     license = lib.licenses.lgpl21Plus;
-    maintainers = with lib.maintainers; [
-      raskin
-    ];
     teams = [ lib.teams.gnome ];
     pkgConfigModules = [
       "gio-2.0"

--- a/pkgs/by-name/gl/glibmm_2_68/package.nix
+++ b/pkgs/by-name/gl/glibmm_2_68/package.nix
@@ -52,7 +52,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "C++ interface to the GLib library";
     homepage = "https://gtkmm.org/";
     license = lib.licenses.lgpl2Plus;
-    maintainers = with lib.maintainers; [ raskin ];
     teams = [ lib.teams.gnome ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/gt/gtk3/package.nix
+++ b/pkgs/by-name/gt/gtk3/package.nix
@@ -295,7 +295,6 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://www.gtk.org/";
     license = lib.licenses.lgpl2Plus;
-    maintainers = with lib.maintainers; [ raskin ];
     teams = [ lib.teams.gnome ];
     pkgConfigModules = [
       "gdk-3.0"

--- a/pkgs/by-name/gt/gtk4/package.nix
+++ b/pkgs/by-name/gt/gtk4/package.nix
@@ -309,7 +309,6 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://www.gtk.org/";
     license = lib.licenses.lgpl2Plus;
-    maintainers = with lib.maintainers; [ raskin ];
     teams = [ lib.teams.gnome ];
     platforms = lib.platforms.all;
     changelog = "https://gitlab.gnome.org/GNOME/gtk/-/raw/${finalAttrs.version}/NEWS";

--- a/pkgs/by-name/gt/gtkmm4/package.nix
+++ b/pkgs/by-name/gt/gtkmm4/package.nix
@@ -91,7 +91,6 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://gtkmm.org/";
     license = lib.licenses.lgpl2Plus;
-    maintainers = with lib.maintainers; [ raskin ];
     teams = [ lib.teams.gnome ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/pa/pango/package.nix
+++ b/pkgs/by-name/pa/pango/package.nix
@@ -129,7 +129,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.pango.org/";
     license = lib.licenses.lgpl2Plus;
 
-    maintainers = with lib.maintainers; [ raskin ];
     teams = [ lib.teams.gnome ];
     platforms = lib.platforms.unix;
 

--- a/pkgs/development/libraries/pangomm/2.48.nix
+++ b/pkgs/development/libraries/pangomm/2.48.nix
@@ -60,9 +60,6 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://www.pango.org/";
     license = lib.licenses.lgpl21Plus;
-    maintainers = with lib.maintainers; [
-      raskin
-    ];
     teams = [ lib.teams.gnome ];
     platforms = lib.platforms.unix;
   };


### PR DESCRIPTION
This is a recognition of the fact that GTK/Gnome packaging is complicated and I am not up to speed and I haven't reacted usefully to auto-review-requests in a long while.

(If someone wants to take this as a moment to ask for a full package handover from me, write me / create an issue, but there are packages I maintain that I do intend to keep to myself even if I am usually open to adding more people to the maintainer lists)

## Things done

Should be 0-eval-change, let's see in CI.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
