### PR TITLE
geekbench_7: init at 7.0.0

### DIFF
--- a/pkgs/by-name/ge/geekbench/6.nix
+++ b/pkgs/by-name/ge/geekbench/6.nix
@@ -11,19 +11,19 @@
 
 let
   inherit (stdenv.hostPlatform.uname) processor;
-  version = "7.0.0";
+  version = "6.7.1";
   sources = {
     "x86_64-linux" = {
       url = "https://cdn.geekbench.com/Geekbench-${version}-Linux.tar.gz";
-      hash = "sha256-lhoArArEMv+mh0dk6GxZ0uCY//ZbWzmLuTgb9/xGyBs=";
+      hash = "sha256-Ddypd9622dtL2GZIX5QI5y4oadDeoHN7GNS/5HKFis4=";
     };
     "aarch64-linux" = {
       url = "https://cdn.geekbench.com/Geekbench-${version}-LinuxARMPreview.tar.gz";
-      hash = "sha256-R2/o8XatHnZZr6fKuKW4jMx442ulLfiUe6K2D1zey5w=";
+      hash = "sha256-blmsuD5t6jZx4uKVNl/DfED90oDNvd1QrPJIkQ4UoOM=";
     };
     "riscv64-linux" = {
       url = "https://cdn.geekbench.com/Geekbench-${version}-LinuxRISCVPreview.tar.gz";
-      hash = "sha256-AKESobr64A9bgMIb12ej2k+t6c2cEO9BBwv0uGHcBRw=";
+      hash = "sha256-TByNeLqqHrnrLcX/meXNy6Evvebf0/xWnUohd/TwiAk=";
     };
   };
   geekbench_avx2 = lib.optionalString stdenv.hostPlatform.isx86_64 "geekbench_avx2";
@@ -32,12 +32,9 @@ stdenv.mkDerivation {
   inherit version;
   pname = "geekbench";
 
-  __structuredAttrs = true;
-
   src = fetchurl (
     sources.${stdenv.system} or (throw "unsupported system ${stdenv.hostPlatform.system}")
   );
-  strictDeps = true;
 
   dontConfigure = true;
   dontBuild = true;
@@ -53,9 +50,9 @@ stdenv.mkDerivation {
     runHook preInstall
 
     mkdir -p $out/bin
-    cp -r geekbench.plxr geekbench-workload.plxr geekbench7 geekbench_${processor} ${geekbench_avx2} $out/bin
+    cp -r geekbench.plar geekbench-workload.plar geekbench6 geekbench_${processor} ${geekbench_avx2} $out/bin
 
-    for f in geekbench7 geekbench_${processor} ${geekbench_avx2} ; do
+    for f in geekbench6 geekbench_${processor} ${geekbench_avx2} ; do
       wrapProgram $out/bin/$f \
         --prefix LD_LIBRARY_PATH : "${
           lib.makeLibraryPath [
@@ -79,6 +76,6 @@ stdenv.mkDerivation {
       asininemonkey
     ];
     platforms = builtins.attrNames sources;
-    mainProgram = "geekbench7";
+    mainProgram = "geekbench6";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1594,7 +1594,8 @@ with pkgs;
 
   geekbench_4 = callPackage ../by-name/ge/geekbench/4.nix { };
   geekbench_5 = callPackage ../by-name/ge/geekbench/5.nix { };
-  geekbench_6 = geekbench;
+  geekbench_6 = callPackage ../by-name/ge/geekbench/6.nix { };
+  geekbench_7 = geekbench;
 
   ghidra = callPackage ../tools/security/ghidra/build.nix {
     protobuf = protobuf_21;


### PR DESCRIPTION
Add Geekbench 7 package.

[Release blogpost](https://www.geekbench.com/blog/2026/07/geekbench-7/)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
