### PR TITLE
nono: 0.68.0 -> 0.71.0

### DIFF
--- a/pkgs/by-name/no/nono/package.nix
+++ b/pkgs/by-name/no/nono/package.nix
@@ -15,7 +15,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nono";
-  version = "0.68.0";
+  version = "0.71.0";
 
   __darwinAllowLocalNetworking = true; # required for tests
 
@@ -23,9 +23,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "nolabs-ai";
     repo = "nono";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-RxVYatzKjv6LJ+M4Js+sTvg0hMnovXxtr6WxwFYF16Y=";
+    hash = "sha256-Xrqd8Do1R2kCwTAmju2VmOLAf329eoOSslfa8i9ogJc=";
   };
-  cargoHash = "sha256-9gMhW2qt5gbf6x/uPLc4vl3rn6UdneoxRmWpeRqI4V0=";
+  cargoHash = "sha256-bMGrLh3DEA3yJsyb62Xdt+SfhzFY5VXawai4V6xttpI=";
 
   nativeBuildInputs = [
     pkg-config
@@ -95,6 +95,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
       "server::tests::reactive_proxy_auth_retry_answered_after_407"
       "server::tests::test_oauth_capture_routes_activate_intercept"
       "server::tests::test_route_diagnostics_groups_credential_and_endpoint_routes"
+
+      # nono's ELF dependency resolution cannot find `libc.so.6` for libgcc_s.so.1
+      # command_policies are broken on nixos without this support
+      "command_policies_allows_compiled_binary_exec_in_writable_grant_dir"
+      "command_policies_allows_script_exec_in_writable_grant_dir"
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       # panics with "exact-path fallback must not recursively cover descendants"
@@ -104,15 +109,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
       # wants access to /var/folders
       "sandbox_state::cap_file_validation_tests::test_acceptable_temp_roots_includes_var_folders_on_macos"
       "sandbox_state::cap_file_validation_tests::test_validate_rejects_path_outside_temp"
-      # don't work inside of the /nix dir
-      # unsure why home is still under /nix with writableTmpDirAsHomeHook
+      # doesn't work inside of the /nix dir, which build-dir is under
       "deprecated_override_deny_flag_emits_single_warning_on_stderr"
       "deprecated_override_deny_flag_warning_is_emitted_once_for_multiple_uses"
       "override_deny_alias_and_bypass_protection_merge_in_argv_order"
+      "shell_dry_run_rejects_block_net_with_upstream_proxy"
+      "run_launch_plan_rejects_block_net_with_upstream_proxy"
 
       # env_vars
-      # don't work inside of the /nix dir
-      # unsure why home is still under /nix with writableTmpDirAsHomeHook
+      # doesn't work inside of the /nix dir, which build-dir is under
       # Sandbox initialization failed: Refusing to grant '/nix' (source: group:system_read_macos) because it overlaps protected nono state root '/nix/build/nix-<ID>/.home/.nono'.
       "allow_net_overrides_profile_external_proxy"
       "cli_flag_overrides_env_var"
@@ -131,11 +136,19 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
       "tool_sandbox::macos::tests::executable_shape_baseline_grants_env_shebang_target_interpreter"
       "tool_sandbox::macos::tests::macos_runtime_baseline_does_not_grant_system_volumes_data"
+      "tool_sandbox::macos::tests::daemon_pid_lineage_attributes_when_helper_names_the_daemon"
+      "tool_sandbox::macos::tests::daemon_pid_lineage_cache_prunes_dead_entries"
+      "tool_sandbox::macos::tests::daemon_pid_lineage_denies_when_helper_names_a_different_pid"
+      "tool_sandbox::macos::tests::run_daemon_pid_source_verify_mode_round_trips_candidate_pid"
       "env_nono_capability_elevation_accepts_truthy"
       "env_nono_trust_override_accepts_truthy"
       "env_nono_trust_proxy_ca_accepts_truthy"
       "dry_run_does_not_modify_workspace"
       "rollback_restores_file_after_write"
+
+      # `git init` intermittently fails with ENOENT, most likely because a
+      # concurrent test mutates PATH under the shared env lock
+      "tool_sandbox::dynamic_providers::tests::git_read_main_worktree_returns_main_repo_root_in_linked_worktree"
     ]
   );
 


### PR DESCRIPTION
Changelog: https://github.com/nolabs-ai/nono/blob/refs/tags/v0.71.0/CHANGELOG.md

Some new tests exercise [command_policies](https://nono.sh/docs/cli/features/dangerous-command-blocking) which fail within the sandbox and also on NixOS. A simple verification against 0.68 shows that this failure is not new with the upgrade, so I'd suggest we proceed.

Here's a simple repro.

```
𑁱 profile=/tmp/nono-elf-repro.json
cat > "$profile" <<'EOF'
{
  "meta": {
    "name": "elf-repro",
    "description": "Minimal tool-sandbox profile to exercise the ELF closure walk"
  },
  "workdir": { "access": "none" },
  "command_policies": {
    "commands": {
      "sh": {
        "executable": "/bin/sh",
        "sandbox": {
          "environment": { "allow_vars": ["PATH", "HOME"] }
        }
      }
    }
  }
}
EOF

𑁱 profile=/tmp/nono-elf-repro.json nix run nixpkgs#nono run -- --profile "$profile" --verbose -- sh -c 'echo reached-the-child'

  nono v0.68.0
2026-08-06T02:04:15.142833Z  INFO Loading profile from path: /tmp/nono-elf-repro.json
2026-08-06T02:04:15.143394Z  INFO Loading profile from path: /tmp/nono-elf-repro.json
  Capabilities:
  ────────────────────────────────────────────────────
<SNIP>
  ────────────────────────────────────────────────────

   scope  Landlock V6 detected
          signal: requested, enforced
          abstract-unix-socket: requested, enforced
2026-08-06T02:04:15.147455Z  INFO Landlock available (Landlock V6, features: Basic filesystem access control, File rename across directories (Refer), File truncation (Truncate), TCP network filtering, Device ioctl filtering, Signal and abstract UNIX socket scoping)
nono: Sandbox initialization failed: failed to resolve ELF dependency 'libc.so.6' for /nix/store/kw26hfd5b653cn2lm6yfh0q7y18d6d9l-gcc-15.3.0-libgcc/lib/libgcc_s.so.1
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
