### PR TITLE
orca-ide: init at 1.4.173

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15239,6 +15239,12 @@
     githubId = 4032;
     name = "Kristoffer Thømt Ravneberg";
   };
+  kreativmonkey = {
+    email = "kreativmonkey@calyrium.org";
+    github = "kreativmonkey";
+    githubId = 8607439;
+    name = "Sebastian Preisner";
+  };
   krishnans2006 = {
     email = "krishnans2006@gmail.com";
     matrix = "@krishnans2006:matrix.org";

--- a/pkgs/by-name/or/orca-ide/package.nix
+++ b/pkgs/by-name/or/orca-ide/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  appimageTools,
+  fetchurl,
+  makeWrapper,
+}:
+let
+  pname = "orca-ide";
+  version = "1.4.173";
+  sources = {
+    x86_64-linux = {
+      url = "https://github.com/stablyai/orca/releases/download/v${version}/orca-linux.AppImage";
+      hash = "sha256-+pAiq3aewtqNTPpj34F8tUtIg2D81Edc+Yxa1Pb8dUQ=";
+    };
+    aarch64-linux = {
+      url = "https://github.com/stablyai/orca/releases/download/v${version}/orca-linux-arm64.AppImage";
+      hash = "sha256-TdvTWiDb6gBti3RW2hGPeu0Ehe4XiEzTr1MtFv69U6Y=";
+    };
+  };
+  src = fetchurl (
+    sources.${stdenv.hostPlatform.system}
+      or (throw "orca-ide: unsupported system ${stdenv.hostPlatform.system}")
+  );
+  appimageContents = appimageTools.extract { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+  nativeBuildInputs = [ makeWrapper ];
+
+  extraInstallCommands = ''
+    install -m 444 -D ${appimageContents}/orca-ide.desktop \
+      -t $out/share/applications
+    substituteInPlace $out/share/applications/orca-ide.desktop \
+      --replace-fail "Exec=AppRun --no-sandbox %U" "Exec=orca-ide %U"
+    install -m 444 -D ${appimageContents}/orca-ide.png \
+      $out/share/icons/hicolor/512x512/apps/orca-ide.png
+    wrapProgram $out/bin/${pname} \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+  '';
+
+  extraPkgs = pkgs: [ pkgs.procps ];
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "ADE for working with a fleet of parallel AI coding agents in isolated git worktrees";
+    homepage = "https://onorca.dev/";
+    changelog = "https://github.com/stablyai/orca/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    maintainers = with lib.maintainers; [
+      kreativmonkey
+    ];
+    mainProgram = pname;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+}

--- a/pkgs/by-name/or/orca-ide/update.sh
+++ b/pkgs/by-name/or/orca-ide/update.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq common-updater-scripts
+#shellcheck shell=bash
+
+set -eu -o pipefail
+
+release_data=$(curl -sSfL "https://api.github.com/repos/stablyai/orca/releases/latest")
+version=$(jq -r '.tag_name[1:]' <<<"$release_data")
+
+# GitHub records a SHA-256 digest for every release asset at upload time, so the
+# hashes can be read from the API instead of downloading ~390 MiB of AppImages.
+asset_hash() {
+    local digest
+    digest=$(jq -r --arg name "$1" '.assets[] | select(.name == $name) | .digest' <<<"$release_data")
+    if [[ $digest != sha256:* ]]; then
+        echo "orca-ide: no sha256 digest published for asset '$1'" >&2
+        return 1
+    fi
+    nix-hash --to-sri --type sha256 "${digest#sha256:}"
+}
+
+hash_x86_64=$(asset_hash "orca-linux.AppImage")
+hash_aarch64=$(asset_hash "orca-linux-arm64.AppImage")
+
+update-source-version orca-ide "$version" "$hash_x86_64" \
+    --system=x86_64-linux --ignore-same-version
+update-source-version orca-ide "$version" "$hash_aarch64" \
+    --system=aarch64-linux --ignore-same-version


### PR DESCRIPTION
Orca IDE — Electron-based IDE for running multiple AI coding agents (Claude Code, Codex, etc.) in parallel, isolated git worktrees.

Homepage: https://onorca.dev/
Upstream: https://github.com/stablyai/orca (MIT)

Packaged as an `appimageTools.wrapType2` wrapper around the official Linux AppImage, for `x86_64-linux` and `aarch64-linux`.

Upstream releases very frequently (multiple times per day), so there is an `update.sh` that bumps the version and both per-architecture hashes. It reads the SHA-256 digests GitHub records for each release asset instead of downloading the AppImages, which avoids ~390 MiB of traffic per update run (same approach as `pkgs/by-name/ha/harmonoid/update.sh`).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux (hash verified against the digest published by GitHub for the release asset; not built/run-tested myself, no aarch64 hardware available)
- [x] Tested basic functionality of all binary files, usually in `./result/bin/` (launched with a real GPU via nixGL; completed onboarding, confirmed via app-emitted UI event logs)
- [x] `update.sh` tested by reverting the package to the previous release and confirming it restores the correct version and both hashes
- [x] Ran `nixpkgs-review` on this PR — `1 package built: orca-ide`, no failures
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs
- [x] Follows the automation/AI policy

Assisted-by: Claude Code (claude-sonnet-5)