### PR TITLE
ocinferno: init at 0.6.2-unstable-2026-08-03

### DIFF
--- a/pkgs/by-name/oc/ocinferno/package.nix
+++ b/pkgs/by-name/oc/ocinferno/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "ocinferno";
+  version = "0.6.2-unstable-2026-08-03";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "NetSPI";
+    repo = "OCInferno";
+    # https://github.com/NetSPI/OCInferno/issues/30
+    rev = "3cb32c783ad3a39ffc378005db8f0b30bb967be6";
+    hash = "sha256-dOemOE3+FOMQxQ7yseBbPjSLCoHQxl/3t7Y6mFfC3yI=";
+  };
+
+  pythonRelaxDeps = [ "oci" ];
+
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [
+    oci
+    oci-lexer-parser
+    pandas
+    prettytable
+    requests
+    xlsxwriter
+  ];
+
+  nativeCheckInputs = with python3Packages; [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "ocinferno" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tool for enumeration/download/graphical analysis of OCI content";
+    homepage = "https://github.com/NetSPI/OCInferno";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "ocinferno";
+  };
+})

--- a/pkgs/development/python-modules/oci-lexer-parser/default.nix
+++ b/pkgs/development/python-modules/oci-lexer-parser/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  antlr4-python3-runtime,
+  pytestCheckHook,
+  nix-update-script,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "oci-lexer-parser";
+  version = "0.1.2-unstable-2026-08-03";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "NetSPI";
+    repo = "oci-lexer-parser";
+    # https://github.com/NetSPI/oci-lexer-parser/issues/15
+    rev = "bc3c90c411009cf12ad44690d4ad2a0b172f9f1b";
+    hash = "sha256-AAOPMR94zH57pW5S8NAjzakXR3CyI5kLFXwfvOoOn4c=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ antlr4-python3-runtime ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "oci_lexer_parser" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Utility to convert OCI IAM Policy Statements and Dynamic Group Matching Rules to serialized JSON output";
+    homepage = "https://github.com/NetSPI/oci-lexer-parser";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12017,6 +12017,8 @@ self: super: with self; {
 
   oci = callPackage ../development/python-modules/oci { };
 
+  oci-lexer-parser = callPackage ../development/python-modules/oci-lexer-parser { };
+
   ocifs = callPackage ../development/python-modules/ocifs { };
 
   ocrmypdf = callPackage ../development/python-modules/ocrmypdf { tesseract = pkgs.tesseract5; };


### PR DESCRIPTION
Tool for enumeration/download/graphical analysis of OCI content

https://github.com/NetSPI/OCInferno

Related to https://github.com/NixOS/nixpkgs/issues/81418

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
