### PR TITLE
harlequin: 2.6.0 -> 2.8.1

### DIFF
--- a/pkgs/by-name/ha/harlequin/package.nix
+++ b/pkgs/by-name/ha/harlequin/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  python3,
+  python3Packages,
   fetchFromGitHub,
   nix-update-script,
   glibcLocales,
@@ -11,60 +11,36 @@
   withBigQueryAdapter ? true,
 }:
 
-let
-  python = python3.override {
-    packageOverrides = _final: prev: {
-      # throws a runtime error with textual 8.2.5:
-      # KeyError: 'textual-ansi'
-      textual = prev.textual.overridePythonAttrs (old: rec {
-        version = "8.2.4";
-        src = old.src.override {
-          tag = "v${version}";
-          hash = "sha256-827cm9pcj1o1FYeaoWKCJ6dEyXeDop4kYd205cySTfg=";
-        };
-      });
-    };
-  };
-  python3Packages = python.pkgs;
-in
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "harlequin";
-  version = "2.6.0";
+  version = "2.8.1";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "tconbeer";
     repo = "harlequin";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-jZGQ6t6djiKK9B+R8TYMPwXKkLPk7Z+dXuUcVQuZMfU=";
+    hash = "sha256-gDK+QpAJzyjIBH1YcoYy7CXSy8yn0OxAc2V1jI/DAUs=";
   };
-
-  pythonRelaxDeps = [
-    "click"
-    "numpy"
-    "pyarrow"
-    "questionary"
-    "rich-click"
-    "textual"
-    "tomlkit"
-    "tree-sitter"
-    "tree-sitter-sql"
-  ];
 
   build-system = with python3Packages; [ hatchling ];
 
   nativeBuildInputs = [ glibcLocales ];
 
+  pythonRelaxDeps = [
+    "questionary"
+    "tomlkit"
+  ];
   dependencies =
     with python3Packages;
     [
       click
       duckdb
-      importlib-metadata
-      numpy
-      packaging
+      pandas
       platformdirs
       pyarrow
+      pyperclip
       questionary
       rich-click
       sqlfmt
@@ -72,7 +48,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
       textual-fastdatatable
       textual-textarea
       tomlkit
-      tree-sitter-sql
+      wcwidth
     ]
     ++ lib.optionals withPostgresAdapter [ harlequin-postgres ]
     ++ lib.optionals withBigQueryAdapter [ harlequin-bigquery ];
