### PR TITLE
[26.05] kdePackages.plasma-login-manager: fix display reconnect recovery

### DIFF
--- a/pkgs/kde/plasma/plasma-login-manager/default.nix
+++ b/pkgs/kde/plasma/plasma-login-manager/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  fetchpatch,
   mkKdeDerivation,
   replaceVars,
   kwin,
@@ -13,6 +14,16 @@ mkKdeDerivation {
   patches = [
     ./config-mtime.patch
     ./config-path.patch
+
+    # Fix greeter and wallpaper recovery after display reconnect.
+    (fetchpatch {
+      url = "https://invent.kde.org/plasma/plasma-login-manager/-/commit/1c99b3b1f161ca880f8a8154d9258ced26ba7a7a.patch";
+      hash = "sha256-g3L7djHpdH6lECT+Of4RYeBzHRUmXxUjyO6oYwD22I8=";
+    })
+    (fetchpatch {
+      url = "https://invent.kde.org/plasma/plasma-login-manager/-/commit/0b4ea53ad4e31a49587199683ba0a6aca21caeea.patch";
+      hash = "sha256-4Ad5g/2z1nOdKTVhYQIpC0ORnMG8VW2xa8v4elbuGRQ=";
+    })
 
     (replaceVars ./kwin-path.patch {
       kwin_wayland = lib.getExe' kwin "kwin_wayland";


### PR DESCRIPTION
Backports two display reconnect fixes from Plasma 6.7.4 to the 6.6.6 package on `release-26.05`. They make the greeter and its wallpaper recover after all displays disappear and reconnect.

- [KDE bug 523313](https://bugs.kde.org/show_bug.cgi?id=523313)
- [Keep the greeter QML engine alive](https://invent.kde.org/plasma/plasma-login-manager/-/commit/1c99b3b1f161ca880f8a8154d9258ced26ba7a7a)
- [Recreate the wallpaper window](https://invent.kde.org/plasma/plasma-login-manager/-/commit/0b4ea53ad4e31a49587199683ba0a6aca21caeea)

Both fixes are listed in the [Plasma 6.7.4 changelog](https://kde.org/announcements/changelogs/plasma/6/6.7.3-6.7.4/) and reached nixpkgs `master` in #549118. The stable branch remains on Plasma 6.6.6, so this applies the two fixes instead of the full Plasma 6.7.4 update.

Both patches apply without offsets or fuzz. `nixpkgs-review` built the one affected package on aarch64-linux. Output reconnect was not retested as part of this change. The existing Plasma NixOS test uses X11 autologin and does not exercise the greeter or output hotplug.

Assisted-by: OpenAI Codex (GPT-5)

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
