### PR TITLE
whisper-cpp: 1.8.7 -> 1.9.2

### DIFF
--- a/pkgs/by-name/wh/whisper-cpp/package.nix
+++ b/pkgs/by-name/wh/whisper-cpp/package.nix
@@ -81,13 +81,13 @@ let
 in
 effectiveStdenv.mkDerivation (finalAttrs: {
   pname = "whisper-cpp";
-  version = "1.8.7";
+  version = "1.9.2";
 
   src = fetchFromGitHub {
     owner = "ggml-org";
     repo = "whisper.cpp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-hzgO2IqV1+JQjiYBBmFSOLfp1BgH0DgU0TZyO7OzFHE=";
+    hash = "sha256-tW3UkERd/4PLpjSObBkZVqJPzue70oGeLDNiQDTDwSU=";
   };
 
   # The upstream download script tries to download the models to the
@@ -95,15 +95,6 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   # inside the nix store. This patch changes the script to download
   # the models to the current directory of where it is being run from.
   patches = [ ./download-models.patch ];
-
-  postPatch = ''
-    for target in examples/{bench,command,cli,quantize,server,stream,talk-llama}/CMakeLists.txt; do
-      if ! grep -q -F 'install('; then
-        echo 'install(TARGETS ''${TARGET} RUNTIME)' >> $target
-        ${lib.optionalString stdenv.hostPlatform.isDarwin "echo 'install(TARGETS whisper.coreml LIBRARY)' >> src/CMakeLists.txt"}
-      fi
-    done
-  '';
 
   nativeBuildInputs = [
     cmake
@@ -185,12 +176,8 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   installCheckPhase = ''
     runHook preInstallCheck
     "$out/bin/whisper-cli" --help >/dev/null
+    "$out/bin/parakeet-cli" --help >/dev/null
     runHook postInstallCheck
-  '';
-
-  postFixup = ''
-    substituteInPlace $out/lib/pkgconfig/whisper.pc \
-      --replace-fail '//' '/'
   '';
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* bump version: 1.8.7 -> 1.9.2
* remove `postPatch` and `postFixup` (no longer needed)
* note: 1.9.x includes support for NVIDIA parakeet (`parakeet-cli`)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
