### PR TITLE
nixos/systemd-boot: Add option to preserve booted system

### DIFF
--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -13,7 +13,8 @@ import sys
 import tempfile
 import warnings
 import json
-from typing import NamedTuple, Any, Protocol, Sequence
+from abc import ABC, abstractmethod
+from typing import Any, Protocol, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -39,6 +40,7 @@ CHECK_MOUNTPOINTS = "@checkMountpoints@"
 STORE_DIR = "@storeDir@"
 BOOT_COUNTING_TRIES = "@bootCountingTries@"
 BOOT_COUNTING = "@bootCounting@" == "True"
+KEEP_BOOTED_SYSTEM = "@keepBootedSystemEntry@" == "1"
 
 
 @dataclass(frozen=True)
@@ -87,7 +89,7 @@ class CopyWriter:
 class InitrdWithSecretsWriter:
     source: Path
     initrd_secrets: Path
-    generation: int
+    system_name: str
 
     def write_boot_file(self, path: Path, *, critical: bool) -> None:
         # Secrets can change between rebuilds, so always rebuild from the
@@ -115,8 +117,8 @@ class InitrdWithSecretsWriter:
                 # exists.
                 CopyWriter(source=self.source).write_boot_file(path, critical=False)
                 print(
-                    "warning: failed to update initrd secrets for an older "
-                    f"generation ({self.generation}). The previous secrets "
+                    "warning: failed to update initrd secrets for "
+                    f"{self.system_name}. The previous secrets "
                     "in this initrd will continue to be used. To silence "
                     "this warning, restore the secret files to their "
                     "original locations or delete this generation.",
@@ -150,10 +152,82 @@ class ContentsWriter:
             os.rename(tmp.name, path)
 
 
-class SystemIdentifier(NamedTuple):
+@dataclass(frozen=True)
+class SystemIdentifier(ABC):
+    @property
+    @abstractmethod
+    def system_directory(self) -> Path: ...
+
+    def system_dir(self, specialisation: str | None) -> Path:
+        d = self.system_directory
+        if specialisation:
+            return d / "specialisation" / specialisation
+        else:
+            return d
+
+    @abstractmethod
+    def title(self, specialisation: str | None) -> str: ...
+
+    @abstractmethod
+    def description(self, label: str, build_date: str) -> str: ...
+
+    @property
+    @abstractmethod
+    def display_name(self) -> str: ...
+
+    @property
+    def emit_specialisations(self) -> bool:
+        return True
+
+
+@dataclass(frozen=True)
+class GenerationIdentifier(SystemIdentifier):
     profile: str | None
     generation: int
-    specialisation: str | None
+
+    @property
+    def system_directory(self) -> Path:
+        return generation_dir(self.profile, self.generation)
+
+    def title(self, specialisation: str | None) -> str:
+        return "{name}{profile}{specialisation}".format(
+            name=DISTRO_NAME,
+            profile=" [" + self.profile + "]" if self.profile else "",
+            specialisation=" (%s)" % specialisation if specialisation else "",
+        )
+
+    def description(self, label: str, build_date: str) -> str:
+        return f"Generation {self.generation} {label}, built on {build_date}"
+
+    @property
+    def display_name(self) -> str:
+        name = f"generation {self.generation}"
+        if self.profile:
+            name += f" of profile {self.profile}"
+        return name
+
+
+@dataclass(frozen=True)
+class BootedSystemIdentifier(SystemIdentifier):
+    @property
+    def system_directory(self) -> Path:
+        return Path("/run/booted-system")
+
+    def title(self, specialisation: str | None) -> str:
+        return f"{DISTRO_NAME} (last booted)"
+
+    # Must be lexicographically later than GenerationIdentifier.description
+    # so that it shows in boot menu later
+    def description(self, label: str, build_date: str) -> str:
+        return f"Last booted system {label}, built on {build_date}"
+
+    @property
+    def display_name(self) -> str:
+        return "last booted system"
+
+    @property
+    def emit_specialisations(self) -> bool:
+        return False
 
 
 @dataclass
@@ -170,7 +244,7 @@ class BootFile:
 
     @staticmethod
     def from_initrd(
-        generation: int,
+        system_name: str,
         source: Path,
         initrd_secrets: Path | None,
     ) -> "BootFile":
@@ -195,7 +269,7 @@ class BootFile:
                 writer=InitrdWithSecretsWriter(
                     source=source,
                     initrd_secrets=initrd_secrets,
-                    generation=generation,
+                    system_name=system_name,
                 ),
             )
 
