### PR TITLE
dwarfs: 0.14.0 -> 0.15.7

### DIFF
--- a/pkgs/by-name/dw/dwarfs/package.nix
+++ b/pkgs/by-name/dw/dwarfs/package.nix
@@ -33,14 +33,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dwarfs";
-  version = "0.15.6";
+  version = "0.15.7";
 
   src = fetchFromGitHub {
     owner = "mhx";
     repo = "dwarfs";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-Nq7H/qm58j77YmYmlkEhU8Hfh59Z2+Vj+4apn31HHHc=";
+    hash = "sha256-oC5Ki0Fc8c+PD39rRTzc2WErXkxEBZM+k9Ac5Xptats=";
   };
 
   cmakeFlags = [

--- a/pkgs/by-name/dw/dwarfs/package.nix
+++ b/pkgs/by-name/dw/dwarfs/package.nix
@@ -33,14 +33,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dwarfs";
-  version = "0.14.0";
+  version = "0.15.6";
 
   src = fetchFromGitHub {
     owner = "mhx";
     repo = "dwarfs";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-4Ec1AqumTSPZpPEi528OaO3bOU1Soc8ZHuuKXIDvCUA=";
+    hash = "sha256-Nq7H/qm58j77YmYmlkEhU8Hfh59Z2+Vj+4apn31HHHc=";
   };
 
   cmakeFlags = [
@@ -108,13 +108,15 @@ stdenv.mkDerivation (finalAttrs: {
         "dwarfs/tools_test.end_to_end/*"
         "dwarfs/tools_test.mutating_and_error_ops/*"
         "dwarfs/tools_test.categorize/*"
+
         # Requires a working FUSE device and fusermount3, unavailable in sandbox.
-        "tools_test.timestamps_fuse*"
-        "tools_test.dwarfs_automount*"
-        "tools_test.dwarfs_fsname_and_subtype*"
+        "dwarfs/fuse_driver_test*"
+        "tools_test.dwarfs_obsolete_options*"
+
         "sparse_files_test.random_large_files*"
         "sparse_files_test.random_small_files_fuse*"
         "sparse_files_test.huge_holes_fuse*"
+
         # Requires xattr support unavailable in sandbox.
         "xattr_test.portable_xattr"
       ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Updated from `0.14.0` to `0.15.7` and refreshed source hash(es).

Adjusted test ignores for sandbox-only constraints during Nix checks.  
Specifically, `tools_test.dwarfs_obsolete_options*` is now skipped because it requires a working FUSE runtime and fails in sandbox with:
- `fuse: device /dev/fuse not found`
- `Could not find 'fusermount3' in PATH`

This is an environment limitation in sandboxed test execution, not a compile/link regression in `dwarfs`.  
Kept existing FUSE/xattr-related sandbox skips.  
Tested basic functionality of binaries and built successfully in NixOS-WSL
Changelog: https://github.com/mhx/dwarfs/compare/v0.14.0...v0.15.7

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
Fixes: #549542
- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
