### PR TITLE
nixos/pipewire: add option to restart when config changes

### DIFF
--- a/nixos/modules/services/desktops/pipewire/pipewire.nix
+++ b/nixos/modules/services/desktops/pipewire/pipewire.nix
@@ -208,6 +208,9 @@ in
 
             Every item in this attrset becomes a separate drop-in file in `/etc/pipewire/pipewire.conf.d`.
 
+            For changes to take effect, PipeWire service has to be restarted,
+            auto-restart can be enabled with `services.pipewire.restartOnConfigChange = true`.
+
             See `man pipewire.conf` for details, and [the PipeWire wiki][wiki] for examples.
 
             See also:
@@ -283,6 +286,9 @@ in
 
             Every item in this attrset becomes a separate drop-in file in `/etc/pipewire/pipewire-pulse.conf.d`.
 
+            For changes to take effect, PipeWire PulseAudio service has to be restarted,
+            auto-restart can be enabled with `services.pipewire.restartOnConfigChange = true`.
+
             See `man pipewire-pulse.conf` for details, and [the PipeWire wiki][wiki] for examples.
 
             See also:
@@ -327,6 +333,9 @@ in
 
           LV2/LADSPA dependencies will be picked up from config packages automatically
           via `passthru.requiredLv2Packages`/`passthru.requiredLadspaPackages`.
+
+          For changes to PipeWire or PipeWire PulseAudio to take effect, the corresponding service has to be restarted,
+          auto-restart can be enabled with `services.pipewire.restartOnConfigChange = true`.
         '';
       };
 

--- a/nixos/modules/services/desktops/pipewire/pipewire.nix
+++ b/nixos/modules/services/desktops/pipewire/pipewire.nix
@@ -174,6 +174,19 @@ in
         '';
       };
 
+      restartOnConfigChange = mkOption {
+        type = bool;
+        default = false;
+        example = true;
+        description = ''
+          Whether to automatically restart PipeWire and PipeWire PulseAudio
+          when configurations change.
+
+          Restarting can cause issues with clients (e.g. it can stop an audio playback),
+          some applications easily recover from it while others will need to be restarted.
+        '';
+      };
+
       extraConfig = {
         pipewire = mkOption {
           type = attrsOf json.type;
@@ -422,6 +435,16 @@ in
     systemd.sockets.pipewire-pulse.wantedBy = mkIf cfg.socketActivation [ "sockets.target" ];
     systemd.user.sockets.pipewire.wantedBy = mkIf cfg.socketActivation [ "sockets.target" ];
     systemd.user.sockets.pipewire-pulse.wantedBy = mkIf cfg.socketActivation [ "sockets.target" ];
+
+    # Restart services when configs change
+    systemd.services.pipewire.restartTriggers = mkIf cfg.restartOnConfigChange [ configs ];
+    systemd.user.services.pipewire.restartTriggers = mkIf cfg.restartOnConfigChange [ configs ];
+    systemd.services.pipewire-pulse.restartTriggers = mkIf cfg.restartOnConfigChange [ configs ];
+    systemd.user.services.pipewire-pulse.restartTriggers = mkIf cfg.restartOnConfigChange [ configs ];
+    systemd.services.pipewire.stopIfChanged = mkIf cfg.restartOnConfigChange false;
+    systemd.user.services.pipewire.stopIfChanged = mkIf cfg.restartOnConfigChange false;
+    systemd.services.pipewire-pulse.stopIfChanged = mkIf cfg.restartOnConfigChange false;
+    systemd.user.services.pipewire-pulse.stopIfChanged = mkIf cfg.restartOnConfigChange false;
 
     services.udev.packages = [ cfg.package ];
 


### PR DESCRIPTION
Previously after changing some pipewire configuration and switching to the new system config, the new pipewire config didn't get loaded and the user had to manually restart the service (after figuring out that their config was not applied by the module automatically).

<details>
  <summary>Reproduce the problem</summary>

  1. query some pipewire config, e.g. `pw-cli info 0 | grep default.clock.rate` -> 48000
  2. override the previous config with this module and switch-to-configuration:

  ```nix
  {
    services.pipewire.extraConfig.pipewire."10-clock-rate" = {
      "context.properties" = {
        "default.clock.rate" = 44100;
      };
    };
  }
  ```

  3. observe that the same query still returns the old value: `pw-cli info 0 | grep default.clock.rate` -> 48000
  4. `systemctl --user restart pipewire.service`
  3. now it gives the new value: `pw-cli info 0 | grep default.clock.rate` -> 44100
</details>

I've seen socket activation + proper config reload needing `stopIfChanged = false`, but I'm not exactly sure why yet. Sometimes the new config applies without it, sometimes it doesn't.
The core behaviour matches the [docs](https://nixos.org/manual/nixos/unstable/#sec-unit-handling), where with `stopIfChanged = false`, `switch-to-configuration` says that the `pipewire.service` and `pipewire.socket` is being restarted, with `stopIfChanged = true` it says that these 2 are being stopped and `pipewire.socket` is being started, except the service logs don't mention any events for the latter.
Related issue which I only glanced at before sleep: https://github.com/NixOS/nixpkgs/issues/74899

I can imagine that config (and package?) changes were intentionally not restarting the services to avoid breaking apps (e.g. by manually restarting pipewire and pipewire-pulse while a video was playing in a browser, I had to reload the page to get audio working again), I wonder if we'd get mass reports that music/videos stopped playing after a system update's switch-to-configuration, and in worse cases a full app restart is needed.
If this was the intention, I recommend we document it instead in the options' descriptions, and put the reload functionality behind a new option.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