@@ -284,16 +358,6 @@ def generation_dir(profile: str | None, generation: int) -> Path:
         return Path(f"/nix/var/nix/profiles/system-{generation}-link")
 
 
-def system_dir(
-    profile: str | None, generation: int, specialisation: str | None
-) -> Path:
-    d = generation_dir(profile, generation)
-    if specialisation:
-        return d / "specialisation" / specialisation
-    else:
-        return d
-
-
 def write_loader_conf(default_entry_id: str | None) -> None:
     tmp = LOADER_CONF.with_suffix(".tmp")
     with tmp.open("x") as f:
@@ -323,13 +387,12 @@ def write_loader_conf(default_entry_id: str | None) -> None:
     os.rename(tmp, LOADER_CONF)
 
 
-def get_bootspec(profile: str | None, generation: int) -> BootSpec | None:
-    system_directory = system_dir(profile, generation, None)
+def get_bootspec(identifier: SystemIdentifier) -> BootSpec | None:
+    system_directory = identifier.system_dir(None)
     boot_json_path = (system_directory / "boot.json").resolve()
     if not boot_json_path.is_file():
         print(
-            f"warning: skipping generation {generation}"
-            + (f" of profile {profile}" if profile else "")
+            f"warning: skipping {identifier.display_name}"
             + f": {boot_json_path} does not exist",
             file=sys.stderr,
         )
