### PR TITLE
ipfetch: 0-unstable-2024-02-02 -> 0-unstable-2024-12-15

### DIFF
--- a/pkgs/by-name/ip/ipfetch/package.nix
+++ b/pkgs/by-name/ip/ipfetch/package.nix
@@ -2,41 +2,38 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  bash,
   wget,
   makeWrapper,
 }:
 
 stdenv.mkDerivation {
   pname = "ipfetch";
-  version = "0-unstable-2024-02-02";
+  version = "0-unstable-2024-12-15";
 
   src = fetchFromGitHub {
     owner = "trakBan";
     repo = "ipfetch";
-    rev = "09b61e0d1d316dbcfab798dd00bc3f9ceb02431d";
-    sha256 = "sha256-RlbNIDRuf4sFS2zw4fIkTu0mB7xgJfPMDIk1I3UYXLk=";
+    rev = "a9cf53c17946fe1cfd786c5edf4cc88e903d80ce";
+    hash = "sha256-EYGVDb8FY8aOSg7AD+2YuFI8BTr9QVGqmzpLHqUw5tI=";
   };
 
   strictDeps = true;
-  buildInputs = [
-    bash
-    wget
-  ];
+
   nativeBuildInputs = [ makeWrapper ];
+
   postPatch = ''
-    patchShebangs --host ipfetch
-    # Not only does `/usr` have to be replaced but also `/flags` needs to be added because with Nix the script is broken without this. The `/flags` is somehow not needed if you install via the install script in the source repository.
-    substituteInPlace ./ipfetch --replace-fail /usr/share/ipfetch $out/usr/share/ipfetch/flags
+    patchShebangs --host ipfetch-wget
+    # The original script hard-coded "/usr/share/ipfetch/$flags", doing replace.
+    substituteInPlace ./ipfetch-wget --replace-fail /usr/share/ipfetch $out/share/ipfetch/flags
   '';
+
   installPhase = ''
     mkdir -p $out/bin
-    mkdir -p $out/usr/share/ipfetch/
-    cp -r flags $out/usr/share/ipfetch/
-    cp ipfetch $out/bin/ipfetch
+    mkdir -p $out/share/ipfetch/
+    cp -r flags $out/share/ipfetch/
+    cp ipfetch-wget $out/bin/ipfetch
     wrapProgram $out/bin/ipfetch --prefix PATH : ${
       lib.makeBinPath [
-        bash
         wget
       ]
     }
@@ -48,6 +45,9 @@ stdenv.mkDerivation {
     homepage = "https://github.com/trakBan/ipfetch";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ annaaurora ];
+    maintainers = with lib.maintainers; [
+      annaaurora
+      VZstless
+    ];
   };
 }


### PR DESCRIPTION
Upstream has some breaking changes as they created a shell script to determine whether install ipfetch-wget or ipfetch-curl, and finally rename as ipfetch. These two scripts has nearly same logic grabbing IP address info from an API so force to install one of them does not affect this package providing all features.  

~~Due to the whole program is just a shell script, it successfully builds with no other dependencies as input.~~

~~Modifying rec to finalAttrs in the script, as well as wrapProgram to runHook.~~

(2026-08-12 update: wrapProgram and runtime dependencies are remaining not modified according to review comment.)

This package has been in unstable status in more than 2 years and remaining in a very slow merging pace.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
