### PR TITLE
ffmpeg_9{,-headless,-full}: init at 9.0

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -165,6 +165,8 @@
   To prevent loading the `early-default` library,
   set `inhibit-early-default-init` in `early-init.el`.
 
+- `ffmpeg_9`, `ffmpeg_9-headless`, and `ffmpeg_9-full` have been added.
+
 - `services.ceph` enabled the generation of Ceph log files at `/var/log/ceph/`.
   They were missing before because Ceph omitted logs when this directory was missing.
   Ceph logs can grow large, so you may want to configure rotation of these logs.

--- a/pkgs/development/libraries/ffmpeg/default.nix
+++ b/pkgs/development/libraries/ffmpeg/default.nix
@@ -33,6 +33,10 @@ let
     version = "8.1.2";
     hash = "sha256-wJ3c8VVo/tK84K7bKYs/UWcln4mSO+tf/w5NLNjKhiI=";
   };
+  v9 = {
+    version = "9.0";
+    hash = "sha256-LbHwxvylAPh5lb/H+o+9eMVTB9X+tphrxYYX0cqAL0k=";
+  };
 in
 
 rec {
@@ -54,6 +58,10 @@ rec {
   ffmpeg_8 = mkFFmpeg v8 "small";
   ffmpeg_8-headless = mkFFmpeg v8 "headless";
   ffmpeg_8-full = mkFFmpeg v8 "full";
+
+  ffmpeg_9 = mkFFmpeg v9 "small";
+  ffmpeg_9-headless = mkFFmpeg v9 "headless";
+  ffmpeg_9-full = mkFFmpeg v9 "full";
 
   # Please make sure this is updated to new major versions once they
   # build and work on all the major platforms. If absolutely necessary

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -55,7 +55,7 @@
   withBzlib ? withHeadlessDeps,
   withCaca ? withFullDeps, # Textual display (ASCII art)
   withCdio ? withFullDeps && withGPL, # Audio CD grabbing
-  withCelt ? withFullDeps, # CELT decoder
+  withCelt ? withFullDeps && lib.versionOlder version "9.0", # CELT decoder, removed in 9.0
   withChromaprint ? withFullDeps, # Audio fingerprinting
   withCodec2 ? withFullDeps, # codec2 en/decoding
   withCuda ? withFullDeps && withNvcodec,
@@ -110,9 +110,11 @@
   withModplug ? withFullDeps && !stdenv.hostPlatform.isDarwin, # ModPlug support
   withMp3lame ? withHeadlessDeps, # LAME MP3 encoder
   withMysofa ? withFullDeps, # HRTF support via SOFAlizer
-  withNpp ? withFullDeps && withUnfree && config.cudaSupport, # Nvidia Performance Primitives-based code
+  # Nvidia Performance Primitives-based code, removed in 9.0
+  withNpp ? withFullDeps && withUnfree && config.cudaSupport && lib.versionOlder version "9.0",
   withNvdec ? withHeadlessDeps && withNvcodec,
   withNvenc ? withHeadlessDeps && withNvcodec,
+  withOnnxruntime ? false, # ONNX Runtime dnn backend, new in 9.0 (increases closure size by ~200 MB)
   withOpenal ? withFullDeps, # OpenAL 1.1 capture support
   withOpenapv ? withHeadlessDeps && lib.versionAtLeast version "8.0", # APV encoding support
   withOpencl ? withHeadlessDeps,
@@ -133,11 +135,20 @@
   withRubberband ? withFullDeps && withGPL && !stdenv.hostPlatform.isFreeBSD, # Rubberband filter
   withSamba ? withFullDeps && !stdenv.hostPlatform.isDarwin && withGPLv3, # Samba protocol
   withSdl2 ? withSmallDeps,
-  withShaderc ? withFullDeps && !stdenv.hostPlatform.isDarwin && lib.versionAtLeast version "5.0",
+  # Compiles the Vulkan shaders at runtime; 9.0 does it at build time instead,
+  # see withSpirvCompiler
+  withShaderc ?
+    withFullDeps
+    && !stdenv.hostPlatform.isDarwin
+    && lib.versionAtLeast version "5.0"
+    && lib.versionOlder version "9.0",
   withShine ? withFullDeps, # Fixed-point MP3 encoding
   withSnappy ? withFullDeps, # Snappy compression, needed for hap encoding
   withSoxr ? withHeadlessDeps, # Resampling via soxr
   withSpeex ? withHeadlessDeps, # Speex de/encoder
+  # glslc compiles the Vulkan shaders at build time; without it, 9.0 loses
+  # every Vulkan filter and encoder and several hwaccels
+  withSpirvCompiler ? withVulkan && lib.versionAtLeast version "9.0",
   withSrt ? withHeadlessDeps, # Secure Reliable Transport (SRT) protocol
   withSsh ? withHeadlessDeps, # SFTP protocol
   withSvg ? withFullDeps, # SVG protocol
@@ -322,6 +333,7 @@
   nv-codec-headers,
   nv-codec-headers-12,
   ocl-icd, # OpenCL ICD
+  onnxruntime,
   openal,
   openapv,
   opencl-headers, # OpenCL headers
@@ -341,6 +353,7 @@
   snappy,
   soxr,
   speex,
+  spirv-headers,
   srt,
   svt-av1,
   uavs3d,
@@ -427,6 +440,9 @@ assert buildSwscale -> buildAvutil;
 
 # External Library dependencies
 assert (withCuda || withCuvid || withNvdec || withNvenc) -> withNvcodec;
+assert withSpirvCompiler -> withVulkan;
+assert lib.versionAtLeast version "9.0" -> !(withCelt || withNpp || withShaderc);
+assert withOnnxruntime -> lib.versionAtLeast version "9.0";
 
 stdenv.mkDerivation (
   finalAttrs:
@@ -610,7 +626,11 @@ stdenv.mkDerivation (
       (enableFeature withBzlib "bzlib")
       (enableFeature withCaca "libcaca")
       (enableFeature withCdio "libcdio")
+    ]
+    ++ optionals (versionOlder version "9.0") [
       (enableFeature withCelt "libcelt")
+    ]
+    ++ [
       (enableFeature withChromaprint "chromaprint")
       (enableFeature withCodec2 "libcodec2")
       (enableFeature withCuda "cuda")
@@ -676,6 +696,11 @@ stdenv.mkDerivation (
       (enableFeature withNpp "libnpp")
       (enableFeature withNvdec "nvdec")
       (enableFeature withNvenc "nvenc")
+    ]
+    ++ optionals (versionAtLeast version "9.0") [
+      (enableFeature withOnnxruntime "libonnxruntime")
+    ]
+    ++ [
       (enableFeature withOpenal "openal")
     ]
     ++ optionals (versionAtLeast version "8.0") [
@@ -709,7 +734,7 @@ stdenv.mkDerivation (
       (enableFeature withSamba "libsmbclient")
       (enableFeature withSdl2 "sdl2")
     ]
-    ++ optionals (versionAtLeast version "5.0") [
+    ++ optionals (versionAtLeast version "5.0" && versionOlder version "9.0") [
       (enableFeature withShaderc "libshaderc")
     ]
     ++ [
@@ -806,6 +831,10 @@ stdenv.mkDerivation (
       "--cc=${stdenv.cc.targetPrefix}clang"
       "--cxx=${stdenv.cc.targetPrefix}clang++"
     ]
+    ++ optionals withSpirvCompiler [
+      # configure otherwise probes $PATH and takes whatever it finds
+      "--glslc=${lib.getExe' buildPackages.shaderc "glslc"}"
+    ]
     ++ optionals withCudaLLVM [
       # Unwrapped compiler because it will be retargeted and used freestanding with --cuda-device-only.
       "--nvcc=${lib.getExe buildPackages.clang.cc}"
@@ -825,9 +854,19 @@ stdenv.mkDerivation (
           map placeholder (lib.remove "data" finalAttrs.outputs) # We want to keep references to the data dir.
           ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) buildPackages.stdenv.cc
           ++ lib.optional withCudaLLVM buildPackages.clang.cc
+          ++ lib.optional withSpirvCompiler buildPackages.shaderc.bin
           ++ lib.optional withMetal xcode;
       in
-      "remove-references-to ${lib.concatMapStringsSep " " (o: "-t ${o}") toStrip} config.h";
+      "remove-references-to ${lib.concatMapStringsSep " " (o: "-t ${o}") toStrip} config.h"
+      # a glslc that doesn't work is not an error to configure, it just drops
+      # every Vulkan component from the build
+      + lib.optionalString (withSpirvCompiler && buildAvfilter) ''
+
+        grep -q 'define CONFIG_AVGBLUR_VULKAN_FILTER 1' config_components.h || {
+          echo "configure disabled spirv_compiler: glslc did not work" >&2
+          exit 1
+        }
+      '';
 
     strictDeps = true;
 
@@ -906,6 +945,7 @@ stdenv.mkDerivation (
         cuda_cudart
         cuda_nvcc
       ]
+      ++ optionals withOnnxruntime [ onnxruntime ]
       ++ optionals withOpenal [ openal ]
       ++ optionals withOpenapv [ openapv ]
       ++ optionals withOpencl [
@@ -960,6 +1000,8 @@ stdenv.mkDerivation (
         vulkan-headers
         vulkan-loader
       ]
+      # swscale's SPIR-V backend, new in 9.0
+      ++ optionals (withVulkan && versionAtLeast version "9.0") [ spirv-headers ]
       ++ optionals withVvenc [ vvenc ]
       ++ optionals withWebp [ libwebp ]
       ++ optionals withWhisper [ whisper-cpp ]
@@ -1100,4 +1142,7 @@ stdenv.mkDerivation (
       "zerocallusedregs"
     ];
   }
+  # required for new packages (NPV-166); versions < 9.0 stay unset to avoid
+  # rebuilding them
+  // lib.optionalAttrs (lib.versionAtLeast version "9.0") { __structuredAttrs = true; }
 )

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5591,6 +5591,9 @@ with pkgs;
     ffmpeg_8
     ffmpeg_8-headless
     ffmpeg_8-full
+    ffmpeg_9
+    ffmpeg_9-headless
+    ffmpeg_9-full
     ffmpeg
     ffmpeg-headless
     ffmpeg-full


### PR DESCRIPTION
FFmpeg 9.0 was tagged upstream on 2026-08-03. This adds `ffmpeg_9{,-headless,-full}`
alongside the existing majors. The `ffmpeg` alias stays on `ffmpeg_8`; moving it is
left for a later staging PR.

**Removed configure options.** 9.0 drops six external-library options. Three of
them we pass:

| option | configure on 9.0 | handling |
| --- | --- | --- |
| `libcelt` | hard error, even as `--disable-` | flag gated to < 9.0 |
| `libshaderc` | hard error, even as `--disable-` | flag gated to < 9.0, successor below |
| `libnpp` | accepted but warns: "removed and enabling it does nothing" | default gated to < 9.0 — otherwise `ffmpeg_9-full` with `cudaSupport` keeps pulling 420 MB of `cudaPackages.libnpp` for nothing |

The other three (`libglslang`, `omx`, `omx-rpi`) were never passed here. An
assert keeps explicit overrides of all three gated options from silently doing
nothing.

**Vulkan shaders are now compiled at build time** by a `glslc` binary instead of
runtime libshaderc. If configure can't run one, it silently disables
`spirv_compiler` and drops everything built from those shaders — all 18
`*_vulkan` filters plus the `ffv1_vulkan` and `prores_ks_vulkan` encoders. The
build still succeeds and configure has no flag to require the feature, so the
loss goes unnoticed. So:

- a new `withSpirvCompiler` option (following `withVulkan`) passes `--glslc=`
  explicitly from `buildPackages.shaderc`, instead of relying on the `$PATH`
  probe
- the store path is scrubbed from `config.h`, as already done for `--nvcc=`
- `postConfigure` fails the build if the Vulkan components didn't survive
  configure; pointing `--glslc=` at a nonexistent binary confirms the guard
  fires

Since shaderc is now build-time only, the Vulkan components land in every
variant at no runtime cost (on 8.x, `withShaderc` was `withFullDeps`-only
because it was a runtime dependency):

|  | vulkan filters | `lib` closure |
| --- | --- | --- |
| `ffmpeg_8` | 0 | 318.1 MB |
| `ffmpeg_9` | 18 | 319.2 MB |
| `ffmpeg_8-full` | 14 | 1562.8 MB |
| `ffmpeg_9-full` | 18 | 1563.4 MB |

`spirv-headers` joins `buildInputs` for 9.x (swscale's SPIR-V backend, warns if
missing); it leaves no runtime reference.

**ONNX Runtime** is the only new external library in 9.0, a DNN backend. Wired
as `withOnnxruntime`, default `false` like `withTensorflow`. Enabling it builds
and exposes the `onnx` backend on `dnn_processing`, at +197 MB `lib` closure.

**`__structuredAttrs` is enabled for 9.x** (required for new packages,
[NPV-166]); versions < 9.0 leave it unset so their drvs don't change. All three
variants build and pass FATE under it.

**FATE runs again on 9.x**, including `-full`: `doCheck` is only disabled by
`withShaderc` (#477464), which 9.x never has. 2892 tests pass in `ffmpeg_9` and
`-headless`, 2896 in `-full`.

**No rebuilds:** the drvs of `ffmpeg_{4,6,7,8}` and the unversioned aliases are
identical to master's.

[NPV-166]: https://github.com/NixOS/nixpkgs-vet/wiki/NPV-166

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Diff and PR text written with Claude Code (Claude Fable 5), reviewed by me.