@@ -383,8 +446,7 @@ def boot_path(file: Path) -> Path:
 
 
 def boot_file(
-    profile: str | None,
-    generation: int,
+    identifier: SystemIdentifier,
     specialisation: str | None,
     machine_id: str | None,
     bootspec: BootSpec,
@@ -393,7 +455,7 @@ def boot_file(
         bootspec = bootspec.specialisations[specialisation]
     kernel = BootFile.from_source(bootspec.kernel)
     initrd = BootFile.from_initrd(
-        generation,
+        identifier.display_name,
         bootspec.initrd,
         Path(bootspec.initrdSecrets) if bootspec.initrdSecrets is not None else None,
     )
@@ -402,15 +464,11 @@ def boot_file(
         devicetree = BootFile.from_source(bootspec.devicetree)
 
     kernel_params = " ".join([f"init={bootspec.init}"] + bootspec.kernelParams)
-    build_time = int(system_dir(profile, generation, specialisation).stat().st_ctime)
+    build_time = int(identifier.system_dir(specialisation).stat().st_ctime)
     build_date = datetime.datetime.fromtimestamp(build_time).strftime("%F")
 
-    title = "{name}{profile}{specialisation}".format(
-        name=DISTRO_NAME,
-        profile=" [" + profile + "]" if profile else "",
-        specialisation=" (%s)" % specialisation if specialisation else "",
-    )
-    description = f"Generation {generation} {bootspec.label}, built on {build_date}"
+    title = identifier.title(specialisation)
+    description = identifier.description(bootspec.label, build_date)
     boot_entry = (
         [
             f"title {title}",
@@ -446,9 +504,9 @@ def get_generations(profile: str | None = None) -> list[SystemIdentifier]:
     gen_lines.pop()
 
     configurationLimit = CONFIGURATION_LIMIT
-    configurations = [
-        SystemIdentifier(
-            profile=profile, generation=int(line.split()[0]), specialisation=None
+    configurations: list[SystemIdentifier] = [
+        GenerationIdentifier(
+            profile=profile, generation=int(line.split()[0])
         )
         for line in gen_lines
     ]
@@ -553,6 +611,9 @@ def install_bootloader(args: argparse.Namespace) -> None:
         )
         sys.exit(1)
 
+    if KEEP_BOOTED_SYSTEM:
+        gens.append(BootedSystemIdentifier())
+
     boot_files: BootFileList = []
     critical_paths: set[Path] = set()
 
@@ -560,20 +621,21 @@ def install_bootloader(args: argparse.Namespace) -> None:
     default_entry_id: str | None = None
 
     for gen in gens:
-        bootspec = get_bootspec(gen.profile, gen.generation)
+        bootspec = get_bootspec(gen)
         if bootspec is None:
             continue
         is_default = Path(bootspec.init).parent == default_config
-        new_boot_files, new_bootctl_id = boot_file(*gen, machine_id, bootspec)
+        new_boot_files, new_bootctl_id = boot_file(gen, None, machine_id, bootspec)
         boot_files.extend(new_boot_files)
         if is_default:
             default_entry_id = new_bootctl_id
             critical_paths.update(bf.path for bf in new_boot_files)
+        if not gen.emit_specialisations:
+            continue
         for specialisation_name, specialisation in bootspec.specialisations.items():
             is_default = Path(specialisation.init).parent == default_config
             new_boot_files, new_bootctl_id = boot_file(
-                gen.profile,
-                gen.generation,
+                gen,
                 specialisation_name,
                 machine_id,
                 bootspec,

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -57,6 +57,7 @@ let
         consoleMode
         graceful
         editor
+        keepBootedSystemEntry
         rebootForBitlocker
         ;
 
@@ -241,6 +242,17 @@ in
 
         `null` means no limit i.e. all generations
         that have not been garbage collected yet.
+      '';
+    };
+
+    keepBootedSystemEntry = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to add a last booted entry to the boot menu.
+
+        If set, the currently booted system when activating this system will be added
+        to the systemd-boot boot menu.
       '';
     };
 

--- a/nixos/tests/systemd-boot.nix
+++ b/nixos/tests/systemd-boot.nix
@@ -946,4 +946,69 @@ in
   defaultEntryWithBootCounting = defaultEntry { withBootCounting = true; };
 
   garbageCollectEntryWithBootCounting = garbage-collect-entry { withBootCounting = true; };
+
+  lastBooted = runTest (
+    { lib, ... }:
+    {
+      name = "systemd-boot-last-booted";
+      meta.maintainers = with lib.maintainers; [
+        elliotberman
+      ];
+
+      nodes = {
+        machine =
+          { nodes, ... }:
+          {
+            imports = [ common ];
+            boot.loader.systemd-boot.keepBootedSystemEntry = true;
+            system.extraDependencies = [ nodes.other_machine.system.build.toplevel ];
+          };
+
+        other_machine =
+          { pkgs, ... }:
+          {
+            imports = [ common ];
+            boot.loader.systemd-boot.keepBootedSystemEntry = true;
+            environment.systemPackages = [ pkgs.hello ];
+          };
+      };
+
+      testScript =
+        { nodes, ... }:
+        let
+          orig = nodes.machine.system.build.toplevel;
+          other = nodes.other_machine.system.build.toplevel;
+        in
+        # python
+        ''
+          ${testScriptPreamble}
+
+          orig = "${orig}"
+          other = "${other}"
+
+          def check_last_booted(system_path):
+              conf_files = machine.succeed(
+                  "grep --line-regexp --fixed-strings --files-with-matches "
+                  "'title NixOS (last booted)' /boot/loader/entries/nixos-*.conf"
+              ).split()
+              assert len(conf_files) == 1, f"Expected exactly one last-booted entry, got {conf_files}"
+              machine.succeed(f"grep --fixed-strings 'init={system_path}/init' {conf_files[0]}")
+
+          machine.start()
+          machine.wait_for_unit("multi-user.target")
+          check_current_system(orig)
+
+          machine.succeed(f"{orig}/bin/switch-to-configuration boot")
+          check_last_booted(orig)
+
+          # Register a newer generation. The booted system is unchanged, so the
+          # last-booted entry must keep pointing at orig even though `other` is now
+          # the newest generation.
+          machine.succeed("nix-env -p /nix/var/nix/profiles/system --set ${other}")
+          machine.succeed(f"{other}/bin/switch-to-configuration boot")
+          check_generation(2)
+          check_last_booted(orig)
+        '';
+    }
+  );
 }


### PR DESCRIPTION
Add an option `boot.loader.systemd-boot.keepBootedSystemEntry`. If true, systemd-boot-builder adds the currently booted system to the list of systemd-boot menu items, even if the system has been switched more than `boot.loader.systemd-boot.configurationLimit` times such that the currently booted system would be removed from this list. This is useful because subsequent systems may not be bootable, so it provides a known fallback.

The booted system entry will not be garbage-collected because /run/booted-system will always provide a gcroot, even if the system profile is removed from /nix/var/nix/profiles/system-*-link.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
