### PR TITLE
zeek: 7.2.2 -> 8.2.2

### DIFF
--- a/pkgs/by-name/ze/zeek/broker/default.nix
+++ b/pkgs/by-name/ze/zeek/broker/default.nix
@@ -12,22 +12,22 @@ let
   src-cmake = fetchFromGitHub {
     owner = "zeek";
     repo = "cmake";
-    rev = "fd0696f9077933660f7da5f81978e86b3e967647";
-    hash = "sha256-21wZVwoOB05l/WX/VrVbSx+lFKFQ9MHWjQQD4weavFs=";
+    rev = "a1482b8f9829cea870b4db75c085de1249e11bcb";
+    hash = "sha256-kFkLig0g/sBKRg8EnfUldj9R7qX6V+c8Ap98p0YBsIw=";
   };
-  src-3rdparty = fetchFromGitHub {
-    owner = "zeek";
-    repo = "zeek-3rdparty";
-    rev = "a6cc3c7603bb535cf3bec7442140e7126e0577a8";
-    hash = "sha256-yzhuTam9zOQ3MP7fk+ACN5P5tHtHXWbyQP73DwISIv8=";
-  };
+  prometheus-cpp' = prometheus-cpp.overrideAttrs (old: {
+    # Zeek expects Broker to include prometheus-cpp symbols rather than link them dynamically.
+    cmakeFlags = builtins.filter (flag: flag != "-DBUILD_SHARED_LIBS=ON") old.cmakeFlags ++ [
+      "-DBUILD_SHARED_LIBS=OFF"
+    ];
+  });
   caf' = caf.overrideAttrs (old: {
