### PR TITLE
freetube: fix Darwin code signing

### DIFF
--- a/pkgs/by-name/fr/freetube/package.nix
+++ b/pkgs/by-name/fr/freetube/package.nix
@@ -13,6 +13,7 @@
   makeShellWrapper,
   copyDesktopItems,
   electron,
+  darwin,
 
   nixosTests,
 }:
@@ -67,6 +68,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     pnpm
     makeShellWrapper
     copyDesktopItems
+  ]
+  ++ lib.optionals stdenvNoCC.hostPlatform.isDarwin [
+    darwin.autoSignDarwinBinariesHook
   ];
 
   installPhase = ''

--- a/pkgs/by-name/fr/freetube/patch-build-script.patch
+++ b/pkgs/by-name/fr/freetube/patch-build-script.patch
@@ -11,3 +11,12 @@ index bef1f6f1d..d2ee86611 100644
    appId: `io.freetubeapp.${packageDetails.name}`,
    copyright: 'Copyleft © 2020-2026 freetubeapp@protonmail.com',
    // asar: false,
+@@ -99,7 +101,7 @@ export default {
+     // Enable ad-hoc signing
+     // If we skip signing entirely, macOS says that the application is damaged, which makes users open bug reports.
+     // With an ad-hoc signature it still refuses to launch by default but with the reason that it cannot verify the signature
+-    identity: '-'
++    identity: null
+   },
+   win: {
+     icon: '_icons/icon.ico',


### PR DESCRIPTION
## Summary

- disable Electron-builder's ad-hoc signing on Darwin
- sign required Darwin binaries during nixpkgs post-fixup instead

FreeTube 0.25.1 explicitly sets `mac.identity` to `-` after [FreeTubeApp/FreeTube#9444](https://github.com/FreeTubeApp/FreeTube/pull/9444). Electron-builder therefore invokes `codesign` with Apple's `--timestamp` and `--options` flags. The `codesign` implementation provided by nixpkgs' `sigtool` does not support those flags, causing the [Darwin failure observed in #544080](https://github.com/NixOS/nixpkgs/pull/544080#issuecomment-5059310755).

Setting the Electron-builder identity to `null` skips its signing step. `darwin.autoSignDarwinBinariesHook` then adds the required ad-hoc signatures after installation.

Fixes #389434

## Testing

- `nix-shell --run 'treefmt pkgs/by-name/fr/freetube/package.nix'`
- `git diff --check upstream/master...HEAD`
- `nix-build -A freetube`
- confirmed Electron-builder reports `skipped macOS code signing  reason=identity explicitly is set to null`
- confirmed post-fixup reports signing the FreeTube output
- confirmed the output executable is ARM64 with an embedded ad-hoc signature
- launched the built `FreeTube.app` on `aarch64-darwin` and verified the Subscriptions UI renders without a damaged-app or signature error

This should be backported to `release-26.05`, which also contains FreeTube 0.25.1.

## Automation/AI disclosure

Non-trivial assistance from Codex (GPT-5) was used to prepare the code changes, commit message, test plan, and pull request summary.  I reviewed the changes and made edits myself.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
