### PR TITLE
vacask: init at 0.3.3

### DIFF
--- a/pkgs/by-name/op/openvaf/package.nix
+++ b/pkgs/by-name/op/openvaf/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  llvmPackages,
+}:
+
+rustPlatform.buildRustPackage.override { inherit (llvmPackages) stdenv; } (finalAttrs: {
+  pname = "openvaf";
+  version = "24.0.1";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "OpenVAF";
+    repo = "OpenVAF-Reloaded";
+    rev = "v${finalAttrs.version}mob";
+    hash = "sha256-wZMZpg4X7yRVssGv8U6dupawTtzs7CLbYhaMBlxxBKo=";
+  };
+
+  cargoHash = "sha256-+jvaiBCmjd3RrlES+Sc1SskEMOtO1ykOdInMTH/Gazo=";
+
+  nativeBuildInputs = [
+    llvmPackages.llvm
+  ];
+
+  buildFeatures = [
+    "llvm${lib.versions.major llvmPackages.llvm.version}"
+  ];
+
+  cargoBuildFlags = [
+    "--package"
+    "openvaf-driver"
+  ];
+
+  cargoTestFlags = [
+    "--package"
+    "openvaf-driver"
+  ];
+
+  # This is required or else nothing will build
+  hardeningDisable = [
+    "pic"
+    "zerocallusedregs"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Verilog-A compiler";
+    homepage = "https://github.com/OpenVAF/OpenVAF-Reloaded";
+    changelog = "https://github.com/OpenVAF/OpenVAF-Reloaded/releases/tag/v${finalAttrs.version}mob";
+    mainProgram = "openvaf-r";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/by-name/va/vacask/package.nix
+++ b/pkgs/by-name/va/vacask/package.nix
@@ -1,0 +1,108 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitea,
+  nix-update-script,
+  runCommand,
+
+  # build-time
+  bison,
+  cmake,
+  flex,
+  openvaf,
+  python3,
+
+  # run-time
+  boost188,
+  suitesparse,
+  tomlplusplus,
+}:
+
+let
+  # VACASK includes SuiteSparse headers as <suitesparse/klu.h>, the layout used
+  # by SuiteSparse >= 6. However, our suitesparse is currently at 5.13.0 and
+  # installs headers flat into include/, so here we're fixing that.
+  # TODO: remove when suitesparse is updated
+  suitesparse-include = runCommand "suitesparse-include" { } ''
+    mkdir -p $out/include/suitesparse
+    ln -s ${suitesparse.dev}/include/*.h $out/include/suitesparse/
+  '';
+
+  pyEnv = python3.withPackages (
+    ps: with ps; [
+      numpy
+      scipy
+    ]
+  );
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vacask";
+  version = "0.3.3";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "arpadbuermen";
+    repo = "VACASK";
+    tag = "_${finalAttrs.version}";
+    hash = "sha256-eU3SuJPqxqc8QO5k4Jb/9zc8V2JQ1VP1bPEoJ6KCi/c=";
+  };
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail \
+        "Boost_USE_STATIC_LIBS ON" \
+        "Boost_USE_STATIC_LIBS OFF" \
+      --replace-fail \
+        'set(PROGRAM_VERSION "unknown")' \
+        'set(PROGRAM_VERSION "${finalAttrs.version}")'
+  '';
+
+  nativeBuildInputs = [
+    bison
+    boost188.dev
+    cmake
+    flex
+    openvaf
+    pyEnv
+  ];
+
+  buildInputs = [
+    boost188
+    suitesparse
+    tomlplusplus
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "FLEX_INCLUDE_DIR" "${flex}/include")
+    (lib.cmakeFeature "SuiteSparse_DIR" "${suitesparse-include}")
+    (lib.cmakeFeature "TOMLPP_DIR" "${tomlplusplus}")
+  ];
+
+  doCheck = true;
+
+  nativeCheckInputs = [
+    openvaf
+    pyEnv
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Analog circuit simulator";
+    longDescription = ''
+      VACASK is a Verilog-A Circuit Analysis Kernel - an analog circuit
+      simulator with a device library built from Verilog-A modules.
+    '';
+    homepage = "https://codeberg.org/arpadbuermen/VACASK";
+    changelog = "https://codeberg.org/arpadbuermen/VACASK/releases/tag/${finalAttrs.src.tag}";
+    mainProgram = "vacask";
+    license = lib.licenses.agpl3Plus;
+    # TODO: add darwin support
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})


### PR DESCRIPTION
[`VACASK`](https://codeberg.org/arpadbuermen/VACASK/) is a Verilog-A Circuit Analysis Kernel - an analog circuit simulator with a device library built from Verilog-A modules.

> [!NOTE]
> Work done as part of the [Nix@NGI](https://nixos.org/community/teams/ngi/) packaging effort 

Assisted-by: nix-init
Assisted-by: DeepSeek V4 Flash Free, with fixing `openvaf` build failures and a few things in `vacask`.

Closes: https://github.com/ngi-nix/projects/issues/2168

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test