### PR TITLE
kener,nixos/kener: init at 4.1.2, init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -70,6 +70,8 @@
 
 - [Solaar](https://github.com/pwr-Solaar/Solaar), a program to control logitech devices.
 
+- [Kener](https://kener.ing), a modern, open-source status page application built with Node.js. Available as [services.kener](#opt-services.kener.enable).
+
 - [FlapAlerted](https://github.com/Kioubit/FlapAlerted), detects BGP flapping events and provides statistics based on BGP update messages. Available as [services.flap-alerted](#opt-services.flap-alerted.enable).
 
 - [gocron](https://github.com/flohoss/gocron), a task scheduler with web interface. Available as [services.gocron](#opt-services.gocron.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1066,6 +1066,7 @@
   ./services/monitoring/incron.nix
   ./services/monitoring/kapacitor.nix
   ./services/monitoring/karma.nix
+  ./services/monitoring/kener.nix
   ./services/monitoring/kthxbye.nix
   ./services/monitoring/librenms.nix
   ./services/monitoring/loki.nix

--- a/nixos/modules/services/monitoring/kener.nix
+++ b/nixos/modules/services/monitoring/kener.nix
@@ -1,0 +1,156 @@
+{
+  config,
+  options,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.services.kener;
+  opt = options.services.kener;
+  isRedisUnixSocket = lib.hasPrefix "/" cfg.redis.host;
+in
+{
+
+  meta.maintainers = [ lib.maintainers.albertlarsan68 ];
+
+  options = {
+    services.kener = {
+      enable = lib.mkEnableOption "Kener, this assumes a reverse proxy to be set";
+
+      package = lib.mkPackageOption pkgs "kener" { };
+
+      environmentFile = lib.mkOption {
+        type = lib.types.path;
+        default = null;
+        description = "Environment file, to put KENER_SECRET_KEY and other sensible values.";
+      };
+
+      redis = {
+        createLocally = lib.mkOption {
+          description = ''
+            Whether to configure a local Redis server for Kener.
+            The connection is performed via Unix sockets by default,
+            but that can be changed by disabling this option and
+            configuring {option}`${opt.redis.host}` and {option}`${opt.redis.port}`.
+          '';
+          type = lib.types.bool;
+          default = true;
+        };
+        host = lib.mkOption {
+          type = lib.types.str;
+          default = config.services.redis.servers.kener.unixSocket;
+          defaultText = lib.literalExpression "config.services.redis.servers.kener.unixSocket";
+          description = "The host that redis will listen on.";
+        };
+        port = lib.mkOption {
+          type = lib.types.port;
+          default = 0;
+          description = "The port that redis will listen on. Set to zero to disable TCP.";
+        };
+      };
+
+      settings = lib.mkOption {
+        type = lib.types.submodule { freeformType = with lib.types; attrsOf str; };
+        default = { };
+        example = {
+          PORT = "4000";
+          NODE_EXTRA_CA_CERTS = lib.literalExpression "config.security.pki.caBundle";
+        };
+        description = ''
+          Additional configuration for Kener, see
+          <https://kener.ing/docs/v4/setup/environment-variables>
+          for supported values.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = (
+          config.services.kener.redis.createLocally
+          -> (config.services.kener.redis.host == config.services.redis.servers.kener.unixSocket)
+        );
+        message = "createLocally should only be used with the local unix socket";
+      }
+    ];
+
+    services.redis.servers = lib.mkIf cfg.redis.createLocally {
+      kener = {
+        enable = true;
+        port = cfg.redis.port;
+        bind = lib.mkIf (!isRedisUnixSocket) cfg.redis.host;
+      };
+    };
+
+    services.kener.settings =
+      let
+        redisEnv =
+          if isRedisUnixSocket then
+            { REDIS_URL = "unix://${cfg.redis.host}"; }
+          else
+            {
+              REDIS_URL = "redis://${cfg.redis.host}:${toString cfg.redis.port}";
+            };
+      in
+      redisEnv
+      // {
+        NODE_ENV = lib.mkDefault "production";
+        DATABASE_URL = lib.mkDefault "sqlite:///var/lib/kener/kener.sqlite.db";
+        HOST = lib.mkDefault "127.0.0.1";
+        PORT = lib.mkDefault "3001";
+      };
+
+    systemd.services.kener = {
+      description = "Kener";
+      after = [ "network.target" ] ++ lib.optional cfg.redis.createLocally "redis-kener.service";
+      wantedBy = [ "multi-user.target" ];
+      environment = cfg.settings;
+      path = with pkgs; [ unixtools.ping ];
+      serviceConfig = {
+        Type = "simple";
+        StateDirectory = "kener";
+        StateDirectoryMode = "750";
+        DynamicUser = true;
+        ExecStart = "${cfg.package}/bin/kener-server";
+        Restart = "on-failure";
+        AmbientCapabilities = "";
+        CapabilityBoundingSet = "";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = false; # enabling it breaks execution
+        MountAPIVFS = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProtectClock = true;
+        ProtectControlGroups = "strict";
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+          "AF_NETLINK"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        UMask = 27;
+        SupplementaryGroups = lib.mkIf (cfg.redis.createLocally && isRedisUnixSocket) [
+          config.services.redis.servers.kener.group
+        ];
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -895,6 +895,7 @@ in
   kea = runTest ./kea.nix;
   keepalived = discoverTests (import ./keepalived.nix);
   keepassxc = runTest ./keepassxc.nix;
+  kener = runTest ./kener.nix;
   kerberos = handleTest ./kerberos/default.nix { };
   kernel-generic = handleTest ./kernel-generic { };
   kernel-latest-ath-user-regd = runTest ./kernel-latest-ath-user-regd.nix;

--- a/nixos/tests/kener.nix
+++ b/nixos/tests/kener.nix
@@ -1,0 +1,27 @@
+{ lib, ... }:
+
+{
+  name = "kener";
+  meta.maintainers = with lib.maintainers; [ albertlarsan68 ];
+
+  containers.machine =
+    { pkgs, ... }:
+    {
+      services.kener = {
+        enable = true;
+        environmentFile = pkgs.writeText "kener-env" ''
+          KENER_SECRET_KEY=kener_secret_key_do_not_use
+        '';
+        settings = {
+          ORIGIN = "http://localhost:3001";
+        };
+      };
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("kener.service")
+    machine.wait_for_open_port(3001)
+    machine.wait_until_succeeds("curl --fail http://localhost:3001/healthcheck?strict=1")
+  '';
+}

--- a/pkgs/by-name/ke/kener/package.nix
+++ b/pkgs/by-name/ke/kener/package.nix
@@ -1,0 +1,48 @@
+{
+  buildNpmPackage,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  nodejs,
+}:
+
+buildNpmPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "kener";
+  version = "4.1.2";
+
+  src = fetchFromGitHub {
+    owner = "rajnandan1";
+    repo = "kener";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+G0RBzSKu3RPvTAAkHtL7KMaNkCUDsawr6Qgyk7BXfo=";
+  };
+
+  npmDepsHash = "sha256-QnsR46mhakCLXqaCBEIZYMTGj3puqLPs4inyV/ZFwAY=";
+  postFixup = ''
+    makeWrapper ${nodejs}/bin/node $out/bin/kener-server \
+      --add-flags $out/lib/node_modules/kener/build/main.js \
+      --chdir $out/lib/node_modules/kener
+  '';
+  postInstall = ''
+    # The build dir is not picked up by `npm pack`. Let’s copy it manually.
+    cp -r build $out/lib/node_modules/kener/
+    # This is needed because kener relies on type stripping for db migration and seeding.
+    # But type stripping cannot occur if the caconical path contains `node_modules` anywhere, which
+    # the default installed path contains. So we move the built artifacts from the standard path to
+    # another, and add a symlink back, to not break anything.
+    mv $out/lib/node_modules/kener $out/lib
+    ln -s $out/lib/kener $out/lib/node_modules/kener
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Modern, open-source status page application built with Node.js";
+    homepage = "https://kener.ing";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ albertlarsan68 ];
+    mainProgram = "kener-server";
+  };
+})

--- a/pkgs/by-name/ke/kener/package.nix
+++ b/pkgs/by-name/ke/kener/package.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   lib,
   nix-update-script,
+  nixosTests,
   nodejs,
 }:
 
@@ -35,6 +36,8 @@ buildNpmPackage (finalAttrs: {
     mv $out/lib/node_modules/kener $out/lib
     ln -s $out/lib/kener $out/lib/node_modules/kener
   '';
+
+  passthru.tests.kener = nixosTests.kener;
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
