### PR TITLE
opencode: drop bundled Windows executables from node_modules

### DIFF
--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -72,13 +72,20 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       mkdir -p $out
       find . -type d -name node_modules -exec cp -R --parents {} $out \;
 
+      # opencode targets only Linux and Darwin (see meta.platforms), so the
+      # Windows executables that "bun install --os=*" fetches are never
+      # executed. Dropping them keeps the output reproducible on hosts whose
+      # security endpoint agents scan the store, and removes the vulnerable
+      # bundled 7za.exe that will be quarantined.
+      find $out -type f -name '*.exe' -delete
+
       runHook postInstall
     '';
 
     # NOTE: Required else we get errors that our fixed-output derivation references store paths
     dontFixup = true;
 
-    outputHash = "sha256-CQGZzD+XP4b452zvocKkdpjGJ2qrnxDhMQ/9846jp9I=";
+    outputHash = "sha256-gb1vgLGiK56A9Xtg71d2J9ct8TJAjDg1A7cOUx0v3cA=";
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
   };


### PR DESCRIPTION
The node_modules fixed-output derivation runs `"bun install --os=*"`, so it fetches every platform variant of each dependency, including Windows executables such as 7zip-bin's 7za.exe, esbuild.exe, turbo.exe, and tsgo.exe. opencode targets only Linux and Darwin (`meta.platforms`), so these files are never executed.

Deleting them keeps the output reproducible on hosts whose security endpoint agents scan the store. On managed macOS, the bundled `7za.exe` is quarantined for a known vulnerability and the scanner intermittently blocks reading the `.exe` files during the install phase copy, which produces nondeterministic fixed-output hash mismatches. Removing the executables is host independent, so the derivation keeps its single outputHash.

Restricting `--os` cannot replace this: `7zip-bin` declares no `os` field and ships `win/`, `mac/`, and `linux/` in one tarball, so bun always unpacks its `7za.exe` regardless of `--os`.

Fix https://github.com/NixOS/nixpkgs/issues/549496.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