-    version = "unstable-2024-09-14-zeek";
+    version = "unstable-2025-07-23-zeek";
     src = fetchFromGitHub {
       owner = "zeek";
       repo = "actor-framework";
-      rev = "10afbbc5ee40263b258b7cf3f0e5abb436f79e89";
-      hash = "sha256-R22eKAFNP2VVA4eL6ycN6aHM0NgDHVll9aFNmOQ/pDc=";
+      rev = "4aa660d003d8bbb922a33fb7a31f80d9d3271262";
+      hash = "sha256-OlrW+gk/oLEEIWRSugI1DqRJ+KYF4ZJxHVWKXWllGjU=";
     };
     cmakeFlags = old.cmakeFlags ++ [
       "-DCAF_ENABLE_TESTING=OFF"
@@ -37,7 +37,7 @@ let
 in
 stdenv.mkDerivation {
   pname = "zeek-broker";
-  version = "2.6.0-unstable-2025-04-23";
+  version = "2.8.0-unstable-2026-08-11";
   outputs = [
     "out"
     "py"
@@ -48,13 +48,13 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "zeek";
     repo = "broker";
-    rev = "5b6cbb8c2d9124aa1fb0bea5799433138dc64cf9";
-    hash = "sha256-L6Z+ltX3tJEwZ05zEftrJlOhwbhs06MY9cEJDM2kcck=";
+    rev = "fdca6b8ef4b95ec6518a32db46503c28cc812be4";
+    hash = "sha256-GuqmbFCIeS9maW9cy+dIMqwOTTiQIKJX1nVQoAIxDpA=";
   };
   postUnpack = ''
-    rmdir $sourceRoot/cmake $sourceRoot/3rdparty
+    rmdir $sourceRoot/cmake $sourceRoot/caf
     ln -s ${src-cmake} ''${sourceRoot}/cmake
-    ln -s ${src-3rdparty} ''${sourceRoot}/3rdparty
+    ln -s ${caf'.src} ''${sourceRoot}/caf
 
     # Refuses to build the bindings unless this file is present, but never
     # actually uses it.
@@ -71,7 +71,7 @@ stdenv.mkDerivation {
   ];
   buildInputs = [
     openssl
-    prometheus-cpp
+    prometheus-cpp'
     python3.pkgs.pybind11
   ];
   propagatedBuildInputs = [ caf' ];
@@ -80,12 +80,11 @@ stdenv.mkDerivation {
     "-DCAF_ROOT=${caf'}"
     "-DENABLE_STATIC_ONLY:BOOL=${if stdenv.hostPlatform.isStatic then "ON" else "OFF"}"
     "-DPY_MOD_INSTALL_DIR=${placeholder "py"}/${python3.sitePackages}/"
-    "-Dprometheus-cpp_ROOT=${lib.getDev prometheus-cpp}"
+    "-Dprometheus-cpp_ROOT=${lib.getDev prometheus-cpp'}"
   ];
 
   meta = {
     description = "Zeek's Messaging Library";
-    mainProgram = "broker-benchmark";
     homepage = "https://github.com/zeek/broker";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/ze/zeek/fix-installation.patch
+++ b/pkgs/by-name/ze/zeek/fix-installation.patch
@@ -80,3 +80,24 @@ index 1ebe7c2..1435509 100644
  
  # A couple of configuration options that are needed are placed in here.
  configure_file(etc/zeekctl.cfg.in
+diff --git a/tools/systemd-generator/CMakeLists.txt b/tools/systemd-generator/CMakeLists.txt
+index 0e6a46f..031eb1f 100644
+--- a/tools/systemd-generator/CMakeLists.txt
++++ b/tools/systemd-generator/CMakeLists.txt
+@@ -14,6 +14,6 @@ if (NOT is_subproject)
+     set(_default_config_file "/usr/local/zeek/etc/zeek/zeek.conf")
+     set(_default_base_dir "/usr/local/zeek/")
+ else ()
+-    set(_default_config_file "${ZEEK_ETC_INSTALL_DIR}/zeek/zeek.conf")
++    set(_default_config_file "${ZEEK_ETC_INSTALL_DIR}/zeek.conf")
+     set(_default_base_dir "${CMAKE_INSTALL_PREFIX}")
+ endif ()
+@@ -49,7 +49,7 @@ if (ENABLE_ZEEK_SYSTEMD_GENERATOR)
+     if (is_subproject)
+         # Install a default configuration at <PREFXI>etc/default/zeek
+         include(InstallPackageConfigFile)
+         InstallPackageConfigFile(${CMAKE_CURRENT_SOURCE_DIR}/etc/zeek/zeek.conf
+-                                 ${ZEEK_ETC_INSTALL_DIR}/zeek zeek.conf)
++                                 ${CMAKE_INSTALL_PREFIX}/etc/zeek zeek.conf)
+     endif ()
+ endif ()

--- a/pkgs/by-name/ze/zeek/package.nix
+++ b/pkgs/by-name/ze/zeek/package.nix
@@ -4,6 +4,7 @@
   callPackage,
   fetchurl,
   cmake,
+  civetweb,
   flex,
   bison,
   openssl,
@@ -19,6 +20,7 @@
   gettext,
   coreutils,
   ncurses,
+  zeromq,
 }:
 
 let
@@ -30,11 +32,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "zeek";
-  version = "7.2.2";
+  version = "8.2.2";
 
   src = fetchurl {
     url = "https://download.zeek.org/zeek-${finalAttrs.version}.tar.gz";
-    hash = "sha256-Kx3ySPlBmaFoThxGDWTPHF5J10ccK1YvlCrF++mAWJM=";
+    hash = "sha256-o7bWDva+w+sSgY/jLK7HB/m21jBT6u7pQuTsmvZNhiw=";
   };
 
   strictDeps = true;
@@ -54,12 +56,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     broker
+    civetweb
     curl
     gperftools
     libmaxminddb
     libpcap
     ncurses
     openssl
+    zeromq
     zlib
     python
   ]
@@ -73,6 +77,12 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     patchShebangs ./ci/collect-repo-info.py
     patchShebangs ./auxil/spicy/scripts
+
+    # Broker statically includes prometheus-cpp, but uses nixpkgs' shared civetweb.
+    substituteInPlace cmake/FindPrometheusCpp.cmake \
+      --replace-fail \
+        '#set(zeekdeps ''${zeekdeps} prometheus-cpp::core prometheus-cpp::pull)' \
+        $'find_package(civetweb CONFIG REQUIRED)\nset(zeekdeps ''${zeekdeps} civetweb::civetweb-cpp)'
   '';
 
   cmakeFlags = [


### PR DESCRIPTION
Updates Zeek from 7.2.2 to 8.2.2 and aligns the Broker, CAF, and CMake revisions used by the upstream bundle.

- Includes the security fixes from the 8.2.1 and 8.2.2 releases.
- Adapts the package to upstream's ZeroMQ cluster backend and systemd generator.
- This major update includes API and log format changes; see the [Zeek 8.2.2 changelog](https://github.com/zeek/zeek/blob/v8.2.2/CHANGES).

Addresses #540321

Stable 26.05 will require a separate update to Zeek 8.0.10 after this PR is merged.

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
