### PR TITLE
nixos/mautrix-meta: add new instagram mode, fix tests

### DIFF
--- a/nixos/modules/services/matrix/mautrix-meta.nix
+++ b/nixos/modules/services/matrix/mautrix-meta.nix
@@ -201,8 +201,10 @@ in
                   '';
                   description = ''
                     {file}`config.yaml` configuration as a Nix attribute set.
-                    Configuration options should match those described in
-                    [example-config.yaml](https://github.com/mautrix/meta/blob/main/example-config.yaml).
+                    Configuration options should match those described in the example configuration.
+                    Get an example configuration by executing one of those commands
+                      - `mautrix-meta -c example.yaml --generate-example-config`
+                      - `mautrix-instagram -c example.yaml --generate-example-config`
 
                     Secret tokens should be specified using {option}`environmentFile`
                     instead

--- a/nixos/modules/services/matrix/mautrix-meta.nix
+++ b/nixos/modules/services/matrix/mautrix-meta.nix
@@ -18,6 +18,7 @@ let
   settingsFileUnsubstituted = cfg: settingsFormat.generate "mautrix-meta-config.yaml" cfg.settings;
 
   metaName = name: "mautrix-meta-${name}";
+  packageName = network: if network == "instagram" then "mautrix-instagram" else "mautrix-meta";
 
   enabledInstances = lib.filterAttrs (
     name: config: config.enable
@@ -471,7 +472,7 @@ in
               cp '${settingsFile cfg}' '${settingsFile cfg}.tmp'
 
               echo "Generating registration file"
-              mautrix-meta \
+              ${lib.getExe' upperCfg.package (packageName cfg.settings.network.mode)} \
                 --generate-registration \
                 --config='${settingsFile cfg}.tmp' \
                 --registration='${cfg.registrationFile}'
@@ -568,7 +569,7 @@ in
               EnvironmentFile = cfg.environmentFile;
 
               ExecStart = lib.escapeShellArgs [
-                (lib.getExe upperCfg.package)
+                (lib.getExe' upperCfg.package (packageName cfg.settings.network.mode))
                 "--config=${settingsFile cfg}"
               ];
             };

--- a/nixos/tests/matrix/mautrix-meta-postgres.nix
+++ b/nixos/tests/matrix/mautrix-meta-postgres.nix
@@ -90,12 +90,21 @@ in
               as_token = "$AS_TOKEN";
               hs_token = "$HS_TOKEN";
 
-              database = {
-                type = "postgres";
-                uri = "postgres:///mautrix-meta-instagram?host=/var/run/postgresql";
+              bot = {
+                username = botUserName;
+                avatar = "";
               };
+            };
 
-              bot.username = botUserName;
+            database = {
+              type = "postgres";
+              uri = "postgres:///mautrix-meta-instagram?host=/var/run/postgresql";
+            };
+
+            encryption = {
+              allow = false;
+              default = false;
+              require = false;
             };
 
             bridge.permissions."@${userName}:server" = "user";
@@ -127,13 +136,14 @@ in
               import functools
               import asyncio
 
-              from nio import AsyncClient, RoomMessageNotice, RoomCreateResponse, RoomInviteResponse
+              from nio import AsyncClient, RoomMessageText, RoomCreateResponse, RoomInviteResponse
 
 
-              async def message_callback(matrix: AsyncClient, msg: str, _r, e):
+              async def message_callback(matrix: AsyncClient, expected_msg: str, expected_sender: str, _r, e):
                   print("Received matrix text message: ", e)
-                  assert msg in e.body
-                  exit(0)  # Success!
+                  if getattr(e, "sender", "") == expected_sender and expected_msg in getattr(e, "body", ""):
+                      print("Success!")
+                      exit(0)  # Success!
 
 
               async def run(homeserver: str):
@@ -151,9 +161,9 @@ in
                   assert isinstance(response, RoomInviteResponse)
 
                   callback = functools.partial(
-                      message_callback, matrix, "Hello, I'm an Instagram bridge bot."
+                      message_callback, matrix, "Hello, I'm a Instagram bridge bot.", "@${botUserName}:${homeserverDomain}"
                   )
-                  matrix.add_event_callback(callback, RoomMessageNotice)
+                  matrix.add_event_callback(callback, RoomMessageText)
 
                   print("Waiting for matrix message...")
                   await matrix.sync_forever(timeout=30000)
@@ -171,11 +181,10 @@ in
     def extract_token(data):
         stdout = data[1]
         stdout = stdout.strip()
-        line = stdout.split('\n')[-1]
-        return line.split(':')[-1].strip("\" '\n")
+        return stdout.split(':')[-1].strip("\" '\n")
 
     def get_token_from(token, file):
-        data = server.execute(f"cat {file} | grep {token}")
+        data = server.execute(f"grep -E '^\\s*{token}:' {file}")
         return extract_token(data)
 
     def get_as_token_from(file):

--- a/nixos/tests/matrix/mautrix-meta-sqlite.nix
+++ b/nixos/tests/matrix/mautrix-meta-sqlite.nix
@@ -4,7 +4,7 @@ let
   homeserverUrl = "http://server:8008";
   username = "alice";
   instagramBotUsername = "instagrambot";
-  facebookBotUsername = "facebookbot";
+  metaBotUsername = "metabot";
 in
 {
   name = "mautrix-meta-sqlite";
@@ -60,7 +60,16 @@ in
             appservice = {
               port = 8009;
 
-              bot.username = facebookBotUsername;
+              bot = {
+                username = metaBotUsername;
+                avatar = "";
+              };
+            };
+
+            encryption = {
+              allow = false;
+              default = false;
+              require = false;
             };
 
             bridge.permissions."@${username}:server" = "user";
@@ -79,7 +88,16 @@ in
             appservice = {
               port = 8010;
 
-              bot.username = instagramBotUsername;
+              bot = {
+                username = instagramBotUsername;
+                avatar = "";
+              };
+            };
+
+            encryption = {
+              allow = false;
+              default = false;
+              require = false;
             };
 
             bridge.permissions."@${username}:server" = "user";
@@ -136,16 +154,17 @@ in
               import functools
               import asyncio
 
-              from nio import AsyncClient, RoomMessageNotice, RoomCreateResponse, RoomInviteResponse
+              from nio import AsyncClient, RoomMessageText, RoomCreateResponse, RoomInviteResponse
 
 
-              async def message_callback(matrix: AsyncClient, msg: str, _r, e):
+              async def message_callback(matrix: AsyncClient, expected_msg: str, expected_sender: str, _r, e):
                   print("Received matrix text message: ", e)
-                  assert msg in e.body
-                  exit(0)  # Success!
+                  if getattr(e, "sender", "") == expected_sender and expected_msg in getattr(e, "body", ""):
+                      print("Success!")
+                      exit(0)  # Success!
 
 
-              async def run(username: str, bot_username: str, homeserver: str):
+              async def run(username: str, bot_username: str, homeserver: str, expected_msg: str):
                   matrix = AsyncClient(homeserver, f"@{username}:${homeserverDomain}")
 
                   response = await matrix.login("foobar")
@@ -161,16 +180,16 @@ in
                   assert isinstance(response, RoomInviteResponse)
 
                   callback = functools.partial(
-                      message_callback, matrix, "Hello, I'm an Instagram bridge bot."
+                      message_callback, matrix, expected_msg, f"@{bot_username}:${homeserverDomain}"
                   )
-                  matrix.add_event_callback(callback, RoomMessageNotice)
+                  matrix.add_event_callback(callback, RoomMessageText)
 
                   print("Waiting for matrix message...")
                   await matrix.sync_forever(timeout=30000)
 
 
               if __name__ == "__main__":
-                  asyncio.run(run(sys.argv[1], sys.argv[2], sys.argv[3]))
+                  asyncio.run(run(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]))
             ''
           )
         ];
@@ -181,11 +200,10 @@ in
     def extract_token(data):
         stdout = data[1]
         stdout = stdout.strip()
-        line = stdout.split('\n')[-1]
-        return line.split(':')[-1].strip("\" '\n")
+        return stdout.split(':')[-1].strip("\" '\n")
 
     def get_token_from(token, file):
-        data = server.execute(f"cat {file} | grep {token}")
+        data = server.execute(f"grep -E '^\\s*{token}:' {file}")
         return extract_token(data)
 
     def get_as_token_from(file):
@@ -216,8 +234,8 @@ in
         client.succeed("register_user ${username} ${homeserverUrl} >&2")
 
     with subtest("ensure messages can be exchanged"):
-        client.succeed("do_test ${username} ${facebookBotUsername} ${homeserverUrl} >&2")
-        client.succeed("do_test ${username} ${instagramBotUsername} ${homeserverUrl} >&2")
+        client.succeed("do_test ${username} ${metaBotUsername} ${homeserverUrl} \"Hello, I'm a Facebook Messenger bridge bot.\" >&2")
+        client.succeed("do_test ${username} ${instagramBotUsername} ${homeserverUrl} \"Hello, I'm a Instagram bridge bot.\" >&2")
 
     with subtest("ensure as_token and hs_token stays same after restart"):
         generated_as_token_facebook = get_as_token_from(config_yaml)
@@ -252,7 +270,7 @@ in
         assert generated_hs_token_facebook == new_hs_token_facebook, f"hs_token should stay the same after restart inside the registration file (is: {new_hs_token_facebook}, was: {generated_hs_token_facebook})"
 
     with subtest("ensure messages can be exchanged after restart"):
-        client.succeed("do_test ${username} ${instagramBotUsername} ${homeserverUrl} >&2")
-        client.succeed("do_test ${username} ${facebookBotUsername} ${homeserverUrl} >&2")
+        client.succeed("do_test ${username} ${instagramBotUsername} ${homeserverUrl} \"Hello, I'm a Instagram bridge bot.\" >&2")
+        client.succeed("do_test ${username} ${metaBotUsername} ${homeserverUrl} \"Hello, I'm a Facebook Messenger bridge bot.\" >&2")
   '';
 }

