### PR TITLE
treewide: clean up failing tests in openstack packages

### DIFF
--- a/pkgs/by-name/ko/kolla/package.nix
+++ b/pkgs/by-name/ko/kolla/package.nix
@@ -57,10 +57,9 @@ python3Packages.buildPythonApplication (finalAttrs: {
     bashate
   ];
 
-  # Tests output a few exceptions but still succeed
   checkPhase = ''
     runHook preCheck
-    stestr run -e <(echo "test_load_ok")
+    stestr run
     runHook postCheck
   '';
 

--- a/pkgs/development/python-modules/keystoneauth1/default.nix
+++ b/pkgs/development/python-modules/keystoneauth1/default.nix
@@ -69,11 +69,8 @@ buildPythonPackage rec {
   ]
   ++ lib.concatAttrValues optional-dependencies;
 
-  # test_keystoneauth_betamax_fixture is incompatible with urllib3 2.0.0
-  # https://bugs.launchpad.net/keystoneauth/+bug/2020112
   checkPhase = ''
-    stestr run \
-      -E "keystoneauth1.tests.unit.test_betamax_fixture.TestBetamaxFixture.test_keystoneauth_betamax_fixture"
+    stestr run
   '';
 
   pythonImportsCheck = [ "keystoneauth1" ];

--- a/pkgs/development/python-modules/oslo-db/default.nix
+++ b/pkgs/development/python-modules/oslo-db/default.nix
@@ -59,7 +59,7 @@ buildPythonPackage rec {
 
   checkPhase = ''
     runHook preCheck
-    stestr run -e <(echo "oslo_db.tests.sqlalchemy.test_utils.TestModelQuery.test_project_filter_allow_none")
+    stestr run
     runHook postCheck
   '';
 

--- a/pkgs/development/python-modules/oslo-i18n/default.nix
+++ b/pkgs/development/python-modules/oslo-i18n/default.nix
@@ -40,10 +40,7 @@ buildPythonPackage rec {
   checkPhase = ''
     runHook preCheck
 
-    stestr run -e <(echo "
-    # list is not deduped
-    oslo_i18n.tests.test_gettextutils.GettextTest.test_get_available_languages
-    ")
+    stestr run
 
     runHook postCheck
   '';

--- a/pkgs/development/python-modules/python-cinderclient/default.nix
+++ b/pkgs/development/python-modules/python-cinderclient/default.nix
@@ -62,19 +62,7 @@ buildPythonPackage rec {
   checkPhase = ''
     runHook preCheck
 
-    #   File "/build/python-cinderclient-9.6.0/cinderclient/client.py", line 196, in request
-    # if raise_exc and resp.status_code >= 400:
-    #                  ^^^^^^^^^^^^^^^^^^^^^^^
-    #
-    # TypeError: '>=' not supported between instances of 'Mock' and 'int'
-    stestr run -e <(echo "
-      cinderclient.tests.unit.test_client.ClientTest.test_keystone_request_raises_auth_failure_exception
-      cinderclient.tests.unit.test_client.ClientTest.test_sessionclient_request_method
-      cinderclient.tests.unit.test_client.ClientTest.test_sessionclient_request_method_raises_badrequest
-      cinderclient.tests.unit.test_client.ClientTest.test_sessionclient_request_method_raises_overlimit
-      cinderclient.tests.unit.test_shell.ShellTest.test_password_prompted
-      cinderclient.tests.unit.test_shell.TestLoadVersionedActions.test_load_versioned_actions_with_help
-    ")
+    stestr run
 
     runHook postCheck
   '';

--- a/pkgs/development/python-modules/python-glanceclient/default.nix
+++ b/pkgs/development/python-modules/python-glanceclient/default.nix
@@ -26,23 +26,10 @@ let
 
   disabledTests = [
     # Skip tests which require networking.
-    "test_http_chunked_response"
-    "test_v1_download_has_no_stray_output_to_stdout"
-    "test_v2_requests_valid_cert_verification"
-    "test_download_has_no_stray_output_to_stdout"
-    "test_v1_requests_cert_verification_no_compression"
-    "test_v1_requests_cert_verification"
-    "test_v2_download_has_no_stray_output_to_stdout"
-    "test_v2_requests_bad_ca"
-    "test_v2_requests_bad_cert"
-    "test_v2_requests_cert_verification_no_compression"
-    "test_v2_requests_cert_verification"
-    "test_v2_requests_valid_cert_no_key"
-    "test_v2_requests_valid_cert_verification_no_compression"
-    "test_log_request_id_once"
-    # asserts exact amount of mock calls
-    "test_cache_schemas_gets_when_forced"
-    "test_cache_schemas_gets_when_not_exists"
+    "glanceclient.tests.unit.test_http.TestClient.test_http_chunked_response"
+    "glanceclient.tests.unit.test_http.TestClient.test_log_request_id_once"
+    "glanceclient.tests.unit.test_http.TestClient.test_log_request_id_once"
+    ''glanceclient\.tests\.unit\.test_ssl\.TestHTTPSVerifyCert\..*''
   ];
 in
 buildPythonPackage {

--- a/pkgs/development/python-modules/python-ironicclient/default.nix
+++ b/pkgs/development/python-modules/python-ironicclient/default.nix
@@ -69,16 +69,7 @@ buildPythonPackage rec {
 
   checkPhase = ''
     runHook preCheck
-    stestr run -e <(echo "
-      ironicclient.tests.unit.osc.v1.test_baremetal_chassis.TestChassisCreate.test_chassis_create_no_options
-      ironicclient.tests.unit.osc.v1.test_baremetal_chassis.TestChassisCreate.test_chassis_create_with_description
-      ironicclient.tests.unit.osc.v1.test_baremetal_chassis.TestChassisCreate.test_chassis_create_with_extra
-      ironicclient.tests.unit.osc.v1.test_baremetal_chassis.TestChassisCreate.test_chassis_create_with_uuid
-      ironicclient.tests.unit.osc.v1.test_baremetal_conductor.TestBaremetalConductorShow.test_conductor_show
-      ironicclient.tests.unit.osc.v1.test_baremetal_node.TestBaremetalCreate
-      ironicclient.tests.unit.osc.v1.test_baremetal_node.TestBaremetalShow.test_baremetal_show
-      ironicclient.tests.unit.osc.v1.test_baremetal_node.TestNodeHistoryEventGet.test_baremetal_node_history_list
-    ")
+    stestr run
     runHook postCheck
   '';
 

--- a/pkgs/development/python-modules/python-jenkins/default.nix
+++ b/pkgs/development/python-modules/python-jenkins/default.nix
@@ -55,10 +55,7 @@ buildPythonPackage rec {
     multiprocess
   ];
   checkPhase = ''
-    # Skip tests that fail due to setuptools>=66.0.0 rejecting PEP 440
-    # non-conforming versions. See
-    # https://github.com/pypa/setuptools/issues/2497 for details.
-    stestr run -E "tests.test_plugins.(PluginsTestScenarios.test_plugin_version_comparison|PluginsTestScenarios.test_plugin_version_object_comparison|PluginsTest.test_plugin_equal|PluginsTest.test_plugin_not_equal)"
+    stestr run
   '';
 
   meta = {


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
