### PR TITLE
Revert "linux: add MODULE_DECOMPRESS to common-config.nix"

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -1182,7 +1182,6 @@ let
         ];
         MODULE_COMPRESS_ALL = whenAtLeast "6.12" yes;
         MODULE_COMPRESS_XZ = yes;
-        MODULE_DECOMPRESS = whenAtLeast "6.0" yes;
 
         SYSVIPC = yes; # System-V IPC
 


### PR DESCRIPTION
This broke the `ena` external module, which just has this `xz` command in its `installPhase` for compressing its module: `xz $dest/ena.ko`

Looks like `xz` wants to use crc64 by default but the kernel can only do crc32. So enabling the kernel-side decompression breaks any modules built with crc64. Obviously in `ena`'s case, that's pretty trivial to fix by just adding a CLI argument to it. But I'm not sure there's any way we could fix it in the general case for all modules, so we probably just need to go through all our module packages, find any that are broken, and manually fix all of them. Until someone's taken the time to do that, we should just revert.