### PR TITLE
python3Packages.tokenspeed-triton: patch CMakeLists to fix build failure

### DIFF
--- a/pkgs/development/python-modules/tokenspeed-triton/default.nix
+++ b/pkgs/development/python-modules/tokenspeed-triton/default.nix
@@ -40,6 +40,20 @@ buildPythonPackage (finalAttrs: {
     substituteInPlace pyproject.toml \
       --replace-fail "cmake>=3.20,<4.0" "cmake>=3.20" \
       --replace-fail "nanobind==2.10.2" "nanobind>=2.10.2"
+  ''
+
+  # nanobind >= 2.13 also requires the `Python::Interpreter`
+  # target, which upstream's `find_package(Python3)` ->
+  # `find_package(Python)` bridge misses:
+  # https://github.com/wjakob/nanobind/commit/706131bef6771ad3634b1d772f029f65b7ea8bd2
+  + ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail \
+        'if(NOT TARGET Python::Module)' \
+        'if(NOT TARGET Python::Interpreter)
+      add_executable(Python::Interpreter ALIAS Python3::Interpreter)
+    endif()
+    if(NOT TARGET Python::Module)'
   '';
 
   build-system = [


### PR DESCRIPTION
```
CMake Error at /nix/store/9fknzc9l9fs0xyixbhih469zx9qgrv6d-python3.14-nanobind-2.13.0/lib/python3.14/site-packages/nanobind/cmake/nanobind-config.cmake:4 (message):
  You must invoke 'find_package(Python COMPONENTS Interpreter Development
  REQUIRED)' prior to including nanobind.
Call Stack (most recent call first):
  CMakeLists.txt:332 (find_package)
```

I am not sure whether this is due to the recent bump of `nanobind` in nixpkgs commit:
a9ad64d20d0f ("python3Packages.nanobind: 2.12.0 -> 2.13.0")

---

Closes #549764 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
