### PR TITLE
frei0r & gavl: fix build failures with cuda and darwin

### DIFF
--- a/pkgs/by-name/fr/frei0r/package.nix
+++ b/pkgs/by-name/fr/frei0r/package.nix
@@ -29,15 +29,26 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     pkg-config
+  ]
+  ++ lib.optionals cudaSupport [
+    cudaPackages.cuda_nvcc
   ];
   buildInputs = [
     cairo
-    gavl
     opencv
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    gavl
   ]
   ++ lib.optionals cudaSupport [
     cudaPackages.cuda_cudart
-    cudaPackages.cuda_nvcc
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "WITHOUT_GAVL" (!stdenv.hostPlatform.isLinux))
+  ]
+  ++ lib.optionals cudaSupport [
+    (lib.cmakeFeature "CUDAToolkit_ROOT" "${lib.getBin cudaPackages.cuda_nvcc}")
   ];
 
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''

--- a/pkgs/by-name/ga/gavl/package.nix
+++ b/pkgs/by-name/ga/gavl/package.nix
@@ -51,6 +51,6 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       nick-linux
     ];
-    platforms = lib.platforms.unix;
+    platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
## Summary
Got an issue of frei0r failing to eval on Darwin due to the update and addition of gavl(Due to #548723 being merged). So here we change platform to Linux and gate the buildInput to Linux I do not use Darwin so I did not catch this but looking at the source code Cmake flags this should take care of the issue.

New issue cropped up due to build failures with Cuda Support I do not have Nvidia so I am taking my best guess at the fix from what I have researched. This PR splits the cuda package for `nvcc` to nativeBuildInputs(It has been suggested this is the proper place.) and adds a cmake feature flag (CUDAToolkit_ROOT) to point CMake at the split package layout. This cropped up now due to enabling `strictDeps` and `structuredAttrs`. This also keeps the Darwin fixes from #549406 and rolls it to 1 PR for efficient use of resources

It will not let me tag the issue creator, but if someone with Nvidia hardware could test I would appreciate that.

Resolves #549598 
Resolves #549395 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
