### PR TITLE
nixos/karakeep: remove meilisearch workaround for dumpless upgrade

### DIFF
--- a/nixos/modules/services/web-apps/karakeep.nix
+++ b/nixos/modules/services/web-apps/karakeep.nix
@@ -90,22 +90,6 @@ in
             required for text search.
           '';
         };
-
-        # TODO: remove when this is either handled by karakeep or becomes default
-        #       in services.meilisearch.
-        experimental_dumpless_upgrade = lib.mkOption {
-          default = true;
-          description = ''
-            Whether to enable (experimental) dumpless upgrade of the search index.
-            Allows upgrading Meilisearch without manually dumping and importing
-            the database.
-            {option}`services.meilisearch.settings.experimental_dumpless_upgrade`
-            overrides this option if set explicitly.
-
-            More information at <https://www.meilisearch.com/docs/learn/update_and_migration/updating#dumpless-upgrade>.
-          '';
-          type = lib.types.bool;
-        };
       };
     };
   };
@@ -121,7 +105,6 @@ in
 
     services.meilisearch = {
       enable = cfg.meilisearch.enable;
-      settings.experimental_dumpless_upgrade = lib.mkDefault cfg.meilisearch.experimental_dumpless_upgrade;
     };
 
     systemd.services.karakeep-init = {


### PR DESCRIPTION
The Karakeep module previously set the `experimental_dumpless_upgrade`
setting, which was renamed in meilisearch 1.51.0, which is causing
meilisearch to fail to parse its config file and crash.

This setting was renamed for the meilisearch module in #548169, but the
Karakeep module was also configuring this setting. Per the karakeep
module's comment, this option was intended to be removed once dumpless
upgrades were the default in meilisearch, so I've removed this option.

Resolves #548609


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
