### PR TITLE
bluez-headers: 5.86 -> 5.87

### DIFF
--- a/pkgs/by-name/bl/bluez-headers/package.nix
+++ b/pkgs/by-name/bl/bluez-headers/package.nix
@@ -10,14 +10,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "bluez-headers";
-  version = "5.86";
+  version = "5.87";
 
   # This package has the source, because of the emulatorAvailable check in the
   # bluez function args, that causes an infinite recursion with Python on cross
   # builds.
   src = fetchurl {
     url = "mirror://kernel/linux/bluetooth/bluez-${finalAttrs.version}.tar.xz";
-    hash = "sha256-mfFEVAxgcFkeTFO8uXfrQmZMYrezbLNaKc9y3tM5Yh0=";
+    hash = "sha256-Jr3PLOvXMQxvWYhQYGsDfvDFFf5mCOvFTSLFDEwys18=";
   };
 
   dontConfigure = true;
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "https://www.bluez.org/";
+    homepage = "https://bluez.github.io/";
     description = "Official Linux Bluetooth protocol stack";
     changelog = "https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/ChangeLog?h=${finalAttrs.version}";
     license = with lib.licenses; [

--- a/pkgs/by-name/bl/bluez/package.nix
+++ b/pkgs/by-name/bl/bluez/package.nix
@@ -32,23 +32,6 @@ stdenv.mkDerivation (finalAttrs: {
   inherit (bluez-headers) version src;
 
   patches = [
-    # https://github.com/bluez/bluez/issues/1896
-    # Remove the following 2 in the next release
-    (fetchpatch2 {
-      name = "fix-btctl-noninteractive-regression";
-      url = "https://git.kernel.org/pub/scm/bluetooth/bluez.git/patch/?id=b33e923b55e4d0e9d78a83cfcb541fd1f687ef54";
-      hash = "sha256-q7eN4ktw7DtdwMHHi7GU7fbvHAdMttKF1kDSWzZqa6A=";
-    })
-    (fetchpatch2 {
-      name = "fix-btctl-noninteractive-regression-2";
-      url = "https://git.kernel.org/pub/scm/bluetooth/bluez.git/patch/?id=21e13976f2e375d701b8b7032ba5c1b2e56c305f";
-      hash = "sha256-JrdmYiC+U0KeMP8oVg12Z8CvkMEKWBVgiiUACx0E7dY=";
-    })
-    (fetchpatch2 {
-      name = "support-libical-4.0.patch";
-      url = "https://git.kernel.org/pub/scm/bluetooth/bluez.git/patch/?id=e60d07255327db3fc4e3a28d7fcc792cd42c34d0";
-      hash = "sha256-1uw+5nTjh+t1/L++fRNIlQWblwDwTJifH0EvAn3dym8=";
-    })
     ./lreadline.patch
   ];
 


### PR DESCRIPTION
https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/ChangeLog
https://github.com/bluez/bluez/releases/tag/5.87

also changed homepage url to 'bluez.github.io' (bluez.org not working)
removed 3 patches (they are included in 5.87)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
