### PR TITLE
hyprmoncfg: 1.8.0 -> 1.9.0

### DIFF
--- a/pkgs/by-name/hy/hyprmoncfg/package.nix
+++ b/pkgs/by-name/hy/hyprmoncfg/package.nix
@@ -11,7 +11,7 @@
 
 buildGoModule (finalAttrs: {
   pname = "hyprmoncfg";
-  version = "1.8.0";
+  version = "1.9.0";
 
   __structuredAttrs = true;
 
@@ -19,7 +19,7 @@ buildGoModule (finalAttrs: {
     owner = "crmne";
     repo = "hyprmoncfg";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-hu3ekA4wAp83DE2v00B2n5gsZt2iSv0/OWbg5Mwo4gY=";
+    hash = "sha256-YHJHW1ArHRhx4RKtwUmIrsMvEyTEZEjDuEXXgc98/ys=";
   };
 
   vendorHash = "sha256-gQbjvdKtO0hCXrs9RnWo1s0YeHf5W9t+8AgS2ELXlPo=";


### PR DESCRIPTION
## Things done

Updates hyprmoncfg to 1.9.0.

- Built on platform(s): x86_64-linux
- Tested the 1.9.0 source and vendor hashes with `nix build` in `nixos/nix:latest` through the upstream packaging flake
- Checked the nixpkgs expression with `nix-instantiate --parse`
- Upstream `go test ./...` passes

No NixOS module changes.

https://github.com/crmne/hyprmoncfg/releases/tag/v1.9.0