### PR TITLE
pinnacle: pin libdisplay-info version for config

### DIFF
--- a/pkgs/by-name/pi/pinnacle/pinnacle-config.nix
+++ b/pkgs/by-name/pi/pinnacle/pinnacle-config.nix
@@ -6,7 +6,7 @@
   libxkbcommon,
   libinput,
   lua5_4,
-  libdisplay-info,
+  libdisplay-info_0_3,
   libgbm,
   pinnacle-src,
 }:
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage (
       libxkbcommon
       libinput
       lua5_4
-      libdisplay-info
+      libdisplay-info_0_3
       libgbm
     ];
   }


### PR DESCRIPTION
the rust config builder also takes libdisplay-info and also needs to be pinned back at v0.3.

example build failure:
https://nixbot.nix-community.org/repos/github/nix-community/home-manager/builds/571/logs/default.nixbot.x86_64-linux.test-chunk-22

## Things done

this just carries over a fix from the main package to the build helper. it's minimal impact.
