### PR TITLE
cava: 0.10.7 -> 1.0.0

### DIFF
--- a/pkgs/by-name/ca/cava/package.nix
+++ b/pkgs/by-name/ca/cava/package.nix
@@ -5,6 +5,7 @@
   autoreconfHook,
   autoconf-archive,
   alsa-lib,
+  darwinMinVersionHook,
   fftw,
   iniparser,
   libGL,
@@ -22,13 +23,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "cava";
-  version = "0.10.7";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "karlstav";
     repo = "cava";
     tag = finalAttrs.version;
-    hash = "sha256-eOGUDGGlja5Cq8XTJFRqyP6qyaoxOJm09vZrlk4KS9k=";
+    hash = "sha256-0vQWobnt9pAZTJc45Lgcfad72BE8DUPGQ5/YwMSmU98=";
   };
 
   buildInputs = [
@@ -42,6 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     alsa-lib
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    (darwinMinVersionHook "14.2")
     portaudio
   ]
   ++ lib.optionals withSDL2 [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
cava 1.0.0 changelog: https://github.com/karlstav/cava/releases/tag/1.0.0
Diff: https://github.com/karlstav/cava/compare/0.10.7...1.0.0

Changelog TLDR:

> This is not really a major update from 0.10.7, but new development on this project has slowed down lately so I feel it is finally time to move to "stable" version. This project have been in development for over 10 years now and I could probably have moved to version 1.0.0 long ago, but I just never felt that it was a need for it. The only API to speak of is the cavacore api and I am not sure if anyone else is using it. Either way it has not changed for years.

Supersedes https://github.com/NixOS/nixpkgs/pull/531480 (I fixed the build on Darwin)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
