### PR TITLE
nixos/immich: add database.package option

### DIFF
--- a/nixos/modules/services/web-apps/immich.nix
+++ b/nixos/modules/services/web-apps/immich.nix
@@ -50,9 +50,6 @@ let
     mkOption
     mkEnableOption
     ;
-
-  postgresqlPackage =
-    if cfg.database.enable then config.services.postgresql.package else pkgs.postgresql;
 in
 {
   imports = [
@@ -251,6 +248,29 @@ in
         default = "immich";
         description = "The database user for immich.";
       };
+      package = mkOption {
+        type = types.package;
+        default =
+          if config.services.postgresql.enable then config.services.postgresql.package else pkgs.postgresql;
+        defaultText = lib.literalExpression ''
+          if config.services.postgresql.enable then
+            config.services.postgresql.package
+          else
+            pkgs.postgresql
+        '';
+        example = lib.literalExpression "pkgs.postgresql_18";
+        description = ''
+          The postgresql package providing the client programs that immich uses,
+          most notably the `pg_dumpall` of its database backup job.
+
+          These programs refuse to talk to a server that is newer than
+          themselves, so this must not be older than the server reachable at
+          {option}`services.immich.database.host`. It is derived from
+          {option}`services.postgresql.package` whenever the postgresql module
+          is enabled on this host; set it explicitly when the database lives on
+          another machine.
+        '';
+      };
     };
     redis = {
       enable = mkEnableOption "a redis cache for use with immich" // {
@@ -329,7 +349,7 @@ in
       in
       [
         ''
-          ${lib.getExe' postgresqlPackage "psql"} -d "${cfg.database.name}" -f "${sqlFile}"
+          ${lib.getExe' cfg.database.package "psql"} -d "${cfg.database.name}" -f "${sqlFile}"
         ''
       ];
 
@@ -399,7 +419,7 @@ in
       path = [
         # gzip and pg_dumpall are used by the backup service
         pkgs.gzip
-        postgresqlPackage
+        cfg.database.package
       ];
 
       preStart = mkIf (cfg.settings != null) secretsReplacement.script;


### PR DESCRIPTION
# nixos/immich: postgresql client version is picked by the wrong condition

## Problem

The package providing `psql` and `pg_dumpall` is selected by:

```nix
postgresqlPackage =
  if cfg.database.enable then config.services.postgresql.package else pkgs.postgresql;
```

It lands in the `PATH` of `immich-server`, where immich's backup job finds `pg_dumpall`.

The condition asks "does immich manage the cluster?", not "do we know the server version?". 

These diverge when `services.postgresql` is configured by hand and `services.immich.database.enable = false`: the local cluster is there, `config.services.postgresql.package` evaluates fine, but the module falls back to `pkgs.postgresql`.

The fallback comes from 62d2b6d593fe, and its guard is needed — the default of `services.postgresql.package` is assigned inside `config = mkIf cfg.enable`, so reading it throws when the postgresql module is disabled. 

Only the condition is too coarse.

## Example case

```nix
services.postgresql = {
  enable = true;
  package = pkgs.postgresql_18;
  ensureDatabases = [ "immich" ];
  ensureUsers = [
    {
      name = "immich";
      ensureDBOwnership = true;
    }
  ];
};

services.immich = {
  enable = true;
  database = {
    enable = false;
    name = "immich";
    user = "immich";
    host = "/run/postgresql";
  };
};
```

My Postgres is 18 but `immich-server` gets `pg_dumpall` from `pkgs.postgresql`, which is 17 on `release-26.05`. 

The backup job then fails:

```
pg_dumpall: error: server version: 18.x; pg_dumpall version: 17.x
pg_dumpall: error: aborting because of server version mismatch
```

Not fixable from the configuration; the only workaround is prepending the package to the unit's `PATH` by hand (`mkBefore`, since the module already fills `path`):

```nix
systemd.services.immich-server.path = lib.mkBefore [ pkgs.postgresql_18 ];
```

## Solution

1. Key the choice on the presence of a local cluster instead:

   ```nix
   if config.services.postgresql.enable then
     config.services.postgresql.package
   else
     pkgs.postgresql
   ```

   The guard from 62d2b6d593fe is preserved, and no recursion is introduced — the postgresql module reads nothing from immich. `mastodon.nix` does the same via its `databaseActuallyCreateLocally` flag.

2. Still a heuristic: a local cluster need not be the one immich talks to. So expose it as `services.immich.database.package`, defaulting to the above, for remote databases where the server version cannot be inferred.

Both call sites use the new option: `psql` for the `ALTER SCHEMA public OWNER` statement, and the `immich-server` `PATH`.

No release note — bug fix plus a new option.

Tested with `nix fmt` and `nixosTests.immich` / `nixosTests.immich-vectorchord-reindex`. 

Worth a backport to the release branch.

Assisted-by: Claude Code (claude-opus-5)
