### PR TITLE
xwin: 0.7.0 -> 0.9.0, add passthru.updateScript & eveeifyeve as maintainer

### DIFF
--- a/pkgs/by-name/xw/xwin/package.nix
+++ b/pkgs/by-name/xw/xwin/package.nix
@@ -55,7 +55,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       lib.licenses.mit
       lib.licenses.asl20
     ];
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.eveeifyeve ];
     platforms = with lib.platforms; linux ++ darwin ++ windows;
   };
 })

--- a/pkgs/by-name/xw/xwin/package.nix
+++ b/pkgs/by-name/xw/xwin/package.nix
@@ -5,19 +5,20 @@
   openssl,
   pkg-config,
   versionCheckHook,
+  nix-update-script,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "xwin";
-  version = "0.7.0";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "Jake-Shadle";
     repo = "xwin";
     tag = finalAttrs.version;
-    hash = "sha256-p7rrZ2yxSpGKNuddcSO2wlvsIFj8LYG91tCK1mWO+NY=";
+    hash = "sha256-tccavt0VhA5l3rDXxbQu1ueQsoHV55g8/twKp11hrk8=";
   };
 
-  cargoHash = "sha256-e2uYAE2veYDNZpHr40bpIbplg7orW8oIxgZORhPpbFY=";
+  cargoHash = "sha256-jJBLrcMVGbP1NPDgdUPQYM8333XGo6ulbs4qBk2Np90=";
 
   strictDeps = true;
   nativeBuildInputs = [
@@ -26,11 +27,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   buildInputs = [
     openssl
-  ];
-
-  buildNoDefaultFeatures = true;
-  buildFeatures = [
-    "native-tls"
   ];
 
   doCheck = true;
@@ -45,6 +41,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     versionCheckHook
   ];
   versionCheckProgram = placeholder "out" + "/bin/xwin";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Utility for downloading the Microsoft CRT & Windows SDK libraries";


### PR DESCRIPTION
Updates xwin from 0.7.0 to 0.9.0, adds passthru.updateScript to keep it up to date as reccomended by #545903 and adds myself as a maintainer.

Changes: https://github.com/Jake-Shadle/xwin/compare/0.7.0...0.9.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
    - `pkgsCross.x86_64-windows.windows.sdk.tests.hello-world`
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. Via building `windows.sdk`
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
