### PR TITLE
bottles-unwrapped: 64.1 −> 65.4

### DIFF
--- a/pkgs/by-name/bo/bottles-unwrapped/package.nix
+++ b/pkgs/by-name/bo/bottles-unwrapped/package.nix
@@ -29,6 +29,7 @@
   vmtouch,
   libportal,
   libportal-gtk4,
+  obs-studio-plugins,
   nix-update-script,
   removeWarningPopup ? false,
 }:
@@ -113,6 +114,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
       mangohud
       vmtouch
       fvs2
+      obs-studio-plugins.obs-vkcapture
 
       # Undocumented (subprocess.Popen())
       lsb-release

--- a/pkgs/by-name/bo/bottles-unwrapped/package.nix
+++ b/pkgs/by-name/bo/bottles-unwrapped/package.nix
@@ -28,19 +28,20 @@
   vulkan-tools,
   vmtouch,
   libportal,
+  libportal-gtk4,
   nix-update-script,
   removeWarningPopup ? false,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "bottles-unwrapped";
-  version = "64.1";
+  version = "65.4";
 
   src = fetchFromGitHub {
     owner = "bottlesdevs";
     repo = "bottles";
     tag = finalAttrs.version;
-    hash = "sha256-RwH2XLY9PmyDvIYu3Wr2qL89ErJBfC58i0jHLLNnKJQ=";
+    hash = "sha256-59Duh4E1kMShhk/iH/SBhpmFfUjYzRClNuWqoDSbTeM=";
   };
 
   patches = [
@@ -75,6 +76,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     gtksourceview5
     libadwaita
     libportal
+    libportal-gtk4
   ];
 
   propagatedBuildInputs =

--- a/pkgs/by-name/bo/bottles-unwrapped/remove-flatpak-check.patch
+++ b/pkgs/by-name/bo/bottles-unwrapped/remove-flatpak-check.patch
@@ -52,16 +52,19 @@ index f897953c..393572ed 100644
              show_chooser()
  
 diff --git a/bottles/frontend/views/bottle_preferences.py b/bottles/frontend/views/bottle_preferences.py
-index 1e0090f8..983097f2 100644
+index 2bc2235e..34db4dbd 100644
 --- a/bottles/frontend/views/bottle_preferences.py
 +++ b/bottles/frontend/views/bottle_preferences.py
-@@ -148,7 +148,7 @@ class PreferencesView(Adw.PreferencesPage):
-         self.queue = details.queue
-         self.details = details
+@@ -173,9 +173,6 @@ class PreferencesView(Adw.PreferencesPage):
+                 )
+             )
  
--        if not gamemode_available or not Xdp.Portal.running_under_sandbox():
-+        if not gamemode_available:
-             return
+-        if not Xdp.Portal.running_under_sandbox():
+-            return
+-
+         _not_available = _("This feature is unavailable on your system.")
+         _flatpak_not_available = _("{} To add this feature, please run").format(
+             _not_available
  
          _not_available = _("This feature is unavailable on your system.")
 diff --git a/bottles/frontend/views/list.py b/bottles/frontend/views/list.py

--- a/pkgs/by-name/bo/bottles/package.nix
+++ b/pkgs/by-name/bo/bottles/package.nix
@@ -21,6 +21,7 @@ let
         # This only allows to enable the toggle, vkBasalt won't work if not installed with environment.systemPackages (or nix-env)
         # See https://github.com/bottlesdevs/Bottles/issues/2401
         vkbasalt
+        lsfg-vk
       ]
       ++ extraPkgs pkgs;
 

--- a/pkgs/by-name/bo/bottles/package.nix
+++ b/pkgs/by-name/bo/bottles/package.nix
@@ -105,6 +105,8 @@ let
         openal
 
         # Steam runtime
+        attr
+        glibc
         libgcrypt
         libgpg-error
         p11-kit

--- a/pkgs/by-name/fv/fvs2/package.nix
+++ b/pkgs/by-name/fv/fvs2/package.nix
@@ -2,27 +2,31 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  git,
 }:
 let
   core = fetchFromGitHub {
     owner = "fvs-lab";
     repo = "core";
-    tag = "v0.0.1";
-    hash = "sha256-IBNNa5LGjtPNWhI0PC0NX8rK8z2LnfzOpKpDE1TZQhw=";
+    tag = "v0.1.1";
+    hash = "sha256-vEQhV9wInqxgJlSyhgp0BV5VaYBJVtqcPrdN2NP33i4=";
   };
 in
 buildGoModule (finalAttrs: {
   pname = "fvs2";
-  version = "0.2.0";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "fvs-lab";
     repo = "fvs2";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-wod+GzJ/tCl0dlAv0PM9I1TG9l96SujrOkSlEsgXp5U=";
+    hash = "sha256-lJZd9QbvjArYMSXG6qHcaxaAe5UOPpko/TXD2L8yxDA=";
   };
 
-  vendorHash = "sha256-MDizWAeXJW0YTMrGEtk3Ulvx0InW0EgytrtE9O7T3Ps=";
+  vendorHash = "sha256-FUst0ccxpZS3NjvthQQE7CVlULWPhXj8KA2cOoksLGI=";
+
+  # Needed for build time tests
+  nativeBuildInputs = [ git ];
 
   preBuild = ''
     cp -r ${core} ../core


### PR DESCRIPTION
Changelog: https://github.com/bottlesdevs/Bottles/releases/tag/65.0
Diff: https://github.com/bottlesdevs/Bottles/compare/64.1...65.1

fvs2 diff: https://github.com/fvs-lab/fvs2/compare/v0.2.0...v0.9.0

This release adds support for `lsfg-vk` for frame-generation, which I successfully tested.

I also added support for `obs-vkcapture`, this is done in a separate commit since it had been a missing feature until now. I do not use obs, and as such did not test it, but it *should* work. Testing is welcomed.

I'm also bumping `fvs2` to it's latest tag, so far `bottles` is the only package using it. Note that the versioning page in bottles (which makes use of `fvs2`) does not work display snapshots, this apply both to the current build in `nixpkgs-unstable` and with this PR. I haven't found a fix yet.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
