### PR TITLE
hayabusa-sec: 3.7.0-unstable-2025-12-02 -> 4.0.0

### DIFF
--- a/pkgs/by-name/ha/hayabusa-sec/package.nix
+++ b/pkgs/by-name/ha/hayabusa-sec/package.nix
@@ -3,26 +3,26 @@
   rustPlatform,
   fetchFromGitHub,
   makeWrapper,
-  unstableGitUpdater,
+  nix-update-script,
   pkg-config,
   openssl,
   rust-jemalloc-sys,
 }:
 
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "hayabusa-sec";
-  version = "3.7.0-unstable-2025-12-02";
+  version = "4.0.0";
 
   src = fetchFromGitHub {
     owner = "Yamato-Security";
     repo = "hayabusa";
-    rev = "1c4f332b446f20af154257b2e9b581f7bcb4b1a2";
-    hash = "sha256-JWb54yudfB6pOMZca8sFeoRqNA7M//xJ3IBKfIcGBnM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MabwaHKbbC8fbnICkVMA+bu7zBasIztMR4m0ro8vhYA=";
     # Include the hayabusa-rules
     fetchSubmodules = true;
   };
 
-  cargoHash = "sha256-JIHkFokaZ+nt1hW+gRxFrb1DVZcm4jsZKT12gx/BRCA=";
+  cargoHash = "sha256-PbzMVJPyBOfpS9j3d0RHOlFNJLApU1Gc5O1ro2LROYY=";
 
   nativeBuildInputs = [
     makeWrapper
@@ -40,6 +40,7 @@ rustPlatform.buildRustPackage {
   # Skipping individual checks causes failure as `--skip` flags
   # end up passed to executing `hayabusa`
   # > error: unexpected argument '--skip' found
+
   doCheck = false;
 
   postInstall = ''
@@ -49,7 +50,7 @@ rustPlatform.buildRustPackage {
     makeWrapper $out/share/hayabusa-sec/hayabusa $out/bin/hayabusa
   '';
 
-  passthru.updateScript = unstableGitUpdater { };
+  passthru.updateScript = nix-update-script { rev-prefix = "v"; };
 
   meta = {
     description = "Sigma-based threat hunting and fast forensics timeline generator for Windows event logs";
@@ -60,4 +61,4 @@ rustPlatform.buildRustPackage {
     ];
     mainProgram = "hayabusa";
   };
-}
+})

--- a/pkgs/by-name/ha/hayabusa-sec/package.nix
+++ b/pkgs/by-name/ha/hayabusa-sec/package.nix
@@ -55,6 +55,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Sigma-based threat hunting and fast forensics timeline generator for Windows event logs";
     homepage = "https://github.com/Yamato-Security/hayabusa";
+    changelog = "https://github.com/Yamato-Security/hayabusa/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [
       jk

--- a/pkgs/by-name/ha/hayabusa-sec/package.nix
+++ b/pkgs/by-name/ha/hayabusa-sec/package.nix
@@ -40,7 +40,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # Skipping individual checks causes failure as `--skip` flags
   # end up passed to executing `hayabusa`
   # > error: unexpected argument '--skip' found
-
   doCheck = false;
 
   postInstall = ''
@@ -59,6 +58,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [
       jk
+      d3vil0p3r
     ];
     mainProgram = "hayabusa";
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
