### PR TITLE
 python314Packages.ast-grep-py: correct patching; python314Packages.ast-grep-cli: init as stub 

### DIFF
--- a/pkgs/development/python-modules/ast-grep-cli/default.nix
+++ b/pkgs/development/python-modules/ast-grep-cli/default.nix
@@ -1,0 +1,32 @@
+{
+  ast-grep,
+  buildPythonPackage,
+  flit-core,
+}:
+
+buildPythonPackage {
+  pname = "ast-grep-cli";
+  inherit (ast-grep) version;
+  pyproject = true;
+
+  src = ./stub;
+
+  postUnpack = ''
+    substituteInPlace "$sourceRoot/pyproject.toml" \
+      --subst-var version
+  '';
+
+  build-system = [ flit-core ];
+
+  pythonImportsCheck = [ "ast_grep_cli" ];
+
+  meta = {
+    inherit (ast-grep.meta)
+      description
+      homepage
+      changelog
+      license
+      maintainers
+      ;
+  };
+}

--- a/pkgs/development/python-modules/ast-grep-cli/stub/pyproject.toml
+++ b/pkgs/development/python-modules/ast-grep-cli/stub/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = ["flit_core"]
+build-backend = "flit_core.buildapi"
+
+[project]
+name = "ast-grep-cli"
+version = "@version@"
+description = "Structural Search and Rewrite code at large scale using precise AST pattern."

--- a/pkgs/development/python-modules/ast-grep-py/default.nix
+++ b/pkgs/development/python-modules/ast-grep-py/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage {
     maturinBuildHook
   ];
 
-  prePatch = ''
+  postPatch = ''
     substituteInPlace ./crates/pyo3/tests/test_register_lang.py \
       --replace-fail '../..' ${ast-grep.src}
   '';

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1413,6 +1413,8 @@ self: super: with self; {
 
   asserts = callPackage ../development/python-modules/asserts { };
 
+  ast-grep-cli = callPackage ../development/python-modules/ast-grep-cli { };
+
   ast-grep-py = callPackage ../development/python-modules/ast-grep-py { };
 
   ast-serialize = callPackage ../development/python-modules/ast-serialize { };


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
