### PR TITLE
agentsploit: init at 1.6.3

### DIFF
--- a/pkgs/by-name/ag/agentsploit/package.nix
+++ b/pkgs/by-name/ag/agentsploit/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  python3Packages,
+  versionCheckHook,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "agentsploit";
+  version = "1.6.3";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "agentsploit";
+    repo = "agentsploit";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-g9h+hM6ujm0uvkWZMoOkZ/wUGA77Yu6lEn1ZNHh6aTg=";
+  };
+
+  build-system = with python3Packages; [ hatchling ];
+
+  dependencies = with python3Packages; [
+    anthropic
+    anyio
+    fastapi
+    httpx
+    ics
+    jinja2
+    mcp
+    openai
+    pydantic
+    pyyaml
+    reportlab
+    rich
+    structlog
+    typer
+    uvicorn
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    jsonschema
+    pytestCheckHook
+    pytest-asyncio
+    pytest-cov-stub
+    types-pyyaml
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  disabledTestPaths = [
+    # Tests need network access
+    "tests/integration/"
+  ];
+
+  doInstallCheck = true;
+
+  versionCheckProgramArg = [ "version" ];
+
+  pythonImportsCheck = [ "agentsploit" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Offensive security framework for AI agents and MCP servers";
+    homepage = "https://github.com/agentsploit/agentsploit";
+    changelog = "https://github.com/agentsploit/agentsploit/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "agentsploit";
+  };
+})


### PR DESCRIPTION
Offensive security framework for AI agents and MCP servers

https://github.com/agentsploit/agentsploit

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
