### PR TITLE
traggo: init at 0.8.3

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -208,6 +208,12 @@
   "module-services-tdarr-server-only": [
     "index.html#module-services-tdarr-server-only"
   ],
+  "module-services-traggo": [
+    "index.html#module-services-traggo"
+  ],
+  "module-services-traggo-configuration": [
+    "index.html#module-services-traggo-configuration"
+  ],
   "module-virtualisation-xen": [
     "index.html#module-virtualisation-xen"
   ],

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -28,6 +28,8 @@
 
 - [scx_loader](https://github.com/sched-ext/scx-loader), a system daemon and DBus-based loader for sched_ext schedulers. `scxctl` is the command-line client for interacting with the loader, allowing users to switch schedulers, modes, and arguments dynamically. Available as [services.scx-loader](#opt-services.scx-loader.enable)
 
+- [traggo](https://traggo.net/), a self-hosted, tag-based time tracking server. Available as [services.traggo](#opt-services.traggo.enable).
+
 - [tap](https://github.com/bluesky-social/indigo/tree/main/cmd/tap), an ATProtocol firehose synchronisation utility. Available as [services.tap](#opt-services.tap.enable).
 
 - [Nezha](https://github.com/nezhahq/nezha), a self-hosted, lightweight server and website monitoring and O&M tool. Available as [services.nezha](#opt-services.nezha.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1823,6 +1823,7 @@
   ./services/web-apps/suwayomi-server.nix
   ./services/web-apps/szurubooru.nix
   ./services/web-apps/tabbyapi.nix
+  ./services/web-apps/traggo.nix
   ./services/web-apps/tranquil-pds.nix
   ./services/web-apps/trilium.nix
   ./services/web-apps/tt-rss.nix

--- a/nixos/modules/services/web-apps/traggo.md
+++ b/nixos/modules/services/web-apps/traggo.md
@@ -1,0 +1,22 @@
+# traggo {#module-services-traggo}
+
+[traggo](https://traggo.net/) is a self-hosted, tag-based time tracking server.
+
+## Configuration {#module-services-traggo-configuration}
+
+```nix
+{
+  services.traggo = {
+    enable = true;
+    environment.TRAGGO_PORT = 8080;
+    environmentFiles = [ "/run/secrets/traggo" ];
+  };
+}
+```
+
+Put secrets such as `TRAGGO_DEFAULT_USER_PASS` in
+{option}`services.traggo.environmentFiles` rather than
+{option}`services.traggo.environment`, since the latter ends up
+world-readable in the Nix store.
+
+See <https://traggo.net/config/> for the full list of settings.

--- a/nixos/modules/services/web-apps/traggo.nix
+++ b/nixos/modules/services/web-apps/traggo.nix
@@ -1,0 +1,125 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.traggo;
+  port = lib.toInt (toString (cfg.environment.TRAGGO_PORT or 3030));
+in
+{
+  meta.doc = ./traggo.md;
+  meta.maintainers = with lib.maintainers; [ elnudev ];
+
+  options.services.traggo = {
+    enable = lib.mkEnableOption "traggo, a self-hosted, tag-based time tracking server";
+
+    package = lib.mkPackageOption pkgs "traggo" { };
+
+    environment = lib.mkOption {
+      type = lib.types.attrsOf (
+        lib.types.oneOf [
+          lib.types.str
+          lib.types.int
+        ]
+      );
+      default = { };
+      example = {
+        TRAGGO_PORT = 3030;
+        TRAGGO_LOG_LEVEL = "info";
+        TRAGGO_DEFAULT_USER_NAME = "admin";
+        TRAGGO_DATABASE_DIALECT = "sqlite3";
+        TRAGGO_DATABASE_CONNECTION = "data/traggo.db";
+      };
+      description = ''
+        Config environment variables for traggo, using the names from
+        <https://traggo.net/config/>. The example lists the upstream defaults.
+      '';
+    };
+
+    environmentFiles = lib.mkOption {
+      type = lib.types.listOf lib.types.path;
+      default = [ ];
+      example = [ "/run/secrets/traggo" ];
+      description = ''
+        Files containing additional config environment variables for
+        traggo. Secrets such as `TRAGGO_DEFAULT_USER_PASS` should be set
+        here instead of in {option}`services.traggo.environment`.
+      '';
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to open the traggo port in the firewall. The port is read
+        from `TRAGGO_PORT` in {option}`services.traggo.environment`.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ port ];
+
+    systemd.services.traggo = {
+      description = "traggo server";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      environment = lib.mapAttrs (_: toString) cfg.environment;
+
+      serviceConfig = {
+        ExecStart = lib.getExe cfg.package;
+        Restart = "on-failure";
+        RestartSec = 5;
+
+        DynamicUser = true;
+        StateDirectory = "traggo";
+        # TRAGGO_DATABASE_CONNECTION defaults to the relative path `data/traggo.db`.
+        WorkingDirectory = "%S/traggo";
+
+        EnvironmentFile = cfg.environmentFiles;
+
+        AmbientCapabilities = lib.optional (port < 1024) "CAP_NET_BIND_SERVICE";
+        # `[ "" ]` clears the bounding set; `[ ]` would leave it unrestricted.
+        CapabilityBoundingSet = if port < 1024 then [ "CAP_NET_BIND_SERVICE" ] else [ "" ];
+        DevicePolicy = "closed";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        # AmbientCapabilities is ineffective under PrivateUsers.
+        PrivateUsers = port >= 1024;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+          "~@resources"
+        ];
+        UMask = "0077";
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1783,6 +1783,7 @@ in
   tracee = handleTestOn [ "x86_64-linux" ] ./tracee.nix { };
   traefik = runTestOn [ "aarch64-linux" "x86_64-linux" ] ./traefik.nix;
   trafficserver = runTest ./trafficserver.nix;
+  traggo = runTest ./traggo.nix;
   tranquil-pds = runTest ./tranquil-pds.nix;
   transfer-sh = runTest ./transfer-sh.nix;
   transmission_4 = runTest ./transmission.nix;

--- a/nixos/tests/traggo.nix
+++ b/nixos/tests/traggo.nix
@@ -1,0 +1,60 @@
+{ lib, ... }:
+{
+  name = "traggo";
+  meta.maintainers = with lib.maintainers; [ elnudev ];
+
+  nodes = {
+    basic.services.traggo.enable = true;
+
+    configured = {
+      environment.etc."traggo-secret".text = "TRAGGO_DEFAULT_USER_PASS=fromfile\n";
+      services.traggo = {
+        enable = true;
+        environment.TRAGGO_PORT = 8080;
+        environmentFiles = [ "/etc/traggo-secret" ];
+      };
+    };
+
+    lowport.services.traggo = {
+      enable = true;
+      environment.TRAGGO_PORT = 80;
+    };
+  };
+
+  testScript = ''
+    import json
+    import shlex
+
+    def gql(port, query):
+        body = shlex.quote(json.dumps({"query": query}))
+        return (
+            "curl -sf -X POST -H 'Content-Type: application/json' "
+            f"-d {body} http://localhost:{port}/graphql"
+        )
+
+    def login(port, user, password):
+        return gql(port, (
+            f'mutation{{login(username:"{user}",pass:"{password}",'
+            'deviceName:"t",type:NoExpiry,cookie:false){token}}'
+        ))
+
+    start_all()
+
+    with subtest("upstream defaults are respected"):
+        basic.wait_for_unit("traggo.service")
+        basic.wait_for_open_port(3030)
+        basic.succeed("test -f /var/lib/traggo/data/traggo.db")
+        basic.succeed("curl -sf http://localhost:3030/ | grep -q '<title>Traggo</title>'")
+        basic.succeed(login(3030, "admin", "admin") + " | grep -q token")
+
+    with subtest("environment and environmentFiles are honored"):
+        configured.wait_for_unit("traggo.service")
+        configured.wait_for_open_port(8080)
+        configured.succeed(login(8080, "admin", "fromfile") + " | grep -q token")
+        configured.fail(login(8080, "admin", "admin") + " | grep -q token")
+
+    with subtest("privileged ports work"):
+        lowport.wait_for_unit("traggo.service")
+        lowport.wait_for_open_port(80)
+  '';
+}

--- a/pkgs/by-name/tr/traggo/gqlgen.nix
+++ b/pkgs/by-name/tr/traggo/gqlgen.nix
@@ -1,0 +1,20 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "gqlgen";
+  version = "0.17.85";
+
+  src = fetchFromGitHub {
+    owner = "99designs";
+    repo = "gqlgen";
+    tag = "v${version}";
+    hash = "sha256-U2qbOjWUE1MfrMJTVaB59Osax8B6CKMlk6uqGioVgBk=";
+  };
+
+  vendorHash = "sha256-9rBdr1fP5LKioz2c6lAZEdcDnG2JL2CO1VXK5+MwGEs=";
+  subPackages = [ "." ];
+  doCheck = false;
+}

--- a/pkgs/by-name/tr/traggo/package.nix
+++ b/pkgs/by-name/tr/traggo/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  callPackage,
+  nixosTests,
+}:
+
+buildGoModule (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "traggo";
+  version = "0.8.3";
+
+  src = fetchFromGitHub {
+    owner = "traggo";
+    repo = "server";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-TMYTlcimcT1bg0frxCHDVbtrF3nbJKpqOiBfdrzjtNc=";
+  };
+
+  # The default `go mod vendor` step loads packages, which fails because
+  # generated/gql* doesn't exist until gqlgen has run. proxyVendor only
+  # reads go.mod/go.sum, so it doesn't have that problem.
+  proxyVendor = true;
+  vendorHash = "sha256-3R8GXr1AoaU7QE3/hQ+VLGoXEmfIs5CkraVqo9Numt0=";
+
+  nativeBuildInputs = [ (callPackage ./gqlgen.nix { }) ];
+
+  preBuild = ''
+    mkdir -p ui/build
+    cp -r ${finalAttrs.passthru.ui}/. ui/build/
+
+    # gqlgen.yml has no trailing newline, and defaults to running
+    # `go mod tidy`, which needs network access.
+    printf '\nskip_mod_tidy: true\n' >> gqlgen.yml
+    gqlgen generate
+  '';
+
+  # Development helper that seeds a database with random data.
+  excludedPackages = [ "hack/datagen" ];
+
+  tags = [
+    "netgo"
+    "osusergo"
+    "sqlite_omit_load_extension"
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.BuildMode=prod"
+    "-X main.BuildVersion=${finalAttrs.version}"
+  ];
+
+  # The Go module is named `server`; upstream ships the binary as `traggo`.
+  postInstall = ''
+    mv $out/bin/server $out/bin/traggo
+  '';
+
+  passthru = {
+    ui = callPackage ./ui.nix { inherit (finalAttrs) src version; };
+    tests.traggo = nixosTests.traggo;
+  };
+
+  meta = {
+    description = "Self-hosted, tag-based time tracking";
+    homepage = "https://traggo.net";
+    changelog = "https://github.com/traggo/server/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ elnudev ];
+    mainProgram = "traggo";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/tr/traggo/ui.nix
+++ b/pkgs/by-name/tr/traggo/ui.nix
@@ -1,0 +1,57 @@
+{
+  src,
+  version,
+  lib,
+  stdenv,
+  nodejs,
+  yarn,
+  yarnConfigHook,
+  yarnBuildHook,
+  fetchYarnDeps,
+}:
+
+stdenv.mkDerivation {
+  pname = "traggo-ui";
+  inherit version;
+
+  src = "${src}/ui";
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = "${src}/ui/yarn.lock";
+    hash = "sha256-BDQ7MgRWBRQQfjS5UCW3KJ0kJrkn4g9o4mU0ZH+vhX0=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    yarn
+    yarnConfigHook
+    yarnBuildHook
+  ];
+
+  env = {
+    # react-scripts 3 runs on webpack 4, which hashes with MD4, rejected by
+    # OpenSSL 3. Same workaround as upstream CI.
+    NODE_OPTIONS = "--openssl-legacy-provider";
+    APOLLO_TELEMETRY_DISABLED = "1";
+  };
+
+  # src/gql/__generated__ is gitignored, so codegen has to run here. It reads
+  # the schema from ../schema.graphql relative to ui/.
+  preBuild = ''
+    cp ${src}/schema.graphql ../schema.graphql
+    yarn --offline generate
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    cp -r build $out
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Web UI for traggo";
+    homepage = "https://traggo.net";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ elnudev ];
+  };
+}


### PR DESCRIPTION
Set up [traggo](https://github.com/traggo/server) package and module, closes #371459.

gqlgen is pinned to 0.17.85 since that's what traggo uses, rather than what's available in nixpkgs, 0.17.94. It *should* build with 0.17.94 as far as I'm aware but I'm keeping it pinned in case latest gqlgen ever updates to a point where it becomes incompatible.

Claude Code assisted in writing this PR, I've put `Assisted-by:` on the commit descriptions as per the AI policy. I've looked through everything and have tested this derivation on my system and everything works.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
