### PR TITLE
librewolf-unwrapped: disbaled MOZ_TELEMETRY_REPORTING

### DIFF
--- a/pkgs/build-support/build-mozilla-mach/default.nix
+++ b/pkgs/build-support/build-mozilla-mach/default.nix
@@ -16,6 +16,7 @@
   extraPostPatch ? "",
   extraNativeBuildInputs ? [ ],
   extraConfigureFlags ? [ ],
+  extraPreConfigure ? "",
   extraBuildInputs ? [ ],
   extraMakeFlags ? [ ],
   extraPassthru ? { },
@@ -470,7 +471,8 @@ buildStdenv.mkDerivation {
     # linking firefox hits the vm.max_map_count kernel limit with the default musl allocator
     # TODO: Default vm.max_map_count has been increased, retest without this
     export LD_PRELOAD=${mimalloc}/lib/libmimalloc.so
-  '';
+  ''
+  + extraPreConfigure;
 
   # firefox has a different definition of configurePlatforms from nixpkgs, see configureFlags
   configurePlatforms = [ ];

--- a/pkgs/by-name/li/librewolf-unwrapped/librewolf.nix
+++ b/pkgs/by-name/li/librewolf-unwrapped/librewolf.nix
@@ -24,6 +24,10 @@ rec {
     "--enable-lto=thin,cross"
   ];
 
+  extraPreConfigure = ''
+    export MOZ_TELEMETRY_REPORTING=
+  '';
+
   extraPostPatch = ''
     while read patch_name; do
       echo "applying LibreWolf patch: $patch_name"

--- a/pkgs/by-name/li/librewolf-unwrapped/package.nix
+++ b/pkgs/by-name/li/librewolf-unwrapped/package.nix
@@ -20,6 +20,7 @@ in
   branding = "browser/branding/librewolf";
   inherit (librewolf-src)
     extraConfigureFlags
+    extraPreConfigure
     extraPatches
     extraPostPatch
     extraPassthru


### PR DESCRIPTION
While talking with an upstream maintainer we've noticed that we aren't disabling ` MOZ_TELEMETRY_REPORTING` which is somewhat of an oopsie on our side.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
