### PR TITLE
android-translation-layer: 0-unstable-2026-01-19 -> 0-unstable-2026-0…

### DIFF
--- a/pkgs/by-name/an/android-translation-layer/package.nix
+++ b/pkgs/by-name/an/android-translation-layer/package.nix
@@ -28,13 +28,13 @@
 
 stdenv.mkDerivation {
   pname = "android-translation-layer";
-  version = "0-unstable-2026-01-19";
+  version = "0-unstable-2026-07-30";
 
   src = fetchFromGitLab {
     owner = "android_translation_layer";
     repo = "android_translation_layer";
-    rev = "bfcfb696d83c9769e1d99d3cb0d7a5908fe3c767";
-    hash = "sha256-BTVduEJhKEOFhqoG0lgqlcg2x4k9RWABURj2nQECaek=";
+    rev = "cf2c759fa93330f45df6107dcf8984cf49b29c64";
+    hash = "sha256-+TTntAnE/5j/FhGcdXRui3/p/sfkc83CKNdBf9Yage0=";
   };
 
   patches = [

--- a/pkgs/by-name/ar/art-standalone/package.nix
+++ b/pkgs/by-name/ar/art-standalone/package.nix
@@ -22,13 +22,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "art-standalone";
-  version = "0-unstable-2025-10-09";
+  version = "0-unstable-2026-08-03";
 
   src = fetchFromGitLab {
     owner = "android_translation_layer";
     repo = "art_standalone";
-    rev = "e78bf68917bcaaf58fef3960cd88793b3b7f39cc";
-    hash = "sha256-0r6Ap41AMSHhZpMJ5QoWiGGcHPj35et4kiA20xs9uLs=";
+    rev = "66a5d9079b159e9c5819bfeef4a6fff6a5f32719";
+    hash = "sha256-4dRKghsPP8XLCcCe6bQDzJVlggBdFWe3l2/ge35HIXA=";
   };
 
   patches = [

--- a/pkgs/by-name/bi/bionic-translation/package.nix
+++ b/pkgs/by-name/bi/bionic-translation/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "bionic-translation";
-  version = "0-unstable-2025-11-25";
+  version = "0-unstable-2026-08-03";
 
   src = fetchFromGitLab {
     owner = "android_translation_layer";
     repo = "bionic_translation";
-    rev = "5c31d4366fbb0af70690e72e5a861e7b44ffb1ef";
-    hash = "sha256-dlHjx6+yymvIjDEs2TZexZUIUz32iKD0r+H4AJ89xig=";
+    rev = "484b1b05795784a5a57dbd4ffad21a3e680a33b2";
+    hash = "sha256-43VJPhN8/J/pJr8mdV9/n+hrVZLzh7aQhAJ8cT53BHc=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
…7-30; art-standalone: 0-unstable-2025-10-09 -> 0-unstable-2026-08-03; bionic-translation: 0-unstable-2025-11-25 -> 0-unstable-2026-08-03


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
