### PR TITLE
yabai: restore LC_UUID on the scripting addition

### DIFF
--- a/pkgs/by-name/ya/yabai/package.nix
+++ b/pkgs/by-name/ya/yabai/package.nix
@@ -53,6 +53,11 @@ stdenv.mkDerivation (finalAttrs: {
   # `xcrun clang`. Collapse it to the host arch and use plain `clang`, since the
   # scripting addition (arm64e) is compiled in preBuild with the unwrapped clang,
   # which needs the SDK/clang/CUPS include paths passed explicitly.
+  #
+  # `-Wl,-no_uuid` is attached to BUILD_FLAGS, which upstream uses only for the
+  # main binary, whose LC_UUID is otherwise non-deterministic. The scripting
+  # addition must keep its LC_UUID, as dyld refuses to dlopen a Mach-O that
+  # lacks one, preventing the scripting addition from injecting.
   postPatch =
     let
       arch = stdenv.hostPlatform.darwinArch;
@@ -65,13 +70,12 @@ stdenv.mkDerivation (finalAttrs: {
         "-isystem ${lib.getDev cups}/include"
         "-F$(SDKROOT)/System/Library/Frameworks"
         "-L$(SDKROOT)/usr/lib"
-        "-Wl,-no_uuid"
       ];
     in
     ''
       substituteInPlace makefile \
         --replace-fail "-arch x86_64 -arch arm64e" "-arch ${archSA}" \
-        --replace-fail "-arch x86_64 -arch arm64" "-arch ${arch}" \
+        --replace-fail "-arch x86_64 -arch arm64" "-arch ${arch} -Wl,-no_uuid" \
         --replace-fail 'xcrun clang' 'clang ${clangFlags}'
     '';
 


### PR DESCRIPTION
3e76a1b13ed2 added `-Wl,-no_uuid` to the shared clang flags to make rebuilds reproducible. That flag also strips LC_UUID from the embedded scripting addition payload and loader, and dyld refuses to dlopen a Mach-O that doesn't have one.

we instead attach `-Wl,-no_uuid` to BUILD_FLAGS instead, which is used for the main binary only only for the main binary. The payload and loader, built separately in preBuild, keep their LC_UUID

This retains the reproducibility, as the main binary LC_UUID was the non-deterministic one.

Closes #547323

the issue was diagnosed with help from Claude Opus 5

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
