### PR TITLE
lame: 3.100 -> 4.0

### DIFF
--- a/pkgs/by-name/la/lame/export-hip-pinfo-symbols.patch
+++ b/pkgs/by-name/la/lame/export-hip-pinfo-symbols.patch
@@ -1,0 +1,18 @@
+Export hip_set_pinfo and hip_finish_pinfo.
+
+The frontend (get_audio.c) links against these symbols when built with
+--enable-analyzer-hooks, but they were missing from the -export-symbols
+list, so linking the lame binary failed. Fixed in upstream SVN trunk
+after the 4.0 release.
+
+--- a/include/libmp3lame.sym
++++ b/include/libmp3lame.sym
+@@ -188,6 +188,8 @@ hip_decode_exit
+ hip_set_errorf
+ hip_set_debugf
+ hip_set_msgf
++hip_set_pinfo
++hip_finish_pinfo
+ hip_decode
+ hip_decode_headers
+ hip_decode1

--- a/pkgs/by-name/la/lame/fix-setlocale-without-iconv.patch
+++ b/pkgs/by-name/la/lame/fix-setlocale-without-iconv.patch
@@ -1,0 +1,18 @@
+Guard setlocale() the same way as its header include.
+
+Upstream SVN r6590. parse.c includes <locale.h> only when both
+HAVE_ICONV and HAVE_LANGINFO_H are defined, but the setlocale() call
+was guarded on HAVE_LANGINFO_H alone, breaking the build on systems
+that have langinfo.h but no working iconv (e.g. macOS).
+
+--- a/frontend/parse.c
++++ b/frontend/parse.c
+@@ -1619,7 +1619,7 @@
+     enum TextEncoding id3_tenc = TENC_LATIN1;
+ #endif
+ 
+-#ifdef HAVE_LANGINFO_H
++#if defined(HAVE_ICONV) && defined(HAVE_LANGINFO_H)
+     setlocale(LC_CTYPE, "");
+ #endif
+     inPath[0] = '\0';

