### PR TITLE
python3Packages.loop-rate-limiters: init at 1.2.0, python3Packages.pin-pink: init at 4.3.0

### DIFF
--- a/pkgs/development/python-modules/loop-rate-limiters/default.nix
+++ b/pkgs/development/python-modules/loop-rate-limiters/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  flit-core,
+  pytest-asyncio,
+  pytestCheckHook,
+  nix-update-script,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "loop-rate-limiters";
+  version = "1.2.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "stephane-caron";
+    repo = "loop-rate-limiters";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-r/Kj8rU3mDWwNKZnbM4NWbCFTi5C6wH7qkfjcjT4bZA=";
+  };
+
+  build-system = [
+    flit-core
+  ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # RuntimeError: There is no current event loop in thread 'MainThread'.
+    "test_period_dt"
+  ];
+
+  pythonImportsCheck = [
+    "loop_rate_limiters"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Loop rate limiters in Python with an API similar to rospy.Rate";
+    homepage = "https://github.com/stephane-caron/loop-rate-limiters";
+    changelog = "https://github.com/stephane-caron/loop-rate-limiters/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nim65s ];
+  };
+})

--- a/pkgs/development/python-modules/pin-pink/default.nix
+++ b/pkgs/development/python-modules/pin-pink/default.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  flit-core,
+  loop-rate-limiters,
+  numpy,
+  pinocchio,
+  qpsolvers,
+  typing-extensions,
+  nix-update-script,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pin-pink";
+  version = "4.3.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "stephane-caron";
+    repo = "pink";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-XioGci++GEFEJNFPh8ZzLK8Y+CUKAmARAzbILD9fFng=";
+  };
+
+  # pinocchio does not install pypa metadata for now
+  postPatch = ''
+    substituteInPlace pyproject.toml --replace-fail \
+      '"pin >=' \
+      '#"pin >='
+  '';
+
+  build-system = [
+    flit-core
+  ];
+
+  dependencies = [
+    loop-rate-limiters
+    numpy
+    pinocchio
+    qpsolvers
+    typing-extensions
+  ];
+
+  # Need to dowload a lot of data for robot_descriptions
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "pink"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Python inverse kinematics using Pinocchio and QP solvers";
+    homepage = "https://github.com/stephane-caron/pink";
+    changelog = "https://github.com/stephane-caron/pink/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nim65s ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9972,6 +9972,8 @@ self: super: with self; {
 
   loompy = callPackage ../development/python-modules/loompy { };
 
+  loop-rate-limiters = callPackage ../development/python-modules/loop-rate-limiters { };
+
   looptime = callPackage ../development/python-modules/looptime { };
 
   loopy = callPackage ../development/python-modules/loopy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13276,6 +13276,8 @@ self: super: with self; {
 
   pims = callPackage ../development/python-modules/pims { };
 
+  pin-pink = callPackage ../development/python-modules/pin-pink { };
+
   pinboard = callPackage ../development/python-modules/pinboard { };
 
   pinecone = callPackage ../development/python-modules/pinecone { };


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
