### PR TITLE
kdePackages.kio-s3: init at 1.0.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6319,6 +6319,13 @@
     github = "darkyzhou";
     githubId = 7220778;
   };
+  daroche = {
+    name = "daroche";
+    email = "him@daroche.me";
+    matrix = "@him:daroche.me";
+    github = "RealDaroche";
+    githubId = 94007359;
+  };
   darshancode2005 = {
     name = "Darshan Thakare";
     email = "darshanthakaregsoc2023@gmail.com";

--- a/pkgs/kde/default.nix
+++ b/pkgs/kde/default.nix
@@ -76,6 +76,7 @@ let
         kirigami-addons = self.callPackage ./misc/kirigami-addons { };
         kio-extras-kf5 = self.callPackage ./misc/kio-extras-kf5 { };
         kio-fuse = self.callPackage ./misc/kio-fuse { };
+        kio-s3 = self.callPackage ./misc/kio-s3 { };
         klevernotes = self.callPackage ./misc/klevernotes { };
         ktextaddons = self.callPackage ./misc/ktextaddons { };
         kup = self.callPackage ./misc/kup { };

--- a/pkgs/kde/misc/kio-s3/default.nix
+++ b/pkgs/kde/misc/kio-s3/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  mkKdeDerivation,
+  fetchurl,
+  pkg-config,
+  aws-sdk-cpp,
+  kcmutils,
+}:
+let
+  aws-sdk-cpp-s3 = aws-sdk-cpp.override { apis = [ "s3" ]; };
+in
+mkKdeDerivation rec {
+  pname = "kio-s3";
+  version = "1.0.2";
+
+  src = fetchurl {
+    url = "mirror://kde/stable/kio-s3/kio-s3-${version}.tar.xz";
+    hash = "sha256-zixxrZm1U6iaCyZeGBe1lP9ojDqd2qOaekkEa6dyEao=";
+  };
+
+  extraNativeBuildInputs = [ pkg-config ];
+  extraBuildInputs = [
+    aws-sdk-cpp-s3
+    kcmutils
+  ];
+
+  meta = {
+    license = with lib.licenses; [
+      bsd3
+      cc-by-10
+      gpl2Plus
+    ];
+    maintainers = with lib.maintainers; [ daroche ];
+  };
+}


### PR DESCRIPTION
Inits the kio-s3 module to interact with AWS S3 and AWS S3-compatible object storage.

Tested locally by appending the package to `environment.systemPackages`, and connecting to a locally hosted `garage` instance. `kioclient` & dolphin operations work as intended. The systemsettings KCM also behaves as expected.

**Caveats**

~~- As this package depends on the AWS SDK, it pulls in a 491MB store path (@ current nixos-unstable). If there is a way to trim it to just the S3 parts, please let me know and I'll advise.~~ Fixed by overriding aws-sdk-cpp to only the s3 part.
- It is also prone to breaking on third party object storage providers because of [changes in default behavior from aws-sdk-cpp](https://github.com/aws/aws-sdk-cpp/discussions/3252). For instance, file mutation operations wouldn't work on garage since `PutObject` operations from the SDK use newer headers than what garage supports.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
