### PR TITLE
zeroclaw: 0.8.3 -> 0.8.4

### DIFF
--- a/pkgs/by-name/ze/zeroclaw/package.nix
+++ b/pkgs/by-name/ze/zeroclaw/package.nix
@@ -10,26 +10,27 @@
   sqlite,
   writableTmpDirAsHomeHook,
   gitMinimal,
+  jq,
   versionCheckHook,
   nix-update-script,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "zeroclaw";
-  version = "0.8.3";
+  version = "0.8.4";
 
   src = fetchFromGitHub {
     owner = "zeroclaw-labs";
     repo = "zeroclaw";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-H1512vayE35bLxlFpWExT6u/z3rMKsrv6gs5un9IPaA=";
+    hash = "sha256-6WAF826aftGuZjSHM/upWYmmVVjMS+vS+Kg4NetvjJc=";
   };
 
-  cargoHash = "sha256-zLj2ItDp8tbldBvFNxlrcoqcE0J5Ce19NDlV+lCu/BY=";
+  cargoHash = "sha256-Pycl0MMyxWtfcssoFhvDT4UQJuVVBDNzN536eBFlND4=";
 
   npmDeps = fetchNpmDeps {
     inherit (finalAttrs) src;
     sourceRoot = "${finalAttrs.src.name}/web";
-    hash = "sha256-SKltlDJm39ZzVaEt1bbnoiXy+wlbq+fC3bO4mW5V15o=";
+    hash = "sha256-0CsPPy5a/jTr8nImwvTwStTgHm9wZbFBwCZVHKPZCvE=";
   };
   npmRoot = "web";
 
@@ -62,16 +63,18 @@ rustPlatform.buildRustPackage (finalAttrs: {
     popd
   '';
 
+  # the release-workflow architecture tests shell out to scripts/release/*.sh
   nativeCheckInputs = [
     writableTmpDirAsHomeHook
     gitMinimal
+    jq
   ];
 
   # wiremock tests require socket binding, which is denied in the darwin sandbox
   checkFlags = [
-    "--skip=commands::update::tests::download_binary_preserves_missing_checksum_fallback"
-    "--skip=commands::update::tests::download_binary_rejects_checksum_mismatch_without_writing"
-    "--skip=commands::update::tests::download_binary_verifies_checksum_before_writing"
+    "--skip=commands::update::tests::download_release_preserves_missing_checksum_fallback"
+    "--skip=commands::update::tests::download_release_rejects_checksum_mismatch_without_writing"
+    "--skip=commands::update::tests::download_release_verifies_checksum_before_writing"
     "--skip=tests::exchange_pairing_code_posts_code_and_returns_token"
     "--skip=tests::fetch_pairing_code_reads_gateway_pair_code_response"
     "--skip=tests::gateway_addr_in_use_message_skips_occupied_restart_hint_port"


### PR DESCRIPTION
Changelog: https://github.com/zeroclaw-labs/zeroclaw/releases/tag/v0.8.4

Also adds `jq` to `nativeCheckInputs`. 0.8.4 introduces `tests/architecture/release_workflow.rs`; its `scoop_publisher_metadata_follows_canonical_url_template` test invokes `scripts/release/scoop_metadata.sh`, which parses JSON with jq. Both the script and the test file are new in this release, so the check phase fails without it. jq is check-time only and does not enter the runtime closure.
Security-relevant content in this release:
- RUSTSEC-2026-0219 — remote denial of service via malformed NIP-04 IV (`nostr`, fixed in 0.44.6)
- RUSTSEC-2026-0224 — verification-cache poisoning allowing forged Nostr events to bypass signature validation (`nostr-relay-pool`, fixed in 0.44.2)
Upstream continues to waive RUSTSEC-2026-0222 (wasmtime 45.0.3) in `.cargo/audit.toml`, tracked at zeroclaw-labs/zeroclaw#8519. wasmtime is reached only through the non-default `plugins-wasm` feature, which this derivation does not enable.
Downstream note, from the upstream release notes: an enabled generic webhook channel now refuses to start without a `secret`, Nextcloud Talk requires the signed Talk Bot API, and ClawHub skill sources were removed. There is no NixOS module for zeroclaw, so nothing in nixpkgs needs adjusting.
## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

zeroclaw has no reverse dependencies in nixpkgs, so `nix-build -A zeroclaw` covers the same build set as a review. The upstream test suite runs in the check phase and passes.

This pull request summary was written by Claude Code (claude/claude-opus-5) and reviewed before submission.
[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test