### PR TITLE
models-dev,opencode: generate JSON schema of model ids patch opencode schema to point to local version

### DIFF
--- a/pkgs/by-name/mo/models-dev/generate-schema.ts
+++ b/pkgs/by-name/mo/models-dev/generate-schema.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env bun
+
+// This script was built after:
+// https://github.com/anomalyco/models.dev/blob/e19e7c6719650b38712d432760eda2ae3136e796/packages/function/src/worker.ts#L67-L102
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+const [, , apiPath, outPath] = process.argv;
+
+const providers = JSON.parse(readFileSync(apiPath, "utf8")) as Record<
+  string,
+  { models: Record<string, unknown> }
+>;
+
+const modelIds: string[] = [];
+for (const [providerId, provider] of Object.entries(providers)) {
+  for (const modelId of Object.keys(provider.models)) {
+    modelIds.push(`${providerId}/${modelId}`);
+  }
+}
+
+const schema = {
+  $schema: "https://json-schema.org/draft/2020-12/schema",
+  $id: "https://models.dev/model-schema.json",
+  $defs: {
+    Model: {
+      type: "string",
+      enum: modelIds.sort(),
+      description: "AI model identifier in provider/model format",
+    },
+  },
+};
+
+writeFileSync(outPath, `${JSON.stringify(schema, null, 2)}\n`);

--- a/pkgs/by-name/mo/models-dev/package.nix
+++ b/pkgs/by-name/mo/models-dev/package.nix
@@ -85,6 +85,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     cd packages/web
     bun run ./script/build.ts
+    bun ${./generate-schema.ts} ./dist/_api.json ./dist/model-schema.json
 
     runHook postBuild
   '';
@@ -98,12 +99,15 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.updateScript = nix-update-script {
-    extraArgs = [
-      "--version=branch"
-      "--subpackage"
-      "node_modules"
-    ];
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version=branch"
+        "--subpackage"
+        "node_modules"
+      ];
+    };
+    jsonschema = "${finalAttrs.finalPackage}/dist/model-schema.json";
   };
 
   meta = {

--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -119,6 +119,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     cd ./packages/opencode
     bun --bun ./script/build.ts --single --skip-install
     bun --bun ./script/schema.ts config.json tui.json
+    substituteInPlace config.json \
+      --replace-fail "https://models.dev/model-schema.json" \
+                     "file://$out/share/model-schema.json"
 
     runHook postBuild
   '';
@@ -140,6 +143,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
      } \
     --set OPENCODE_DISABLE_AUTOUPDATE true
 
+    install -Dm644 ${models-dev.jsonschema} $out/share/model-schema.json
     install -Dm644 config.json $out/share/config.json
     install -Dm644 tui.json $out/share/tui.json
     install -Dm644 ../web/public/theme.json $out/share/theme.json


### PR DESCRIPTION
models-dev now generates the `model-schema.json` and exposes it via as passthru. In `opencode` we install `model-schema.json` to `$out/share` and update links in `config.json` pointing to https://models.dev/model-schema.json to the installed file.

The generate script was AI generated from the upstream sources (see the link in the file). I tested the schema locally.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
