### PR TITLE
ncdu: 2.10.0 -> 2.11.0, enable system integration options

### DIFF
--- a/pkgs/by-name/nc/ncdu/package.nix
+++ b/pkgs/by-name/nc/ncdu/package.nix
@@ -11,9 +11,11 @@
   versionCheckHook,
   pie ? stdenv.hostPlatform.isDarwin,
 }:
+
 let
   zig = zig_0_16;
 in
+
 stdenv.mkDerivation (finalAttrs: {
   pname = "ncdu";
   version = "2.10.0";
@@ -29,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   nativeBuildInputs = [
-    zig.hook
+    zig
     installShellFiles
     pkg-config
   ];
@@ -39,26 +41,19 @@ stdenv.mkDerivation (finalAttrs: {
     zstd
   ];
 
-  deps = zig.fetchDeps {
+  zigDeps = zig.fetchDeps {
     inherit (finalAttrs) pname version src;
     fetchAll = true;
     hash = "sha256-vk4wMIpKEQObFXuNd5szQQU6z0NyVJKInOMDiEn4A5k=";
   };
 
-  postPatch = ''
-    mkdir -p zig-system-dir
-
-    for file in ${finalAttrs.deps}/*; do
-       dir="zig-system-dir/$(basename "$file" .tar.gz)"
-       mkdir -p "$dir"
-
-       tar -xzf "$file" -C "$dir" --strip-components=1
-    done
+  postConfigure = ''
+    ln -s ${finalAttrs.zigDeps} "$ZIG_GLOBAL_CACHE_DIR/p"
   '';
 
   zigBuildFlags = [
-    "--system"
-    "zig-system-dir"
+    "-fsys=ncurses"
+    "-fsys=zstd"
   ]
   ++ lib.optional pie "-Dpie=true";
 

--- a/pkgs/by-name/nc/ncdu/package.nix
+++ b/pkgs/by-name/nc/ncdu/package.nix
@@ -18,13 +18,13 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ncdu";
-  version = "2.10.0";
+  version = "2.11.0";
 
   src = fetchFromGitHub {
     owner = "BratishkaErik";
     repo = "ncdu";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-YfvuXW0IaRaUNReLe/hMgYA2geDLvt1bprJAbOCFCQk=";
+    hash = "sha256-wKDo8f2PVXqFopnUgZ1mTJmsdzs6iUkzXFl3VpMkGIc=";
   };
 
   __structuredAttrs = true;
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
   zigDeps = zig.fetchDeps {
     inherit (finalAttrs) pname version src;
     fetchAll = true;
-    hash = "sha256-vk4wMIpKEQObFXuNd5szQQU6z0NyVJKInOMDiEn4A5k=";
+    hash = "sha256-plS7YUHWysZCQ1hHVWlgKvZkDtnjYSFfi3fdMYJVI9I=";
   };
 
   postConfigure = ''


### PR DESCRIPTION
Supersedes and closes #549717

cc @tree-sapii @BratishkaErik

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
