### PR TITLE
groff-full: init

### DIFF
--- a/pkgs/by-name/gr/groff-full/package.nix
+++ b/pkgs/by-name/gr/groff-full/package.nix
@@ -1,0 +1,14 @@
+{
+  groff,
+}@args:
+
+groff.override (
+  {
+    enableGhostscript = true;
+    enableHtml = true;
+    enableIconv = true;
+    enableLibuchardet = true;
+    enableUrwFonts = true;
+  }
+  // removeAttrs args [ "groff" ]
+)

--- a/pkgs/by-name/gr/groff/package.nix
+++ b/pkgs/by-name/gr/groff/package.nix
@@ -42,6 +42,7 @@ in
 stdenv.mkDerivation (finalAttrs: {
   pname = "groff";
   version = "1.24.1";
+  __structuredAttrs = true;
 
   src = fetchurl {
     url = "mirror://gnu/groff/groff-${finalAttrs.version}.tar.gz";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add `groff-full` package for folks interested in using groff typesetting capabilities beyond formatting manpages and wanting to avoid an almost full-system rebuild when doing a `groff.override { enableGhostscript = true; };` due to groff being such a low-level dependency.

In order to avoid many rebuilds that would require this PR to target `staging` I've added `__structuredAttrs = true;` to the new `groff-full` package via `overrideAttrs` and a comment to the `groff` package to update both accordingly (remove `__structuredAttrs` from `groff-full` and add to `groff`) on the next update to `groff`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
