### PR TITLE
factorio-experimental: 2.1.11 -> 2.1.12

### DIFF
--- a/pkgs/by-name/fa/factorio/versions.json
+++ b/pkgs/by-name/fa/factorio/versions.json
@@ -3,14 +3,14 @@
     "alpha": {
       "experimental": {
         "candidateHashFilenames": [
-          "factorio_linux_2.1.11.tar.xz"
+          "factorio_linux_2.1.12.tar.xz"
         ],
-        "name": "factorio_alpha_x64-2.1.11.tar.xz",
+        "name": "factorio_alpha_x64-2.1.12.tar.xz",
         "needsAuth": true,
-        "sha256": "da45e9d77b1824a04c1962f568351ed2adc84ea5f54c47a71c9888bb2e586669",
+        "sha256": "551765f1c0b3d7500cdfd86f6ee9811d081341f23326ee07d6cb8b649d890b0e",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.1.11/alpha/linux64",
-        "version": "2.1.11"
+        "url": "https://factorio.com/get-download/2.1.12/alpha/linux64",
+        "version": "2.1.12"
       },
       "stable": {
         "candidateHashFilenames": [
@@ -51,14 +51,14 @@
     "expansion": {
       "experimental": {
         "candidateHashFilenames": [
-          "factorio-space-age_linux_2.1.11.tar.xz"
+          "factorio-space-age_linux_2.1.12.tar.xz"
         ],
-        "name": "factorio_expansion_x64-2.1.11.tar.xz",
+        "name": "factorio_expansion_x64-2.1.12.tar.xz",
         "needsAuth": true,
-        "sha256": "6366cdfb2816d8aaddfc872fe99810e8a08c198bc0d3fe266abb16c63718d003",
+        "sha256": "abffbe356b15081017e0d319e4498210d162557cfc61aea0c425c892ffad3214",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.1.11/expansion/linux64",
-        "version": "2.1.11"
+        "url": "https://factorio.com/get-download/2.1.12/expansion/linux64",
+        "version": "2.1.12"
       },
       "stable": {
         "candidateHashFilenames": [
@@ -75,15 +75,15 @@
     "headless": {
       "experimental": {
         "candidateHashFilenames": [
-          "factorio-headless_linux_2.1.11.tar.xz",
-          "factorio_headless_x64_2.1.11.tar.xz"
+          "factorio-headless_linux_2.1.12.tar.xz",
+          "factorio_headless_x64_2.1.12.tar.xz"
         ],
-        "name": "factorio_headless_x64-2.1.11.tar.xz",
+        "name": "factorio_headless_x64-2.1.12.tar.xz",
         "needsAuth": false,
-        "sha256": "a11c63ccf7fc56538254b16df2640f6caead8abe1b87a3f7c970e33b60926196",
+        "sha256": "885ff029a40b0edd815cfe1fc13845f232723da1ea8fe9a83eae114d1eccd3fe",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.1.11/headless/linux64",
-        "version": "2.1.11"
+        "url": "https://factorio.com/get-download/2.1.12/headless/linux64",
+        "version": "2.1.12"
       },
       "stable": {
         "candidateHashFilenames": [


### PR DESCRIPTION
r-ryantm doesn't seem to be updating the `-experimental` packages for some reason (anyone know why?) so I ran the update script manually.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
