### PR TITLE
binaryen: fetchSubmodules to keep tests in sync

### DIFF
--- a/pkgs/development/compilers/binaryen/default.nix
+++ b/pkgs/development/compilers/binaryen/default.nix
@@ -10,14 +10,6 @@
   nodejs,
   filecheck,
 }:
-let
-  testsuite = fetchFromGitHub {
-    owner = "WebAssembly";
-    repo = "testsuite";
-    rev = "4b24564c844e3d34bf46dfcb3c774ee5163e31cc";
-    hash = "sha256-8VirKLRro0iST58Rfg17u4tTO57KNC/7F/NB43dZ7w4=";
-  };
-in
 stdenv.mkDerivation rec {
   pname = "binaryen";
   version = "130";
@@ -26,7 +18,8 @@ stdenv.mkDerivation rec {
     owner = "WebAssembly";
     repo = "binaryen";
     rev = "version_${version}";
-    hash = "sha256-vwnW/5sKcVR20ys8V8ag66CUBcCjcufnn/ChxDFxd4k=";
+    fetchSubmodules = true;
+    hash = "sha256-1QPV7Btklq/2cOyMA8Z1EennQYvfZgqojiFbTjYo8iI=";
   };
 
   nativeBuildInputs = [
@@ -39,8 +32,8 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     if [ $doCheck -eq 1 ]; then
       sed -i '/gtest/d' third_party/CMakeLists.txt
-      rmdir test/spec/testsuite
-      ln -s ${testsuite} test/spec/testsuite
+      # prevent vendored headers from conflicting with the gtest from Nixpkgs
+      rm -rf third_party/googletest
       # scripts/test/finalize.py checks `'64' in input_path` to enable the
       # memory64/bigint flags; the full Nix build path leaks digits that
       # can accidentally contain "64", wrongly triggering those flags for


### PR DESCRIPTION
This PR addresses the issues pointed out in https://github.com/NixOS/nixpkgs/pull/547378#pullrequestreview-4830096205 by adding `fetchSubmodules = true` to `src`.

This package did use `fetchSubmodules = true` in the past, introduced by b50add8f56b03ea72bc92f668aee604eca10f804, but it was removed a day later by d531cd40af1f8385eb1f0c2384dc5a9e1ccb32db. Is there a good reason for not using it? The two possible reasons I can think of:

- The size of `src` goes up from 47 megabytes to 74 megabytes, with the difference being made up of things we don't use.

- The fetcher in `fetchFromGitHub` switches from `fetchzip` to `fetchgit`:

  https://github.com/NixOS/nixpkgs/blob/914077e9cc12b94b2887adeaaea10bde82d1d738/doc/build-helpers/fetchers.chapter.md?plain=1#L870-L873

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
