### PR TITLE
python3Packages.langchain-sail: init at 0.2.1

### DIFF
--- a/pkgs/development/python-modules/langchain-sail/default.nix
+++ b/pkgs/development/python-modules/langchain-sail/default.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  langchain-core,
+  langchain-community,
+  langchain-classic,
+
+  # tests
+  pytestCheckHook,
+  pytest-asyncio,
+
+  # passthru
+  nix-update-script,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "langchain-sail";
+  version = "0.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "lakehq";
+    repo = "langchain-sail";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-geXv2vzvRyjVyslTam1yIkRsgmyTr5A84BIVsqXODes=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    langchain-core
+    langchain-community
+    langchain-classic
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+  ];
+
+  # The integration tests need pyspark-client (not packaged) and a running Sail
+  # server, so only the unit tests can run in the sandbox.
+  enabledTestPaths = [ "tests/unit_tests" ];
+
+  pythonImportsCheck = [ "langchain_sail" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "LangChain integration for Sail, a Spark-compatible compute engine on Apache Arrow and DataFusion";
+    homepage = "https://github.com/lakehq/langchain-sail";
+    changelog = "https://github.com/lakehq/langchain-sail/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.davidlghellin ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9057,6 +9057,8 @@ self: super: with self; {
 
   langchain-protocol = callPackage ../development/python-modules/langchain-protocol { };
 
+  langchain-sail = callPackage ../development/python-modules/langchain-sail { };
+
   langchain-tests = callPackage ../development/python-modules/langchain-tests { };
 
   langchain-text-splitters = callPackage ../development/python-modules/langchain-text-splitters { };


### PR DESCRIPTION
Changelog: https://github.com/lakehq/langchain-sail/releases/tag/v0.2.1

Adds `python3Packages.langchain-sail` 0.2.1 — the LangChain integration for [Sail](https://github.com/lakehq/sail), a Rust-based Spark-compatible compute engine built on Apache Arrow and DataFusion. It provides a `SailSQL` utility (a `SparkSQL` subclass that connects over Spark Connect), a toolkit, and a SQL agent constructor.

Homepage: https://github.com/lakehq/langchain-sail

This complements `python3Packages.pysail`, already in Nixpkgs.

Note on tests: the upstream test suite is split into `tests/unit_tests` and `tests/integration_tests`. Only the unit tests are enabled — the integration tests require `pyspark-client` (not packaged) and a running Sail server, so they cannot work in the sandbox. The three unit tests pass at build time.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`. (N/A — library, no executables; `pythonImportsCheck` covers the import)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test