### PR TITLE
fastnetmon-advanced: 2.0.380 -> 2.0.383

### DIFF
--- a/pkgs/by-name/fa/fastnetmon-advanced/package.nix
+++ b/pkgs/by-name/fa/fastnetmon-advanced/package.nix
@@ -9,11 +9,11 @@
 
 stdenv.mkDerivation rec {
   pname = "fastnetmon-advanced";
-  version = "2.0.380";
+  version = "2.0.383";
 
   src = fetchurl {
-    url = "https://repo.fastnetmon.com/fastnetmon_ubuntu_noble/pool/fastnetmon/f/fastnetmon/fastnetmon_${version}_amd64.deb";
-    hash = "sha256-4hCrDaFat0kEbyzKg6nHdV+LlqCBYYJEojyvXyPYKD0=";
+    url = "https://noble.ubuntu.repo.fastnetmon.com/pool/stable/f/fa/fastnetmon_${version}_amd64.deb";
+    hash = "sha256-n43LDnkk5cMvnfbHc8MtR+zmQok7DEbUwR0ZeHOq2UY=";
   };
 
   nativeBuildInputs = [
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     tar xf data.tar.xz
 
     # unused libraries, which have additional dependencies
-    rm opt/fastnetmon/libraries/gcc1210/lib/libgccjit.so*
+    rm opt/fastnetmon/libraries/gcc1610/lib/libgccjit.so*
   '';
 
   installPhase = ''

--- a/pkgs/by-name/fa/fastnetmon-advanced/package.nix
+++ b/pkgs/by-name/fa/fastnetmon-advanced/package.nix
@@ -62,7 +62,10 @@ stdenv.mkDerivation rec {
     homepage = "https://fastnetmon.com";
     changelog = "https://github.com/FastNetMon/fastnetmon-advanced-releases/releases/tag/v${version}";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    maintainers = with lib.maintainers; [ yureka-wdz ];
+    maintainers = with lib.maintainers; [
+      yureka-wdz
+      netali
+    ];
     license = lib.licenses.unfree;
     platforms = [ "x86_64-linux" ];
   };


### PR DESCRIPTION
Updates `fastnetmon-advanced` to the latest release 2.0.383. This is relatively urgent, because as stated in the [Changelog](https://fastnetmon.com/2026/08/06/fastnetmon-advanced-2-0-383/):
> FastNetMon Advanced 2.0.383 is a mandatory update for customers using online licensing. This release includes a new CA certificate required for communication with the FastNetMon licensing service as part of our infrastructure update. All customers using online licensing must upgrade to FastNetMon Advanced v2.0.383 no later than August 14, 2026, to ensure uninterrupted automatic license renewals.

Changelogs since 2.0.380:
* https://fastnetmon.com/2026/07/13/fastnetmon-advanced-2-0-381/
* https://fastnetmon.com/2026/07/20/fastnetmon-advanced-2-0-382/
* https://fastnetmon.com/2026/08/06/fastnetmon-advanced-2-0-383/

This PR additionally adds me as a maintainer of the `fastnetmon-advanced` package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
