### PR TITLE
lambdock: init at 0.6.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13199,6 +13199,12 @@
     githubId = 156372486;
     name = "Vaios Karastathis";
   };
+  jjba23 = {
+    email = "jjbigorra@gmail.com";
+    github = "jjba23";
+    githubId = 42377845;
+    name = "Josep Bigorra";
+  };
   jjjollyjim = {
     email = "jamie@kwiius.com";
     github = "JJJollyjim";

--- a/pkgs/by-name/la/lambdock/package.nix
+++ b/pkgs/by-name/la/lambdock/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  stdenv,
+  fetchFromCodeberg,
+  meson,
+  ninja,
+  pkg-config,
+  wayland-scanner,
+  glib,
+  wrapGAppsHook4,
+  xvfb-run,
+  dbus,
+  fontconfig,
+  gtk4,
+  gtk4-layer-shell,
+  guile,
+  wayland,
+  wayland-protocols,
+  wlr-protocols,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lambdock";
+  version = "0.6.7";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromCodeberg {
+    owner = "jjba23";
+    repo = "lambdock";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0Ca2twkV6lKdqlw5jp8/bzE5lBoGhR8zaECRRg2wWrY=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    wayland-scanner
+    glib
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    gtk4
+    gtk4-layer-shell
+    guile
+    wayland
+    wayland-protocols
+    wlr-protocols
+  ];
+
+  doCheck = true;
+
+  nativeCheckInputs = [
+    xvfb-run
+    dbus
+    fontconfig
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    # GTK / X11 test environment configuration
+    export HOME=$TMPDIR
+    export XDG_RUNTIME_DIR=$TMPDIR
+    export FONTCONFIG_FILE=${fontconfig.out}/etc/fonts/fonts.conf
+
+    # Disable accessibility bus queries and force GTK to use X11 under Xvfb
+    export GTK_A11Y=none
+    export GDK_BACKEND=x11
+
+    # Start DBus session bus
+    dbus-daemon --config-file=${dbus}/share/dbus-1/session.conf --fork --print-address 5 5>dbus_address
+    export DBUS_SESSION_BUS_ADDRESS=$(cat dbus_address)
+
+    # Run tests on virtual display
+    xvfb-run -s "-screen 0 1024x768x24" meson test --print-errorlogs
+
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    description = "Wayland desktop dock customizable with GNU Guile Scheme";
+    homepage = "https://codeberg.org/jjba23/lambdock";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    mainProgram = "lambdock";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
