### PR TITLE
lazarus: 4.4 -> 4.8; gtk2 -> gtk3

### DIFF
--- a/pkgs/development/compilers/fpc/lazarus.nix
+++ b/pkgs/development/compilers/fpc/lazarus.nix
@@ -5,11 +5,12 @@
   makeWrapper,
   writeText,
   fpc,
-  gtk2,
+  gtk3,
   glib,
   pango,
   atk,
   gdk-pixbuf,
+  harfbuzz,
   libxi,
   xorgproto,
   libx11,
@@ -27,7 +28,7 @@
 #  1. the build date is embedded in the binary through `$I %DATE%` - we should dump that
 
 let
-  version = "4.4-0";
+  version = "4.8-0";
 
   # as of 2.0.10 a suffix is being added. That may or may not disappear and then
   # come back, so just leave this here.
@@ -43,7 +44,7 @@ let
     )
   );
 
-  LCL_PLATFORM = if withQt then "qt${qtVersion}" else "gtk2";
+  LCL_PLATFORM = if withQt then "qt${qtVersion}" else "gtk3";
 
   qtVersion = lib.versions.major qtbase.version;
 in
@@ -53,7 +54,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://sourceforge/lazarus/Lazarus%20Zip%20_%20GZip/Lazarus%20${majorMinorPatch version}/lazarus-${version}.tar.gz";
-    hash = "sha256-GQ7ce3p7GEMFAslkpF399UGP8Wu8rVwEQjszoJ0izAY=";
+    hash = "sha256-a0yeyU/nn+TlgCfde/ENm2w1ycsvkdtZMLdYC0ogGpk=";
   };
 
   postPatch = ''
@@ -61,9 +62,9 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [
-    # we need gtk2 unconditionally as that is the default target when building applications with lazarus
+    # we need gtk unconditionally as that is the default target when building applications with lazarus
     fpc
-    gtk2
+    gtk3
     glib
     libxi
     xorgproto
@@ -73,6 +74,7 @@ stdenv.mkDerivation rec {
     atk
     stdenv.cc
     gdk-pixbuf
+    harfbuzz
   ]
   ++ lib.optionals withQt [
     libqtpas
@@ -109,11 +111,13 @@ stdenv.mkDerivation rec {
         "-lc"
         "-lcairo"
         "-lgcc_s"
-        "-lgdk-x11-2.0"
+        "-lgdk-3"
         "-lgdk_pixbuf-2.0"
         "-lglib-2.0"
-        "-lgtk-x11-2.0"
+        "-lgtk-3"
         "-lpango-1.0"
+        "-lharfbuzz"
+        "-lharfbuzz-gobject"
       ]
       ++ lib.optionals withQt [
         "-L${lib.getLib libqtpas}/lib"


### PR DESCRIPTION
Qt version seems to work well

GTK3 version has bugs but can compile working executables at least

doublecmd and lazpaint and cudatext seem to be working, from the first glance

#410814

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
