### PR TITLE
nixos/programs/ioquake3: add baseq3 option

### DIFF
--- a/nixos/modules/programs/ioquake3.nix
+++ b/nixos/modules/programs/ioquake3.nix
@@ -27,7 +27,7 @@ let
     paths = [ cfg.package ];
     nativeBuildInputs = [ pkgs.makeWrapper ];
     postBuild = ''
-      wrapProgram "$out/bin/ioquake3" --add-flags  "+set fs_basepath ${fsBasepath} +exec settings.cfg"
+      wrapProgram "$out/bin/ioquake3" --add-flags "+set fs_basepath ${cfg.baseq3} +set fs_cdpath ${fsBasepath} +exec settings.cfg"
     '';
   };
 in
@@ -36,6 +36,32 @@ in
     enable = lib.mkEnableOption "ioquake3, an enhanced, cross-platform, open source engine for id Software's Quake 3";
 
     package = lib.mkPackageOption pkgs "ioquake3" { };
+
+    baseq3 = lib.mkOption {
+      type = with lib.types; (either package path);
+      default = pkgs.symlinkJoin {
+        name = "quake3-demo-content";
+        paths = [
+          pkgs.quake3demodata
+          pkgs.quake3pointrelease
+        ];
+      };
+      defaultText = "Freely redistributable Quake 3 demo data (`pak0`) plus the 1.32 point release files (`pak1`-`pak8`), merged together.";
+      example = "/var/lib/quake3";
+      description = ''
+        Path to the directory containing the baseq3 files (pak*.pk3).
+
+        Defaults to the freely redistributable demo data (pak0) merged
+        with the 1.32 point release files (pak1-pak8), so the game runs
+        out of the box without owning a retail copy.
+
+        This value is passed directly as fs_basepath, so pak files are
+        searched for in `''${baseq3}/baseq3/`, e.g. a value of
+        `/var/lib/quake3` expects `/var/lib/quake3/baseq3/pak0.pk3` and
+        so on. To use a full retail install instead, point this at the
+        directory containing its `baseq3` folder.
+      '';
+    };
 
     settings = lib.mkOption {
       type = lib.types.attrsOf (


### PR DESCRIPTION
Add option to configure game dir path (baseq3). If its not set, the demo files will be used.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
