### PR TITLE
libfm{,-extra}: drop gtk 2 support

### DIFF
--- a/pkgs/by-name/li/libfm/package.nix
+++ b/pkgs/by-name/li/libfm/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   autoreconfHook,
   gtk-doc,
   glib,
@@ -11,14 +10,11 @@
   pango,
   pkg-config,
   vala,
-  extraOnly ? false,
-  withGtk3 ? false,
-  gtk2,
   gtk3,
+  extraOnly ? false,
 }:
 
 let
-  gtk = if withGtk3 then gtk3 else gtk2;
   inherit (lib) optional optionalString;
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -41,16 +37,16 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   buildInputs = [
     glib
-    gtk
+    gtk3
     pango
   ]
   ++ optional (!extraOnly) menu-cache;
 
   configureFlags = [
     "--sysconfdir=/etc"
+    "--with-gtk=3"
   ]
-  ++ optional extraOnly "--with-extra-only"
-  ++ optional withGtk3 "--with-gtk=3";
+  ++ optional extraOnly "--with-extra-only";
 
   installFlags = [ "sysconfdir=${placeholder "out"}/etc" ];
 

--- a/pkgs/by-name/lx/lxpanel/package.nix
+++ b/pkgs/by-name/lx/lxpanel/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    (libfm.override { withGtk3 = true; })
+    libfm
     keybinder3
     gtk3
     libx11

--- a/pkgs/by-name/pc/pcmanfm/package.nix
+++ b/pkgs/by-name/pc/pcmanfm/package.nix
@@ -16,9 +16,6 @@
   nix-update-script,
 }:
 
-let
-  libfm' = libfm.override { withGtk3 = true; };
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "pcmanfm";
   version = "1.4.0";
@@ -40,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     glib
     gtk3
-    libfm'
+    libfm
     libx11
     pango
     adwaita-icon-theme


### PR DESCRIPTION
gtk 2 is long deprecated and being removed from Nixpkgs (#410814), and all the consumers are using gtk 3 anyway, so let's just make that the default and drop the old behavior.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
