### PR TITLE
libcpucycles: update `meta.license`

### DIFF
--- a/pkgs/by-name/li/libcpucycles/package.nix
+++ b/pkgs/by-name/li/libcpucycles/package.nix
@@ -37,14 +37,15 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://cpucycles.cr.yp.to/";
     description = "Microlibrary for counting CPU cycles";
     changelog = "https://cpucycles.cr.yp.to/download.html";
-    license = with lib.licenses; [
-      # Upstream specifies the public domain licenses with the terms here https://cr.yp.to/spdx.html
-      publicDomain
-      cc0
-      bsd0
-      mit
-      mit0
-    ];
+    license =
+      # Upstream specifies the public domain licenses with the terms here https://cpucycles.cr.yp.to/license.html
+      lib.licenses.OR [
+        lib.licenses.publicDomain
+        lib.licenses.cc0
+        lib.licenses.bsd0
+        lib.licenses.mit
+        lib.licenses.mit0
+      ];
     maintainers = with lib.maintainers; [
       kiike
       imadnyc


### PR DESCRIPTION
- Add `OR` operator, as per https://cpucycles.cr.yp.to/license.html
- Update URL to license in comment (the previous URL is included in the page the replaced one points to).

Ref: https://github.com/ngi-nix/projects/issues/102
Ref: https://github.com/NixOS/nixpkgs/pull/549383#discussion_r3718101305

This work is done as part of Summer of Nix 2026.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
