### PR TITLE
[26.05] opencloud{,-web}: 7.0.0 -> 7.2.0

### DIFF
--- a/nixos/tests/opencloud.nix
+++ b/nixos/tests/opencloud.nix
@@ -21,12 +21,14 @@ let
         from selenium.webdriver.common.by import By
         from selenium.webdriver import Firefox
         from selenium.webdriver.firefox.options import Options
+        from selenium.webdriver.firefox.service import Service
         from selenium.webdriver.support.ui import WebDriverWait
         from selenium.webdriver.support import expected_conditions as EC
 
         options = Options()
         options.add_argument('--headless')
-        driver = Firefox(options=options)
+        service = Service(executable_path="${lib.getExe pkgs.geckodriver}")
+        driver = Firefox(options=options, service=service)
 
         host = sys.argv[1]
         user = sys.argv[2]
@@ -71,6 +73,7 @@ in
       environment = {
         ADMIN_PASSWORD = adminPassword;
         IDM_CREATE_DEMO_USERS = "true";
+        IDM_LDAPS_ADDR = "127.0.0.1:9235";
         IDM_LDAPS_CERT = "${certs.${domain}.cert}";
         IDM_LDAPS_KEY = "${certs.${domain}.key}";
         OC_INSECURE = "false";

--- a/pkgs/by-name/op/opencloud/idp-web.nix
+++ b/pkgs/by-name/op/opencloud/idp-web.nix
@@ -20,7 +20,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     pnpm = pnpm_11;
     sourceRoot = "${finalAttrs.src.name}/${finalAttrs.pnpmRoot}";
     fetcherVersion = 4;
-    hash = "sha256-NN5MmWYQgaG4s8+mnLWo8EzOobACOnYhdwt4+/4kz9o=";
+    hash = "sha256-pQ01vBvC29B5oxDWtt7anI5QtFbvQFFBVamQtA2WTNo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/op/opencloud/idp-web.nix
+++ b/pkgs/by-name/op/opencloud/idp-web.nix
@@ -2,7 +2,7 @@
   stdenvNoCC,
   lib,
   opencloud,
-  pnpm_9,
+  pnpm_11,
   fetchPnpmDeps,
   pnpmConfigHook,
   pnpmBuildHook,
@@ -17,17 +17,17 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_9;
+    pnpm = pnpm_11;
     sourceRoot = "${finalAttrs.src.name}/${finalAttrs.pnpmRoot}";
-    fetcherVersion = 3;
-    hash = "sha256-E0bP15T2Ekj992Y1xFXL/4rko34AY+I5Lbn+blJhXYg=";
+    fetcherVersion = 4;
+    hash = "sha256-NN5MmWYQgaG4s8+mnLWo8EzOobACOnYhdwt4+/4kz9o=";
   };
 
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
     pnpmBuildHook
-    pnpm_9
+    pnpm_11
   ];
 
   postBuild = ''

--- a/pkgs/by-name/op/opencloud/idp-web.nix
+++ b/pkgs/by-name/op/opencloud/idp-web.nix
@@ -31,16 +31,16 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   ];
 
   postBuild = ''
-    mkdir -p assets/identifier/static
-    cp -v src/images/favicon.svg assets/identifier/static/favicon.svg
-    cp -v src/images/icon-lilac.svg assets/identifier/static/icon-lilac.svg
+    mkdir -p services/idp/assets/identifier/static
+    cp -v services/idp/src/images/favicon.svg services/idp/assets/identifier/static/favicon.svg
+    cp -v services/idp/src/images/icon-lilac.svg services/idp/assets/identifier/static/icon-lilac.svg
   '';
 
   installPhase = ''
     runHook preInstall
 
     mkdir $out
-    cp -r assets $out
+    cp -r services/idp/assets $out
 
     runHook postInstall
   '';

--- a/pkgs/by-name/op/opencloud/idp-web.nix
+++ b/pkgs/by-name/op/opencloud/idp-web.nix
@@ -5,6 +5,7 @@
   pnpm_9,
   fetchPnpmDeps,
   pnpmConfigHook,
+  pnpmBuildHook,
   nodejs,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -25,19 +26,14 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
+    pnpmBuildHook
     pnpm_9
   ];
 
-  buildPhase = ''
-    runHook preBuild
-
-    cd $pnpmRoot
-    pnpm build
+  postBuild = ''
     mkdir -p assets/identifier/static
     cp -v src/images/favicon.svg assets/identifier/static/favicon.svg
     cp -v src/images/icon-lilac.svg assets/identifier/static/icon-lilac.svg
-
-    runHook postBuild
   '';
 
   installPhase = ''

