### PR TITLE
pantheon.pantheon-agent-polkit: 8.0.2 -> 8.1.0

### DIFF
--- a/nixos/modules/services/desktop-managers/pantheon.nix
+++ b/nixos/modules/services/desktop-managers/pantheon.nix
@@ -197,6 +197,7 @@ in
         pantheon.gnome-settings-daemon
         pantheon.elementary-session-settings
         pantheon.elementary-settings-daemon
+        pantheon.pantheon-agent-polkit
       ];
       programs.dconf.enable = true;
       networking.networkmanager.enable = mkDefault true;
@@ -212,6 +213,12 @@ in
         # https://github.com/NixOS/nixpkgs/issues/81138
         wantedBy = [ "gnome-session-initialized.target" ];
         # The daemon might launch external applications via g_app_info_launch.
+        environment.PATH = lib.mkForce null;
+      };
+
+      systemd.user.services."io.elementary.desktop.agent-polkit" = {
+        # Same as above.
+        wantedBy = [ "gnome-session-initialized.target" ];
         environment.PATH = lib.mkForce null;
       };
 

--- a/pkgs/desktops/pantheon/services/pantheon-agent-polkit/default.nix
+++ b/pkgs/desktops/pantheon/services/pantheon-agent-polkit/default.nix
@@ -7,24 +7,26 @@
   meson,
   ninja,
   vala,
+  gcr_4,
   gtk4,
   libadwaita,
   libgee,
   granite7,
   pantheon-wayland,
   polkit,
+  systemd,
   wrapGAppsHook4,
 }:
 
 stdenv.mkDerivation rec {
   pname = "pantheon-agent-polkit";
-  version = "8.0.2";
+  version = "8.1.0";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = "pantheon-agent-polkit";
     rev = version;
-    hash = "sha256-tuugtrnamY9QMlF/ju5+4gwcEESFqH4jDH/kz790v5Y=";
+    hash = "sha256-ge/RZhzujI++ye7Gka/28W9CQjbmy+/5NstjqcVDUXw=";
   };
 
   nativeBuildInputs = [
@@ -36,12 +38,14 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    gcr_4
     granite7
     gtk4
     libadwaita
     libgee
     pantheon-wayland
     polkit
+    systemd
   ];
 
   passthru = {


### PR DESCRIPTION
https://github.com/elementary/pantheon-agent-polkit/compare/8.0.2...8.1.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