--- a/pkgs/by-name/la/lame/fix-utf8-id3-tag.patch
+++ b/pkgs/by-name/la/lame/fix-utf8-id3-tag.patch
@@ -1,0 +1,156 @@
+frontend, libmp3lame: fix ID3v2 UTF-8 tag path (SF #524).
+
+Upstream SVN r6562. The ID3v2 tag writer routed both the UTF-8 and
+UTF-16 command-line encodings through a single path typed for UTF-16.
+For --id3v2-utf8 that mismatches the actual byte-oriented data and
+reaches tag setters GCC 15 rejects as incompatible-pointer-types,
+so LAME fails to build with GCC 15.
+
+Give each encoding its own path so the data and the setters it feeds
+match. The test infrastructure changes are omitted as they do not
+exist in the 4.0 release tarball.
+
+--- a/frontend/parse.c
++++ b/frontend/parse.c
+@@ -402,41 +402,45 @@
+ }
+ 
+ #ifdef ID3TAGS_EXTENDED
++/* Set an ID3v2 tag field from UTF-16 data. The data pointer is genuinely
++   UTF-16 here, so the UTF-16 id3tag_* setters are used throughout. */
+ static int
+-set_id3v2tag(lame_global_flags* gfp, TextEncoding enc, int type, unsigned short const* str)
++set_id3v2tag_utf16(lame_global_flags* gfp, int type, unsigned short const* str)
+ {
+-    switch (enc)
++    switch (type)
+     {
+-        case TENC_UTF8:
+-            switch (type)
+-            {
+-                case 'a': return id3tag_set_textinfo_utf8(gfp, "TPE1", str);
+-                case 't': return id3tag_set_textinfo_utf8(gfp, "TIT2", str);
+-                case 'l': return id3tag_set_textinfo_utf8(gfp, "TALB", str);
+-                case 'g': return id3tag_set_textinfo_utf8(gfp, "TCON", str);
+-                case 'c': return id3tag_set_comment_ucs2(gfp, 0, 0, str);
+-                case 'n': return id3tag_set_textinfo_utf8(gfp, "TRCK", str);
+-                case 'y': return id3tag_set_textinfo_utf8(gfp, "TYER", str);
+-                case 'v': return id3tag_set_fieldvalue_ucs2(gfp, str);
+-            }
+-            ;;
+-        case TENC_UTF16:
+-            switch (type)
+-            {
+-                case 'a': return id3tag_set_textinfo_utf16(gfp, "TPE1", str);
+-                case 't': return id3tag_set_textinfo_utf16(gfp, "TIT2", str);
+-                case 'l': return id3tag_set_textinfo_utf16(gfp, "TALB", str);
+-                case 'g': return id3tag_set_textinfo_utf16(gfp, "TCON", str);
+-                case 'c': return id3tag_set_comment_utf16(gfp, 0, 0, str);
+-                case 'n': return id3tag_set_textinfo_utf16(gfp, "TRCK", str);
+-                case 'y': return id3tag_set_textinfo_utf16(gfp, "TYER", str);
+-                case 'v': return id3tag_set_fieldvalue_utf16(gfp, str);
+-            }
+-            ;;
+-        default:
+-            return -3;
++        case 'a': return id3tag_set_textinfo_utf16(gfp, "TPE1", str);
++        case 't': return id3tag_set_textinfo_utf16(gfp, "TIT2", str);
++        case 'l': return id3tag_set_textinfo_utf16(gfp, "TALB", str);
++        case 'g': return id3tag_set_textinfo_utf16(gfp, "TCON", str);
++        case 'c': return id3tag_set_comment_utf16(gfp, 0, 0, str);
++        case 'n': return id3tag_set_textinfo_utf16(gfp, "TRCK", str);
++        case 'y': return id3tag_set_textinfo_utf16(gfp, "TYER", str);
++        case 'v': return id3tag_set_fieldvalue_utf16(gfp, str);
+     }
++    return -3;
+ }
++
++/* Set an ID3v2 tag field from UTF-8 data. The data pointer is a UTF-8 char
++   string (not UTF-16 as the old, mistyped single handler assumed), so the
++   UTF-8 id3tag_* setters are used - including id3tag_set_fieldvalue_utf8 for
++   'v', which replaces the removed *_ucs2 calls the UTF-8 path used to make. */
++static int
++set_id3v2tag_utf8(lame_global_flags* gfp, int type, char const* str)
++{
++    switch (type)
++    {
++        case 'a': return id3tag_set_textinfo_utf8(gfp, "TPE1", str);
++        case 't': return id3tag_set_textinfo_utf8(gfp, "TIT2", str);
++        case 'l': return id3tag_set_textinfo_utf8(gfp, "TALB", str);
++        case 'g': return id3tag_set_textinfo_utf8(gfp, "TCON", str);
++        case 'c': return id3tag_set_comment_utf8(gfp, 0, 0, str);
++        case 'n': return id3tag_set_textinfo_utf8(gfp, "TRCK", str);
++        case 'y': return id3tag_set_textinfo_utf8(gfp, "TYER", str);
++        case 'v': return id3tag_set_fieldvalue_utf8(gfp, str);
++    }
++    return -3;
++}
+ #endif
+ 
+ static int
+@@ -480,8 +484,8 @@
+         default:
+ #ifdef ID3TAGS_EXTENDED
+         case TENC_LATIN1: result = set_id3tag(gfp, type, x);   break;
+-        case TENC_UTF16:  result = set_id3v2tag(gfp, enc, type, x); break;
+-        case TENC_UTF8:   result = set_id3v2tag(gfp, enc, type, x); break;
++        case TENC_UTF16:  result = set_id3v2tag_utf16(gfp, type, x); break;
++        case TENC_UTF8:   result = set_id3v2tag_utf8(gfp, type, x);  break;
+ #else
+         case TENC_RAW:    result = set_id3tag(gfp, type, x);   break;
+ #endif
+--- a/include/lame.h
++++ b/include/lame.h
+@@ -1297,6 +1297,9 @@
+ int CDECL id3tag_set_fieldvalue_utf16(lame_t gfp, const unsigned short *fieldvalue);
+ 
+ /* experimental */
++int CDECL id3tag_set_fieldvalue_utf8(lame_t gfp, const char *fieldvalue);
++
++/* experimental */
+ int CDECL id3tag_set_textinfo_utf16(lame_t gfp, char const *id, unsigned short const *text);
+ 
+ /* experimental */
+--- a/include/lame.def
++++ b/include/lame.def
+@@ -306,3 +306,6 @@
+ ; two external functions for ID3v2.4 tag support
+ id3tag_add_v2_4_UTF8 @2029
+ id3tag_v2_4_UTF8_only @2030
++
++; UTF-8 field-value setter (companion to id3tag_set_fieldvalue_utf16)
++id3tag_set_fieldvalue_utf8 @2031
+--- a/include/libmp3lame.sym
++++ b/include/libmp3lame.sym
+@@ -229,6 +229,7 @@
+ id3tag_set_comment_ucs2
+ id3tag_set_fieldvalue_ucs2
+ id3tag_set_fieldvalue_utf16
++id3tag_set_fieldvalue_utf8
+ id3tag_set_textinfo_utf16
+ id3tag_set_comment_utf16
+ id3tag_set_textinfo_utf8
+--- a/libmp3lame/id3tag.c
++++ b/libmp3lame/id3tag.c
+@@ -1844,6 +1844,21 @@
+     return id3tag_set_fieldvalue_utf16(gfp, fieldvalue);
+ }
+ 
++int
++id3tag_set_fieldvalue_utf8(lame_t gfp, const char *fieldvalue)
++{
++    if (is_lame_internal_flags_null(gfp)) {
++        return 0;
++    }
++    if (fieldvalue && *fieldvalue) {
++        if (strlen(fieldvalue) < 5 || fieldvalue[4] != '=') {
++            return -1;
++        }
++        return id3tag_set_textinfo_utf8(gfp, fieldvalue, &fieldvalue[5]);
++    }
++    return 0;
++}
++
+ size_t
+ lame_get_id3v2_tag(lame_t gfp, unsigned char *buffer, size_t size)
+ {

--- a/pkgs/by-name/la/lame/package.nix
+++ b/pkgs/by-name/la/lame/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  pkg-config,
   nasmSupport ? true,
   nasm, # Assembly optimizations
   cpmlSupport ? true, # Compaq's fast math library
@@ -10,6 +11,7 @@
   libsndfile, # Use libsndfile, instead of lame's internal routines
   analyzerHooksSupport ? true, # Use analyzer hooks
   decoderSupport ? true, # mpg123 decoder
+  libmpg123,
   frontendSupport ? true, # Build the lame executable
   #, mp3xSupport ? false, gtk1 # Build GTK frame analyzer
   mp3rtpSupport ? false, # Build mp3rtp
@@ -18,11 +20,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lame";
-  version = "3.100";
+  version = "4.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/lame/lame-${finalAttrs.version}.tar.gz";
-    sha256 = "07nsn5sy3a8xbmw1bidxnsj5fj6kg9ai04icmqw40ybkp353dznx";
+    hash = "sha256-PfUSTVrTqYMS/9e6aps2Iw5Pij5m084PQl4zbDLSFus=";
   };
 
   outputs = [
@@ -32,13 +34,23 @@ stdenv.mkDerivation (finalAttrs: {
   ]; # a small single header
   outputMan = "out";
 
-  nativeBuildInputs = [ ] ++ lib.optional nasmSupport nasm;
+  patches = [
+    # fix ID3v2 UTF-8 tag path to avoid incompatible-pointer-types
+    # with GCC 15; upstream SVN r6562, SF bug #524
+    ./fix-utf8-id3-tag.patch
+    # setlocale() is used under HAVE_LANGINFO_H, but <locale.h> was only
+    # included together with HAVE_ICONV, breaking the build on macOS;
+    # upstream SVN r6590
+    ./fix-setlocale-without-iconv.patch
+    # hip_set_pinfo/hip_finish_pinfo are used by the frontend but were missing
+    # from the exported symbol list, breaking the link with analyzer hooks
+    # enabled; upstream SVN r6564, SF bug #515
+    ./export-hip-pinfo-symbols.patch
+  ];
 
-  buildInputs =
-    [ ]
-    #++ optional efenceSupport libefence
-    #++ optional mp3xSupport gtk1
-    ++ lib.optional sndfileFileIOSupport libsndfile;
+  nativeBuildInputs = [ pkg-config ] ++ lib.optional nasmSupport nasm;
+
+  buildInputs = lib.optional decoderSupport libmpg123 ++ lib.optional sndfileFileIOSupport libsndfile;
 
   configureFlags = [
     (lib.enableFeature nasmSupport "nasm")
@@ -54,15 +66,9 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.optionalString debugSupport "--enable-debug=alot")
   ];
 
-  preConfigure = ''
-    # Prevent a build failure for 3.100 due to using outdated symbol list
-    # https://hydrogenaud.io/index.php/topic,114777.msg946373.html#msg946373
-    sed -i '/lame_init_old/d' include/libmp3lame.sym
-  '';
-
   meta = {
     description = "High quality MPEG Audio Layer III (MP3) encoder";
-    homepage = "http://lame.sourceforge.net";
+    homepage = "https://lame.sourceforge.io";
     license = lib.licenses.lgpl2;
     maintainers = [ ];
     platforms = lib.platforms.all;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