--- a/pkgs/by-name/ma/mautrix-meta/package.nix
+++ b/pkgs/by-name/ma/mautrix-meta/package.nix
@@ -18,7 +18,10 @@ buildGoModule rec {
   version = "26.07";
   tag = "v0.2607.0";
 
-  subPackages = [ "cmd/mautrix-meta" ];
+  subPackages = [
+    "cmd/mautrix-meta"
+    "cmd/mautrix-instagram"
+  ];
 
   src = fetchFromGitHub {
     owner = "mautrix";


### PR DESCRIPTION
Fixes : #545243
See: https://github.com/mautrix/meta/releases/tag/v0.2607.0
Since the latest release, the package for Instagram is split from the other Meta services.
This causes that currently with the mautrix-meta-instagram setup, the connection fails on nixos : 
```
State update for xxxx xxxx: TRANSIENT_DISCONNECT (meta-transient-disconnect) not resolved after waiting 3 minutes: Disconnected from server, trying to reconnect
```

For this PR, I tried to follow the path that involved no migration on the end user. 
- I chose not to split the package in two because it is still based on the same source, and probably that code is shared between the two packages:
  - This is the downside of requiring the usage of `getExe'` because now we have multiple binaries, and mautrix-meta is still the default
- I chose to keep the same module for Mautrix Meta and Mautrix Instagram, as I would love to one day merge all the Mautrix modules (see #338249). This also has the benefit of requiring no change in the end NixOS configuration
  - The downside is added complexity in the module (even if it is pretty simple)

This PR is currently in production on my NixOS server: https://github.com/hatch01/flake/blob/main/apps/matrix/instagram.nix


During my tests on this PR, I noticed that the two mautrix-meta tests (mautrix-meta-sqlite, mautrix-meta-postgres) were broken even before my modifications. So I fixed them on the side: recent upstream Mautrix updates changed the configuration schema (moving the database block out of appservice), altered the bots' welcome messages, and added YAML comments that broke our regex-based token extraction.
Broken since: #342988


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
