### PR TITLE
python3Packages.stoatpy: init at 1.2.1-unstable-2026-05-03

### DIFF
--- a/pkgs/development/python-modules/stoatpy/default.nix
+++ b/pkgs/development/python-modules/stoatpy/default.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  setuptools,
+
+  aiohttp,
+  attrs,
+
+  pytestCheckHook,
+
+  orjson,
+  aiodns,
+  brotli,
+
+  pytest-asyncio,
+  typing-extensions,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "stoatpy";
+  version = "1.2.1-unstable-2026-05-03";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "MCausc78";
+    repo = "stoat.py";
+    rev = "b8f6b2d65e24fe40548872c63ce648beac54ef9a";
+    hash = "sha256-hAwgzT8YvUuqBluRzHTASowJaOqp+bfOtJgxfypMDzI=";
+  };
+
+  patches = [ ./fix-tests.patch ];
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    aiohttp
+    attrs
+  ]
+  ++ finalAttrs.passthru.optional-dependencies.speed;
+
+  pythonImportsCheck = [ "stoat" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ]
+  ++ finalAttrs.passthru.optional-dependencies.test;
+
+  passthru.optional-dependencies = {
+    speed = [
+      orjson
+      aiodns
+      brotli
+    ];
+
+    test = [
+      pytest-asyncio
+      typing-extensions
+    ];
+  };
+
+  meta = {
+    description = "Simple, flexible API wrapper for Stoat";
+    homepage = "https://github.com/MCausc78/stoat.py";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.ryand56 ];
+  };
+})

--- a/pkgs/development/python-modules/stoatpy/fix-tests.patch
+++ b/pkgs/development/python-modules/stoatpy/fix-tests.patch
@@ -1,0 +1,22 @@
+diff --git a/tests/test_discovery.py b/tests/test_discovery.py
+index 56a8be905c..395da5a26b 100644
+--- a/tests/test_discovery.py
++++ b/tests/test_discovery.py
+@@ -73,7 +73,7 @@
+ 
+     state = stoat.State()
+     state.setup(parser=stoat.Parser(state=state))
+-    client = stoat.DiscoveryClient(base_url='http://127.0.0.1:5103/', state=state)
++    client = stoat.DiscoveryClient(base_url='http://127.0.0.1:5101/', state=state)
+ 
+     page = await client.bots()
+     assert len(page.bots) == 21
+@@ -136,7 +136,7 @@
+ 
+     state = stoat.State()
+     state.setup(parser=stoat.Parser(state=state))
+-    client = stoat.DiscoveryClient(base_url='http://127.0.0.1:5103/', state=state)
++    client = stoat.DiscoveryClient(base_url='http://127.0.0.1:5102/', state=state)
+ 
+     page = await client.servers()
+ 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19651,6 +19651,8 @@ self: super: with self; {
 
   stm32loader = callPackage ../development/python-modules/stm32loader { };
 
+  stoatpy = callPackage ../development/python-modules/stoatpy { };
+
   stomp-py = callPackage ../development/python-modules/stomp-py { };
 
   stone = callPackage ../development/python-modules/stone { };


### PR DESCRIPTION
A simple, flexible API wrapper written in Python for Stoat Chat.
https://github.com/MCausc78/stoat.py

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
