### PR TITLE
nixos/tests/rosenpass: various fixes

### DIFF
--- a/nixos/tests/rosenpass.nix
+++ b/nixos/tests/rosenpass.nix
@@ -118,7 +118,7 @@ in
   testScript =
     { ... }:
     ''
-      from os import system
+      import subprocess
 
       # Full path to rosenpass in the store, to avoid fiddling with `$PATH`.
       rosenpass = "${pkgs.rosenpass}/bin/rosenpass"
@@ -137,7 +137,10 @@ in
 
       for (name, machine, remote) in [("server", server, client), ("client", client, server)]:
           pk, sk = f"{name}.pqpk", f"{name}.pqsk"
-          system(f"{rosenpass} gen-keys --force --secret-key {sk} --public-key {pk}")
+          subprocess.run(
+              [rosenpass, "gen-keys", "--force", "--secret-key", sk, "--public-key", pk],
+              check=True,
+          )
           machine.copy_from_host(sk, f"{etc}/pqsk")
           machine.copy_from_host(pk, f"{etc}/pqpk")
           remote.copy_from_host(pk, f"{etc}/peers/{name}/pqpk")

--- a/nixos/tests/rosenpass.nix
+++ b/nixos/tests/rosenpass.nix
@@ -41,6 +41,7 @@ in
             };
           };
 
+          networking.useNetworkd = true;
           networking.firewall.allowedUDPPorts = [ 9999 ];
 
           systemd.network = {
@@ -72,6 +73,7 @@ in
       server = {
         imports = [ (shared server) ];
 
+        networking.useNetworkd = true;
         networking.firewall.allowedUDPPorts = [ server.wg.listen ];
 
         systemd.network.netdevs."10-${deviceName}" = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This nixos test was broken due to use of a deprecated python API `os.system`. In addition, I also fixed a complaint about the network configuration that appeared during eval.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
