### PR TITLE
python3Packages.sslib: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/sslib/default.nix
+++ b/pkgs/development/python-modules/sslib/default.nix
@@ -6,15 +6,18 @@
   isPy3k,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "sslib";
   version = "0.2.0";
   pyproject = true;
+
+  __structuredAttrs = true;
+
   disabled = !isPy3k;
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "0b5zrjkvx4klmv57pzhcmvbkdlyn745mn02k7hp811hvjrhbz417";
+    inherit (finalAttrs) pname version;
+    hash = "sha256-J5C/YJYbhoAuPFMAWws51tM2164M/nvKrnSSvqfMvyw=";
   };
 
   build-system = [ setuptools ];
@@ -22,10 +25,12 @@ buildPythonPackage rec {
   # No tests available
   doCheck = false;
 
+  pythonImportsCheck = [ "sslib" ];
+
   meta = {
     homepage = "https://github.com/jqueiroz/python-sslib";
     description = "Python3 library for sharing secrets";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ jqueiroz ];
   };
-}
+})

--- a/pkgs/development/python-modules/sslib/default.nix
+++ b/pkgs/development/python-modules/sslib/default.nix
@@ -2,19 +2,22 @@
   lib,
   fetchPypi,
   buildPythonPackage,
+  setuptools,
   isPy3k,
 }:
 
 buildPythonPackage rec {
   pname = "sslib";
   version = "0.2.0";
-  format = "setuptools";
+  pyproject = true;
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "0b5zrjkvx4klmv57pzhcmvbkdlyn745mn02k7hp811hvjrhbz417";
   };
+
+  build-system = [ setuptools ];
 
   # No tests available
   doCheck = false;


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