--- a/pkgs/by-name/op/opencloud/package.nix
+++ b/pkgs/by-name/op/opencloud/package.nix
@@ -28,13 +28,13 @@ let
 in
 buildGoModule (finalAttrs: {
   pname = "opencloud";
-  version = "7.1.0";
+  version = "7.2.0";
 
   src = fetchFromGitHub {
     owner = "opencloud-eu";
     repo = "opencloud";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Lr/YF+vuaBIe6sQ+CeVuqV6BDe9jAIQLTZbCKyvn6As=";
+    hash = "sha256-GAoDEXk7sBN7N0V/msi/fcJS72RqqlF6Qb5B9hArmvk=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/op/opencloud/package.nix
+++ b/pkgs/by-name/op/opencloud/package.nix
@@ -28,13 +28,13 @@ let
 in
 buildGoModule (finalAttrs: {
   pname = "opencloud";
-  version = "7.0.0";
+  version = "7.1.0";
 
   src = fetchFromGitHub {
     owner = "opencloud-eu";
     repo = "opencloud";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-5bGsJcmrF01E0zXKxwRQpTZl/OinfW7da3nf3/T74hg=";
+    hash = "sha256-Lr/YF+vuaBIe6sQ+CeVuqV6BDe9jAIQLTZbCKyvn6As=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/op/opencloud/web.nix
+++ b/pkgs/by-name/op/opencloud/web.nix
@@ -10,20 +10,20 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "opencloud-web";
-  version = "7.1.0";
+  version = "7.1.2";
 
   src = fetchFromGitHub {
     owner = "opencloud-eu";
     repo = "web";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-awEGCmdauqHkigXqumOYs8woOyY8gIccmzKOyrZ7SwQ=";
+    hash = "sha256-zwD/Mn7jL960EVaG3gVqFo6FPPMhQTMz3LKy8ZnOObk=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_11;
     fetcherVersion = 4;
-    hash = "sha256-oIVbhvFiVu0S7sSs5u14M0A1+Q1WmiAsyoBt8QtojyE=";
+    hash = "sha256-YEdZ5B11I6U140qam7e1TMOacRqUeINhr/TI13ddAa0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/op/opencloud/web.nix
+++ b/pkgs/by-name/op/opencloud/web.nix
@@ -3,33 +3,33 @@
   stdenvNoCC,
   fetchFromGitHub,
   nodejs,
-  pnpm_10,
+  pnpm_11,
   fetchPnpmDeps,
   pnpmConfigHook,
   nix-update-script,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "opencloud-web";
-  version = "7.0.1";
+  version = "7.1.0";
 
   src = fetchFromGitHub {
     owner = "opencloud-eu";
     repo = "web";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-kkNdP3IpWnfOv5GEhQqKJwnnRXCHyxMcI2RA6vK7NrA=";
+    hash = "sha256-awEGCmdauqHkigXqumOYs8woOyY8gIccmzKOyrZ7SwQ=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_10;
-    fetcherVersion = 3;
-    hash = "sha256-Md6KcP5BV9Pskqg+o9D3RD0WconqyiizAvXNMZ9htfw=";
+    pnpm = pnpm_11;
+    fetcherVersion = 4;
+    hash = "sha256-oIVbhvFiVu0S7sSs5u14M0A1+Q1WmiAsyoBt8QtojyE=";
   };
 
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
-    pnpm_10
+    pnpm_11
   ];
 
   buildPhase = ''

--- a/pkgs/by-name/op/opencloud/web.nix
+++ b/pkgs/by-name/op/opencloud/web.nix
@@ -10,20 +10,20 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "opencloud-web";
-  version = "7.1.2";
+  version = "7.2.0";
 
   src = fetchFromGitHub {
     owner = "opencloud-eu";
     repo = "web";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-zwD/Mn7jL960EVaG3gVqFo6FPPMhQTMz3LKy8ZnOObk=";
+    hash = "sha256-BiOue8+zQ3+6RLiDbLMnxKEen2aav3bljji4d+0Hr5c=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_11;
     fetcherVersion = 4;
-    hash = "sha256-YEdZ5B11I6U140qam7e1TMOacRqUeINhr/TI13ddAa0=";
+    hash = "sha256-gCsgnOEi9rvtwTZy8J/i63D92Gl2V9ZihxCJ+Y5hLUE=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Diff: https://github.com/opencloud-eu/opencloud/compare/v7.0.0...v7.1.0

Changelog: https://github.com/opencloud-eu/opencloud/blob/v7.1.0/CHANGELOG.md (cherry picked from commit 3b4b66aa34551bbb1762b75042dade6dd31f685f)


This is the first time I am attempting to do a manual backport, I followed the instructions given in https://github.com/NixOS/nixpkgs/pull/529410 when the automatic backport failed.


Ran `nix-build -A opencloud`, and it built fine, but an error came (related to cgroups) because I do not have a linux machine nearby, only my darwin laptop.

```
checkPhase completed in 3 minutes 52 seconds
Running phase: glibPreInstallPhase
Running phase: installPhase
Running phase: fixupPhase
checking for references to /nix/var/nix/builds/nix-83416-3241002432/ in /nix/store/z53y9kalq9vzza2mbvd0i6xclblw9mm6-opencloud-7.1.0...
patching script interpreter paths in /nix/store/z53y9kalq9vzza2mbvd0i6xclblw9mm6-opencloud-7.1.0
stripping (with command strip and flags -S) in  /nix/store/z53y9kalq9vzza2mbvd0i6xclblw9mm6-opencloud-7.1.0/bin
Running phase: installCheckPhase
Executing versionCheckPhase
Successfully managed to find version 7.1.0 in the output of the command /nix/store/z53y9kalq9vzza2mbvd0i6xclblw9mm6-opencloud-7.1.0/bin/opencloud version
2026/08/05 17:18:10 ERROR failed to set GOMEMLIMIT package=github.com/KimMachineGun/automemlimit/memlimit error="failed to set GOMEMLIMIT: cgroups is not supported on this system"
Version: 7.1.0+nixos
Edition: dev
Compiled: 1970-01-01 00:00:00 +0000 UTC

could not list services: Failed to connect to NATS Server: nats: no servers available for connection
Error: Failed to connect to NATS Server: nats: no servers available for connection
Usage:
  opencloud version [flags]

Flags:
  -h, --help            help for version
      --skip-services   skip service listing

Failed to connect to NATS Server: nats: no servers available for connection
Finished versionCheckPhase
no Makefile or custom installCheckPhase, doing nothing
/nix/store/z53y9kalq9vzza2mbvd0i6xclblw9mm6-opencloud-7.1.0
```

I also saw https://github.com/NixOS/nixpkgs/issues/543956 requesting to update to 7.3.0 on stable, but I do not know if it is better to apply the backport first and update to 7.3.0 in another PR, or do everything at once.

Please let me know if I did something wrong.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
