### PR TITLE
linuxPackages.openafs: fix xz options for CONFIG_MODULE_DECOMPRESS

### DIFF
--- a/pkgs/by-name/op/openafs/module.nix
+++ b/pkgs/by-name/op/openafs/module.nix
@@ -81,7 +81,7 @@ stdenv.mkDerivation {
   installPhase = ''
     mkdir -p ${modDestDir}
     cp src/libafs/MODLOAD-*/libafs-${kernel.modDirVersion}.* ${modDestDir}/libafs.ko
-    xz -f ${modDestDir}/libafs.ko
+    xz --check=crc32 --lzma2=dict=1MiB -f ${modDestDir}/libafs.ko
   '';
 
   meta = {


### PR DESCRIPTION
The Linux kernel with `CONFIG_MODULE_DECOMPRESS=y` (#546157) decompresses modules with a stripped-down version of XZ Embedded lacking support for CRC64 and dictionaries larger than 1 MiB, leading to “insmod: ERROR: could not insert module …/libafs.ko.xz: Invalid parameters” from insmod and “decompression failed with status 6” in the kernel log.

Switch to `xz --check=crc32 --lzma2=dict=1MiB`, as used in `linux/scripts/Makefile.modinst`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
