### PR TITLE
buzz-cli: init at 0.1.0-unstable-2026-08-27

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25933,6 +25933,11 @@
     name = "Otto Sabart";
     keys = [ { fingerprint = "0AF6 4C3B 1F12 14B3 8C8C  5786 1FA2 DBE6 7438 7CC3"; } ];
   };
+  sebfried = {
+    name = "Sebastian W. Friedrich";
+    github = "sebfried";
+    githubId = 35170732;
+  };
   sebimarkgraf = {
     email = "sebastian-markgraf@t-online.de";
     github = "sebimarkgraf";

--- a/pkgs/by-name/bu/buzz-cli/package.nix
+++ b/pkgs/by-name/bu/buzz-cli/package.nix
@@ -1,0 +1,49 @@
+{
+  cacert,
+  fetchFromGitHub,
+  lib,
+  rustPlatform,
+  stdenv,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "buzz-cli";
+  version = "0.1.0-unstable-2026-08-27";
+  __structuredAttrs = true;
+  __darwinAllowLocalNetworking = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "block";
+    repo = "buzz";
+    rev = "0808ab485c39c3c12ef02af2188c65a5145eb99d";
+    hash = "sha256-+vYRX6yZmyWxtpcaQj62ujmcG2uwo3fdaX5Oo6Q1jEE=";
+  };
+
+  cargoHash = "sha256-y067FJWvsJAe6mvtnLPSW1YK0/gcBrKuZX45OCO8/2U=";
+  cargoBuildFlags = [ "--package=buzz-cli" ];
+  cargoTestFlags = [ "--package=buzz-cli" ];
+
+  # reqwest initializes its rustls client in tests and needs a CA bundle.
+  nativeCheckInputs = [ cacert ];
+
+  env = lib.optionalAttrs (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) {
+    # Avoid nondeterministic LC_UUIDs emitted by ld64 on arm64.
+    RUSTFLAGS = "-C link-arg=-Wl,-no_uuid";
+  };
+
+  preBuild = ''
+    # Remap transient Nix build paths for reproducible output.
+    export RUSTFLAGS="--remap-path-prefix=$NIX_BUILD_TOP=/build ''${RUSTFLAGS:-}"
+    export NIX_CFLAGS_COMPILE="-ffile-prefix-map=$NIX_BUILD_TOP=/build ''${NIX_CFLAGS_COMPILE:-}"
+  '';
+
+  meta = {
+    description = "Agent-first CLI for Buzz relay";
+    homepage = "https://github.com/block/buzz";
+    license = lib.licenses.asl20;
+    mainProgram = "buzz";
+    maintainers = [ lib.maintainers.sebfried ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+}


### PR DESCRIPTION
Adds `buzz-cli`, the command-line client for [Buzz](https://github.com/block/buzz).

The package pins `0808ab485c39c3c12ef02af2188c65a5145eb99d` from 2026-08-27. A path-specific history check on 2026-08-29 found this to be the newest upstream commit touching `crates/buzz-cli`. Compared with the previous pin, it adds project-home support and per-candidate presence and profile hints to template-cardinality errors.

Upstream's workspace and CLI manifests changed, but its root `Cargo.lock` is byte-identical. The existing `cargoHash` is therefore retained, and the offline Cargo vendor consistency check passed on both native builds. The package continues to allow local networking for Darwin tests under a relaxed sandbox.

Validation of tree `f8fa31703629eb3d9887278d20e2a5e35d9894b0`:

- Native sandboxed build on `x86_64-linux`: 413 tests passed, 0 failed, plus 1 intentionally ignored doctest.
- Native build on `aarch64-darwin`: 413 tests passed, 0 failed, plus 1 intentionally ignored doctest. The local Darwin Nix daemon has sandboxing disabled.
- `buzz --help` passed from both final package outputs.
- Forced rebuild comparison with `nix-build --check` passed on both platforms.
- `nixpkgs-review` built one package, `buzz-cli`, on `x86_64-linux` for the complete PR diff.
- `nixpkgs-vet` passed after a clean synthetic merge with current `master`.
- Strict evaluation passed for `x86_64-linux` and `aarch64-darwin`; `nixfmt --check` and `git diff --check` also passed.

Automation/AI disclosure: OpenAI Codex (gpt-5.6-sol) materially assisted with the upstream comparison, package update, validation, commit preparation, and this pull request summary. It also coordinated a private Claude Code, Codex, and Grok review of the pin and validation scope. I, Sebastian W. Friedrich, reviewed the complete diff and validation evidence, understand the contribution, and accept responsibility for its correctness and licensing.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] Upstream Rust test suite via `cargoCheckHook`.
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR (`x86_64-linux`). See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
