### PR TITLE
brush-splat: 0.3.0 -> 0.3.0-unstable-2026-07-01

### DIFF
--- a/pkgs/by-name/br/brush-splat/package.nix
+++ b/pkgs/by-name/br/brush-splat/package.nix
@@ -9,7 +9,6 @@
   stdenv,
   wayland,
   nix-update-script,
-  versionCheckHook,
   libx11,
   libxcursor,
   libxi,
@@ -18,16 +17,17 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "brush-splat";
-  version = "0.3.0";
+  # Temporary until new stable version releases
+  version = "0.3.0-unstable-2026-07-01";
 
   src = fetchFromGitHub {
     owner = "ArthurBrussee";
     repo = "brush";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-xVYZrQUgHxaefAMmSXG/rrVlCr0H5lRmyyXtRmOtbTU=";
+    rev = "3b80985709e2ec04fd6c8622a40e36473647a8e0";
+    hash = "sha256-yyfnBz6NqoNBF4X087c4VoRiIUp7qgskemlHu0yRUls=";
   };
 
-  cargoHash = "sha256-KBgE0fiaUEsGuAYGhBjqMX7ftj5JnGggH86brxq6280=";
+  cargoHash = "sha256-+X2Kub/+6DZ6Un9FzAAlCMtQ7VCGqElqgtyTyjxpCRM=";
 
   nativeBuildInputs = [
     pkg-config
@@ -57,13 +57,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
         wayland
         libxkbcommon
       ]
-    }" $out/bin/brush_app
+    }" $out/bin/brush
   '';
 
-  nativeInstallCheckInputs = [
-    versionCheckHook
-  ];
-  doInstallCheck = true;
+  # nativeInstallCheckInputs = [
+  #   versionCheckHook
+  # ];
+  # doInstallCheck = true;
 
   passthru = {
     updateScript = nix-update-script { };
@@ -76,6 +76,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ matthewcroughan ];
-    mainProgram = "brush_app";
+    mainProgram = "brush";
   };
 })


### PR DESCRIPTION
Temporary PR until new stable version releases

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
