### PR TITLE
various pkgs: drop setuptools dependency, pin setuptools_80; jenkins-job-builder: 6.4.4 -> 6.5.0

### DIFF
--- a/pkgs/development/python-modules/jenkins-job-builder/default.nix
+++ b/pkgs/development/python-modules/jenkins-job-builder/default.nix
@@ -10,7 +10,7 @@
   six,
   stevedore,
   pytestCheckHook,
-  setuptools,
+  setuptools_80,
   testtools,
   pytest-mock,
   nixosTests,
@@ -18,21 +18,21 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "jenkins-job-builder";
-  version = "6.4.4";
+  version = "6.5.0";
   pyproject = true;
 
   # forge at opendev.org does not provide release tarballs
   src = fetchPypi {
     pname = "jenkins_job_builder";
     inherit (finalAttrs) version;
-    hash = "sha256-7PpCDpe3KLRpt+R/Nu+qxdDxLKWVqTiCPK3j+nNaum8=";
+    hash = "sha256-9E3tWR9olpAZrloh/dxsIztz2PJJfRJrPUzMvpuLFJ0=";
   };
 
   postPatch = ''
     export HOME=$(mktemp -d)
   '';
 
-  build-system = [ setuptools ];
+  build-system = [ setuptools_80 ];
 
   dependencies = [
     pbr

--- a/pkgs/development/python-modules/pbr/default.nix
+++ b/pkgs/development/python-modules/pbr/default.nix
@@ -4,7 +4,7 @@
   callPackage,
   distutils,
   fetchPypi,
-  setuptools,
+  setuptools_80,
 }:
 
 buildPythonPackage rec {
@@ -17,11 +17,11 @@ buildPythonPackage rec {
     hash = "sha256-tGAE7DClMkZyaD7ISK7Z6PxQCw0mHUCjIpwtK7/O3Ck=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [ setuptools_80 ];
 
   dependencies = [
     distutils # for distutils.command in pbr/packaging.py
-    setuptools # for pkg_resources
+    setuptools_80 # for pkg_resources
   ];
 
   # check in passthru.tests.pytest to escape infinite recursion with fixtures

--- a/pkgs/development/python-modules/python-jenkins/default.nix
+++ b/pkgs/development/python-modules/python-jenkins/default.nix
@@ -6,7 +6,6 @@
   mock,
   pbr,
   pyyaml,
-  setuptools,
   six,
   multi-key-dict,
   testscenarios,
@@ -40,7 +39,6 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     pbr
     pyyaml
-    setuptools
     six
     multi-key-dict
     requests

--- a/pkgs/development/python-modules/testscenarios/default.nix
+++ b/pkgs/development/python-modules/testscenarios/default.nix
@@ -5,7 +5,6 @@
 
   # build-system
   pbr,
-  setuptools,
 
   # dependencies
   testtools,
@@ -32,7 +31,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     pbr
-    setuptools
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/testtools/default.nix
+++ b/pkgs/development/python-modules/testtools/default.nix
@@ -7,9 +7,6 @@
   # build-system
   hatchling,
   hatch-vcs,
-
-  # dependencies
-  setuptools,
 }:
 
 buildPythonPackage rec {
@@ -28,8 +25,6 @@ buildPythonPackage rec {
   ];
 
   pythonRemoveDeps = [ "fixtures" ];
-
-  propagatedBuildInputs = lib.optionals (pythonAtLeast "3.12") [ setuptools ];
 
   # testscenarios has a circular dependency on testtools
   doCheck = false;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
