### PR TITLE
pyinfra: 3.9.2 -> 3.10.0, add pyinfra-testing

### DIFF
--- a/pkgs/development/python-modules/pyinfra-testing/default.nix
+++ b/pkgs/development/python-modules/pyinfra-testing/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  uv-build,
+  freezegun,
+  pyyaml,
+}:
+
+buildPythonPackage rec {
+  pname = "pyinfra-testing";
+  version = "0.2.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "pyinfra_testing";
+    inherit version;
+    hash = "sha256-I5rR+Ew4pFYExoWmXSY/kqUDyiuEJ8jTASS4L8Gklx0=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.8.14,<0.9.0" uv_build
+  '';
+
+  build-system = [ uv-build ];
+
+  dependencies = [
+    freezegun
+    pyyaml
+  ];
+
+  pythonImportsCheck = [ "pyinfra_testing" ];
+
+  # the test suite needs pyinfra itself which depends on pyinfra-testing
+  doCheck = false;
+
+  meta = {
+    description = "Generate unittest tests for pyinfra facts and operations from data files";
+    homepage = "https://github.com/pyinfra-dev/pyinfra-testing";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.robsliwi ];
+  };
+}

--- a/pkgs/development/python-modules/pyinfra/default.nix
+++ b/pkgs/development/python-modules/pyinfra/default.nix
@@ -21,7 +21,7 @@
 
   # tests
   freezegun,
-  pyinfra-testgen,
+  pyinfra-testing,
   pytest-testinfra,
   pytestCheckHook,
   versionCheckHook,
@@ -29,7 +29,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pyinfra";
-  version = "3.9.2";
+  version = "3.10.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -37,7 +37,7 @@ buildPythonPackage (finalAttrs: {
     owner = "pyinfra-dev";
     repo = "pyinfra";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-5qgPfBtPqysEtNCLFAgGAxlVK/CRH9VYmiC/98VWomI=";
+    hash = "sha256-b1z6ZHt/fbDplJXZMx3/Ao/I9f4KHJcG1hmnWCLJJwY=";
   };
 
   build-system = [
@@ -60,8 +60,8 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [
     freezegun
-    pyinfra-testgen
     pytest-testinfra
+    pyinfra-testing
     pytestCheckHook
     versionCheckHook
   ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14805,6 +14805,8 @@ self: super: with self; {
 
   pyinfra-testgen = callPackage ../development/python-modules/pyinfra-testgen { };
 
+  pyinfra-testing = callPackage ../development/python-modules/pyinfra-testing { };
+
   pyinotify = callPackage ../development/python-modules/pyinotify { };
 
   pyinputevent = callPackage ../development/python-modules/pyinputevent { };


### PR DESCRIPTION
Update pyinfra to 3.10.0 ([changelog](https://github.com/pyinfra-dev/pyinfra/blob/v3.10.0/CHANGELOG.md)).

Highlights: lots of security fixes in user input quoting, a new `@fake` no-op execution connector, `--exclude` CLI argument to restrict target hosts, SSH fixes for ED25519-SK (FIDO2) keys, and the pathlib refactor.

This release migrated pyinfra's facts/operations test suite onto the new [pyinfra-testing](https://github.com/pyinfra-dev/pyinfra-testing) harness (upstream [#1878](https://github.com/pyinfra-dev/pyinfra/pull/1878)), so we add it as a new Python package:

- **pyinfra-testing 0.2.1** - follows the existing `pyinfra-testgen` package with `doCheck = false` because the sdist ships no tests and its test suite imports pyinfra itself (which would create a check-time cycle between pyinfra and pyinfra-testing).
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
