### PR TITLE
grayjay: 17 -> 18

### DIFF
--- a/pkgs/by-name/gr/grayjay/package.nix
+++ b/pkgs/by-name/gr/grayjay/package.nix
@@ -40,7 +40,7 @@
   krb5,
   wrapGAppsHook3,
   _experimental-update-script-combinators,
-  unzip
+  unzip,
 }:
 let
   version = "18";
@@ -69,8 +69,8 @@ let
     '';
   };
   justcefNative = fetchurl {
-	url = "https://static.grayjay.app/justcef/1/JustCefNative-linux-x64.zip";
-	hash = "sha256-LXOp+QZZcWBd8eP+BpK++AMBo9303+aIDEEYNVWekhE=";
+    url = "https://static.grayjay.app/justcef/1/JustCefNative-linux-x64.zip";
+    hash = "sha256-LXOp+QZZcWBd8eP+BpK++AMBo9303+aIDEEYNVWekhE=";
   };
 in
 buildDotnetModule (finalAttrs: {
@@ -96,7 +96,7 @@ buildDotnetModule (finalAttrs: {
     autoPatchelfHook
     wrapGAppsHook3
     copyDesktopItems
-	unzip
+    unzip
   ];
 
   dontWrapGApps = true;
@@ -143,10 +143,10 @@ buildDotnetModule (finalAttrs: {
   preBuild = ''
     rm -r Grayjay.ClientServer/wwwroot/web
     cp -r ${frontend} Grayjay.ClientServer/wwwroot/web
-	
-	mkdir -p JustCef/obj/justcef/net8.0/1/linux-x64
-  	cp ${justcefNative} \
-	JustCef/obj/justcef/net8.0/1/linux-x64/JustCefNative-linux-x64.zip
+
+    mkdir -p JustCef/obj/justcef/net8.0/1/linux-x64
+    cp ${justcefNative} \
+    JustCef/obj/justcef/net8.0/1/linux-x64/JustCefNative-linux-x64.zip
   '';
 
   postInstall = ''

--- a/pkgs/by-name/gr/grayjay/package.nix
+++ b/pkgs/by-name/gr/grayjay/package.nix
@@ -1,6 +1,7 @@
 {
   buildDotnetModule,
   fetchFromGitLab,
+  fetchurl,
   dotnetCorePackages,
   buildNpmPackage,
   lib,
@@ -39,15 +40,16 @@
   krb5,
   wrapGAppsHook3,
   _experimental-update-script-combinators,
+  unzip
 }:
 let
-  version = "17";
+  version = "18";
   src = fetchFromGitLab {
     domain = "gitlab.futo.org";
     owner = "videostreaming";
     repo = "Grayjay.Desktop";
     tag = version;
-    hash = "sha256-/oeoLXKewjYkCO7naZNOzauWm1OYDKnsxXY9EkI7fTM=";
+    hash = "sha256-dhXUjj9x8v1bfHLPxNtcysj/eKeT3kkSeVuX6PKoykE=";
     fetchSubmodules = true;
     fetchLFS = true;
   };
@@ -65,6 +67,10 @@ let
       cp -r dist/ $out
       runHook postInstall
     '';
+  };
+  justcefNative = fetchurl {
+	url = "https://static.grayjay.app/justcef/1/JustCefNative-linux-x64.zip";
+	hash = "sha256-LXOp+QZZcWBd8eP+BpK++AMBo9303+aIDEEYNVWekhE=";
   };
 in
 buildDotnetModule (finalAttrs: {
@@ -90,6 +96,7 @@ buildDotnetModule (finalAttrs: {
     autoPatchelfHook
     wrapGAppsHook3
     copyDesktopItems
+	unzip
   ];
 
   dontWrapGApps = true;
@@ -110,7 +117,7 @@ buildDotnetModule (finalAttrs: {
     "Grayjay.Engine/Grayjay.Engine/Grayjay.Engine.csproj"
     "Grayjay.Desktop.CEF/Grayjay.Desktop.CEF.csproj"
     "FUTO.MDNS/FUTO.MDNS/FUTO.MDNS.csproj"
-    "JustCef/DotCef.csproj"
+    "JustCef/JustCef.csproj"
   ];
 
   testProjectFile = [
@@ -136,10 +143,14 @@ buildDotnetModule (finalAttrs: {
   preBuild = ''
     rm -r Grayjay.ClientServer/wwwroot/web
     cp -r ${frontend} Grayjay.ClientServer/wwwroot/web
+	
+	mkdir -p JustCef/obj/justcef/net8.0/1/linux-x64
+  	cp ${justcefNative} \
+	JustCef/obj/justcef/net8.0/1/linux-x64/JustCefNative-linux-x64.zip
   '';
 
   postInstall = ''
-    chmod +x $out/lib/grayjay/cef/dotcefnative
+    chmod +x $out/lib/grayjay/cef/justcefnative
     chmod +x $out/lib/grayjay/ffmpeg
     rm $out/lib/grayjay/Portable
     ln -s /tmp/grayjay-launch $out/lib/grayjay/launch


### PR DESCRIPTION
Updated grayjay to version 18 and fixed resulting issues. This also fixes a build error that I didn't see mentioned in any issues which was caused by git history changes in upstream repos (https://github.com/futo-org/JustCef/tree/b1b5680ce42b4fd1c36070d28bbd6766ba2bae33).
## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
