### PR TITLE
Re-enable MODULE_DECOMPRESS and fix out-of-tree module packages

### DIFF
--- a/pkgs/os-specific/linux/kernel/build.nix
+++ b/pkgs/os-specific/linux/kernel/build.nix
@@ -23,6 +23,8 @@
   rustc-unwrapped,
   rust-bindgen-unwrapped,
   rustPlatform,
+  makeSetupHook,
+  xz,
 }:
 
 let
@@ -158,6 +160,11 @@ lib.makeOverridable (
       elfutils
       # module makefiles often run uname commands to find out the kernel version
       (buildPackages.deterministic-uname.override { inherit modDirVersion; })
+      (makeSetupHook {
+        name = "setup-module-compression";
+        substitutions = { inherit configfile modDirVersion; };
+        propagatedNativeBuildInputs = [ xz ];
+      } ./setup-module-compression.sh)
     ]
     ++ optional (lib.versionAtLeast version "5.13") zstd
     ++ optionals withRust [

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -1182,6 +1182,7 @@ let
         ];
         MODULE_COMPRESS_ALL = whenAtLeast "6.12" yes;
         MODULE_COMPRESS_XZ = yes;
+        MODULE_DECOMPRESS = whenAtLeast "6.0" yes;
 
         SYSVIPC = yes; # System-V IPC
 

--- a/pkgs/os-specific/linux/kernel/setup-module-compression.sh
+++ b/pkgs/os-specific/linux/kernel/setup-module-compression.sh
@@ -1,0 +1,11 @@
+# shellcheck shell=bash
+
+setupModuleCompressionHook() {
+  # Ensure CRC32 is used, which the kernel is capable of decompressing natively (enabled by CONFIG_MODULE_DECOMPRESS=y).
+  export XZ_OPT="--check=crc32"
+}
+
+if [[ -z "${dontSetupModuleCompression-}" ]]; then
+  nixInfoLog "Using setupModuleCompressionHook"
+  postConfigureHooks+=(setupModuleCompressionHook)
+fi


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This reapplies the original commit that enabled CONFIG_MODULE_DECOMPRESS, as well as adds a setup hook that ensures compressed kernel modules are valid for the active kernel so that we can fail at build-time rather than run-time. In addition, out-of-tree modules that are packaged here have been fixed.

Failure in the setup hook looks like this:

```console
Executing checkModuleCompressionHook
Detected kernel modules that were not compressed with the following xz parameters "--check=crc32":
  /nix/store/cncvrx340f2w5xd1k6gbwvzh1r6ih0yk-rtw88-0-unstable-2026-02-12/lib/modules/6.18.42/kernel/drivers/net/wireless/realtek/rtw88/rtw_core.ko.xz
  /nix/store/cncvrx340f2w5xd1k6gbwvzh1r6ih0yk-rtw88-0-unstable-2026-02-12/lib/modules/6.18.42/kernel/drivers/net/wireless/realtek/rtw88/rtw_8703b.ko.xz
  /nix/store/cncvrx340f2w5xd1k6gbwvzh1r6ih0yk-rtw88-0-unstable-2026-02-12/lib/modules/6.18.42/kernel/drivers/net/wireless/realtek/rtw88/rtw_8723cs.ko.xz
  /nix/store/cncvrx340f2w5xd1k6gbwvzh1r6ih0yk-rtw88-0-unstable-2026-02-12/lib/modules/6.18.42/kernel/drivers/net/wireless/realtek/rtw88/rtw_8723d.ko.xz
  /nix/store/cncvrx340f2w5xd1k6gbwvzh1r6ih0yk-rtw88-0-unstable-2026-02-12/lib/modules/6.18.42/kernel/drivers/net/wireless/realtek/rtw88/rtw_8723de.ko.xz
  /nix/store/cncvrx340f2w5xd1k6gbwvzh1r6ih0yk-rtw88-0-unstable-2026-02-12/lib/modules/6.18.42/kernel/drivers/net/wireless/realtek/rtw88/rtw_8723ds.ko.xz
  /nix/store/cncvrx340f2w5xd1k6gbwvzh1r6ih0yk-rtw88-0-unstable-2026-02-12/lib/modules/6.18.42/kernel/drivers/net/wireless/realtek/rtw88/rtw_8723du.ko.xz
  /nix/store/cncvrx340f2w5xd1k6gbwvzh1r6ih0yk-rtw88-0-unstable-2026-02-12/lib/modules/6.18.42/kernel/drivers/net/wireless/realtek/rtw88/rtw_8723x.ko.xz
  /nix/store/cncvrx340f2w5xd1k6gbwvzh1r6ih0yk-rtw88-0-unstable-2026-02-12/lib/modules/6.18.42/kernel/drivers/net/wireless/realtek/rtw88/rtw_8812ae.ko.xz
  /nix/store/cncvrx340f2w5xd1k6gbwvzh1r6ih0yk-rtw88-0-unstable-2026-02-12/lib/modules/6.18.42/kernel/drivers/net/wireless/realtek/rtw88/rtw_8812au.ko.xz
  /nix/store/cncvrx340f2w5xd1k6gbwvzh1r6ih0yk-rtw88-0-unstable-2026-02-12/lib/modules/6.18.42/kernel/drivers/net/wireless/realtek/rtw88/rtw_8821a.ko.xz
  /nix/store/cncvrx340f2w5xd1k6gbwvzh1r6ih0yk-rtw88-0-unstable-2026-02-12/lib/modules/6.18.42/kernel/drivers/net/wireless/realtek/rtw88/rtw_8812a.ko.xz
...
```

I also validated that modules compressed with xz dictionary sizes larger than 1MiB can load successfully (e.g. the `xz` default of 8MiB works), and will work on all kernels that have CONFIG_MODULE_DECOMPRESS enabled, since the max dictionary size used by the kernel has not changed since the introduction of that kconfig option.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
