### PR TITLE
tauon: use libayatana-appindicator and expose it at runtime

### DIFF
--- a/pkgs/by-name/ta/tauon/package.nix
+++ b/pkgs/by-name/ta/tauon/package.nix
@@ -10,7 +10,7 @@
   flac,
   game-music-emu,
   gtk3,
-  libappindicator,
+  libayatana-appindicator,
   libnotify,
   libopenmpt,
   librsvg,
@@ -93,7 +93,6 @@ python3Packages.buildPythonApplication {
     flac
     game-music-emu
     gtk3
-    libappindicator
     libnotify
     libopenmpt
     librsvg
@@ -141,6 +140,7 @@ python3Packages.buildPythonApplication {
       lib.makeLibraryPath (
         [
           game-music-emu
+          libayatana-appindicator
           libopenmpt
           pulseaudio
         ]


### PR DESCRIPTION
Since 11.1.1 Tauon creates its tray through SDL3's `SDL_CreateTray()` instead of pygobject, and SDL loads the indicator library at runtime with `dlopen()` by soname. Listing the library in `buildInputs` therefore does not make it reachable — it has to be on the wrapper's `LD_LIBRARY_PATH`. With the tray enabled (`settings` > `View` > `Tray`, or `--tray`; the pref defaults to off) tauon aborts on startup:

```
  File ".../site-packages/tauon/t_modules/t_main.py", line 6957, in init_sdl_tray
    raise RuntimeError(f"SDL_CreateTray failed: {sdl3.SDL_GetError().decode()}")
RuntimeError: SDL_CreateTray failed: Could not load AppIndicator libraries
```

Resolves #549538

### Why `libayatana-appindicator` instead of the existing `libappindicator`

SDL's loader tries `libayatana-appindicator3.so.1` first and only falls back to `libappindicator3.so.1` ([`src/tray/unix/SDL_tray.c#L81-L89`](https://github.com/libsdl-org/SDL/blob/release-3.4.12/src/tray/unix/SDL_tray.c#L81-L89)), and upstream's CI builds against `libayatana-appindicator3-dev` ([`build_and_release.yaml#L38`](https://github.com/Taiko2k/Tauon/blob/v11.1.1/.github/workflows/build_and_release.yaml#L38)).

The current `libappindicator` dependency predates the SDL migration: it was only reachable through `GI_TYPELIB_PATH`, and Tauon no longer uses the AppIndicator3 typelib at all — the sole remaining mention in the tree is a commented-out signature in `t_main.py`. So this replaces it rather than adding a second indicator library, which also moves one package off the dead library per #96420.

### Why gtk3 is not added to `LD_LIBRARY_PATH`

SDL dlopens `libgtk-3.so.0` too ([`src/core/unix/SDL_gtk.c#L52`](https://github.com/libsdl-org/SDL/blob/release-3.4.12/src/core/unix/SDL_gtk.c#L52)), which would suggest gtk3 needs the same treatment. It does not: `SDL_CreateTray()` calls `init_appindicator()` before `SDL_Gtk_EnterContext()` ([`SDL_tray.c#L249-L254`](https://github.com/libsdl-org/SDL/blob/release-3.4.12/src/tray/unix/SDL_tray.c#L249-L254)), and the indicator library pulls its own gtk3 in through RPATH, so the soname is already in the link map by the time SDL asks for it. Verified:

```console
$ LD_LIBRARY_PATH=$(nix eval --raw nixpkgs#libayatana-appindicator)/lib python3 -c '
import ctypes
try: ctypes.CDLL("libgtk-3.so.0"); print("gtk before: OK")
except OSError: print("gtk before: FAIL")
ctypes.CDLL("libayatana-appindicator3.so.1"); print("appindicator: OK")
ctypes.CDLL("libgtk-3.so.0"); print("gtk after: OK")'
gtk before: FAIL
appindicator: OK
gtk after: OK
```

### Verification

Ran `./result/bin/tauon` on x86_64-linux (Wayland, `use-system-tray = true`). It no longer aborts, and the indicator really reaches the session bus rather than just failing silently:

```console
$ busctl --user get-property org.kde.StatusNotifierWatcher /StatusNotifierWatcher \
    org.kde.StatusNotifierWatcher RegisteredStatusNotifierItems | tr ' ' '\n' | grep sdl
":1.1838/org/ayatana/NotificationItem/sdl_appindicator_40856_0"

$ busctl --user call :1.1838 /org/ayatana/NotificationItem/sdl_appindicator_40856_0/Menu \
    com.canonical.dbusmenu GetLayout iias 0 2 1 label | grep -o '"[^"]*"'
"label"
"Open Tauon Music Box"
"label"
"Play/Pause"
...
"Quit"
```

The item is `Active`, its id matches SDL's `sdl-appindicator-%d-%d`, and the dbusmenu layout carries the entries Tauon inserts. Shutdown on `SIGINT` is clean. Also confirmed that the four symbols SDL resolves (`app_indicator_new`, `app_indicator_set_status`, `app_indicator_set_icon`, `app_indicator_set_menu`) are exported by `libayatana-appindicator3.so.1`, and that nothing in Tauon uses the AppIndicator3 typelib that `libappindicator` was contributing to `GI_TYPELIB_PATH` — there is no `gi.require_version("AppIndicator3", …)` in the tree, so dropping the `buildInputs` entry along with it changes nothing at runtime.

### Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

### Disclosure

Per the [automation/AI policy]: this change was investigated and drafted with Claude Code (claude-opus-5), and this pull request summary was written by it as well. Its findings were checked against primary sources rather than taken on trust — the SDL loader order and the two `dlopen` sites were read in the SDL 3.4.12 tree that nixpkgs builds, the library-resolution claims were reproduced with the `ctypes` snippet above, and the resulting package was built and its tray inspected over D-Bus rather than judged by eye. The commit carries an `Assisted-by:` trailer.

cc maintainers @jansol @alfarelcynthesis

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

