### PR TITLE
silo: 2026-06-18T00-00-00Z -> 2026-08-04T00-00-00Z

### DIFF
--- a/pkgs/by-name/si/silo/package.nix
+++ b/pkgs/by-name/si/silo/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  testers,
 }:
 let
   # The web client verifies that the server version is a valid datetime string:
@@ -29,33 +30,20 @@ buildGoModule (finalAttrs: {
   __structuredAttrs = true;
 
   pname = "silo";
-  version = "2026-06-18T00-00-00Z";
+  version = "2026-08-04T00-00-00Z";
 
   src = fetchFromGitHub {
     owner = "pgsty";
     repo = "minio";
     tag = "RELEASE.${finalAttrs.version}";
-    hash = "sha256-TwuqWof8FozryQoZt1lybw7z8z8E3Ose4jbKZ0To2lk=";
+    hash = "sha256-F5gyhSBVH4RUoOyo+8UQ0RXuraXkGVO/mGkuFIi0hoc=";
   };
 
-  vendorHash = "sha256-rewz3Sez/01iWGCEhMVmcVnIxxjgBzmeUyMqFi6s4mc=";
+  vendorHash = "sha256-gDcO0q6beKEGSs6MM/C3iKC2+eFk1o6Ug5KLMmK12ek=";
 
   subPackages = [ "." ];
 
   env.CGO_ENABLED = 0;
-
-  # nixpkgs go_1_26 pinned to 1.26.3; pgsty/minio's go.mod says go 1.26.4.
-  # Step down to 1.26.3 to use the available toolchain. If pgsty/minio
-  # genuinely needs 1.26.4 features, we can replace this with one of:
-  #   - Go toolchain auto-switch: prePatch GOTOOLCHAIN=go1.26.4+auto
-  #     (fails inside Nix sandbox since GOPROXY=off blocks toolchain download)
-  #   - Override go: buildGoModule.override { go = go_1_26.overrideAttrs ... }
-  #     (compile go 1.26.4 from source, ~5–10 min)
-  #   - Wait for nixpkgs to bump go_1_26 past 1.26.4
-  postPatch = ''
-    substituteInPlace go.mod \
-      --replace-fail "go 1.26.4" "go 1.26.3"
-  '';
 
   tags = [ "kqueue" ];
 
@@ -75,6 +63,11 @@ buildGoModule (finalAttrs: {
   postInstall = ''
     ln -s "$out/bin/minio" "$out/bin/silo"
   '';
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    version = "RELEASE.${finalAttrs.version}";
+  };
 
   meta = {
     description = "Community-maintained fork of MinIO packaged as silo";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This is the most recent release of Silo (minio community fork https://github.com/pgsty/silo). I removed the postPatch section since nixpkgs `go_1_26` meets the minimum requirements (go 1.26.4 or higher). Additionally, added a simple smoke test checking version after successful install. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
