### PR TITLE
haskellPackages: Fix multiple packages maintained by turion

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2947,22 +2947,11 @@ with haskellLib;
   # 2025-04-13: jailbreak to allow hedgehog >= 1.5
   hw-bits = warnAfterVersion "0.7.2.2" (doJailbreak super.hw-bits);
 
-  monad-bayes =
-    # Floating point precision issues. Test suite is only checked on x86_64.
-    # https://github.com/tweag/monad-bayes/issues/368
-    dontCheckIf
-      (
-        let
-          inherit (pkgs.stdenv) hostPlatform;
-        in
-        !hostPlatform.isx86_64
-        # Presumably because we emulate x86_64-darwin via Rosetta, x86_64-darwin
-        # also fails on Hydra
-        || hostPlatform.isDarwin
-      )
-      # Too strict bounds on brick (<2.6), vty (<6.3)
-      # https://github.com/tweag/monad-bayes/issues/378
-      (doJailbreak super.monad-bayes);
+  # Test suite is brittle, dependent on the random number generator
+  # implementation and architecture. See:
+  # * https://github.com/tweag/monad-bayes/pull/389
+  # * https://github.com/tweag/monad-bayes/issues/368
+  monad-bayes = dontCheck (doJailbreak super.monad-bayes);
 
   # 2025-04-13: jailbreak to allow th-abstraction >= 0.7
   crucible = doJailbreak super.crucible;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2958,10 +2958,8 @@ with haskellLib;
   # once a release/Hackage revision with the relaxed bound reaches nixpkgs.
   automaton = dontCheck super.automaton;
 
-  # Test suite has a too-strict bound QuickCheck <2.16, but nightly ships 2.16.
-  # Bound bumped upstream in https://github.com/turion/rhine/pull/449; drop this
-  # once a release/Hackage revision with the relaxed bound reaches nixpkgs.
-  monad-schedule = dontCheck super.monad-schedule;
+  # Not maintained anymore, but still builds
+  monad-schedule = dontCheck (doJailbreak super.monad-schedule);
 
   # Test suite has a too-strict bound QuickCheck <2.16, but nightly ships 2.16.
   # Bound bumped upstream in https://github.com/turion/rhine/pull/449; drop this

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2953,6 +2953,11 @@ with haskellLib;
   # * https://github.com/tweag/monad-bayes/issues/368
   monad-bayes = dontCheck (doJailbreak super.monad-bayes);
 
+  # Test suite has a too-strict bound QuickCheck <2.16, but nightly ships 2.16.
+  # Bound bumped upstream in https://github.com/turion/rhine/pull/449; drop this
+  # once a release/Hackage revision with the relaxed bound reaches nixpkgs.
+  automaton = dontCheck super.automaton;
+
   # 2025-04-13: jailbreak to allow th-abstraction >= 0.7
   crucible = doJailbreak super.crucible;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2958,6 +2958,11 @@ with haskellLib;
   # once a release/Hackage revision with the relaxed bound reaches nixpkgs.
   automaton = dontCheck super.automaton;
 
+  # Test suite has a too-strict bound QuickCheck <2.16, but nightly ships 2.16.
+  # Bound bumped upstream in https://github.com/turion/rhine/pull/449; drop this
+  # once a release/Hackage revision with the relaxed bound reaches nixpkgs.
+  monad-schedule = dontCheck super.monad-schedule;
+
   # 2025-04-13: jailbreak to allow th-abstraction >= 0.7
   crucible = doJailbreak super.crucible;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2963,6 +2963,11 @@ with haskellLib;
   # once a release/Hackage revision with the relaxed bound reaches nixpkgs.
   monad-schedule = dontCheck super.monad-schedule;
 
+  # Test suite has a too-strict bound QuickCheck <2.16, but nightly ships 2.16.
+  # Bound bumped upstream in https://github.com/turion/rhine/pull/449; drop this
+  # once a release/Hackage revision with the relaxed bound reaches nixpkgs.
+  rhine = dontCheck super.rhine;
+
   # 2025-04-13: jailbreak to allow th-abstraction >= 0.7
   crucible = doJailbreak super.crucible;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2968,6 +2968,11 @@ with haskellLib;
   # once a release/Hackage revision with the relaxed bound reaches nixpkgs.
   rhine = dontCheck super.rhine;
 
+  # The warp test suite runs an HTTP server that needs the threaded RTS, but the
+  # test suite is missing `ghc-options: -threaded`. Fixed upstream in
+  # https://github.com/turion/essence-of-live-coding/pull/153; drop once released.
+  essence-of-live-coding-warp = dontCheck super.essence-of-live-coding-warp;
+
   # 2025-04-13: jailbreak to allow th-abstraction >= 0.7
   crucible = doJailbreak super.crucible;
 

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -662,7 +662,6 @@ package-maintainers:
     - finite-typelits
     - has-transformers
     - monad-bayes
-    - monad-schedule
     - pulse-simple
     - openapi3-code-generator
     - rhine


### PR DESCRIPTION
EDITING: I need to rebase onto upstream haskell-updates, just a moment

Fix my maintained packages.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Assisted by an LLM, partially coded and reviewed by myself.