### PR TITLE
gstreamer: 1.28.5 -> 1.28.6

### DIFF
--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -116,7 +116,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gst-plugins-bad";
-  version = "1.28.5";
+  version = "1.28.6";
 
   outputs = [
     "out"
@@ -125,7 +125,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-${finalAttrs.version}.tar.xz";
-    hash = "sha256-2K9V+u8pWMGoZjdRR17kb1Fkh3z02MWRPqkG7xgK63E=";
+    hash = "sha256-Zjbywiic7aUsSrqXEzjIHitXgNM4G9NnPBwRbsh1h8M=";
   };
 
   patches = [

--- a/pkgs/development/libraries/gstreamer/base/default.nix
+++ b/pkgs/development/libraries/gstreamer/base/default.nix
@@ -129,37 +129,48 @@ stdenv.mkDerivation (finalAttrs: {
     libdrm
   ];
 
-  mesonFlags = [
-    "-Dglib_debug=disabled" # cast checks should be disabled on stable releases
-    "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
-    # See https://github.com/GStreamer/gst-plugins-base/blob/d64a4b7a69c3462851ff4dcfa97cc6f94cd64aef/meson_options.txt#L15 for a list of choices
-    "-Dgl_winsys=${
-      lib.concatStringsSep "," (
+  mesonFlags =
+    let
+      # For a list of choices, see
+      # https://gitlab.freedesktop.org/gstreamer/gstreamer/-/blob/d529453528a5dd11c15eab788cce6676141134b7/subprojects/gst-plugins-base/meson.options#L14-1
+      # unsupported platforms: win32, winrt, android
+      # deprecated/ancient platforms: dispmanx, eagl
+      # TODO: should we add egl, surfaceless, viv-fb, gbm?
+      # (on Linux, autodiscovery would automatically add egl and surfaceless)
+      # 'egl', 'surfaceless', 'viv-fb', 'gbm',
+      enabledGlWinSys =
         lib.optional enableX11 "x11"
         ++ lib.optional enableWayland "wayland"
-        ++ lib.optional enableCocoa "cocoa"
-      )
-    }"
-    (lib.mesonEnable "introspection" withIntrospection)
-    (lib.mesonEnable "doc" enableDocumentation)
-    (lib.mesonEnable "libvisual" false)
-    (lib.mesonEnable "tremor" false) # unmaintained in nixpkgs, just use regular libvorbis instead
-    (lib.mesonEnable "vorbis" true)
-  ]
-  ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
-    "-Dtests=disabled"
-  ]
-  ++ lib.optionals (!enableX11) [
-    "-Dx11=disabled"
-    "-Dxi=disabled"
-    "-Dxshm=disabled"
-    "-Dxvideo=disabled"
-  ]
-  # TODO How to disable Wayland?
-  ++ lib.optional (!enableGl) "-Dgl=disabled"
-  ++ lib.optional (!enableAlsa) "-Dalsa=disabled"
-  ++ lib.optional (!enableCdparanoia) "-Dcdparanoia=disabled"
-  ++ lib.optional stdenv.hostPlatform.isDarwin "-Ddrm=disabled";
+        ++ lib.optional enableCocoa "cocoa";
+    in
+    lib.mapAttrsToList lib.mesonEnable {
+      orc = true;
+      orc-compiler = true;
+      nls = true;
+
+      glib_debug = false; # cast checks should be disabled on stable releases
+      examples = false; # requires many dependencies and probably not useful for our users
+      introspection = withIntrospection;
+      doc = enableDocumentation;
+
+      tests = finalAttrs.finalPackage.doCheck;
+
+      libvisual = false;
+      tremor = false; # unmaintained in nixpkgs, just use regular libvorbis instead
+      vorbis = true;
+
+      x11 = enableX11;
+      xi = enableX11;
+      xshm = enableX11;
+      xvideo = enableX11;
+
+      # TODO How to disable Wayland?
+      gl = enableGl;
+      alsa = enableAlsa;
+      cdparanoia = enableCdparanoia;
+      drm = !stdenv.hostPlatform.isDarwin;
+    }
+    ++ [ (lib.mesonOption "gl_winsys" (lib.concatStringsSep "," enabledGlWinSys)) ];
 
   postPatch = ''
     patchShebangs \
