### PR TITLE
nxv: 0.7.0 -> 0.7.1

### DIFF
--- a/pkgs/by-name/nx/nxv/package.nix
+++ b/pkgs/by-name/nx/nxv/package.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nxv";
-  version = "0.7.0";
+  version = "0.7.1";
 
   src = fetchFromGitHub {
     owner = "utensils";
     repo = "nxv";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-tjVhLHn2FH4QQ5ynLEiB2nJTmpu4viho2Sf+mc7YWX8=";
+    hash = "sha256-CkwOJaOumxBx5kGOfkEHDmEBxrTzGXVNKJdZld3uxdA=";
   };
 
-  cargoHash = "sha256-Gx45+hiRByQc/OcHlJ7L4G+xh/IZHWipslQ3Xv5+fHE=";
+  cargoHash = "sha256-itYpea4CBSGVdzFiRtA1Yib3U2mFyMmo/P9jicrJCrc=";
 
   # Tests use mockito which needs to bind to localhost
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
Patch release for `nxv`, a tool for finding versions of Nix packages across nixpkgs history.

0.7.1 is a single bug fix: boolean environment variables are now parsed with clap's `BoolishValueParser`, so `NXV_SKIP_VERIFY=false` (and `0`/`no`/`off`) correctly disables the flag instead of enabling it because the variable merely existed. `NO_COLOR` was also dropped as a clap `env` binding for the same reason.

No dependency changes — `Cargo.lock` differs from 0.7.0 only in `nxv`'s own version field, so this is a version + hash bump only. The `cargoHash` still changes because the lockfile is part of the vendor derivation.

Diff: https://github.com/utensils/nxv/compare/v0.7.0...v0.7.1
Changelog: https://github.com/utensils/nxv/blob/v0.7.1/CHANGELOG.md

cc @yzhou216 (co-maintainer), @NickCao (merged the 0.7.0 bump #548600)

This supersedes the stale r-ryantm PR #514996, which is titled `0.1.4 -> 0.6.1` and diffs against a pre-0.6.0 base — it would reintroduce the `fetchSubmodules = true` that was removed in 0.6.0 when the vestigial nixpkgs submodule was deleted upstream.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

The upstream test suite runs in `checkPhase` (104 passed, 5 ignored) and `versionCheckHook` confirms `nxv 0.7.1`. I also exercised the fix itself against `./result/bin/nxv`: `NXV_SKIP_VERIFY` now accepts `true`/`1`/`yes`/`on`/`false`/`0`/`no`/`off` and rejects a non-boolean value with `value was not a boolean`.

This PR was prepared with AI assistance (Claude Code); the commit carries an `Assisted-by:` trailer. I reviewed the change and ran the build and tests locally before opening it.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
