### PR TITLE
btcpayserver: 2.3.4 -> 2.4.2

### DIFF
--- a/pkgs/by-name/bt/btcpayserver/deps.json
+++ b/pkgs/by-name/bt/btcpayserver/deps.json
@@ -1,8 +1,18 @@
 [
   {
     "pname": "AngleSharp",
+    "version": "0.17.0",
+    "hash": "sha256-cQvLOL296TROZkL2nVLoLEuRaN5UfjFFJIzG0/JgYrg="
+  },
+  {
+    "pname": "AngleSharp",
     "version": "0.17.1",
     "hash": "sha256-8DLs4SGXeG4ilbAJ8H6KLjaK/GmaXizMEMc3P8ZrEQ0="
+  },
+  {
+    "pname": "AngleSharp",
+    "version": "1.5.2",
+    "hash": "sha256-81rDtnwvR0SDXNNUnPirWIa782gwkgRlz1Fbzm2ywwc="
   },
   {
     "pname": "AngleSharp.Css",
@@ -41,8 +51,8 @@
   },
   {
     "pname": "BouncyCastle.Cryptography",
-    "version": "2.4.0",
-    "hash": "sha256-DoDZNWtYM+0OLIclOEZ+tjcGXymGlXvdvq2ZMPmiAJA="
+    "version": "2.6.2",
+    "hash": "sha256-Yjk2+x/RcVeccGOQOQcRKCiYzyx1mlFnhS5auCII+Ms="
   },
   {
     "pname": "BTCPayServer.Hwi",
@@ -51,18 +61,13 @@
   },
   {
     "pname": "BTCPayServer.Lightning.All",
-    "version": "1.6.11",
-    "hash": "sha256-HId8axtrx8i205y1uytHp/04/DyKsXzJwSEMzpr7Mzk="
-  },
-  {
-    "pname": "BTCPayServer.Lightning.Charge",
-    "version": "1.5.2",
-    "hash": "sha256-98YtDZBzc5qKO2sK2fpDxodrnVqcfjBPQaagLFXxbss="
+    "version": "1.7.6",
+    "hash": "sha256-weaWvC+NcL5/3rkGkKEh5Deltiyi0X3CDNdbj4LeC88="
   },
   {
     "pname": "BTCPayServer.Lightning.CLightning",
-    "version": "1.6.4",
-    "hash": "sha256-H6eskDDjfcgIcy6O1w44qrEwFLi2DrqOtgerj6sQhBQ="
+    "version": "1.7.5",
+    "hash": "sha256-gahNBgA4tWgMBvx7kL3vh5Eq/ZgjH6P3Rmc0FAvH34Y="
   },
   {
     "pname": "BTCPayServer.Lightning.Common",
@@ -71,33 +76,28 @@
   },
   {
     "pname": "BTCPayServer.Lightning.Common",
-    "version": "1.5.2",
-    "hash": "sha256-5SFwNAIJBBbrix/qqrtsad5QOKQbCUOm7Un/LDA8c6E="
+    "version": "1.7.1",
+    "hash": "sha256-BCugPGQ1Pb4V6zbcproD8OjH0zW5PWbqviCDv59lcxE="
   },
   {
     "pname": "BTCPayServer.Lightning.Eclair",
-    "version": "1.5.7",
-    "hash": "sha256-UueCAJjSQtY6zH38M4Fc5qY1OaZDAvdNqgY8p6ARTng="
-  },
-  {
-    "pname": "BTCPayServer.Lightning.LNBank",
-    "version": "1.5.3",
-    "hash": "sha256-zuiPaypkMAq0y0/9XYu1c7QmezdbvEUufOxpbo6CaoA="
+    "version": "1.7.1",
+    "hash": "sha256-b81YxcY9qNl6M5sg9Adq8O8zcKGOtJaTL9U33u5zG4A="
   },
   {
     "pname": "BTCPayServer.Lightning.LND",
-    "version": "1.5.6",
-    "hash": "sha256-dCx/TarqZSwio0TMQtwL/sxJ2GtnoHj72+Mwe+xoCf8="
+    "version": "1.7.1",
+    "hash": "sha256-OqxqqDVxBe5hy4fDz5GqOLVodQQgdJlQRFGg9lpCYyA="
   },
   {
     "pname": "BTCPayServer.Lightning.LNDhub",
-    "version": "1.5.3",
-    "hash": "sha256-CbSjeix4JCVtgb8WCfsKgThpl/YbnhbJ3wcPoexpSew="
+    "version": "1.7.1",
+    "hash": "sha256-L8gCb1Go9Yf2ZE/yZnbXyLXRIhGgQzMlHDBVD/EH64U="
   },
   {
     "pname": "BTCPayServer.Lightning.Phoenixd",
-    "version": "1.5.8",
-    "hash": "sha256-pISNuSZW/B0MZ5VkW8nHAENTOUoFI+YfvrubD/vh74w="
+    "version": "1.7.1",
+    "hash": "sha256-hPnmmoIwAl+sTzp9Bbu10SfWMdvGmI1a6hnQTLl2VLo="
   },
   {
     "pname": "BTCPayServer.NTag424",
@@ -106,33 +106,33 @@
   },
   {
     "pname": "CsvHelper",
-    "version": "32.0.3",
-    "hash": "sha256-XbRxWNgxYe3sUZQZr5d9DxLAOl10cBCZ7JGm4xujuMQ="
+    "version": "33.1.0",
+    "hash": "sha256-pEfX4o63xupI7uuwe6qa05One0pJ7UbzzJqLh4Shju8="
   },
   {
     "pname": "Dapper",
-    "version": "2.1.35",
-    "hash": "sha256-zeroySx7lO1yLtbhKhFQ87diWXOq9gPnv3qFcmNcs9M="
+    "version": "2.1.79",
+    "hash": "sha256-QIGZ+vlnwhSl+nnVZ//s3uwFh/vKJ5kDpgGkmpMjhmw="
   },
   {
     "pname": "DigitalRuby.ExchangeSharp",
-    "version": "1.2.0",
-    "hash": "sha256-yKgWUkLVpu8EapAOx8jXWEmwsHpUNWAbu2utD3CpNjI="
+    "version": "1.2.1",
+    "hash": "sha256-36JtWd7Bxa7+UBONuWFoGNOq27Kt6H130qU/1AREPXI="
   },
   {
     "pname": "Fido2",
-    "version": "3.0.1",
-    "hash": "sha256-v8hND0a17nQ94TC0lmfdr35j3I8y/fwO2Ay7oNyPKRs="
+    "version": "4.0.1",
+    "hash": "sha256-bTTmj5//YSgaUENgXMKXY2s1dAxhtdYNu7TAa4iXbEU="
   },
   {
     "pname": "Fido2.AspNet",
-    "version": "3.0.1",
-    "hash": "sha256-nVAXITj4CkcOD2NQaLBaoLr0QPDo/HE7rTrlBfcDXXM="
+    "version": "4.0.1",
+    "hash": "sha256-ZxWp3u8vUbE4cOIWtRxK95A1vzC7D8UR6vQE8OJrov4="
   },
   {
     "pname": "Fido2.Models",
-    "version": "3.0.1",
-    "hash": "sha256-awp0JKQxYKZTTA9LygvIUqG36r36ZZWfs6sfcu9yU4U="
+    "version": "4.0.1",
+    "hash": "sha256-upadIQMUYlznjb/0ZTSpjjkCscSF9NrikGjbP88f5cU="
   },
   {
     "pname": "Google.Api.Gax",
@@ -186,8 +186,8 @@
   },
   {
     "pname": "HtmlSanitizer",
-    "version": "8.0.838",
-    "hash": "sha256-L2Nxc1qnRMv+FXNRt2SkkB2f3A41+UXh+lQcZEajBcw="
+    "version": "9.0.967",
+    "hash": "sha256-88jTkQSISDXnBXyIgdGtsfs90aBh244cxh9o6jrarvU="
   },
   {
     "pname": "Humanizer.Core",
@@ -196,13 +196,13 @@
   },
   {
     "pname": "JetBrains.Annotations.Sources",
-    "version": "2025.2.2",
-    "hash": "sha256-9Aui689O6j0E34FSwTLGEwar5etuswWg3FU7+mIzpdU="
+    "version": "2026.2.0",
+    "hash": "sha256-AqShNJbFCrtUbrqti44j6cUglBApw+VdXWFgsTrO3TU="
   },
   {
     "pname": "libsodium",
-    "version": "1.0.18.2",
-    "hash": "sha256-gjaW2AYXQSb3LLjtQDjWSxkTmEiqIoIb7NFx0+AlrQs="
+    "version": "1.0.20.1",
+    "hash": "sha256-wd/z31FRbcaVGrogSNVjefEYWjNxTGzQd04DOlY1PFE="
   },
   {
     "pname": "LNURL",
@@ -211,8 +211,8 @@
   },
   {
     "pname": "MailKit",
-    "version": "4.8.0",
-    "hash": "sha256-ONvrVOwjxyNrIQM8FMzT5mLzlU56Kc8oOwkzegNAiXM="
+    "version": "4.17.0",
+    "hash": "sha256-LGruedMrHrI0AXHcXOFxsYP2awwPbrC9Q41AeQk4+9U="
   },
   {
     "pname": "Microsoft.AspNet.SignalR.Client",
@@ -230,84 +230,24 @@
     "hash": "sha256-lNL5C4W7/p8homWooO/3ZKDZQ2M0FUTDixJwqWBPVbo="
   },
   {
-    "pname": "Microsoft.AspNetCore.Connections.Abstractions",
-    "version": "8.0.11",
-    "hash": "sha256-46JBknVJqIAU3YF87sMs7kKZ0p9vMgxX7DpsGJMeA1Y="
-  },
-  {
-    "pname": "Microsoft.AspNetCore.Cryptography.Internal",
-    "version": "8.0.11",
-    "hash": "sha256-xEIbxQbMcTvkzNw7KKeYOK9wNMShbTAzhx7DR8QMrvM="
-  },
-  {
-    "pname": "Microsoft.AspNetCore.Cryptography.KeyDerivation",
-    "version": "8.0.11",
-    "hash": "sha256-qt8zkqW3Q8GbnWqPn7YaVGX8r35N5r4iPqENPmu8iPA="
-  },
-  {
-    "pname": "Microsoft.AspNetCore.Http.Connections.Client",
-    "version": "8.0.11",
-    "hash": "sha256-umvY77/tqcwWRqrDwnjVwAW7HYurWOOElmqxRobSWj8="
-  },
-  {
-    "pname": "Microsoft.AspNetCore.Http.Connections.Common",
-    "version": "8.0.11",
-    "hash": "sha256-v2kVUWConlb+5WjVt6pdWbWw43EMxBtpmNHJggGrWaY="
-  },
-  {
     "pname": "Microsoft.AspNetCore.Identity.EntityFrameworkCore",
-    "version": "8.0.11",
-    "hash": "sha256-CGnMxU5tYyhALmSnWEMeaNqQmmA1iXqV503HHoWMAfs="
+    "version": "10.0.10",
+    "hash": "sha256-r2ZhBjaF7d5M+HYtN8FsBMK7hndICSefPkbOfigjS9k="
   },
   {
     "pname": "Microsoft.AspNetCore.JsonPatch",
-    "version": "8.0.11",
-    "hash": "sha256-7n0O/CWYMjWyicwPZgUUh+YTmdNNZA02rWhBHAzPDPU="
+    "version": "10.0.10",
+    "hash": "sha256-NIFI6z2X1blS3ab3G/CgY42WuJULni5wTa4X8AMx1c0="
   },
   {
     "pname": "Microsoft.AspNetCore.Mvc.NewtonsoftJson",
-    "version": "8.0.11",
-    "hash": "sha256-oaSZize0xvrX1qf45gjMmXHipD21tBGTp2pkr7ReS5U="
-  },
-  {
-    "pname": "Microsoft.AspNetCore.Mvc.Razor.Extensions",
-    "version": "6.0.0",
-    "hash": "sha256-TrR4soDtsyg+czs3P0nYByalKC6g6cmdQiRnOg6NRtA="
-  },
-  {
-    "pname": "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation",
-    "version": "8.0.11",
-    "hash": "sha256-O+ssoIAS4R9X80bP+f8U/2c3KZhZkTV34qGsAHEAM7k="
-  },
-  {
-    "pname": "Microsoft.AspNetCore.Razor.Language",
-    "version": "6.0.0",
-    "hash": "sha256-P0bdoAG+VBR/PuYQQN4tXhJomfXw+lArXx5UQqRoWlM="
-  },
-  {
-    "pname": "Microsoft.AspNetCore.SignalR.Client",
-    "version": "8.0.11",
-    "hash": "sha256-Bh3scWPi7Zf0FidyILH5ANrUXNiImHKAyX74ToIEKAE="
-  },
-  {
-    "pname": "Microsoft.AspNetCore.SignalR.Client.Core",
-    "version": "8.0.11",
-    "hash": "sha256-pYkxXOwUo+me25kUZSgmbDrJ9sed91tDOUMwuwgAFjI="
-  },
-  {
-    "pname": "Microsoft.AspNetCore.SignalR.Common",
-    "version": "8.0.11",
-    "hash": "sha256-Bq/maWmZpIZx8DTN81O9m617bepcgVeO5augSI8WiNU="
-  },
-  {
-    "pname": "Microsoft.AspNetCore.SignalR.Protocols.Json",
-    "version": "8.0.11",
-    "hash": "sha256-drCZEQdUBvWviUe4McpS5EuHmiNor8P3vxTlVnqkkOM="
+    "version": "10.0.10",
+    "hash": "sha256-QlXe8Il3kcDQZTSZg3tCvW7c8ERix7lIWvYGSrrleNE="
   },
   {
     "pname": "Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson",
-    "version": "8.0.11",
-    "hash": "sha256-8TisgYgVIth+MGVxshkggCq4l4eRS29tKG718VjUeaM="
+    "version": "10.0.10",
+    "hash": "sha256-iaG84GdwHEgNNyG7Q9/6NPLg+I91rjEpBjeTowxcm7Y="
   },
   {
     "pname": "Microsoft.Bcl.AsyncInterfaces",
@@ -320,114 +260,104 @@
     "hash": "sha256-fAcX4sxE0veWM1CZBtXR/Unky+6sE33yrV7ohrWGKig="
   },
   {
-    "pname": "Microsoft.Bcl.AsyncInterfaces",
-    "version": "6.0.0",
-    "hash": "sha256-49+H/iFwp+AfCICvWcqo9us4CzxApPKC37Q5Eqrw+JU="
+    "pname": "Microsoft.Bcl.Memory",
+    "version": "9.0.14",
+    "hash": "sha256-/1YVk+lrwfq7hpr1T5URizzU9keMEO5YVifavEi9c8M="
+  },
+  {
+    "pname": "Microsoft.Bcl.TimeProvider",
+    "version": "8.0.1",
+    "hash": "sha256-TQRaWjk1aZu+jn/rR8oOv8BJEG31i6mPkf3BkIR7C+c="
+  },
+  {
+    "pname": "Microsoft.Build.Framework",
+    "version": "17.11.31",
+    "hash": "sha256-YS4oASrmC5dmZrx5JPS7SfKmUpIJErlUpVDsU3VrfFE="
+  },
+  {
+    "pname": "Microsoft.Build.Framework",
+    "version": "18.0.2",
+    "hash": "sha256-fO31KAdDs2J0RUYD1ov9UB3ucsbALan7K0YdWW+yg7A="
   },
   {
     "pname": "Microsoft.CodeAnalysis.Analyzers",
-    "version": "3.3.2",
-    "hash": "sha256-pDeaMqX7a01Hp1Qd9P/y/B2rEGAv2eIY0Ld/klBZW5g="
+    "version": "3.11.0",
+    "hash": "sha256-hQ2l6E6PO4m7i+ZsfFlEx+93UsLPo4IY3wDkNG11/Sw="
   },
   {
     "pname": "Microsoft.CodeAnalysis.Analyzers",
-    "version": "3.3.3",
-    "hash": "sha256-pkZiggwLw8k+CVSXKTzsVGsT+K49LxXUS3VH5PNlpCY="
-  },
-  {
-    "pname": "Microsoft.CodeAnalysis.Analyzers",
-    "version": "3.3.4",
-    "hash": "sha256-qDzTfZBSCvAUu9gzq2k+LOvh6/eRvJ9++VCNck/ZpnE="
+    "version": "5.3.0",
+    "hash": "sha256-eUjU7MDekcbDQxUButcWK7siHx6HmrgdDMLnpGYRVLM="
   },
   {
     "pname": "Microsoft.CodeAnalysis.Common",
-    "version": "4.0.0",
-    "hash": "sha256-SfQYaC9FbN60PhSzU3iM56ZeUlb/Y2FFGEnF43/5luc="
+    "version": "5.0.0",
+    "hash": "sha256-g4ALvBSNyHEmSb1l5TFtWW7zEkiRmhqLx4XWZu9sr2U="
   },
   {
     "pname": "Microsoft.CodeAnalysis.Common",
-    "version": "4.10.0",
-    "hash": "sha256-gtGxb7gPSOWVN2SS5CaHtZO+i6hvBbiXyA2AZ8dOKzY="
-  },
-  {
-    "pname": "Microsoft.CodeAnalysis.Common",
-    "version": "4.5.0",
-    "hash": "sha256-qo1oVNTB9JIMEPoiIZ+02qvF/O8PshQ/5gTjsY9iX0I="
+    "version": "5.6.0",
+    "hash": "sha256-Q+34cKCUHLMUdigLSuCunqcpAzagynq7O6LJ09EPu6g="
   },
   {
     "pname": "Microsoft.CodeAnalysis.CSharp",
-    "version": "4.0.0",
-    "hash": "sha256-ZGE+DM8siy3DHhBQcNesEHz9bEL4at+L6Cmj24+X/dc="
+    "version": "5.0.0",
+    "hash": "sha256-ctBCkQGFpH/xT5rRE3xibu9YxPD108RuC4a4Z25koG8="
   },
   {
     "pname": "Microsoft.CodeAnalysis.CSharp",
-    "version": "4.10.0",
-    "hash": "sha256-HjKeyCBJ+tylS3EaF18Z99Qj2F0eJQvUZo/pYrBcfLI="
-  },
-  {
-    "pname": "Microsoft.CodeAnalysis.CSharp",
-    "version": "4.5.0",
-    "hash": "sha256-5dZTS9PYtY83vyVa5bdNG3XKV5EjcnmddfUqWmIE29A="
+    "version": "5.6.0",
+    "hash": "sha256-nrzGZk9oLuCEvhDT+IS+XBVOuHVrwL8RGj0rZFP4SRo="
   },
   {
     "pname": "Microsoft.CodeAnalysis.CSharp.Workspaces",
-    "version": "4.5.0",
-    "hash": "sha256-Kmyt1Xfcs0rSZHvN9PH94CKAooqMS9abZQY7EpEqb2o="
-  },
-  {
-    "pname": "Microsoft.CodeAnalysis.Razor",
-    "version": "6.0.0",
-    "hash": "sha256-j1/Mpe9Ta+4dhoa2+Zd7BaMm6MllJfaMtZ4pX+P2cqA="
+    "version": "5.0.0",
+    "hash": "sha256-yWVcLt/f2CouOfFy966glGdtSFy+RcgrU1dd9UtlL/Q="
   },
   {
     "pname": "Microsoft.CodeAnalysis.Workspaces.Common",
-    "version": "4.5.0",
-    "hash": "sha256-WM7AXJYHagaPx2waj2E32gG0qXq6Kx4Zhiq7Ym3WXPI="
+    "version": "5.0.0",
+    "hash": "sha256-Bir5e1gEhgQQ6upQmVKQHAKLRfenAu60DAzNupNnZsQ="
   },
   {
-    "pname": "Microsoft.CSharp",
-    "version": "4.5.0",
-    "hash": "sha256-dAhj/CgXG5VIy2dop1xplUsLje7uBPFjxasz9rdFIgY="
-  },
-  {
-    "pname": "Microsoft.CSharp",
-    "version": "4.7.0",
-    "hash": "sha256-Enknv2RsFF68lEPdrf5M+BpV1kHoLTVRApKUwuk/pj0="
+    "pname": "Microsoft.CodeAnalysis.Workspaces.MSBuild",
+    "version": "5.0.0",
+    "hash": "sha256-+58+iqTayTiE0pDaog1U8mjaDA8bNNDLA8gjCQZZudo="
   },
   {
     "pname": "Microsoft.EntityFrameworkCore",
-    "version": "8.0.11",
-    "hash": "sha256-uvcAmj7ob2X/JKLleNwanpNs0X3PkJl3je6ZsHeWooE="
+    "version": "10.0.10",
+    "hash": "sha256-xVZPHGNo5BD9rPUD+G8lzOnK5SwqXrXfo5A7dRBUxPE="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore",
+    "version": "10.0.4",
+    "hash": "sha256-V3Vwl1MtVMRTPo7a9lAgs6UaeMnFV3eEsKnLyPaPMHA="
   },
   {
     "pname": "Microsoft.EntityFrameworkCore.Abstractions",
-    "version": "8.0.11",
-    "hash": "sha256-qKe+WBIlyZ1CS2H9JGWsYiWxkUzGjwIHtx/q3FPCDr8="
+    "version": "10.0.10",
+    "hash": "sha256-On3X52C76cx9WobuQIBu8Rt1IV8dKf2VdY+98SJ2lKo="
   },
   {
     "pname": "Microsoft.EntityFrameworkCore.Analyzers",
-    "version": "8.0.11",
-    "hash": "sha256-eKhcGqCN34F2i7/FeKSq1gyMjNq3ikq+UpE/1SbXecY="
+    "version": "10.0.10",
+    "hash": "sha256-tOI7t2TWw1a5BLiiUcoVfR8ai23KO5Fqjh7mnskJRsU="
   },
   {
     "pname": "Microsoft.EntityFrameworkCore.Design",
-    "version": "8.0.11",
-    "hash": "sha256-in7Ppl/tEEM/2r+l+uuSjWLXk7fHbJRVmLzskYfAhMQ="
+    "version": "10.0.10",
+    "hash": "sha256-yLbrgLp+YZalYX/5OvfOSnZZsKuVDW3dOX1n2BhrY20="
   },
   {
     "pname": "Microsoft.EntityFrameworkCore.Relational",
-    "version": "8.0.11",
-    "hash": "sha256-st6V0S7j+FyK7r9X6uObpuhSoac/z5QOF1DUPnhffgE="
+    "version": "10.0.10",
+    "hash": "sha256-3YyfZyXSZpdjW1S+qaVNFURiRyzHwy0sofx+gILCZFQ="
   },
   {
-    "pname": "Microsoft.Extensions.Caching.Abstractions",
-    "version": "8.0.0",
-    "hash": "sha256-xGpKrywQvU1Wm/WolYIxgHYEFfgkNGeJ+GGc5DT3phI="
-  },
-  {
-    "pname": "Microsoft.Extensions.Caching.Memory",
-    "version": "8.0.1",
-    "hash": "sha256-5Q0vzHo3ZvGs4nPBc/XlBF4wAwYO8pxq6EGdYjjXZps="
+    "pname": "Microsoft.EntityFrameworkCore.Relational",
+    "version": "10.0.4",
+    "hash": "sha256-WwGoCwNxDXyqfBvUX9fGa/6X+yiDBuE7hf3csU78+Os="
   },
   {
     "pname": "Microsoft.Extensions.Configuration",
@@ -438,16 +368,6 @@
     "pname": "Microsoft.Extensions.Configuration.Abstractions",
     "version": "6.0.0",
     "hash": "sha256-Evg+Ynj2QUa6Gz+zqF+bUyfGD0HI5A2fHmxZEXbn3HA="
-  },
-  {
-    "pname": "Microsoft.Extensions.Configuration.Abstractions",
-    "version": "8.0.0",
-    "hash": "sha256-4eBpDkf7MJozTZnOwQvwcfgRKQGcNXe0K/kF+h5Rl8o="
-  },
-  {
-    "pname": "Microsoft.Extensions.Configuration.Binder",
-    "version": "8.0.0",
-    "hash": "sha256-GanfInGzzoN2bKeNwON8/Hnamr6l7RTpYLA49CNXD9Q="
   },
   {
     "pname": "Microsoft.Extensions.Configuration.EnvironmentVariables",
@@ -465,64 +385,19 @@
     "hash": "sha256-5tUoqvIsWL5hfmMCpCpBW6V1tw/sMUCwfnm/7Y8LD6M="
   },
   {
-    "pname": "Microsoft.Extensions.DependencyInjection",
-    "version": "6.0.0",
-    "hash": "sha256-gZuMaunMJVyvvepuzNodGPRc6eqKH//bks3957dYkPI="
-  },
-  {
-    "pname": "Microsoft.Extensions.DependencyInjection",
-    "version": "8.0.0",
-    "hash": "sha256-+qIDR8hRzreCHNEDtUcPfVHQdurzWPo/mqviCH78+EQ="
-  },
-  {
-    "pname": "Microsoft.Extensions.DependencyInjection",
-    "version": "8.0.1",
-    "hash": "sha256-O9g0jWS+jfGoT3yqKwZYJGL+jGSIeSbwmvomKDC3hTU="
-  },
-  {
-    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
-    "version": "6.0.0",
-    "hash": "sha256-SZke0jNKIqJvvukdta+MgIlGsrP2EdPkkS8lfLg7Ju4="
-  },
-  {
-    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
-    "version": "8.0.0",
-    "hash": "sha256-75KzEGWjbRELczJpCiJub+ltNUMMbz5A/1KQU+5dgP8="
-  },
-  {
-    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
-    "version": "8.0.2",
-    "hash": "sha256-UfLfEQAkXxDaVPC7foE/J3FVEXd31Pu6uQIhTic3JgY="
+    "pname": "Microsoft.Extensions.DependencyModel",
+    "version": "10.0.0",
+    "hash": "sha256-oCcIjmwH8H0n9bT3wQBWdotMvYuoiazfiKrXAs2bLiI="
   },
   {
     "pname": "Microsoft.Extensions.DependencyModel",
-    "version": "8.0.0",
-    "hash": "sha256-qkCdwemqdZY/yIW5Xmh7Exv74XuE39T8aHGHCofoVgo="
-  },
-  {
-    "pname": "Microsoft.Extensions.DependencyModel",
-    "version": "8.0.2",
-    "hash": "sha256-PyuO/MyCR9JtYqpA1l/nXGh+WLKCq34QuAXN9qNza9Q="
-  },
-  {
-    "pname": "Microsoft.Extensions.Diagnostics.Abstractions",
-    "version": "8.0.0",
-    "hash": "sha256-USD5uZOaahMqi6u7owNWx/LR4EDrOwqPrAAim7iRpJY="
-  },
-  {
-    "pname": "Microsoft.Extensions.Features",
-    "version": "8.0.11",
-    "hash": "sha256-/q25irYLMbgzuvIHDva43NmKF+BuFCiZX4cmINKu2/4="
+    "version": "10.0.10",
+    "hash": "sha256-dbMT/THhkYtvENQvdRMnPrn7lKXxpPKjWQlG1HbvaS8="
   },
   {
     "pname": "Microsoft.Extensions.FileProviders.Abstractions",
     "version": "6.0.0",
     "hash": "sha256-uBjWjHKEXjZ9fDfFxMjOou3lhfTNhs1yO+e3fpWreLk="
-  },
-  {
-    "pname": "Microsoft.Extensions.FileProviders.Abstractions",
-    "version": "8.0.0",
-    "hash": "sha256-uQSXmt47X2HGoVniavjLICbPtD2ReQOYQMgy3l0xuMU="
   },
   {
     "pname": "Microsoft.Extensions.FileProviders.Physical",
@@ -535,41 +410,6 @@
     "hash": "sha256-RAWHjkkfvGpjc49Q0kJbZyXgU6UEq/EJ0j557sj2/iU="
   },
   {
-    "pname": "Microsoft.Extensions.Hosting.Abstractions",
-    "version": "8.0.0",
-    "hash": "sha256-0JBx+wwt5p1SPfO4m49KxNOXPAzAU0A+8tEc/itvpQE="
-  },
-  {
-    "pname": "Microsoft.Extensions.Http",
-    "version": "6.0.0",
-    "hash": "sha256-JVUjIgj7kblLhiEPsbL1psav8pWrKmjB5Csr4d3GuvM="
-  },
-  {
-    "pname": "Microsoft.Extensions.Identity.Core",
-    "version": "8.0.11",
-    "hash": "sha256-5ZeJEyzyyQpBBjrS6/z3sWoD/o+jwtyFKksG35wLu3E="
-  },
-  {
-    "pname": "Microsoft.Extensions.Identity.Stores",
-    "version": "8.0.11",
-    "hash": "sha256-75vJxLs+zzM3TtdxK1ccZx82xwdZzePNss0H/8DnAww="
-  },
-  {
-    "pname": "Microsoft.Extensions.Logging",
-    "version": "6.0.0",
-    "hash": "sha256-8WsZKRGfXW5MsXkMmNVf6slrkw+cR005czkOP2KUqTk="
-  },
-  {
-    "pname": "Microsoft.Extensions.Logging",
-    "version": "8.0.0",
-    "hash": "sha256-Meh0Z0X7KyOEG4l0RWBcuHHihcABcvCyfUXgasmQ91o="
-  },
-  {
-    "pname": "Microsoft.Extensions.Logging",
-    "version": "8.0.1",
-    "hash": "sha256-vkfVw4tQEg86Xg18v6QO0Qb4Ysz0Njx57d1XcNuj6IU="
-  },
-  {
     "pname": "Microsoft.Extensions.Logging.Abstractions",
     "version": "1.0.0",
     "hash": "sha256-asIXVFsAK7ELd/f+vLwhxYDdazqRTmf+fGJ4WFtcCeo="
@@ -580,74 +420,54 @@
     "hash": "sha256-QNqcQ3x+MOK7lXbWkCzSOWa/2QyYNbdM/OEEbWN15Sw="
   },
   {
-    "pname": "Microsoft.Extensions.Logging.Abstractions",
-    "version": "8.0.0",
-    "hash": "sha256-Jmddjeg8U5S+iBTwRlVAVLeIHxc4yrrNgqVMOB7EjM4="
-  },
-  {
-    "pname": "Microsoft.Extensions.Logging.Abstractions",
-    "version": "8.0.2",
-    "hash": "sha256-cHpe8X2BgYa5DzulZfq24rg8O2K5Lmq2OiLhoyAVgJc="
-  },
-  {
-    "pname": "Microsoft.Extensions.Options",
-    "version": "6.0.0",
-    "hash": "sha256-DxnEgGiCXpkrxFkxXtOXqwaiAtoIjA8VSSWCcsW0FwE="
-  },
-  {
-    "pname": "Microsoft.Extensions.Options",
-    "version": "8.0.0",
-    "hash": "sha256-n2m4JSegQKUTlOsKLZUUHHKMq926eJ0w9N9G+I3FoFw="
-  },
-  {
-    "pname": "Microsoft.Extensions.Options",
-    "version": "8.0.2",
-    "hash": "sha256-AjcldddddtN/9aH9pg7ClEZycWtFHLi9IPe1GGhNQys="
-  },
-  {
     "pname": "Microsoft.Extensions.Primitives",
     "version": "6.0.0",
     "hash": "sha256-AgvysszpQ11AiTBJFkvSy8JnwIWTj15Pfek7T7ThUc4="
   },
   {
-    "pname": "Microsoft.Extensions.Primitives",
-    "version": "8.0.0",
-    "hash": "sha256-FU8qj3DR8bDdc1c+WeGZx/PCZeqqndweZM9epcpXjSo="
+    "pname": "Microsoft.Identity.Abstractions",
+    "version": "9.3.0",
+    "hash": "sha256-vzR37PdbKQaCveLin2/o+nwgGl9EY2ISB36y+t7k1Qc="
   },
   {
     "pname": "Microsoft.IdentityModel.Abstractions",
-    "version": "8.2.1",
-    "hash": "sha256-+9aIQ5tVPM915SEaquiiVUYaW2wk2MvkYWEMTzGYEl4="
+    "version": "8.13.1",
+    "hash": "sha256-zDoi55HDQG0Xr1W0PLbmBXGccRaSMI4afT/73J4GRuo="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Abstractions",
+    "version": "8.2.0",
+    "hash": "sha256-e+BmN/Et9mTqWt4M38udL47M4wHHs25Ob299gJSBZIM="
   },
   {
     "pname": "Microsoft.IdentityModel.JsonWebTokens",
-    "version": "6.17.0",
-    "hash": "sha256-mtryNDUNNApvIZLQ0jOiuNqLS/TH+7/zQUoViUvGVzQ="
+    "version": "8.13.1",
+    "hash": "sha256-V8w1vp4BU54GUCn1MeMzbk1erJOhRkaGvfT36CQoQMg="
   },
   {
     "pname": "Microsoft.IdentityModel.JsonWebTokens",
-    "version": "8.2.1",
-    "hash": "sha256-0tL7K87O8w2IOje7+WFZQiPiYFWLMqMRsVoHKVose+0="
+    "version": "8.2.0",
+    "hash": "sha256-tOzI2GmMISuWO/vDtJIeKmYAaFPYjrB5NhpzCWWcIw4="
   },
   {
     "pname": "Microsoft.IdentityModel.Logging",
-    "version": "6.17.0",
-    "hash": "sha256-vdpxEm0mDravY2SQT/AVgmzkQMjhNe3BcoXxWU0ayLo="
+    "version": "8.13.1",
+    "hash": "sha256-Y/djq0pR3iKykXY8TALZnJaU8PhWDcEweCNUWz99QQk="
   },
   {
     "pname": "Microsoft.IdentityModel.Logging",
-    "version": "8.2.1",
-    "hash": "sha256-0FHmPBoogYIEAa7hxVvxIYy1jCCB3NmnVS5eoVWsjrU="
+    "version": "8.2.0",
+    "hash": "sha256-JdrIo2Dg9UPu/eK5TIPKLWfRmvPGhKZrBCQL+MIv72I="
   },
   {
     "pname": "Microsoft.IdentityModel.Tokens",
-    "version": "6.17.0",
-    "hash": "sha256-XuYVKil1tUQ+cLAPnBe9+OWeLgy4AFAiIrXUhEPXLCg="
+    "version": "8.13.1",
+    "hash": "sha256-+bXBDOsA5qxYRbyIHLCt6h/Zs0y/k/KA4Yyof5q9g7k="
   },
   {
     "pname": "Microsoft.IdentityModel.Tokens",
-    "version": "8.2.1",
-    "hash": "sha256-kO/Xrv/XbJ0hKqA0PFWMKJA8EBCuAjBO7D6XoPH0l8k="
+    "version": "8.2.0",
+    "hash": "sha256-QxhnZVUrKKUZEKZgok2+4HjawuXZtVhXCJ2+BDomja8="
   },
   {
     "pname": "Microsoft.NETCore.Platforms",
@@ -660,54 +480,44 @@
     "hash": "sha256-FeM40ktcObQJk4nMYShB61H/E8B7tIKfl9ObJ0IOcCM="
   },
   {
-    "pname": "Microsoft.NETCore.Platforms",
-    "version": "1.1.1",
-    "hash": "sha256-8hLiUKvy/YirCWlFwzdejD2Db3DaXhHxT7GSZx/znJg="
-  },
-  {
-    "pname": "Microsoft.NETCore.Platforms",
-    "version": "2.1.2",
-    "hash": "sha256-gYQQO7zsqG+OtN4ywYQyfsiggS2zmxw4+cPXlK+FB5Q="
-  },
-  {
     "pname": "Microsoft.NETCore.Targets",
     "version": "1.0.1",
     "hash": "sha256-lxxw/Gy32xHi0fLgFWNj4YTFBSBkjx5l6ucmbTyf7V4="
   },
   {
-    "pname": "Microsoft.NETCore.Targets",
-    "version": "1.1.0",
-    "hash": "sha256-0AqQ2gMS8iNlYkrD+BxtIg7cXMnr9xZHtKAuN4bjfaQ="
+    "pname": "Microsoft.VisualStudio.SolutionPersistence",
+    "version": "1.0.52",
+    "hash": "sha256-KZGPtOXe6Hv8RrkcsgoLKTRyaCScIpQEa2NhNB3iOXw="
   },
   {
-    "pname": "Microsoft.NETCore.Targets",
-    "version": "1.1.3",
-    "hash": "sha256-WLsf1NuUfRWyr7C7Rl9jiua9jximnVvzy6nk2D2bVRc="
-  },
-  {
-    "pname": "Microsoft.Win32.Primitives",
-    "version": "4.3.0",
-    "hash": "sha256-mBNDmPXNTW54XLnPAUwBRvkIORFM7/j0D0I2SyQPDEg="
+    "pname": "Microsoft.Win32.SystemEvents",
+    "version": "6.0.0",
+    "hash": "sha256-N9EVZbl5w1VnMywGXyaVWzT9lh84iaJ3aD48hIBk1zA="
   },
   {
     "pname": "MimeKit",
-    "version": "4.8.0",
-    "hash": "sha256-4EB54ktBXuq5QRID9i8E7FzU7YZTE4wwH+2yr7ivi/Q="
+    "version": "4.17.0",
+    "hash": "sha256-GpWv+8shoprshuPNB+H+C5saffiKQ6Pek3zhLUGklRo="
   },
   {
     "pname": "Mono.TextTemplating",
-    "version": "2.2.1",
-    "hash": "sha256-4TYsfc8q74P8FuDwkIWPO+VYY0mh4Hs4ZL8v0lMaBsY="
+    "version": "3.0.0",
+    "hash": "sha256-VlgGDvgNZb7MeBbIZ4DE2Nn/j2aD9k6XqNHnASUSDr0="
   },
   {
     "pname": "NBitcoin",
-    "version": "9.0.0",
-    "hash": "sha256-FLqOA3Axa2Xyz7MRgXPnbIQHwMcuKqduTJrUt87/W8Q="
+    "version": "10.0.1",
+    "hash": "sha256-LdxZgCZNaVKpc5aZXVoM63LIzNM+zvf+Cg2c0nxjtCE="
+  },
+  {
+    "pname": "NBitcoin",
+    "version": "10.0.7",
+    "hash": "sha256-4arn8+u0dy2iOmwMH/tjcTXR+/4viRf9dlUeMCRqXvI="
   },
   {
     "pname": "NBitcoin.Altcoins",
-    "version": "5.0.0",
-    "hash": "sha256-3dPvHLcVvM26NW1MHcZeHkoIFm/ypcpiv+W948ff1ys="
+    "version": "6.0.3",
+    "hash": "sha256-U6xigLzDH9TpA6XkLTJRVBsL2OsaYjTD5evaVJ9NP7g="
   },
   {
     "pname": "NBitpayClient",
@@ -716,13 +526,18 @@
   },
   {
     "pname": "NBXplorer.Client",
-    "version": "5.0.5",
-    "hash": "sha256-vUP1bGd5iw3roNcvG525JV3SnL/6eXIqjvJKxdy+7dY="
+    "version": "5.0.6",
+    "hash": "sha256-DN5tG7RSPZwn/c7SdL4OkrlSqT1wrEQmS7Jg7GGEiBo="
   },
   {
     "pname": "NETStandard.Library",
     "version": "1.6.1",
     "hash": "sha256-iNan1ix7RtncGWC9AjAZ2sk70DoxOsmEOgQ10fXm4Pw="
+  },
+  {
+    "pname": "NETStandard.Library.Ref",
+    "version": "2.1.0",
+    "hash": "sha256-Ruovy9EKgXaFuFr3zgw5fRKUS9yBIJ4nLeHgXv0zx4o="
   },
   {
     "pname": "Newtonsoft.Json",
@@ -733,6 +548,11 @@
     "pname": "Newtonsoft.Json",
     "version": "13.0.3",
     "hash": "sha256-hy/BieY4qxBWVVsDqqOPaLy1QobiIapkbrESm6v2PHc="
+  },
+  {
+    "pname": "Newtonsoft.Json",
+    "version": "13.0.4",
+    "hash": "sha256-8JCB1FdAW681qXP6DFDWvycu1oPyVoxaYgpJ2pUvZSk="
   },
   {
     "pname": "Newtonsoft.Json.Bson",
@@ -766,28 +586,28 @@
   },
   {
     "pname": "NLog",
-    "version": "5.3.4",
-    "hash": "sha256-Cwr1Wu9VbOcRz3GdVKkt7lIpNwC1E4Hdb0g+qEkEr3k="
+    "version": "6.0.3",
+    "hash": "sha256-lrF4+wTsVr7/hD9sJVAMk3+zwH7JMoOEw/pCZm3ki4g="
   },
   {
     "pname": "Npgsql",
-    "version": "8.0.6",
-    "hash": "sha256-HebK3NmiuFvq6KfjNwpUs6B/RqA5Uwl9QzTRfaOrK34="
+    "version": "10.0.3",
+    "hash": "sha256-ddCXCSOoyfy7035OvnL+4LEDYqHjZyPoZ3ffG2coMW0="
   },
   {
     "pname": "Npgsql.EntityFrameworkCore.PostgreSQL",
-    "version": "8.0.11",
-    "hash": "sha256-r4BpmSg4HGvA6TnfftY6QQRJsCeUdDsMLE82Oa8eleI="
+    "version": "10.0.3",
+    "hash": "sha256-2ImviEfJ21Dk7pjLJRFCndi5fqDLOl4gkmtGxH3O48Q="
   },
   {
     "pname": "NSec.Cryptography",
-    "version": "22.4.0",
-    "hash": "sha256-TVB8MDXan3dQphaYG/rLQMWgpYJ6WE5ORiqiQrfnCW0="
+    "version": "25.4.0",
+    "hash": "sha256-jwsuS+Kp+sD31S41tTHv/zkFqnzxnGOEty2iZVmBb6E="
   },
   {
     "pname": "QRCoder",
-    "version": "1.6.0",
-    "hash": "sha256-2Ev/6d7PH6K4dVYQQHlZ+ZggkCnDtrlaGygs65mDo28="
+    "version": "1.7.0",
+    "hash": "sha256-sssSQBTHf1cUWNQYFEEJ8PRLs486ciDsXtrwL+ozZIU="
   },
   {
     "pname": "runtime.any.System.Collections",
@@ -795,24 +615,9 @@
     "hash": "sha256-4L3fXzSgw8UaCTvdb3cEyihka3K8JHBz/Ujsx0JdhPQ="
   },
   {
-    "pname": "runtime.any.System.Collections",
-    "version": "4.3.0",
-    "hash": "sha256-4PGZqyWhZ6/HCTF2KddDsbmTTjxs2oW79YfkberDZS8="
-  },
-  {
-    "pname": "runtime.any.System.Diagnostics.Tools",
-    "version": "4.3.0",
-    "hash": "sha256-8yLKFt2wQxkEf7fNfzB+cPUCjYn2qbqNgQ1+EeY2h/I="
-  },
-  {
     "pname": "runtime.any.System.Diagnostics.Tracing",
     "version": "4.1.0",
     "hash": "sha256-+PJZWFl6hkqryCerWVtbG+ppIGvZf2l6fu2HWyGqMRA="
-  },
-  {
-    "pname": "runtime.any.System.Diagnostics.Tracing",
-    "version": "4.3.0",
-    "hash": "sha256-dsmTLGvt8HqRkDWP8iKVXJCS+akAzENGXKPV18W2RgI="
   },
   {
     "pname": "runtime.any.System.Globalization",
@@ -820,24 +625,9 @@
     "hash": "sha256-BgmoUM3WsMUCjtO9KmtjPKsjYRAEVjp74KvEa8zNgAg="
   },
   {
-    "pname": "runtime.any.System.Globalization",
-    "version": "4.3.0",
-    "hash": "sha256-PaiITTFI2FfPylTEk7DwzfKeiA/g/aooSU1pDcdwWLU="
-  },
-  {
-    "pname": "runtime.any.System.Globalization.Calendars",
-    "version": "4.3.0",
-    "hash": "sha256-AYh39tgXJVFu8aLi9Y/4rK8yWMaza4S4eaxjfcuEEL4="
-  },
-  {
     "pname": "runtime.any.System.IO",
     "version": "4.1.0",
     "hash": "sha256-ZbG7B6GOO90k/prj/Z60UGloQUrBepsvmlPQGuV0Wk0="
-  },
-  {
-    "pname": "runtime.any.System.IO",
-    "version": "4.3.0",
-    "hash": "sha256-vej7ySRhyvM3pYh/ITMdC25ivSd0WLZAaIQbYj/6HVE="
   },
   {
     "pname": "runtime.any.System.Reflection",
@@ -845,24 +635,9 @@
     "hash": "sha256-BtdDCQLHDdAgO9qhwE0JBuUqFKc7l9On8p+VlgrQbBo="
   },
   {
-    "pname": "runtime.any.System.Reflection",
-    "version": "4.3.0",
-    "hash": "sha256-ns6f++lSA+bi1xXgmW1JkWFb2NaMD+w+YNTfMvyAiQk="
-  },
-  {
-    "pname": "runtime.any.System.Reflection.Extensions",
-    "version": "4.3.0",
-    "hash": "sha256-Y2AnhOcJwJVYv7Rp6Jz6ma0fpITFqJW+8rsw106K2X8="
-  },
-  {
     "pname": "runtime.any.System.Reflection.Primitives",
     "version": "4.0.1",
     "hash": "sha256-H2ZzRIWLN6FbSh8+q4OXqhssn3nGRnv7/NiV3OO+uf8="
-  },
-  {
-    "pname": "runtime.any.System.Reflection.Primitives",
-    "version": "4.3.0",
-    "hash": "sha256-LkPXtiDQM3BcdYkAm5uSNOiz3uF4J45qpxn5aBiqNXQ="
   },
   {
     "pname": "runtime.any.System.Resources.ResourceManager",
@@ -870,19 +645,9 @@
     "hash": "sha256-eZasny65yEQESxMJHOBaqJQzlrd8CIOIc1ks6+HRr8o="
   },
   {
-    "pname": "runtime.any.System.Resources.ResourceManager",
-    "version": "4.3.0",
-    "hash": "sha256-9EvnmZslLgLLhJ00o5MWaPuJQlbUFcUF8itGQNVkcQ4="
-  },
-  {
     "pname": "runtime.any.System.Runtime",
     "version": "4.1.0",
     "hash": "sha256-FZC+BNSzSkN3rObLJJAqwW/vNnJ+PiwdvNNufuISWVY="
-  },
-  {
-    "pname": "runtime.any.System.Runtime",
-    "version": "4.3.0",
-    "hash": "sha256-qwhNXBaJ1DtDkuRacgHwnZmOZ1u9q7N8j0cWOLYOELM="
   },
   {
     "pname": "runtime.any.System.Runtime.Handles",
@@ -890,19 +655,9 @@
     "hash": "sha256-WlmU4OzK6IpszOCuEb5pdh4dwpkuoBQTYRuT4SF+XM8="
   },
   {
-    "pname": "runtime.any.System.Runtime.Handles",
-    "version": "4.3.0",
-    "hash": "sha256-PQRACwnSUuxgVySO1840KvqCC9F8iI9iTzxNW0RcBS4="
-  },
-  {
     "pname": "runtime.any.System.Runtime.InteropServices",
     "version": "4.1.0",
     "hash": "sha256-H9FNiCk+Qrm+15K+Rje+wnQxwUmkVx60x+FWBoGLqD4="
-  },
-  {
-    "pname": "runtime.any.System.Runtime.InteropServices",
-    "version": "4.3.0",
-    "hash": "sha256-Kaw5PnLYIiqWbsoF3VKJhy7pkpoGsUwn4ZDCKscbbzA="
   },
   {
     "pname": "runtime.any.System.Text.Encoding",
@@ -910,59 +665,9 @@
     "hash": "sha256-pyaH3Lcuv/pEM9NSFWlLcljav/Ksnwwk7cjPEH99m1Q="
   },
   {
-    "pname": "runtime.any.System.Text.Encoding",
-    "version": "4.3.0",
-    "hash": "sha256-Q18B9q26MkWZx68exUfQT30+0PGmpFlDgaF0TnaIGCs="
-  },
-  {
-    "pname": "runtime.any.System.Text.Encoding.Extensions",
-    "version": "4.3.0",
-    "hash": "sha256-6MYj0RmLh4EVqMtO/MRqBi0HOn5iG4x9JimgCCJ+EFM="
-  },
-  {
     "pname": "runtime.any.System.Threading.Tasks",
     "version": "4.0.11",
     "hash": "sha256-c/8eunlNexFpzZ+GvNF0p1hi5Xo0VPo7LnkhjRO47eM="
-  },
-  {
-    "pname": "runtime.any.System.Threading.Tasks",
-    "version": "4.3.0",
-    "hash": "sha256-agdOM0NXupfHbKAQzQT8XgbI9B8hVEh+a/2vqeHctg4="
-  },
-  {
-    "pname": "runtime.any.System.Threading.Timer",
-    "version": "4.3.0",
-    "hash": "sha256-BgHxXCIbicVZtpgMimSXixhFC3V+p5ODqeljDjO8hCs="
-  },
-  {
-    "pname": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-    "version": "4.3.0",
-    "hash": "sha256-LXUPLX3DJxsU1Pd3UwjO1PO9NM2elNEDXeu2Mu/vNps="
-  },
-  {
-    "pname": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-    "version": "4.3.2",
-    "hash": "sha256-EbnOqPOrAgI9eNheXLR++VnY4pHzMsEKw1dFPJ/Fl2c="
-  },
-  {
-    "pname": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-    "version": "4.3.0",
-    "hash": "sha256-qeSqaUI80+lqw5MK4vMpmO0CZaqrmYktwp6L+vQAb0I="
-  },
-  {
-    "pname": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-    "version": "4.3.2",
-    "hash": "sha256-mVg02TNvJc1BuHU03q3fH3M6cMgkKaQPBxraSHl/Btg="
-  },
-  {
-    "pname": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-    "version": "4.3.0",
-    "hash": "sha256-SrHqT9wrCBsxILWtaJgGKd6Odmxm8/Mh7Kh0CUkZVzA="
-  },
-  {
-    "pname": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-    "version": "4.3.2",
-    "hash": "sha256-g9Uiikrl+M40hYe0JMlGHe/lrR0+nN05YF64wzLmBBA="
   },
   {
     "pname": "runtime.native.System",
@@ -970,124 +675,9 @@
     "hash": "sha256-bmaM0ovT4X4aqDJOR255Yda/u3fmHZskU++lMnsy894="
   },
   {
-    "pname": "runtime.native.System",
-    "version": "4.3.0",
-    "hash": "sha256-ZBZaodnjvLXATWpXXakFgcy6P+gjhshFXmglrL5xD5Y="
-  },
-  {
-    "pname": "runtime.native.System.IO.Compression",
-    "version": "4.3.0",
-    "hash": "sha256-DWnXs4vlKoU6WxxvCArTJupV6sX3iBbZh8SbqfHace8="
-  },
-  {
-    "pname": "runtime.native.System.Net.Http",
-    "version": "4.3.0",
-    "hash": "sha256-c556PyheRwpYhweBjSfIwEyZHnAUB8jWioyKEcp/2dg="
-  },
-  {
     "pname": "runtime.native.System.Security.Cryptography",
     "version": "4.0.0",
     "hash": "sha256-6Q8eYzC32BbGIiTHoQaE6B3cD81vYQcH5SCswYRSp0w="
-  },
-  {
-    "pname": "runtime.native.System.Security.Cryptography.Apple",
-    "version": "4.3.0",
-    "hash": "sha256-2IhBv0i6pTcOyr8FFIyfPEaaCHUmJZ8DYwLUwJ+5waw="
-  },
-  {
-    "pname": "runtime.native.System.Security.Cryptography.OpenSsl",
-    "version": "4.3.0",
-    "hash": "sha256-Jy01KhtcCl2wjMpZWH+X3fhHcVn+SyllWFY8zWlz/6I="
-  },
-  {
-    "pname": "runtime.native.System.Security.Cryptography.OpenSsl",
-    "version": "4.3.2",
-    "hash": "sha256-xqF6LbbtpzNC9n1Ua16PnYgXHU0LvblEROTfK4vIxX8="
-  },
-  {
-    "pname": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-    "version": "4.3.0",
-    "hash": "sha256-wyv00gdlqf8ckxEdV7E+Ql9hJIoPcmYEuyeWb5Oz3mM="
-  },
-  {
-    "pname": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-    "version": "4.3.2",
-    "hash": "sha256-aJBu6Frcg6webvzVcKNoUP1b462OAqReF2giTSyBzCQ="
-  },
-  {
-    "pname": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-    "version": "4.3.0",
-    "hash": "sha256-zi+b4sCFrA9QBiSGDD7xPV27r3iHGlV99gpyVUjRmc4="
-  },
-  {
-    "pname": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-    "version": "4.3.2",
-    "hash": "sha256-Mpt7KN2Kq51QYOEVesEjhWcCGTqWckuPf8HlQ110qLY="
-  },
-  {
-    "pname": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
-    "version": "4.3.0",
-    "hash": "sha256-serkd4A7F6eciPiPJtUyJyxzdAtupEcWIZQ9nptEzIM="
-  },
-  {
-    "pname": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-    "version": "4.3.0",
-    "hash": "sha256-gybQU6mPgaWV3rBG2dbH6tT3tBq8mgze3PROdsuWnX0="
-  },
-  {
-    "pname": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-    "version": "4.3.2",
-    "hash": "sha256-JvMltmfVC53mCZtKDHE69G3RT6Id28hnskntP9MMP9U="
-  },
-  {
-    "pname": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-    "version": "4.3.0",
-    "hash": "sha256-VsP72GVveWnGUvS/vjOQLv1U80H2K8nZ4fDAmI61Hm4="
-  },
-  {
-    "pname": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-    "version": "4.3.2",
-    "hash": "sha256-QfFxWTVRNBhN4Dm1XRbCf+soNQpy81PsZed3x6op/bI="
-  },
-  {
-    "pname": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-    "version": "4.3.0",
-    "hash": "sha256-4yKGa/IrNCKuQ3zaDzILdNPD32bNdy6xr5gdJigyF5g="
-  },
-  {
-    "pname": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-    "version": "4.3.2",
-    "hash": "sha256-EaJHVc9aDZ6F7ltM2JwlIuiJvqM67CKRq682iVSo+pU="
-  },
-  {
-    "pname": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-    "version": "4.3.0",
-    "hash": "sha256-HmdJhhRsiVoOOCcUvAwdjpMRiyuSwdcgEv2j9hxi+Zc="
-  },
-  {
-    "pname": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-    "version": "4.3.2",
-    "hash": "sha256-PHR0+6rIjJswn89eoiWYY1DuU8u6xRJLrtjykAMuFmA="
-  },
-  {
-    "pname": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-    "version": "4.3.0",
-    "hash": "sha256-pVFUKuPPIx0edQKjzRon3zKq8zhzHEzko/lc01V/jdw="
-  },
-  {
-    "pname": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
-    "version": "4.3.2",
-    "hash": "sha256-LFkh7ua7R4rI5w2KGjcHlGXLecsncCy6kDXLuy4qD/Q="
-  },
-  {
-    "pname": "runtime.unix.Microsoft.Win32.Primitives",
-    "version": "4.3.0",
-    "hash": "sha256-LZb23lRXzr26tRS5aA0xyB08JxiblPDoA7HBvn6awXg="
-  },
-  {
-    "pname": "runtime.unix.System.Console",
-    "version": "4.3.1",
-    "hash": "sha256-dxyn/1Px4FKLZ2QMUrkFpW619Y1lhPeTiGLWYM6IbpY="
   },
   {
     "pname": "runtime.unix.System.Diagnostics.Debug",
@@ -1095,34 +685,9 @@
     "hash": "sha256-TTzJP6sR0/mDbbU3+ySnt9LVEcPPLfiAzxnfTaJazRY="
   },
   {
-    "pname": "runtime.unix.System.Diagnostics.Debug",
-    "version": "4.3.0",
-    "hash": "sha256-ReoazscfbGH+R6s6jkg5sIEHWNEvjEoHtIsMbpc7+tI="
-  },
-  {
-    "pname": "runtime.unix.System.IO.FileSystem",
-    "version": "4.3.0",
-    "hash": "sha256-Pf4mRl6YDK2x2KMh0WdyNgv0VUNdSKVDLlHqozecy5I="
-  },
-  {
-    "pname": "runtime.unix.System.Net.Primitives",
-    "version": "4.3.0",
-    "hash": "sha256-pHJ+I6i16MV6m77uhTC6GPY6jWGReE3SSP3fVB59ti0="
-  },
-  {
-    "pname": "runtime.unix.System.Net.Sockets",
-    "version": "4.3.0",
-    "hash": "sha256-IvgOeA2JuBjKl5yAVGjPYMPDzs9phb3KANs95H9v1w4="
-  },
-  {
     "pname": "runtime.unix.System.Private.Uri",
     "version": "4.0.1",
     "hash": "sha256-1Q50COfWkU4/y9eBWj0jPDp3qvy19vRCZnDKQthrhUU="
-  },
-  {
-    "pname": "runtime.unix.System.Private.Uri",
-    "version": "4.3.0",
-    "hash": "sha256-c5tXWhE/fYbJVl9rXs0uHh3pTsg44YD1dJvyOA0WoMs="
   },
   {
     "pname": "runtime.unix.System.Runtime.Extensions",
@@ -1130,54 +695,49 @@
     "hash": "sha256-xB8TkAadhz7gi8Ag3+uYtLdfjtxO8dCLrd/FzU7jLHQ="
   },
   {
-    "pname": "runtime.unix.System.Runtime.Extensions",
-    "version": "4.3.0",
-    "hash": "sha256-l8S9gt6dk3qYG6HYonHtdlYtBKyPb29uQ6NDjmrt3V4="
-  },
-  {
     "pname": "Serilog",
-    "version": "3.1.1",
-    "hash": "sha256-L263y8jkn7dNFD2jAUK6mgvyRTqFe39i1tRhVZsNZTI="
+    "version": "4.3.0",
+    "hash": "sha256-jyIy4BjsyFXge3aO4GRFAdnX4/rz1MHfBkBDIpCDsTw="
   },
   {
     "pname": "Serilog.AspNetCore",
-    "version": "8.0.0",
-    "hash": "sha256-0V4BmXmKeSy5ND5aONhSW3iL/+fZ2jB781HdooJlOjw="
+    "version": "10.0.0",
+    "hash": "sha256-z7dY6pY2Kkns20mpzZN2GOfV172gDWpamKDXHyLhEJs="
   },
   {
     "pname": "Serilog.Extensions.Hosting",
-    "version": "8.0.0",
-    "hash": "sha256-OEVkEQoONawJF+SXeyqqgU0OGp9ubtt9aXT+rC25j4E="
+    "version": "10.0.0",
+    "hash": "sha256-zFQMZkAPqg+j2ZI0oBN07hO+9MFiyy5YECRbz7msxeU="
   },
   {
     "pname": "Serilog.Extensions.Logging",
-    "version": "8.0.0",
-    "hash": "sha256-GoWxCpkdahMvYd7ZrhwBxxTyjHGcs9ENNHJCp0la6iA="
+    "version": "10.0.0",
+    "hash": "sha256-MgfWK/SJWUPxPzrnCUnxn6Sy+SBVmP3dYd60uy80NdE="
   },
   {
     "pname": "Serilog.Formatting.Compact",
-    "version": "2.0.0",
-    "hash": "sha256-c3STGleyMijY4QnxPuAz/NkJs1r+TZAPjlmAKLF4+3g="
+    "version": "3.0.0",
+    "hash": "sha256-nejEYqJEMG9P2iFZvbsCUPr5LZRtxbdUTLCI9N71jHY="
   },
   {
     "pname": "Serilog.Settings.Configuration",
-    "version": "8.0.0",
-    "hash": "sha256-JQ39fvhOFSUHE6r9DXJvLaZI+Lk7AYzuskQu3ux+hQg="
+    "version": "10.0.0",
+    "hash": "sha256-WJK+wR7XPGAtD+vO+pjF5mn4qy8tO5uWIqHhovL0lAs="
   },
   {
     "pname": "Serilog.Sinks.Console",
-    "version": "5.0.0",
-    "hash": "sha256-UOVlegJLhs0vK1ml2DZCjFE5roDRZsGCAqD/53ZaZWI="
+    "version": "6.1.1",
+    "hash": "sha256-CfIg4Us4kSMQAn6rU2rsAeE22g6MpFiZdhoZWySpZeY="
   },
   {
     "pname": "Serilog.Sinks.Debug",
-    "version": "2.0.0",
-    "hash": "sha256-/PLVAE33lTdUEXdahkI5ddFiGZufWnvfsOodQsFB8sQ="
+    "version": "3.0.0",
+    "hash": "sha256-7/LmoRF1rUDFhJ47bTRQQFRgSHnZDO8484r3sCGqYvE="
   },
   {
     "pname": "Serilog.Sinks.File",
-    "version": "5.0.1-dev-00968",
-    "hash": "sha256-gXrvlnNVi2TKtsFfjqoPkGZS3JM+p6vjvy3p2by/4A4="
+    "version": "7.0.0",
+    "hash": "sha256-LxZYUoUPkCjIIVarJilnXnqQiMrFNJtoRilmzTNtUjo="
   },
   {
     "pname": "SocketIO.Core",
@@ -1201,33 +761,13 @@
   },
   {
     "pname": "SSH.NET",
-    "version": "2023.0.0",
-    "hash": "sha256-YiAfBOu8KLKPFk4humKCe+Ne79ppxdODKXgjbcni8po="
-  },
-  {
-    "pname": "SshNet.Security.Cryptography",
-    "version": "1.3.0",
-    "hash": "sha256-kDpV7/n4plAPh+FqsPbCA/kFHHfmJGsJDTQg2wRLOfk="
-  },
-  {
-    "pname": "System.AppContext",
-    "version": "4.3.0",
-    "hash": "sha256-yg95LNQOwFlA1tWxXdQkVyJqT4AnoDc+ACmrNvzGiZg="
-  },
-  {
-    "pname": "System.Buffers",
-    "version": "4.3.0",
-    "hash": "sha256-XqZWb4Kd04960h4U9seivjKseGA/YEIpdplfHYHQ9jk="
-  },
-  {
-    "pname": "System.Buffers",
-    "version": "4.5.1",
-    "hash": "sha256-wws90sfi9M7kuCPWkv1CEYMJtCqx9QB/kj0ymlsNaxI="
+    "version": "2025.1.0",
+    "hash": "sha256-vtpvE5B+IxoMkq9CQMehoR5ZRtihaHQ4VyhmkkIjL98="
   },
   {
     "pname": "System.CodeDom",
-    "version": "4.4.0",
-    "hash": "sha256-L1xyspJ8pDJNVPYKl+FMGf4Zwm0tlqtAyQCNW6pT6/0="
+    "version": "6.0.0",
+    "hash": "sha256-uPetUFZyHfxjScu5x4agjk9pIhbCkt5rG4Axj25npcQ="
   },
   {
     "pname": "System.Collections",
@@ -1235,74 +775,44 @@
     "hash": "sha256-puoFMkx4Z55C1XPxNw3np8nzNGjH+G24j43yTIsDRL0="
   },
   {
-    "pname": "System.Collections",
-    "version": "4.3.0",
-    "hash": "sha256-afY7VUtD6w/5mYqrce8kQrvDIfS2GXDINDh73IjxJKc="
-  },
-  {
     "pname": "System.Collections.Concurrent",
     "version": "4.0.12",
     "hash": "sha256-zIEM7AB4SyE9u6G8+o+gCLLwkgi6+3rHQVPdn/dEwB8="
   },
   {
-    "pname": "System.Collections.Concurrent",
-    "version": "4.3.0",
-    "hash": "sha256-KMY5DfJnDeIsa13DpqvyN8NkReZEMAFnlmNglVoFIXI="
-  },
-  {
-    "pname": "System.Collections.Immutable",
-    "version": "5.0.0",
-    "hash": "sha256-GdwSIjLMM0uVfE56VUSLVNgpW0B//oCeSFj8/hSlbM8="
-  },
-  {
-    "pname": "System.Collections.Immutable",
-    "version": "6.0.0",
-    "hash": "sha256-DKEbpFqXCIEfqp9p3ezqadn5b/S1YTk32/EQK+tEScs="
-  },
-  {
-    "pname": "System.Collections.Immutable",
-    "version": "8.0.0",
-    "hash": "sha256-F7OVjKNwpqbUh8lTidbqJWYi476nsq9n+6k0+QVRo3w="
-  },
-  {
     "pname": "System.Composition",
-    "version": "6.0.0",
-    "hash": "sha256-H5TnnxOwihI0VyRuykbOWuKFSCWNN+MUEYyloa328Nw="
+    "version": "9.0.0",
+    "hash": "sha256-FehOkQ2u1p8mQ0/wn3cZ+24HjhTLdck8VZYWA1CcgbM="
   },
   {
     "pname": "System.Composition.AttributedModel",
-    "version": "6.0.0",
-    "hash": "sha256-03DR8ecEHSKfgzwuTuxtsRW0Gb7aQtDS4LAYChZdGdc="
+    "version": "9.0.0",
+    "hash": "sha256-a7y7H6zj+kmYkllNHA402DoVfY9IaqC3Ooys8Vzl24M="
   },
   {
     "pname": "System.Composition.Convention",
-    "version": "6.0.0",
-    "hash": "sha256-a3DZS8CT2kV8dVpGxHKoP5wHVKsT+kiPJixckpYfdQo="
+    "version": "9.0.0",
+    "hash": "sha256-tw4vE5JRQ60ubTZBbxoMPhtjOQCC3XoDFUH7NHO7o8U="
   },
   {
     "pname": "System.Composition.Hosting",
-    "version": "6.0.0",
-    "hash": "sha256-fpoh6WBNmaHEHszwlBR/TNjd85lwesfM7ZkQhqYtLy4="
+    "version": "9.0.0",
+    "hash": "sha256-oOxU+DPEEfMCuNLgW6wSkZp0JY5gYt44FJNnWt+967s="
   },
   {
     "pname": "System.Composition.Runtime",
-    "version": "6.0.0",
-    "hash": "sha256-nGZvg2xYhhazAjOjhWqltBue+hROKP0IOiFGP8yMBW8="
+    "version": "9.0.0",
+    "hash": "sha256-AyIe+di1TqwUBbSJ/sJ8Q8tzsnTN+VBdJw4K8xZz43s="
   },
   {
     "pname": "System.Composition.TypedParts",
-    "version": "6.0.0",
-    "hash": "sha256-4uAETfmL1CvGjHajzWowsEmJgTKnuFC8u9lbYPzAN3k="
+    "version": "9.0.0",
+    "hash": "sha256-F5fpTUs3Rr7yP/NyIzr+Xn5NdTXXp8rrjBnF9UBBUog="
   },
   {
     "pname": "System.Configuration.ConfigurationManager",
-    "version": "9.0.0",
-    "hash": "sha256-+pLnTC0YDP6Kjw5DVBiFrV/Q3x5is/+6N6vAtjvhVWk="
-  },
-  {
-    "pname": "System.Console",
-    "version": "4.3.0",
-    "hash": "sha256-Xh3PPBZr0pDbDaK8AEHbdGz7ePK6Yi1ZyRWI1JM6mbo="
+    "version": "9.0.8",
+    "hash": "sha256-i9i8sf1yUj0c1C+Kukl0e3bBHGo1sdvayftw2FoYXtA="
   },
   {
     "pname": "System.Diagnostics.Debug",
@@ -1310,59 +820,14 @@
     "hash": "sha256-P+rSQJVoN6M56jQbs76kZ9G3mAWFdtF27P/RijN8sj4="
   },
   {
-    "pname": "System.Diagnostics.Debug",
-    "version": "4.3.0",
-    "hash": "sha256-fkA79SjPbSeiEcrbbUsb70u9B7wqbsdM9s1LnoKj0gM="
-  },
-  {
-    "pname": "System.Diagnostics.DiagnosticSource",
-    "version": "4.3.0",
-    "hash": "sha256-OFJRb0ygep0Z3yDBLwAgM/Tkfs4JCDtsNhwDH9cd1Xw="
-  },
-  {
-    "pname": "System.Diagnostics.DiagnosticSource",
-    "version": "6.0.0",
-    "hash": "sha256-RY9uWSPdK2fgSwlj1OHBGBVo3ZvGQgBJNzAsS5OGMWc="
-  },
-  {
-    "pname": "System.Diagnostics.DiagnosticSource",
-    "version": "6.0.1",
-    "hash": "sha256-Xi8wrUjVlioz//TPQjFHqcV/QGhTqnTfUcltsNlcCJ4="
-  },
-  {
-    "pname": "System.Diagnostics.DiagnosticSource",
-    "version": "8.0.0",
-    "hash": "sha256-+aODaDEQMqla5RYZeq0Lh66j+xkPYxykrVvSCmJQ+Vs="
-  },
-  {
-    "pname": "System.Diagnostics.EventLog",
-    "version": "9.0.0",
-    "hash": "sha256-tPvt6yoAp56sK/fe+/ei8M65eavY2UUhRnbrREj/Ems="
-  },
-  {
-    "pname": "System.Diagnostics.Tools",
-    "version": "4.3.0",
-    "hash": "sha256-gVOv1SK6Ape0FQhCVlNOd9cvQKBvMxRX9K0JPVi8w0Y="
-  },
-  {
     "pname": "System.Diagnostics.Tracing",
     "version": "4.1.0",
     "hash": "sha256-JA0jJcLbU3zh52ub3zweob2EVHvxOqiC6SCYHrY5WbQ="
   },
   {
-    "pname": "System.Diagnostics.Tracing",
-    "version": "4.3.0",
-    "hash": "sha256-hCETZpHHGVhPYvb4C0fh4zs+8zv4GPoixagkLZjpa9Q="
-  },
-  {
-    "pname": "System.Formats.Asn1",
-    "version": "8.0.1",
-    "hash": "sha256-may/Wg+esmm1N14kQTG4ESMBi+GQKPp0ZrrBo/o6OXM="
-  },
-  {
-    "pname": "System.Formats.Cbor",
+    "pname": "System.Drawing.Common",
     "version": "6.0.0",
-    "hash": "sha256-cm27ykIUZ/Ypj8/R73gd+mluE7m/WZFNlTsY5sYjAqQ="
+    "hash": "sha256-/9EaAbEeOjELRSMZaImS1O8FmUe8j4WuFUw1VOrPyAo="
   },
   {
     "pname": "System.Globalization",
@@ -1370,29 +835,9 @@
     "hash": "sha256-rbSgc2PIEc2c2rN6LK3qCREAX3DqA2Nq1WcLrZYsDBw="
   },
   {
-    "pname": "System.Globalization",
-    "version": "4.3.0",
-    "hash": "sha256-caL0pRmFSEsaoeZeWN5BTQtGrAtaQPwFi8YOZPZG5rI="
-  },
-  {
-    "pname": "System.Globalization.Calendars",
-    "version": "4.3.0",
-    "hash": "sha256-uNOD0EOVFgnS2fMKvMiEtI9aOw00+Pfy/H+qucAQlPc="
-  },
-  {
-    "pname": "System.Globalization.Extensions",
-    "version": "4.3.0",
-    "hash": "sha256-mmJWA27T0GRVuFP9/sj+4TrR4GJWrzNIk2PDrbr7RQk="
-  },
-  {
     "pname": "System.IdentityModel.Tokens.Jwt",
-    "version": "6.17.0",
-    "hash": "sha256-H3n0I6H3d5TmaVQ6kUZQ1/8BFrsQcVrwxAoty3eKTfg="
-  },
-  {
-    "pname": "System.IdentityModel.Tokens.Jwt",
-    "version": "8.2.1",
-    "hash": "sha256-osV3VbG9k5Jb4XSlUsDxqbMEASNR3c7DA6+AKVXVhHQ="
+    "version": "8.13.1",
+    "hash": "sha256-v0JRCOzoOoaWRYd+5M/xd/MIorTjUXgFuNWxCX9j5ZA="
   },
   {
     "pname": "System.IO",
@@ -1400,44 +845,9 @@
     "hash": "sha256-V6oyQFwWb8NvGxAwvzWnhPxy9dKOfj/XBM3tEC5aHrw="
   },
   {
-    "pname": "System.IO",
-    "version": "4.3.0",
-    "hash": "sha256-ruynQHekFP5wPrDiVyhNiRIXeZ/I9NpjK5pU+HPDiRY="
-  },
-  {
-    "pname": "System.IO.Compression",
-    "version": "4.3.0",
-    "hash": "sha256-f5PrQlQgj5Xj2ZnHxXW8XiOivaBvfqDao9Sb6AVinyA="
-  },
-  {
-    "pname": "System.IO.Compression.ZipFile",
-    "version": "4.3.0",
-    "hash": "sha256-WQl+JgWs+GaRMeiahTFUbrhlXIHapzcpTFXbRvAtvvs="
-  },
-  {
-    "pname": "System.IO.FileSystem",
-    "version": "4.3.0",
-    "hash": "sha256-vNIYnvlayuVj0WfRfYKpDrhDptlhp1pN8CYmlVd2TXw="
-  },
-  {
-    "pname": "System.IO.FileSystem.Primitives",
-    "version": "4.3.0",
-    "hash": "sha256-LMnfg8Vwavs9cMnq9nNH8IWtAtSfk0/Fy4s4Rt9r1kg="
-  },
-  {
     "pname": "System.IO.Hashing",
     "version": "6.0.0",
     "hash": "sha256-gSxLJ/ujWthLknylguRv40mwMl/qNcqnFI9SNjQY6lE="
-  },
-  {
-    "pname": "System.IO.Pipelines",
-    "version": "6.0.3",
-    "hash": "sha256-v+FOmjRRKlDtDW6+TfmyMiiki010YGVTa0EwXu9X7ck="
-  },
-  {
-    "pname": "System.IO.Pipelines",
-    "version": "8.0.0",
-    "hash": "sha256-LdpB1s4vQzsOODaxiKstLks57X9DTD5D6cPx8DE1wwE="
   },
   {
     "pname": "System.Linq",
@@ -1445,64 +855,9 @@
     "hash": "sha256-ZQpFtYw5N1F1aX0jUK3Tw+XvM5tnlnshkTCNtfVA794="
   },
   {
-    "pname": "System.Linq",
-    "version": "4.3.0",
-    "hash": "sha256-R5uiSL3l6a3XrXSSL6jz+q/PcyVQzEAByiuXZNSqD/A="
-  },
-  {
-    "pname": "System.Linq.Expressions",
-    "version": "4.3.0",
-    "hash": "sha256-+3pvhZY7rip8HCbfdULzjlC9FPZFpYoQxhkcuFm2wk8="
-  },
-  {
-    "pname": "System.Memory",
-    "version": "4.5.4",
-    "hash": "sha256-3sCEfzO4gj5CYGctl9ZXQRRhwAraMQfse7yzKoRe65E="
-  },
-  {
-    "pname": "System.Memory",
-    "version": "4.5.5",
-    "hash": "sha256-EPQ9o1Kin7KzGI5O3U3PUQAZTItSbk9h/i4rViN3WiI="
-  },
-  {
     "pname": "System.Memory.Data",
     "version": "1.0.2",
     "hash": "sha256-XiVrVQZQIz4NgjiK/wtH8iZhhOZ9MJ+X2hL2/8BrGN0="
-  },
-  {
-    "pname": "System.Net.Http",
-    "version": "4.3.0",
-    "hash": "sha256-UoBB7WPDp2Bne/fwxKF0nE8grJ6FzTMXdT/jfsphj8Q="
-  },
-  {
-    "pname": "System.Net.Http",
-    "version": "4.3.4",
-    "hash": "sha256-FMoU0K7nlPLxoDju0NL21Wjlga9GpnAoQjsFhFYYt00="
-  },
-  {
-    "pname": "System.Net.NameResolution",
-    "version": "4.3.0",
-    "hash": "sha256-eGZwCBExWsnirWBHyp2sSSSXp6g7I6v53qNmwPgtJ5c="
-  },
-  {
-    "pname": "System.Net.Primitives",
-    "version": "4.3.0",
-    "hash": "sha256-MY7Z6vOtFMbEKaLW9nOSZeAjcWpwCtdO7/W1mkGZBzE="
-  },
-  {
-    "pname": "System.Net.Sockets",
-    "version": "4.3.0",
-    "hash": "sha256-il7dr5VT/QWDg/0cuh+4Es2u8LY//+qqiY9BZmYxSus="
-  },
-  {
-    "pname": "System.Numerics.Vectors",
-    "version": "4.5.0",
-    "hash": "sha256-qdSTIFgf2htPS+YhLGjAGiLN8igCYJnCCo6r78+Q+c8="
-  },
-  {
-    "pname": "System.ObjectModel",
-    "version": "4.3.0",
-    "hash": "sha256-gtmRkWP2Kwr3nHtDh0yYtce38z1wrGzb6fjm4v8wN6Q="
   },
   {
     "pname": "System.Private.Uri",
@@ -1510,54 +865,9 @@
     "hash": "sha256-MjVaZHx8DUFnVUxOEEaU9GxF6EyEXbcuI1V7yRXEp0w="
   },
   {
-    "pname": "System.Private.Uri",
-    "version": "4.3.0",
-    "hash": "sha256-fVfgcoP4AVN1E5wHZbKBIOPYZ/xBeSIdsNF+bdukIRM="
-  },
-  {
     "pname": "System.Reflection",
     "version": "4.1.0",
     "hash": "sha256-idZHGH2Yl/hha1CM4VzLhsaR8Ljo/rV7TYe7mwRJSMs="
-  },
-  {
-    "pname": "System.Reflection",
-    "version": "4.3.0",
-    "hash": "sha256-NQSZRpZLvtPWDlvmMIdGxcVuyUnw92ZURo0hXsEshXY="
-  },
-  {
-    "pname": "System.Reflection.Emit",
-    "version": "4.3.0",
-    "hash": "sha256-5LhkDmhy2FkSxulXR+bsTtMzdU3VyyuZzsxp7/DwyIU="
-  },
-  {
-    "pname": "System.Reflection.Emit.ILGeneration",
-    "version": "4.3.0",
-    "hash": "sha256-mKRknEHNls4gkRwrEgi39B+vSaAz/Gt3IALtS98xNnA="
-  },
-  {
-    "pname": "System.Reflection.Emit.Lightweight",
-    "version": "4.3.0",
-    "hash": "sha256-rKx4a9yZKcajloSZHr4CKTVJ6Vjh95ni+zszPxWjh2I="
-  },
-  {
-    "pname": "System.Reflection.Extensions",
-    "version": "4.3.0",
-    "hash": "sha256-mMOCYzUenjd4rWIfq7zIX9PFYk/daUyF0A8l1hbydAk="
-  },
-  {
-    "pname": "System.Reflection.Metadata",
-    "version": "5.0.0",
-    "hash": "sha256-Wo+MiqhcP9dQ6NuFGrQTw6hpbJORFwp+TBNTq2yhGp8="
-  },
-  {
-    "pname": "System.Reflection.Metadata",
-    "version": "6.0.1",
-    "hash": "sha256-id27sU4qIEIpgKenO5b4IHt6L1XuNsVe4TR9TKaLWDo="
-  },
-  {
-    "pname": "System.Reflection.Metadata",
-    "version": "8.0.0",
-    "hash": "sha256-dQGC30JauIDWNWXMrSNOJncVa1umR1sijazYwUDdSIE="
   },
   {
     "pname": "System.Reflection.Primitives",
@@ -1565,24 +875,9 @@
     "hash": "sha256-SFSfpWEyCBMAOerrMCOiKnpT+UAWTvRcmoRquJR6Vq0="
   },
   {
-    "pname": "System.Reflection.Primitives",
-    "version": "4.3.0",
-    "hash": "sha256-5ogwWB4vlQTl3jjk1xjniG2ozbFIjZTL9ug0usZQuBM="
-  },
-  {
-    "pname": "System.Reflection.TypeExtensions",
-    "version": "4.3.0",
-    "hash": "sha256-4U4/XNQAnddgQIHIJq3P2T80hN0oPdU2uCeghsDTWng="
-  },
-  {
     "pname": "System.Resources.ResourceManager",
     "version": "4.0.1",
     "hash": "sha256-cZ2/3/fczLjEpn6j3xkgQV9ouOVjy4Kisgw5xWw9kSw="
-  },
-  {
-    "pname": "System.Resources.ResourceManager",
-    "version": "4.3.0",
-    "hash": "sha256-idiOD93xbbrbwwSnD4mORA9RYi/D/U48eRUsn/WnWGo="
   },
   {
     "pname": "System.Runtime",
@@ -1590,34 +885,9 @@
     "hash": "sha256-FViNGM/4oWtlP6w0JC0vJU+k9efLKZ+yaXrnEeabDQo="
   },
   {
-    "pname": "System.Runtime",
-    "version": "4.3.0",
-    "hash": "sha256-51813WXpBIsuA6fUtE5XaRQjcWdQ2/lmEokJt97u0Rg="
-  },
-  {
-    "pname": "System.Runtime",
-    "version": "4.3.1",
-    "hash": "sha256-R9T68AzS1PJJ7v6ARz9vo88pKL1dWqLOANg4pkQjkA0="
-  },
-  {
-    "pname": "System.Runtime.CompilerServices.Unsafe",
-    "version": "5.0.0",
-    "hash": "sha256-neARSpLPUzPxEKhJRwoBzhPxK+cKIitLx7WBYncsYgo="
-  },
-  {
-    "pname": "System.Runtime.CompilerServices.Unsafe",
-    "version": "6.0.0",
-    "hash": "sha256-bEG1PnDp7uKYz/OgLOWs3RWwQSVYm+AnPwVmAmcgp2I="
-  },
-  {
     "pname": "System.Runtime.Extensions",
     "version": "4.1.0",
     "hash": "sha256-X7DZ5CbPY7jHs20YZ7bmcXs9B5Mxptu/HnBUvUnNhGc="
-  },
-  {
-    "pname": "System.Runtime.Extensions",
-    "version": "4.3.0",
-    "hash": "sha256-wLDHmozr84v1W2zYCWYxxj0FR0JDYHSVRaRuDm0bd/o="
   },
   {
     "pname": "System.Runtime.Handles",
@@ -1625,94 +895,19 @@
     "hash": "sha256-j2QgVO9ZOjv7D1het98CoFpjoYgxjupuIhuBUmLLH7w="
   },
   {
-    "pname": "System.Runtime.Handles",
-    "version": "4.3.0",
-    "hash": "sha256-KJ5aXoGpB56Y6+iepBkdpx/AfaJDAitx4vrkLqR7gms="
-  },
-  {
     "pname": "System.Runtime.InteropServices",
     "version": "4.1.0",
     "hash": "sha256-QceAYlJvkPRJc/+5jR+wQpNNI3aqGySWWSO30e/FfQY="
   },
   {
-    "pname": "System.Runtime.InteropServices",
-    "version": "4.3.0",
-    "hash": "sha256-8sDH+WUJfCR+7e4nfpftj/+lstEiZixWUBueR2zmHgI="
-  },
-  {
-    "pname": "System.Runtime.InteropServices.RuntimeInformation",
-    "version": "4.3.0",
-    "hash": "sha256-MYpl6/ZyC6hjmzWRIe+iDoldOMW1mfbwXsduAnXIKGA="
-  },
-  {
-    "pname": "System.Runtime.Numerics",
-    "version": "4.3.0",
-    "hash": "sha256-P5jHCgMbgFMYiONvzmaKFeOqcAIDPu/U8bOVrNPYKqc="
-  },
-  {
-    "pname": "System.Security.Claims",
-    "version": "4.3.0",
-    "hash": "sha256-Fua/rDwAqq4UByRVomAxMPmDBGd5eImRqHVQIeSxbks="
-  },
-  {
-    "pname": "System.Security.Cryptography.Algorithms",
-    "version": "4.3.0",
-    "hash": "sha256-tAJvNSlczYBJ3Ed24Ae27a55tq/n4D3fubNQdwcKWA8="
-  },
-  {
-    "pname": "System.Security.Cryptography.Cng",
-    "version": "4.3.0",
-    "hash": "sha256-u17vy6wNhqok91SrVLno2M1EzLHZm6VMca85xbVChsw="
-  },
-  {
-    "pname": "System.Security.Cryptography.Cng",
-    "version": "4.5.0",
-    "hash": "sha256-9llRbEcY1fHYuTn3vGZaCxsFxSAqXl4bDA6Rz9b0pN4="
-  },
-  {
-    "pname": "System.Security.Cryptography.Csp",
-    "version": "4.3.0",
-    "hash": "sha256-oefdTU/Z2PWU9nlat8uiRDGq/PGZoSPRgkML11pmvPQ="
-  },
-  {
-    "pname": "System.Security.Cryptography.Encoding",
-    "version": "4.3.0",
-    "hash": "sha256-Yuge89N6M+NcblcvXMeyHZ6kZDfwBv3LPMDiF8HhJss="
-  },
-  {
-    "pname": "System.Security.Cryptography.OpenSsl",
-    "version": "4.3.0",
-    "hash": "sha256-DL+D2sc2JrQiB4oAcUggTFyD8w3aLEjJfod5JPe+Oz4="
-  },
-  {
     "pname": "System.Security.Cryptography.Pkcs",
-    "version": "8.0.0",
-    "hash": "sha256-yqfIIeZchsII2KdcxJyApZNzxM/VKknjs25gDWlweBI="
-  },
-  {
-    "pname": "System.Security.Cryptography.Primitives",
-    "version": "4.3.0",
-    "hash": "sha256-fnFi7B3SnVj5a+BbgXnbjnGNvWrCEU6Hp/wjsjWz318="
+    "version": "10.0.0",
+    "hash": "sha256-d3sLG+LZ3+N/h/6gdJcVKOgbBO6wYb66NfXalAEDqnE="
   },
   {
     "pname": "System.Security.Cryptography.ProtectedData",
-    "version": "9.0.0",
-    "hash": "sha256-gPgPU7k/InTqmXoRzQfUMEKL3QuTnOKowFqmXTnWaBQ="
-  },
-  {
-    "pname": "System.Security.Cryptography.X509Certificates",
-    "version": "4.3.0",
-    "hash": "sha256-MG3V/owDh273GCUPsGGraNwaVpcydupl3EtPXj6TVG0="
-  },
-  {
-    "pname": "System.Security.Principal",
-    "version": "4.3.0",
-    "hash": "sha256-rjudVUHdo8pNJg2EVEn0XxxwNo5h2EaYo+QboPkXlYk="
-  },
-  {
-    "pname": "System.Security.Principal.Windows",
-    "version": "4.3.0",
-    "hash": "sha256-mbdLVUcEwe78p3ZnB6jYsizNEqxMaCAWI3tEQNhRQAE="
+    "version": "9.0.8",
+    "hash": "sha256-2My/dEWSuQ9SRGc4USEbZj25mafyORGjOS7CJguOc68="
   },
   {
     "pname": "System.Text.Encoding",
@@ -1720,79 +915,9 @@
     "hash": "sha256-PEailOvG05CVgPTyKLtpAgRydlSHmtd5K0Y8GSHY2Lc="
   },
   {
-    "pname": "System.Text.Encoding",
-    "version": "4.3.0",
-    "hash": "sha256-GctHVGLZAa/rqkBNhsBGnsiWdKyv6VDubYpGkuOkBLg="
-  },
-  {
-    "pname": "System.Text.Encoding.CodePages",
-    "version": "4.5.1",
-    "hash": "sha256-PIhkv59IXjyiuefdhKxS9hQfEwO9YWRuNudpo53HQfw="
-  },
-  {
-    "pname": "System.Text.Encoding.CodePages",
-    "version": "6.0.0",
-    "hash": "sha256-nGc2A6XYnwqGcq8rfgTRjGr+voISxNe/76k2K36coj4="
-  },
-  {
-    "pname": "System.Text.Encoding.Extensions",
-    "version": "4.3.0",
-    "hash": "sha256-vufHXg8QAKxHlujPHHcrtGwAqFmsCD6HKjfDAiHyAYc="
-  },
-  {
-    "pname": "System.Text.Encodings.Web",
-    "version": "4.7.2",
-    "hash": "sha256-CUZOulSeRy1CGBm7mrNrTumA9od9peKiIDR/Nb1B4io="
-  },
-  {
-    "pname": "System.Text.Encodings.Web",
-    "version": "8.0.0",
-    "hash": "sha256-IUQkQkV9po1LC0QsqrilqwNzPvnc+4eVvq+hCvq8fvE="
-  },
-  {
-    "pname": "System.Text.Json",
-    "version": "4.7.2",
-    "hash": "sha256-xA8PZwxX9iOJvPbfdi7LWjM2RMVJ7hmtEqS9JvgNsoM="
-  },
-  {
-    "pname": "System.Text.Json",
-    "version": "5.0.2",
-    "hash": "sha256-3eHI5WsaclD9/iV4clLtSAurQxpcJ/qsZA82lkTjoG0="
-  },
-  {
-    "pname": "System.Text.Json",
-    "version": "8.0.0",
-    "hash": "sha256-XFcCHMW1u2/WujlWNHaIWkbW1wn8W4kI0QdrwPtWmow="
-  },
-  {
-    "pname": "System.Text.Json",
-    "version": "8.0.5",
-    "hash": "sha256-yKxo54w5odWT6nPruUVsaX53oPRe+gKzGvLnnxtwP68="
-  },
-  {
-    "pname": "System.Text.RegularExpressions",
-    "version": "4.3.1",
-    "hash": "sha256-DxsEZ0nnPozyC1W164yrMUXwnAdHShS9En7ImD/GJMM="
-  },
-  {
     "pname": "System.Threading",
     "version": "4.0.11",
     "hash": "sha256-mob1Zv3qLQhQ1/xOLXZmYqpniNUMCfn02n8ZkaAhqac="
-  },
-  {
-    "pname": "System.Threading",
-    "version": "4.3.0",
-    "hash": "sha256-ZDQ3dR4pzVwmaqBg4hacZaVenQ/3yAF/uV7BXZXjiWc="
-  },
-  {
-    "pname": "System.Threading.Channels",
-    "version": "6.0.0",
-    "hash": "sha256-klGYnsyrjvXaGeqgfnMf/dTAMNtcHY+zM4Xh6v2JfuE="
-  },
-  {
-    "pname": "System.Threading.Channels",
-    "version": "8.0.0",
-    "hash": "sha256-c5TYoLNXDLroLIPnlfyMHk7nZ70QAckc/c7V199YChg="
   },
   {
     "pname": "System.Threading.Tasks",
@@ -1800,68 +925,33 @@
     "hash": "sha256-5SLxzFg1df6bTm2t09xeI01wa5qQglqUwwJNlQPJIVs="
   },
   {
-    "pname": "System.Threading.Tasks",
-    "version": "4.3.0",
-    "hash": "sha256-Z5rXfJ1EXp3G32IKZGiZ6koMjRu0n8C1NGrwpdIen4w="
-  },
-  {
-    "pname": "System.Threading.Tasks.Extensions",
-    "version": "4.3.0",
-    "hash": "sha256-X2hQ5j+fxcmnm88Le/kSavjiGOmkcumBGTZKBLvorPc="
-  },
-  {
-    "pname": "System.Threading.Tasks.Extensions",
-    "version": "4.5.4",
-    "hash": "sha256-owSpY8wHlsUXn5xrfYAiu847L6fAKethlvYx97Ri1ng="
-  },
-  {
-    "pname": "System.Threading.ThreadPool",
-    "version": "4.3.0",
-    "hash": "sha256-wW0QdvssRoaOfQLazTGSnwYTurE4R8FxDx70pYkL+gg="
-  },
-  {
-    "pname": "System.Threading.Timer",
-    "version": "4.3.0",
-    "hash": "sha256-pmhslmhQhP32TWbBzoITLZ4BoORBqYk25OWbru04p9s="
-  },
-  {
-    "pname": "System.Xml.ReaderWriter",
-    "version": "4.3.0",
-    "hash": "sha256-QQ8KgU0lu4F5Unh+TbechO//zaAGZ4MfgvW72Cn1hzA="
-  },
-  {
-    "pname": "System.Xml.XDocument",
-    "version": "4.3.0",
-    "hash": "sha256-rWtdcmcuElNOSzCehflyKwHkDRpiOhJJs8CeQ0l1CCI="
-  },
-  {
     "pname": "TwentyTwenty.Storage",
-    "version": "2.24.2",
-    "hash": "sha256-RBMEajSVvYTJzJkhekjIzcXWX7ERQvLJ38TJXSBhvFc="
+    "version": "2.26.1",
+    "hash": "sha256-/f+ZsEUyBqRNRU1msH2uvVNvrs+5TdhxW/07PCWxvCY="
   },
   {
     "pname": "TwentyTwenty.Storage.Amazon",
-    "version": "2.24.2",
-    "hash": "sha256-U/RYB3l16hQ6Ez8ARVkz3kyMIPMI0icxkHHjVKd2HS0="
+    "version": "2.26.1",
+    "hash": "sha256-iBikYcLLjBoweopXo9gbORqKWEowTGzmLiqMsdMxM+g="
   },
   {
     "pname": "TwentyTwenty.Storage.Azure",
-    "version": "2.24.2",
-    "hash": "sha256-SrjAhf5KTMMvbCv+unogNT3m2MB6ZUbBsz5HsX0zEqE="
+    "version": "2.26.1",
+    "hash": "sha256-1P1TqeomAe8nmDtlN5XZiH2Nkeq6MSH1gdbTzGAlJRE="
   },
   {
     "pname": "TwentyTwenty.Storage.Google",
-    "version": "2.24.2",
-    "hash": "sha256-EJJnEJbSidOxsiRWBbiO0NhB6K5LdGcXSQ40+JrviiE="
+    "version": "2.26.1",
+    "hash": "sha256-a9bFk18MNYhI0Y32hUx5VjRQD0L5nDxfDAnc7+VKDd4="
   },
   {
     "pname": "TwentyTwenty.Storage.Local",
-    "version": "2.24.2",
-    "hash": "sha256-OD3TCPNH+So2SZeACLV1KN4Ifjft0csOuiROCuPNSsw="
+    "version": "2.26.1",
+    "hash": "sha256-dUOvIUus5BizZvVMnHFUH6qaTWHJpXLFfsFAVdpvlC4="
   },
   {
     "pname": "YamlDotNet",
-    "version": "8.0.0",
-    "hash": "sha256-9VInbvbrc9su5rcSyT4/t0wBSfLDpHvSvAy6WqMMGSY="
+    "version": "16.3.0",
+    "hash": "sha256-4Gi8wSQ8Rsi/3+LyegJr//A83nxn2fN8LN1wvSSp39Q="
   }
 ]

