### PR TITLE
haskell.compiler.ghc966DebianBinary: bootstrap natively on riscv64-linux

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -199,7 +199,7 @@ nixos/modules/installer/tools/nix-fallback-paths.nix  @Artturin @Ericson2314 @lo
 /doc/languages-frameworks/haskell.section.md  @sternenseemann @maralorn @wolfgangwalther
 /maintainers/scripts/haskell                  @sternenseemann @maralorn @wolfgangwalther
 /pkgs/development/compilers/ghc               @sternenseemann @maralorn @wolfgangwalther
-/pkgs/development/compilers/ghc/9.6.6-debian-binary.nix  @sternenseemann @maralorn @wolfgangwalther @OPNA2608
+/pkgs/development/compilers/ghc/9.6.6-debian-binary.nix  @sternenseemann @maralorn @wolfgangwalther @OPNA2608 @liberodark
 /pkgs/development/haskell-modules             @sternenseemann @maralorn @wolfgangwalther
 /pkgs/test/haskell                            @sternenseemann @maralorn @wolfgangwalther
 /pkgs/top-level/release-haskell.nix           @sternenseemann @maralorn @wolfgangwalther

--- a/pkgs/development/compilers/ghc/9.6.6-debian-binary.nix
+++ b/pkgs/development/compilers/ghc/9.6.6-debian-binary.nix
@@ -314,7 +314,12 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Glasgow Haskell Compiler";
     license = lib.licenses.bsd3;
     platforms = builtins.attrNames ghcDebs;
-    maintainers = [ lib.maintainers.OPNA2608 ];
+    maintainers = [
+      # powerpc64-linux
+      lib.maintainers.OPNA2608
+      # riscv64-linux
+      lib.maintainers.liberodark
+    ];
     teams = [ lib.teams.haskell ];
   };
 })

--- a/pkgs/development/compilers/ghc/9.6.6-debian-binary.nix
+++ b/pkgs/development/compilers/ghc/9.6.6-debian-binary.nix
@@ -12,6 +12,8 @@
   libffi,
   coreutils,
   targetPackages,
+  llvmPackages,
+  replaceVarsWith,
 }:
 
 # Prebuilt only does native
@@ -20,10 +22,13 @@ assert stdenv.targetPlatform == stdenv.hostPlatform;
 let
   version = "9.6.6";
 