@@ -194,20 +205,39 @@ stdenv.mkDerivation (finalAttrs: {
     waylandEnabled = enableWayland;
 
     updateScript = directoryListingUpdater { odd-unstable = true; };
-  };
 
-  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    tests.pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+      versionCheck = true;
+    };
+  };
 
   meta = {
     description = "Base GStreamer plug-ins and helper libraries";
     homepage = "https://gstreamer.freedesktop.org";
     license = lib.licenses.lgpl2Plus;
-    pkgConfigModules = [
-      "gstreamer-audio-1.0"
-      "gstreamer-base-1.0"
-      "gstreamer-net-1.0"
-      "gstreamer-video-1.0"
-    ];
+    pkgConfigModules = lib.map (m: "gstreamer-${m}-1.0") (
+      [
+        "allocators"
+        "app"
+        "audio"
+        "fft"
+        "pbutils"
+        "plugins-base"
+        "riff"
+        "rtp"
+        "rtsp"
+        "sdp"
+        "tag"
+      ]
+      ++ lib.optionals enableGl [
+        "gl"
+        "gl-egl"
+        "gl-prototypes"
+      ]
+      ++ lib.optional (enableGl && enableWayland) "gl-wayland"
+      ++ lib.optional (enableGl && enableX11) "gl-x11"
+    );
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ tmarkus ];
   };

--- a/pkgs/development/libraries/gstreamer/base/default.nix
+++ b/pkgs/development/libraries/gstreamer/base/default.nix
@@ -50,7 +50,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gst-plugins-base";
-  version = "1.28.5";
+  version = "1.28.6";
 
   outputs = [
     "out"
@@ -61,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-${finalAttrs.version}.tar.xz";
-    hash = "sha256-d28ZIo+R/SW79U2YUFl+FYUH9ZSHKlK5toFOJCm0Pqo=";
+    hash = "sha256-C6aZx8bGb0umQL54yziiRxWt2Wg/PjoZn1Np3FpPBKw=";
   };
 
   __structuredAttrs = true;

