### PR TITLE
Revert "ci/github-script/get-pr-commit-details: output file list for merge commits"

### DIFF
--- a/ci/github-script/get-pr-commit-details.js
+++ b/ci/github-script/get-pr-commit-details.js
@@ -84,7 +84,6 @@ async function getCommitDetailsForPR({ core, pr, repoPath }) {
             'log',
             '--format=%s\t%aN\t%aE\t%cN\t%cE',
             '--name-only',
-            '-m',
             '-1',
             sha,
           ],


### PR DESCRIPTION
Reverts NixOS/nixpkgs#548277

Merge commits can show as changing files that weren't manually edited. See e.g. `git show -m --stat 752e10e708481f7b954d8003460a82a2e557d3a6`, which came from PR #540153 (which did not edit the github-teams file). That one caused a false positive, reported at https://github.com/NixOS/nixpkgs/pull/549606#issuecomment-5195819534 and https://github.com/NixOS/nixpkgs/pull/509418#issuecomment-5195824442.

Since this wasn't really needed, remove it.