### PR TITLE
pandora-launcher: add packages needed for sandboxing support

### DIFF
--- a/pkgs/by-name/pa/pandora-launcher/package.nix
+++ b/pkgs/by-name/pa/pandora-launcher/package.nix
@@ -5,6 +5,7 @@
 {
   addDriverRunpath,
   alsa-lib,
+  bubblewrap,
   flite,
   gamemode,
   glfw3-minecraft,
@@ -31,6 +32,7 @@
   symlinkJoin,
   udev,
   vulkan-loader,
+  xdg-dbus-proxy,
   xrandr,
 
   additionalLibs ? [ ],
@@ -45,6 +47,7 @@
   ],
   msaClientID ? null,
   textToSpeechSupport ? stdenv.hostPlatform.isLinux,
+  sandboxSupport ? stdenv.hostPlatform.isLinux,
 }:
 
 assert lib.assertMsg (
@@ -54,6 +57,10 @@ assert lib.assertMsg (
 assert lib.assertMsg (
   textToSpeechSupport -> stdenv.hostPlatform.isLinux
 ) "textToSpeechSupport only has an effect on Linux.";
+
+assert lib.assertMsg (
+  sandboxSupport -> stdenv.hostPlatform.isLinux
+) "sandboxSupport only has an effect on Linux.";
 
 let
   pandora-launcher' = pandora-launcher-unwrapped.override { inherit msaClientID; };
@@ -105,6 +112,10 @@ symlinkJoin {
       runtimePrograms = [
         pciutils # need lspci
         xrandr # needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
+      ]
+      ++ lib.optionals sandboxSupport [
+        bubblewrap
+        xdg-dbus-proxy
       ]
       ++ additionalPrograms;
 


### PR DESCRIPTION
Adds the sandboxSupport option (defaults to true on Linux) that appends `bubblewrap` and `xdg-dbus-proxy` to runtimePrograms, allowing the user to enable the Sandbox option for their instances


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
