### PR TITLE
miracl-core: init at 0-unstable-2026-06-09

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21890,6 +21890,12 @@
     githubId = 1748936;
     keys = [ { fingerprint = "FEDA B009 17FA A574 F536 ED52 4AB1 3530 3377 4DA3"; } ];
   };
+  pauloaviana = {
+    name = "Paulo A. Viana";
+    email = "pa.viana@protonmail.ch";
+    github = "pauloaviana";
+    githubId = 27158951;
+  };
   paulsmith = {
     email = "paulsmith@pobox.com";
     github = "paulsmith";

--- a/pkgs/by-name/mi/miracl-core/package.nix
+++ b/pkgs/by-name/mi/miracl-core/package.nix
@@ -1,0 +1,103 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  python3,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "miracl-core";
+  version = "0-unstable-2026-06-09";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "miracl";
+    repo = "core";
+    rev = "a6df6733c1ad1ad0918306abd0c3983b4cd4a58c";
+    hash = "sha256-Nc+UxmmNxZWHTm0WA+OYdqkQS+accIZGOaanqMg0C78=";
+  };
+
+  nativeBuildInputs = [ python3 ];
+
+  strictDeps = true;
+
+  # config64.py -> configure and build in one step.
+  dontConfigure = true;
+
+  # The upstream test programs link against many different curves, so any subset of curves would make the test suite unbuildable.
+  # The full set is what makes a single static library generally useful downstream.
+
+  buildPhase = ''
+    runHook preBuild
+    cd c
+    python3 config64.py test
+    runHook postBuild
+  '';
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  checkPhase = ''
+    runHook preCheck
+
+    # Upstream test programs print failure markers but exit `0` even when a sub-test fails
+    # so their output should be checked regardless of the exit status.
+
+    failRe='Failed|FAILED|FAILURE|INVALID|NOT verified|Error from'
+
+    # `testmpin` prompts for a PIN several times. The registration and authentication must use the same PIN for the protocol to work.
+    printf '1234\n%.0s' $(seq 1 32) > mpin-input.txt
+
+    for t in testecc testeddsa testmpin testbls testnhs testdlthm testkyber; do
+      if [ ! -x "./$t" ]; then
+        echo "ERROR: expected upstream test program '$t' was not built" >&2
+        exit 1          ### Checks the existance of the test executable
+      fi
+      echo "==== running $t"
+      set +e
+      if [ "$t" = testmpin ]; then
+        "./$t" < mpin-input.txt > "$t.log" 2>&1   ### the M-PIN is fed
+      else
+        "./$t" > "$t.log" 2>&1
+      fi
+      status=$?
+      set -e
+      if [ "$status" -ne 0 ]; then
+        cat "$t.log"
+        echo "ERROR: $t exited with status $status" >&2
+        exit 1
+      fi
+      if grep -Eq "$failRe" "$t.log"; then
+        cat "$t.log"
+        echo "ERROR: $t reported a failure (matched: $failRe)" >&2
+        exit 1
+      fi
+    done
+
+    runHook postCheck
+  '';
+
+  # Upstream's header names are generic (core.h, config_big.h, big_*.h) so they are gathered under `include/miracl/`.
+  # The library is renamed from upstream's core.a so that -lmiracl-core links without ambiguity.
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib $out/include/miracl
+    cp core.a $out/lib/libmiracl-core.a
+    cp *.h $out/include/miracl/
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
+
+  meta = {
+    description = "Multi-language cryptographic library supporting elliptic curves, pairings, RSA and NIST post-quantum schemes";
+    homepage = "https://github.com/miracl/core";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ pauloaviana ];
+    platforms = lib.platforms.unix;
+    badPlatforms = [ lib.systems.inspect.patterns.is32bit ];
+  };
+})


### PR DESCRIPTION
Adds MIRACL Core, a multi-language cryptographic library (elliptic curves, pairings, RSA, and NIST post-quantum schemes ML-KEM/Kyber and ML-DSA/Dilithium) -- https://github.com/miracl/core.

Upstream has no tagged releases, so the package pins the latest commit as `0-unstable-2026-06-09` and wires `unstableGitUpdater` for automated bumps.

Packaging notes:

- **All curves/schemes are built** (`config64.py test`): the upstream test programs link against many different curves, so a curated subset would make the test suite unbuildable, and consumers select curves at link time by simply not referencing the others.
- **The check phase greps test output** in addition to exit codes: the upstream test programs print failure markers but exit 0 even on failure. Upstream plans to fix it, meanwhile grep is used as a reliable verdict.
- **`core.a` is installed as `libmiracl-core.a`** and headers are namespaced under `include/miracl/` because upstream's names (`core.h`, `big_*.h`) are too generic.
- **64-bit platforms only** `badPlatforms` excludes 32-bit. The packaged `config64.py` generates a 64-bit word-length configuration, so 32-bit hosts would need upstream's separate `config32.py` entry point.
- **`testmpin` is interactive** It reads PINs from stdin, the check phase drives it with a fixed PIN.

The upstream test suite (testecc, testeddsa, testmpin, testbls, testnhs, testdlthm, testkyber) runs in the derivation's `checkPhase`. This is a library-only package (static library + headers), basic functionality was additionally verified by compiling and running a minimal downstream C program against the output.

AI disclosure: The PR description was drafted with assistance from Claude (Opus 5). I reviewed and edited it before submission. Also, the `checkPhase` exit check logic + M-PIN was also assisted with by it.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review --package miracl-core`
Commit: `8ff27e853e4056fe4f29b32ac83fd30ae6fecf6a`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automated-and-ai-assisted-contributions