### PR TITLE
liteparse: minor cleanup

### DIFF
--- a/pkgs/by-name/li/liteparse/package.nix
+++ b/pkgs/by-name/li/liteparse/package.nix
@@ -65,6 +65,7 @@ in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "liteparse";
   version = "2.8.0";
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "run-llama";
@@ -77,9 +78,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mkdir -p .tesseract-rs/third_party
     ln -s ${leptonicaSrc} .tesseract-rs/third_party/leptonica
     ln -s ${tesseractSrc} .tesseract-rs/third_party/tesseract
-
-    # tesseract-rs builds leptonica/tesseract via cmake and expects libraries under
-    # lib/, while newer upstream sources may install to lib64 on some platforms.
+  ''
+  # tesseract-rs builds leptonica/tesseract via cmake and expects libraries under
+  # lib/, while newer upstream sources may install to lib64 on some platforms.
+  + ''
     tesseractRsBuildRs=$(echo "$cargoDepsCopy"/source-registry-*/tesseract-rs-*/build.rs)
     substituteInPlace "$tesseractRsBuildRs" \
       --replace-fail \
@@ -126,13 +128,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   env = {
     OPENSSL_NO_VENDOR = true;
-    PDFIUM_INCLUDE_PATH = "${pdfium}/include";
-    PDFIUM_LIB_PATH = "${pdfium}/lib";
+    PDFIUM_INCLUDE_PATH = "${lib.getInclude pdfium}/include";
+    PDFIUM_LIB_PATH = "${lib.getLib pdfium}/lib";
   };
 
   postInstall = ''
     wrapProgram $out/bin/lit \
-      --set PDFIUM_LIB_PATH "${pdfium}/lib" \
+      --set PDFIUM_LIB_PATH "${lib.getLib pdfium}/lib" \
       --set TESSDATA_PREFIX "${tesseract}/share/tessdata"
   '';
 


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
