### PR TITLE
python3Packages.django_6: respect NIX_BUILD_CORES during test

### DIFF
--- a/pkgs/development/python-modules/django/6.nix
+++ b/pkgs/development/python-modules/django/6.nix
@@ -127,8 +127,7 @@ buildPythonPackage (finalAttrs: {
     runHook preCheck
 
     pushd tests
-    # without --parallel=1, tests fail with an "unexpected error due to a database lock" on Darwin
-    ${python.interpreter} runtests.py --settings=test_sqlite ${lib.optionalString stdenv.hostPlatform.isDarwin "--parallel=1"}
+    ${python.interpreter} runtests.py --settings=test_sqlite --parallel=$NIX_BUILD_CORES
     popd
 
     runHook postCheck


### PR DESCRIPTION
https://hydra.nixos.org/build/340763801

Not respecting the scheduling can lead to issues like this on hydra.

```pytb
FAIL: test_crafted_xml_performance (serializers.test_deserialization.TestDeserializer.test_crafted_xml_performance) [varying depth, varying length]
The time to process invalid inputs is not quadratic.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/nix/store/41m77i1296n33p6liin8ynr6wh3h6b7m-python3-3.14.6/lib/python3.14/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/nix/store/41m77i1296n33p6liin8ynr6wh3h6b7m-python3-3.14.6/lib/python3.14/unittest/case.py", line 565, in subTest
    yield
  File "/build/source/tests/serializers/test_deserialization.py", line 182, in assertFactor
    self.assertLessEqual(sum(factors) / len(factors), factor)
    ^^^^^^^
  File "/nix/store/41m77i1296n33p6liin8ynr6wh3h6b7m-python3-3.14.6/lib/python3.14/unittest/case.py", line 1303, in assertLessEqual
    self.fail(self._formatMessage(msg, standardMsg))
    ^^^^^^^^^^^
  File "/nix/store/41m77i1296n33p6liin8ynr6wh3h6b7m-python3-3.14.6/lib/python3.14/unittest/case.py", line 750, in fail
    raise self.failureException(msg)
    ^^^^^^^^^^^^^^^
AssertionError: 4.4416589666711195 not less than or equal to 2
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
