### PR TITLE
elio-bin: init at 1.11.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4488,6 +4488,12 @@
     githubId = 1516457;
     name = "Christian Albrecht";
   };
+  caliguIa = {
+    email = "acc@calrichards.io";
+    github = "caliguIa";
+    githubId = 30220663;
+    name = "Cal Richards";
+  };
   callumio = {
     email = "git@cleslie.uk";
     github = "callumio";

--- a/pkgs/by-name/el/elio-bin/darwin.nix
+++ b/pkgs/by-name/el/elio-bin/darwin.nix
@@ -1,0 +1,31 @@
+{
+  stdenvNoCC,
+  fetchurl,
+  testers,
+  pname,
+  version,
+  meta,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  inherit pname version;
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchurl {
+    url = "https://github.com/elio-fm/elio/releases/download/v${version}/elio-${version}-aarch64-apple-darwin.tar.gz";
+    hash = "sha256-h0wX5ytVYfpmj6dqrANLyareBklenrEBgVZXKbisSow=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 elio -t $out/bin
+    runHook postInstall
+  '';
+
+  passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
+
+  meta = meta // {
+    platforms = [ "aarch64-darwin" ];
+  };
+})

--- a/pkgs/by-name/el/elio-bin/linux.nix
+++ b/pkgs/by-name/el/elio-bin/linux.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  testers,
+  pname,
+  version,
+  meta,
+}:
+let
+  arch =
+    {
+      x86_64-linux = "x86_64-unknown-linux-gnu";
+      aarch64-linux = "aarch64-unknown-linux-gnu";
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+in
+stdenv.mkDerivation (finalAttrs: {
+  inherit pname version;
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchurl {
+    url = "https://github.com/elio-fm/elio/releases/download/v${version}/elio-${version}-${arch}.tar.gz";
+    hash =
+      {
+        x86_64-linux = "sha256-9cW/xUA9p0LEYI3/j4MGPVZvcyJpV1JYKYBuHur4sTM=";
+        aarch64-linux = "sha256-zg141Dp+jHwAqzoaCNvOoC7ZFeAX+cO8HZF5W7wz1Qs=";
+      }
+      .${stdenv.hostPlatform.system};
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  buildInputs = [ (lib.getLib stdenv.cc.cc) ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 elio -t $out/bin
+    install -Dm644 packaging/linux/elio.desktop -t $out/share/applications
+    cp -r packaging/linux/icons $out/share/icons
+
+    runHook postInstall
+  '';
+
+  passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
+
+  meta = meta // {
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+})

--- a/pkgs/by-name/el/elio-bin/package.nix
+++ b/pkgs/by-name/el/elio-bin/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenv,
+  callPackage,
+}:
+let
+  pname = "elio-bin";
+  version = "1.11.2";
+
+  meta = {
+    description = "Snappy, batteries-included terminal file manager with rich previews, inline images, bulk actions, and trash support";
+    homepage = "https://github.com/elio-fm/elio";
+    changelog = "https://github.com/elio-fm/elio/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    mainProgram = "elio";
+    maintainers = with lib.maintainers; [
+      caliguIa
+    ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+in
+if stdenv.hostPlatform.isDarwin then
+  callPackage ./darwin.nix {
+    inherit
+      pname
+      version
+      meta
+      ;
+  }
+else if stdenv.hostPlatform.isLinux then
+  callPackage ./linux.nix {
+    inherit
+      pname
+      version
+      meta
+      ;
+  }
+else
+  throw "Unsupported platform: ${stdenv.hostPlatform.system}"


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].