### PR TITLE
trivial-builders/linkFarm: use listToAttrs instead of folding

### DIFF
--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -637,9 +637,17 @@ rec {
       entries' =
         if (lib.isAttrs entries) then
           entries
-        # We do this foldl to have last-wins semantics in case of repeated entries
         else if (lib.isList entries) then
-          foldl' (a: b: a // { "${b.name}" = b.path; }) { } entries
+          # listToAttrs takes the first attribute with a given name, so we
+          # reverse the list to get last-wins semantics in case of repeated entries
+          lib.listToAttrs (
+            lib.reverseList (
+              map (entry: {
+                inherit (entry) name;
+                value = entry.path;
+              }) entries
+            )
+          )
         else
           throw "linkFarm entries must be either attrs or a list!";
 


### PR DESCRIPTION
This kind of repeated folding on a list of attrsets has a very bad time complexity, and was previously removed in https://github.com/NixOS/nixpkgs/issues/528515, which gave a 330x speed improvement for very long lists. If we really wanted to microoptimize, we could use a custom `genList` instead of iterating twice (once to reverse, once to map) - but that's small-O problems.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
