### PR TITLE
sv-lang: fix build on darwin

### DIFF
--- a/pkgs/by-name/sv/sv-lang/package.nix
+++ b/pkgs/by-name/sv/sv-lang/package.nix
@@ -7,6 +7,7 @@
   cmake,
   ninja,
   fmt,
+  llvmPackages,
   mimalloc,
   python3,
 }:
@@ -36,6 +37,10 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     python3
     ninja
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # needs the wrapped clang-scan-deps to find the C++20 module headers
+    llvmPackages.clang-tools
   ];
 
   strictDeps = true;
@@ -48,17 +53,17 @@ stdenv.mkDerivation (finalAttrs: {
     catch2_3
   ];
 
-  # TODO: a mysterious linker error occurs when building the unittests on darwin.
-  # The error occurs when using catch2_3 in nixpkgs, not when fetching catch2_3 using CMake
-  doCheck = !stdenv.hostPlatform.isDarwin;
+  doCheck = true;
 
   meta = {
     description = "SystemVerilog compiler and language services";
     homepage = "https://github.com/MikePopoloski/slang";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ sharzy ];
+    maintainers = with lib.maintainers; [
+      sharzy
+      carlossless
+    ];
     mainProgram = "slang";
     platforms = lib.platforms.all;
-    broken = stdenv.hostPlatform.isDarwin;
   };
 })

--- a/pkgs/by-name/sv/sv-lang_10/package.nix
+++ b/pkgs/by-name/sv/sv-lang_10/package.nix
@@ -8,6 +8,7 @@
   cmake,
   ninja,
   fmt,
+  llvmPackages,
   mimalloc,
   python3,
 }:
@@ -52,6 +53,10 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     python3
     ninja
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # needs the wrapped clang-scan-deps to find the C++20 module headers
+    llvmPackages.clang-tools
   ];
 
   strictDeps = true;
@@ -63,15 +68,17 @@ stdenv.mkDerivation (finalAttrs: {
     catch2_3
   ];
 
-  doCheck = !stdenv.hostPlatform.isDarwin;
+  doCheck = true;
 
   meta = {
     description = "SystemVerilog compiler and language services";
     homepage = "https://github.com/MikePopoloski/slang";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ sharzy ];
+    maintainers = with lib.maintainers; [
+      sharzy
+      carlossless
+    ];
     mainProgram = "slang";
     platforms = lib.platforms.all;
-    broken = stdenv.hostPlatform.isDarwin;
   };
 })

--- a/pkgs/by-name/sv/sv-lang_9/package.nix
+++ b/pkgs/by-name/sv/sv-lang_9/package.nix
@@ -7,6 +7,7 @@
   cmake,
   ninja,
   fmt,
+  llvmPackages,
   mimalloc,
   python3,
 }:
@@ -42,6 +43,10 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     python3
     ninja
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # needs the wrapped clang-scan-deps to find the C++20 module headers
+    llvmPackages.clang-tools
   ];
 
   strictDeps = true;
@@ -54,17 +59,17 @@ stdenv.mkDerivation (finalAttrs: {
     catch2_3
   ];
 
-  # TODO: a mysterious linker error occurs when building the unittests on darwin.
-  # The error occurs when using catch2_3 in nixpkgs, not when fetching catch2_3 using CMake
-  doCheck = !stdenv.hostPlatform.isDarwin;
+  doCheck = true;
 
   meta = {
     description = "SystemVerilog compiler and language services";
     homepage = "https://github.com/MikePopoloski/slang";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ sharzy ];
+    maintainers = with lib.maintainers; [
+      sharzy
+      carlossless
+    ];
     mainProgram = "slang";
     platforms = lib.platforms.all;
-    broken = stdenv.hostPlatform.isDarwin;
   };
 })

--- a/pkgs/by-name/ve/veridian/package.nix
+++ b/pkgs/by-name/ve/veridian/package.nix
@@ -2,6 +2,7 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  stdenv,
 
   cmake,
   makeWrapper,
@@ -87,5 +88,6 @@ rustPlatform.buildRustPackage {
     homepage = "https://github.com/vivekmalneedi/veridian";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.hakan-demirli ];
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/548109 included sv-lang into yosys, but since sv-lang is marked broken on darwin it broke yosys and everything that depends on it on darwin.

This is https://github.com/NixOS/nixpkgs/pull/461994 with some changes applied and fixes sv-langs build on darwin and all of its dependents.

Also adding myself as maintainer here to help keep darwin builds in check.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
