### PR TITLE
fishnet: 2.13.2 -> 2.14.0

### DIFF
--- a/pkgs/by-name/fi/fishnet/package.nix
+++ b/pkgs/by-name/fi/fishnet/package.nix
@@ -12,40 +12,32 @@
 }:
 
 let
-  # These files can be found in Stockfish/src/evaluate.h
-  nnueBigFile = "nn-9a0cc2a62c52.nnue";
-  nnueBigHash = "sha256-mgzCpixSClN6rTrG6QiowJiqkAidyny8h0zCGXYYvyM=";
-  nnueBig = fetchurl {
-    url = "https://tests.stockfishchess.org/api/nn/${nnueBigFile}";
-    hash = nnueBigHash;
-  };
-  nnueSmallFile = "nn-47fc8b7fff06.nnue";
-  nnueSmallHash = "sha256-R/yLf/8GfSQEdJO4TkKrhVwPzrUFjAFsafjuXE7kvWk=";
-  nnueSmall = fetchurl {
-    url = "https://tests.stockfishchess.org/api/nn/${nnueSmallFile}";
-    hash = nnueSmallHash;
+  # This file can be found in Stockfish/src/evaluate.h
+  nnueFile = "nn-89cb98a217f7.nnue";
+  nnueHash = "sha256-icuYohf3IBR8coYXYQl76koEKJl90iDsioGlYkMbu+Y=";
+  nnue = fetchurl {
+    url = "https://tests.stockfishchess.org/api/nn/${nnueFile}";
+    hash = nnueHash;
   };
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "fishnet";
-  version = "2.13.2";
+  version = "2.14.0";
 
   src = fetchFromGitHub {
     owner = "lichess-org";
     repo = "fishnet";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-0ArTovfr9znjudo53W5hnnSZlzfEnAd7E+7DXTqtN6w=";
+    hash = "sha256-p6gZEQfC/XX0qp7nJZps5FNDea5iOVXN4hQ6f5nGKCc=";
     fetchSubmodules = true;
   };
 
   postPatch = ''
-    cp -v '${nnueBig}' 'Stockfish/src/${nnueBigFile}'
-    cp -v '${nnueBig}' 'Fairy-Stockfish/src/${nnueBigFile}'
-    cp -v '${nnueSmall}' 'Stockfish/src/${nnueSmallFile}'
-    cp -v '${nnueSmall}' 'Fairy-Stockfish/src/${nnueSmallFile}'
+    cp -v '${nnue}' 'Stockfish/src/${nnueFile}'
+    cp -v '${nnue}' 'Fairy-Stockfish/src/${nnueFile}'
   '';
 
-  cargoHash = "sha256-mkioBmawYR5GvR0WSlaicGyXV4EVVVQuai5UF5+Thk8=";
+  cargoHash = "sha256-S3mgeYujRLvEoJYLG8Np1f1JYuftF3lZlptG33QqbNM=";
 
   nativeInstallCheckInputs = [
     versionCheckHook
@@ -68,10 +60,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
         PNAME = finalAttrs.pname;
         PKG_FILE = toString ./package.nix;
         GITHUB_REPOSITORY = "${finalAttrs.src.owner}/${finalAttrs.src.repo}";
-        NNUE_BIG_FILE = nnueBigFile;
-        NNUE_BIG_HASH = nnueBigHash;
-        NNUE_SMALL_FILE = nnueSmallFile;
-        NNUE_SMALL_HASH = nnueSmallHash;
+        NNUE_FILE = nnueFile;
+        NNUE_HASH = nnueHash;
       };
 
       text = builtins.readFile ./update.bash;

--- a/pkgs/by-name/fi/fishnet/update.bash
+++ b/pkgs/by-name/fi/fishnet/update.bash
@@ -9,31 +9,20 @@ stockfish_revision="$(
 stockfish_header="$(
     curl --fail --silent "https://raw.githubusercontent.com/official-stockfish/Stockfish/$stockfish_revision/src/evaluate.h"
 )"
-new_nnue_big_file="$(
+new_nnue_file="$(
     echo "$stockfish_header" |
-        grep --perl-regexp --only-matching 'EvalFileDefaultNameBig "\Knn-(\w+).nnue'
+        grep --perl-regexp --only-matching 'EvalFileDefaultName "\Knn-(\w+).nnue'
 )"
-new_nnue_big_hash="$(
+new_nnue_hash="$(
     nix --extra-experimental-features nix-command hash to-sri --type sha256 "$(
-        nix-prefetch-url --type sha256 "https://tests.stockfishchess.org/api/nn/${new_nnue_big_file}"
-    )"
-)"
-new_nnue_small_file="$(
-    echo "$stockfish_header" |
-        grep --perl-regexp --only-matching 'EvalFileDefaultNameSmall "\Knn-(\w+).nnue'
-)"
-new_nnue_small_hash="$(
-    nix --extra-experimental-features nix-command hash to-sri --type sha256 "$(
-        nix-prefetch-url --type sha256 "https://tests.stockfishchess.org/api/nn/${new_nnue_small_file}"
+        nix-prefetch-url --type sha256 "https://tests.stockfishchess.org/api/nn/${new_nnue_file}"
     )"
 )"
 
 # Update NNUE
 pkg_body="$(<"$PKG_FILE")"
-pkg_body="${pkg_body//"$NNUE_BIG_FILE"/"$new_nnue_big_file"}"
-pkg_body="${pkg_body//"$NNUE_BIG_HASH"/"$new_nnue_big_hash"}"
-pkg_body="${pkg_body//"$NNUE_SMALL_FILE"/"$new_nnue_small_file"}"
-pkg_body="${pkg_body//"$NNUE_SMALL_HASH"/"$new_nnue_small_hash"}"
+pkg_body="${pkg_body//"$NNUE_FILE"/"$new_nnue_file"}"
+pkg_body="${pkg_body//"$NNUE_HASH"/"$new_nnue_hash"}"
 echo "$pkg_body" >"$PKG_FILE"
 
 # Update version, src


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Diff: https://github.com/lichess-org/fishnet/compare/v2.13.2...v2.14.0

Changelog: https://github.com/lichess-org/fishnet/releases/tag/v2.14.0

This update also updates updateScript.
The new stockfish revision https://github.com/official-stockfish/Stockfish/tree/f4bcd40409f94bd397a083c5d6243bac6dcc6d85 includes https://github.com/official-stockfish/Stockfish/commit/ab8f901d25def6c17f83b7a1b4b84eaec404c0f4 which drops the small net.

cc @tu-maurice @ornicar

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
