### PR TITLE
lib: improve implementation of `overrideExisting`

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -1863,7 +1863,7 @@ rec {
 
     :::
   */
-  overrideExisting = old: new: mapAttrs (name: value: new.${name} or value) old;
+  overrideExisting = old: new: old // intersectAttrs old new;
 
   /**
     Turns a list of strings into a human-readable description of those


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Similar to #547436

This PR improves on the implementation of `lib.attrsets.overrideExisting`.

It's not used a lot throughout nixpkgs, so it unfortunately doesn't lead to any big eval gains, but might be beneficial out of tree.

Here's my test setup:

```nix
lib:
let
  overrideExistingOld =
    old:
    new:
    builtins.mapAttrs (name: value: new.${name} or value) old;

  overrideExistingNew =
    old:
    new:
    old // builtins.intersectAttrs old new;

  smalldata = lib.genAttrs (lib.imap0 (i: _: toString i) (lib.replicate 3 null)) (_: null);
  bigdata = lib.genAttrs (lib.imap0 (i: _: toString i) (lib.replicate 999 null)) (_: null);
  attrsToOverride = {
    "1" = "a";
    "2" = "b";
    "1823" = "c";
    "1223" = "d";
    "ads;fkjasdlfkja" = "e";
  };
in {
  old = overrideExistingOld bigdata attrsToOverride;
  new = overrideExistingNew bigdata attrsToOverride;
  oldS = overrideExistingOld smalldata attrsToOverride;
  newS = overrideExistingNew smalldata attrsToOverride;
  sanity = (overrideExistingOld bigdata attrsToOverride) == (overrideExistingNew bigdata attrsToOverride);
}
```

Here are the stats:

<details>
  <summary><code>NIX_SHOW_STATS=1 nix eval .#old</code></summary>

```json
{
  "cpuTime": 0.1400270015001297,
  "envs": {
    "bytes": 147800,
    "elements": 9416,
    "number": 9059
  },
  "gc": {
    "cycles": 1,
    "heapSize": 402915328,
    "totalBytes": 501712
  },
  "list": {
    "bytes": 23984,
    "concats": 0,
    "elements": 2998
  },
  "nrAvoided": 6065,
  "nrExprs": 3421,
  "nrFunctionCalls": 9033,
  "nrLookups": 1051,
  "nrOpUpdateValuesCopied": 28,
  "nrOpUpdates": 20,
  "nrPrimOpCalls": 1023,
  "nrThunks": 3293,
  "sets": {
    "bytes": 114312,
    "elements": 5562,
    "number": 1055
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 24,
    "Env": 8,
    "Value": 16
  },
  "symbols": {
    "bytes": 11483,
    "number": 1856
  },
  "time": {
    "cpu": 0.1400270015001297,
    "gc": 0.001,
    "gcFraction": 0.007141479780948346
  },
  "values": {
    "bytes": 167376,
    "number": 10461
  }
}
```

</details>

<details>
  <summary><code>NIX_SHOW_STATS=1 nix eval .#new</code></summary>

```json
{
  "cpuTime": 0.03855099901556969,
  "envs": {
    "bytes": 115832,
    "elements": 7418,
    "number": 7061
  },
  "gc": {
    "cycles": 1,
    "heapSize": 402915328,
    "totalBytes": 424368
  },
  "list": {
    "bytes": 23984,
    "concats": 0,
    "elements": 2998
  },
  "nrAvoided": 6066,
  "nrExprs": 3421,
  "nrFunctionCalls": 7035,
  "nrLookups": 52,
  "nrOpUpdateValuesCopied": 30,
  "nrOpUpdates": 22,
  "nrPrimOpCalls": 1023,
  "nrThunks": 3292,
  "sets": {
    "bytes": 98464,
    "elements": 4570,
    "number": 1056
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 24,
    "Env": 8,
    "Value": 16
  },
  "symbols": {
    "bytes": 11483,
    "number": 1856
  },
  "time": {
    "cpu": 0.03855099901556969,
    "gc": 0.0,
    "gcFraction": 0.0
  },
  "values": {
    "bytes": 135392,
    "number": 8462
  }
}
```

</details>

<details>
  <summary><code>NIX_SHOW_STATS=1 nix eval .#oldS</code></summary>

```json
{
  "cpuTime": 0.038488999009132385,
  "envs": {
    "bytes": 4376,
    "elements": 452,
    "number": 95
  },
  "gc": {
    "cycles": 1,
    "heapSize": 402915328,
    "totalBytes": 75360
  },
  "list": {
    "bytes": 80,
    "concats": 0,
    "elements": 10
  },
  "nrAvoided": 89,
  "nrExprs": 3421,
  "nrFunctionCalls": 69,
  "nrLookups": 55,
  "nrOpUpdateValuesCopied": 28,
  "nrOpUpdates": 20,
  "nrPrimOpCalls": 27,
  "nrThunks": 1301,
  "sets": {
    "bytes": 26664,
    "elements": 1578,
    "number": 59
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 24,
    "Env": 8,
    "Value": 16
  },
  "symbols": {
    "bytes": 8599,
    "number": 860
  },
  "time": {
    "cpu": 0.038488999009132385,
    "gc": 0.0,
    "gcFraction": 0.0
  },
  "values": {
    "bytes": 23952,
    "number": 1497
  }
}
```

</details>

<details>
  <summary><code>NIX_SHOW_STATS=1 nix eval .#newS</code></summary>

```json
{
  "cpuTime": 0.04659000039100647,
  "envs": {
    "bytes": 4280,
    "elements": 446,
    "number": 89
  },
  "gc": {
    "cycles": 1,
    "heapSize": 402915328,
    "totalBytes": 75424
  },
  "list": {
    "bytes": 80,
    "concats": 0,
    "elements": 10
  },
  "nrAvoided": 90,
  "nrExprs": 3421,
  "nrFunctionCalls": 63,
  "nrLookups": 52,
  "nrOpUpdateValuesCopied": 30,
  "nrOpUpdates": 22,
  "nrPrimOpCalls": 27,
  "nrThunks": 1300,
  "sets": {
    "bytes": 26720,
    "elements": 1580,
    "number": 60
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 24,
    "Env": 8,
    "Value": 16
  },
  "symbols": {
    "bytes": 8599,
    "number": 860
  },
  "time": {
    "cpu": 0.04659000039100647,
    "gc": 0.0,
    "gcFraction": 0.0
  },
  "values": {
    "bytes": 23840,
    "number": 1490
  }
}
```

</details>

Negligible difference for small counts, for large attrsets we reduce function calls and set handling.

Sanity check and `nix-instantiate --eval --strict lib/tests/misc.nix` passes successfully.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [X] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
