### PR TITLE
fmi-reference-fmus: 0.0.39 -> 0.0.40

### DIFF
--- a/pkgs/by-name/fm/fmi-reference-fmus/package.nix
+++ b/pkgs/by-name/fm/fmi-reference-fmus/package.nix
@@ -10,26 +10,23 @@
 
 # C.f. <https://fmi-standard.org/>
 assert lib.asserts.assertMsg (
-  FMIVersion >= 1 && FMIVersion <= 3
-) "FMIVersion must be a valid FMI specification standard: 1, 2, or 3; not ${toString FMIVersion}";
+  FMIVersion >= 2 && FMIVersion <= 3
+) "FMIVersion must be a valid FMI specification standard of: 2 or 3; not ${toString FMIVersion}";
 
-# NB: this derivation does not package the fmusim executables, only
-# the FMUs.
 stdenv.mkDerivation (finalAttrs: {
   pname = "reference-fmus";
-  version = "0.0.39";
+  version = "0.0.40";
   src = fetchFromGitHub {
     owner = "modelica";
     repo = "reference-fmus";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-3bjqfEyPhqVrJOHHhniacyUAo82InCd6LLx3tyC8DYg=";
+    hash = "sha256-GRyvfOncJ6PPQpqxFELlIEZCijcxnSAzbPilmMEwmJQ=";
   };
 
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [
     "-DFMI_VERSION=${toString FMIVersion}"
-    (lib.cmakeBool "WITH_FMUSIM" false)
   ];
 
   env = lib.optionalAttrs (FMIVersion == 3) {


### PR DESCRIPTION
0.0.40 removes build support for FMI version 1 and removes the previously vendored fmusim executable, which we no longer need to disable.

https://github.com/modelica/Reference-FMUs/releases/tag/v0.0.40

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
