### PR TITLE
home-assistant.python3Packages.pytest-homeassistant-custom-component: fix e2e tests

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/blitzortung/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/blitzortung/package.nix
@@ -28,11 +28,6 @@ buildHomeAssistantComponent (finalAttrs: {
     pytestCheckHook
   ];
 
-  disabledTests = [
-    # 2026.5.0 compat issue
-    "test_connect_with_server_stats"
-  ];
-
   meta = {
     description = "Custom Component for fetching lightning data from blitzortung.org";
     homepage = "https://github.com/mrk-its/homeassistant-blitzortung";

--- a/pkgs/servers/home-assistant/custom-components/blueprints-updater/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/blueprints-updater/package.nix
@@ -46,13 +46,6 @@ buildHomeAssistantComponent rec {
     pytestCheckHook
   ];
 
-  disabledTestPaths = [
-    # pytest-homeassistant-custom-component tries to create temporary directories inside the nix store
-    "tests/integration/test_init.py::test_full_update_lifecycle"
-    "tests/integration/test_services.py::test_restore_blueprint_service"
-    "tests/integration/test_services.py::test_update_all_service"
-  ];
-
   meta = {
     description = "Automatically update Home Assistant blueprints via native update entities";
     homepage = "https://github.com/luuquangvu/blueprints-updater/";

--- a/pkgs/servers/home-assistant/custom-components/homematicip_local/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/homematicip_local/package.nix
@@ -49,13 +49,8 @@ buildHomeAssistantComponent rec {
   ];
 
   disabledTestPaths = [
-    # tries to write to the Nix store
-    "tests/test_blueprints.py"
-  ];
-
-  disabledTests = [
-    # custom_components.homematicip_local.support.InvalidConfig: C
-    "test_async_validate_config_and_get_system_information"
+    # zeroconf fails with: No such device
+    "tests/test_config_flow.py::TestReauthFlow::test_reauth_flow_success"
   ];
 
   meta = {

--- a/pkgs/servers/home-assistant/custom-components/midea_ac/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/midea_ac/package.nix
@@ -26,17 +26,6 @@ buildHomeAssistantComponent rec {
     pytestCheckHook
   ];
 
-  disabledTests = [
-    # tests try to open sockets
-    "test_manual_flow_ac_device"
-    "test_manual_flow_cc_device"
-    # lingering datacoordinator timer on test teardown
-    "test_refresh_apply_race_condition"
-    "test_refresh_apply_race_condition_with_proxy"
-    "test_group5_entity_request_enable"
-    "test_energy_sensor_request_enable"
-  ];
-
   meta = {
     changelog = "https://github.com/mill1000/midea-ac-py/releases/tag/${src.tag}";
     description = "Home Assistant custom integration to control Midea (and associated brands) air conditioners via LAN";

--- a/pkgs/servers/home-assistant/custom-components/moonraker/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/moonraker/package.nix
@@ -34,15 +34,6 @@ buildHomeAssistantComponent rec {
   ]
   ++ home-assistant.getPackages "camera" home-assistant.python3Packages;
 
-  disabledTests = [
-    # tests try to open sockets
-    "test_thumbnail_camera_from_img_to_none"
-    "test_bad_connection_config_flow"
-  ];
-
-  #skip phases with nothing to do
-  dontConfigure = true;
-
   meta = {
     changelog = "https://github.com/marcolivierarsenault/moonraker-home-assistant/releases/tag/${version}";
     description = "Custom integration for Moonraker and Klipper in Home Assistant";

--- a/pkgs/servers/home-assistant/custom-components/plant/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/plant/package.nix
@@ -30,12 +30,6 @@ buildHomeAssistantComponent rec {
     pytestCheckHook
   ];
 
-  disabledTestPaths = [
-    # pytest_homeassistant_custom_component wants to write into its nix store path
-    "tests/test_conditions.py"
-    "tests/test_triggers.py"
-  ];
-
   meta = {
     description = "Alternative Plant component of home assistant";
     homepage = "https://github.com/Olen/homeassistant-plant";

--- a/pkgs/servers/home-assistant/custom-components/powercalc/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/powercalc/package.nix
@@ -41,11 +41,6 @@ buildHomeAssistantComponent rec {
     tests/setup.sh
   '';
 
-  disabledTests = [
-    # test contacts api.powercalc.nl
-    "test_exception_is_raised_on_github_resource_unavailable"
-  ];
-
   meta = {
     changelog = "https://github.com/bramstroker/homeassistant-powercalc/releases/tag/${src.tag}";
     description = "Custom Home Assistant component for virtual power sensors";

--- a/pkgs/servers/home-assistant/custom-components/thewatchman/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/thewatchman/package.nix
@@ -37,8 +37,6 @@ buildHomeAssistantComponent rec {
   ];
 
   disabledTests = [
-    # the test relies on NOT changing the hass config_dir and tries to write into the nix store
-    "test_status_sensor_safe_mode"
     # flaky
     "test_automations_parsing"
     # Timing sensitive: Should still not be called (T=2.5 < T=3)

--- a/pkgs/servers/home-assistant/custom-components/yandex-station/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/yandex-station/package.nix
@@ -23,15 +23,6 @@ buildHomeAssistantComponent rec {
     zeroconf
   ];
 
-  disabledTests = [
-    # 'µg/m³' vs 'μg/m³'
-    "test_sensor_qingping"
-  ];
-
-  disabledTestPaths = [
-    # this test seems to be broken
-    "tests/test_local.py::test_track"
-  ];
   nativeCheckInputs = [
     home-assistant
     pytestCheckHook

--- a/pkgs/servers/home-assistant/pytest-homeassistant-custom-component-tmpdir.patch
+++ b/pkgs/servers/home-assistant/pytest-homeassistant-custom-component-tmpdir.patch
@@ -1,0 +1,16 @@
+diff --git a/src/pytest_homeassistant_custom_component/common.py b/src/pytest_homeassistant_custom_component/common.py
+--- a/src/pytest_homeassistant_custom_component/common.py
++++ b/src/pytest_homeassistant_custom_component/common.py
+@@ -167,7 +167,11 @@
+ 
+ def get_test_config_dir(*add_path):
+     """Return a path to a test config dir."""
+-    return os.path.join(os.path.dirname(__file__), "testing_config", *add_path)
++    if not hasattr(get_test_config_dir, "_tmpdir"):
++        import tempfile
++        get_test_config_dir._tmpdir = tempfile.mkdtemp(prefix="pytest-hass-")
++        os.makedirs(os.path.join(get_test_config_dir._tmpdir, "testing_config"), exist_ok=True)
++    return os.path.join(get_test_config_dir._tmpdir, "testing_config", *add_path)
+ 
+ 
+ class StoreWithoutWriteLoad[_T: (Mapping[str, Any] | Sequence[Any])](storage.Store[_T]):

--- a/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
+++ b/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
@@ -31,6 +31,11 @@ buildPythonPackage rec {
     hash = "sha256-odLMKgdhaG0Wd6Pi4pX4WtCosKxSDRIALhiVjah16no=";
   };
 
+  patches = [
+    # e2e tests should write temporary files into a temporary directory instead of into the installation directory aka the nix store
+    ./pytest-homeassistant-custom-component-tmpdir.patch
+  ];
+
   build-system = [ setuptools ];
 
   pythonRemoveDeps = true;


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