+  useLLVM = !(import ./common-have-ncg.nix { inherit lib stdenv version; });
+
   # GHC upstream doesn't release bindist tarballs for some platforms.
   # We're using Debian's binary package, and patching it into a usable-in-Nixpkgs state.
   ghcDebs = {
     powerpc64-linux = {
+      toolPrefix = "powerpc64-linux-gnu-";
       src = {
         urls = [
           "http://ftp.ports.debian.org/debian-ports/pool-ppc64/main/g/ghc/ghc_9.6.6-4_ppc64.deb"
@@ -32,6 +37,35 @@ let
         sha256 = "722cc301b6ba70b342e5e3d9d0671440bcd749cd2f13dcccbd23c3f6a6060171";
       };
       exePathForLibraryCheck = null;
+      archSpecificLibraries = [
+        {
+          nixPackage = gmp;
+          fileToCheckFor = null;
+        }
+        {
+          nixPackage = ncurses6;
+          fileToCheckFor = "libtinfo.so.6";
+        }
+        {
+          nixPackage = numactl;
+          fileToCheckFor = null;
+        }
+        {
+          nixPackage = libffi;
+          fileToCheckFor = null;
+        }
+      ];
+    };
+    riscv64-linux = {
+      toolPrefix = "riscv64-linux-gnu-";
+      src = {
+        urls = [
+          "https://deb.debian.org/debian/pool/main/g/ghc/ghc_9.6.6-4_riscv64.deb"
+          "https://snapshot.debian.org/archive/debian/20250218T211057Z/pool/main/g/ghc/ghc_9.6.6-4_riscv64.deb"
+        ];
+        sha256 = "01ff1fdec9e7581b05998b216399b316c41bdbbc813e3379c7f7a38223550ad0";
+      };
+      exePathForLibraryCheck = "ghc-debian-binary-9.6.6/usr/lib/ghc/bin/ghc-9.6.6";
       archSpecificLibraries = [
         {
           nixPackage = gmp;
@@ -66,6 +100,23 @@ let
     targetPackages.stdenv.cc
     targetPackages.stdenv.cc.bintools
     coreutils # for cat
+  ]
+  # GHC 9.6 has no NCG for riscv64, it uses LLVM.
+  ++ lib.optionals useLLVM [
+    (replaceVarsWith {
+      name = "subopt";
+      src = ./subopt.bash;
+      dir = "bin";
+      isExecutable = true;
+      preBuild = ''
+        name=opt
+      '';
+      replacements = {
+        inherit (stdenv) shell;
+        opt = lib.getExe' llvmPackages.llvm "opt";
+      };
+    })
+    (lib.getBin llvmPackages.llvm)
   ];
 
   extraLibraryMapping = {
@@ -191,11 +242,11 @@ stdenv.mkDerivation (finalAttrs: {
     # Patch ghc settings
     + ''
       substituteInPlace $out/lib/ghc/lib/settings \
-        --replace-fail powerpc64-linux-gnu-gcc gcc \
-        --replace-fail powerpc64-linux-gnu-g++ g++ \
-        --replace-fail powerpc64-linux-gnu-ld ld \
-        --replace-fail powerpc64-linux-gnu-ar ar \
-        --replace-fail powerpc64-linux-gnu-ranlib ranlib \
+        --replace-fail ${debUsed.toolPrefix}gcc gcc \
+        --replace-fail ${debUsed.toolPrefix}g++ g++ \
+        --replace-fail ${debUsed.toolPrefix}ld ld \
+        --replace-fail ${debUsed.toolPrefix}ar ar \
+        --replace-fail ${debUsed.toolPrefix}ranlib ranlib \
         --replace-fail llc-18 llc \
         --replace-fail opt-18 opt
     '';
@@ -247,7 +298,7 @@ stdenv.mkDerivation (finalAttrs: {
     targetPrefix = "";
     enableShared = true;
 
-    llvmPackages = null;
+    inherit llvmPackages;
 
     # Our Cabal compiler name
     haskellCompilerName = "ghc-${version}";

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -254,6 +254,21 @@
               "sha256-vtjT+TL/7sYPu4rcVV3xCqJQ+uqkyBbf9l0KIi97j/0=";
         })
       ]
+      ++
+        lib.optionals
+          (
+            stdenv.hostPlatform.isRiscV64
+            && lib.versionAtLeast version "9.10"
+            && lib.versionOlder version "9.12"
+          )
+          [
+            # Fix LLVM backend split sections causing bin/out reference cycles: https://gitlab.haskell.org/ghc/ghc/-/issues/26770
+            (fetchpatch {
+              name = "ghc-llvm-fix-split-sections.patch";
+              url = "https://gitlab.haskell.org/ghc/ghc/-/commit/b18b2c42c32488ad6d3480a56a1fcd753cad2023.patch";
+              hash = "sha256-kEgZARwcdnWcvjuTfyqnn8V1zAUczZN0qiy/1WbCy1s=";
+            })
+          ]
       ++ lib.optionals (lib.versionOlder version "9.12") [
         (fetchpatch {
           name = "ghc-rts-Fix-compile-on-powerpc64-elf-v1.patch";

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -927,6 +927,7 @@ stdenv.mkDerivation (
 
       inherit llvmPackages;
       inherit enableShared;
+      inherit enableProfiledLibs;
       inherit hasHaddock;
 
       # Expose hadrian used for bootstrapping, for debugging purposes

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -123,7 +123,8 @@ in
   doInstallIntermediates ? false,
   editedCabalFile ? null,
   # Cabal does not build the profiled dynamic objects required by wasm TH.
-  enableLibraryProfiling ? !stdenv.hostPlatform.isGhcjs && !stdenv.hostPlatform.isWasm,
+  enableLibraryProfiling ?
+    !stdenv.hostPlatform.isGhcjs && !stdenv.hostPlatform.isWasm && (ghc.enableProfiledLibs or true),
   enableExecutableProfiling ? false,
   profilingDetail ? "exported-functions",
   # TODO enable shared libs for cross-compiling

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -121,6 +121,8 @@ in
           then
             # No bindist, "borrowing" the GHC from Debian
             bb.packages.ghc966DebianBinary
+          else if stdenv.buildPlatform.isRiscV64 then
+            bb.packages.ghc966DebianBinary
           else
             bb.packages.ghc948;
         inherit (buildPackages.python3Packages) sphinx;
@@ -135,6 +137,8 @@ in
             && pkgs.stdenv.hostPlatform.isAbiElfv1
           then
             # No bindist, "borrowing" the GHC from Debian
+            bb.packages.ghc966DebianBinary
+          else if stdenv.buildPlatform.isRiscV64 then
             bb.packages.ghc966DebianBinary
           else if stdenv.buildPlatform.isi686 then
             bb.packages.ghc948
@@ -152,6 +156,8 @@ in
             && pkgs.stdenv.hostPlatform.isAbiElfv1
           then
             # No bindist, "borrowing" the GHC from Debian
+            bb.packages.ghc966DebianBinary
+          else if stdenv.buildPlatform.isRiscV64 then
             bb.packages.ghc966DebianBinary
           else if stdenv.buildPlatform.isi686 then
             bb.packages.ghc967


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] riscv64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
