### PR TITLE
obah: init at 0.1.1

### DIFF
--- a/pkgs/by-name/ob/obah/package.nix
+++ b/pkgs/by-name/ob/obah/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "obah";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "galister";
+    repo = "obah";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-s4YvyNm/XBiRQc2WQqkrHun2+vn4vXf1Okzw040gtsc=";
+  };
+
+  cargoHash = "sha256-o71CVr5Zr2ZGzRfJbqXxGMX8HZbOW0Cyf6mk2isUHEs=";
+  cargoDepsName = finalAttrs.pname;
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "OpenVR bindings TUI for xrizer, VapoR and OpenComposite";
+    homepage = "https://github.com/galister/obah";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bddvlpr ];
+    mainProgram = "obah";
+  };
+})


### PR DESCRIPTION
OpenVR bindings TUI for xrizer, VapoR and OpenComposite.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
