### PR TITLE
lasuite-meet: 1.22.0 -> 1.25.0

### DIFF
--- a/pkgs/by-name/la/lasuite-meet/addon-outlook.nix
+++ b/pkgs/by-name/la/lasuite-meet/addon-outlook.nix
@@ -23,7 +23,7 @@ buildNpmPackage (finalAttrs: {
 
   npmDeps = fetchNpmDeps {
     inherit (finalAttrs) version src sourceRoot;
-    hash = "sha256-1CoY0A4KMdn76SbgfRULn+O4yZhJgwNdk/bZ9Fk2rwY=";
+    hash = "sha256-1xsvOHTIO1dxNlb+lISr0Qtt7/QScLS1AUXzpZWTIuc=";
   };
   npmBuildScript = "build";
 

--- a/pkgs/by-name/la/lasuite-meet/frontend.nix
+++ b/pkgs/by-name/la/lasuite-meet/frontend.nix
@@ -3,26 +3,11 @@
   version,
   meta,
   fetchNpmDeps,
-  fetchpatch,
   buildNpmPackage,
 }:
 buildNpmPackage (finalAttrs: {
   pname = "lasuite-meet-frontend";
   inherit src version;
-
-  patches = [
-    # backport build fix
-    # FIXME: remove in next release
-    (fetchpatch {
-      url = "https://github.com/suitenumerique/meet/commit/df1495c97bc913866169ee8875a9a3169fcfc87e.diff";
-      stripLen = 2;
-      includes = [
-        "package.json"
-        "package-lock.json"
-      ];
-      hash = "sha256-1A26T6LtFlOiJNVGD/fZs562feoQXY37A2ecUfvDGpk=";
-    })
-  ];
 
   sourceRoot = "${finalAttrs.src.name}/src/frontend";
 
@@ -30,10 +15,9 @@ buildNpmPackage (finalAttrs: {
     inherit (finalAttrs)
       version
       src
-      patches
       sourceRoot
       ;
-    hash = "sha256-uiD5pcpmka43uraMFo7lRuQFx/4aq1BEhQvyCAzo8fg=";
+    hash = "sha256-X+RzRM1rRZZ2k1kjtk0JVXBIbEIuX5mk/zRzwjGKr1s=";
   };
   npmBuildScript = "build";
 

--- a/pkgs/by-name/la/lasuite-meet/mail.nix
+++ b/pkgs/by-name/la/lasuite-meet/mail.nix
@@ -22,7 +22,7 @@ buildNpmPackage (finalAttrs: {
     pname = "${finalAttrs.pname}-npm-deps";
     inherit version src;
     inherit (finalAttrs) sourceRoot;
-    hash = "sha256-EPVkSzhecDZpvz+uOW0GZnmWl9KfE3UpkTCnhVnJ7dg=";
+    hash = "sha256-nZURiOcSgXZwXBkB43GPerXUF2RSTiEPnjsVLSyXKxw=";
   };
   npmBuildScript = "build";
 

--- a/pkgs/by-name/la/lasuite-meet/package.nix
+++ b/pkgs/by-name/la/lasuite-meet/package.nix
@@ -6,13 +6,13 @@
   python3,
 }:
 let
-  version = "1.22.0";
+  version = "1.25.0";
 
   src = fetchFromGitHub {
     owner = "suitenumerique";
     repo = "meet";
     tag = "v${version}";
-    hash = "sha256-w2Lw5K62Iaqzqa/ckxK36o5ZHFLXUpHnGGGl5PYGjaI=";
+    hash = "sha256-0+X7kqydIkISYh+zy8/dqOkhkNmkpCuRgyq32OKtbcY=";
   };
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
