### PR TITLE
cudaPackages.tensorrt: 10.14.1 -> 10.16.1

### DIFF
--- a/pkgs/development/cuda-modules/packages/tensorrt-samples/passthru.nix
+++ b/pkgs/development/cuda-modules/packages/tensorrt-samples/passthru.nix
@@ -17,8 +17,8 @@ in
       # Releases prior to 10.14.1 don't have any sample data available to them, so just use the 10.14.1 release's
       # sample data.
       sample-data_10_14_1 = {
-        url = "https://github.com/NVIDIA/TensorRT/releases/download/v10.14/tensorrt_sample_data_20251106.zip";
-        hash = "sha256-IA1pH8idtk/7FD1Tf0hKtyP7A5SW/2ugezyBRluG8yk=";
+        url = "https://github.com/NVIDIA/TensorRT/releases/download/v10.14/tensorrt_sample_data_20260128.zip";
+        hash = "sha256-KSUKJsBaOSRHJKDp5SUzmfHNWlcEP1TwTgXja3nhVKI=";
       };
     in
     fetchzip (

--- a/pkgs/development/python-modules/tensorrt/default.nix
+++ b/pkgs/development/python-modules/tensorrt/default.nix
@@ -1,10 +1,11 @@
 {
-  autoPatchelfHook,
-  buildPythonPackage,
-  cudaPackages,
   lib,
-  python,
   stdenv,
+  cudaPackages,
+  buildPythonPackage,
+  pythonAtLeast,
+  python,
+  autoPatchelfHook,
 }:
 let
   inherit (cudaPackages.tensorrt)
@@ -23,6 +24,9 @@ buildPythonPackage {
 
   inherit version;
 
+  # cudaPackages.tensorrt.src does not contain the wheel for python>=3.14.
+  disabled = pythonAtLeast "3.14";
+
   src =
     let
       # https://peps.python.org/pep-0427/#file-name-convention
@@ -34,6 +38,7 @@ buildPythonPackage {
     src + "/python/${distribution}-${version}-${pythonTag}-${abiTag}-${platformTag}.whl";
 
   format = "wheel";
+  __structuredAttrs = true;
 
   nativeBuildInputs = [
     autoPatchelfHook

--- a/pkgs/top-level/cuda-packages.nix
+++ b/pkgs/top-level/cuda-packages.nix
@@ -46,7 +46,7 @@ let
         else if hostPlatform.isAarch64 then
           "10.13.0"
         else
-          "10.14.1";
+          "10.16.1";
     };
 
   cudaPackages_12_8 =
@@ -73,7 +73,7 @@ let
         else if hostPlatform.isAarch64 then
           "10.13.0"
         else
-          "10.14.1";
+          "10.16.1";
     };
 
   cudaPackages_12_9 =
@@ -100,7 +100,7 @@ let
         else if hostPlatform.isAarch64 then
           "10.13.0"
         else
-          "10.14.1";
+          "10.16.1";
     };
 
   # NOTE: Thor is supported from CUDA 13.0, so our check needs to capture whether pre-Thor devices were selected.
@@ -126,7 +126,7 @@ let
       nvpl = "25.5";
       nvtiff = "0.5.1";
       tensorrt =
-        if hasPreThorJetsonCudaCapability requestedJetsonCudaCapabilities then "10.7.0" else "10.14.1";
+        if hasPreThorJetsonCudaCapability requestedJetsonCudaCapabilities then "10.7.0" else "10.16.1";
     };
 
   cudaPackages_13_1 =
@@ -149,7 +149,7 @@ let
       nvpl = "25.5";
       nvtiff = "0.5.1";
       tensorrt =
-        if hasPreThorJetsonCudaCapability requestedJetsonCudaCapabilities then "10.7.0" else "10.14.1";
+        if hasPreThorJetsonCudaCapability requestedJetsonCudaCapabilities then "10.7.0" else "10.16.1";
     };
 
   cudaPackages_13_2 =
@@ -172,7 +172,7 @@ let
       nvpl = "25.5";
       nvtiff = "0.5.1";
       tensorrt =
-        if hasPreThorJetsonCudaCapability requestedJetsonCudaCapabilities then "10.7.0" else "10.14.1";
+        if hasPreThorJetsonCudaCapability requestedJetsonCudaCapabilities then "10.7.0" else "10.16.1";
     };
 
   cudaPackages_13_3 =
@@ -195,7 +195,7 @@ let
       nvpl = "25.5";
       nvtiff = "0.5.1";
       tensorrt =
-        if hasPreThorJetsonCudaCapability requestedJetsonCudaCapabilities then "10.7.0" else "10.14.1";
+        if hasPreThorJetsonCudaCapability requestedJetsonCudaCapabilities then "10.7.0" else "10.16.1";
     };
 in
 {


### PR DESCRIPTION
Bumps tensorrt. This version contains a fix to a security vulnerability which was identified in https://github.com/NixOS/nixpkgs/issues/522570 and partially addressed in https://github.com/NixOS/nixpkgs/pull/523147 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
