### PR TITLE
attyx: 0.4.15 -> 0.4.16

### DIFF
--- a/pkgs/by-name/at/attyx/package.nix
+++ b/pkgs/by-name/at/attyx/package.nix
@@ -18,13 +18,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "attyx";
-  version = "0.4.15";
+  version = "0.4.16";
 
   src = fetchFromGitHub {
     owner = "semos-labs";
     repo = "attyx";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-WB3qMFmVmv/FkZX60MTKFewk3kEA3yDEoaUFL2LY1bQ=";
+    hash = "sha256-j6VahzpBZFd6lOtBlqrjK5oZ7sPwet6+FZcZ2fn3STE=";
   };
 
   deps = callPackage ./build.zig.zon.nix { };


### PR DESCRIPTION
## Description of changes

Update [attyx](https://github.com/semos-labs/attyx) from 0.4.15 to 0.4.16.

## Things done
- Built on platform(s): linux (via ofborg CI)
- Fetched tarball with hash verified
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)