### PR TITLE
cudaPackages: add some missing dynamic dependencies (dlopen)

### DIFF
--- a/pkgs/development/cuda-modules/packages/cuda_cupti.nix
+++ b/pkgs/development/cuda-modules/packages/cuda_cupti.nix
@@ -3,7 +3,7 @@
   buildRedist,
   lib,
 }:
-buildRedist {
+buildRedist (finalAttrs: {
   redistName = "cuda";
   pname = "cuda_cupti";
 
@@ -14,7 +14,13 @@ buildRedist {
     "lib"
     "samples"
   ]
-  ++ lib.optionals (backendStdenv.hostNixSystem == "x86_64-linux") [ "static" ];
+  # NOTE: declaring an output with nothing to move into it is a build failure, and which redist
+  # systems ship static archives has changed over time: linux-x86_64 always has, linux-sbsa only
+  # since 12.6.37, and linux-aarch64 (Jetson) and linux-ppc64le never have.
+  ++ lib.optionals (
+    backendStdenv.hostRedistSystem == "linux-x86_64"
+    || (backendStdenv.hostRedistSystem == "linux-sbsa" && lib.versionAtLeast finalAttrs.version "12.6")
+  ) [ "static" ];
 
   allowFHSReferences = true;
 
@@ -27,4 +33,4 @@ buildRedist {
     homepage = "https://docs.nvidia.com/cupti";
     changelog = "https://docs.nvidia.com/cupti/release-notes/release-notes.html";
   };
-}
+})

--- a/pkgs/development/cuda-modules/packages/cudnn-frontend/package.nix
+++ b/pkgs/development/cuda-modules/packages/cudnn-frontend/package.nix
@@ -21,8 +21,11 @@ let
   inherit (lib.lists) optionals;
   inherit (lib.strings)
     cmakeBool
+    escapeShellArg
     optionalString
     ;
+  compileFeatures = "target_compile_features(cudnn_frontend INTERFACE cxx_std_17)";
+  linkCudart = "target_link_libraries(cudnn_frontend INTERFACE CUDA::cudart)";
 in
 backendStdenv.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
