### PR TITLE
plezy: 2.11.0 -> 2.12.1

### DIFF
--- a/pkgs/by-name/pl/plezy/package.nix
+++ b/pkgs/by-name/pl/plezy/package.nix
@@ -27,13 +27,13 @@
 
 let
   pname = "plezy";
-  version = "2.11.0";
+  version = "2.12.1";
 
   src = fetchFromGitHub {
     owner = "edde746";
     repo = "plezy";
     tag = version;
-    hash = "sha256-nv2hYuPZEUkmcM7sVzmcKZm17CHjxmEWlXLdCPKFXU0=";
+    hash = "sha256-Ib1ZBKbuan8GfkxKVytQ5Bn0sPKtDR3o4em4h8p78Xk=";
   };
 
   simdutf = fetchurl {
@@ -146,7 +146,7 @@ let
 
     src = fetchurl {
       url = "https://github.com/edde746/plezy/releases/download/${version}/plezy-macos.dmg";
-      hash = "sha256-cqanTS+PSsdtg9AF/yiVezq8ydgNfVdXEN8DHRLByM8=";
+      hash = "sha256-el4w0SXVo3kQi/aRrozl4q8KGs+Y7kCJeQmpV26+Pvk=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/by-name/pl/plezy/pubspec.lock.json
+++ b/pkgs/by-name/pl/plezy/pubspec.lock.json
@@ -1052,7 +1052,7 @@
       "version": "2.6.0"
     },
     "path_provider_linux": {
-      "dependency": "transitive",
+      "dependency": "direct dev",
       "description": {
         "name": "path_provider_linux",
         "sha256": "58c2005f147315b11e9b4a7bc889cd5203e250cba8e3f012dae259b4972b5c16",
@@ -1072,7 +1072,7 @@
       "version": "2.1.3"
     },
     "path_provider_windows": {
-      "dependency": "transitive",
+      "dependency": "direct dev",
       "description": {
         "name": "path_provider_windows",
         "sha256": "bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7",
@@ -1371,13 +1371,12 @@
       "version": "2.5.6"
     },
     "shared_preferences_linux": {
-      "dependency": "transitive",
+      "dependency": "direct dev",
       "description": {
-        "name": "shared_preferences_linux",
-        "sha256": "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f",
-        "url": "https://pub.dev"
+        "path": "packages/shared_preferences_linux",
+        "relative": true
       },
-      "source": "hosted",
+      "source": "path",
       "version": "2.4.1"
     },
     "shared_preferences_platform_interface": {
@@ -1401,13 +1400,12 @@
       "version": "2.4.3"
     },
     "shared_preferences_windows": {
-      "dependency": "transitive",
+      "dependency": "direct dev",
       "description": {
-        "name": "shared_preferences_windows",
-        "sha256": "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1",
-        "url": "https://pub.dev"
+        "path": "packages/shared_preferences_windows",
+        "relative": true
       },
-      "source": "hosted",
+      "source": "path",
       "version": "2.4.1"
     },
     "shelf": {


### PR DESCRIPTION
https://github.com/edde746/plezy/releases/tag/2.12.1
https://github.com/edde746/plezy/compare/2.11.1...2.12.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
