### PR TITLE
ocamlPackages.httpcats: 0.2.1 → 0.3.1

### DIFF
--- a/pkgs/development/ocaml-modules/httpcats/default.nix
+++ b/pkgs/development/ocaml-modules/httpcats/default.nix
@@ -1,6 +1,5 @@
 {
-  fetchpatch2,
-  fetchzip,
+  fetchurl,
   buildDunePackage,
   lib,
   logs,
@@ -12,26 +11,19 @@
   tls-miou-unix,
   dns-client-miou-unix,
   happy-eyeballs-miou-unix,
-  mirage-crypto-rng-miou-unix,
+  mirage-crypto-rng,
   alcotest,
   digestif,
 }:
 
 buildDunePackage (finalAttrs: {
   pname = "httpcats";
-  version = "0.2.1";
+  version = "0.3.1";
 
-  src = fetchzip {
+  src = fetchurl {
     url = "https://github.com/robur-coop/httpcats/releases/download/v${finalAttrs.version}/httpcats-${finalAttrs.version}.tbz";
-    hash = "sha256-ehtwxQGHw8igzI0dy2Zzs+VOqvck/tAUuuJl+jSpVU8=";
+    hash = "sha256-5BymoyJS5JykTnSee0HhSKzbHkb8j6COuY7tZtGDGh0=";
   };
-
-  patches = [
-    (fetchpatch2 {
-      url = "https://github.com/robur-coop/httpcats/commit/d8787555d4831e0488780d42bd2c65de662d1d38.patch";
-      hash = "sha256-6zXPb+mvw2rcEMv28b0npcL8cKl3CASxDbl7FOAGsXs=";
-    })
-  ];
 
   propagatedBuildInputs = [
     h2
@@ -49,7 +41,7 @@ buildDunePackage (finalAttrs: {
   checkInputs = [
     logs
     fmt
-    mirage-crypto-rng-miou-unix
+    mirage-crypto-rng
     alcotest
     digestif
   ];


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
