### PR TITLE
[26.05] docker-compose: 5.1.4 -> 5.4.0

### DIFF
--- a/pkgs/applications/virtualization/docker/compose.nix
+++ b/pkgs/applications/virtualization/docker/compose.nix
@@ -6,16 +6,16 @@
 }:
 buildGoModule rec {
   pname = "docker-compose";
-  version = "5.1.4";
+  version = "5.2.0";
 
   src = fetchFromGitHub {
     owner = "docker";
     repo = "compose";
     tag = "v${version}";
-    hash = "sha256-sdRxssZ6bRGRB/WPp2BiDTVHQ5LBmNGwXQYBdSpylQg=";
+    hash = "sha256-sKfsPn8CV62TXY0LoquQYEUgSBVDRiKW0Z3/py1RFng=";
   };
 
-  vendorHash = "sha256-hgNboIZx5QOGjPadey4f2TKpPw+b2sja6mcwoMjINuY=";
+  vendorHash = "sha256-1cYmWaj6gvmM6207dj8E7kVKIOJlS4js9EwNXhnv13A=";
 
   nativeInstallCheckInputs = [ versionCheckHook ];
 

--- a/pkgs/applications/virtualization/docker/compose.nix
+++ b/pkgs/applications/virtualization/docker/compose.nix
@@ -6,16 +6,16 @@
 }:
 buildGoModule rec {
   pname = "docker-compose";
-  version = "5.2.0";
+  version = "5.3.0";
 
   src = fetchFromGitHub {
     owner = "docker";
     repo = "compose";
     tag = "v${version}";
-    hash = "sha256-sKfsPn8CV62TXY0LoquQYEUgSBVDRiKW0Z3/py1RFng=";
+    hash = "sha256-Vq1CJcneoFYGlQjJgAZsPN8kR/xrnsF7abG7HACkdKA=";
   };
 
-  vendorHash = "sha256-1cYmWaj6gvmM6207dj8E7kVKIOJlS4js9EwNXhnv13A=";
+  vendorHash = "sha256-aEM+iHtwy/axoI5KwG2BnqSYKEwmuUPr5KcmdaO1mho=";
 
   nativeInstallCheckInputs = [ versionCheckHook ];
 

--- a/pkgs/applications/virtualization/docker/compose.nix
+++ b/pkgs/applications/virtualization/docker/compose.nix
@@ -6,16 +6,16 @@
 }:
 buildGoModule rec {
   pname = "docker-compose";
-  version = "5.3.0";
+  version = "5.3.1";
 
   src = fetchFromGitHub {
     owner = "docker";
     repo = "compose";
     tag = "v${version}";
-    hash = "sha256-Vq1CJcneoFYGlQjJgAZsPN8kR/xrnsF7abG7HACkdKA=";
+    hash = "sha256-UNORlxZ/b4Jrp9v8pbsxTt8PrYq1/u4AjBU8+pfuG1k=";
   };
 
-  vendorHash = "sha256-aEM+iHtwy/axoI5KwG2BnqSYKEwmuUPr5KcmdaO1mho=";
+  vendorHash = "sha256-Ug6/hpuHgJ2CAUX87/+Tt3cHm4AbJF9oznx61kTVKI4=";
 
   nativeInstallCheckInputs = [ versionCheckHook ];
 

--- a/pkgs/applications/virtualization/docker/compose.nix
+++ b/pkgs/applications/virtualization/docker/compose.nix
@@ -6,16 +6,16 @@
 }:
 buildGoModule rec {
   pname = "docker-compose";
-  version = "5.3.1";
+  version = "5.4.0";
 
   src = fetchFromGitHub {
     owner = "docker";
     repo = "compose";
     tag = "v${version}";
-    hash = "sha256-UNORlxZ/b4Jrp9v8pbsxTt8PrYq1/u4AjBU8+pfuG1k=";
+    hash = "sha256-BLApJ1RWI2nUM3EDFLWBPwIbT+wUUCqxCRjc7QlkFd4=";
   };
 
-  vendorHash = "sha256-Ug6/hpuHgJ2CAUX87/+Tt3cHm4AbJF9oznx61kTVKI4=";
+  vendorHash = "sha256-NCHNe+aLNsJNtKdgQxyL6cMuu9XxA5ycleHf9gToEks=";
 
   nativeInstallCheckInputs = [ versionCheckHook ];
 


### PR DESCRIPTION
Backports #534661, #537860, #539276, and #548861.

Compose 5.1.4 directly depends on [`moby/go-archive` 0.2.0](https://github.com/docker/compose/blob/v5.1.4/go.mod#L32). Its container-to-host `docker compose cp` path calls [`CopyTo`](https://github.com/docker/compose/blob/v5.1.4/pkg/compose/cp.go#L321), which calls the affected [`Untar`](https://github.com/moby/go-archive/blob/v0.2.0/copy.go#L418-L437) helper. `moby/go-archive` 0.3.0 [fixes CVE-2026-17106](https://github.com/moby/go-archive/releases/tag/v0.3.0). Compose 5.4.0 [resolves version 0.3.2](https://github.com/docker/compose/blob/v5.4.0/go.mod#L32), including the follow-up [0.3.1](https://github.com/moby/go-archive/releases/tag/v0.3.1) and [0.3.2](https://github.com/moby/go-archive/releases/tag/v0.3.2) extraction regression fixes.

This update also adopts Compose [5.2.0](https://github.com/docker/compose/releases/tag/v5.2.0)'s new reconciliation algorithm and [5.4.0](https://github.com/docker/compose/releases/tag/v5.4.0)'s volume and network reconciliation changes. [5.3.0](https://github.com/docker/compose/releases/tag/v5.3.0) adds native init-container support, while [5.3.1](https://github.com/docker/compose/releases/tag/v5.3.1) contains dependency and internal updates.

On aarch64-linux, `docker-compose`, `docker`, `docker-client`, `copacetic`, `arion`, and `devcontainer` built in `nixpkgs-review`. Standalone and Docker CLI plugin version checks reported 5.4.0. Compose config validation and a NixOS VM smoke test covering `up -d`, a repeated `up -d`, service availability, and teardown passed.

Assisted-by: OpenAI Codex (GPT-5)

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test