### PR TITLE
minimal-bootstrap: drop gcc runtime refs

### DIFF
--- a/pkgs/os-specific/linux/minimal-bootstrap/binutils/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/binutils/static.nix
@@ -33,6 +33,8 @@ let
   ];
 
   configureFlags = [
+    # otherwise the binary links dynamically and pulls gcc into the closure
+    "LDFLAGS=--static"
     "--prefix=${placeholder "out"}"
     "--build=${buildPlatform.config}"
     "--host=${hostPlatform.config}"

--- a/pkgs/os-specific/linux/minimal-bootstrap/gcc/wrapper.sh
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gcc/wrapper.sh
@@ -41,7 +41,7 @@ done
 exec -a "@origname@" @gcc@ -Wl,-dynamic-linker=@dynlinker@ \
   @extraflags@ \
   $extraRpath \
-  -Wl,-rpath,@libc@,-rpath,@libgcc@ \
+  -Wl,-rpath,@libc@ \
   -B@libc@/.. \
   -B@libgcc@ \
   -B@libc@ \

--- a/pkgs/os-specific/linux/minimal-bootstrap/gcc/wrappercxx.sh
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gcc/wrappercxx.sh
@@ -43,7 +43,7 @@ done
 exec -a "@origname@" @gcc@ -Wl,-dynamic-linker=@dynlinker@ \
   @extraflags@ \
   $extraRpath \
-  -Wl,-rpath,@libc@,-rpath,@libgcc@,-rpath,@libstdcxx@ \
+  -Wl,-rpath,@libc@,-rpath,@libstdcxx@ \
   -I @libstdcxxarchinc@ \
   -I @libstdcxxinc@ \
   -B@libc@/.. \


### PR DESCRIPTION
Two minimal-bootstrap outputs have been keeping a 140 MiB reference to the modern gcc since #507836: binutils-static lost its `--static` flag, and the new gcc wrapper adds an rpath to a directory containing no shared objects.

| attribute | before | after |
|---|---|---|
| `minimal-bootstrap.binutils-static` | 186.8 MiB, 7 paths, dynamically linked | 21.1 MiB, 1 path, statically linked |
| `minimal-bootstrap.python` | 261.2 MiB, 9 paths | 120.0 MiB, 7 paths |

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

