### PR TITLE
drydock: init at 1.1.1

### DIFF
--- a/pkgs/by-name/dr/drydock/package.nix
+++ b/pkgs/by-name/dr/drydock/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+  git,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "drydock";
+  version = "1.1.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "yetidevworks";
+    repo = "drydock";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-R0mFtrqIQ4aIa30YW8dwqGVYm2wyL5UyTDZwwCICeLg=";
+  };
+
+  cargoHash = "sha256-tpZx7bWk6NwuSqtPXCn0Iqdng3YhB9QXVmj4cibK/68=";
+
+  nativeCheckInputs = [ git ];
+
+  checkFlags = [
+    # relies on fs watching and timeouts which are flaky in the Nix sandbox
+    "--skip=watch::tests::a_real_edit_reaches_the_callback"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    mainProgram = "drydock";
+    description = "A live TUI dashboard for a fleet of git repos";
+    longDescription = ''
+      What's uncommitted, unpushed, and unreleased across every repo you own.
+
+      A drydock is where vessels sit while work is done on them, before they go back out.
+      If you keep dozens or hundreds of checkouts on disk and lose track of which ones
+      still have work sitting in them, this tells you, in one screen, live.
+    '';
+    homepage = "https://github.com/yetidevworks/drydock";
+    downloadPage = "https://yetidevworks.com/drydock";
+    changelog = "https://github.com/yetidevworks/drydock/releases#release-v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    identifiers = {
+      cpeParts = lib.meta.cpeFullVersionWithVendor "yetidevworks" finalAttrs.version;
+      purlParts = {
+        type = "github";
+        namespace = "yetidevworks";
+        name = "drydock";
+        version = finalAttrs.version;
+      };
+    };
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ KristijanZic ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added drydock at 1.1.1 from https://github.com/yetidevworks/drydock

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
