### PR TITLE
claude-code: 2.1.222 -> 2.1.223

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,22 +21,22 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-s1V+SxZ4O5EHcxE9ZxacnydNjfnK1Dv0y3YIPfsy3cs=";
+          hash = "sha256-3V4N8zHj7nB987ImVtBS84LGxdQgkDp14kTPps72fHo=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-G9bJ6xNCiC72gR0k89sTh96alnHguSE5cqqOVu/3kCg=";
+          hash = "sha256-6p09GcEfmSQs4nRuaFxQ1tKK25ENo2KOPkRQTPndNcw=";
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-ZDel1FfsiRbdw9pxn1H5nkOIlVdt1GLr68W2mBtl1mg=";
+          hash = "sha256-qbYE3f0fkxvfGyFAR8UPIFodOEYA0aJK6JK/r8PbI/k=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.222";
+      version = "2.1.223";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.222",
-  "commit": "fbf49312c28437bf9c2546b9ace3bd7b34eb6ff6",
-  "buildDate": "2026-08-04T01:46:04Z",
+  "version": "2.1.223",
+  "commit": "4535f69721056abf01650c73ee8a91c69ba00838",
+  "buildDate": "2026-08-05T21:55:19Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "c66a6cc6fa2e8145bb1a6e77831f2caf4b83690ff04650500dfa6e2c05ca997c",
-      "size": 271289792
+      "checksum": "fcbe0b8d47570c501302dd1ad31cc26ac2810f022c45fa253936a6961dee32bf",
+      "size": 272553824
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "36bfc6482a25730dbb1cee72589e522c66c45a4dc9ebfdd8a76a8113b01b6188",
-      "size": 280847136
+      "checksum": "350e657428a6d34f7cf71f6738c5ebb6a1952ccb12fc1747f64297e065b1846f",
+      "size": 282118560
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "a04be0a8d7fe0259571ab7411d51d85658d71a4a26ce62b60c908290372e6016",
-      "size": 286178232
+      "checksum": "60e83d8db0e894d0e54413e5e7daa256d180db660f51e139a51b614fc30cf3ac",
+      "size": 287423416
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "10caae8f22b915c26bfff0e013a4d45608c4f1ae287583626569156f447730e5",
-      "size": 289467400
+      "checksum": "98226474f802e3094d6a86c5ade8883c16206d0fcb5c400b7401c800063e99d7",
+      "size": 290728968
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "a3c3e3202ae8842a5e9d2b4ce1dcea9fa00d4e0ae27b5b3e8d778332ba3bb23c",
-      "size": 279491944
+      "checksum": "f41692eab23ebcd836d342fbc494d8783b1f19efb13d04fbf8461d2806ccb586",
+      "size": 280737128
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "e0b0fb4005e1ac0ebcee136254c638722f1c49e171a23d0843c605d72aac9029",
-      "size": 284074576
+      "checksum": "8a4e561e8af19746d2defcf1a5661f5c0384c9c26dadd87d45e11b67802ad147",
+      "size": 285336144
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "032cb799d2abfaa6ca440f6458304b9a2a250521063d21ebcea7f3c77c443db7",
-      "size": 279014048
+      "checksum": "a708ba811c4cc46907df358e22f2aa6da3dbc28192747e4d3c4a0869752fe722",
+      "size": 280233632
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "f760aa2782019e55b1e44fda9eddec85ca8499429da87efddd47ab18d4a716a2",
-      "size": 273687200
+      "checksum": "8efb44f04fda50fac3c7602276903e44ff82d48f1a29a41f1a5d98891a01864b",
+      "size": 274906784
     }
   },
   "sdkCompat": {


### PR DESCRIPTION
Update claude-code and vscode-extensions.anthropic.claude-code to 2.1.223.

https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md

> [!NOTE]
> Prepared with the assistance of Claude Code (Claude Opus 5). Version and hash bumps were produced by the standard `maintainers/scripts/update.nix` script; the change was built locally and validated across arches via `nixpkgs-review`, and reviewed by a human (@markus1189) before being marked ready.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
