### PR TITLE
 python3Packages.wheelMetadataVersionPatchHook: init

### DIFF
--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -505,6 +505,19 @@ in
     ) { }
   );
 
+  wheelMetadataVersionPatchHook = callPackage (
+    { makePythonHook }:
+    makePythonHook {
+      name = "wheel-metadata-version-patch-hook.sh";
+      substitutions = {
+        inherit pythonInterpreter pythonSitePackages wheel;
+      };
+      meta = {
+        maintainers = [ lib.maintainers.dotlambda ];
+      };
+    } ./wheel-metadata-version-patch-hook.sh
+  ) { };
+
   wheelUnpackHook = callPackage (
     { makePythonHook, wheel }:
     makePythonHook {

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -510,7 +510,11 @@ in
     makePythonHook {
       name = "wheel-metadata-version-patch-hook.sh";
       substitutions = {
-        inherit pythonInterpreter pythonSitePackages wheel;
+        inherit pythonSitePackages wheel;
+        pythonInterpreter =
+          (pythonOnBuildForHost.withPackages (ps: [
+            ps.packaging
+          ])).interpreter;
       };
       meta = {
         maintainers = [ lib.maintainers.dotlambda ];

--- a/pkgs/development/interpreters/python/hooks/wheel-metadata-version-patch-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/wheel-metadata-version-patch-hook.sh
@@ -12,16 +12,26 @@ _patchMetadataVersion() {
         return 1
     fi
 
-    if grep -q "^Version: $version" "$metadata_file"; then
-        echo "Error: The version already matches the derivation's version. Remove this hook"
+    if ! grep -q "^Version:" "$metadata_file"; then
+        echo "Error: No patchable version specification found"
         return 1
     fi
 
-    if grep -q "^Version:" "$metadata_file"; then
+    local -r current_version=$(grep -P "^Version:" "$metadata_file" | cut -d ' ' -f 2-)
+
+    if PYTHONPATH="@wheel@/@pythonSitePackages@:$PYTHONPATH" @pythonInterpreter@ -c "
+      from packaging.version import Version
+      import sys
+
+      sys.exit(Version(sys.argv[1]) == Version(sys.argv[2]))
+    " "$current_version" "$version"; then
         sed -i -E "s/^(Version:).*/\1 $version/" "$metadata_file"
     else
-        echo "Error: No patchable version specification found"
+        echo "Error: The version already matches the derivation's version. Remove wheelMetadataVersionPatchHook"
+        return 1
     fi
+
+    sed -i -E "s/^(Version:).*/\1 $version/" "$metadata_file"
 }
 
 wheelMatadataVersionPatchPhase() {

--- a/pkgs/development/interpreters/python/hooks/wheel-metadata-version-patch-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/wheel-metadata-version-patch-hook.sh
@@ -1,0 +1,60 @@
+# Setup hook for patching version metadata of python packages.
+# mostly following `python-relax-deps-hook` implementation
+# shellcheck shell=bash
+
+echo "Sourcing wheel-metadata-version-patch-hook.sh"
+
+_patchMetadataVersion() {
+    local -r metadata_file="$1"
+
+    if [[ ! -f "$metadata_file" ]]; then
+        echo "Error: Metadata file not found at '$metadata_file'"
+        return 1
+    fi
+
+    if grep -q "^Version: $version" "$metadata_file"; then
+        echo "Error: The version already matches the derivation's version. Remove this hook"
+        return 1
+    fi
+
+    if grep -q "^Version:" "$metadata_file"; then
+        sed -i -E "s/^(Version:).*/\1 $version/" "$metadata_file"
+    else
+        echo "Error: No patchable version specification found"
+    fi
+}
+
+wheelMatadataVersionPatchPhase() {
+    pushd dist
+
+    local -r unpack_dir="unpacked"
+    local -r metadata_file="$unpack_dir/*/*.dist-info/METADATA"
+
+    # We generally shouldn't have multiple wheel files, but let's be safer here
+    for wheel in *".whl"; do
+
+        PYTHONPATH="@wheel@/@pythonSitePackages@:$PYTHONPATH" \
+            @pythonInterpreter@ -m wheel unpack --dest "$unpack_dir" "$wheel"
+        rm -rf "$wheel"
+
+        # Using no quotes on purpose since we need to expand the glob from `$metadata_file`
+        # shellcheck disable=SC2086
+        _patchMetadataVersion $metadata_file
+
+        if (("${NIX_DEBUG:-0}" >= 1)); then
+            echo "resulting METADATA for '$wheel':"
+            # shellcheck disable=SC2086
+            cat $metadata_file
+        fi
+
+        PYTHONPATH="@wheel@/@pythonSitePackages@:$PYTHONPATH" \
+            @pythonInterpreter@ -m wheel pack "$unpack_dir/"*
+    done
+
+    # Remove the folder since it will otherwise be in the dist output.
+    rm -rf "$unpack_dir"
+
+    popd
+}
+
+postBuild+=" wheelMatadataVersionPatchPhase"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Make `pyprojectVersionPatchHook` alter the wheel `METADATA` file directly, has discussed with @dotlambda 
- Rename to `wheelMetadataVersionPatchHook` to make the name reflect the behavior explicitly.
 
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