@@ -89,7 +65,9 @@ python3Packages.buildPythonApplication (finalAttrs: {
   };
 
   nativeCheckInputs = with python3Packages; [
+    flaky
     pytest-asyncio
+    pytest-textual-snapshot
     pytest-xdist
     pytestCheckHook
     versionCheckHook
@@ -100,10 +78,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     # Tests require network access
     "test_connect_extensions"
     "test_connect_prql"
-
-    # Broken since click was updated to 8.2.1 in https://github.com/NixOS/nixpkgs/pull/448189
-    # AssertionError
-    "test_bad_adapter_opt"
   ]
   ++ lib.optionals (!stdenv.hostPlatform.isx86_64) [
     # Test incorrectly tries to load a dylib/so compiled for x86_64

--- a/pkgs/development/python-modules/google-cloud-bigquery/default.nix
+++ b/pkgs/development/python-modules/google-cloud-bigquery/default.nix
@@ -12,6 +12,7 @@
   google-cloud-core,
   google-resumable-media,
   grpcio,
+  packaging,
   proto-plus,
   protobuf,
   python-dateutil,
@@ -54,6 +55,7 @@ buildPythonPackage rec {
     google-cloud-core
     google-resumable-media
     grpcio
+    packaging
     proto-plus
     protobuf
     python-dateutil

--- a/pkgs/development/python-modules/textual-fastdatatable/default.nix
+++ b/pkgs/development/python-modules/textual-fastdatatable/default.nix
@@ -2,38 +2,43 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
   hatchling,
-  pandas,
+
+  # dependencies
   pyarrow,
-  pytz,
   textual,
-  tzdata,
+  typing-extensions,
+
+  # optional-dependencies
   polars,
+
+  # tests
   pytest-asyncio,
   pytest-textual-snapshot,
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "textual-fastdatatable";
-  version = "0.14.0";
+  version = "0.17.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "tconbeer";
     repo = "textual-fastdatatable";
-    tag = "v${version}";
-    hash = "sha256-gm1h+r8rZO1/9sXoNwqVuBbv7CpZm2a3YAMHRHGg5uo=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-aDbYwPISsmk9af3yQWh4ClHj3SRljzBMVxvYgWk61rM=";
   };
 
   build-system = [ hatchling ];
 
   dependencies = [
-    pandas
     pyarrow
-    pytz
     textual
-    tzdata
+    typing-extensions
   ]
   ++ textual.optional-dependencies.syntax;
 
@@ -46,13 +51,7 @@ buildPythonPackage rec {
     pytest-textual-snapshot
     pytestCheckHook
   ]
-  ++ lib.concatAttrValues optional-dependencies;
-
-  pythonRelaxDeps = [
-    "numpy"
-    "pandas"
-    "pyarrow"
-  ];
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
 
   pythonImportsCheck = [ "textual_fastdatatable" ];
 
@@ -64,8 +63,8 @@ buildPythonPackage rec {
   meta = {
     description = "Performance-focused reimplementation of Textual's DataTable widget, with a pluggable data storage backend";
     homepage = "https://github.com/tconbeer/textual-fastdatatable";
-    changelog = "https://github.com/tconbeer/textual-fastdatatable/releases/tag/${src.tag}";
+    changelog = "https://github.com/tconbeer/textual-fastdatatable/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ pcboy ];
   };
-}
+})

--- a/pkgs/development/python-modules/textual-textarea/default.nix
+++ b/pkgs/development/python-modules/textual-textarea/default.nix
@@ -20,21 +20,18 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "textual-textarea";
-  version = "0.17.3";
+  version = "0.18.1";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "tconbeer";
     repo = "textual-textarea";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-m3aXTUKOklk6TJgxRV+KqxeHBL+Y7XDNCJaW12SLj0E=";
+    hash = "sha256-ixSzT6Mxh7n7pLlXnb9y2XJoSUwcETpJ9qylON0NxIo=";
   };
 
   build-system = [ hatchling ];
-
-  pythonRelaxDeps = [
-    "textual"
-  ];
 
   dependencies = [
     pyperclip
@@ -62,7 +59,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Text area (multi-line input) with syntax highlighting for Textual";
     homepage = "https://github.com/tconbeer/textual-textarea";
-    changelog = "https://github.com/tconbeer/textual-textarea/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/tconbeer/textual-textarea/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ pcboy ];
   };


### PR DESCRIPTION
## Things done

- **python3Packages.google-cloud-bigquery: add missing packaging dependency**
- **python3Packages.textual-fastdatatable: 0.14.0 -> 0.17.0** ([Diff](https://github.com/tconbeer/textual-fastdatatable/compare/v0.14.0...v0.17.0), [Changelog](https://github.com/tconbeer/textual-fastdatatable/releases/tag/v0.17.0))
- **python3Packages.textual-textarea: 0.17.3 -> 0.18.1** ([Diff](https://github.com/tconbeer/textual-textarea/compare/v0.17.3...v0.18.1), [Changelog](https://github.com/tconbeer/textual-textarea/releases/tag/v0.18.1))
- **harlequin: 2.6.0 -> 2.8.1** ([Diff](https://github.com/tconbeer/harlequin/compare/v2.6.0...v2.8.1), [Changelog](https://github.com/tconbeer/harlequin/releases/tag/v2.8.1))

cc @pcboy

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
