### PR TITLE
goofcord: 2.2.1 → 2.3.0

### DIFF
--- a/pkgs/by-name/go/goofcord/goofbind-addon.nix
+++ b/pkgs/by-name/go/goofcord/goofbind-addon.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   rustPlatform,
   fetchFromGitHub,
   cmake,
@@ -13,20 +12,23 @@
   libxcb,
   wayland,
   xorgproto,
+  libxi,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "venbind";
+  pname = "goofbind";
   version = "0.1.7";
 
   src = fetchFromGitHub {
-    owner = "tuxinal";
-    repo = "venbind";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-6gPyQ6JjqvM2AUuIxCfO0nOLJfyQTX5bbsbKDzlNSqo=";
+    owner = "Milkshiift";
+    repo = "goofbind";
+
+    # Fetch commit from repo, until the tag version is released
+    rev = "703237071f61d1ceede8076b0015488773a7c4ae";
+    hash = "sha256-XAt0ThqDRPun5nrp1sFWEeX3vEIGOpXpwQsx1I4bfqA=";
     fetchSubmodules = true;
   };
 
-  cargoHash = "sha256-FZTXj8f+ezRhElovKhF3khWc5SqC+22tDHlFe9IHuwo=";
+  cargoHash = "sha256-GAtNCaMFAbgHktLU+/rQGfbjVEY4iFCmfuQw0y5wFcY=";
 
   nativeBuildInputs = [
     rustPlatform.bindgenHook
@@ -42,6 +44,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     libxkbcommon
     libxcb
     wayland
+    libxi
     xorgproto
   ];
 

--- a/pkgs/by-name/go/goofcord/node-modules.nix
+++ b/pkgs/by-name/go/goofcord/node-modules.nix
@@ -50,8 +50,8 @@ stdenv.mkDerivation {
 
   outputHash =
     {
-      x86_64-linux = "sha256-2PH4qa4M/y4AzVT9dW4BK1jE3RWSr+NWY1AhU3cfUTE=";
-      aarch64-linux = "sha256-RGJGUdp3i6Q/tCuQ42NfF4eFGrrgoyhx1l14fPwlCN8=";
+      x86_64-linux = "sha256-J26DRSUa/C7lvI8JFPQ92yj4zUVnD+SPkKwRQA9ITB8=";
+      aarch64-linux = "sha256-WIjcl//+OGB5J6Dp4Q2x24MA/cWqdtHYNwBBOgCD/tU=";
     }
     .${stdenv.hostPlatform.system} or (throw "Unsupported system ${stdenv.hostPlatform.system}");
   outputHashAlgo = "sha256";

--- a/pkgs/by-name/go/goofcord/package.nix
+++ b/pkgs/by-name/go/goofcord/package.nix
@@ -17,17 +17,17 @@
 }:
 let
   patchcordAddon = callPackage ./patchcord-addon.nix { };
-  venbindAddon = callPackage ./venbind-addon.nix { };
+  goofbindAddon = callPackage ./goofbind-addon.nix { };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "goofcord";
-  version = "2.2.1";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "Milkshiift";
     repo = "GoofCord";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-qcgEUkPh671q9aJtge+PSbBTrg7vY+iz+H+SKXPFqFI=";
+    hash = "sha256-cg9NVL/dPIQ9xyMrUmWd42HxEsTSnhUGiqB7qaU2LuQ=";
   };
 
   nativeBuildInputs = [
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
   env = {
     ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
     GOOFCORD_PATCHCORD_PATH = "${patchcordAddon}/bin/patchcord";
-    GOOFCORD_VENBIND_PATH = "${venbindAddon}/lib/libvenbind.so";
+    GOOFCORD_VENBIND_PATH = "${goofbindAddon}/lib/libvenbind.so";
   };
 
   configurePhase = ''

--- a/pkgs/by-name/go/goofcord/patchcord-addon.nix
+++ b/pkgs/by-name/go/goofcord/patchcord-addon.nix
@@ -10,8 +10,8 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "Milkshiift";
     repo = "patchcord";
-    rev = "f2611630f143a53b46514d4916af0971d7aab2b5";
-    hash = "sha256-VTHS5psVqg4RjSrAs9vPkixsVwwIYE2E4o0vXVN58tE=";
+    rev = "cb0d3d48f0c217e9621c48c576ec340fdfd9b9b7";
+    hash = "sha256-MYcLrDVnyhNZ0Wb/X6dNEtc4S1K6k9/XBUyaNCeTli4=";
   };
 
   cargoHash = "sha256-/IbHvs9SEuulNcWkihwFwaFcqMM0rdFBVjCWgUu7dys=";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Migrating from `venbind` to `goofbind`
Added `libxi` to `goofbind`
Changed package. Tested auth and basic functionality
Fixes: #549115

Diff: https://github.com/Milkshiift/GoofCord/compare/v2.2.1...v2.3.0

~I can't calc sha256 for aarch64-linux~ Calculated!


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
