### PR TITLE
gnome-settings-daemon: cleanup dependencies

### DIFF
--- a/pkgs/by-name/gn/gnome-settings-daemon/package.nix
+++ b/pkgs/by-name/gn/gnome-settings-daemon/package.nix
@@ -1,43 +1,43 @@
 {
-  stdenv,
-  lib,
-  replaceVars,
-  fetchpatch,
+  alsa-lib,
   buildPackages,
+  colord,
+  docbook-xsl-nons,
+  fetchpatch,
   fetchurl,
-  meson,
-  ninja,
-  pkg-config,
-  gnome,
-  perl,
+  gcr_4,
+  geoclue2,
+  geocode-glib_2,
   gettext,
   glib,
-  libnotify,
-  libgnomekbd,
-  libpulseaudio,
-  alsa-lib,
-  libcanberra,
-  upower,
-  colord,
-  libgweather,
-  polkit,
+  gnome,
+  gnome-desktop,
+  gnome-session-ctl,
   gsettings-desktop-schemas,
-  geoclue2,
-  systemd,
+  lib,
+  libcanberra,
+  libgnomekbd,
   libgudev,
-  libxslt,
+  libgweather,
+  libnotify,
+  libpulseaudio,
   libxml2,
+  libxslt,
+  meson,
   modemmanager,
   networkmanager,
-  gnome-desktop,
-  geocode-glib_2,
-  docbook-xsl-nons,
-  wrapGAppsNoGuiHook,
+  ninja,
+  perl,
+  pkg-config,
+  polkit,
   python3,
+  replaceVars,
+  stdenv,
+  systemd,
   tzdata,
-  gcr_4,
-  gnome-session-ctl,
   udevCheckHook,
+  upower,
+  wrapGAppsNoGuiHook,
   withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
 }:
 
@@ -65,39 +65,39 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   nativeBuildInputs = [
-    meson
-    ninja
-    pkg-config
-    perl
+    docbook-xsl-nons
     gettext
     glib
     libxml2
     libxslt
-    docbook-xsl-nons
-    wrapGAppsNoGuiHook
+    meson
+    ninja
+    perl
+    pkg-config
     python3
     udevCheckHook
+    wrapGAppsNoGuiHook
   ];
 
   buildInputs = [
+    alsa-lib
+    colord
+    gcr_4
+    geoclue2
+    geocode-glib_2
     glib
+    gnome-desktop
     gsettings-desktop-schemas
+    libcanberra
+    libgnomekbd # for org.gnome.libgnomekbd.keyboard schema
+    libgudev
+    libgweather
+    libnotify
+    libpulseaudio
     modemmanager
     networkmanager
-    libnotify
-    libgnomekbd # for org.gnome.libgnomekbd.keyboard schema
-    gnome-desktop
-    libpulseaudio
-    alsa-lib
-    libcanberra
-    upower
-    colord
-    libgweather
     polkit
-    geocode-glib_2
-    geoclue2
-    libgudev
-    gcr_4
+    upower
   ]
   ++ lib.optionals withSystemd [
     systemd

--- a/pkgs/by-name/gn/gnome-settings-daemon/package.nix
+++ b/pkgs/by-name/gn/gnome-settings-daemon/package.nix
@@ -133,6 +133,8 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
+    description = "GNOME Settings Daemon";
+    homepage = "https://gitlab.gnome.org/GNOME/gnome-settings-daemon/";
     license = lib.licenses.gpl2Plus;
     teams = [ lib.teams.gnome ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/gn/gnome-settings-daemon/package.nix
+++ b/pkgs/by-name/gn/gnome-settings-daemon/package.nix
@@ -1,10 +1,11 @@
 {
   alsa-lib,
+  bashNonInteractive,
   buildPackages,
   colord,
-  docbook-xsl-nons,
-  fetchpatch,
+  cups,
   fetchurl,
+  fontconfig,
   gcr_4,
   geoclue2,
   geocode-glib_2,
@@ -16,13 +17,12 @@
   gsettings-desktop-schemas,
   lib,
   libcanberra,
-  libgnomekbd,
   libgudev,
   libgweather,
   libnotify,
   libpulseaudio,
-  libxml2,
-  libxslt,
+  libx11,
+  libxfixes,
   meson,
   modemmanager,
   networkmanager,
@@ -30,7 +30,6 @@
   perl,
   pkg-config,
   polkit,
-  python3,
   replaceVars,
   stdenv,
   systemd,
@@ -44,6 +43,9 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-settings-daemon";
   version = "50.1";
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-settings-daemon/${lib.versions.major finalAttrs.version}/gnome-settings-daemon-${finalAttrs.version}.tar.xz";
@@ -65,23 +67,22 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   nativeBuildInputs = [
-    docbook-xsl-nons
     gettext
     glib
-    libxml2
-    libxslt
     meson
     ninja
     perl
     pkg-config
-    python3
     udevCheckHook
     wrapGAppsNoGuiHook
   ];
 
   buildInputs = [
     alsa-lib
+    bashNonInteractive
     colord
+    cups
+    fontconfig
     gcr_4
     geoclue2
     geocode-glib_2
@@ -89,11 +90,12 @@ stdenv.mkDerivation (finalAttrs: {
     gnome-desktop
     gsettings-desktop-schemas
     libcanberra
-    libgnomekbd # for org.gnome.libgnomekbd.keyboard schema
     libgudev
     libgweather
     libnotify
     libpulseaudio
+    libx11
+    libxfixes
     modemmanager
     networkmanager
     polkit


### PR DESCRIPTION
I noticed that our package of `gnome-settings-daemon` still had `libgnomekbd` in its `buildInputs` even though that package is long abandoned and no longer used. When removing that input other dependencies were failing, so I did a bigger cleanup, including the ordering of things. 

The removed `nativeBuildInputs` were unused and the added `buildInputs` were required because they were previously provided indirectly via `libgnomekbd`

Build logs before and after suggest that everything is still built the same.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
