### PR TITLE
xboard: 4.9.1 -> 4.9.1-unstable-2026-08-03

### DIFF
--- a/pkgs/by-name/xb/xboard/package.nix
+++ b/pkgs/by-name/xb/xboard/package.nix
@@ -1,8 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  fetchpatch,
+  fetchgit,
   libx11,
   xorgproto,
   libxt,
@@ -18,29 +17,26 @@
   librsvg,
   cairo,
   pango,
-  gtk2,
+  gtk3,
+  autoreconfHook,
+  perl,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xboard";
-  version = "4.9.1";
+  version = "4.9.1-unstable-2026-08-03";
 
-  src = fetchurl {
-    url = "mirror://gnu/xboard/xboard-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-Ky5T6EKK2bbo3IpVs6UYM4GRGk2uLABy+pYpa7sZcNY=";
+  src = fetchgit {
+    url = "https://https.git.savannah.gnu.org/git/xboard.git";
+    rev = "46b3c1d4ea45529cb2054516ff50feb902628d1c";
+    sha256 = "sha256-P21e6ikimEvm0k98RCeEuvC/ZVtWbosXzioOB18tUbI=";
   };
 
-  patches = [
-    # Pull patch pending upstream inclusion for -fno-common toolchain support:
-    #   https://savannah.gnu.org/patch/index.php?10211
-    (fetchpatch {
-      name = "fno-common.patch";
-      url = "https://savannah.gnu.org/patch/download.php?file_id=53275";
-      sha256 = "sha256-ZOo9jAy1plFjhC5HXJQvXL+Zf7FL14asV3G4AwfgqTY=";
-    })
+  nativeBuildInputs = [
+    pkg-config
+    autoreconfHook
+    perl
   ];
-
-  nativeBuildInputs = [ pkg-config ];
   buildInputs = [
     libx11
     xorgproto
@@ -56,8 +52,12 @@ stdenv.mkDerivation (finalAttrs: {
     librsvg
     cairo
     pango
-    gtk2
+    gtk3
   ];
+
+  preConfigure = ''
+    patchShebangs .
+  '';
 
   meta = {
     description = "GUI for chess engines";


### PR DESCRIPTION
Switch from gtk2 to gtk3

Upstream no longer does releases, but development is active

#410814 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
