### PR TITLE
gomarkdoc: restore checks on Go 1.26

### DIFF
--- a/pkgs/by-name/go/gomarkdoc/package.nix
+++ b/pkgs/by-name/go/gomarkdoc/package.nix
@@ -21,10 +21,12 @@ buildGoModule (finalAttrs: {
 
   vendorHash = "sha256-gCuYqk9agH86wfGd7k6QwLUiG3Mv6TrEd9tdyj8AYPs=";
 
-  # Tests call gomarkdoc's main() directly, which reads GOFLAGS from the
-  # environment. nixpkgs sets GOFLAGS=-mod=vendor, but gomarkdoc's own flag
-  # parser only accepts -tags, so -mod triggers "flag provided but not defined".
-  doCheck = false;
+  # Go 1.26 resolves this field reference while generating the command golden.
+  postPatch = ''
+    substituteInPlace testData/docs/README.md \
+      --replace-fail 'GetField gets \[\*AnotherStruct.Field\].' \
+      'GetField gets [\\\*AnotherStruct.Field](<#AnotherStruct>).'
+  '';
 
   ldflags = [
     "-s"


### PR DESCRIPTION
Closes #516481.

`gomarkdoc` 1.1.0’s command tests generate Markdown from fixture packages and compare it with expected output.

With Go 1.26, one field reference is rendered as a documentation link instead of escaped plain text. We can update that expected line and remove `doCheck = false` so the existing `cmd/gomarkdoc` tests run again.

The `GOFLAGS` and missing-config messages reported in the issue aren’t the failing assertion. Testing showed that removing `-mod=vendor` or creating `.gomarkdoc-empty.yml` doesn’t fix the Go 1.26 failure. The failing assertion is the generated-Markdown mismatch.

The existing `subPackages = [ "cmd/gomarkdoc" ]` selection remains unchanged. This doesn’t change the package version, source hash, vendor hash, Go toolchain, linker flags, or installed program.

## Validation

The same package-file change was tested on:

- x86_64-linux:
  - `cmd/gomarkdoc` tests passed;
  - `gomarkdoc --help` passed;
  - the version test reported `1.1.0`;
  - `nixpkgs-review` built the affected package.
- aarch64-darwin:
  - `cmd/gomarkdoc` tests passed;
  - help and version checks passed;
  - the checks-enabled executable matched the checks-disabled executable byte-for-byte.
- Go 1.27rc2:
  - command tests, help, and version checks passed.

The current commit applies the same one-file change to a newer Nixpkgs `master` revision. Tests for the current commit are pending.

Automation disclosure: ChatGPT using GPT-5.6 Thinking assisted with source analysis, test planning, review, and drafting. I reviewed the change and evidence and am responsible for the contribution.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests.
  - [ ] Package tests at `passthru.tests`.
  - [ ] Tests in `lib/tests` or `pkgs/test` for functions and core functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [ ] Tested basic functionality of all binary files, usually in `./result/bin`.
- Nixpkgs Release Notes:
  - [ ] Package update when the change is major or breaking.
- NixOS Release Notes:
  - [ ] Module addition when adding a new NixOS module.
  - [ ] Module update when the change is significant.
- [x] Fits the Nixpkgs contribution guidelines and relevant READMEs.
- [x] Follows the automation/AI policy.