### PR TITLE
litestream: 0.5.15 -> 0.5.16

### DIFF
--- a/pkgs/by-name/li/litestream/package.nix
+++ b/pkgs/by-name/li/litestream/package.nix
@@ -7,13 +7,13 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "litestream";
-  version = "0.5.15";
+  version = "0.5.16";
 
   src = fetchFromGitHub {
     owner = "benbjohnson";
     repo = "litestream";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-SsHyi7E/1dHEzFQgKr8eSi1fEf61iqTQ6Avr4c/h9j4=";
+    hash = "sha256-06ZQbOol87HZVaBFOyYbSasl3eHFcdwrYTnmProg9uY=";
   };
 
   ldflags = [
@@ -22,7 +22,7 @@ buildGoModule (finalAttrs: {
     "-X main.Version=${finalAttrs.version}"
   ];
 
-  vendorHash = "sha256-Ms33rbFjsWzGbLy9v6kFGl6b62QQI4XAZ4wr73g5udw=";
+  vendorHash = "sha256-xoJwxmQzWSQ055+W1I+hNyEcB3bfShCoAfdMU4Pckjc=";
 
   # httptest servers in tests
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
Release: https://github.com/benbjohnson/litestream/releases/tag/v0.5.16

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests] — `nixosTests.litestream` passes on aarch64-darwin (30.4s, including the disaster-recovery subtest).
  - [x] [Package tests] at `passthru.tests` — `tests.version` passes on both platforms.
- [x] Ran `nixpkgs-review` on this PR — 1 package built, 0 failed, on both x86_64-linux and aarch64-darwin.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/` — `litestream version` reports `0.5.16` on both platforms.

`cmd/litestream-vfs` fails its Go test setup (`build constraints exclude all Go files`) on both platforms. This reproduces identically on 0.5.15 (verified with `nix-build --check`), so it is pre-existing upstream rather than a regression from this bump.

cc @cideM @konradmalik

---

Version and hash changes were produced by `nix-update`. This pull request description was drafted with Claude Code (Opus 5) and reviewed by me before submission.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
