### PR TITLE
nixos.security: remove option unprivilegedUsernsClone

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -139,6 +139,9 @@
 
 - `services.firezone.server.provision` has been removed due to it being unmaintanable. Remove all uses of provisioning and use the WebUI to configure firezone.
 
+- `security.unprivilegedUsernsClone` has been removed. The option controls a sysctl only provided by the removed -hardened kernels. The removal should only affect users running custom hardened kernels.
+  Disabling user-namespace is possible by setting `boot.kernel.sysctl."user.max_user_namespaces"` to zero, but not generally advised, as browsers, like firefox and chrome, and many other user tools use namespaces for sandboxing.
+
 - The `services.syncthing` module now updates the Syncthing REST API using partial updates (`PATCH`) instead of full replacements (`PUT`) for general settings. Updating these settings was broken and prone to errors after updates, see [#428808](https://github.com/NixOS/nixpkgs/issues/428808) and [#528889](https://github.com/NixOS/nixpkgs/issues/528889). As a result, settings modified manually through the Syncthing Web UI that are not explicitly defined in your Nix configuration will now persist across rebuilds.
 
 - `services.plantuml-server.packages.jetty` now supports `jetty_12`, it no longer supports `jetty_11`.

--- a/nixos/modules/programs/benchexec.nix
+++ b/nixos/modules/programs/benchexec.nix
@@ -86,9 +86,6 @@ in
     programs = {
       cpu-energy-meter.enable = lib.mkDefault true;
     };
-
-    # See <https://github.com/sosy-lab/benchexec/blob/3.18/doc/INSTALL.md#kernel-requirements>.
-    security.unprivilegedUsernsClone = true;
   };
 
   meta.maintainers = with lib.maintainers; [ lorenzleutgeb ];

--- a/nixos/modules/security/misc.nix
+++ b/nixos/modules/security/misc.nix
@@ -9,6 +9,16 @@
       [ "security" "virtualization" "flushL1DataCache" ]
       [ "security" "virtualisation" "flushL1DataCache" ]
     )
+    (lib.mkRemovedOptionModule
+      [
+        "security"
+        "unprivilegedUsernsClone"
+      ]
+      ''
+        to disable or enable unprivileged user namespaces please use
+        the sysctl "user.max_user_namespaces".
+      ''
+    )
   ];
 
   options = {
@@ -28,16 +38,6 @@
         When user namespace creation is disallowed, attempting to create a
         user namespace fails with "no space left on device" (ENOSPC).
         root may re-enable user namespace creation at runtime.
-      '';
-    };
-
-    security.unprivilegedUsernsClone = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = ''
-        When disabled, unprivileged users will not be able to create new namespaces.
-        By default unprivileged user namespaces are disabled.
-        This option only works in a hardened profile.
       '';
     };
 
@@ -119,10 +119,6 @@
           message = "`nix.settings.sandbox = true` conflicts with `!security.allowUserNamespaces`.";
         }
       ];
-    })
-
-    (lib.mkIf config.security.unprivilegedUsernsClone {
-      boot.kernel.sysctl."kernel.unprivileged_userns_clone" = lib.mkDefault true;
     })
 
     (lib.mkIf config.security.protectKernelImage {


### PR DESCRIPTION
The sysctl "kernel.unprivilegedUsernsClone" is a non-mainline feature that was only available using the hardened kernels, that disable unprivileged namespaces by default.
Since hardened kernels and profile have been removed the option doesn't have an purpose anymore and might only confuse users by implying that unprivileged namespaces are disabled by default, when that option is actually controlled by setting "user.max_user_namespaces".

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
