### PR TITLE
[26.05] radicle-node{,-unstable}: 1.9.1 -> 1.10.0

### DIFF
--- a/pkgs/by-name/ra/radicle-node/package.nix
+++ b/pkgs/by-name/ra/radicle-node/package.nix
@@ -15,9 +15,9 @@
   xdg-utils,
   versionCheckHook,
 
-  version ? "1.9.1",
-  srcHash ? "sha256-8wLVNHF9qkKBK2s6RdH0/2To2zamx8RON5iBjkQoQY4=",
-  cargoHash ? "sha256-holYrCL0FApbnFRj0+bVnjkiNL14jclaM8xIqRHfEkc=",
+  version ? "1.10.0",
+  srcHash ? "sha256-msKnRL6T9Z+bSxknRvhKSE6rDlGA0e8aWwM1/PhUzZw=",
+  cargoHash ? "sha256-g23LqCXZt+/JX+1Nb9JCORxI0P/LJL2MZHg3lATKLd8=",
   updateScript ? ./update.sh,
 }:
 

--- a/pkgs/by-name/ra/radicle-node/unstable.nix
+++ b/pkgs/by-name/ra/radicle-node/unstable.nix
@@ -1,8 +1,8 @@
 { radicle-node }:
 
 radicle-node.override {
-  version = "1.9.1";
-  srcHash = "sha256-8wLVNHF9qkKBK2s6RdH0/2To2zamx8RON5iBjkQoQY4=";
-  cargoHash = "sha256-holYrCL0FApbnFRj0+bVnjkiNL14jclaM8xIqRHfEkc=";
+  version = "1.10.0-rc.1";
+  srcHash = "sha256-20dW6KcbeB6Xi5aWsIfV71CtEj37LIUpKbFWMjMF+g8=";
+  cargoHash = "sha256-cmsunitIfD6guWI1tIJCrL5WRHJDfmEO3+Xs4bv6IOw=";
   updateScript = ./update-unstable.sh;
 }

--- a/pkgs/by-name/ra/radicle-node/unstable.nix
+++ b/pkgs/by-name/ra/radicle-node/unstable.nix
@@ -1,8 +1,8 @@
 { radicle-node }:
 
 radicle-node.override {
-  version = "1.10.0-rc.2";
-  srcHash = "sha256-8cFYsR5fGiChBduBmNcYp0MLVqlY2KnfieFa+yzbL7E=";
-  cargoHash = "sha256-E5CDlHcdFFwRw3S+wLcRLpLzrGVn43z4FznJrYemYP4=";
+  version = "1.10.0";
+  srcHash = "sha256-msKnRL6T9Z+bSxknRvhKSE6rDlGA0e8aWwM1/PhUzZw=";
+  cargoHash = "sha256-g23LqCXZt+/JX+1Nb9JCORxI0P/LJL2MZHg3lATKLd8=";
   updateScript = ./update-unstable.sh;
 }

--- a/pkgs/by-name/ra/radicle-node/unstable.nix
+++ b/pkgs/by-name/ra/radicle-node/unstable.nix
@@ -1,8 +1,8 @@
 { radicle-node }:
 
 radicle-node.override {
-  version = "1.10.0-rc.1";
-  srcHash = "sha256-20dW6KcbeB6Xi5aWsIfV71CtEj37LIUpKbFWMjMF+g8=";
-  cargoHash = "sha256-cmsunitIfD6guWI1tIJCrL5WRHJDfmEO3+Xs4bv6IOw=";
+  version = "1.10.0-rc.2";
+  srcHash = "sha256-8cFYsR5fGiChBduBmNcYp0MLVqlY2KnfieFa+yzbL7E=";
+  cargoHash = "sha256-E5CDlHcdFFwRw3S+wLcRLpLzrGVn43z4FznJrYemYP4=";
   updateScript = ./update-unstable.sh;
 }


### PR DESCRIPTION
Backport of #539949, #544526, and #549597

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
