### PR TITLE
keymapp: fix aarch64-linux meta.platforms

### DIFF
--- a/pkgs/by-name/ke/keymapp/package.nix
+++ b/pkgs/by-name/ke/keymapp/package.nix
@@ -16,16 +16,15 @@ let
   pname = "keymapp";
   version = "1.3.7";
 
-  sources = rec {
+  sources = {
     aarch64-darwin = {
       url = "https://oryx.nyc3.cdn.digitaloceanspaces.com/keymapp/keymapp-${version}.dmg";
       hash = "sha256-H6xRau7pWuSF5Aa6lblwi/Lg5KxC+HM3rtUMjX+hEE8=";
     };
-    aarch64-linux = {
+    x86_64-linux = {
       url = "https://oryx.nyc3.cdn.digitaloceanspaces.com/keymapp/keymapp-${version}.tar.gz";
       hash = "sha256-qHvHCDzWRhuhDg2kuU8kmikQDXElQtVEmPAelHz4aPo=";
     };
-    x86_64-linux = aarch64-linux;
   };
   src = fetchurl {
     inherit (sources.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}")) url hash;
@@ -39,7 +38,7 @@ let
       jankaifer
       shawn8901
     ];
-    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    platforms = [ "x86_64-linux" ] ++ lib.platforms.darwin;
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
     license = lib.licenses.unfree;
   };


### PR DESCRIPTION
`keymapp` fails with `Exec format error` on `aarch64-linux` (e.g. Asahi Linux / Apple Silicon). The tarball fetched for `sources.aarch64-linux` (`keymapp-${version}.tar.gz`) is actually an x86_64 ELF binary — checked its `e_machine` field directly, it's `EM_X86_64`, not `EM_AARCH64`. That's because `sources.aarch64-linux` and `sources.x86_64-linux` were pointed at the exact same upstream URL: there never was a real aarch64 build, just an alias.

Confirmed against ZSA's own download page (zsa.io/flash) — they publish exactly one Linux tarball, x86_64 only, no ARM variant. So `meta.platforms = lib.platforms.linux ++ lib.platforms.darwin` was overclaiming; `aarch64-linux` should never have been listed.

This is the same class of bug as #201454 (zotero installing x86_64 binaries on aarch64).

Fix: drop the bogus `aarch64-linux` source entry and narrow `meta.platforms` to `x86_64-linux` + darwin, matching what upstream actually ships.

Disclosure per the automation/AI policy: root-cause investigation, diagnosis, and this patch were done with Claude Code (claude-sonnet-5) assistance; I reviewed the diagnosis (ELF header check, upstream download page) and the resulting diff myself before submitting. See the `Assisted-by:` trailer on the commit.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