--- a/pkgs/by-name/bt/btcpayserver/deps.json
+++ b/pkgs/by-name/bt/btcpayserver/deps.json
@@ -186,8 +186,8 @@
   },
   {
     "pname": "HtmlSanitizer",
-    "version": "9.0.967",
-    "hash": "sha256-88jTkQSISDXnBXyIgdGtsfs90aBh244cxh9o6jrarvU="
+    "version": "9.1.982",
+    "hash": "sha256-poXCxuxW8Ln+xCbuHeCh2t35SVAENV0xfCOr2NJomHk="
   },
   {
     "pname": "Humanizer.Core",
@@ -511,13 +511,13 @@
   },
   {
     "pname": "NBitcoin",
-    "version": "10.0.7",
-    "hash": "sha256-4arn8+u0dy2iOmwMH/tjcTXR+/4viRf9dlUeMCRqXvI="
+    "version": "10.0.8",
+    "hash": "sha256-SnJ60lhDv94oD0370ZyrvFG2LDJ0wkixNP1pIvcq8AA="
   },
   {
     "pname": "NBitcoin.Altcoins",
-    "version": "6.0.3",
-    "hash": "sha256-U6xigLzDH9TpA6XkLTJRVBsL2OsaYjTD5evaVJ9NP7g="
+    "version": "6.0.4",
+    "hash": "sha256-BpXLxjmFf1JUud0Mwz/Zph0jPVqrEfa6KiMMnsOeIU8="
   },
   {
     "pname": "NBitpayClient",
@@ -526,8 +526,8 @@
   },
   {
     "pname": "NBXplorer.Client",
-    "version": "5.0.6",
-    "hash": "sha256-DN5tG7RSPZwn/c7SdL4OkrlSqT1wrEQmS7Jg7GGEiBo="
+    "version": "5.0.8",
+    "hash": "sha256-io1df2tgBDDoZL+55yR7Nmb1JmZBDLpuiV2A7LlRF/c="
   },
   {
     "pname": "NETStandard.Library",

--- a/pkgs/by-name/bt/btcpayserver/package.nix
+++ b/pkgs/by-name/bt/btcpayserver/package.nix
@@ -8,13 +8,13 @@
 
 buildDotnetModule rec {
   pname = "btcpayserver";
-  version = "2.4.1";
+  version = "2.4.2";
 
   src = fetchFromGitHub {
     owner = "btcpayserver";
     repo = "btcpayserver";
     tag = "v${version}";
-    hash = "sha256-79qWOCs1jdJ7cQa0CqbH3SIw4Ib7Nnw7FuBv+oOJf2o=";
+    hash = "sha256-4efp/uhEaCxfQ+oWKBK06dE3jm7bTf+GA0DP+tMCdLs=";
   };
 
   projectFile = "BTCPayServer/BTCPayServer.csproj";

--- a/pkgs/by-name/bt/btcpayserver/package.nix
+++ b/pkgs/by-name/bt/btcpayserver/package.nix
@@ -8,20 +8,20 @@
 
 buildDotnetModule rec {
   pname = "btcpayserver";
-  version = "2.3.4";
+  version = "2.4.1";
 
   src = fetchFromGitHub {
     owner = "btcpayserver";
     repo = "btcpayserver";
     tag = "v${version}";
-    hash = "sha256-u4VNDKLOb6bEkdhRTmnGxyM+2a6mcdWwV1T4+HFK/14=";
+    hash = "sha256-79qWOCs1jdJ7cQa0CqbH3SIw4Ib7Nnw7FuBv+oOJf2o=";
   };
 
   projectFile = "BTCPayServer/BTCPayServer.csproj";
   nugetDeps = ./deps.json;
 
-  dotnet-sdk = dotnetCorePackages.sdk_8_0;
-  dotnet-runtime = dotnetCorePackages.aspnetcore_8_0;
+  dotnet-sdk = dotnetCorePackages.sdk_10_0;
+  dotnet-runtime = dotnetCorePackages.aspnetcore_10_0;
 
   buildType = if altcoinSupport then "Altcoins-Release" else "Release";
 


### PR DESCRIPTION
## Summary

Bumps `btcpayserver` from 2.3.4 to 2.4.2 (latest upstream release).

BTCPay Server 2.4.2 contains a **fix for a critical security vulnerability** (TOTP bypass via Greenfield Basic authentication).
It also continues the migration to .NET 10 started in 2.4.0.

Release notes:
- https://github.com/btcpayserver/btcpayserver/releases/tag/v2.4.2 (Critical security fix)
- https://github.com/btcpayserver/btcpayserver/releases/tag/v2.4.1
- https://github.com/btcpayserver/btcpayserver/releases/tag/v2.4.0
- https://blog.btcpayserver.org/migrating-to-net10/

## Things done

- [x] Updated `package.nix` to 2.4.2
- [x] Manually updated `deps.json` to include new versions of `NBitcoin`, `NBXplorer.Client`, `HtmlSanitizer`, and `NBitcoin.Altcoins`
- [x] Followed the [contribution guidelines](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)

I used AI to build this for me. 