### PR TITLE
vscode: add mimetypes

### DIFF
--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -229,6 +229,11 @@ stdenv.mkDerivation (
           "Development"
           "IDE"
         ];
+        mimeTypes = [
+          "application/x-code-workspace"
+          "text/plain"
+          "inode/directory"
+        ];
         keywords = [ "vscode" ];
         actions.new-empty-window = {
           name = "New Empty Window";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
reference: #549452
I added the mimetypes: `application/x-code-workspace;text/plain;inode/directory`

Why did i add them?

- application/x-code-workspace
Is from the official .deb package (https://code.visualstudio.com/) extracted from the shipped code.dektop
- text/plain
As it is an editor it should be able to handle text/plain files and sub-classes of text/plain.
It now adds vscode as a viable alternative under the submenu "Open With" for files
<img width="553" height="244" alt="image" src="https://github.com/user-attachments/assets/52b1e08f-93a2-408e-b14b-33d73bdd2d4b" />

- inode/directory
On windows a right click in/ on a folder allows the start of vscode from this folder.
Same for kate on linux.
It now adds vscode as a viable alternative under the submenu "Open Folder With" for folder
<img width="538" height="193" alt="image" src="https://github.com/user-attachments/assets/0c4b6abc-1e27-4995-9288-44a194663471" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

# Notify maintainers

@eadwu, @bobby285271, @JohnRTitor, @JeffLabonte, @wetrustinprize, @oenu, @yuannan

As i am not sure who handles the changed file i am pinging the maintainers of vscode.
As it is a metadata change i didn't test it rigorously. Especially i am unsure on what other packages call `buildVscode` and if it will negatively affect them.