### PR TITLE
nixos/pipewire: fix nix formatting

### DIFF
--- a/nixos/modules/services/desktops/pipewire/pipewire.nix
+++ b/nixos/modules/services/desktops/pipewire/pipewire.nix
@@ -286,27 +286,28 @@ in
         default = [ ];
         example = literalExpression ''
           [
-                    (pkgs.writeTextDir "share/pipewire/pipewire.conf.d/10-loopback.conf" '''
-                      context.modules = [
-                      {   name = libpipewire-module-loopback
-                          args = {
-                            node.description = "Scarlett Focusrite Line 1"
-                            capture.props = {
-                                audio.position = [ FL ]
-                                stream.dont-remix = true
-                                node.target = "alsa_input.usb-Focusrite_Scarlett_Solo_USB_Y7ZD17C24495BC-00.analog-stereo"
-                                node.passive = true
-                            }
-                            playback.props = {
-                                node.name = "SF_mono_in_1"
-                                media.class = "Audio/Source"
-                                audio.position = [ MONO ]
-                            }
-                          }
-                      }
-                      ]
-                    ''')
-                  ]'';
+            (pkgs.writeTextDir "share/pipewire/pipewire.conf.d/10-loopback.conf" '''
+              context.modules = [
+              {   name = libpipewire-module-loopback
+                  args = {
+                    node.description = "Scarlett Focusrite Line 1"
+                    capture.props = {
+                        audio.position = [ FL ]
+                        stream.dont-remix = true
+                        node.target = "alsa_input.usb-Focusrite_Scarlett_Solo_USB_Y7ZD17C24495BC-00.analog-stereo"
+                        node.passive = true
+                    }
+                    playback.props = {
+                        node.name = "SF_mono_in_1"
+                        media.class = "Audio/Source"
+                        audio.position = [ MONO ]
+                    }
+                  }
+              }
+              ]
+            ''')
+          ]
+        '';
         description = ''
           List of packages that provide PipeWire configuration, in the form of
           `share/pipewire/*/*.conf` files.


### PR DESCRIPTION
This caught my eyes when browsing the pipewire options.
For the pipewire config itself I don't think there's really a standard as I've seen different kinds of formatting so I'll leave it as is (e.g. in https://docs.pipewire.org/page_man_pipewire_conf_5.html at the "CONTEXT PROPERTIES RULES" heading and one heading below the formatting is different).
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
