### PR TITLE
nuke-references: replace perl with sed, add tests and documentation

### DIFF
--- a/doc/packages/build-support.md
+++ b/doc/packages/build-support.md
@@ -103,3 +103,62 @@ replaceVarsWith {
 
 This will make the resulting file executable, put it in `bin/say-goodbye` and set `meta` attributes respectively.
 :::
+
+## `pkgs.nukeReferences` {#pkgs-nukereferences}
+
+`nuke-refs` replaces unwanted Nix store references in a file.
+
+:::{.example #ex-pkgs-nuke-references}
+# Usage of `pkgs.nukeReferences`
+
+```nix
+{
+  stdenv,
+  nukeReferences,
+  libfoo,
+  libbar,
+}:
+stdenv.mkDerivation {
+  pname = "baz";
+  version = "1.0";
+  src = ./src;
+
+  nativeBuildInputs = [
+    nukeReferences
+    libfoo
+  ];
+  buildInputs = [ libbar ];
+
+  postFixup = ''
+    nuke-refs -e "$out" -e "${libbar}" "$out/lib/baz.so"
+  '';
+}
+```
+
+- `$out/lib/baz.so` links against `libbar`, so `libbar` is still needed at runtime.
+- `libfoo` was only needed at buildtime to build `baz.so`, but its path ended up embedded anyway.
+- `baz.so` also has its own install path, `$out/share/baz`, compiled in as a data directory, which is an intentional self-reference.
+- `-e "${libbar}"` keeps all `libbar` references.
+- `-e "$out"` keeps that self-reference to `$out`.
+
+`nuke-refs` replaces the `libfoo` reference, along with any other unwanted store path reference embedded in `$out/lib/baz.so`.
+For example:
+
+```
+/nix/store/lxra5fkapsdbdjqi6wa205s7vmqh1vxb-libfoo-1.2.3/lib/libfoo.so -> /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-libfoo-1.2.3/lib/libfoo.so
+```
+:::
+
+[Nix scans all outputs for Nix store references, and registers them as runtime dependencies](https://nix.dev/manual/nix/stable/store/building.html#processing-outputs).
+Any reference left behind by a build tool, e.g. a compiler path embedded in a generated file, can therefore pull in a much larger closure than intended.
+Such references might even fail the build outright if it forms a reference cycle or violates [`disallowedReferences`](https://nix.dev/manual/nix/stable/language/advanced-attributes.html#adv-attr-disallowedReferences).
+
+`nuke-refs [-e <path>]... file...` replaces unwanted references in each `file` in place.
+Pass one or more `-e path` arguments to keep certain store paths from being replaced.
+
+::: {.note}
+`nuke-refs` replaces the hash of each store path with `eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee`.
+
+`-e` only matches on the hash, not the derivation name.
+If you pass `-e /nix/store/<hash>-foo`, `nuke-refs` also keeps `/nix/store/<hash>-bar`.
+:::

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -128,6 +128,9 @@
   "ex-pkgs-replace-vars-with": [
     "index.html#ex-pkgs-replace-vars-with"
   ],
+  "ex-pkgs-nuke-references": [
+    "index.html#ex-pkgs-nuke-references"
+  ],
   "ex-pnpm-build-hook": [
     "index.html#ex-pnpm-build-hook"
   ],
@@ -366,6 +369,9 @@
   ],
   "pkgs-replacevarswith": [
     "index.html#pkgs-replacevarswith"
+  ],
+  "pkgs-nukereferences": [
+    "index.html#pkgs-nukereferences"
   ],
   "part-toolchains": [
     "index.html#part-toolchains"

--- a/pkgs/build-support/nuke-references/default.nix
+++ b/pkgs/build-support/nuke-references/default.nix
@@ -1,7 +1,4 @@
-# The program `nuke-refs' created by this derivation replaces all
-# references to the Nix store in the specified files by a non-existent
-# path (/nix/store/eeee...).  This is useful for getting rid of
-# dependencies that you know are not actually needed at runtime.
+# See https://nixos.org/manual/nixpkgs/unstable/#pkgs-nukereferences
 
 {
   lib,

--- a/pkgs/build-support/nuke-references/default.nix
+++ b/pkgs/build-support/nuke-references/default.nix
@@ -6,7 +6,7 @@
 {
   lib,
   replaceVarsWith,
-  perl,
+  gnused,
   signingUtils,
   stdenvNoCC,
   shell ? stdenvNoCC.shell,
@@ -14,8 +14,10 @@
 replaceVarsWith {
   src = ./nuke-refs;
   replacements = {
-    inherit perl; # FIXME: get rid of perl dependency.
-    inherit (builtins) storeDir;
+    sed = lib.getExe gnused;
+    # `,` is used as the delimiter in multiple sed expressions
+    storeDir = lib.escape [ "," ] builtins.storeDir;
+    storeDirEscaped = lib.escape [ "," ] (lib.escapeRegex builtins.storeDir);
     shell = lib.getBin shell + (shell.shellPath or "");
     signingUtils = lib.optionalString (
       stdenvNoCC.targetPlatform.isDarwin && stdenvNoCC.targetPlatform.isAarch64

--- a/pkgs/build-support/nuke-references/nuke-refs
+++ b/pkgs/build-support/nuke-references/nuke-refs
@@ -6,23 +6,36 @@ if [[ -n "@signingUtils@" ]]; then
     source "@signingUtils@"
 fi
 
-excludes=""
+declare -a excludeHashes=()
 while getopts e: o; do
     case "$o" in
-        e) storeId=$(echo "$OPTARG" | @perl@/bin/perl -ne "print \"\$1\" if m|^\Q@storeDir@\E/([a-z0-9]{32})-.*|")
-           if [ -z "$storeId" ]; then
+        e) if [[ "$OPTARG" =~ ^@storeDirEscaped@/([a-z0-9]{32})- ]]; then
+               excludeHashes+=("${BASH_REMATCH[1]}")
+           else
                echo "-e argument must be a Nix store path"
                exit 1
            fi
-           excludes="$excludes(?!$storeId)"
         ;;
     esac
 done
 shift $(($OPTIND-1))
 
+declare -a sedArgs=()
+if [[ "${#excludeHashes[@]}" -gt 0 ]]; then
+    declare excludeAlternation oldIFS="$IFS"
+    IFS='|'
+    excludeAlternation="${excludeHashes[*]}"
+    IFS="$oldIFS"
+    sedArgs+=(-e "s,@storeDirEscaped@/($excludeAlternation)-,@storeDir@/#\1-,g")
+fi
+sedArgs+=(-e "s,@storeDirEscaped@/[a-z0-9]{32}-,@storeDir@/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-,g")
+if [[ "${#excludeHashes[@]}" -gt 0 ]]; then
+    sedArgs+=(-e "s,@storeDirEscaped@/#([a-z0-9]{32})-,@storeDir@/\1-,g")
+fi
+
 for i in "$@"; do
     if test ! -L "$i" -a -f "$i"; then
-        cat "$i" | @perl@/bin/perl -pe "s|\Q@storeDir@\E/$excludes[a-z0-9]{32}-|@storeDir@/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-|g" > "$i.tmp"
+        @sed@ -E "${sedArgs[@]}" "$i" > "$i.tmp"
         if test -x "$i"; then chmod +x "$i.tmp"; fi
         mv "$i.tmp" "$i"
         if [[ -n "@signingUtils@" ]]; then

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -277,6 +277,8 @@ in
 
   substitute = recurseIntoAttrs (callPackage ./substitute { });
 
+  nukeReferences = recurseIntoAttrs (callPackage ./nuke-references { });
+
   build-environment-info = callPackage ./build-environment-info { };
 
   rust-hooks = recurseIntoAttrs (callPackages ../build-support/rust/hooks/test { });

--- a/pkgs/test/nuke-references/default.nix
+++ b/pkgs/test/nuke-references/default.nix
@@ -1,0 +1,96 @@
+{
+  lib,
+  nukeReferences,
+  runCommand,
+}:
+
+let
+  hash1 = lib.strings.replicate 32 "a";
+  hash2 = lib.strings.replicate 32 "b";
+  hash3 = lib.strings.replicate 32 "c";
+  fakeHash = lib.strings.replicate 32 "e";
+
+  mkTest =
+    {
+      name,
+      input,
+      expected,
+      extraNukeRefsArgs ? [ ],
+    }:
+    runCommand "nuke-refs-test-${name}" { } ''
+      printf -- ${lib.escapeShellArg input} > input
+      printf -- ${lib.escapeShellArg expected} > expected
+
+      cp input actual
+      ${lib.getExe nukeReferences} ${lib.escapeShellArgs extraNukeRefsArgs} actual
+
+      if ! cmp -s actual expected; then
+        echo "nuke-refs test '${name}' failed: output did not match expectation"
+        echo "--- input ---"; od -c input
+        echo "--- expected ---"; od -c expected
+        echo "--- actual ---"; od -c actual
+        exit 1
+      fi
+
+      touch $out
+    '';
+in
+{
+  storeDirPrefixWithoutValidHash =
+    let
+      content = ''
+        ${builtins.storeDir}/short-name
+        ${builtins.storeDir}/ABCDEFGHIJKLMNOPQRSTUVWXYZ012345-name
+        ${builtins.storeDir}/${hash1}NODASH
+        ${builtins.storeDir}/
+      '';
+    in
+    mkTest {
+      name = "storedir-prefix-without-valid-hash";
+      input = content;
+      expected = content;
+    };
+
+  hashWithoutStoreDirPrefix =
+    let
+      content = ''
+        ${hash1}-name.so
+        /some/other/dir/${hash1}-name.so
+      '';
+    in
+    mkTest {
+      name = "hash-without-storedir-prefix";
+      input = content;
+      expected = content;
+    };
+
+  bytes = mkTest {
+    name = "bytes";
+    # `\x..` will be interpreted by `printf`
+    input = "\\x7fELF\\x00\\x00\\x00\\x00${builtins.storeDir}/${hash1}-foo.so\\x00\\x00\\x00some\\x00embedded\\x00nulls\\x00here${builtins.storeDir}/${hash2}-bar.so\\x00";
+    expected = "\\x7fELF\\x00\\x00\\x00\\x00${builtins.storeDir}/${fakeHash}-foo.so\\x00\\x00\\x00some\\x00embedded\\x00nulls\\x00here${builtins.storeDir}/${fakeHash}-bar.so\\x00";
+  };
+
+  excludeOnBytes = mkTest {
+    name = "exclude-on-bytes";
+    input = "\\x7fELF\\x00\\x00\\x00\\x00${builtins.storeDir}/${hash1}-foo.so\\x00\\x00\\x00some\\x00embedded\\x00nulls\\x00here${builtins.storeDir}/${hash2}-bar.so\\x00";
+    expected = "\\x7fELF\\x00\\x00\\x00\\x00${builtins.storeDir}/${hash1}-foo.so\\x00\\x00\\x00some\\x00embedded\\x00nulls\\x00here${builtins.storeDir}/${fakeHash}-bar.so\\x00";
+    extraNukeRefsArgs = [
+      "-e"
+      "${builtins.storeDir}/${hash1}-foo.so"
+    ];
+  };
+
+  # This verifies that the regex built by multiple `-e` arguments works correctly
+  excludeTwoOnBytes = mkTest {
+    name = "exclude-two-on-bytes";
+    input = "\\x7fELF\\x00\\x00\\x00\\x00${builtins.storeDir}/${hash1}-a.so\\x00${builtins.storeDir}/${hash2}-b.so\\x00${builtins.storeDir}/${hash3}-c.so\\x00";
+    expected = "\\x7fELF\\x00\\x00\\x00\\x00${builtins.storeDir}/${hash1}-a.so\\x00${builtins.storeDir}/${fakeHash}-b.so\\x00${builtins.storeDir}/${hash3}-c.so\\x00";
+    extraNukeRefsArgs = [
+      "-e"
+      "${builtins.storeDir}/${hash1}-a.so"
+      "-e"
+      "${builtins.storeDir}/${hash3}-c.so"
+    ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR fixes the TODO listed in `default.nix` by replacing perl with gnused. This reduces the closure size on linux from ~106MiB to ~39MiB (~380MiB to ~324MiB during early bootstrap).

I used a trick I found [here](https://learnbyexample.github.io/sed-lookarounds/#negative-lookarounds) to emulate the negative lookaheads. We add a temporary `#` in the middle of any exclude patterns to hide them from the substitution, and then revert the `#`s again afterwards.

I'd be happy if someone could take a close look at the wording in the proposed documentation - I feel like I'm treading on shaky ground with the details about the motivation behind the tool.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux (built `pkgs.nukeReferences` + tests)
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [X] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
