### PR TITLE
orchis-theme: re-add without murrine

### DIFF
--- a/pkgs/by-name/or/orchis-theme/package.nix
+++ b/pkgs/by-name/or/orchis-theme/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  gtk3,
+  gnome-themes-extra,
+  sassc,
+  border-radius ? null, # Suggested: 2 < value < 16
+  tweaks ? [ ], # can be "solid" "compact" "black" "primary" "macos" "submenu" "nord|dracula"
+  withWallpapers ? false,
+}:
+
+let
+  pname = "orchis-theme";
+
+  validTweaks = [
+    "solid"
+    "compact"
+    "black"
+    "primary"
+    "macos"
+    "submenu"
+    "nord"
+    "dracula"
+  ];
+
+  nordXorDracula =
+    with builtins;
+    lib.assertMsg (!(elem "nord" tweaks) || !(elem "dracula" tweaks)) ''
+      ${pname}: dracula and nord cannot be mixed. Tweaks ${toString tweaks}
+    '';
+in
+
+assert nordXorDracula;
+lib.checkListOfEnum "${pname}: theme tweaks" validTweaks tweaks
+
+  stdenvNoCC.mkDerivation
+  rec {
+    inherit pname;
+    version = "2025-04-25";
+
+    src = fetchFromGitHub {
+      repo = "Orchis-theme";
+      owner = "vinceliuice";
+      rev = version;
+      hash = "sha256-+2/CsgJ+rdDpCp+r5B/zys3PtFgtnu+ohTEUOtJNd1Y=";
+    };
+
+    nativeBuildInputs = [
+      gtk3
+      sassc
+    ];
+
+    buildInputs = [ gnome-themes-extra ];
+
+    preInstall = ''
+      mkdir -p $out/share/themes
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      bash install.sh -d $out/share/themes -t all \
+        ${lib.optionalString (tweaks != [ ]) "--tweaks " + toString tweaks} \
+        ${lib.optionalString (border-radius != null) ("--round " + toString border-radius + "px")}
+      ${lib.optionalString withWallpapers ''
+        mkdir -p $out/share/backgrounds
+        cp src/wallpaper/{1080p,2k,4k}.jpg $out/share/backgrounds
+      ''}
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Material Design theme for GNOME/GTK based desktop environments";
+      homepage = "https://github.com/vinceliuice/Orchis-theme";
+      license = lib.licenses.gpl3Plus;
+      platforms = lib.platforms.linux;
+      maintainers = [ lib.maintainers.ncfavier ];
+    };
+  }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1840,7 +1840,6 @@ mapAliases {
   openzwave = throw "openzwave was removed because upstream is no longer maintained. Consider using zwave-js-server"; # Added 2026-05-14
   opera = throw "'opera' has been removed due to lack of maintenance in nixpkgs"; # Added 2025-05-19
   opusTools = warnAlias "'opusTools' has been renamed to 'opus-tools'" opus-tools; # Added 2026-02-12
-  orchis-theme = throw "'orchis-theme' has been removed because it depended on 'gtk-engine-murrine', which was removed because it was unmaintained upstream and depended on GTK 2."; # Added 2026-07-22
   orion = throw "'orion' was removed because it depended on the deprecated GTK2 engine."; # Added 2026-07-22
   orogene = throw "'orogene' uses a wasm-specific fork of async-tar that is vulnerable to CVE-2025-62518, which is not supported by its upstream"; # Added 2025-10-24
   ortp = throw "'ortp' has been moved to 'linphonePackages.ortp'"; # Added 2025-09-20


### PR DESCRIPTION
Similar to https://github.com/NixOS/nixpkgs/pull/547751, https://github.com/NixOS/nixpkgs/pull/547790, https://github.com/NixOS/nixpkgs/pull/547796, https://github.com/NixOS/nixpkgs/pull/548594...

Revert the removal of `orchis-theme` in https://github.com/NixOS/nixpkgs/pull/544598 and only remove the dependency on murrine.

Maybe this should be done more systematically, as it seems that murrine is not a critical dependency in many cases.

Also added myself as a maintainer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
