### PR TITLE
freetype-demos: init at 2.14.3

### DIFF
--- a/pkgs/by-name/fr/freetype-demos/package.nix
+++ b/pkgs/by-name/fr/freetype-demos/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  meson,
+  ninja,
+  pkg-config,
+  freetype,
+  zlib,
+  bzip2,
+  brotli,
+  libpng,
+  librsvg,
+  libx11,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "freetype-demos";
+  # must match freetype.version: the demos build against the FreeType
+  # source tree of the same release
+  version = "2.14.3";
+
+  src = fetchurl {
+    url = "mirror://savannah/freetype/ft2demos-${finalAttrs.version}.tar.xz";
+    hash = "sha256-GslqBmw5EI8rDMiqgFEG7Sw4FGyJE9wjltwkLpHjVoY=";
+  };
+
+  # Some demos (e.g. ttdebug) need FreeType internal headers, so
+  # upstream builds FreeType as a static meson subproject whose wrap
+  # file fetches git HEAD. Provide the matching release tarball
+  # instead — the wrap download is unavailable in the sandbox.
+  postPatch = ''
+    mkdir -p subprojects/freetype2
+    tar -xf ${freetype.src} -C subprojects/freetype2 --strip-components=1
+  '';
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    zlib
+    bzip2
+    brotli
+    libpng
+    librsvg
+    libx11
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  meta = {
+    description = "Demo and diagnostic programs for FreeType (ftview, ftgrid, ftdump, ...)";
+    homepage = "https://www.freetype.org/";
+    changelog = "https://gitlab.freedesktop.org/freetype/freetype-demos/-/raw/VER-${
+      builtins.replaceStrings [ "." ] [ "-" ] finalAttrs.version
+    }/ChangeLog";
+    license = lib.licenses.gpl2Plus; # or the FreeType License (BSD + advertising clause)
+    platforms = lib.platforms.unix;
+    mainProgram = "ftview";
+    maintainers = with lib.maintainers; [ fraggerfox ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Import [freetype-demos](https://gitlab.freedesktop.org/freetype/freetype-demos) into nixpkgs.
- This is in a way continuation of https://github.com/NixOS/nixpkgs/pull/99594#issuecomment-703355498 and implementing the suggestion there to have it as a separate package.
- This is also how it is done in other Linux distributions, for example
  - https://archlinux.org/packages/extra/x86_64/freetype2-demos/
  - https://packages.ubuntu.com/freetype2-demos 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
