### PR TITLE
mame: 0.287 -> 0.289

### DIFF
--- a/pkgs/by-name/ma/mame/package.nix
+++ b/pkgs/by-name/ma/mame/package.nix
@@ -24,7 +24,7 @@
   portmidi,
   pugixml,
   python3,
-  libsForQt5,
+  qt6,
   rapidjson,
   sqlite,
   utf8proc,
@@ -36,14 +36,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mame";
-  version = "0.287";
+  version = "0.289";
   srcVersion = builtins.replaceStrings [ "." ] [ "" ] finalAttrs.version;
 
   src = fetchFromGitHub {
     owner = "mamedev";
     repo = "mame";
     rev = "mame${finalAttrs.srcVersion}";
-    hash = "sha256-d1Y3KrJwL8iDjQDqG6FRN82WzVAqTcY1YJaayUQO8sk=";
+    hash = "sha256-tbveDIOPZjEoTmo5rV2fR9An1I6X4P8Ec7HYHWL6H6U=";
   };
 
   outputs = [
@@ -87,7 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
     SDL2
     SDL2_ttf
     sqlite
-    libsForQt5.qtbase
+    qt6.qtbase
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     alsa-lib
@@ -107,7 +107,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     python3
     which
-    libsForQt5.wrapQtAppsHook
+    qt6.wrapQtAppsHook
   ];
 
   patches = [


### PR DESCRIPTION
mame: 0.287 -> 0.289
change from qt5 to qt6

https://github.com/mamedev/mame/releases/download/mame0288/whatsnew_0288.txt
https://github.com/mamedev/mame/releases/download/mame0289/whatsnew_0289.txt


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
