### PR TITLE
whatsapp-electron: 1.1.1 -> 1.2.9

### DIFF
--- a/pkgs/by-name/wh/whatsapp-electron/icon.patch
+++ b/pkgs/by-name/wh/whatsapp-electron/icon.patch
@@ -1,13 +1,13 @@
-diff --git a/src/index.js b/src/index.js
-index cf77b75..4ceb2da 100644
---- a/src/index.js
-+++ b/src/index.js
-@@ -14,7 +14,7 @@ class WhatsAppElectron
+diff --git a/src/main.js b/src/main.js
+index 339d5a1..0301844 100644
+--- a/src/main.js
++++ b/src/main.js
+@@ -13,7 +13,7 @@ class WhatsAppElectron
  {
  	constructor() {
- 		this.store    = new Store();
--		this.baseIcon = isDev ? path.join(__dirname, "../assets/whatsapp-icon-512x512.png") : path.join(process.resourcesPath, "app.asar.unpacked/assets/whatsapp-icon-512x512.png");
-+		this.baseIcon = isDev ? path.join(__dirname, "../assets/whatsapp-icon-512x512.png") : path.join(app.getAppPath(), "assets/whatsapp-icon-512x512.png");
- 		this.isQuit   = false;
+ 		this.store      = new Store();
+-		this.baseIcon   = !app.isPackaged ? path.join(__dirname, "../assets/whatsapp-icon-512x512.png") : path.join(process.resourcesPath, "app.asar.unpacked/assets/whatsapp-icon-512x512.png");
++		this.baseIcon   = !app.isPackaged ? path.join(__dirname, "../assets/whatsapp-icon-512x512.png") : path.join(app.getAppPath(), "assets/whatsapp-icon-512x512.png");
+ 		this.isQuit     = false;
+ 		this.spellLangs = ["en-US", "pt-BR"];
  
- 		this.bounds = this.store.get("bounds");

--- a/pkgs/by-name/wh/whatsapp-electron/package.nix
+++ b/pkgs/by-name/wh/whatsapp-electron/package.nix
@@ -13,18 +13,18 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "whatsapp";
-  version = "1.1.1";
+  version = "1.2.9";
 
   src = fetchFromGitHub {
     owner = "dagmoller";
     repo = "whatsapp-electron";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-i3rk/wAr2MtJqXv7Z9uG0YzIsvaxrDvcXsXQhDEmzxw=";
+    hash = "sha256-g7EYdPYN1KRS8JQtO0RMkoHyp/2A14YekI1MAzLFoFA=";
   };
 
   npmDeps = fetchNpmDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-5AlnAtxiQDbJEbxthGT8DQhZG5tdkrFk0+47czalnlU=";
+    hash = "sha256-Z+dukXaK5V/eWBCyKqp1/Nm9rDQcUqH8XJSi1WqPPL8=";
   };
 
   patches = [ ./icon.patch ];


### PR DESCRIPTION
Bump `whatsapp-electron` from 1.1.1 to 1.2.9.

`icon.path` refactored to target `src/main.js` now as upstream has renamed from `index.js` to `main.js`


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
