### PR TITLE
lib.fileset: Optimise source filters

### DIFF
--- a/lib/fileset/internal.nix
+++ b/lib/fileset/internal.nix
@@ -587,7 +587,7 @@ rec {
           # With base /foo/bar this matches /foo/bar and /foo/bar/baz
           # hasPrefix "/foo/bar/" "/foo/bar/baz/"
           if getBaseStringPrefix pathSlash == baseString then
-            if stringLength pathSlash == baseLength then
+            if pathSlash == baseString then
               # The path is the base directory itself, which is always included
               true
             else

--- a/lib/fileset/internal.nix
+++ b/lib/fileset/internal.nix
@@ -802,21 +802,34 @@ rec {
   */
   _unionTrees =
     trees:
-    let
-      stringIndex = findFirstIndex isString null trees;
-      withoutNull = filter (tree: tree != null) trees;
-    in
-    if stringIndex != null then
+    if length trees == 1 then
+      # The union of a single tree simply returns the first element
+      head trees
+    else
+      let
+        # Like lib.findFirstIndex but without indexing.
+        # This is a hot path so the indexing arithmetic adds up.
+        firstStr = foldl' (
+          found: tree:
+          if found != null then
+            found
+          else if isString tree then
+            tree
+          else
+            found # null
+        ) null trees;
+        nonNulls = filter (tree: tree != null) trees;
+      in
       # If there's a string, it's always a fully included tree (dir or file),
       # no need to look at other elements
-      elemAt trees stringIndex
-    else if withoutNull == [ ] then
-      # If all trees are null, then the resulting tree is also null
-      null
-    else
-      # The non-null elements have to be attribute sets representing partial trees
-      # We need to recurse into those
-      zipAttrsWith (name: _unionTrees) withoutNull;
+      if firstStr != null then
+        firstStr
+      else if nonNulls == [ ] then
+        null
+      else
+        # The non-null elements have to be attribute sets representing partial trees
+        # We need to recurse into those
+        zipAttrsWith (name: _unionTrees) nonNulls;
 
   /**
     Computes the intersection of two filesets.

--- a/lib/fileset/internal.nix
+++ b/lib/fileset/internal.nix
@@ -359,11 +359,10 @@ rec {
       recurse =
         path: tree:
         let
-          entries = _directoryEntries path tree;
           normalisedSubtrees = mapAttrs (
             name: subtree:
             if subtree == "directory" || isAttrs subtree then recurse (path + "/${name}") subtree else subtree
-          ) entries;
+          ) (_directoryEntries path tree);
           subtreeValues = attrValues normalisedSubtrees;
         in
         # This triggers either when all files in a directory are filtered out

--- a/lib/fileset/internal.nix
+++ b/lib/fileset/internal.nix
@@ -350,23 +350,34 @@ rec {
   */
   _normaliseTreeFilter =
     path: tree:
-    if tree == "directory" || isAttrs tree then
-      let
-        entries = _directoryEntries path tree;
-        normalisedSubtrees = mapAttrs (name: _normaliseTreeFilter (path + "/${name}")) entries;
-        subtreeValues = attrValues normalisedSubtrees;
-      in
-      # This triggers either when all files in a directory are filtered out
-      # Or when the directory doesn't contain any files at all
-      if all isNull subtreeValues then
-        null
-      # Triggers when we have the same as a `readDir path`, so we can turn it back into an equivalent "directory".
-      else if all isString subtreeValues then
-        "directory"
-      else
-        normalisedSubtrees
-    else
-      tree;
+    let
+      # Recurses into a tree that's already known to be a directory (either a "directory" or an attrset).
+      #
+      # Only directories need to be recursed into:
+      # Files are either null (excluded) or a file type string (included), which are already normalised.
+      #
+      # Checking this in the caller instead of here also avoids the thunk allocation for the path concatenation below.
+      recurse =
+        path: tree:
+        let
+          entries = _directoryEntries path tree;
+          normalisedSubtrees = mapAttrs (
+            name: subtree:
+            if subtree == "directory" || isAttrs subtree then recurse (path + "/${name}") subtree else subtree
+          ) entries;
+          subtreeValues = attrValues normalisedSubtrees;
+        in
+        # This triggers either when all files in a directory are filtered out
+        # Or when the directory doesn't contain any files at all
+        if all isNull subtreeValues then
+          null
+        # Triggers when we have the same as a `readDir path`, so we can turn it back into an equivalent "directory".
+        else if all isString subtreeValues then
+          "directory"
+        else
+          normalisedSubtrees;
+    in
+    if tree == "directory" || isAttrs tree then recurse path tree else tree;
 
   /**
     A minimal normalisation of a filesetTree, intended for pretty-printing:

--- a/lib/fileset/internal.nix
+++ b/lib/fileset/internal.nix
@@ -563,7 +563,12 @@ rec {
               # or a string ("directory" or "regular", etc.) in which case it's included
               localTree != null;
         in
-        recurse 0 tree;
+        # Start by recursing into the first element. This is guaranteed to be
+        # safe. components will never be empty (builtins.split can't make an
+        # empty list). Tree can be something other than an attrset, but if so,
+        # the isAttrs check will fail when being passed `or tree`, and the index
+        # being ahead doesn't matter.
+        recurse 2 (tree.${head components} or tree);
 
       # Filter suited when there's no files
       empty = _: _: false;

--- a/lib/fileset/internal.nix
+++ b/lib/fileset/internal.nix
@@ -580,25 +580,34 @@ rec {
           pathSlash = path + "/";
         in
         (
+          # Same as `hasPrefix baseString pathSlash`, but more efficient.
+          # The path is either the base itself or underneath it,
+          # but only on the few paths above it, so its checked first.
+          # With base /foo/bar this matches /foo/bar and /foo/bar/baz
+          # hasPrefix "/foo/bar/" "/foo/bar/baz/"
+          if substring 0 baseLength pathSlash == baseString then
+            if stringLength pathSlash == baseLength then
+              # The path is the base directory itself, which is always included
+              true
+            else
+              # Same as `removePrefix baseString path`, but more efficient.
+              # From the above code we know that hasPrefix baseString pathSlash holds, so this is safe.
+              # We don't use pathSlash here because we only needed the trailing slash for the prefix matching.
+              # With base /foo and path /foo/bar/baz this gives
+              # inTree (split "/" (removePrefix "/foo/" "/foo/bar/baz"))
+              # == inTree (split "/" "bar/baz")
+              # == inTree [ "bar" "baz" ]
+              inTree (split "/" (substring baseLength (-1) path))
           # Same as `hasPrefix pathSlash baseString`, but more efficient.
+          # The path is a proper ancestor of the base, which needs to be included for the base to be reachable:
           # With base /foo/bar we need to include /foo:
           # hasPrefix "/foo/" "/foo/bar/"
-          if substring 0 (stringLength pathSlash) baseString == pathSlash then
+          else if substring 0 (stringLength pathSlash) baseString == pathSlash then
             true
-          # Same as `! hasPrefix baseString pathSlash`, but more efficient.
-          # With base /foo/bar we need to exclude /baz
-          # ! hasPrefix "/baz/" "/foo/bar/"
-          else if substring 0 baseLength pathSlash != baseString then
-            false
           else
-            # Same as `removePrefix baseString path`, but more efficient.
-            # From the above code we know that hasPrefix baseString pathSlash holds, so this is safe.
-            # We don't use pathSlash here because we only needed the trailing slash for the prefix matching.
-            # With base /foo and path /foo/bar/baz this gives
-            # inTree (split "/" (removePrefix "/foo/" "/foo/bar/baz"))
-            # == inTree (split "/" "bar/baz")
-            # == inTree [ "bar" "baz" ]
-            inTree (split "/" (substring baseLength (-1) path))
+            # The path is unrelated to the base, so nothing from it is included
+            # With base /foo/bar this matches e.g. /baz
+            false
         )
         # This is a way have an additional check in case the above is true without any significant performance cost
         && (

--- a/lib/fileset/internal.nix
+++ b/lib/fileset/internal.nix
@@ -349,7 +349,6 @@ rec {
     ```
   */
   _normaliseTreeFilter =
-    path: tree:
     let
       # Recurses into a tree that's already known to be a directory (either a "directory" or an attrset).
       #
@@ -377,7 +376,7 @@ rec {
         else
           normalisedSubtrees;
     in
-    if tree == "directory" || isAttrs tree then recurse path tree else tree;
+    path: tree: if tree == "directory" || isAttrs tree then recurse path tree else tree;
 
   /**
     A minimal normalisation of a filesetTree, intended for pretty-printing:

--- a/lib/fileset/internal.nix
+++ b/lib/fileset/internal.nix
@@ -536,6 +536,9 @@ rec {
         else
           "/" + concatStringsSep "/" fileset._internalBaseComponents + "/";
 
+      getBaseStringPrefix = substring 0 baseLength;
+      removeBaseStringPrefix = substring baseLength (-1);
+
       baseLength = stringLength baseString;
 
       # Check whether a list of path components under the base path exists in the tree.
@@ -584,7 +587,7 @@ rec {
           # but only on the few paths above it, so its checked first.
           # With base /foo/bar this matches /foo/bar and /foo/bar/baz
           # hasPrefix "/foo/bar/" "/foo/bar/baz/"
-          if substring 0 baseLength pathSlash == baseString then
+          if getBaseStringPrefix pathSlash == baseString then
             if stringLength pathSlash == baseLength then
               # The path is the base directory itself, which is always included
               true
@@ -596,7 +599,7 @@ rec {
               # inTree (split "/" (removePrefix "/foo/" "/foo/bar/baz"))
               # == inTree (split "/" "bar/baz")
               # == inTree [ "bar" "baz" ]
-              inTree (split "/" (substring baseLength (-1) path))
+              inTree (split "/" (removeBaseStringPrefix path))
           # Same as `hasPrefix pathSlash baseString`, but more efficient.
           # The path is a proper ancestor of the base, which needs to be included for the base to be reachable:
           # With base /foo/bar we need to include /foo:


### PR DESCRIPTION
## Things done

Optimise fileset performance. Found these as the root cause (~9% CPU time) of slow eval in a very large monorepo.

Benchmarked with the following Nix expression:
```nix
{
  lib ? import ./lib,
  pkgsDir ? ./pkgs,
}:
let
  fs = lib.fileset;
in
{
  unions = builtins.length (
    fs.toList (
      fs.unions (
        lib.mapAttrsToList (name: _: fs.fileFilter (f: f.hasExt "nix") (pkgsDir + "/by-name/${name}")) (
          builtins.readDir (pkgsDir + "/by-name")
        )
      )
    )
  );

  union-overlap = builtins.length (
    fs.toList (
      fs.union (fs.fileFilter (f: f.hasExt "nix") pkgsDir) (fs.fileFilter (f: f.hasExt "md") pkgsDir)
    )
  );

  to-source =
    (fs.toSource {
      root = pkgsDir;
      fileset = fs.fileFilter (f: f.hasExt "nix") pkgsDir;
    }).outPath;
}
```

The numbers:
- `unions`
  - Before
```json
{
  "cpuTime": 0.3081420063972473,
  "envs": {
    "bytes": 21146528,
    "elements": 1350461,
    "number": 1292855
  },
  "gc": {
    "cycles": 1,
    "heapSize": 402915328,
    "totalBytes": 63392192
  },
  "list": {
    "bytes": 2055768,
    "concats": 29519,
    "elements": 256971
  },
  "nrAvoided": 1767397,
  "nrExprs": 8475,
  "nrFunctionCalls": 1127497,
  "nrLookups": 42033,
  "nrOpUpdateValuesCopied": 1,
  "nrOpUpdates": 2,
  "nrPrimOpCalls": 889742,
  "nrThunks": 826846,
  "sets": {
    "bytes": 8260864,
    "elements": 330883,
    "number": 123614
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 24,
    "Env": 8,
    "Value": 16
  },
  "symbols": {
    "bytes": 315924,
    "number": 27622
  },
  "time": {
    "cpu": 0.3081420063972473,
    "gc": 0.001,
    "gcFraction": 0.0032452569894376245
  },
  "values": {
    "bytes": 21626560,
    "number": 1351660
  }
}
```
  - After
```json
{
  "cpuTime": 0.27952098846435547,
  "envs": {
    "bytes": 11342904,
    "elements": 712252,
    "number": 705611
  },
  "gc": {
    "cycles": 1,
    "heapSize": 402915328,
    "totalBytes": 36675776
  },
  "list": {
    "bytes": 1654120,
    "concats": 29519,
    "elements": 206765
  },
  "nrAvoided": 831137,
  "nrExprs": 8511,
  "nrFunctionCalls": 642184,
  "nrLookups": 42033,
  "nrOpUpdateValuesCopied": 1,
  "nrOpUpdates": 2,
  "nrPrimOpCalls": 436511,
  "nrThunks": 447401,
  "sets": {
    "bytes": 6913056,
    "elements": 280677,
    "number": 100926
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 24,
    "Env": 8,
    "Value": 16
  },
  "symbols": {
    "bytes": 315916,
    "number": 27622
  },
  "time": {
    "cpu": 0.27952098846435547,
    "gc": 0.0,
    "gcFraction": 0.0
  },
  "values": {
    "bytes": 11514672,
    "number": 719667
  }
}
```
- `union-overlap`
  - Before
```json
{
  "cpuTime": 0.6730189919471741,
  "envs": {
    "bytes": 39481728,
    "elements": 2510838,
    "number": 2424378
  },
  "gc": {
    "cycles": 1,
    "heapSize": 402915328,
    "totalBytes": 121250608
  },
  "list": {
    "bytes": 3410352,
    "concats": 37367,
    "elements": 426294
  },
  "nrAvoided": 3203142,
  "nrExprs": 8475,
  "nrFunctionCalls": 2137907,
  "nrLookups": 57449,
  "nrOpUpdateValuesCopied": 1,
  "nrOpUpdates": 2,
  "nrPrimOpCalls": 1633910,
  "nrThunks": 1405790,
  "sets": {
    "bytes": 18685320,
    "elements": 745614,
    "number": 281479
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 24,
    "Env": 8,
    "Value": 16
  },
  "symbols": {
    "bytes": 554720,
    "number": 45434
  },
  "time": {
    "cpu": 0.6730189919471741,
    "gc": 0.002,
    "gcFraction": 0.002971684341646308
  },
  "values": {
    "bytes": 38984576,
    "number": 2436536
  }
}
```
  - After
```json
{
  "cpuTime": 0.6428729891777039,
  "envs": {
    "bytes": 33985664,
    "elements": 2167334,
    "number": 2080874
  },
  "gc": {
    "cycles": 1,
    "heapSize": 402915328,
    "totalBytes": 112366384
  },
  "list": {
    "bytes": 3410352,
    "concats": 37367,
    "elements": 426294
  },
  "nrAvoided": 2046708,
  "nrExprs": 8511,
  "nrFunctionCalls": 1880279,
  "nrLookups": 57448,
  "nrOpUpdateValuesCopied": 1,
  "nrOpUpdates": 2,
  "nrPrimOpCalls": 1164594,
  "nrThunks": 1194212,
  "sets": {
    "bytes": 18685320,
    "elements": 745614,
    "number": 281479
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 24,
    "Env": 8,
    "Value": 16
  },
  "symbols": {
    "bytes": 554712,
    "number": 45434
  },
  "time": {
    "cpu": 0.6428729891777039,
    "gc": 0.002,
    "gcFraction": 0.0031110344246352483
  },
  "values": {
    "bytes": 35599328,
    "number": 2224958
  }
}
```

- `to-source`
  - Before
```json
{
  "cpuTime": 1.456470012664795,
  "envs": {
    "bytes": 34287704,
    "elements": 2180647,
    "number": 2105316
  },
  "gc": {
    "cycles": 1,
    "heapSize": 402915328,
    "totalBytes": 161283136
  },
  "list": {
    "bytes": 4946984,
    "concats": 21,
    "elements": 618373
  },
  "nrAvoided": 3795931,
  "nrExprs": 9418,
  "nrFunctionCalls": 1801806,
  "nrLookups": 321852,
  "nrOpUpdateValuesCopied": 85876,
  "nrOpUpdates": 74708,
  "nrPrimOpCalls": 2458268,
  "nrThunks": 2046936,
  "sets": {
    "bytes": 18464560,
    "elements": 745018,
    "number": 272678
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 24,
    "Env": 8,
    "Value": 16
  },
  "symbols": {
    "bytes": 555268,
    "number": 45490
  },
  "time": {
    "cpu": 1.456470012664795,
    "gc": 0.003,
    "gcFraction": 0.0020597746427412694
  },
  "values": {
    "bytes": 49515296,
    "number": 3094706
  }
}
```

  - After
```json
{
  "cpuTime": 1.4617420434951782,
  "envs": {
    "bytes": 34108968,
    "elements": 2169476,
    "number": 2094145
  },
  "gc": {
    "cycles": 1,
    "heapSize": 402915328,
    "totalBytes": 153570368
  },
  "list": {
    "bytes": 4946984,
    "concats": 21,
    "elements": 618373
  },
  "nrAvoided": 3701579,
  "nrExprs": 9454,
  "nrFunctionCalls": 1790635,
  "nrLookups": 321852,
  "nrOpUpdateValuesCopied": 85876,
  "nrOpUpdates": 74708,
  "nrPrimOpCalls": 2411092,
  "nrThunks": 1913885,
  "sets": {
    "bytes": 18464560,
    "elements": 745018,
    "number": 272678
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 24,
    "Env": 8,
    "Value": 16
  },
  "symbols": {
    "bytes": 555260,
    "number": 45490
  },
  "time": {
    "cpu": 1.4617420434951782,
    "gc": 0.002,
    "gcFraction": 0.0013682304678175575
  },
  "values": {
    "bytes": 47386480,
    "number": 2961655
  }
}
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
