### PR TITLE
 comfyui: 0.29.0 -> 0.30.1 

### DIFF
--- a/pkgs/by-name/co/comfyui/package.nix
+++ b/pkgs/by-name/co/comfyui/package.nix
@@ -74,7 +74,7 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "comfyui";
-  version = "0.29.0";
+  version = "0.30.1";
 
   strictDeps = true;
   __structuredAttrs = true;
@@ -83,7 +83,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     owner = "Comfy-Org";
     repo = "ComfyUI";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-sbIsVBHfs8aPPmNDklbrqPnz5ekQUguIPjGm2v2WTis=";
+    hash = "sha256-z8bBKnW2iF8WXI3Ju6Ei+8YpOWqmbUgYiErKiVBBwEk=";
   };
 
   nativeBuildInputs = [ makeBinaryWrapper ];

--- a/pkgs/development/python-modules/comfy-aimdo/default.nix
+++ b/pkgs/development/python-modules/comfy-aimdo/default.nix
@@ -21,14 +21,14 @@ let
 in
 buildPythonPackage (finalAttrs: {
   pname = "comfy-aimdo";
-  version = "0.4.10";
+  version = "0.4.11";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Comfy-Org";
     repo = "comfy-aimdo";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-57z8NrEabc0RrTJavbdbpOZSLkNarPA2D+hZ+WUS4r4=";
+    hash = "sha256-i/1/j+VKikPrgltmaaDGGp2KOAUY5VzjowZJZDQAbow=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/comfy-kitchen/default.nix
+++ b/pkgs/development/python-modules/comfy-kitchen/default.nix
@@ -6,6 +6,7 @@
   cudaSupport ? config.cudaSupport,
   fetchFromGitHub,
   nanobind,
+  ninja,
   setuptools,
   torch,
   comfyui,
@@ -16,19 +17,15 @@ let
 in
 buildPythonPackage (finalAttrs: {
   pname = "comfy-kitchen";
-  version = "0.2.22";
+  version = "0.2.26";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Comfy-Org";
     repo = "comfy-kitchen";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-3neQWBLlB0bFQYbbkIy78eaBBwWQEdpUtDFIt0EIzb0=";
+    hash = "sha256-T/govRMiwiANbVXRizY4W3jz4iN8NuLyM0nVA990Lwg=";
   };
-
-  nativeBuildInputs = lib.optionals cudaSupport [
-    cmake
-  ];
 
   buildInputs = lib.optionals cudaSupport (
     with cudaPackages;
@@ -39,7 +36,9 @@ buildPythonPackage (finalAttrs: {
   );
 
   build-system = [
+    cmake
     nanobind
+    ninja
     setuptools
   ];
 

--- a/pkgs/development/python-modules/comfyui-frontend-package/default.nix
+++ b/pkgs/development/python-modules/comfyui-frontend-package/default.nix
@@ -8,13 +8,13 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "comfyui-frontend-package";
-  version = "1.47.10";
+  version = "1.47.12";
   pyproject = true;
 
   src = fetchPypi {
     pname = "comfyui_frontend_package";
     inherit (finalAttrs) version;
-    hash = "sha256-+nGk04r/AtHsoc+Rgg/NOe7+ErFlOlmFCNfFao1QlGo=";
+    hash = "sha256-exS4vZBbwZ3KlYTv6OVljZTJKjSg3td2x7ZAj/aAUXk=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/comfyui-workflow-templates-core/default.nix
+++ b/pkgs/development/python-modules/comfyui-workflow-templates-core/default.nix
@@ -8,13 +8,13 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "comfyui-workflow-templates-core";
-  version = "0.3.284";
+  version = "0.3.292";
   pyproject = true;
 
   src = fetchPypi {
     pname = "comfyui_workflow_templates_core";
     inherit (finalAttrs) version;
-    hash = "sha256-KNw2OqMz3AhK+kVpTjABIqGz9jDwqimN3xjs0w2jCfI=";
+    hash = "sha256-sUOd5A3U8XdbEZ/lyFD55oDKQ9qKCqDNNnpytk9DUVc=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/comfyui-workflow-templates-json/default.nix
+++ b/pkgs/development/python-modules/comfyui-workflow-templates-json/default.nix
@@ -8,13 +8,13 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "comfyui-workflow-templates-json";
-  version = "0.1.18";
+  version = "0.1.27";
   pyproject = true;
 
   src = fetchPypi {
     pname = "comfyui_workflow_templates_json";
     inherit (finalAttrs) version;
-    hash = "sha256-ukfUq3sFMzjQxHzK7rXVHuEU2nKrEbHkr84R8C9DZW0=";
+    hash = "sha256-rA9gikXDIskrknaHAWak3JffQGp3I+vXIY7cvVSH4D0=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/comfyui-workflow-templates-media-assets-01/default.nix
+++ b/pkgs/development/python-modules/comfyui-workflow-templates-media-assets-01/default.nix
@@ -8,13 +8,13 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "comfyui-workflow-templates-media-assets-01";
-  version = "0.1.12";
+  version = "0.1.17";
   pyproject = true;
 
   src = fetchPypi {
     pname = "comfyui_workflow_templates_media_assets_01";
     inherit (finalAttrs) version;
-    hash = "sha256-tacQwHCXNgBbG3POe7bAER3asMZxVj2YVSzuRH1W92A=";
+    hash = "sha256-wpa3o4tC6IztwBRNwSZTQP0itQpNzvAcGlViCz3zhKk=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/comfyui-workflow-templates/default.nix
+++ b/pkgs/development/python-modules/comfyui-workflow-templates/default.nix
@@ -15,13 +15,13 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "comfyui-workflow-templates";
-  version = "0.11.19";
+  version = "0.11.27";
   pyproject = true;
 
   src = fetchPypi {
     pname = "comfyui_workflow_templates";
     inherit (finalAttrs) version;
-    hash = "sha256-m+CuTEisHzMDvceaVesYLA5cDuNxpwR/ftunKkv4uj8=";
+    hash = "sha256-ct20s0Z61lY/xZb1pIIVvpaxaq/O94/x7DPFz6PqdOg=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
