### PR TITLE
lib.types: small performance improvements

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1026,11 +1026,10 @@ rec {
           {
             headError = checkDefsForError check loc defs;
             value = mapAttrs (
-              n: v:
               if lazy then
-                v.optionalValue.value or elemType.emptyValue.value or v.mergedValue
+                n: v: v.optionalValue.value or elemType.emptyValue.value or v.mergedValue
               else
-                v.optionalValue.value
+                n: v: v.optionalValue.value
             ) evals;
             valueMeta.attrs = mapAttrs (n: v: v.checkedAndMerged.valueMeta) evals;
           };

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -597,7 +597,9 @@ rec {
     name = "attrs";
     description = "attribute set";
     check = isAttrs;
-    merge = loc: foldl' (res: def: res // def.value) { };
+    merge =
+      loc: defs:
+      if length defs == 1 then (head defs).value else foldl' (res: def: res // def.value) { } defs;
     emptyValue = {
       value = { };
     };

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1430,7 +1430,7 @@ rec {
     let
       allModules = map (
         { value, file }:
-        if isAttrs value && shorthandOnlyDefinesConfig then
+        if shorthandOnlyDefinesConfig && isAttrs value then
           {
             _file = file;
             config = value;

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1428,21 +1428,19 @@ rec {
       class ? null,
     }@attrs:
     let
-      allModules =
-        defs:
-        map (
-          { value, file }:
-          if isAttrs value && shorthandOnlyDefinesConfig then
-            {
-              _file = file;
-              config = value;
-            }
-          else
-            {
-              _file = file;
-              imports = [ value ];
-            }
-        ) defs;
+      allModules = map (
+        { value, file }:
+        if isAttrs value && shorthandOnlyDefinesConfig then
+          {
+            _file = file;
+            config = value;
+          }
+        else
+          {
+            _file = file;
+            imports = [ value ];
+          }
+      );
 
       base = evalModules {
         inherit class specialArgs;

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1390,6 +1390,36 @@ rec {
   };
 
   submoduleWith =
+    let
+      inherit (lib.modules) evalModules;
+
+      defaultModules = [
+        {
+          # This is a work-around for the fact that some sub-modules,
+          # such as the one included in an attribute set, expects an "args"
+          # attribute to be given to the sub-module. As the option
+          # evaluation does not have any specific attribute name yet, we
+          # provide a default for the documentation and the freeform type.
+          #
+          # This is necessary as some option declaration might use the
+          # "name" attribute given as argument of the submodule and use it
+          # as the default of option declarations.
+          #
+          # We use lookalike unicode single angle quotation marks because
+          # of the docbook transformation the options receive. In all uses
+          # &gt; and &lt; wouldn't be encoded correctly so the encoded values
+          # would be used, and use of `<` and `>` would break the XML document.
+          # It shouldn't cause an issue since this is cosmetic for the manual.
+          _module.args.name = lib.mkOptionDefault "‹name›";
+        }
+      ];
+
+      name = "submodule";
+      check = {
+        __functor = _self: x: isAttrs x || isFunction x || path.check x;
+        isV2MergeCoherent = true;
+      };
+    in
     {
       modules,
       specialArgs ? { },
@@ -1398,8 +1428,6 @@ rec {
       class ? null,
     }@attrs:
     let
-      inherit (lib.modules) evalModules;
-
       allModules =
         defs:
         map (
@@ -1418,37 +1446,10 @@ rec {
 
       base = evalModules {
         inherit class specialArgs;
-        modules = [
-          {
-            # This is a work-around for the fact that some sub-modules,
-            # such as the one included in an attribute set, expects an "args"
-            # attribute to be given to the sub-module. As the option
-            # evaluation does not have any specific attribute name yet, we
-            # provide a default for the documentation and the freeform type.
-            #
-            # This is necessary as some option declaration might use the
-            # "name" attribute given as argument of the submodule and use it
-            # as the default of option declarations.
-            #
-            # We use lookalike unicode single angle quotation marks because
-            # of the docbook transformation the options receive. In all uses
-            # &gt; and &lt; wouldn't be encoded correctly so the encoded values
-            # would be used, and use of `<` and `>` would break the XML document.
-            # It shouldn't cause an issue since this is cosmetic for the manual.
-            _module.args.name = lib.mkOptionDefault "‹name›";
-          }
-        ]
-        ++ modules;
+        modules = defaultModules ++ modules;
       };
 
       freeformType = base._module.freeformType;
-
-      name = "submodule";
-
-      check = {
-        __functor = _self: x: isAttrs x || isFunction x || path.check x;
-        isV2MergeCoherent = true;
-      };
     in
     mkOptionType {
       inherit name;

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1015,12 +1015,12 @@ rec {
           let
             evals =
               if lazy then
-                zipAttrsWith (name: defs: mergeDefinitions (loc ++ [ name ]) elemType defs) (pushPositions defs)
+                zipAttrsWith (name: mergeDefinitions (loc ++ [ name ]) elemType) (pushPositions defs)
               else
                 # Filtering makes the merge function more strict
                 # Meaning it is less lazy
                 filterAttrs (n: v: v.optionalValue ? value) (
-                  zipAttrsWith (name: defs: mergeDefinitions (loc ++ [ name ]) elemType defs) (pushPositions defs)
+                  zipAttrsWith (name: mergeDefinitions (loc ++ [ name ]) elemType) (pushPositions defs)
                 );
           in
           {


### PR DESCRIPTION
Caught the first change while reading this and decided to throw in some other stuff.

Stats diff for a minimal NixOS config:
```nix
 NIX_SHOW_STATS_PATH=after.json NIX_SHOW_STATS=1 nix eval --impure --expr '
    let nixos = import ./nixos/lib/eval-config.nix {
      modules = [
        ./nixos/modules/profiles/minimal.nix
        { 
          fileSystems."/" = { device = "/dev/sda1"; fsType = "ext4"; };
          boot.loader.grub.devices = [ "/dev/sda" ]; 
        } 
      ];
    }; in nixos.config.system.build.toplevel
    '
```
```json
{
  "attrset": {
    "lookups": "-0.02%",
    "merges": "-0%",
    "mergeCopies": null
  },
  "list": {
    "concats": null
  },
  "parser": {
    "expressions": "+0%"
  },
  "memoryBytes": {
    "envs": "-0.2%",
    "list": "-0.02%",
    "sets": "-0.02%",
    "symbols": "+0%",
    "values": "-0.09%",
    "total": "-0.08%"
  },
  "speed": {
    "primops": "-0%",
    "functionCalls": "-0.18%",
    "thunksMade": "-0.14%",
    "thunksAvoided": "-0.19%"
  }
}
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
