### PR TITLE
nodejs_26: 26.6.0 -> 26.7.0

### DIFF
--- a/pkgs/development/web/nodejs/fix-temporal-integration-with-shared-icu.patch
+++ b/pkgs/development/web/nodejs/fix-temporal-integration-with-shared-icu.patch
@@ -74,7 +74,7 @@ index e09fcc1ce8c59f..2f0fd30771881b 100644
 +              'action_name': 'make_temporal_zoneinfo_cpp_action',
 +              'inputs': [
 +                '<(V8_ROOT)/tools/include-file-as-bytes.py',
-+                '<(V8_ROOT)/../crates/vendor/zoneinfo64/src/data/zoneinfo64.res',
++                '<(V8_ROOT)/../crates/vendor/zoneinfo64-v0_3/src/data/zoneinfo64.res',
 +              ],
 +              'outputs': [
 +                '<(SHARED_INTERMEDIATE_DIR)/src/builtins/builtins-temporal-zoneinfo64-data.cc',
@@ -82,7 +82,7 @@ index e09fcc1ce8c59f..2f0fd30771881b 100644
 +              'action': [
 +                '<(python)',
 +                '<(V8_ROOT)/tools/include-file-as-bytes.py',
-+                '<(V8_ROOT)/../crates/vendor/zoneinfo64/src/data/zoneinfo64.res',
++                '<(V8_ROOT)/../crates/vendor/zoneinfo64-v0_3/src/data/zoneinfo64.res',
 +                '<@(_outputs)',
 +                'zoneinfo64_static_data',
 +              ],

--- a/pkgs/development/web/nodejs/v26.nix
+++ b/pkgs/development/web/nodejs/v26.nix
@@ -23,8 +23,8 @@ let
       [ ];
 in
 buildNodejs {
-  version = "26.6.0";
-  sha256 = "ecb6eec812505c9292529087a2436ec6c891ffe0e3a897833416e5d7436d659f";
+  version = "26.7.0";
+  sha256 = "e6b182cbeeab032d1082ca4ac4fe15e3a57de691d3bde78ecf8a761fd56ee356";
   patches =
     (lib.optional (!(stdenv.hostPlatform.emulatorAvailable buildPackages)) (fetchpatch2 {
       url = "https://raw.githubusercontent.com/buildroot/buildroot/2f0c31bffdb59fb224387e35134a6d5e09a81d57/package/nodejs/nodejs-src/0003-include-obj-name-in-shared-intermediate.patch";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
