### PR TITLE
anytype: retry bun install on flaky tarball downloads

### DIFF
--- a/pkgs/by-name/an/anytype/package.nix
+++ b/pkgs/by-name/an/anytype/package.nix
@@ -61,17 +61,38 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     buildPhase = ''
       runHook preBuild
 
-      export BUN_INSTALL_CACHE_DIR=$(mktemp -d)
       # https://bun.com/docs/pm/cli/install#configuring-with-environment-variables
+      export BUN_INSTALL_CACHE_DIR=$(mktemp -d)
 
-      # Bun always tries to use the fastest available installation method for the target platform. On macOS, that’s clonefile and on Linux, that’s hardlink.
-      bun install \
-        --backend=copyfile \
-        --cpu="*" \
-        --frozen-lockfile \
-        --ignore-scripts \
-        --no-progress \
-        --os="*"
+      # TODO: drop the retry loop once a bun release carries the fixes below
+      # When a tarball download hiccups, bun gives up on the spot instead of asking for
+      # it again. We pull in every platform's binaries below, which is around 90 extra
+      # downloads, so sooner or later one goes wrong and the build dies with
+      # error: Fail extracting tarball for "@esbuild/android-x64"
+      # https://github.com/oven-sh/bun/pull/34827 (retry cut short bodies, still open)
+      # https://github.com/oven-sh/bun/pull/34861 (merged to main, not in 1.3.13)
+      for attempt in 1 2 3; do
+        # Bun always tries to use the fastest available installation method for the target platform. On macOS, that’s clonefile and on Linux, that’s hardlink.
+        if bun install \
+          --backend=copyfile \
+          --cpu="*" \
+          --frozen-lockfile \
+          --ignore-scripts \
+          --no-progress \
+          --os="*"; then
+          break
+        fi
+
+        if [ "$attempt" = 3 ]; then
+          echo "error: bun install kept failing after $attempt attempts, giving up" >&2
+          exit 1
+        fi
+
+        # Wipe the tree before going again, otherwise a half written package could stick
+        # around and change the output hash. Everything that did download is still in the
+        # cache dir, so this costs almost nothing
+        find . -type d -name node_modules -prune -exec rm -rf {} +
+      done
 
       runHook postBuild
     '';


### PR DESCRIPTION
`bun install` in the `node_modules` FOD dies the first time a tarball download
  hiccups, and it never asks for that tarball again:

      error: Fail extracting tarball for "@esbuild/android-x64"

  We pass `--os="*" --cpu="*"` so one `outputHash` works on every platform, which
  drags in around 90 prebuilt binaries and a 2.2 GiB tree. That is a lot of large
  downloads, and one of them going wrong is enough to fail the build. It is flaky,
  not reproducible, the same drv builds fine on the next try.

  Upstream knows: oven-sh/bun#34827 (a body cut short is never retried) and
  oven-sh/bun#34861 (fixed in main, not in any release, we ship 1.3.13).

  So just retry three times. `node_modules` gets wiped in between so a half written
  package cannot end up in the output, and the download cache is shared across
  attempts, so a retry only refetches what failed.
 
Fixes #549831



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
