### PR TITLE
linuxPackages.nvidiaPackages.vulkan_beta: 595.44.09 -> 595.44.14

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -100,14 +100,15 @@ rec {
   # Vulkan developer beta driver
   # See here for more information: https://developer.nvidia.com/vulkan-driver
   vulkan_beta = generic rec {
-    version = "595.44.09";
+    version = "595.44.14";
     persistencedVersion = "595.45.04";
     settingsVersion = "595.45.04";
-    sha256_64bit = "sha256-LOcwE47hUG1aZX7JvLmTb/yC5qQgXYZ0TAavSn38Xug=";
-    openSha256 = "sha256-QboSiRWRZWseFg7GN/a4vZVQGGBF1UJlC9MyAxUxyF4=";
+    sha256_64bit = "sha256-J6D06V5gp9k8zoEF6ptUJFOIHjsy/ApFvcRnrdR2z4I=";
+    sha256_aarch64 = "sha256-TNtghgHyShHxF6rfFMfwWBgli9++vzoB6gfdY20q+vo=";
+    openSha256 = "sha256-HPRsOaPoafpcYO78ohRGvNUeHblMT5WX+/SNizwy4pE=";
     settingsSha256 = "sha256-Y45pryyM+6ZTJyRaRF3LMKaiIWxB5gF5gGEEcQVr9nA=";
     persistencedSha256 = "sha256-5FoeUaRRMBIPEWGy4Uo0Aho39KXmjzQsuAD9m/XkNpA=";
-    url = "https://developer.nvidia.com/downloads/vulkan-beta-${lib.concatStrings (lib.splitVersion version)}-linux";
+    url = "https://developer.nvidia.com/downloads/assets/gameworks/downloads/secure/Vulkan_Beta_Drivers/NVIDIA-Linux-${stdenv.hostPlatform.parsed.cpu.name}-${version}.run";
   };
 
   # data center driver compatible with current default cudaPackages


### PR DESCRIPTION
- new mirror ` > 595.44.11`
- `aarch64` support

- August 6th, 2026 - Windows 596.99, Linux 595.44.14
  - New:
    - [VK_EXT_cooperative_matrix_maintenance1](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_cooperative_matrix_maintenance1.html)
    - Added support for version 6 of the linux-dmabuf protocol in the Wayland WSI
  - Fixes:
    - Fixed shader access to 8-bit constants within a descriptor heap
    - VulkanSC Driver: ICD Manifest Fixes and PCC Discovery Support:
      - Fixed nv-vksc64.json on Windows to no longer include invalid layer definitions
      - Fixed the Windows installer to remove the incorrect VulkanSCImplicitLayers registry key
      - Add a PCC discovery manifest (nvidia-pcc.json) which enables third-party VulkanSC CMake projects to automatically locate the NVIDIA Pipeline Cache Compiler via the [VulkanSCPccDiscovery](https://github.com/KhronosGroup/VulkanSC-pcutil/blob/main/docs/PccDiscovery.md) module without requiring manual configuration
        - On Windows this is added to the Windows driver store and includes the associated registry key to enable discovery
        - On Linux this is installed to /etc/vulkansc/pcc.d/
- August 3rd, 2026 - Windows 596.97, Linux 595.44.13
  - New:
    - [VK_EXT_image_tiling_control](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_image_tiling_control.html)
    - Added NV16 (8-bit 4:2:2) and P216 (10-bit 4:2:2) format support for H.264/H.265 decode on Blackwell
    - Added P016 (10-bit 4:2:0) format support for H.264 decode on Blackwell
  - Fixes:
    - Fixed DontInline functionality crashing under some circumstances
    - Fixed regression with AV1 encode introduced in previous beta driver
    - Improve interoperability of video format images with CUDA
    - Miscellaneous minor Vulkan Video fixes
- July 2nd, 2026 - Windows 596.83, Linux 595.44.11
  - New:
    - [VK_EXT_shader_ocp_microscaling_types](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_shader_ocp_microscaling_types.html)
  - Fixes:
    - Fixed regression with VK_NV_device_checkpoints where checkpoints sometimes got dropped
    - Improvements to descriptor_heap stability, correctness and performance
- June 12th, 2026 - Windows 596.75, Linux 595.44.10
  - New:
    - [VK_KHR_extended_flags](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_extended_flags.html)
    - [VK_KHR_video_encode_feedback2](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_video_encode_feedback2.html)
  - Fixes:
    - Fixed regression with descriptor buffer capture/replay
    - Fixed clearing of the NV12 Y-plane not working under some conditions
    - Fixed some incorrect H.265 encoder capabilities

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
