### PR TITLE
olsak-grid: init

### DIFF
--- a/pkgs/by-name/ol/olsak-grid/package.nix
+++ b/pkgs/by-name/ol/olsak-grid/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  fetchzip,
+  stdenv,
+}:
+stdenv.mkDerivation {
+  pname = "olsak-grid";
+  version = "1.2";
+  src = fetchzip {
+    url = "https://petr.olsak.net/ftp/olsak/grid/grid.tgz";
+    hash = "sha256-76OxCKYDDP2y/hnH9IuElNVp57B4UE1Kgp0HRlgXZso=";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+    $CC grid.c -o grid -fno-builtin-logf -std=c89
+    runHook postBuild
+  '';
+  installPhase = ''
+    runHook preInstall
+    install -D -m755 grid "$out/bin/grid"
+    runHook postInstall
+  '';
+  installCheckPhase = ''
+    runHook preInstallCheck
+    PATH="$out/bin:$PATH" ./testall
+    runHook postInstallCheck
+  '';
+  doInstallCheck = true;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Nonogram solver";
+    homepage = "https://www.olsak.net/grid.html";
+    mainProgram = "grid";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.all;
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
+    maintainers = [ lib.maintainers.magistau ];
+  };
+}


### PR DESCRIPTION
[`grid`](https://www.olsak.net/grid.html#English) is a Nonogram solver

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
