### PR TITLE
ani-cli-rs: init

### DIFF
--- a/pkgs/by-name/an/ani-cli-rs/package.nix
+++ b/pkgs/by-name/an/ani-cli-rs/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  makeWrapper,
+  syncplay,
+  aria2,
+  mpv,
+  vlc,
+  iina,
+  withMpv ? true,
+  withVlc ? false,
+  withIina ? false,
+  syncSupport ? false,
+}:
+let
+  players = lib.optional withMpv mpv ++ lib.optional withVlc vlc ++ lib.optional withIina iina;
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ani-cli-rs";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "vorlie";
+    repo = "ani-cli-rs";
+    tag = finalAttrs.version;
+    hash = "sha256-t7xyuXjJUKPtmY+pxFe/rVRvRpET9dh8ZBLqI1LkcGo=";
+  };
+
+  cargoHash = "sha256-HxWftqADCCSxvuUNu95iUN8dN0mlx9g+GBE1IeJdLOg=";
+
+  checkType = "debug";
+
+  nativeBuildInputs = [ makeWrapper ];
+  runtimeInputs = [
+    aria2
+  ]
+  ++ lib.optional syncSupport syncplay;
+
+  postInstall = ''
+    wrapProgram $out/bin/ani-cli-rs \
+      --prefix PATH : ${lib.makeBinPath finalAttrs.runtimeInputs} \
+      ${lib.optionalString (builtins.length players > 0) "--suffix PATH : ${lib.makeBinPath players}"}
+  '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A cross-platform Rust port of ani-cli focused on the current AllAnime workflow";
+    homepage = "https://github.com/vorlie/ani-cli-rs";
+    license = lib.licenses.gpl3Only;
+    changelog = "https://github.com/vorlie/ani-cli-rs/blob/${finalAttrs.version}/release-notes.md";
+    mainProgram = "ani-cli-rs";
+    maintainers = with lib.maintainers; [ kuflierl ];
+  };
+})


### PR DESCRIPTION
Have not yet tested functionality

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
