### PR TITLE
zsh-autocomplete: 26.08.03 -> 26.08.04

### DIFF
--- a/pkgs/by-name/zs/zsh-autocomplete/package.nix
+++ b/pkgs/by-name/zs/zsh-autocomplete/package.nix
@@ -2,24 +2,43 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  zsh,
 }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "zsh-autocomplete";
-  version = "26.08.03";
+  version = "26.08.04";
 
   src = fetchFromGitHub {
     owner = "marlonrichert";
     repo = "zsh-autocomplete";
     rev = version;
-    sha256 = "sha256-NZLlRJZobUj3W94mRG245lGqDb1hE9x0nC9tRx58+Js=";
+    sha256 = "sha256-aba38Cmnps2n6Tr/1i3BjPZ4TbQPsDBURXF1fcd8cDI=";
   };
 
   strictDeps = true;
+
+  nativeInstallCheckInputs = [ zsh ];
+
   installPhase = ''
     install -D zsh-autocomplete.plugin.zsh $out/share/zsh-autocomplete/zsh-autocomplete.plugin.zsh
+    install -D z-async/z-async $out/share/zsh-autocomplete/z-async/z-async
     cp -R Completions $out/share/zsh-autocomplete/Completions
     cp -R Functions $out/share/zsh-autocomplete/Functions
+  '';
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    zsh -f -c '
+      fpath=( "$out/share/zsh-autocomplete/z-async" )
+      autoload -Uz z-async
+      z-async help >/dev/null
+    '
+
+    runHook postInstallCheck
   '';
 
   meta = {


### PR DESCRIPTION
`zsh-autocomplete` 26.08.03 introduced `z-async` as a Git submodule. GitHub's auto-generated source archive omitted the submodule contents, so the Nixpkgs derivation built successfully but the installed plugin failed at runtime with `z-async: function definition file not found` during interactive completion.

Upstream fixed the release artifact in [26.08.04](https://github.com/marlonrichert/zsh-autocomplete/releases/tag/26.08.04) by [vendoring `z-async` as a subtree](https://github.com/marlonrichert/zsh-autocomplete/commit/52ce8176d280d58a4a2af6a829d2266fffae568c), resolving [upstream issue #883](https://github.com/marlonrichert/zsh-autocomplete/issues/883). This updates Nixpkgs to that self-contained release, installs the vendored runtime function, and adds an install check that autoloads and invokes `z-async` so a build-only update cannot miss the runtime dependency again.

This repairs the regression introduced by #548892 without enabling submodule fetching or rewriting Git URLs.

Thi PR was prepared with assistance from Codex (OpenAI GPT-5). I reviewed the implementation.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR: one impacted package, `zsh-autocomplete`, built successfully on `aarch64-darwin`.
- [x] Ran the package's new install check and directly verified the installed `z-async` function can be autoloaded and invoked with `z-async help`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
