### PR TITLE
concord-tui: 2.5.0 -> 2.5.4

### DIFF
--- a/pkgs/by-name/co/concord-tui/package.nix
+++ b/pkgs/by-name/co/concord-tui/package.nix
@@ -1,37 +1,39 @@
 {
   rustPlatform,
   fetchFromGitHub,
+  cmake,
   pkg-config,
   makeWrapper,
   nasm,
   alsa-lib,
-  opus,
   pipewire,
+  libva,
+  mesa,
   lib,
   stdenv,
   nix-update-script,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "concord-tui";
-  version = "2.5.0";
+  version = "2.5.4";
 
   src = fetchFromGitHub {
     owner = "chojs23";
     repo = "concord";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-DkbZZlURGwQCajhWmkcYmgFZDLvUOg6aU/JjGRiZY4Y=";
+    hash = "sha256-nliUyeoz/7MIBZK5ChwRjDNFpyXuXYRk/ito0Km7Ybw=";
   };
 
-  cargoHash = "sha256-ISWQjHUPoYPgMu+aJUDlLjp5AahauHG9BuOAANMXKRA=";
+  cargoHash = "sha256-hQAYjkugGqpLntt7ToXtu5jJV215SLXr11PkE0V0OH0=";
 
-  buildInputs = [
-    opus
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     alsa-lib
     pipewire
+    libva
+    mesa
   ];
   nativeBuildInputs = [
+    cmake
     pkg-config
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [


### PR DESCRIPTION
## Summary

- Update `concord-tui` from 2.5.0 to 2.5.4.
- Refresh the source and Cargo vendor hashes.
- Remove the system `opus` input after upstream replaced `audiopus_sys` with bundled `opusic-c`.
- Add `cmake` for the bundled Opus build.
- Add `libva` and `mesa` on Linux for the new VA-API and EGL hardware H.264 encoder paths.

Upstream changes: https://github.com/chojs23/concord/releases/tag/v2.5.4

The dependency update is needed because the old package definition still linked system Opus and did not provide the native tools and libraries required by the 2.5.4 build.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [x] The package `checkPhase` passed 1,669 upstream Rust tests.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - `concord --version` prints `concord 2.5.4`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Disclosure: This pull request summary and the package update were prepared with OpenAI Codex using `gpt-5.6-sol`. The result was reviewed through source diff inspection, Nix formatting, native build and tests, a binary smoke test, and x86_64-linux evaluation.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
