### PR TITLE
inklecate: Remove aarch64 as bad platform

### DIFF
--- a/pkgs/by-name/in/inklecate/package.nix
+++ b/pkgs/by-name/in/inklecate/package.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   buildDotnetModule,
   dotnetCorePackages,
   fetchFromGitHub,
@@ -23,8 +22,6 @@ buildDotnetModule rec {
     find . -name "*.csproj" -exec sed -i 's/netstandard1.0;//g' {} +
   '';
 
-  buildInputs = [ (lib.getLib stdenv.cc.cc) ];
-
   projectFile = "inklecate/inklecate.csproj";
   nugetDeps = ./deps.json;
   executables = [ "inklecate" ];
@@ -42,7 +39,8 @@ buildDotnetModule rec {
     downloadPage = "https://github.com/inkle/ink/";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
-    badPlatforms = lib.platforms.aarch64;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      robinheghan
+    ];
   };
 }


### PR DESCRIPTION
I've removed aarch64 as a badPlatform after having built and tested the resulting executable on linux-aarch64 and darwin-aarch64.

I also added myself as a maintainer, as I intend to use this package for a project of mine, and because the list of maintainers was empty.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
