### PR TITLE
python3Packages.paddle2onnx: 2.0.1 -> 2.1.0, build from source; py 3.13 support

### DIFF
--- a/pkgs/development/python-modules/paddle2onnx/cmake-external-deps.patch
+++ b/pkgs/development/python-modules/paddle2onnx/cmake-external-deps.patch
@@ -1,0 +1,29 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 816d78d..d5afa6f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -86,7 +86,7 @@ else()
+   add_library(paddle2onnx SHARED ${ALL_SRCS})
+ 
+   # add pybind11
+-  add_subdirectory(third_party/pybind11)
++  find_package(pybind11 CONFIG REQUIRED)
+ 
+   # add glog
+   if(MSVC)
+@@ -219,14 +219,7 @@ if(BUILD_PADDLE2ONNX_PYTHON)
+             ${PYTHON_INCLUDE_DIR}
+             ${PADDLE_INCLUDE_DIR})
+ 
+-  if(EXISTS
+-     ${PROJECT_SOURCE_DIR}/third_party/pybind11/include/pybind11/pybind11.h)
+-    target_include_directories(
+-      paddle2onnx_cpp2py_export
+-      PUBLIC ${PROJECT_SOURCE_DIR}/third_party/pybind11/include)
+-  else()
+-    message(FATAL_ERROR "cannot find pybind")
+-  endif()
++  target_link_libraries(paddle2onnx_cpp2py_export PUBLIC pybind11::headers)
+ 
+   if(APPLE)
+     set_target_properties(paddle2onnx_cpp2py_export

--- a/pkgs/development/python-modules/paddle2onnx/default.nix
+++ b/pkgs/development/python-modules/paddle2onnx/default.nix
@@ -1,42 +1,119 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   pythonOlder,
   pythonAtLeast,
   python,
+  cmake,
   onnx,
+  packaging,
   paddlepaddle,
+  protobuf_21,
+  pybind11,
+  setuptools,
+  setuptools-scm,
+  wheel,
 }:
 let
-  pname = "paddle2onnx";
-  version = "2.0.1";
-  format = "wheel";
-  pyShortVersion = "cp${builtins.replaceStrings [ "." ] [ "" ] python.pythonVersion}";
-  src = fetchPypi {
-    inherit pname version;
-    format = "wheel";
-    dist = pyShortVersion;
-    python = pyShortVersion;
-    abi = pyShortVersion;
-    platform = "manylinux_2_24_x86_64.manylinux_2_28_x86_64";
-    hash = "sha256-RCD6iTvzhGrFjW02lasTwQoM+Xa68Q5b6Ito3KvqdHg=";
+  version = "2.1.0";
+
+  # submodules compiled in, revisions from upstream .gitmodules
+  onnx-src = fetchFromGitHub {
+    owner = "onnx";
+    repo = "onnx";
+    rev = "990217f043af7222348ca8f0301e17fa7b841781";
+    hash = "sha256-mgYrY3IXUMgG/2/SjwMWAX0FneY+E8SpLDMnB9EUbF4=";
+  };
+
+  onnx-optimizer-src = fetchFromGitHub {
+    owner = "onnx";
+    repo = "optimizer";
+    rev = "b3a4611861734e0731bbcc2bed1f080139e4988b";
+    hash = "sha256-PIm039A/YccE5dRMXt1lptQ+kxxdQFtAdkZZQaiGo9c=";
+  };
+
+  # libpaddle.so exports its own bundled glog under `google::`, and those symbols
+  # interpose over ours. A newer glog links fine but segfaults on import.
+  glog-src = fetchFromGitHub {
+    owner = "google";
+    repo = "glog";
+    tag = "v0.4.0";
+    hash = "sha256-K3X199xY2uLDeNeScDufu1tRemF05ZwYrH25G6Oqo/U=";
   };
 in
 buildPythonPackage {
-  inherit
-    pname
-    version
-    src
-    format
-    ;
+  pname = "paddle2onnx";
+  inherit version;
+  pyproject = true;
 
-  disabled = pythonOlder "3.12" || pythonAtLeast "3.13";
+  src = fetchFromGitHub {
+    owner = "PaddlePaddle";
+    repo = "Paddle2ONNX";
+    tag = "v${version}";
+    hash = "sha256-EZDhQUI9WgLTsZx2bUC31JfMudI3hqjshAVkfnleXHI=";
+  };
+
+  disabled = pythonOlder "3.12" || pythonAtLeast "3.14";
+
+  # Use nixpkgs' pybind11 instead of the bundled copy.
+  patches = [ ./cmake-external-deps.patch ];
+
+  postPatch = ''
+    cp -r --no-preserve=mode ${onnx-src}/. third_party/onnx
+    cp -r --no-preserve=mode ${onnx-optimizer-src}/. third_party/optimizer
+    cp -r --no-preserve=mode ${glog-src}/. third_party/glog
+
+    # cmake locates libpaddle.so and paddle's headers by probing site-packages,
+    # which never turns up a PYTHONPATH dependency.
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "import site; print(';'.join(site.getsitepackages()))" \
+                     "print('${paddlepaddle}/${python.sitePackages}')"
+
+    substituteInPlace pyproject.toml \
+      --replace-fail '"cmake>=3.16",' "" \
+      --replace-fail '"paddlepaddle==3.0.0.dev20250426",' '"paddlepaddle",'
+  '';
+
+  build-system = [
+    paddlepaddle
+    setuptools
+    setuptools-scm
+    wheel
+  ];
+
+  # setup.py drives cmake itself.
+  dontUseCmakeConfigure = true;
+
+  nativeBuildInputs = [
+    cmake
+    protobuf_21
+  ];
+
+  buildInputs = [
+    protobuf_21
+    pybind11
+  ];
 
   dependencies = [
     onnx
+    packaging # imported by __init__.py, undeclared upstream
     paddlepaddle
   ];
+
+  env = {
+    # Without CMAKE_INSTALL_LIBDIR the vendored onnx fails to find libprotobuf
+    # next to protoc and tries to download its own copy.
+    CMAKE_ARGS = "-DCMAKE_INSTALL_LIBDIR=lib";
+    SETUPTOOLS_SCM_PRETEND_VERSION = version;
+  };
+
+  pythonRelaxDeps = [ "onnx" ];
+
+  # optional, imported lazily and skipped when missing
+  pythonRemoveDeps = [ "polygraphy" ];
+
+  pythonImportsCheck = [ "paddle2onnx" ];
 
   meta = {
     description = "ONNX Model Exporter for PaddlePaddle";
@@ -44,7 +121,10 @@ buildPythonPackage {
     changelog = "https://github.com/PaddlePaddle/Paddle2ONNX/releases/tag/v${version}";
     mainProgram = "paddle2onnx";
     license = lib.licenses.asl20;
-    platforms = [ "x86_64-linux" ];
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
     maintainers = with lib.maintainers; [ happysalada ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12727,7 +12727,7 @@ self: super: with self; {
 
   paddle-bfloat = callPackage ../development/python-modules/paddle-bfloat { };
 
-  paddle2onnx = callPackage ../development/python-modules/paddle2onnx { };
+  paddle2onnx = callPackage ../development/python-modules/paddle2onnx { inherit (pkgs) cmake; };
 
   paddleocr = callPackage ../development/python-modules/paddleocr { };
 


### PR DESCRIPTION
main motivation to build from source is to gain py 3.13 support

Changelog: https://github.com/PaddlePaddle/Paddle2ONNX/releases/tag/v2.1.0
Diff: https://github.com/PaddlePaddle/Paddle2ONNX/compare/v2.0.1...v2.1.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
