### PR TITLE
python3Packages.emerge: 2.8.1 -> 2.8.2; set update script

### DIFF
--- a/pkgs/development/python-modules/emerge/default.nix
+++ b/pkgs/development/python-modules/emerge/default.nix
@@ -5,6 +5,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   writableTmpDirAsHomeHook,
+  nix-update-script,
 
   cudaPackages,
 
@@ -37,6 +38,7 @@
   callPackage,
 
   cudaSupport ? config.cudaSupport,
+  withMkl ? stdenv.hostPlatform.isx86_64 && config.allowUnfree,
 }:
 
 let
@@ -61,7 +63,7 @@ in
 
 buildPythonPackage (finalAttrs: {
   pname = "emerge";
-  version = "2.8.1";
+  version = "2.8.2";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -69,7 +71,7 @@ buildPythonPackage (finalAttrs: {
     owner = "FennisRobert";
     repo = "EMerge";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-TArhxtPAGEmPI4L+/pgy+RhV9atAZ5Ig0TkUDoV+eXQ=";
+    hash = "sha256-wxJeSiHfYTY7mRll8cxJSpdciun+uw5V7FLTUKuHu28=";
   };
 
   postPatch = ''
@@ -103,7 +105,7 @@ buildPythonPackage (finalAttrs: {
   ];
 
   buildInputs =
-    lib.optionals stdenv.hostPlatform.isx86_64 [
+    lib.optionals withMkl [
       mkl
     ]
     ++ lib.optionals cudaSupport [
@@ -145,11 +147,16 @@ buildPythonPackage (finalAttrs: {
       ;
 
     tests = callPackage ./tests { };
+
+    updateScript = nix-update-script {
+      extraArgs = [ "--version-regex=^v(2\\.[0-9].*)$" ];
+    };
   };
 
   meta = {
     description = "Electromagnetic field computation program";
     homepage = "https://github.com/FennisRobert/EMerge";
+    mainProgram = "emerge";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ eljamm ];
     teams = with lib.teams; [ ngi ];

--- a/pkgs/development/python-modules/emsutil/default.nix
+++ b/pkgs/development/python-modules/emsutil/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  nix-update-script,
 
   # build-system
   hatchling,
@@ -50,6 +51,11 @@ buildPythonPackage (finalAttrs: {
   pythonImportsCheck = [
     "emsutil"
   ];
+
+  # TODO: remove after new release (>0.8.3)
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
 
   meta = {
     description = "Utilities for the EMerge software suite";


### PR DESCRIPTION
version to 2.x because 3.x is still in development and may not be ready
for production.

Also, use unstable version in `python3Packages.emsutil`'s update script.

Closes https://github.com/NixOS/nixpkgs/pull/549353
Closes https://github.com/NixOS/nixpkgs/pull/549360

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
