### PR TITLE
codex-history: init at 0.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11259,6 +11259,11 @@
     github = "hitsmaxft";
     githubId = 352727;
   };
+  HizKz = {
+    name = "Kazushi Hizume";
+    github = "HizKz";
+    githubId = 190076537;
+  };
   hkjn = {
     email = "me@hkjn.me";
     name = "Henrik Jonsson";

--- a/pkgs/by-name/co/codex-history/package.nix
+++ b/pkgs/by-name/co/codex-history/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildGoModule,
+  codex,
+  fetchFromGitHub,
+  makeWrapper,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "codex-history";
+  version = "0.5.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "HizKz";
+    repo = "codex-history";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0cm/tCg2Na6ojNIXupmHKTkkyFqtFNWVTORnbFe0bno=";
+  };
+
+  vendorHash = "sha256-eA9P3TJHxwmfgmeqpj0SufJx/p2Bt+gAC0+Q/TwSetE=";
+
+  subPackages = [ "cmd/codex-history" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/HizKz/codex-history/internal/buildinfo.Version=${finalAttrs.version}"
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postFixup = ''
+    wrapProgram $out/bin/codex-history \
+      --prefix PATH : ${lib.makeBinPath [ codex ]}
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  meta = {
+    description = "Browse, search, and resume local Codex conversations";
+    homepage = "https://github.com/HizKz/codex-history";
+    changelog = "https://github.com/HizKz/codex-history/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ HizKz ];
+    mainProgram = "codex-history";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Adds [codex-history](https://github.com/HizKz/codex-history) 0.5.0, a Go TUI for browsing, searching, and resuming local Codex conversations through the Codex app-server protocol.

The package builds the `cmd/codex-history` subpackage, installs `codex` on the wrapped runtime `PATH`, checks the reported version during installation, and registers HizKz as maintainer.

## Validation

- `nix-build -A codex-history`
- `nix-build maintainers/scripts/build.nix --argstr maintainer HizKz`
- `nix-build ci -A nixpkgs-vet ...` (`Validated successfully`)
- `nixpkgs-review rev --branch b73c8df00162937c86088669324a949cf7f68169 HEAD`
- `./result/bin/codex-history --version`
- `./result/bin/codex-history --help`

## AI assistance disclosure

Prepared with assistance from OpenAI Codex (GPT-5). I reviewed the package definition, source and vendor hashes, commit diff, and validation results. The package commit also includes the required `Assisted-by` trailer. This PR remains a draft pending final human review.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
