### PR TITLE
python3Packages.dateparser: 1.4.1 -> 1.4.2

### DIFF
--- a/pkgs/development/python-modules/dateparser/default.nix
+++ b/pkgs/development/python-modules/dateparser/default.nix
@@ -18,6 +18,7 @@
   parsel,
   requests,
   ruamel-yaml,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -61,12 +62,9 @@ buildPythonPackage (finalAttrs: {
     parsel
     requests
     ruamel-yaml
+    writableTmpDirAsHomeHook
   ]
   ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
-
-  preCheck = ''
-    export HOME="$TEMPDIR"
-  '';
 
   # Upstream only runs the tests in tests/ in CI, others use git clone
   enabledTestPaths = [ "tests" ];

--- a/pkgs/development/python-modules/dateparser/default.nix
+++ b/pkgs/development/python-modules/dateparser/default.nix
@@ -22,7 +22,7 @@
 
 buildPythonPackage rec {
   pname = "dateparser";
-  version = "1.4.1";
+  version = "1.4.2";
 
   pyproject = true;
 
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     owner = "scrapinghub";
     repo = "dateparser";
     tag = "v${version}";
-    hash = "sha256-TA4GZb24++RF1sw4tECJF5UzouRCwwhPiim5z5/hMzU=";
+    hash = "sha256-ulwX8yLLXm3V4eldiK+j0XWzgrPepeWiA3BAjDJv9iM=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/dateparser/default.nix
+++ b/pkgs/development/python-modules/dateparser/default.nix
@@ -20,7 +20,7 @@
   ruamel-yaml,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "dateparser";
   version = "1.4.2";
 
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "scrapinghub";
     repo = "dateparser";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ulwX8yLLXm3V4eldiK+j0XWzgrPepeWiA3BAjDJv9iM=";
   };
 
@@ -62,7 +62,7 @@ buildPythonPackage rec {
     requests
     ruamel-yaml
   ]
-  ++ lib.concatAttrValues optional-dependencies;
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
 
   preCheck = ''
     export HOME="$TEMPDIR"
@@ -80,11 +80,11 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "dateparser" ];
 
   meta = {
-    changelog = "https://github.com/scrapinghub/dateparser/blob/${src.tag}/HISTORY.rst";
+    changelog = "https://github.com/scrapinghub/dateparser/blob/${finalAttrs.src.tag}/HISTORY.rst";
     description = "Date parsing library designed to parse dates from HTML pages";
     homepage = "https://github.com/scrapinghub/dateparser";
     license = lib.licenses.bsd3;
     mainProgram = "dateparser-download";
     maintainers = with lib.maintainers; [ dotlambda ];
   };
-}
+})

--- a/pkgs/development/python-modules/htmldate/default.nix
+++ b/pkgs/development/python-modules/htmldate/default.nix
@@ -5,6 +5,7 @@
   dateparser,
   faust-cchardet,
   fetchFromGitHub,
+  fetchpatch,
   lxml,
   pytestCheckHook,
   python-dateutil,
@@ -23,6 +24,15 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-3qtksgzqcgWtUv81Aqeh0nTWYnH0PjPLG4NuYChbV0g=";
   };
+
+  patches = [
+    # https://github.com/adbar/htmldate/pull/199
+    (fetchpatch {
+      name = "fix-tests-with-dateparser-1.4.2.patch";
+      url = "https://github.com/adbar/htmldate/commit/14c70c4944f1a6950bedaf8b6e46b6ec726984b8.patch";
+      hash = "sha256-rtRUk9lGsNQyOZ5RAjvMP5JRa4WGWdo0Xzh0OvskYPs=";
+    })
+  ];
 
   build-system = [ setuptools ];
 


### PR DESCRIPTION
Diff: https://github.com/scrapinghub/dateparser/compare/v1.4.1...v1.4.2

Changelog: https://github.com/scrapinghub/dateparser/blob/v1.4.2/HISTORY.rst


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
