### PR TITLE
python3Packages.apache-tvm-ffi: 0.1.12 -> 0.1.13-post2

### DIFF
--- a/pkgs/development/python-modules/apache-tvm-ffi/default.nix
+++ b/pkgs/development/python-modules/apache-tvm-ffi/default.nix
@@ -15,13 +15,14 @@
 
   # tests
   numpy,
+  pytest-xdist,
   pytestCheckHook,
   writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "apache-tvm-ffi";
-  version = "0.1.12";
+  version = "0.1.13-post2";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -30,8 +31,15 @@ buildPythonPackage (finalAttrs: {
     repo = "tvm-ffi";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-ZFi7MKFiHK2lNoVkQbPhOc7NpIf24PLLP8SqGQiQ9Lw=";
+    hash = "sha256-TovUbVld/IcTuVYc2CGPcARDyKZ3XrQDEtQaTV1fT2k=";
   };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail \
+        "cython>=3.2.8" \
+        "cython"
+  '';
 
   build-system = [
     cmake
@@ -56,6 +64,7 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [
     numpy
+    pytest-xdist
     pytestCheckHook
     writableTmpDirAsHomeHook
   ];

--- a/pkgs/development/python-modules/hoptorch/default.nix
+++ b/pkgs/development/python-modules/hoptorch/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -12,7 +11,6 @@
   torch,
 
   # tests
-  llvmPackages,
   pytestCheckHook,
 }:
 

--- a/pkgs/development/python-modules/kserve/default.nix
+++ b/pkgs/development/python-modules/kserve/default.nix
@@ -73,11 +73,16 @@ buildPythonPackage (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/python/kserve";
 
+  build-system = [
+    setuptools
+  ];
+
   pythonRelaxDeps = [
     "cryptography"
     "fastapi"
     "httpx"
     "numpy"
+    "pandas"
     "prometheus-client"
     "protobuf"
     "psutil"
@@ -85,11 +90,6 @@ buildPythonPackage (finalAttrs: {
     "starlette"
     "uvicorn"
   ];
-
-  build-system = [
-    setuptools
-  ];
-
   dependencies = [
     aiohttp
     cloudevents

--- a/pkgs/development/python-modules/kserve/default.nix
+++ b/pkgs/development/python-modules/kserve/default.nix
@@ -179,6 +179,9 @@ buildPythonPackage (finalAttrs: {
   ];
 
   disabledTests = [
+    # TypeError: Cannot interpret '<StringDtype(na_value=nan)>' as a data type
+    "test_fp16_input_as_binary_data"
+
     # AttributeError: 'google._upb._message.FieldDescriptor' object has no attribute 'label'
     "test_health_handler"
     "test_list_handler"

--- a/pkgs/development/python-modules/tensordict/default.nix
+++ b/pkgs/development/python-modules/tensordict/default.nix
@@ -80,6 +80,9 @@ buildPythonPackage (finalAttrs: {
   ];
 
   disabledTests = [
+    # TypeError: not all arguments converted during string formatting
+    "test_dtensor"
+
     # FileNotFoundError: [Errno 2] No such file or directory: '/build/source/tensordict/tensorclass.pyi
     "test_tensorclass_instance_methods"
     "test_tensorclass_stub_methods"

--- a/pkgs/development/python-modules/tilelang/default.nix
+++ b/pkgs/development/python-modules/tilelang/default.nix
@@ -43,7 +43,7 @@
 }:
 buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
   pname = "tilelang";
-  version = "0.1.11";
+  version = "0.1.13";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -52,7 +52,7 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
     repo = "tilelang";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-C/c99/26/dBnQJYGrZ+NXl1Rqk3bjM2kpkgP/hWkTGE=";
+    hash = "sha256-mUma33LlPw2bwB+mryshlY5wuVSDmPSMjWmDAefdN/w=";
   };
 
   postPatch =
@@ -67,14 +67,18 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
     + ''
       sed -i '/def get_git_commit_id()/a\\    return None' version_provider.py
     ''
-    # fix permissions for install_name_tool -id
+    # fix permissions for install_name_tool -id and use the toolchain's
+    # install_name_tool, as /usr/bin is not available in the sandbox
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
       substituteInPlace cmake/pypi-z3/FindZ3.cmake \
         --replace-fail COPYONLY 'FILE_PERMISSIONS
           OWNER_READ OWNER_WRITE OWNER_EXECUTE
           GROUP_READ GROUP_WRITE GROUP_EXECUTE
           WORLD_READ WORLD_WRITE WORLD_EXECUTE
-          COPYONLY'
+          COPYONLY' \
+        --replace-fail \
+          "COMMAND /usr/bin/install_name_tool" \
+          "COMMAND ${lib.getExe' stdenv.cc.bintools.bintools "install_name_tool"}"
     '';
 
   nativeBuildInputs = [
@@ -133,17 +137,23 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
   };
 
   preFixup =
-    lib.optionalString stdenv.hostPlatform.isLinux ''
+    lib.optionalString stdenv.hostPlatform.isLinux (
       # libtvm_ffi.so
-      addAutoPatchelfSearchPath "${finalAttrs.passthru.apache-tvm-ffi}/${python.sitePackages}/tvm_ffi/lib"
+      ''
+        addAutoPatchelfSearchPath "${finalAttrs.passthru.apache-tvm-ffi}/${python.sitePackages}/tvm_ffi/lib"
+      ''
       # libz3.so.4.16
-      addAutoPatchelfSearchPath "${z3-solver.lib}/lib"
-    ''
-    + lib.optionalString stdenv.hostPlatform.isDarwin ''
-      # @rpath/libz3.dylib
-      install_name_tool -add_rpath "${z3-solver.lib}/lib" \
-        "$out/${python.sitePackages}/tilelang/lib/libtvm_compiler.dylib"
-    '';
+      + ''
+        addAutoPatchelfSearchPath "${z3-solver.lib}/lib"
+      ''
+    )
+    +
+      lib.optionalString stdenv.hostPlatform.isDarwin
+        # @rpath/libz3.dylib
+        ''
+          install_name_tool -add_rpath "${z3-solver.lib}/lib" \
+            "$out/${python.sitePackages}/tilelang/lib/libtvm_compiler.dylib"
+        '';
 
   pythonImportsCheck = [ "tilelang" ];
 
@@ -167,16 +177,20 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
     doCheck = true;
   };
 
-  passthru.apache-tvm-ffi = apache-tvm-ffi.overrideAttrs (previousAttrs: {
-    version = "0.1.10";
-    src = previousAttrs.src.override {
-      tag = null;
-      rev = "3c35034fd1026011736e19a4e0e1ed0f22058c42";
-      hash = "sha256-dqAO6RLLGIRzPk7dNQsQCck+ziyONddhK/t4+S28cn8=";
-    };
-    # fix eval
-    meta.changelog = "";
-  });
+  passthru.apache-tvm-ffi = apache-tvm-ffi.overrideAttrs (
+    previousAttrs:
+    let
+      version = "0.1.12";
+    in
+    {
+      inherit version;
+      src = previousAttrs.src.override {
+        tag = "v${version}";
+        hash = "sha256-ZFi7MKFiHK2lNoVkQbPhOc7NpIf24PLLP8SqGQiQ9Lw=";
+      };
+      postPatch = "";
+    }
+  );
 
   meta = {
     description = "Tile level programming language to generate high performance code";

--- a/pkgs/development/python-modules/torch-c-dlpack-ext/default.nix
+++ b/pkgs/development/python-modules/torch-c-dlpack-ext/default.nix
@@ -14,6 +14,7 @@ buildPythonPackage (finalAttrs: {
   pname = "torch-c-dlpack-ext";
   inherit (apache-tvm-ffi) version src;
   pyproject = true;
+  __structuredAttrs = true;
 
   sourceRoot = "${finalAttrs.src.name}/addons/torch_c_dlpack_ext";
 

--- a/pkgs/development/python-modules/torch-c-dlpack-ext/default.nix
+++ b/pkgs/development/python-modules/torch-c-dlpack-ext/default.nix
@@ -12,7 +12,9 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "torch-c-dlpack-ext";
-  inherit (apache-tvm-ffi) version src;
+  # This addon lives in the tvm-ffi repository, but is versioned independently
+  version = "0.1.5";
+  inherit (apache-tvm-ffi) src;
   pyproject = true;
   __structuredAttrs = true;
 

--- a/pkgs/development/python-modules/torchrl/default.nix
+++ b/pkgs/development/python-modules/torchrl/default.nix
@@ -15,6 +15,7 @@
 
   # dependencies
   cloudpickle,
+  hoptorch,
   packaging,
   pyvers,
   tensordict,
@@ -75,7 +76,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "torchrl";
-  version = "0.13.1";
+  version = "0.13.3";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -83,7 +84,7 @@ buildPythonPackage (finalAttrs: {
     owner = "pytorch";
     repo = "rl";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-xnQLwOofHwdRvrOMNJpAEiOT7BEfxoPmrcxw2H3CTvI=";
+    hash = "sha256-GdiGZZlx8olRMzl4CJD11S1+q0+pOeCD2wrDPcji5p0=";
   };
 
   postPatch = ''
@@ -104,10 +105,11 @@ buildPythonPackage (finalAttrs: {
 
   dependencies = [
     cloudpickle
+    hoptorch
     numpy
     packaging
-    tensordict
     pyvers
+    tensordict
     torch
   ];
 
@@ -204,6 +206,15 @@ buildPythonPackage (finalAttrs: {
   ++ finalAttrs.passthru.optional-dependencies.rendering;
 
   disabledTests = [
+    # mujoco.FatalError: an OpenGL platform library has not been loaded into this process, this most
+    # likely means that a valid OpenGL context has not been created before mjr_makeContext was
+    # called
+    "test_from_pixels_spec_and_rollout"
+
+    # Hang forever
+    "test_pixels_only_drops_observation_key"
+    "test_render_method"
+
     # Require network
     "test_create_or_load_dataset"
     "test_from_text_env_tokenizer"


### PR DESCRIPTION
## Things done

- **python3Packages.apache-tvm-ffi: 0.1.12 -> 0.1.13-post2** ([Diff](https://github.com/apache/tvm-ffi/compare/v0.1.12...v0.1.13-post2), [Changelog](https://github.com/apache/tvm-ffi/releases/tag/v0.1.13-post2))
- **python3Packages.torch-c-dlpack-ext: enable __structuredAttrs**
- **python3Packages.torch-c-dlpack-ext: fix version**
- **python3Packages.tilelang: 0.1.11 -> 0.1.13** ([Diff](https://github.com/tile-ai/tilelang/compare/v0.1.11...v0.1.13), [Changelog](https://github.com/tile-ai/tilelang/releases/tag/v0.1.13))
- **python3Packages.kserve: relax pandas**
- **python3Packages.kserve: skip failing test**
- **python3Packages.tensordict: skip failing test**
- **python3Packages.torchrl: 0.13.1 -> 0.13.3** ([Diff](https://github.com/pytorch/rl/compare/v0.13.1...v0.13.3), [Changelog](https://github.com/pytorch/rl/releases/tag/v0.13.3))
- **python3Packages.hoptorch: remove unused inputs**

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

