### PR TITLE
ftb-app: 1.27.2 -> 1.30.0

### DIFF
--- a/pkgs/by-name/ft/ftb-app/package.nix
+++ b/pkgs/by-name/ft/ftb-app/package.nix
@@ -7,7 +7,7 @@
 }:
 let
   pname = "ftb-app";
-  version = "1.27.2";
+  version = "1.30.0";
 
   src =
     let
@@ -15,11 +15,11 @@ let
         {
           aarch64-linux = {
             url = "https://piston.feed-the-beast.com/app/ftb-app-linux-${version}-arm64.AppImage";
-            hash = "sha256-il7DIY1c5TDmRSzc86BTOCn4P20P3Wd4STkLGyFm2+c=";
+            hash = "sha256-ldH3LhdXwS3vhiUYA/DdO2l7tRpRMs0EC70eeNNHcSc=";
           };
           x86_64-linux = {
             url = "https://piston.feed-the-beast.com/app/ftb-app-linux-${version}-x86_64.AppImage";
-            hash = "sha256-35GEI1OBvVkUvHvQAzzGz8ux9h+5W3acH0Wr5VkqyBw=";
+            hash = "sha256-NsZXfQj6exU2JWHCT+/NQJ/ivjVrIWVU7lajeS4bDrY=";
           };
         }
         .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");


### PR DESCRIPTION
Changelog: https://www.feed-the-beast.com/ftb-app/changes
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
