### PR TITLE
Nordvpn fix nix update, 5.2.0 -> 5.3.0

### DIFF
--- a/pkgs/by-name/no/nordvpn/cli.nix
+++ b/pkgs/by-name/no/nordvpn/cli.nix
@@ -56,7 +56,7 @@ buildGoModule (finalAttrs: {
     makeWrapper
   ];
 
-  vendorHash = "sha256-I81sn+tHTny9bX5eNGQLPQtoabbaNZINMjYotCXt88A=";
+  vendorHash = "sha256-yNeoj4W/eFoycY4AfajF8FkpkCCcj6kRbfOjZObp+VE=";
 
   preBuild = ''
     # redirect AppDataPathStatic (/usr/lib/nordvpn) to $out/bin so that

--- a/pkgs/by-name/no/nordvpn/package.nix
+++ b/pkgs/by-name/no/nordvpn/package.nix
@@ -38,6 +38,7 @@ in
 symlinkJoin {
   pname = "nordvpn";
   inherit version;
+  inherit (common) src;
 
   strictDeps = true;
   __structuredAttrs = true;
@@ -50,7 +51,14 @@ symlinkJoin {
   passthru = {
     cli = callPackage ./cli.nix common;
     gui = callPackage ./gui.nix common;
-    updateScript = nix-update-script { };
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--subpackage"
+        "cli"
+        "--subpackage"
+        "gui"
+      ];
+    };
   };
 
   meta = common.meta // {

--- a/pkgs/by-name/no/nordvpn/package.nix
+++ b/pkgs/by-name/no/nordvpn/package.nix
@@ -6,7 +6,7 @@
   symlinkJoin,
 }:
 let
-  version = "5.2.0";
+  version = "5.3.0";
 
   common = {
     inherit version;
@@ -15,7 +15,7 @@ let
       owner = "NordSecurity";
       repo = "nordvpn-linux";
       tag = version;
-      hash = "sha256-F7iw856HVLbOz97j9sMkVwyZl0ZDwID1Tf0YwtdvZsU=";
+      hash = "sha256-5iWQE4fiXbDG/M072H1gigUO3YTjoRQVolXHjcxP1Mw=";
     };
 
     # rec so that changelog can reference homepage


### PR DESCRIPTION
Update version from 5.2.0 -> 5.3.0.
Fix **package.nix** to support nix bot auto-updating package version.
Verified by running
```sh
nix-shell maintainers/scripts/update.nix --argstr package nordvpn --arg skip-prompt true
```
Verified that NordVPN cli and gui work as expected.

Assisted-by: Claude Code (Claude Sonnet 5)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

---

To test, use this **configuration.nix**:
```nix
{
  pkgs,
  lib,
  ...
}:

{
  imports = [
    ./hardware-configuration.nix
  ];

  boot.loader.systemd-boot.enable = true;
  boot.loader.efi.canTouchEfiVariables = true;
  networking.firewall.enable = true;
  networking.firewall.checkReversePath = "loose";

  services.xserver.enable = true;
  services.displayManager.gdm.enable = true;
  services.desktopManager.plasma6.enable = true;

  services.timesyncd.enable = lib.mkForce true;
  services.timesyncd.servers = [
    "time.google.com"
    "pool.ntp.org"
  ];

  services.nordvpn = {
    enable = true;
  };

  virtualisation.vmVariant = {
    virtualisation = {
      memorySize = 8192;
      cores = 3;
    };
  };
  users.groups.alice = { };
  users.users.alice = {
    isNormalUser = true;
    password = "alice";
    group = "alice";
    extraGroups = [
      "wheel"
      "nordvpn"
    ];
    shell = pkgs.bash;
    home = "/home/alice";
    createHome = true;
    packages = with pkgs; [
      dunst
      firefox
      libnotify
      nftables
      socat
      tmux
      tree
      vim
    ];
  };
  system.stateVersion = "24.11"; # Did you read the comment?
}
```

and build the VM with the present PR's changes using the following command:

```sh
nixos-rebuild build-vm \
  -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/pull/549793/head.tar.gz \
  -I nixos-config=/path/to/configuration.nix
```


---

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
