### PR TITLE
ansipath: init at 0.1.1

### DIFF
--- a/pkgs/by-name/an/ansipath/package.nix
+++ b/pkgs/by-name/an/ansipath/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "ansipath";
+  version = "0.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "averyfreeman";
+    repo = "ansipath";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0BIkl1uM/WYm/xUUL1le+Lv3QGPg3/n9F1bav4Ux1nc=";
+  };
+
+  build-system = [ python3Packages.hatchling ];
+
+  pythonImportsCheck = [ "ansipath" ];
+
+  meta = {
+    description = "A colorized diagnostic view of shell PATH entries";
+    homepage = "https://github.com/averyfreeman/ansipath";
+    changelog = "https://github.com/averyfreeman/ansipath/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "ansipath";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform
  - [x] aarch64-darwin
- [x] Tested the installed executable with a controlled PATH (`/usr/bin:/bin`)

The package is pinned to the GPL-3.0-only `v0.1.1` release source with a fixed hash.


###### Note for maintainers

Please tag @averyfreeman for review.