--- a/pkgs/development/libraries/gstreamer/core/default.nix
+++ b/pkgs/development/libraries/gstreamer/core/default.nix
@@ -40,7 +40,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gstreamer";
-  version = "1.28.5";
+  version = "1.28.6";
 
   outputs = [
     "bin"
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-${finalAttrs.version}.tar.xz";
-    hash = "sha256-pan3g4CbF6jrd09KdpWyy4y6axVSASmQb4fq8w5/hGk=";
+    hash = "sha256-Yra58K0xR6bdZCCsZKkRgLFOmQaVvd01O5YEFhHQUso=";
   };
 
   depsBuildBuild = [

--- a/pkgs/development/libraries/gstreamer/devtools/default.nix
+++ b/pkgs/development/libraries/gstreamer/devtools/default.nix
@@ -27,7 +27,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gst-devtools";
-  version = "1.28.5";
+  version = "1.28.6";
 
   outputs = [
     "out"
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/gst-devtools/gst-devtools-${finalAttrs.version}.tar.xz";
-    hash = "sha256-dFkEXbMdbkRgC8vgEdySV1AmiHDnuQ9+ego69KIcCeU=";
+    hash = "sha256-FNQfquA2GSUflZWdPVe/ZcYQaDiztUIY3JXHE14euhM=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {

--- a/pkgs/development/libraries/gstreamer/ges/default.nix
+++ b/pkgs/development/libraries/gstreamer/ges/default.nix
@@ -23,7 +23,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gst-editing-services";
-  version = "1.28.5";
+  version = "1.28.6";
 
   outputs = [
     "out"
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/gst-editing-services/gst-editing-services-${finalAttrs.version}.tar.xz";
-    hash = "sha256-0C+d99108qUCQ6b6XjJ8+71cEhKc57bnPXDAhTJJGog=";
+    hash = "sha256-PRUeUJfWhsWJCudvFMV+4ZU4/WHGz2NxcfkLMJyv1Tw=";
   };
 
   separateDebugInfo = true;

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -78,7 +78,7 @@ assert raspiCameraSupport -> hostSupportsRaspiCamera;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gst-plugins-good";
-  version = "1.28.5";
+  version = "1.28.6";
 
   outputs = [
     "out"
@@ -87,7 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-${finalAttrs.version}.tar.xz";
-    hash = "sha256-WLRdJKHXeznXu32czG4tdrvyhhiZjDNcFj8Y5vlKkyQ=";
+    hash = "sha256-sMYgpLGLbukxtMQ7vxdg0whmbcN/cwp+fxrTJ+Wc4t8=";
   };
 
   patches = [

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  fetchpatch,
   replaceVars,
   meson,
   nasm,
@@ -16,8 +15,6 @@
   libGL,
   libv4l,
   libdv,
-  libavc1394,
-  libiec61883,
   libvpx,
   libdrm,
   speex,
@@ -53,6 +50,10 @@
   libxext,
   libxdamage,
   ncurses,
+  enableFireWire ? stdenv.hostPlatform.isLinux,
+  libavc1394,
+  libiec61883,
+  enableOSS ? stdenv.hostPlatform.isLinux,
   enableWayland ? stdenv.hostPlatform.isLinux,
   wayland,
   wayland-protocols,
@@ -200,9 +201,11 @@ stdenv.mkDerivation (finalAttrs: {
     libGL
     libv4l
     libpulseaudio
+    libgudev
+  ]
+  ++ lib.optionals enableFireWire [
     libavc1394
     libiec61883
-    libgudev
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     apple-sdk_gstreamer
@@ -214,45 +217,38 @@ stdenv.mkDerivation (finalAttrs: {
     libjack2
   ];
 
-  mesonFlags = [
-    "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
-    "-Dglib_debug=disabled" # cast checks should be disabled on stable releases
-    (lib.mesonEnable "doc" enableDocumentation)
-    (lib.mesonEnable "asm" true)
-  ]
-  ++ lib.optionals (!qt5Support) [
-    "-Dqt5=disabled"
-  ]
-  ++ lib.optionals (!qt6Support) [
-    "-Dqt6=disabled"
-  ]
-  ++ lib.optionals (!gtkSupport) [
-    "-Dgtk3=disabled"
-  ]
-  ++ lib.optionals (!enableX11) [
-    "-Dximagesrc=disabled" # Linux-only
-  ]
-  ++ lib.optionals (!enableJack) [
-    "-Djack=disabled"
-  ]
-  ++ lib.optionals (!stdenv.hostPlatform.isLinux) [
-    "-Ddv1394=disabled" # Linux only
-    "-Doss4=disabled" # Linux only
-    "-Doss=disabled" # Linux only
-    "-Dpulse=disabled" # TODO check if we can keep this enabled
-    "-Dv4l2-gudev=disabled" # Linux-only
-    "-Dv4l2=disabled" # Linux-only
-  ]
-  ++ (
-    if raspiCameraSupport then
-      [
-        "-Drpi-lib-dir=${libraspberrypi}/lib"
-      ]
-    else
-      [
-        "-Drpicamsrc=disabled"
-      ]
-  );
+  mesonFlags =
+    lib.mapAttrsToList lib.mesonEnable {
+      orc = true;
+      orc-compiler = true;
+      nls = true;
+
+      tests = finalAttrs.finalPackage.doCheck;
+
+      examples = false; # requires many dependencies and probably not useful for our users
+      glib_debug = false; # cast checks should be disabled on stable releases
+      doc = enableDocumentation;
+      asm = true;
+      qt5 = qt5Support;
+      qt6 = qt6Support;
+      gtk3 = gtkSupport;
+      ximagesrc = enableX11; # Linux-only
+      jack = enableJack;
+
+      # Linux only
+      dv1394 = enableFireWire;
+      oss = enableOSS;
+      oss4 = enableOSS;
+      pulse = stdenv.hostPlatform.isLinux; # TODO check if we can keep this enabled
+      v4l2 = stdenv.hostPlatform.isLinux;
+      v4l2-gudev = stdenv.hostPlatform.isLinux;
+
+      rpicamsrc = raspiCameraSupport;
+    }
+    ++ lib.optionals raspiCameraSupport [
+      (lib.mesonOption "rpi-header-dir" "${lib.getDev libraspberrypi}/include")
+      (lib.mesonOption "rpi-lib-dir" "${lib.getLib libraspberrypi}/lib")
+    ];
 
   postPatch = ''
     patchShebangs \
@@ -264,7 +260,7 @@ stdenv.mkDerivation (finalAttrs: {
     NIX_LDFLAGS =
       # linking error on Darwin
       # https://github.com/NixOS/nixpkgs/pull/70690#issuecomment-553694896
-      "-lncurses";
+      lib.optionalString stdenv.hostPlatform.isDarwin "-lncurses";
   };
 
   # fails 1 tests with "Unexpected critical/warning: g_object_set_is_valid_property: object class 'GstRtpStorage' has no property named ''"
@@ -273,6 +269,7 @@ stdenv.mkDerivation (finalAttrs: {
   # must be explicitly set since 5590e365
   dontWrapQtApps = true;
 
+  # Note: gst-plugins-good produces no pkg-config files unless building static libraries
   preFixup = ''
     moveToOutput "lib/gstreamer-1.0/pkgconfig" "$dev"
   '';

--- a/pkgs/development/libraries/gstreamer/libav/default.nix
+++ b/pkgs/development/libraries/gstreamer/libav/default.nix
@@ -9,8 +9,7 @@
   gstreamer,
   gst-plugins-base,
   gettext,
-  # FIXME: unpin when upstream supports ffmpeg 9
-  ffmpeg_8-headless,
+  ffmpeg-headless,
   # Checks meson.is_cross_build(), so even canExecute isn't enough.
   enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform,
   hotdoc,
@@ -51,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     gstreamer
     gst-plugins-base
-    ffmpeg_8-headless
+    ffmpeg-headless
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     apple-sdk_gstreamer

--- a/pkgs/development/libraries/gstreamer/libav/default.nix
+++ b/pkgs/development/libraries/gstreamer/libav/default.nix
@@ -20,7 +20,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gst-libav";
-  version = "1.28.5";
+  version = "1.28.6";
 
   outputs = [
     "out"
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/gst-libav/gst-libav-${finalAttrs.version}.tar.xz";
-    hash = "sha256-RShUZWBW8LFlEaHZrU8mef9eWofIn5DPfuXewAXdseQ=";
+    hash = "sha256-cebq+0//KmbRuwuo0HgiTf5+M5cwfYwLuj3CNgbgj1E=";
   };
 
   separateDebugInfo = true;

--- a/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
+++ b/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
@@ -19,7 +19,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gst-rtsp-server";
-  version = "1.28.5";
+  version = "1.28.6";
 
   outputs = [
     "out"
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/gst-rtsp-server/gst-rtsp-server-${finalAttrs.version}.tar.xz";
-    hash = "sha256-fhn93rEmG+vD7Dl4V/7dXHcSm2arUniP2trQURdWYiU=";
+    hash = "sha256-DLclsTUfdeiIA8Vd3eofJ74JUj3c1/KasYJw4YKipGM=";
   };
 
   separateDebugInfo = true;

--- a/pkgs/development/libraries/gstreamer/ugly/default.nix
+++ b/pkgs/development/libraries/gstreamer/ugly/default.nix
@@ -27,7 +27,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gst-plugins-ugly";
-  version = "1.28.5";
+  version = "1.28.6";
 
   outputs = [
     "out"
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-${finalAttrs.version}.tar.xz";
-    hash = "sha256-DvTPnDyaXndqbKjRkKMYYzkbaBmAJSFDuCKymqgx4SA=";
+    hash = "sha256-7iedoTp0D9fwYNYxpnMiP6O8yMM9NQyNAmS9Myok7Ng=";
   };
 
   separateDebugInfo = true;

--- a/pkgs/development/python-modules/gst-python/default.nix
+++ b/pkgs/development/python-modules/gst-python/default.nix
@@ -21,7 +21,7 @@
 
 buildPythonPackage rec {
   pname = "gst-python";
-  version = "1.28.5";
+  version = "1.28.6";
 
   pyproject = false;
 
@@ -32,7 +32,7 @@ buildPythonPackage rec {
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/gst-python/gst-python-${version}.tar.xz";
-    hash = "sha256-CsRhtXALl2aZiqaGQ5BkyvWMpP2vhI39R3tadwCxdsw=";
+    hash = "sha256-NNWEQMU7VJWhI9Ckt7ervG6XkqWyGVTbhqB5Gxb24BI=";
   };
 
   patches = [


### PR DESCRIPTION
- https://gstreamer.freedesktop.org/releases/1.28/#1.28.6
- remove the pin to ffmpeg_8 introduced in bf3686205021724fa601041ac8205ceb4b23c293, as 1.28.6 adds support for ffmpeg 9

Edit: Most of the changes below were moved to #551819 and #551844. This PR now only includes the update to 1.28.6 itself and the mesonFlags refactoring for `gst-plugins-{base,good}`.

Contains some additional refactoring:
- ~~Fix packaging issues in rtmpdump and tinyalsa to enable using them in gst-plugins-bad~~
- ~~Refactor `gst-plugins-{base,good,bad}` to run the test suite (with some ugly hacks because meson doesn't support something like `disabledTests` yet)~~
- Refactor `gst-plugins-{base,good}` to use `lib.mesonEnable` more consistently
- ~~Enable support for some other additional plugins in gst-plugins-bad and update outdated comments: including `teletext`, `vulkan`, `gs`, `onnx`, `voamrwbenc`~~
- ~~Remove not applicable `meta.mainProgram` in `gst-plugins-bad`~~
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
