### PR TITLE
uutils-coreutils: 0.9.0 -> 0.10.0

### DIFF
--- a/pkgs/by-name/uu/uutils-coreutils/package.nix
+++ b/pkgs/by-name/uu/uutils-coreutils/package.nix
@@ -13,21 +13,20 @@
 
   selinuxSupport ? false,
   libselinux,
-
-  acl,
 }:
 
 assert selinuxSupport -> lib.meta.availableOn stdenv.hostPlatform libselinux;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "uutils-coreutils";
-  version = "0.9.0";
+  version = "0.10.0";
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "uutils";
     repo = "coreutils";
     tag = finalAttrs.version;
-    hash = "sha256-g+RuVQr7CNtF9eqEJb3dlgfgPO3aRwWgXWPniNmhXeA=";
+    hash = "sha256-bqMrYVFa21Tu3t2Y5na9gFYr6AkklSnszbX8vKxI4gg=";
   };
 
   # error: linker `aarch64-linux-gnu-gcc` not found
@@ -37,16 +36,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname src version;
-    hash = "sha256-WoPqxO1TBt4eCOR3tlzuoXqH9u/mTHR5Dr/WnKLxyYM=";
+    hash = "sha256-7ROe9xrFcaXWYxoe9lfAfZxDxPcrETU8Mcj2HsdoqpA=";
   };
 
-  buildInputs =
-    lib.optionals (lib.meta.availableOn stdenv.hostPlatform acl) [
-      acl
-    ]
-    ++ lib.optionals selinuxSupport [
-      libselinux
-    ];
+  buildInputs = lib.optionals selinuxSupport [
+    libselinux
+  ];
 
   nativeBuildInputs = [
     cargo
@@ -60,19 +55,13 @@ stdenv.mkDerivation (finalAttrs: {
     "PROFILE=release"
     "SELINUX_ENABLED=${if selinuxSupport then "1" else "0"}"
     "INSTALLDIR_MAN=${placeholder "out"}/share/man/man1"
-    # Explicitly enable acl, and if requested selinux.
     # We cannot rely on SELINUX_ENABLED here since our explicit assignment
     # overrides its effect in the makefile.
     "BUILD_SPEC_FEATURE=${
       lib.concatStringsSep "," (
-        # We can always enable acl, on non-Linux, libc provides the headers,
-        # only in Linux we need to add the acl lib to buildInputs.
-        [
-          "feat_acl"
-        ]
-        ++ (lib.optionals selinuxSupport [
+        lib.optionals selinuxSupport [
           "feat_selinux"
-        ])
+        ]
       )
     }"
     "SKIP_UTILS=${lib.optionalString stdenv.hostPlatform.isStatic "stdbuf"}"


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/uutils/coreutils/compare/0.9.0...0.10.0
Changelog: https://github.com/uutils/coreutils/releases/tag/0.10.0

cc @siraben @matthiasbeyer

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test