### PR TITLE
pinocchio, stl-to-obj, mptcpd, qgv, structuresynth, eigenrand, gruppled-black-cursors, gruppled-black-lite-cursors, osqp-eigen, mim-solvers, trlib, tsid, doxygen-awesome-css, fatrop, ipopt, ndcurves, sleqp, blasfeo, libigl, eiquadprog: rev -> tag

### DIFF
--- a/pkgs/by-name/bl/blasfeo/package.nix
+++ b/pkgs/by-name/bl/blasfeo/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "giaf";
     repo = "blasfeo";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-p1pxqJ38h6RKXMg1t+2RHlfmRKPuM18pbUarUx/w9lw=";
   };
 

--- a/pkgs/by-name/do/doxygen-awesome-css/package.nix
+++ b/pkgs/by-name/do/doxygen-awesome-css/package.nix
@@ -12,7 +12,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "jothepro";
     repo = "doxygen-awesome-css";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-AlnoIgH4DeIWM+Da7y7P6vkey0a0rlko9/slKHce49E=";
   };
 

--- a/pkgs/by-name/ei/eigenrand/package.nix
+++ b/pkgs/by-name/ei/eigenrand/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "bab2min";
     repo = "EigenRand";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-mrpkWIb6kfLvppmIfzhjF1/3m1zSd8XG1D07V6Zjlu0=";
   };
 

--- a/pkgs/by-name/ei/eiquadprog/package.nix
+++ b/pkgs/by-name/ei/eiquadprog/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "stack-of-tasks";
     repo = "eiquadprog";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ukYIc5ZCIDunXMyC44Dd1qac4Ku4pNv9p4ik+xyI0i0=";
   };
 

--- a/pkgs/by-name/fa/fatrop/package.nix
+++ b/pkgs/by-name/fa/fatrop/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "meco-group";
     repo = "fatrop";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-WiIryO2bMtupJ2tvMY24Smrf86wgCNNxZbQJMn6ey/A=";
   };
 

--- a/pkgs/by-name/gr/gruppled-black-cursors/package.nix
+++ b/pkgs/by-name/gr/gruppled-black-cursors/package.nix
@@ -17,7 +17,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "nim65s";
     repo = "gruppled-cursors";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ejlgdogjIYevZvB23si6bEeU6qY7rWXflaUyVk5MzqU=";
   };
 

--- a/pkgs/by-name/gr/gruppled-black-lite-cursors/package.nix
+++ b/pkgs/by-name/gr/gruppled-black-lite-cursors/package.nix
@@ -17,7 +17,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "nim65s";
     repo = "gruppled-lite-cursors";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-adCXYu8v6mFKXubVQb/RCZXS87//YgixQp20kMt7KT8=";
   };
 

--- a/pkgs/by-name/ip/ipopt/package.nix
+++ b/pkgs/by-name/ip/ipopt/package.nix
@@ -24,8 +24,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "coin-or";
     repo = "Ipopt";
-    rev = "releases/${finalAttrs.version}";
-    sha256 = "sha256-85fUBMwQtG+RWQYk9YzdZYK3CYcDKgWroo4blhVWBzE=";
+    tag = "releases/${finalAttrs.version}";
+    hash = "sha256-85fUBMwQtG+RWQYk9YzdZYK3CYcDKgWroo4blhVWBzE=";
   };
 
   outputs =

--- a/pkgs/by-name/li/libigl/package.nix
+++ b/pkgs/by-name/li/libigl/package.nix
@@ -11,7 +11,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "libigl";
     repo = "libigl";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-7Cvz/yOb5kQaIceUwyijBNplXvok5reJoJsTnvKWt4M=";
   };
 

--- a/pkgs/by-name/mi/mim-solvers/package.nix
+++ b/pkgs/by-name/mi/mim-solvers/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "machines-in-motion";
     repo = "mim_solvers";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-t21zzUo+Oiqvr3lYN9v1lCeoki3I1FWPqo3gWzM6Kdw=";
   };
 

--- a/pkgs/by-name/mp/mptcpd/package.nix
+++ b/pkgs/by-name/mp/mptcpd/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "multipath-tcp";
     repo = "mptcpd";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-gPXtYmCLJ8eL6VfCi3kpDA7lNn38WB6J4FXefdu2D7M=";
   };
 

--- a/pkgs/by-name/nd/ndcurves/package.nix
+++ b/pkgs/by-name/nd/ndcurves/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "loco-3d";
     repo = "ndcurves";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-X9p01hMoAx6fMSEU/nf/eqyFgy23mZrpBFonjoT1DLo=";
   };
 

--- a/pkgs/by-name/os/osqp-eigen/package.nix
+++ b/pkgs/by-name/os/osqp-eigen/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "gbionics";
     repo = "osqp-eigen";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-/9M7DufsgjlG4UbBfi64FQsMms06OsljZP2C9uCQe7w=";
   };
 

--- a/pkgs/by-name/pi/pinocchio/package.nix
+++ b/pkgs/by-name/pi/pinocchio/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "stack-of-tasks";
     repo = "pinocchio";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-wWuW58okWARbF/nonybw3DbGY4hrHDiEsdjiF6RoaVc=";
   };
 

--- a/pkgs/by-name/qg/qgv/package.nix
+++ b/pkgs/by-name/qg/qgv/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "gepetto";
     repo = "qgv";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-602+CQAScZPNkuudwbRS1NJYYSoQCDwcRJcj8cS/10Q=";
   };
 

--- a/pkgs/by-name/sl/sleqp/package.nix
+++ b/pkgs/by-name/sl/sleqp/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "chrhansk";
     repo = "sleqp";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ycO7s13LT/Gi01XFjTeZQCN+TiAVlp2zXjrlI7vfgTk=";
   };
 

--- a/pkgs/by-name/st/stl-to-obj/package.nix
+++ b/pkgs/by-name/st/stl-to-obj/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "Neizvestnyj";
     repo = "stl-to-obj";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-+R7rNpMxKFC7sLYQXZX3Ikb5MqNd57r1M8gma73kCcg=";
   };
 

--- a/pkgs/by-name/st/structuresynth/package.nix
+++ b/pkgs/by-name/st/structuresynth/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "alemuntoni";
     repo = "structuresynth";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-uFz4WPwA586B/5p+DUJ/W8KzbHLBhLIwP6mySZJ1vPY=";
   };
 

--- a/pkgs/by-name/tr/trlib/package.nix
+++ b/pkgs/by-name/tr/trlib/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "felixlen";
     repo = "trlib";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-pD2MGsIQgMO4798Gp9oLprKhmV0lcjgtUHh1rvEjSIY=";
   };
 

--- a/pkgs/by-name/ts/tsid/package.nix
+++ b/pkgs/by-name/ts/tsid/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "stack-of-tasks";
     repo = "tsid";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-f/SecQfEmrlelVR5584KIHFwwrp5Cy2aBMKI/rxuPmc=";
   };
 


### PR DESCRIPTION
Hi,

This PR update the packages I maintain (`nvim -O (rg -l 'rev =' (rg -l nim65s))`) from `rev` to `tag`.

For each of those, I made the change, then removed the hash, tried to rebuild the package, and visually checked that the hash in the error was the same as the hash I removed.

There is no rebuild.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
