### PR TITLE
quarto: 1.9.37 -> 1.10.18, add aarch64-linux and aarch64-darwin support

### DIFF
--- a/pkgs/by-name/qu/quarto/package.nix
+++ b/pkgs/by-name/qu/quarto/package.nix
@@ -39,11 +39,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "quarto";
-  version = "1.9.37";
+  version = "1.10.18";
 
   src = fetchurl {
     url = "https://github.com/quarto-dev/quarto-cli/releases/download/v${finalAttrs.version}/quarto-${finalAttrs.version}-linux-amd64.tar.gz";
-    hash = "sha256-ePzZDpg+Pn2+Pw0ZIcwQJTweynuSwg3UvCo8G8oKmvU=";
+    hash = "sha256-r60HG1vSLALy0wBpV0MYnTZQ4FN6Uwc+ZUtjDP8rDHM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/qu/quarto/package.nix
+++ b/pkgs/by-name/qu/quarto/package.nix
@@ -41,10 +41,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "quarto";
   version = "1.10.18";
 
-  src = fetchurl {
-    url = "https://github.com/quarto-dev/quarto-cli/releases/download/v${finalAttrs.version}/quarto-${finalAttrs.version}-linux-amd64.tar.gz";
-    hash = "sha256-r60HG1vSLALy0wBpV0MYnTZQ4FN6Uwc+ZUtjDP8rDHM=";
-  };
+  src =
+    finalAttrs.passthru.sources.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  # the macOS tarball unpacks flat instead of into a versioned directory
+  sourceRoot = if stdenv.hostPlatform.isDarwin then "." else "quarto-${finalAttrs.version}";
 
   nativeBuildInputs = [
     makeWrapper
@@ -82,17 +84,35 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.tests = {
-    quarto-check =
-      runCommand "quarto-check"
-        {
-          nativeBuildInputs = [ which ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ sysctl ];
-        }
-        ''
-          export HOME="$(mktemp -d)"
-          ${quarto}/bin/quarto check
-          touch $out
-        '';
+  passthru = {
+    sources = {
+      x86_64-linux = fetchurl {
+        url = "https://github.com/quarto-dev/quarto-cli/releases/download/v${finalAttrs.version}/quarto-${finalAttrs.version}-linux-amd64.tar.gz";
+        hash = "sha256-r60HG1vSLALy0wBpV0MYnTZQ4FN6Uwc+ZUtjDP8rDHM=";
+      };
+      aarch64-linux = fetchurl {
+        url = "https://github.com/quarto-dev/quarto-cli/releases/download/v${finalAttrs.version}/quarto-${finalAttrs.version}-linux-arm64.tar.gz";
+        hash = "sha256-9qB99o4lMwtd809l099mvKYFrM47gwxZOljpGITUz2w=";
+      };
+      # the macOS asset is a universal binary carrying both architectures
+      aarch64-darwin = fetchurl {
+        url = "https://github.com/quarto-dev/quarto-cli/releases/download/v${finalAttrs.version}/quarto-${finalAttrs.version}-macos.tar.gz";
+        hash = "sha256-3danGp4ESKsV+2VbxYnhHLZYmiSOw1zNf39EE3UxaI4=";
+      };
+    };
+
+    tests = {
+      quarto-check =
+        runCommand "quarto-check"
+          {
+            nativeBuildInputs = [ which ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ sysctl ];
+          }
+          ''
+            export HOME="$(mktemp -d)"
+            ${quarto}/bin/quarto check
+            touch $out
+          '';
+    };
   };
 
   meta = {
@@ -109,7 +129,7 @@ stdenv.mkDerivation (finalAttrs: {
       minijackson
       mrtarantoga
     ];
-    platforms = lib.platforms.all;
+    platforms = builtins.attrNames finalAttrs.passthru.sources;
     sourceProvenance = with lib.sourceTypes; [
       binaryNativeCode
       binaryBytecode

--- a/pkgs/by-name/qu/quarto/package.nix
+++ b/pkgs/by-name/qu/quarto/package.nix
@@ -17,6 +17,8 @@
   extraPythonPackages ? ps: [ ],
   sysctl,
   which,
+  autoPatchelfHook,
+  bashNonInteractive,
 }:
 
 let
@@ -36,6 +38,12 @@ let
     ]
     ++ (extraPythonPackages ps)
   );
+
+  # bin/quarto resolves every bundled tool through bin/tools/$ARCH_DIR, which it
+  # derives from uname and can only ever be x86_64 or aarch64
+  archDir = stdenv.hostPlatform.parsed.cpu.name;
+  denoDomExt = if stdenv.hostPlatform.isDarwin then "dylib" else "so";
+  denoDomPlugin = "libplugin.${denoDomExt}";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "quarto";
@@ -48,10 +56,20 @@ stdenv.mkDerivation (finalAttrs: {
   # the macOS tarball unpacks flat instead of into a versioned directory
   sourceRoot = if stdenv.hostPlatform.isDarwin then "." else "quarto-${finalAttrs.version}";
 
+  strictDeps = true;
+
   nativeBuildInputs = [
     makeWrapper
-    which
-  ];
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+
+  buildInputs = [
+    # bin/quarto is a bash script; under strictDeps patchShebangs only resolves
+    # its interpreter from the host dependencies
+    bashNonInteractive
+  ]
+  # libgcc_s.so.1 for the retained typst-gather and deno_dom binaries
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ (stdenv.cc.cc.libgcc or null) ];
 
   dontStrip = true;
 
@@ -62,6 +80,8 @@ stdenv.mkDerivation (finalAttrs: {
       --set-default QUARTO_ESBUILD ${lib.getExe esbuild} \
       --set-default QUARTO_DART_SASS ${lib.getExe dart-sass} \
       --set-default QUARTO_TYPST ${lib.getExe typst} \
+      --set-default QUARTO_DENO_DOM $out/bin/tools/${archDir}/deno_dom/${denoDomPlugin} \
+      --suffix PATH : ${lib.makeBinPath [ which ]} \
       ${lib.optionalString (rWrapper != null) "--set-default QUARTO_R ${rWithPackages}/bin/R"} \
       ${
         lib.optionalString (python3 != null) "--set-default QUARTO_PYTHON ${pythonWithPackages}/bin/python3"
@@ -75,8 +95,41 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     mkdir -p $out/bin $out/share
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # the macOS asset bundles a complete tool tree for every architecture,
+    # alongside AppleDouble metadata files
+    find bin/tools -mindepth 1 -maxdepth 1 -type d ! -name ${archDir} -exec rm -r {} +
+    find . -name '._*' -delete
+  ''
+  + ''
+    tools=bin/tools/${archDir}
+    if [ ! -d "$tools" ]; then
+      echo "upstream no longer ships $tools, which is where quarto looks up its tools" >&2
+      exit 1
+    fi
 
-    rm -r bin/tools
+    # swap the vendored tools for the nixpkgs builds. typst-gather and deno_dom
+    # have no nixpkgs equivalent and are kept: dropping the whole directory
+    # broke `quarto call typst-gather` and the DENO_DOM_PLUGIN export.
+    rm -r "$tools"/deno "$tools"/pandoc "$tools"/typst "$tools"/esbuild "$tools"/dart-sass
+
+    ln -s ${lib.getExe deno} "$tools"/deno
+    ln -s ${lib.getExe pandoc} "$tools"/pandoc
+    ln -s ${lib.getExe typst} "$tools"/typst
+    ln -s ${lib.getExe esbuild} "$tools"/esbuild
+    mkdir "$tools"/dart-sass
+    ln -s ${lib.getExe dart-sass} "$tools"/dart-sass/sass
+
+    # the linux-arm64 asset names the plugin libplugin-linux-aarch64.so, while
+    # bin/quarto and QUARTO_DENO_DOM only ever point at the unsuffixed name; a
+    # dlopen miss is swallowed and silently downgrades quarto to the wasm parser
+    if [ ! -e "$tools"/deno_dom/${denoDomPlugin} ]; then
+      mv "$tools"/deno_dom/libplugin*.${denoDomExt} "$tools"/deno_dom/${denoDomPlugin}
+    fi
+
+    # pre-1.4 location, still probed by the VS Code extension
+    ln -s ${archDir}/pandoc bin/tools/pandoc
 
     mv bin/* $out/bin
     mv share/* $out/share

--- a/pkgs/by-name/qu/quarto/package.nix
+++ b/pkgs/by-name/qu/quarto/package.nix
@@ -7,18 +7,24 @@
   deno,
   fetchurl,
   dart-sass,
+  installShellFiles,
   rWrapper,
   rPackages,
   extraRPackages ? [ ],
   makeWrapper,
   runCommand,
   python3,
-  quarto,
   extraPythonPackages ? ps: [ ],
   sysctl,
   which,
   autoPatchelfHook,
   bashNonInteractive,
+  coreutils,
+  versionCheckHook,
+  writeShellScript,
+  curl,
+  jq,
+  common-updater-scripts,
 }:
 
 let
@@ -59,6 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   nativeBuildInputs = [
+    installShellFiles
     makeWrapper
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
@@ -81,7 +88,12 @@ stdenv.mkDerivation (finalAttrs: {
       --set-default QUARTO_DART_SASS ${lib.getExe dart-sass} \
       --set-default QUARTO_TYPST ${lib.getExe typst} \
       --set-default QUARTO_DENO_DOM $out/bin/tools/${archDir}/deno_dom/${denoDomPlugin} \
-      --suffix PATH : ${lib.makeBinPath [ which ]} \
+      --suffix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          which
+        ]
+      } \
       ${lib.optionalString (rWrapper != null) "--set-default QUARTO_R ${rWithPackages}/bin/R"} \
       ${
         lib.optionalString (python3 != null) "--set-default QUARTO_PYTHON ${pythonWithPackages}/bin/python3"
@@ -131,11 +143,19 @@ stdenv.mkDerivation (finalAttrs: {
     # pre-1.4 location, still probed by the VS Code extension
     ln -s ${archDir}/pandoc bin/tools/pandoc
 
+    # share/man also holds the qmd the page is generated from, which
+    # compressManPages would gzip in place for mandb to trip over
+    installManPage --name quarto.1 share/man/quarto-man.man
+    rm -r share/man
+
     mv bin/* $out/bin
     mv share/* $out/share
 
     runHook postInstall
   '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   passthru = {
     sources = {
@@ -162,10 +182,35 @@ stdenv.mkDerivation (finalAttrs: {
           }
           ''
             export HOME="$(mktemp -d)"
-            ${quarto}/bin/quarto check
+            ${lib.getExe finalAttrs.finalPackage} check
             touch $out
           '';
     };
+
+    updateScript = writeShellScript "update-quarto" ''
+      set -o errexit -o pipefail
+      export PATH="${
+        lib.makeBinPath [
+          curl
+          jq
+          common-updater-scripts
+        ]
+      }"
+      NEW_VERSION=$(curl --fail --silent --show-error --location https://api.github.com/repos/quarto-dev/quarto-cli/releases/latest | jq '.tag_name | ltrimstr("v")' --raw-output)
+      # a truncated response still leaves jq at exit 0, and an empty version
+      # would reach update-source-version
+      if [[ -z "$NEW_VERSION" || "$NEW_VERSION" = "null" ]]; then
+          echo "Could not read the latest release tag from the GitHub API." >&2
+          exit 1
+      fi
+      if [[ "${finalAttrs.version}" = "$NEW_VERSION" ]]; then
+          echo "The new version same as the old version."
+          exit 0
+      fi
+      for platform in ${lib.escapeShellArgs finalAttrs.meta.platforms}; do
+        update-source-version "''${UPDATE_NIX_ATTR_PATH:-quarto}" "$NEW_VERSION" --ignore-same-version --source-key="sources.$platform"
+      done
+    '';
   };
 
   meta = {
@@ -177,7 +222,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://quarto.org/";
     changelog = "https://github.com/quarto-dev/quarto-cli/releases/tag/v${finalAttrs.version}";
-    license = lib.licenses.gpl2Plus;
+    license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       minijackson
       mrtarantoga


### PR DESCRIPTION
Resolves: #268427, #544275, and #393246
Partially addresses: #256074
Related: #521260, #461018, #547564

Updates quarto to 1.10.18 and makes the package work on the platforms aarch64-linux and aarch64-darwin.
plus a set of runtime and metadata defects found while verifying it.

Changelog: https://github.com/quarto-dev/quarto-cli/releases/tag/v1.10.18
Compare: https://github.com/quarto-dev/quarto-cli/compare/v1.9.37...v1.10.18

Four commits:

1. `quarto: 1.9.37 -> 1.10.18`. Hashes taken from the release's own
   `quarto-1.10.18-checksums.txt` and converted with `nix hash to-sri`.
2. `quarto: support aarch64-linux and aarch64-darwin`.
3. `quarto: provide bin/tools with nixpkgs tools and upstream typst-gather`. `bin/tools/$ARCH_DIR` is now rebuilt with symlinks to the nixpkgs deno,
   pandoc, typst, esbuild and dart-sass, the two binaries without a substitute are kept and patchelfed, and `bin/tools/pandoc` is restored for the pre-1.4 layout.
4. `quarto: fix meta.license, install man page, add version check and update script`.
   Correct license. The man page moves to
   `share/man/man1/quarto.1` so `man quarto` resolves. `passthru.tests.quarto-check` used the
   top-level `quarto` attribute, so `quartoMinimal` tested full `quarto` instead of itself.


### Known pre-existing limitation, not introduced here

`passthru.tests.quarto-check` fails, and so does `quarto render`, with:

```
Aeson exception:
Error in $: Unknown option "syntax-highlighting"
```

quarto >= 1.10.18 pins pandoc >= 3.10 and emits pandoc >= 3.8 flags, while nixpkgs `pandoc` is 3.7.0.2.

not a regression from this PR. The root cause is the outdated `pandoc` in nixpkgs, tracked by #519484 and #521713.


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

### Validation run

```
nix-build -A quarto                                          # versionCheckPhase passes
nix-build -A quartoMinimal
nix-build --argstr system aarch64-linux -A quartoMinimal      # via binfmt
nix-instantiate --eval --strict -A quarto.meta.platforms
nix-instantiate --eval --strict --argstr system <s> -A quarto.src.url   # each platform
./result/bin/quarto --version                                 # 1.10.18
./result/bin/quarto call typst-gather --help                  # exits 0, errored before
ls -l result/bin/tools/*/                                     # symlinks resolve, typst-gather
                                                              # and deno_dom present
test -e result/bin/tools/pandoc
man -l result/share/man/man1/quarto.1.gz
update-source-version quarto 1.10.18 --ignore-same-version --source-key=sources.<platform>
nixfmt --check pkgs/by-name/qu/quarto/package.nix
nix-instantiate -A rstudio -A rPackages.quarto -A vimPlugins.quarto-nvim
```
