### PR TITLE
sword: fix cross-compile

### DIFF
--- a/pkgs/by-name/sw/sword/package.nix
+++ b/pkgs/by-name/sw/sword/package.nix
@@ -10,13 +10,21 @@
   bzip2,
   curl,
   xz,
+  zlib,
 }:
 
 stdenv.mkDerivation (
   finalAttrs:
   let
     # Used on Windows, where libpsl doesn't compile, yet
-    curlDep = curl.override { pslSupport = false; };
+    curlDep = (curl.override { pslSupport = false; }).overrideAttrs (finalCurlAttrs: {
+      buildInputs = [ ]; # Does not need runtimeShellPackage, which is Bash and unsupported on MinGW targets
+      # This is the shell script that requires runtimeShellPackage on systems, but we are
+      # only interested in the library here, not the binaries
+      postInstall = finalCurlAttrs.postInstall + ''
+        rm "''${!outputBin}/bin/wcurl"
+      '';
+    });
   in
   {
     pname = "sword";
@@ -70,6 +78,7 @@ stdenv.mkDerivation (
       "--with-xz"
       "--with-bzip2"
       "--with-icuregex"
+      "--without-zlib"
     ]);
 
     makeFlags = lib.optionals stdenv.hostPlatform.isWindows [


### PR DESCRIPTION
* Curl package is broken on Windows ever since the introduction of
  dependency on runtimeShellPackage, which Windows lacks
* The shell script that introduces this dep is unused by sword, which
  needs only the library


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
