### PR TITLE
rawtherapee: 5.12 -> 5.13

### DIFF
--- a/pkgs/by-name/ra/rawtherapee/package.nix
+++ b/pkgs/by-name/ra/rawtherapee/package.nix
@@ -33,27 +33,21 @@
   exiv2,
   libraw,
   libjxl,
+  fmt,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rawtherapee";
-  version = "5.12";
+  version = "5.13";
 
   src = fetchurl {
     # The developers ask not to use the tarball from Github releases, see
     # https://www.rawtherapee.com/downloads/5.12/#news-relevant-to-package-maintainers
-    url = "https://rawtherapee.com/shared/source/rawtherapee-${finalAttrs.version}.tar.xz";
-    hash = "sha256-2abBBTfWSihbxGVnX+WaqpTOMiOCPfvs8K4slZkILVc=";
+    url = "https://github.com/RawTherapee/RawTherapee/releases/download/${finalAttrs.version}/rawtherapee-${finalAttrs.version}.tar.xz";
+    hash = "sha256-I73/SxgX4SdMEalLEdIcrFnpwbHSCXldMZRxDuc+d78=";
   };
 
   postPatch = ''
-    # https://github.com/NixOS/nixpkgs/issues/475835
-    # https://github.com/RawTherapee/RawTherapee/issues/7443#issuecomment-3014132156
-    # remove for 5.13
-    substituteInPlace rtengine/procparams.cc --replace \
-      'outputProfile(options.rtSettings.srgb),' \
-      'outputProfile("RTv4_sRGB"),'
-
     cat <<EOF > ReleaseInfo.cmake
     set(GIT_DESCRIBE ${finalAttrs.version})
     set(GIT_BRANCH ${finalAttrs.version})
@@ -102,6 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
     exiv2
     libraw
     libjxl
+    fmt
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     libcanberra-gtk3
@@ -114,6 +109,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-DPROC_TARGET_NUMBER=2"
     "-DCACHE_NAME_SUFFIX=\"\""
     "-DWITH_SYSTEM_LIBRAW=\"ON\""
+    "-DWITH_SYSTEM_FMT=\"ON\""
     "-DWITH_JXL=\"ON\""
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/by-name/ra/rawtherapee/package.nix
+++ b/pkgs/by-name/ra/rawtherapee/package.nix
@@ -141,6 +141,9 @@ stdenv.mkDerivation (finalAttrs: {
     description = "RAW converter and digital photo processing software";
     homepage = "http://www.rawtherapee.com/";
     license = lib.licenses.gpl3Plus;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+    ];
     maintainers = with lib.maintainers; [
       jcumming
       mahe


### PR DESCRIPTION
Release notes: https://github.com/RawTherapee/RawTherapee/blob/5.13/RELEASE_NOTES.txt
Diff: https://github.com/RawTherapee/RawTherapee/compare/5.12...5.13

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
