### PR TITLE
findent: fix install-check phase

### DIFF
--- a/pkgs/by-name/fi/findent/package.nix
+++ b/pkgs/by-name/fi/findent/package.nix
@@ -16,8 +16,9 @@ stdenv.mkDerivation (finalAttrs: {
   enableParallelBuilding = true;
 
   doCheck = true;
+  doInstallCheck = true;
 
-  checkTargets = [ "installcheck" ];
+  installCheckTarget = "installcheck";
 
   meta = {
     description = "Fortran source code formatter";


### PR DESCRIPTION
`stdenv`'s `setup.sh` only ever reads the singular `checkTarget` (regular check phase) and `installCheckTarget` (install-check phase, gated by `doInstallCheck`). The plural `checkTargets` set on this derivation is never read by anything, so it silently did nothing: `make check`/`make test` ran instead (whichever target findent's own Makefile provides for the default check phase), and the intended `installcheck` target never ran.

Replaces the dead `checkTargets = [ "installcheck" ];` with `doInstallCheck = true; installCheckTarget = "installcheck";`, so the install-check phase (which runs against the *installed* tree, the standard GNU Autotools convention for `installcheck`) actually executes.

Verified by reading the shipped `pkgs/stdenv/generic/setup.sh` directly: no other code path reads `checkTargets`. Found via a Levenshtein-distance scan of the mega-issue #532401 ("Typos in derivation attribute names") for unclaimed checklist entries; `checkTargets` genuinely isn't read anywhere, ruling out the alternative reading that it's an intentional, distinct attribute.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

None of the "Built on platform" or `nixpkgs-review`/binary-testing boxes are checked because I don't have a working local build environment here: I tried building this exact commit with `nix build "github:NixOS/nixpkgs/<this-PR-head>#findent" --option substitute false` to force a from-scratch build (so the changed `installCheckPhase` would actually run), and it fails bootstrapping `bash` itself in this sandbox, well before it ever reaches `findent`. That's a real, verified environment limitation, not an unchecked assumption.

The one test box I *did* check is `passthru.tests`, on the basis of CI, not a local run: `findent, findent.passthru.tests on x86_64-linux` passed via ofborg (aarch64-linux skipped, aarch64-darwin/x86_64-darwin still pending as of this edit). I'm relying on that plus the direct read of `setup.sh` for confidence in this change; a maintainer's own build is still the strongest confirmation, given I can't produce one myself here.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---
Disclosure: this PR (code and description) was prepared with AI assistance (Claude) and reviewed by me before submitting, per nixpkgs' Automation/AI contribution policy.