@@ -50,6 +53,31 @@ backendStdenv.mkDerivation (finalAttrs: {
       --replace-fail \
         '#include "cudnn_frontend/thirdparty/nlohmann/json.hpp"' \
         '#include <nlohmann/json.hpp>'
+  ''
+  # Upstream resolves CUDAToolkit at configure time and freezes the result into the exported target
+  # as a bare absolute path, while its config file never forwards the dependency. Consumers then
+  # inherit a build-machine path -- under Nixpkgs, cuda_nvcc's include, a nativeBuildInput -- instead
+  # of resolving the toolkit themselves. Confine the path to the build and export the dependency, so
+  # consumers re-run find_package(CUDAToolkit) in their own environment. This matters beyond the
+  # closure: on CUDA 12 crt/ lives in cuda_nvcc, and cuda_runtime_api.h includes it, so consumers
+  # that do not otherwise pull in the toolkit would fail to compile.
+  # NOTE: the multi-line replacements are built as Nix strings with explicit newlines, so the
+  # formatter cannot reindent them into the substitution.
+  + ''
+    nixLog "patching $PWD/CMakeLists.txt to export CUDAToolkit as a dependency rather than a path"
+    substituteInPlace ./CMakeLists.txt \
+      --replace-fail \
+        '    ''${CUDAToolkit_INCLUDE_DIRS}' \
+        '    $<BUILD_INTERFACE:''${CUDAToolkit_INCLUDE_DIRS}>' \
+      --replace-fail \
+        ${escapeShellArg compileFeatures} \
+        ${escapeShellArg "${linkCudart}\n${compileFeatures}"}
+
+    nixLog "patching $PWD/cudnn_frontend-config.cmake.in to forward the CUDAToolkit dependency"
+    substituteInPlace ./cudnn_frontend-config.cmake.in \
+      --replace-fail \
+        '@PACKAGE_INIT@' \
+        ${escapeShellArg "@PACKAGE_INIT@\n\ninclude(CMakeFindDependencyMacro)\nfind_dependency(CUDAToolkit)"}
   '';
 
   # TODO: As a header-only library, we should make sure we have an `include` directory or similar which is not a

--- a/pkgs/development/cuda-modules/packages/cudnn.nix
+++ b/pkgs/development/cuda-modules/packages/cudnn.nix
@@ -45,8 +45,11 @@ buildRedist (
 
     # CuDNN depends on libnvrtc.so at runtime, as mentioned here in one small error description
     # https://docs.nvidia.com/deeplearning/cudnn/backend/latest/api/cudnn-graph-library.html
-    appendRunpaths = [
-      "${lib.getLib cuda_nvrtc}/lib"
+    # libcudnn_adv and libcudnn_engines_precompiled dlopen libcublasLt -- the soname lives in
+    # .rodata and is never DT_NEEDED, so the buildInputs entry above never reaches a runpath.
+    appendRunpaths = map (pkg: "${lib.getLib pkg}/lib") [
+      cuda_nvrtc # libnvrtc.so.%s
+      libcublas # libcublasLt.so.%s
     ];
 
     # NOTE:

--- a/pkgs/development/cuda-modules/packages/gdrcopy.nix
+++ b/pkgs/development/cuda-modules/packages/gdrcopy.nix
@@ -8,6 +8,7 @@
   fetchFromGitHub,
   flags,
   lib,
+  removeReferencesTo,
   # passthru.updateScript
   gitUpdater,
 }:
@@ -35,6 +36,7 @@ backendStdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cuda_nvcc
+    removeReferencesTo
   ];
 
   postPatch = ''
@@ -84,6 +86,23 @@ backendStdenv.mkDerivation (finalAttrs: {
     # NOTE: We cannot use `all` because it includes the driver, which needs the driver source code.
     "lib"
     "exes"
+  ];
+
+  # Since CUDA 13, gdrcopy_pplat -- the only test built with relocatable device code -- embeds the
+  # nvlink command line, naming the store paths of both nvcc and the cudart supplying cudadevrt.
+  # Neither is needed at runtime: no binary here has libcudart in DT_NEEDED, and libcuda.so.1 comes
+  # from the driver. Same leak as nccl's; see https://github.com/NixOS/nixpkgs/pull/457803
+  postFixup = ''
+    remove-references-to \
+      -t "${lib.getBin cuda_nvcc}" \
+      -t "${lib.getLib cuda_cudart}" \
+      "$out"/bin/*
+  '';
+
+  # C.f. remove-references-to above. Ensure *all* such references are removed.
+  disallowedRequisites = [
+    (lib.getBin cuda_nvcc)
+    (lib.getLib cuda_cudart)
   ];
 
   # Tests require gdrdrv be installed (don't know how to communicate dependency on the driver).

--- a/pkgs/development/cuda-modules/packages/libcublas.nix
+++ b/pkgs/development/cuda-modules/packages/libcublas.nix
@@ -1,7 +1,16 @@
-{ buildRedist }:
-buildRedist {
+{
+  buildRedist,
+  cuda_nvrtc,
+  lib,
+}:
+buildRedist (finalAttrs: {
   redistName = "cuda";
   pname = "libcublas";
+
+  # libcublasLt dlopens NVRTC to compile kernels at runtime; absent before 12.8.
+  appendRunpaths = lib.optionals (lib.versionAtLeast finalAttrs.version "12.8") [
+    "${lib.getLib cuda_nvrtc}/lib" # libnvrtc.so.%s
+  ];
 
   outputs = [
     "out"
@@ -19,4 +28,4 @@ buildRedist {
     '';
     homepage = "https://developer.nvidia.com/cublas";
   };
-}
+})

--- a/pkgs/development/cuda-modules/packages/libcufft.nix
+++ b/pkgs/development/cuda-modules/packages/libcufft.nix
@@ -1,7 +1,22 @@
-{ buildRedist }:
+{
+  buildRedist,
+  cuda_nvrtc,
+  cudaAtLeast,
+  lib,
+  libnvjitlink,
+}:
 buildRedist {
   redistName = "cuda";
   pname = "libcufft";
+
+  # dlopen'd for LTO callbacks (cufftXtSetJITCallback, CUFFT_FORCE_LTO). Gated because libnvjitlink
+  # does not exist before CUDA 12.0, and 11.x libcufft references neither soname.
+  appendRunpaths = lib.optionals (cudaAtLeast "12.0") (
+    map (pkg: "${lib.getLib pkg}/lib") [
+      cuda_nvrtc # libnvrtc.so.%s
+      libnvjitlink # libnvJitLink.so.%s
+    ]
+  );
 
   outputs = [
     "out"

--- a/pkgs/development/cuda-modules/packages/libcufile.nix
+++ b/pkgs/development/cuda-modules/packages/libcufile.nix
@@ -2,8 +2,11 @@
   buildRedist,
   cudaOlder,
   lib,
+  liburcu,
   numactl,
   rdma-core,
+  systemdLibs,
+  util-linux,
 }:
 buildRedist {
   redistName = "cuda";
@@ -23,6 +26,15 @@ buildRedist {
   buildInputs = [
     numactl
     rdma-core
+  ];
+
+  # dlopen'd by libcufile.so, which is why the buildInputs above do not cover it. Note the
+  # unversioned sonames: the providing output must carry the .so symlink.
+  appendRunpaths = map (pkg: "${lib.getLib pkg}/lib") [
+    systemdLibs # libudev.so
+    util-linux # libmount.so
+    liburcu # liburcu-bp.so, liburcu-cds.so
+    numactl # libnuma.so.%s
   ];
 
   # Before 11.7 libcufile depends on itself for some reason.

--- a/pkgs/development/cuda-modules/packages/libcuobjclient.nix
+++ b/pkgs/development/cuda-modules/packages/libcuobjclient.nix
@@ -2,6 +2,7 @@
   buildRedist,
   libcufile,
   numactl,
+  rdma-core,
 }:
 buildRedist {
   redistName = "cuda";
@@ -17,6 +18,9 @@ buildRedist {
   buildInputs = [
     libcufile
     numactl
+    # NOTE: DT_NEEDED, but until now resolved only because auto-patchelf harvests the runpath of
+    # libcufile's libcufile_rdma.so, which happens to point at rdma-core.
+    rdma-core # libibverbs.so.1, librdmacm.so.1, libmlx5.so.1
   ];
 
   meta = {

--- a/pkgs/development/cuda-modules/packages/libcusolver.nix
+++ b/pkgs/development/cuda-modules/packages/libcusolver.nix
@@ -35,5 +35,10 @@ buildRedist {
       Optimization applications.
     '';
     homepage = "https://developer.nvidia.com/cusolver";
+    # The static output vendors METIS 5.1.0 (lib/libmetis_static.a).
+    license = [
+      lib.licenses.nvidiaCudaRedist
+      lib.licenses.asl20
+    ];
   };
 }

--- a/pkgs/development/cuda-modules/packages/libcusparse.nix
+++ b/pkgs/development/cuda-modules/packages/libcusparse.nix
@@ -17,6 +17,15 @@ buildRedist {
     "stubs"
   ];
 
+  # Through 12.6.3.3 libnvJitLink is DT_NEEDED and the buildInputs entry below covers it; from
+  # 12.7.3.1 it is dlopen'd instead, so it needs a runpath. Unconditional from 12.0 because the
+  # entry is a no-op on the releases which already resolve it. 12.7.x asks for the unversioned
+  # soname, so the providing output must carry the .so symlink. Gated like the buildInputs entry:
+  # libnvjitlink does not exist before CUDA 12.0, and libcusparse does not reference it there.
+  appendRunpaths = lib.optionals (cudaAtLeast "12.0") [
+    "${lib.getLib libnvjitlink}/lib" # libnvJitLink.so, libnvJitLink.so.%s
+  ];
+
   buildInputs =
     # Dependency from 12.0 and on
     lib.optionals (cudaAtLeast "12.0") [ libnvjitlink ];

--- a/pkgs/development/cuda-modules/packages/libcusparse_lt.nix
+++ b/pkgs/development/cuda-modules/packages/libcusparse_lt.nix
@@ -2,8 +2,8 @@
   _cuda,
   buildRedist,
   cuda_cudart,
+  cuda_nvrtc,
   lib,
-  libcublas,
 }:
 buildRedist (finalAttrs: {
   redistName = "cusparselt";
@@ -17,11 +17,15 @@ buildRedist (finalAttrs: {
     "static"
   ];
 
-  buildInputs = [
-    (lib.getLib libcublas)
-  ]
-  # For some reason, the 1.4.x release of cusparselt requires the cudart library.
-  ++ lib.optionals (lib.hasPrefix "1.4" finalAttrs.version) [ (lib.getLib cuda_cudart) ];
+  # libcusparseLt dlopens NVRTC (the CASK kernel compiler) from 0.8.
+  appendRunpaths = lib.optionals (lib.versionAtLeast finalAttrs.version "0.8") [
+    "${lib.getLib cuda_nvrtc}/lib" # libnvrtc.so.%s
+  ];
+
+  # NOTE: libcusparseLt does not reference libcublas at all, so it is deliberately not an input.
+  buildInputs =
+    # For some reason, the 1.4.x release of cusparselt requires the cudart library.
+    lib.optionals (lib.hasPrefix "1.4" finalAttrs.version) [ (lib.getLib cuda_cudart) ];
 
   meta = {
     description = "High-performance CUDA library dedicated to general matrix-matrix operations in which at least one operand is a structured sparse matrix with 50% sparsity ratio";

--- a/pkgs/development/cuda-modules/packages/libnvshmem.nix
+++ b/pkgs/development/cuda-modules/packages/libnvshmem.nix
@@ -1,5 +1,6 @@
 {
   _cuda,
+  autoAddDriverRunpath,
   backendStdenv,
   buildPackages,
   cmake,
@@ -21,6 +22,7 @@
   mpi,
   nccl,
   ninja,
+  patchelf,
   pmix,
   python3Packages,
   rdma-core,
@@ -48,7 +50,9 @@ let
     getLib
     licenses
     maintainers
+    makeLibraryPath
     optional
+    optionalString
     optionals
     teams
     ;
@@ -72,9 +76,13 @@ backendStdenv.mkDerivation (finalAttrs: {
   outputs = [ "out" ];
 
   nativeBuildInputs = [
+    # libnvshmem_host dlopens libcuda.so.1 and libnvidia-ml.so.1 by bare soname
+    # (src/host/init/{cudawrap,nvmlwrap}.cpp).
+    autoAddDriverRunpath
     cuda_nvcc
     cmake
     ninja
+    patchelf
 
     # NOTE: Python is required even if not building nvshmem4py:
     # https://github.com/NVIDIA/nvshmem/blob/131da55f643ac87c810ba0bc51d359258bf433a1/CMakeLists.txt#L173
@@ -189,28 +197,53 @@ backendStdenv.mkDerivation (finalAttrs: {
     mv -v "$out"/{changelog,git_commit.txt,License.txt,version.txt} "$out/share/"
   '';
 
-  # cmake_config/NVSHMEMEnv.cmake:156 bakes every -D*_HOME we pass into NVSHMEM_BUILD_VARS, a
-  # diagnostic banner that nvshmem-info and init.cu only print. Nix still counts the store paths, so
-  # build-only inputs become runtime dependencies -- and the banner is substituted into an installed
-  # header, so consumers inherit them too. Only the dev outputs and nvcc are stripped: gdrcopy and
-  # mpi appear in the same string but are genuine runtime dependencies. No disallowedRequisites
-  # guard here, unlike nccl and gdrcopy, because ucx and openmpi pull nvcc in on their own.
-  postFixup = ''
-    nixLog "removing build-time references baked into NVSHMEM_BUILD_VARS"
-    remove-references-to ${
-      concatMapStringsSep " " (p: ''-t "${p}"'') (
-        [ (getBin cuda_nvcc) ]
-        ++ optional withNccl (getDev nccl)
-        ++ optional withUcx (getDev ucx)
-        ++ optional withLibfabric (getDev libfabric)
-        ++ optional withPmix (getDev pmix)
-      )
-    } \
-      "$out"/bin/nvshmem-info \
-      "$out"/lib/libnvshmem_host.so.*.* \
-      "$out"/include/non_abi/nvshmem_version.h \
-      "$out"/share/src/*/include/non_abi/nvshmem_version.h
-  '';
+  # These are all dlopen'd by bare soname, so buildInputs alone never reaches a RUNPATH. The contrast
+  # is visible within this package: ibgda links libmlx5.so.1 and so does pick up rdma-core, while
+  # ibrc -- the default transport -- only dlopens libibverbs.so.1 and would get nothing.
+  postFixup =
+    # Skips entries already present, so ibgda does not end up with rdma-core twice.
+    ''
+      addMissing() {
+        local elf=$1 rp d
+        shift
+        rp=$(patchelf --print-rpath "$elf")
+        for d in "$@"; do [[ ":$rp:" == *":$d:"* ]] || rp=''${rp:+$rp:}$d; done
+        patchelf --set-rpath "$rp" "$elf"
+      }
+    ''
+    + ''
+      nixLog "adding dlopen'd transport libraries to the transport plugins' runpath"
+      for transport in "$out"/lib/nvshmem_transport_*.so.*.*; do
+        addMissing "$transport" ${makeLibraryPath ([ rdma-core ] ++ optional withGdrcopy gdrcopy)}
+      done
+    ''
+    # libnvshmem_host dlopens libnccl.so.2 for host-side collectives (src/host/coll/cpu_coll.cpp).
+    + optionalString withNccl ''
+      nixLog "adding nccl to libnvshmem_host's runpath"
+      addMissing "$out"/lib/libnvshmem_host.so.*.* "${getLib nccl}/lib"
+    ''
+    # cmake_config/NVSHMEMEnv.cmake:156 bakes every -D*_HOME we pass into NVSHMEM_BUILD_VARS, a
+    # diagnostic banner that nvshmem-info and init.cu only print. Nix still counts the store paths, so
+    # build-only inputs become runtime dependencies -- and the banner is substituted into an installed
+    # header, so consumers inherit them too. Only the dev outputs and nvcc are stripped: gdrcopy and
+    # mpi appear in the same string but are genuine runtime dependencies. No disallowedRequisites
+    # guard here, unlike nccl and gdrcopy, because ucx and openmpi pull nvcc in on their own.
+    + ''
+      nixLog "removing build-time references baked into NVSHMEM_BUILD_VARS"
+      remove-references-to ${
+        concatMapStringsSep " " (p: ''-t "${p}"'') (
+          [ (getBin cuda_nvcc) ]
+          ++ optional withNccl (getDev nccl)
+          ++ optional withUcx (getDev ucx)
+          ++ optional withLibfabric (getDev libfabric)
+          ++ optional withPmix (getDev pmix)
+        )
+      } \
+        "$out"/bin/nvshmem-info \
+        "$out"/lib/libnvshmem_host.so.*.* \
+        "$out"/include/non_abi/nvshmem_version.h \
+        "$out"/share/src/*/include/non_abi/nvshmem_version.h
+    '';
 
   doCheck = false;
 

--- a/pkgs/development/cuda-modules/packages/libnvshmem.nix
+++ b/pkgs/development/cuda-modules/packages/libnvshmem.nix
@@ -24,6 +24,7 @@
   pmix,
   python3Packages,
   rdma-core,
+  removeReferencesTo,
   ucx,
   # passthru.updateScript
   gitUpdater,
@@ -40,6 +41,7 @@ let
   inherit (lib)
     cmakeBool
     cmakeFeature
+    concatMapStringsSep
     getBin
     getDev
     getExe
@@ -77,6 +79,7 @@ backendStdenv.mkDerivation (finalAttrs: {
     # NOTE: Python is required even if not building nvshmem4py:
     # https://github.com/NVIDIA/nvshmem/blob/131da55f643ac87c810ba0bc51d359258bf433a1/CMakeLists.txt#L173
     python3Packages.python
+    removeReferencesTo
   ]
   ++ optionals withMpi [
     # NOTE: mpi is in nativeBuildInputs because it contains compilers and is only discoverable by CMake
@@ -184,6 +187,29 @@ backendStdenv.mkDerivation (finalAttrs: {
   postInstall = ''
     nixLog "moving top-level files in $out to $out/share"
     mv -v "$out"/{changelog,git_commit.txt,License.txt,version.txt} "$out/share/"
+  '';
+
+  # cmake_config/NVSHMEMEnv.cmake:156 bakes every -D*_HOME we pass into NVSHMEM_BUILD_VARS, a
+  # diagnostic banner that nvshmem-info and init.cu only print. Nix still counts the store paths, so
+  # build-only inputs become runtime dependencies -- and the banner is substituted into an installed
+  # header, so consumers inherit them too. Only the dev outputs and nvcc are stripped: gdrcopy and
+  # mpi appear in the same string but are genuine runtime dependencies. No disallowedRequisites
+  # guard here, unlike nccl and gdrcopy, because ucx and openmpi pull nvcc in on their own.
+  postFixup = ''
+    nixLog "removing build-time references baked into NVSHMEM_BUILD_VARS"
+    remove-references-to ${
+      concatMapStringsSep " " (p: ''-t "${p}"'') (
+        [ (getBin cuda_nvcc) ]
+        ++ optional withNccl (getDev nccl)
+        ++ optional withUcx (getDev ucx)
+        ++ optional withLibfabric (getDev libfabric)
+        ++ optional withPmix (getDev pmix)
+      )
+    } \
+      "$out"/bin/nvshmem-info \
+      "$out"/lib/libnvshmem_host.so.*.* \
+      "$out"/include/non_abi/nvshmem_version.h \
+      "$out"/share/src/*/include/non_abi/nvshmem_version.h
   '';
 
   doCheck = false;

--- a/pkgs/development/cuda-modules/packages/nccl.nix
+++ b/pkgs/development/cuda-modules/packages/nccl.nix
@@ -1,5 +1,6 @@
 {
   _cuda,
+  autoAddDriverRunpath,
   backendStdenv,
   cccl,
   cuda_cudart,
@@ -8,12 +9,18 @@
   cudaNamePrefix,
   fetchFromGitHub,
   flags,
+  gdrcopy,
   lib,
+  patchelf,
   python3,
+  rdma-core,
   removeReferencesTo,
   which,
   # passthru.updateScript
   gitUpdater,
+
+  withGdrcopy ? true,
+  withRdmaCore ? true,
 }:
 let
   inherit (_cuda.lib) _mkMetaBadPlatforms;
@@ -27,6 +34,8 @@ let
     getLib
     licenses
     maintainers
+    makeLibraryPath
+    optional
     optionalString
     teams
     versionAtLeast
@@ -74,7 +83,11 @@ backendStdenv.mkDerivation (finalAttrs: {
   ];
 
   nativeBuildInputs = [
+    # libnccl dlopens libnvidia-ml.so.1 (src/os/linux.cc), and the statically linked CUDA runtime
+    # (src/Makefile: CUDARTLIB ?= cudart_static) dlopens libcuda.so.1, both by bare soname.
+    autoAddDriverRunpath
     cuda_nvcc
+    patchelf
     python3
     removeReferencesTo
     which
@@ -137,6 +150,15 @@ backendStdenv.mkDerivation (finalAttrs: {
     remove-references-to -t "${lib.getBin cuda_nvcc}" \
       ''${!outputLib}/lib/libnccl.so.* \
       ''${!outputStatic}/lib/*.a
+  ''
+  # makefiles/common.mk sets RDMA_CORE=0 and MLX5DV=0, so libibverbs/libmlx5/libgdrapi are dlopen'd
+  # rather than DT_NEEDED and buildInputs would not reach the runpath. Losing them is quiet: NCCL
+  # logs at INFO and falls back to the socket transport.
+  + optionalString (withRdmaCore || withGdrcopy) ''
+    nixLog "adding dlopen'd transport libraries to libnccl's runpath"
+    patchelf --add-rpath "${
+      makeLibraryPath (optional withRdmaCore rdma-core ++ optional withGdrcopy gdrcopy)
+    }" "''${!outputLib:?}"/lib/libnccl.so.*.*
   '';
 
   # C.f. remove-references-to above. Ensure *all* references to cuda_nvcc are removed


### PR DESCRIPTION
> [!NOTE]
> This PR was created with assistance from Claude Opus 5.

Reviewed 19 components from CUDA redist and their dependencies/dlopens. Some packages are fine and didn't need modifications.

Changed — 11 of 19
                                                                        
- cuda_cupti
- cudnn
- libcublas
- libcufile
- libcuobjclient
- libcusolver
- libcusparse
- libcusparse_lt
- libnvshmem
- nccl

No change needed — 8 of 19                                                                                               
                                                                                                                           
- cuda_cccl
- cuda_cudart
- cuda_nvcc
- cuda_nvrtc
- cuda_nvtx
- cuda_profiler_api
- libcurand
- libnvjitlink

Other files were changed to reduce unnecessary propagation of dependencies.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
