### PR TITLE
python3Packages.gitpython: 3.1.57 -> 3.1.58

### DIFF
--- a/pkgs/development/python-modules/gitpython/default.nix
+++ b/pkgs/development/python-modules/gitpython/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "gitpython";
-  version = "3.1.57";
+  version = "3.1.58";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "gitpython-developers";
     repo = "GitPython";
     tag = finalAttrs.version;
-    hash = "sha256-pCGDKwIefGqx/UJaVqrsofc0t+ntqZRPMhsdbK2XBB0=";
+    hash = "sha256-C6hrN7SRWngwkD/NYvsoEVQUagdurkxzWbnn42EJOHE=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Updates GitPython to 3.1.58 as a follow-up to [#548847](https://redirect.github.com/NixOS/nixpkgs/pull/548847). This security release fixes five high- and one medium-severity advisories:

- [GHSA-hh9p-6wh2-4mfc](https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-hh9p-6wh2-4mfc)
- [GHSA-9rj7-rf2p-w77r](https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-9rj7-rf2p-w77r)
- [GHSA-4gmw-gg2m-w46p](https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-4gmw-gg2m-w46p)
- [GHSA-wvpp-8hx9-p66j](https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-wvpp-8hx9-p66j)
- [GHSA-jm78-9fvv-mhgr](https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-jm78-9fvv-mhgr)
- [GHSA-hmq2-w58f-27jc](https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-hmq2-w58f-27jc)

Changelog: https://redirect.github.com/gitpython-developers/GitPython/blob/3.1.58/doc/source/changes.rst

Both Python 3.13 and 3.14 packages build on the current `staging` merge state. Thirteen targeted upstream security regression tests pass on each interpreter. An explicit baseline/candidate probe confirms that 3.1.57 permits the six affected paths while 3.1.58 blocks them; the documented unsafe-option opt-out remains functional.

**Backport note:** This commit is not independently auto-backportable to 26.05 because it is based on the preceding 3.1.51 → 3.1.57 update. A manual stacked backport through 3.1.51, 3.1.57, and 3.1.58 is being prepared in [#548820](https://redirect.github.com/NixOS/nixpkgs/pull/548820). Please do not add an automatic backport label.

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
