### PR TITLE
tinfoil-proxy: init at 0.1.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16465,6 +16465,11 @@
     matrix = "@lostmsu:matrix.org";
     name = "Victor Nova";
   };
+  lothan = {
+    name = "Joe Lothan";
+    github = "lothan";
+    githubId = 18651528;
+  };
   loucass003 = {
     name = "Lucas Lelievre";
     email = "loucass003@gmail.com";

--- a/pkgs/by-name/ti/tinfoil-proxy/package.nix
+++ b/pkgs/by-name/ti/tinfoil-proxy/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+}:
+buildGoModule (finalAttrs: {
+  pname = "tinfoil-proxy";
+  version = "0.1.9";
+
+  src = fetchFromGitHub {
+    owner = "tinfoilsh";
+    repo = "tinfoil-proxy";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rlAEWdxgpGNDAb1nm32bdFvb9FfK4CSVyO/yyZKvmEo=";
+  };
+
+  vendorHash = "sha256-zv7OQEWxiJXWOwkEoiMgLoj1T4x9X9i6njPxK8EVpbg=";
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Local proxy that secures connections to Tinfoil enclaves";
+    homepage = "https://github.com/tinfoilsh/tinfoil-proxy";
+    changelog = "https://github.com/tinfoilsh/tinfoil-proxy/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.lothan ];
+    mainProgram = "tinfoil-proxy";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Adds `tinfoil-proxy`, a local proxy that secures connections to Tinfoil enclaves.

Packaged upstream (https://github.com/tinfoilsh/tinfoil-proxy) using `buildGoModule` and added myself as the maintainer. 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test