### PR TITLE
gittype: 0.10.0 -> 0.10.1

### DIFF
--- a/pkgs/by-name/gi/gittype/package.nix
+++ b/pkgs/by-name/gi/gittype/package.nix
@@ -7,6 +7,7 @@
   openssl,
   libgit2,
   libssh2,
+  cacert,
   gitMinimal,
   versionCheckHook,
   nix-update-script,
@@ -14,16 +15,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "gittype";
-  version = "0.10.0";
+  version = "0.10.1";
 
   src = fetchFromGitHub {
     owner = "unhappychoice";
     repo = "gittype";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-pzJWXVCGUn85OCHMRlMY5ufrGyJyuhhkYLUk4e01Ri0=";
+    hash = "sha256-9FzmL+52cOmaYR6sZYC9+rme7wAqtf6aHZHWs1cy/Y4=";
   };
 
-  cargoHash = "sha256-E1LKaiTClHmrF7zhGEj1rfELKryIiyVKIf/8Rozm1RQ=";
+  cargoHash = "sha256-XMcLJ2aD1QUoQt0F3szWfHSX0zQ4k9V8yJPLtv8ljj4=";
 
   nativeBuildInputs = [ pkg-config ];
 
@@ -37,23 +38,31 @@ rustPlatform.buildRustPackage (finalAttrs: {
     OPENSSL_NO_VENDOR = 1;
     LIBGIT2_NO_VENDOR = 1;
     LIBSSH2_SYS_USE_PKG_CONFIG = 1;
+    SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
   };
 
   nativeCheckInputs = [ gitMinimal ];
 
-  checkFlags = [
-    "--skip=unit::domain::services::challenge_generator::challenge_generator_tests::"
-  ]
-  ++ lib.optionals stdenvNoCC.hostPlatform.isDarwin [
-    "--skip=unit::domain::services::scoring::tracker::stage::test_pause_resume"
-    "--skip=unit::domain::services::scoring::calculator::stage::test_calculate_with_pauses"
-    "--skip=unit::domain::services::scoring::calculator::stage::test_pause_resume"
-  ];
+  checkFlags = lib.forEach (
+    [
+      "unit::infrastructure::git::remote_git_repository_client_test::tests::"
+      "unit::domain::services::challenge_generator::challenge_generator_tests::"
+      "unit::domain::models::loading::cloning_step_execute_tests::execute_uses_complete_cached_repository"
+      "unit::domain::models::loading::extracting_step_execute_tests::execute_returns_no_supported_files_when_all_files_are_filtered_out"
+      "unit::domain::models::loading::step_manager_tests::execute_pipeline_propagates_scanning_error_without_loading_screen"
+    ]
+    ++ lib.optionals stdenvNoCC.hostPlatform.isDarwin [
+      "unit::domain::services::scoring::tracker::stage::test_pause_resume"
+      "unit::domain::services::scoring::calculator::stage::test_calculate_with_pauses"
+      "unit::domain::services::scoring::calculator::stage::test_pause_resume"
+    ]
+  ) (test: "--skip=${test}");
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
+  strictDeps = true;
   __structuredAttrs = true;
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
