### PR TITLE
[Backport release-26.05] claude-code: 2.1.187 -> 2.1.223

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,26 +21,26 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-t5vsIeDjsChMxZVUjjn01J0YDxSzpSAafhZa1JssE70=";
+          hash = "sha256-2CLYzW2or4n3+7+7rEW5pSIj4b+CYRxsf+eOIGe1+bE=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-gEe6jf9EgLnN+L6dzu/g9TarOnYZL20CeuBcJjDtcpI=";
+          hash = "sha256-443PFzX3FNJnNBtlOrS9sqhFDYyyn9JMwD8IbgtxSl0=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
-          hash = "sha256-Tq2RGqcziPwHV/kRyz+KSbMgKHyUNWky605QkbdwRn4=";
+          hash = "sha256-VASKef90bu3Q+s3bJfN7Uq3x8Bk9qYGuKWE4uz9x5Hs=";
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-NSbcgKiIhFxozKIDy/rWXLgCk35w52LdH96UDSdyzck=";
+          hash = "sha256-sZAJil10KuGowarQp+MzIyuN7cdwGs/lzTRBl6OWDm0=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.193";
+      version = "2.1.195";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,26 +21,26 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-wlsp+GNwhobe7RW2RsBAiSyAjhzJ7w5r9U6LCCpiBA0=";
+          hash = "sha256-fgIxS3c3+teMTMCXzRINFuV1aebJAQFIXfXC7Q2zHhg=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-emj4el3Sy0bWMp+XaU96cS0rOP/b2kthmUHDpuhbinM=";
+          hash = "sha256-LdSx/7CspsT5hff6oQKRFmxQS+vi0kpvCgbcq8OQSAA=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
-          hash = "sha256-zbfo97wQmyrN1QWbP/ZyAcJrYc5TbTge7WncLt+HOcg=";
+          hash = "sha256-ct7RcbzKHiZ/PRl42IFoHroR4i4gDVuHSX1t4FDN+R0=";
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-NScb6fr1OIr1jCo8Gdi71r84e2uT2mrO75JBVPFgdek=";
+          hash = "sha256-N/AeA4E0tSHH3lrPhuyqPDl5nE+aNK/ntsW4ai+Sf5s=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.196";
+      version = "2.1.197";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,26 +21,26 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-2CLYzW2or4n3+7+7rEW5pSIj4b+CYRxsf+eOIGe1+bE=";
+          hash = "sha256-wlsp+GNwhobe7RW2RsBAiSyAjhzJ7w5r9U6LCCpiBA0=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-443PFzX3FNJnNBtlOrS9sqhFDYyyn9JMwD8IbgtxSl0=";
+          hash = "sha256-emj4el3Sy0bWMp+XaU96cS0rOP/b2kthmUHDpuhbinM=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
-          hash = "sha256-VASKef90bu3Q+s3bJfN7Uq3x8Bk9qYGuKWE4uz9x5Hs=";
+          hash = "sha256-zbfo97wQmyrN1QWbP/ZyAcJrYc5TbTge7WncLt+HOcg=";
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-sZAJil10KuGowarQp+MzIyuN7cdwGs/lzTRBl6OWDm0=";
+          hash = "sha256-NScb6fr1OIr1jCo8Gdi71r84e2uT2mrO75JBVPFgdek=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.195";
+      version = "2.1.196";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,26 +21,26 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-bsb0OLDPKWnNnZ4tFedYFiFKmTih81oZnaV/BH4p6o4=";
+          hash = "sha256-t5vsIeDjsChMxZVUjjn01J0YDxSzpSAafhZa1JssE70=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-PZBjzxg/kQbCiosd79YFDor1MvBHAdk167PmNIA8ANw=";
+          hash = "sha256-gEe6jf9EgLnN+L6dzu/g9TarOnYZL20CeuBcJjDtcpI=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
-          hash = "sha256-z4OekFyKQsbva5mlBPR6z8g6Is0fwL+xZg/fjKf42cI=";
+          hash = "sha256-Tq2RGqcziPwHV/kRyz+KSbMgKHyUNWky605QkbdwRn4=";
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-gLFoIhxXKunB6ftLEq5p+rfjs8QM5PTOXElu3OtbeIo=";
+          hash = "sha256-NSbcgKiIhFxozKIDy/rWXLgCk35w52LdH96UDSdyzck=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.191";
+      version = "2.1.193";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,26 +21,26 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-/ns84fHAyTY7sSvhUNzq1XQYq2Xy303zs2BxJY8DBVA=";
+          hash = "sha256-bsb0OLDPKWnNnZ4tFedYFiFKmTih81oZnaV/BH4p6o4=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-U69X5lpeJaeNVL4WWzCUpI6IfbKSJXGpl30AYnx1fBQ=";
+          hash = "sha256-PZBjzxg/kQbCiosd79YFDor1MvBHAdk167PmNIA8ANw=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
-          hash = "sha256-DHE09NtGNOjB0HdBqTKRtDsZXpxb651kiVGhRwO1tBU=";
+          hash = "sha256-z4OekFyKQsbva5mlBPR6z8g6Is0fwL+xZg/fjKf42cI=";
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-5YIZVBMsoF0bWP27sVEVHAaAiqvmoSUgdbc8wsqUCLA=";
+          hash = "sha256-gLFoIhxXKunB6ftLEq5p+rfjs8QM5PTOXElu3OtbeIo=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.187";
+      version = "2.1.191";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,26 +21,26 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-fgIxS3c3+teMTMCXzRINFuV1aebJAQFIXfXC7Q2zHhg=";
+          hash = "sha256-0iSA2ck0tJdOiiDlhwp7XaqYDFEAMZyI9mALIvYD6Zw=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-LdSx/7CspsT5hff6oQKRFmxQS+vi0kpvCgbcq8OQSAA=";
+          hash = "sha256-35dMOAr9pb7Tb5gkiDp2K0xdodGduOEcJ9IFSenD03s=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
-          hash = "sha256-ct7RcbzKHiZ/PRl42IFoHroR4i4gDVuHSX1t4FDN+R0=";
+          hash = "sha256-rojFi5393B56j86IAtWWVP0XiNeCsnAvTFIr3CcGZYY=";
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-N/AeA4E0tSHH3lrPhuyqPDl5nE+aNK/ntsW4ai+Sf5s=";
+          hash = "sha256-X8nXfpfaM9KtZLvL4ACyevrtdm+eihtjXVlYHSSas78=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.197";
+      version = "2.1.198";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,26 +21,26 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-m1c/d6ZnIKxuzwh62BVITwOrU+O3iarvvzGy8O0Q2fg=";
+          hash = "sha256-xg4iAUwPeEiHU4C+Iz0foAUlxmPVNZI27mdZXJZwe00=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-QXufvHESQtNG0MDO3+ELONqSr7Ugzje4ZPX/VYWOmQ4=";
+          hash = "sha256-Z8WXyItCJmYfMacZQwMMfWwZEDxxhFu8lu6PM14ysmE=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
-          hash = "sha256-gtHPurMqM93UhE6VfqR8y/XiF0nICkrPxwlV+ca7Bd4=";
+          hash = "sha256-bo9p5pNB9ZDh7SGIwOnI754cW9z1rLJYz9VcnmLINV8=";
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-9YxeN0pYu7E8J1lz1IAzTFluBes7joCEOAzQpkRi7SM=";
+          hash = "sha256-phewYuZ0LcMxzdH/iIIs/ea5ygojlwHyItSR5Njdexw=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.202";
+      version = "2.1.204";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,26 +21,26 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-/uvQIg773WUzalc9XFtBrocsGye3v5y1rvKyJVpXWS0=";
+          hash = "sha256-m1c/d6ZnIKxuzwh62BVITwOrU+O3iarvvzGy8O0Q2fg=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-zC0iYoAxmymxdqo2JgDcMOvUOA3pFbkx0s9C4F6E75k=";
+          hash = "sha256-QXufvHESQtNG0MDO3+ELONqSr7Ugzje4ZPX/VYWOmQ4=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
-          hash = "sha256-mhZBWpV3Gl5TLieIEvrtDmtqQBKeiCcDCwOShQnp++Y=";
+          hash = "sha256-gtHPurMqM93UhE6VfqR8y/XiF0nICkrPxwlV+ca7Bd4=";
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-I570YO5mvXgzXG52NdoGjgVgHbyshm6fIkCIN0li9+4=";
+          hash = "sha256-9YxeN0pYu7E8J1lz1IAzTFluBes7joCEOAzQpkRi7SM=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.201";
+      version = "2.1.202";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,26 +21,26 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-OY34TyyPj0Vjc6rLdR7uaVYsgmCXQFTS/1+QLA9pGgk=";
+          hash = "sha256-QxZa6ugaMC7otLQmDZU54Fv3OGMNYO5iyjqjCLDNdbI=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-A8CrNx6GfFmaFWe1Awck/2B0VuJhNX6HHI5YNSG1qVo=";
+          hash = "sha256-lgE5dld8lvt/dyGVNjR1ZiV2qtBu9pMZayNe5dBfHo0=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
-          hash = "sha256-egXg308OJWvMyMqLHiANNEIGCSza/yKPFIqWq1X6JdE=";
+          hash = "sha256-AnqO7aZ3uybYnAHYCi5ppZ/5xOuiTqs+75TflN7bVow=";
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-BmI7NTlKUVMnTBS8nf2jqYYSA+LT3qP9Yu5gQIv7Mxo=";
+          hash = "sha256-KKuUXjfIsngnKrSLTMYNzb6XVZkJszUwIihCGHQJ0gU=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.206";
+      version = "2.1.207";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,11 +21,11 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-QxZa6ugaMC7otLQmDZU54Fv3OGMNYO5iyjqjCLDNdbI=";
+          hash = "sha256-YVomTY/KpBcR4dZr0EN4egkuzvQXUCj7RvwgMo88z9Q=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-lgE5dld8lvt/dyGVNjR1ZiV2qtBu9pMZayNe5dBfHo0=";
+          hash = "sha256-jbTFmXqtdt6+1SdhfOLcnhOhtSESYM9th8k5EJ4Nex4=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
@@ -33,14 +33,14 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-KKuUXjfIsngnKrSLTMYNzb6XVZkJszUwIihCGHQJ0gU=";
+          hash = "sha256-YFLVhDckeXIItc+AvHlJ/B45c43Ubi3BKr8gy3Ui68w=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.207";
+      version = "2.1.209";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,11 +21,11 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-Y6MXjJBmhMzuQMwhkPLHK/vtciTdjsGvkEblH3ofju0=";
+          hash = "sha256-Z/tQ+KV+3MdbknA/1kmiIpVfOsUM8NUu+0iHlPVbYV0=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-8VvDtb+8SoLTRC7pXwH40amRurxTQgCmhdi0u7e5AfU=";
+          hash = "sha256-d2GjWr0FHOoORI5KRdwUQvcFfBB8xV6j9wj5OS9VL9o=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
@@ -33,14 +33,14 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-bqjEgsjY+zyG1g/KtkRNxAlazIpc+HwGWvsMQNnPI2M=";
+          hash = "sha256-dlfGTxf2EoiNb0g9uqwjTNW8fi2d1tzubGdIDyp4xTw=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.218";
+      version = "2.1.219";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,26 +21,26 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-d9v6prKyua7/Hu/ZeFQDR5J4VvttDcwpTVbM3GxEJRA=";
+          hash = "sha256-OY34TyyPj0Vjc6rLdR7uaVYsgmCXQFTS/1+QLA9pGgk=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-W/oIsBjYv0C2pygo0KbGVDyoOCWYUA3j0Im5Opb9JAQ=";
+          hash = "sha256-A8CrNx6GfFmaFWe1Awck/2B0VuJhNX6HHI5YNSG1qVo=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
-          hash = "sha256-BgWV9hTYrAKICO3JV4g7Vuffeuo6e2sGbQHu/4xMSaI=";
+          hash = "sha256-egXg308OJWvMyMqLHiANNEIGCSza/yKPFIqWq1X6JdE=";
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-c79GFH3aCu7XrM/AodZGQgFCZ56wtJJHt3dGDNfwdQM=";
+          hash = "sha256-BmI7NTlKUVMnTBS8nf2jqYYSA+LT3qP9Yu5gQIv7Mxo=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.205";
+      version = "2.1.206";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,11 +21,11 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-JswgBhADhoEUug2h1ZZ7OtFjFUVgCxiqIaWCYCMf+Sw=";
+          hash = "sha256-pPgl7MTzkBqZ/KatgAme7F6w873GLxZ1ZTYfkXzD4kw=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-+TBwLHUsPx+TiFP+5Gg59Yii76IERNbBQT3RLidogSo=";
+          hash = "sha256-gnaECK1yMNatDn/ZJ6od8wBQYMlJJ/Q49Z+Ur4SxWU8=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
@@ -33,14 +33,14 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-Xglh5yLP4QoeMxqqUUAJyuyehN9hdDookhjwU6znRX4=";
+          hash = "sha256-g0DEP2f+ooEgYz8TFUYTMoVV83HGR2eK2dL5MWa92F8=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.211";
+      version = "2.1.212";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,11 +21,11 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-f3LZmh6UYiMK1fUwlwG+oeaukvbf5cy9yOPay+l5XfU=";
+          hash = "sha256-s1V+SxZ4O5EHcxE9ZxacnydNjfnK1Dv0y3YIPfsy3cs=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-T/LEgnwGBuB/+1kbyedKr9MKH2J9sJrIIT3HAU1LYPU=";
+          hash = "sha256-G9bJ6xNCiC72gR0k89sTh96alnHguSE5cqqOVu/3kCg=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
@@ -33,14 +33,14 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-0duH4OMNXXciZmWG+Y+oPmWWcemn+Y0t0GTJOQ1jSyQ=";
+          hash = "sha256-ZDel1FfsiRbdw9pxn1H5nkOIlVdt1GLr68W2mBtl1mg=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.221";
+      version = "2.1.222";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,26 +21,26 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-0iSA2ck0tJdOiiDlhwp7XaqYDFEAMZyI9mALIvYD6Zw=";
+          hash = "sha256-n6UmUqfzOADzZzJMvY40gBCBKYgDtig41AD1aieA/kQ=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-35dMOAr9pb7Tb5gkiDp2K0xdodGduOEcJ9IFSenD03s=";
+          hash = "sha256-/T7H1itSllf1h6vPzXlwokBvNOVQjZjNuhmC/ocqmPI=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
-          hash = "sha256-rojFi5393B56j86IAtWWVP0XiNeCsnAvTFIr3CcGZYY=";
+          hash = "sha256-qj9K/BlKbl5ZuowRMSVBXLknM6NeOxtIYynIcSE+K5A=";
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-X8nXfpfaM9KtZLvL4ACyevrtdm+eihtjXVlYHSSas78=";
+          hash = "sha256-kXKnSZ6VQa/NPXroEbQT1pNwIy1eKnIDgOWX5WvA3JI=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.198";
+      version = "2.1.199";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,11 +21,11 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-Z/tQ+KV+3MdbknA/1kmiIpVfOsUM8NUu+0iHlPVbYV0=";
+          hash = "sha256-GUuO8kJczyQOV/wIxFd8AJ5Td6kuSqPCxB/pPsbwxi4=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-d2GjWr0FHOoORI5KRdwUQvcFfBB8xV6j9wj5OS9VL9o=";
+          hash = "sha256-EhN34a1o8qMPp8oOnoBfUQDTaibTQq5DlQo++kl/ugQ=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
@@ -33,14 +33,14 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-dlfGTxf2EoiNb0g9uqwjTNW8fi2d1tzubGdIDyp4xTw=";
+          hash = "sha256-5nHyEKub7LLHN+bpN+u36wAs7Q4iY+vgVgd4VPgzOXg=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.219";
+      version = "2.1.220";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,11 +21,11 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-/RKpbsdp7MjakNvKWvq2OiwLJ7mftHKKrb5xwKlM76Y=";
+          hash = "sha256-JYg1P0t3YadTxmqeRSky8X9emLnP2cO3BYO9R7PgQfM=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-mdgzM0dymFjSYFm018wsuWzzUJJsA896YmRwoH1wLmM=";
+          hash = "sha256-miK4K8THmT+ebjcAl/3Cp9vtVWfMlpIWWIqyAm5+YeQ=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
@@ -33,14 +33,14 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-0EFuSvcSLTfrR74Uxpwiq2K39cWqi33q80AhtlilCnQ=";
+          hash = "sha256-ao9yGH9xIBmNrp/sHpwpxKZnR8LjXl1Cegfgw7Nq+2M=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.214";
+      version = "2.1.215";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,11 +21,11 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-uWghjE/Ue+i2kUD4KedN4NDTllgiZPMFFXbT0RQnGrE=";
+          hash = "sha256-JswgBhADhoEUug2h1ZZ7OtFjFUVgCxiqIaWCYCMf+Sw=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-pIwEx6+1Wc+MazqJQYA4h9oOqNOOA8MyJcJOd9Bx2ZM=";
+          hash = "sha256-+TBwLHUsPx+TiFP+5Gg59Yii76IERNbBQT3RLidogSo=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
@@ -33,14 +33,14 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-Iq5C55YrV5ud74a218pTPIyq1oJisbDRNNefkzjpGs4=";
+          hash = "sha256-Xglh5yLP4QoeMxqqUUAJyuyehN9hdDookhjwU6znRX4=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.210";
+      version = "2.1.211";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,11 +21,11 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-vx8fRGGW9fJYKC1Q1627NrjxqqO/zRkH83aLyc4Rxn0=";
+          hash = "sha256-nDKqXhU97h0iBPPFASaCSzEdi6H48IW1rn4iB9cD36Y=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-ZWwau/aSMsamcVBrtuSWI2HiKeZHfMqBLj9WQO8IA20=";
+          hash = "sha256-gIN2FE6ROma6v3vJX/Wi+OqFrq5/YV7kJXNMwGRw0Z8=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
@@ -33,14 +33,14 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-a4yKVABQ0nVzlqS071ae5DYEqv8jgjSwLjxkEAroZvE=";
+          hash = "sha256-rb50iFTniwhY/iqsKBN4jfV4j+RxjLF126opVkReyGA=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.216";
+      version = "2.1.217";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,11 +21,11 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-nDKqXhU97h0iBPPFASaCSzEdi6H48IW1rn4iB9cD36Y=";
+          hash = "sha256-Y6MXjJBmhMzuQMwhkPLHK/vtciTdjsGvkEblH3ofju0=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-gIN2FE6ROma6v3vJX/Wi+OqFrq5/YV7kJXNMwGRw0Z8=";
+          hash = "sha256-8VvDtb+8SoLTRC7pXwH40amRurxTQgCmhdi0u7e5AfU=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
@@ -33,14 +33,14 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-rb50iFTniwhY/iqsKBN4jfV4j+RxjLF126opVkReyGA=";
+          hash = "sha256-bqjEgsjY+zyG1g/KtkRNxAlazIpc+HwGWvsMQNnPI2M=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.217";
+      version = "2.1.218";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,11 +21,11 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-pPgl7MTzkBqZ/KatgAme7F6w873GLxZ1ZTYfkXzD4kw=";
+          hash = "sha256-/RKpbsdp7MjakNvKWvq2OiwLJ7mftHKKrb5xwKlM76Y=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-gnaECK1yMNatDn/ZJ6od8wBQYMlJJ/Q49Z+Ur4SxWU8=";
+          hash = "sha256-mdgzM0dymFjSYFm018wsuWzzUJJsA896YmRwoH1wLmM=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
@@ -33,14 +33,14 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-g0DEP2f+ooEgYz8TFUYTMoVV83HGR2eK2dL5MWa92F8=";
+          hash = "sha256-0EFuSvcSLTfrR74Uxpwiq2K39cWqi33q80AhtlilCnQ=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.212";
+      version = "2.1.214";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,11 +21,11 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-YVomTY/KpBcR4dZr0EN4egkuzvQXUCj7RvwgMo88z9Q=";
+          hash = "sha256-uWghjE/Ue+i2kUD4KedN4NDTllgiZPMFFXbT0RQnGrE=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-jbTFmXqtdt6+1SdhfOLcnhOhtSESYM9th8k5EJ4Nex4=";
+          hash = "sha256-pIwEx6+1Wc+MazqJQYA4h9oOqNOOA8MyJcJOd9Bx2ZM=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
@@ -33,14 +33,14 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-YFLVhDckeXIItc+AvHlJ/B45c43Ubi3BKr8gy3Ui68w=";
+          hash = "sha256-Iq5C55YrV5ud74a218pTPIyq1oJisbDRNNefkzjpGs4=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.209";
+      version = "2.1.210";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,11 +21,11 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-GUuO8kJczyQOV/wIxFd8AJ5Td6kuSqPCxB/pPsbwxi4=";
+          hash = "sha256-f3LZmh6UYiMK1fUwlwG+oeaukvbf5cy9yOPay+l5XfU=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-EhN34a1o8qMPp8oOnoBfUQDTaibTQq5DlQo++kl/ugQ=";
+          hash = "sha256-T/LEgnwGBuB/+1kbyedKr9MKH2J9sJrIIT3HAU1LYPU=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
@@ -33,14 +33,14 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-5nHyEKub7LLHN+bpN+u36wAs7Q4iY+vgVgd4VPgzOXg=";
+          hash = "sha256-0duH4OMNXXciZmWG+Y+oPmWWcemn+Y0t0GTJOQ1jSyQ=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.220";
+      version = "2.1.221";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,26 +21,26 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-n6UmUqfzOADzZzJMvY40gBCBKYgDtig41AD1aieA/kQ=";
+          hash = "sha256-/uvQIg773WUzalc9XFtBrocsGye3v5y1rvKyJVpXWS0=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-/T7H1itSllf1h6vPzXlwokBvNOVQjZjNuhmC/ocqmPI=";
+          hash = "sha256-zC0iYoAxmymxdqo2JgDcMOvUOA3pFbkx0s9C4F6E75k=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
-          hash = "sha256-qj9K/BlKbl5ZuowRMSVBXLknM6NeOxtIYynIcSE+K5A=";
+          hash = "sha256-mhZBWpV3Gl5TLieIEvrtDmtqQBKeiCcDCwOShQnp++Y=";
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-kXKnSZ6VQa/NPXroEbQT1pNwIy1eKnIDgOWX5WvA3JI=";
+          hash = "sha256-I570YO5mvXgzXG52NdoGjgVgHbyshm6fIkCIN0li9+4=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.199";
+      version = "2.1.201";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,26 +21,26 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-s1V+SxZ4O5EHcxE9ZxacnydNjfnK1Dv0y3YIPfsy3cs=";
+          hash = "sha256-3V4N8zHj7nB987ImVtBS84LGxdQgkDp14kTPps72fHo=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-G9bJ6xNCiC72gR0k89sTh96alnHguSE5cqqOVu/3kCg=";
+          hash = "sha256-6p09GcEfmSQs4nRuaFxQ1tKK25ENo2KOPkRQTPndNcw=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
-          hash = "sha256-AnqO7aZ3uybYnAHYCi5ppZ/5xOuiTqs+75TflN7bVow=";
+          hash = "sha256-emzKjYD2vRVb7HXffiK57+Xj6a9dfV+52SNk41Wk7UA=";
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-ZDel1FfsiRbdw9pxn1H5nkOIlVdt1GLr68W2mBtl1mg=";
+          hash = "sha256-qbYE3f0fkxvfGyFAR8UPIFodOEYA0aJK6JK/r8PbI/k=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.222";
+      version = "2.1.223";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,26 +21,26 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-xg4iAUwPeEiHU4C+Iz0foAUlxmPVNZI27mdZXJZwe00=";
+          hash = "sha256-d9v6prKyua7/Hu/ZeFQDR5J4VvttDcwpTVbM3GxEJRA=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-Z8WXyItCJmYfMacZQwMMfWwZEDxxhFu8lu6PM14ysmE=";
+          hash = "sha256-W/oIsBjYv0C2pygo0KbGVDyoOCWYUA3j0Im5Opb9JAQ=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
-          hash = "sha256-bo9p5pNB9ZDh7SGIwOnI754cW9z1rLJYz9VcnmLINV8=";
+          hash = "sha256-BgWV9hTYrAKICO3JV4g7Vuffeuo6e2sGbQHu/4xMSaI=";
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-phewYuZ0LcMxzdH/iIIs/ea5ygojlwHyItSR5Njdexw=";
+          hash = "sha256-c79GFH3aCu7XrM/AodZGQgFCZ56wtJJHt3dGDNfwdQM=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.204";
+      version = "2.1.205";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,11 +21,11 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-JYg1P0t3YadTxmqeRSky8X9emLnP2cO3BYO9R7PgQfM=";
+          hash = "sha256-vx8fRGGW9fJYKC1Q1627NrjxqqO/zRkH83aLyc4Rxn0=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-miK4K8THmT+ebjcAl/3Cp9vtVWfMlpIWWIqyAm5+YeQ=";
+          hash = "sha256-ZWwau/aSMsamcVBrtuSWI2HiKeZHfMqBLj9WQO8IA20=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
@@ -33,14 +33,14 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-ao9yGH9xIBmNrp/sHpwpxKZnR8LjXl1Cegfgw7Nq+2M=";
+          hash = "sha256-a4yKVABQ0nVzlqS071ae5DYEqv8jgjSwLjxkEAroZvE=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.215";
+      version = "2.1.216";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.193",
-  "commit": "a1938d2a07a2e4fecbef4eeac813221929e97d22",
-  "buildDate": "2026-06-25T18:25:46Z",
+  "version": "2.1.195",
+  "commit": "4603aa3f2ea164bd0974f82eb413ae7acc99a7ee",
+  "buildDate": "2026-06-26T01:56:37Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "f7513a30385ad9019c237226fd6ec46508b3062ebefca8aedbe397d111a818ff",
-      "size": 222248240
+      "checksum": "8b45adad93f336ab95f33e714494b19fd3377a494eb05c122c8677bc895876ad",
+      "size": 224682640
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "cba5c3bdca8ab5f8e7590406702d418f6114d9b39f48f16876680e881abf1ee8",
-      "size": 230317808
+      "checksum": "7eb8716e6d6e6a278d13158793529336290837fca457facfec656f1b1a287c60",
+      "size": 234066032
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "39454ce62e795eeb4871a81f6453cda96e926e2db9a4dd41d0ec1b60b0153448",
-      "size": 237419248
+      "checksum": "b02279999058dc80a0e1c5d39463d1545a178615492f84139aac8d61214a7e9a",
+      "size": 241154800
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "c9f04d929f18bd9a101f3897f27de4e1e0f15ebe8400d4aaf02983d73dd66b1d",
-      "size": 240556856
+      "checksum": "8323e70125063147a4478b957745d835a87e5e72ffd25b838ea9a841c03e6a37",
+      "size": 244276024
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "658bbae05441c2d3792f9870a5001a1dfa7a62956abffc151aed7cae0adf9f7d",
-      "size": 230667448
+      "checksum": "52713b5f7690764b3b4742807b1a6fab24ce5e01dabf82964b97f519e8f9e7fe",
+      "size": 234403000
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "b37861314ace243d8425ebce503c657c5d9f76af361f9bd8ca3bd34b2e71474a",
-      "size": 235258240
+      "checksum": "63a2b3291369ff85e970c0cfd3767bb48065071ec12fb2d0055387ccde511541",
+      "size": 238977408
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "ffea22269bf66ce778ce845ea0c15cb5b21d39be82601a065c3eca6f7368da3e",
-      "size": 231359136
+      "checksum": "3ef7fb7b16e169739640fe2903ee7011cff8b43d2dbb15f9badc9b11cfad18a3",
+      "size": 234930336
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "0bea15edaf5791220c646f9066bda84397a73053d88f225c7622c7a2ab45ff59",
-      "size": 225839264
+      "checksum": "038fb49213c0ac828b5a8a1f31cf510753d7e7891e9ae4596673a602cff251f5",
+      "size": 229410464
     }
   }
 }

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.196",
-  "commit": "a4ca500badcac68511fb5f04303e32e4360f3dfb",
-  "buildDate": "2026-06-29T01:55:28Z",
+  "version": "2.1.197",
+  "commit": "c8fd8048f30950a21d28734718275aa7e97f5143",
+  "buildDate": "2026-06-29T19:16:30Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "6fc6e61ab7582c2bf241225ff90d9f79e91d69380cb9589fc9dedd3a30070f5a",
-      "size": 225782608
+      "checksum": "8cc0c4d1e4eb1dca3b0cc92ab02ee3505de764e023f8c901761c167b72041fb8",
+      "size": 227251472
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "32c74d66e27b9ca77aea638fc46cb11c90470bd0d294b2a981065da8896d1ee0",
-      "size": 235139408
+      "checksum": "5e8a57cc7a92377f0744fa4c79191cf93d4b26c79cb919b07a407511fed1be26",
+      "size": 235288016
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "05aa9189d335d1e921ca9608acd699193e661559aff56704456ce5bda6fd4dd8",
-      "size": 242203376
+      "checksum": "fb48473c467c27615ac799a754f4ef0b68c363e4596cefbb59c3815d51a0cc8a",
+      "size": 242334448
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "eb933c6dd5534db89b83ba09009d5c0932bd1395f7e3bb0f34ba37eec37bbade",
-      "size": 245373752
+      "checksum": "f54e69cbc89b2da61a415700af7ff52a147e862517d4f1b0eecf768448cf7f83",
+      "size": 245517112
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "0591ff8e1378d3773c85456d0c812bf79b333cac2d06396cd076ecfc75022ba4",
-      "size": 235451576
+      "checksum": "acb885610ba06d90c46206ded9b14121bc30e96affecbfb3c37d511bf02af2bd",
+      "size": 235582648
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "fa7e93303ea5eda7defce9f70f360c1f951b06f9f36b03296baffbade512049f",
-      "size": 240058752
+      "checksum": "2f610c0f81341052426981b5dc59277a33e6ec3df924071b24edbc05e6a096dc",
+      "size": 240202112
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "180d7b279455e8b89d4353a5146447be2f80b80fb0db14bdc6dd9cb98c0aef09",
-      "size": 235977376
+      "checksum": "038bd9fe90c60304601e19751269a50d62925c541dd6a2b3da5274549e9416ee",
+      "size": 236121248
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "882ed64ae93385067bff7b1e1d1975898f1cbca739dff322e0e370cd2db3e6ed",
-      "size": 230444704
+      "checksum": "8d2baeaf77b0e79ea33cf5ce78a37e64804c3a26d63d35355a830fda404a4f61",
+      "size": 230588064
     }
   }
 }

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.215",
-  "commit": "316ce99628e89900bf0b1328fed3b8fec0c0c92d",
-  "buildDate": "2026-07-19T00:11:19Z",
+  "version": "2.1.216",
+  "commit": "7fead72f57c595d5a353a2e477bd2608d27ddcc6",
+  "buildDate": "2026-07-20T18:40:59Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "90608b5c5ab504e96e77365cea6203d046e291d59b2bb42cf28dcb2ccdf9dd58",
-      "size": 247124336
+      "checksum": "d01b49210d72ecbe277a2665d104bacccddf2d22185be99446d2929e0edfc48d",
+      "size": 249225584
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "1ef5f5e56ede9f7765a9bef654ece6045dba58f48b7f5b699765375953d52b6b",
-      "size": 256540048
+      "checksum": "e17cdc51437bd7a80ce0244d25045f568d67b212eea4ff81b83ee90f8666e42f",
+      "size": 258670096
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "2b43a3d5b0787217e5d7381fad42c7314292546fe9db9eb8b9b379de90509b30",
-      "size": 262060960
+      "checksum": "9e3a6aecc5164f607e1183aea2092c7d7705d146e504a6207df291776996a8ea",
+      "size": 264158112
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "c1efffaaf370aa187cb6a09dd93d4e511c646899b0078476f83791b664bde7fe",
-      "size": 265239536
+      "checksum": "74deca45220b8080ec75ab099bd5a5980e41a2b5879846a008fb115d436de085",
+      "size": 267353072
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "95f1bb89dd94ae099c7b5e53832f99624fdf82da8e0f11d81e1632b26e61973e",
-      "size": 255309160
+      "checksum": "70b5dcf81bd13212ab26ec9427fa87527cd44ceb3a2a21ac04308d0f1a418a52",
+      "size": 257406312
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "3a14b862d102d0b6b88650a00b8489b1dfec7f84b367f8192ee62c8bdaeb9220",
-      "size": 259863120
+      "checksum": "54ac63736128b3aa9a73e2d9ba1f35177eb69d7b97d975f63a36d33fe0666652",
+      "size": 261976656
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "f14452d1e199273795f2920c00fd7a7f818178ddf1f3efb4d005a7e3d4ec4eff",
-      "size": 256247968
+      "checksum": "902215367918866f3c36564e115bd5636d60178acf28181713d449275b833540",
+      "size": 258288288
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "0e976441467cb09e35b52c83e661ce8e148c5a8766e0899a4255d95c4b8110f6",
-      "size": 250623648
+      "checksum": "850ba4969ca49964b418863648131f65f76107be36d6719ff0aaaf3dfc9a422e",
+      "size": 252663968
     }
   },
   "sdkCompat": {
@@ -66,7 +66,8 @@
       "0.3.205",
       "0.3.207",
       "0.3.208",
-      "0.3.209"
+      "0.3.209",
+      "0.3.215"
     ],
     "harnessSchema": 1
   }

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.205",
-  "commit": "4cf2699a14277d4a8edf7e74442381071fc0cfd2",
-  "buildDate": "2026-07-08T17:46:21Z",
+  "version": "2.1.206",
+  "commit": "edc8ebf7f852d3abffad32a5bf8e49e439f92afb",
+  "buildDate": "2026-07-09T01:48:20Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "33e28624c5ae84f2bd7d2d8761e5d2e77997ba965cb11b6448de6b6e2c566f9c",
-      "size": 237437968
+      "checksum": "3197aba4442dbd5b3df42b6f35e6d7bd03b5e48ce18b7a3c5c6f5f8c28e03b7f",
+      "size": 240395024
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "4299a3f48551ef365f2d056f24d87e84b822c4c10b6acc46979446b7b5c60ceb",
-      "size": 246862928
+      "checksum": "b1e1636917a12c7d4e1fa54cd13f7f76ba3779fb988180610b6ca483258c2f46",
+      "size": 248431568
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "c1874c85bcd3a88b70439fd50ff5910b7e6ac5371c14dd49d4ccc2878a592d09",
-      "size": 253803248
+      "checksum": "cb8ccaf4ae6beb558747227a362010c6b32b4f4a5868c3a7e96aa9972fc6ef58",
+      "size": 255376112
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "dd8734c0b6a503fe1d17425184e57b397c30bb0337a33f1470d9985febfe5b09",
-      "size": 257006392
+      "checksum": "d131494be407ff56a62f4e99a96ba60102002d01e3b6b1494db16bef4b7f060f",
+      "size": 258566968
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "a8cd2a626d7d0b5fb3516164a4cf3b4acbbadb053a5b1b2a2462ccbd2ebf6bde",
-      "size": 247051448
+      "checksum": "b1920556c3b077694d52397f4e5221df2419ad9b44af641be0f49647b51f87ad",
+      "size": 248624312
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "20018df16e75f4287c3bfb088e04019452cf262f66ee43041e285113c4e479d8",
-      "size": 251695488
+      "checksum": "b0d780783401de979024c25f14a2cae665873afbcfe718c090b73e13c4cd08a0",
+      "size": 253251968
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "f09120889098672074e7c5166d5474da0c5482f2bec898b3510cacd9c1fefa42",
-      "size": 247162528
+      "checksum": "d5072b25b9a20bffb24625d36129a05ed2be4d2eb7e35625aad6aa35596892c2",
+      "size": 248682144
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "9a86e5acbc584ab7c1b684f1cc1bf5c7bddd6afd4817c0d2c2113d15bfbff0a9",
-      "size": 241629344
+      "checksum": "c17ac3a5a8edf5cfa658e82bd41fcf83170af21538e51cc9d4cbaeefe382aba3",
+      "size": 243149984
     }
   }
 }

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.204",
-  "commit": "51bd0ba270a17535ce551f0eff5d09553b44a9e1",
-  "buildDate": "2026-07-07T23:24:03Z",
+  "version": "2.1.205",
+  "commit": "4cf2699a14277d4a8edf7e74442381071fc0cfd2",
+  "buildDate": "2026-07-08T17:46:21Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "1677b67595b6251156d62600dc85d4070ec385b72dd0b07e73742a56030952c3",
-      "size": 236961904
+      "checksum": "33e28624c5ae84f2bd7d2d8761e5d2e77997ba965cb11b6448de6b6e2c566f9c",
+      "size": 237437968
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "9ccea5f19ec0462f3b983ff3400a97adaf16a83c3dc36a69b916805f2bc8c829",
-      "size": 246384080
+      "checksum": "4299a3f48551ef365f2d056f24d87e84b822c4c10b6acc46979446b7b5c60ceb",
+      "size": 246862928
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "c37256a8c3998b8675e8385f1ae4677d69bdff1e717c389296eec70e02e317ef",
-      "size": 253344496
+      "checksum": "c1874c85bcd3a88b70439fd50ff5910b7e6ac5371c14dd49d4ccc2878a592d09",
+      "size": 253803248
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "c8ee1ea69154533c691a68f46abb645196fe7339d26e6fc204cc7f08220139d3",
-      "size": 256535352
+      "checksum": "dd8734c0b6a503fe1d17425184e57b397c30bb0337a33f1470d9985febfe5b09",
+      "size": 257006392
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "d87a3b19f01bbf28d05e7ff7c449923fc520f2d64c4227373ccbf24dec6438f3",
-      "size": 246592696
+      "checksum": "a8cd2a626d7d0b5fb3516164a4cf3b4acbbadb053a5b1b2a2462ccbd2ebf6bde",
+      "size": 247051448
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "b2d7a23342e315f8dd0d253b14f394bffb5ba04d434b7631c9837e38d99fde35",
-      "size": 251224448
+      "checksum": "20018df16e75f4287c3bfb088e04019452cf262f66ee43041e285113c4e479d8",
+      "size": 251695488
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "e1d82bf346d99db3e611b75a4afc5fdf1530d8d8c546389cf45ac8250bce4af1",
-      "size": 246707360
+      "checksum": "f09120889098672074e7c5166d5474da0c5482f2bec898b3510cacd9c1fefa42",
+      "size": 247162528
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "085f7d5c98dfec2681996cacbf6185d1439fdc7208087afa99c22c07132b9a56",
-      "size": 241173664
+      "checksum": "9a86e5acbc584ab7c1b684f1cc1bf5c7bddd6afd4817c0d2c2113d15bfbff0a9",
+      "size": 241629344
     }
   }
 }

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.201",
-  "commit": "5bb45156ece6b12214696c88adec695b2dca1338",
-  "buildDate": "2026-07-03T20:01:44Z",
+  "version": "2.1.202",
+  "commit": "23f7f00042c9899630a3a02963fe4bb349512614",
+  "buildDate": "2026-07-06T20:02:44Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "a0852d76afc47b30f5cb0b7625ec9a7714cb189f2eeef6c28c77e2be954fb7fd",
-      "size": 231708784
+      "checksum": "7414f707861e2fe5afef33a466f888a8d2170e5028f5e9d2858f1d3ef45ffca5",
+      "size": 243631376
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "1889287a92d25356ae8bd8d8e67b11456015516ee8ba4277a0c7074786c49bb6",
-      "size": 241100240
+      "checksum": "0dc578bb294094f5041e99a0444030ac6ae7236b387e56f00d4a5214816763bd",
+      "size": 251667920
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "86b2eab34d382c7b428fc2e9f4c97f04e46805e950582472a13eb7d48de60516",
-      "size": 248101616
+      "checksum": "de5e0bb28e2b32409444ed4c1431e2931001c05ed270a3dc96c6706b0693867f",
+      "size": 258587376
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "a34809a6839fdefff21b9347d7fb5b6b58e6a9cc208a5e62853f29c83eb107a3",
-      "size": 251300664
+      "checksum": "71590202249892db3805ecd5b867f831f04b8129eaabd3f9a5bd4ba16b52c839",
+      "size": 261786424
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "5b4cde588b0196c8f88654ca9652c4703788f4d9fbab32a17ab3c444830085ae",
-      "size": 241349816
+      "checksum": "80405fead329dd67d786b2a3d49bb121797a157937c99dedae2e36fcc77b55e6",
+      "size": 251835576
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "a0f81ec99ac65e8c5919e7aae54b8a496488e0f1311884fc9ffd05c7cbf6bd2f",
-      "size": 245985664
+      "checksum": "bd62d47b677b8867e34f32642ee13f9fb87ad31b8acfdd326307eeffec02ec89",
+      "size": 256471424
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "fb804ee019bfbb8d7e85abf965e528e53b5aa5a4e4ebc0f164139dc10a9e0320",
-      "size": 241591968
+      "checksum": "7ff0787ebdc19fc509ccea8886ebf6a53ad8213407fa3a2b7c6d1446efc419f6",
+      "size": 252038816
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "a3ad78a0b593dea94c3ee787b1f5b17a173a7679203a296acf9aae7ef4705d42",
-      "size": 236058784
+      "checksum": "67a437feb7489620063f57e3bb073b8b7b82252d9373c9edc1d4969e42796be4",
+      "size": 246505120
     }
   }
 }

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.211",
-  "commit": "17a4b6d7b2ee1936b95e595054c7e7d38fddafb7",
-  "buildDate": "2026-07-15T16:42:49Z",
+  "version": "2.1.212",
+  "commit": "8b2783a8f907ce5c5ad1241ecdbab0ff3301c617",
+  "buildDate": "2026-07-16T16:50:33Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "5a728a76198b6eca7f3c7cdbff43bab44b77b48c2108f7a3107d889773382629",
-      "size": 242445680
+      "checksum": "09ecba2ab2df9b6ee5b0695e26f65dea60fb3b6af3d3542ee09f466838d1e574",
+      "size": 244530512
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "33049eb14cf4702b992b7eda41ec077fc6e76539f7fd046e6d32538757235da4",
-      "size": 251966736
+      "checksum": "7681a0634c89fa4474e53c0c794e992944aebf3409a7a2b87ea9f9b0194ea341",
+      "size": 254080272
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "1fff7e8f947c07b19d10b1fbf714b7e547e9536253b9b58230d8adbc4624f867",
-      "size": 258849520
+      "checksum": "66e88634a8573a002702e6a9de0d80cb9bb7c9072f9e6f4486778539057dfd3c",
+      "size": 260946672
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "8272c8a474ac9ea1bc35f19b9f7c7e7dc4dc4eb6d5ad3e484b19335ac72446b2",
-      "size": 262023992
+      "checksum": "044a88cf3a5180776617fd3da1238dcbf9141ddec449a39cf7d2af1ac78e684e",
+      "size": 264096568
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "ca094a85ea464b2ebec2ecfcc9e2c056573d4ca95ebe12ffae2c7dccb722e17b",
-      "size": 252097720
+      "checksum": "6996b65fc90aa1e0b8f80824df77295d93fa43b12388915a762b58fd982a1d16",
+      "size": 254194872
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "c99bd7934ac841d5be6ee7d3644cb63bccef2cd495c6c1bb982a1b1deac1b466",
-      "size": 256680320
+      "checksum": "a17757970a1f7ef0c47a31ea8fa40798fd7796854ba9422e1a4175f3f149de2c",
+      "size": 258756992
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "3d8509ae7de11d77dbdc711aa320fc6d5064ce795464a8670696611b57093caf",
-      "size": 253293728
+      "checksum": "fe639693fd7e9a881c799867711abb7666dec2a5fefbaba41af6a09e71bcbefa",
+      "size": 255334560
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "a0f9bab0dbdda9b43a8765d54e329e44484d9dd7d4f40cf31db6eee27a2da41c",
-      "size": 247643808
+      "checksum": "adaa6e3dadb8016755ccd1907a5f249c1bc9bdb6c71d3f7dcea7d5db8f72d0a5",
+      "size": 249684640
     }
   },
   "sdkCompat": {

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.207",
-  "commit": "bc512d56332530b2be3f5079e29ec17aa20b8553",
-  "buildDate": "2026-07-10T21:39:38Z",
+  "version": "2.1.209",
+  "commit": "0fe048596fd45e79e99353cbe2c3d1b1ac069568",
+  "buildDate": "2026-07-14T03:58:29Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "1397a062c6889675055e3314dd956376ac51262a7734ad9e819c26975d71547a",
-      "size": 241237136
+      "checksum": "59d2de7f49db2f75d5c33bbb46a6b8f288ad24d40b61e30602a502bb7ddc380c",
+      "size": 240377264
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "8a4355d251a60c90d8cf08f32fdb22a8157dd3d085542f95d0da0475f9a2c57c",
-      "size": 249273680
+      "checksum": "4cc3f44b905d45bd27a6db9306ec6de928aea758537205329851ae478f2fa2c6",
+      "size": 249886224
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "8bc14a284065383460f37981d724b8f7aa7ca93c9849d2fe367e08f03383f454",
-      "size": 256228080
+      "checksum": "278cb68ef7217cfcc5c949d2573bb8e59a8b1305f76689fba88eb722b0d9e2f0",
+      "size": 256817904
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "85e7e988a392d859f90802ca21fb26e89d3c9ab527f5ed0b08df3955e34d5c83",
-      "size": 259402552
+      "checksum": "b882f4b8b27772f897540df50f24000206f43a9426e8f7d19bd065959b69e9dd",
+      "size": 259951416
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "ec3b657344dcf6693f434fe11ffe4592381d31d4e6a7976649c1a610770dcc74",
-      "size": 249476280
+      "checksum": "d5785d7c25f86a00ba5d5fe81d98726c89ea7d6f45dca90fcc4cbabef6a9e0b5",
+      "size": 250066104
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "09a43ff41e33cbb0c4903a4939353933ee8f0d1964abab4b837004a951edb9ee",
-      "size": 254091648
+      "checksum": "7ad8e7d428e1ddef18040fe43f54110541ced063a7b5903091aac8f45c57ee21",
+      "size": 254607744
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "781fdc2c89868b1cb05cc22c253ef142a0b44e7cc36236aecd6335745c7d42d0",
-      "size": 249485472
+      "checksum": "b9d5e8542338a0918534e55d046a7c960ae4af5ee214c7e4e80a89067b63ea2c",
+      "size": 251303072
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "fa0c887a3f944ba1915766b525538b82b029ca8078ed6ee180c3b83c1b862521",
-      "size": 243952800
+      "checksum": "a29607da80ac0d6f2620553e52026ecc7744b27d49128f143eacd120e5f2ad9d",
+      "size": 245652640
     }
   },
   "sdkCompat": {
@@ -61,7 +61,9 @@
       "0.3.201",
       "0.3.202",
       "0.3.204",
-      "0.3.205"
+      "0.3.205",
+      "0.3.207",
+      "0.3.208"
     ],
     "harnessSchema": 1
   }

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.216",
-  "commit": "7fead72f57c595d5a353a2e477bd2608d27ddcc6",
-  "buildDate": "2026-07-20T18:40:59Z",
+  "version": "2.1.217",
+  "commit": "9963b018d22c3e6659c99e135e687870301b5c67",
+  "buildDate": "2026-07-21T18:45:36Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "d01b49210d72ecbe277a2665d104bacccddf2d22185be99446d2929e0edfc48d",
-      "size": 249225584
+      "checksum": "5840c777fd47115e9ca276e165563c6e121e7c7e2b4d86598e0025f8cc37de56",
+      "size": 250456784
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "e17cdc51437bd7a80ce0244d25045f568d67b212eea4ff81b83ee90f8666e42f",
-      "size": 258670096
+      "checksum": "8387a6fd44edfd40d7e74c5fdc3270a15f5e6b1b58c7c6fee560e70d3d1943da",
+      "size": 259908496
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "9e3a6aecc5164f607e1183aea2092c7d7705d146e504a6207df291776996a8ea",
-      "size": 264158112
+      "checksum": "40c53507ac669c1d438366c19760c22f52748a06e50e0fc0e353d2cb73425597",
+      "size": 265337760
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "74deca45220b8080ec75ab099bd5a5980e41a2b5879846a008fb115d436de085",
-      "size": 267353072
+      "checksum": "2630fc5dc6db61bc03f86b95daf47766e5ed5b61873f7bb7cfea764c5ac5a9ba",
+      "size": 268573680
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "70b5dcf81bd13212ab26ec9427fa87527cd44ceb3a2a21ac04308d0f1a418a52",
-      "size": 257406312
+      "checksum": "e219a631e194e71bccbea2f81f5678c75f745aa6e7a74e8a407610c906d1299b",
+      "size": 258585960
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "54ac63736128b3aa9a73e2d9ba1f35177eb69d7b97d975f63a36d33fe0666652",
-      "size": 261976656
+      "checksum": "7c44188927edbf7b918b41bc7a284292359b1ad556b7802db0148adb4b395732",
+      "size": 263197264
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "902215367918866f3c36564e115bd5636d60178acf28181713d449275b833540",
-      "size": 258288288
+      "checksum": "6e4a3a4679f381178a90cf741de9ce924a3274304b09277695ac3a679628ca17",
+      "size": 259460768
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "850ba4969ca49964b418863648131f65f76107be36d6719ff0aaaf3dfc9a422e",
-      "size": 252663968
+      "checksum": "f0128e1a50b8d7dec5bb4dbdff0ef622f617e798df61ebb009ed3f03d2afe613",
+      "size": 253836448
     }
   },
   "sdkCompat": {

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.195",
-  "commit": "4603aa3f2ea164bd0974f82eb413ae7acc99a7ee",
-  "buildDate": "2026-06-26T01:56:37Z",
+  "version": "2.1.196",
+  "commit": "a4ca500badcac68511fb5f04303e32e4360f3dfb",
+  "buildDate": "2026-06-29T01:55:28Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "8b45adad93f336ab95f33e714494b19fd3377a494eb05c122c8677bc895876ad",
-      "size": 224682640
+      "checksum": "6fc6e61ab7582c2bf241225ff90d9f79e91d69380cb9589fc9dedd3a30070f5a",
+      "size": 225782608
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "7eb8716e6d6e6a278d13158793529336290837fca457facfec656f1b1a287c60",
-      "size": 234066032
+      "checksum": "32c74d66e27b9ca77aea638fc46cb11c90470bd0d294b2a981065da8896d1ee0",
+      "size": 235139408
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "b02279999058dc80a0e1c5d39463d1545a178615492f84139aac8d61214a7e9a",
-      "size": 241154800
+      "checksum": "05aa9189d335d1e921ca9608acd699193e661559aff56704456ce5bda6fd4dd8",
+      "size": 242203376
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "8323e70125063147a4478b957745d835a87e5e72ffd25b838ea9a841c03e6a37",
-      "size": 244276024
+      "checksum": "eb933c6dd5534db89b83ba09009d5c0932bd1395f7e3bb0f34ba37eec37bbade",
+      "size": 245373752
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "52713b5f7690764b3b4742807b1a6fab24ce5e01dabf82964b97f519e8f9e7fe",
-      "size": 234403000
+      "checksum": "0591ff8e1378d3773c85456d0c812bf79b333cac2d06396cd076ecfc75022ba4",
+      "size": 235451576
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "63a2b3291369ff85e970c0cfd3767bb48065071ec12fb2d0055387ccde511541",
-      "size": 238977408
+      "checksum": "fa7e93303ea5eda7defce9f70f360c1f951b06f9f36b03296baffbade512049f",
+      "size": 240058752
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "3ef7fb7b16e169739640fe2903ee7011cff8b43d2dbb15f9badc9b11cfad18a3",
-      "size": 234930336
+      "checksum": "180d7b279455e8b89d4353a5146447be2f80b80fb0db14bdc6dd9cb98c0aef09",
+      "size": 235977376
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "038fb49213c0ac828b5a8a1f31cf510753d7e7891e9ae4596673a602cff251f5",
-      "size": 229410464
+      "checksum": "882ed64ae93385067bff7b1e1d1975898f1cbca739dff322e0e370cd2db3e6ed",
+      "size": 230444704
     }
   }
 }

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.214",
-  "commit": "e158e55a79995c80ed463a5d2de322bc0ac2f711",
-  "buildDate": "2026-07-17T23:32:51Z",
+  "version": "2.1.215",
+  "commit": "316ce99628e89900bf0b1328fed3b8fec0c0c92d",
+  "buildDate": "2026-07-19T00:11:19Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "59796dd18e9d77f1256f367db6d28ce4bd9cd5968e402ad3a327aac36abc6dec",
-      "size": 247091504
+      "checksum": "90608b5c5ab504e96e77365cea6203d046e291d59b2bb42cf28dcb2ccdf9dd58",
+      "size": 247124336
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "d979ba15662828969e5d0f39f1367798a07ef6e031b524efdad37fe7caf84010",
-      "size": 256507024
+      "checksum": "1ef5f5e56ede9f7765a9bef654ece6045dba58f48b7f5b699765375953d52b6b",
+      "size": 256540048
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "4c38f26a57a42619ee813f15dc39fc1fa4fe0bb403215c3cdc342b58fa689c3c",
-      "size": 261995424
+      "checksum": "2b43a3d5b0787217e5d7381fad42c7314292546fe9db9eb8b9b379de90509b30",
+      "size": 262060960
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "3c029136f7c81f54ed4a38e9d52e655aad536433dbbde50519c8c31bb646ad14",
-      "size": 265210864
+      "checksum": "c1efffaaf370aa187cb6a09dd93d4e511c646899b0078476f83791b664bde7fe",
+      "size": 265239536
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "bbcdec27500f1c7f04a8697fa1d55cdae183ba9054b984ac95d82ccdcccaec3e",
-      "size": 255243624
+      "checksum": "95f1bb89dd94ae099c7b5e53832f99624fdf82da8e0f11d81e1632b26e61973e",
+      "size": 255309160
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "1744afe6baa7d5321917bc6f807883daf4f0abda8e9e5d006c03356eb3df8945",
-      "size": 259838544
+      "checksum": "3a14b862d102d0b6b88650a00b8489b1dfec7f84b367f8192ee62c8bdaeb9220",
+      "size": 259863120
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "da26afacbc58d6f569d0921ff6825772220c734327f5f976c0c73bd0b7dd3cf8",
-      "size": 256220832
+      "checksum": "f14452d1e199273795f2920c00fd7a7f818178ddf1f3efb4d005a7e3d4ec4eff",
+      "size": 256247968
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "4c62218523c562991ef05985af3cffa1a69a588bbcfb3b3bf7b59e9bcb69e963",
-      "size": 250596512
+      "checksum": "0e976441467cb09e35b52c83e661ce8e148c5a8766e0899a4255d95c4b8110f6",
+      "size": 250623648
     }
   },
   "sdkCompat": {
@@ -58,6 +58,7 @@
       "0.3.196",
       "0.3.197",
       "0.3.198",
+      "0.3.199",
       "0.3.200",
       "0.3.201",
       "0.3.202",

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.209",
-  "commit": "0fe048596fd45e79e99353cbe2c3d1b1ac069568",
-  "buildDate": "2026-07-14T03:58:29Z",
+  "version": "2.1.210",
+  "commit": "88e9fbf39bf4efa5bca44549b7fd9461628657e6",
+  "buildDate": "2026-07-14T15:12:31Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "59d2de7f49db2f75d5c33bbb46a6b8f288ad24d40b61e30602a502bb7ddc380c",
-      "size": 240377264
+      "checksum": "1b471d62d1117482689d75447f5e050c640da717a5a3c91e6c13792450f8c662",
+      "size": 241509968
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "4cc3f44b905d45bd27a6db9306ec6de928aea758537205329851ae478f2fa2c6",
-      "size": 249886224
+      "checksum": "892f2c878050d8829e67119328dd9768345fba18a58c169212b70597c9175c40",
+      "size": 251025552
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "278cb68ef7217cfcc5c949d2573bb8e59a8b1305f76689fba88eb722b0d9e2f0",
-      "size": 256817904
+      "checksum": "84feb193c1d91f3b5eba836ed47c0e4dee953195abba950917c3e101eff174e8",
+      "size": 257932016
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "b882f4b8b27772f897540df50f24000206f43a9426e8f7d19bd065959b69e9dd",
-      "size": 259951416
+      "checksum": "e7d2ceb53ed4c2ced1fe7fc1c6331c98dc5f7b4c9b2722d9c5fa3dd5dff6f719",
+      "size": 261081912
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "d5785d7c25f86a00ba5d5fe81d98726c89ea7d6f45dca90fcc4cbabef6a9e0b5",
-      "size": 250066104
+      "checksum": "17f617e24a05533cea8a344f44f0a25b6fb20ee467500601c3cd8392064ec528",
+      "size": 251180216
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "7ad8e7d428e1ddef18040fe43f54110541ced063a7b5903091aac8f45c57ee21",
-      "size": 254607744
+      "checksum": "03012f856faa1a9409d9add13936794f168e530c9746c8a099dec6ce8415c32b",
+      "size": 255742336
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "b9d5e8542338a0918534e55d046a7c960ae4af5ee214c7e4e80a89067b63ea2c",
-      "size": 251303072
+      "checksum": "29aa99c436f0d4125780691123b756176d83b59cc7d492304cd4694292d3f04f",
+      "size": 252385952
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "a29607da80ac0d6f2620553e52026ecc7744b27d49128f143eacd120e5f2ad9d",
-      "size": 245652640
+      "checksum": "4a603da0a33d49478e55938898ddd06c4ec5d1ec7f443d92dd4352665faaef05",
+      "size": 246736544
     }
   },
   "sdkCompat": {
@@ -63,7 +63,8 @@
       "0.3.204",
       "0.3.205",
       "0.3.207",
-      "0.3.208"
+      "0.3.208",
+      "0.3.209"
     ],
     "harnessSchema": 1
   }

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.191",
-  "commit": "397db5e73d569118815b8037ca9ff2483a06bbfe",
-  "buildDate": "2026-06-24T11:32:23Z",
+  "version": "2.1.193",
+  "commit": "a1938d2a07a2e4fecbef4eeac813221929e97d22",
+  "buildDate": "2026-06-25T18:25:46Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "99fdfb552a5260e649aedd06c024d0a4105b09cefec0bf67d558e017ee66c400",
-      "size": 219856224
+      "checksum": "f7513a30385ad9019c237226fd6ec46508b3062ebefca8aedbe397d111a818ff",
+      "size": 222248240
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "6e83aad5fc4fd459fd74539cda06d2279105eac2befc603d2fba6494974cb2a4",
-      "size": 229178416
+      "checksum": "cba5c3bdca8ab5f8e7590406702d418f6114d9b39f48f16876680e881abf1ee8",
+      "size": 230317808
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "1a31a7cbcfd784f8c073bfc8a0a1583fb6e93e60ef70b76d7fcf663ffed8949b",
-      "size": 236305136
+      "checksum": "39454ce62e795eeb4871a81f6453cda96e926e2db9a4dd41d0ec1b60b0153448",
+      "size": 237419248
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "1038dba88bdf1b80941dc3e383e93b088325b00497329ac50da460c8786d5bee",
-      "size": 239438648
+      "checksum": "c9f04d929f18bd9a101f3897f27de4e1e0f15ebe8400d4aaf02983d73dd66b1d",
+      "size": 240556856
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "7e5d3ac86e28dbd224f84d9349372b74bed39ad6392408df63356fd8a810c96e",
-      "size": 229553336
+      "checksum": "658bbae05441c2d3792f9870a5001a1dfa7a62956abffc151aed7cae0adf9f7d",
+      "size": 230667448
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "b80e0066fb208cbd50fe539ed9c03dadd24fcc058bb67774fd36a316bca396ad",
-      "size": 234123648
+      "checksum": "b37861314ace243d8425ebce503c657c5d9f76af361f9bd8ca3bd34b2e71474a",
+      "size": 235258240
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "83397a6a029c7da663fb1ce27211e05174a3546d8b151e42451bf4590b8343d7",
-      "size": 230281888
+      "checksum": "ffea22269bf66ce778ce845ea0c15cb5b21d39be82601a065c3eca6f7368da3e",
+      "size": 231359136
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "ec8c342e835ee8891ef2c6d0eb9ac460f2d5e6a668788c8a03faa3451748c275",
-      "size": 224756384
+      "checksum": "0bea15edaf5791220c646f9066bda84397a73053d88f225c7622c7a2ab45ff59",
+      "size": 225839264
     }
   }
 }

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.210",
-  "commit": "88e9fbf39bf4efa5bca44549b7fd9461628657e6",
-  "buildDate": "2026-07-14T15:12:31Z",
+  "version": "2.1.211",
+  "commit": "17a4b6d7b2ee1936b95e595054c7e7d38fddafb7",
+  "buildDate": "2026-07-15T16:42:49Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "1b471d62d1117482689d75447f5e050c640da717a5a3c91e6c13792450f8c662",
-      "size": 241509968
+      "checksum": "5a728a76198b6eca7f3c7cdbff43bab44b77b48c2108f7a3107d889773382629",
+      "size": 242445680
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "892f2c878050d8829e67119328dd9768345fba18a58c169212b70597c9175c40",
-      "size": 251025552
+      "checksum": "33049eb14cf4702b992b7eda41ec077fc6e76539f7fd046e6d32538757235da4",
+      "size": 251966736
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "84feb193c1d91f3b5eba836ed47c0e4dee953195abba950917c3e101eff174e8",
-      "size": 257932016
+      "checksum": "1fff7e8f947c07b19d10b1fbf714b7e547e9536253b9b58230d8adbc4624f867",
+      "size": 258849520
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "e7d2ceb53ed4c2ced1fe7fc1c6331c98dc5f7b4c9b2722d9c5fa3dd5dff6f719",
-      "size": 261081912
+      "checksum": "8272c8a474ac9ea1bc35f19b9f7c7e7dc4dc4eb6d5ad3e484b19335ac72446b2",
+      "size": 262023992
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "17f617e24a05533cea8a344f44f0a25b6fb20ee467500601c3cd8392064ec528",
-      "size": 251180216
+      "checksum": "ca094a85ea464b2ebec2ecfcc9e2c056573d4ca95ebe12ffae2c7dccb722e17b",
+      "size": 252097720
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "03012f856faa1a9409d9add13936794f168e530c9746c8a099dec6ce8415c32b",
-      "size": 255742336
+      "checksum": "c99bd7934ac841d5be6ee7d3644cb63bccef2cd495c6c1bb982a1b1deac1b466",
+      "size": 256680320
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "29aa99c436f0d4125780691123b756176d83b59cc7d492304cd4694292d3f04f",
-      "size": 252385952
+      "checksum": "3d8509ae7de11d77dbdc711aa320fc6d5064ce795464a8670696611b57093caf",
+      "size": 253293728
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "4a603da0a33d49478e55938898ddd06c4ec5d1ec7f443d92dd4352665faaef05",
-      "size": 246736544
+      "checksum": "a0f9bab0dbdda9b43a8765d54e329e44484d9dd7d4f40cf31db6eee27a2da41c",
+      "size": 247643808
     }
   },
   "sdkCompat": {

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.187",
-  "commit": "6a53320fad5541a68d79e4b6c53677df77b98e33",
-  "buildDate": "2026-06-23T17:07:42Z",
+  "version": "2.1.191",
+  "commit": "397db5e73d569118815b8037ca9ff2483a06bbfe",
+  "buildDate": "2026-06-24T11:32:23Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "a59a16ba4922adab7a145728f215d042184d349f5f7e72cddb7fc114250a4ce3",
-      "size": 215994048
+      "checksum": "99fdfb552a5260e649aedd06c024d0a4105b09cefec0bf67d558e017ee66c400",
+      "size": 219856224
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "7f57b6935b4246d03cb7acee90dc22153083483a267da589c5c920dd04744c36",
-      "size": 224795776
+      "checksum": "6e83aad5fc4fd459fd74539cda06d2279105eac2befc603d2fba6494974cb2a4",
+      "size": 229178416
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "b49be8a5e565bf2d45b50d2de62017b25462131acc9425d2fdb98b8f29c9dce2",
-      "size": 232240864
+      "checksum": "1a31a7cbcfd784f8c073bfc8a0a1583fb6e93e60ef70b76d7fcf663ffed8949b",
+      "size": 236305136
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "bb02fcb33626f8c599d10d8bee38585d4cf8d4225c3b497869dee7454e7bf361",
-      "size": 234874664
+      "checksum": "1038dba88bdf1b80941dc3e383e93b088325b00497329ac50da460c8786d5bee",
+      "size": 239438648
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "972fc2e0bc8104edb593ce7723d4414c0ed8e4df6d90ad26ae48097b1d910478",
-      "size": 225620168
+      "checksum": "7e5d3ac86e28dbd224f84d9349372b74bed39ad6392408df63356fd8a810c96e",
+      "size": 229553336
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "c5a783d13aac71d42324f2e9dcd395c266bd5774951faf0d94855c737024bee3",
-      "size": 229858704
+      "checksum": "b80e0066fb208cbd50fe539ed9c03dadd24fcc058bb67774fd36a316bca396ad",
+      "size": 234123648
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "24964d08c5100bac6071352e5837101b333de1c1afefd2b8b0e7a60db6c0ef5c",
-      "size": 226329760
+      "checksum": "83397a6a029c7da663fb1ce27211e05174a3546d8b151e42451bf4590b8343d7",
+      "size": 230281888
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "04124c0ba09ece85a856de652e84386094c372f002ff767a94d4a43ecf776f96",
-      "size": 220992160
+      "checksum": "ec8c342e835ee8891ef2c6d0eb9ac460f2d5e6a668788c8a03faa3451748c275",
+      "size": 224756384
     }
   }
 }

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.202",
-  "commit": "23f7f00042c9899630a3a02963fe4bb349512614",
-  "buildDate": "2026-07-06T20:02:44Z",
+  "version": "2.1.204",
+  "commit": "51bd0ba270a17535ce551f0eff5d09553b44a9e1",
+  "buildDate": "2026-07-07T23:24:03Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "7414f707861e2fe5afef33a466f888a8d2170e5028f5e9d2858f1d3ef45ffca5",
-      "size": 243631376
+      "checksum": "1677b67595b6251156d62600dc85d4070ec385b72dd0b07e73742a56030952c3",
+      "size": 236961904
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "0dc578bb294094f5041e99a0444030ac6ae7236b387e56f00d4a5214816763bd",
-      "size": 251667920
+      "checksum": "9ccea5f19ec0462f3b983ff3400a97adaf16a83c3dc36a69b916805f2bc8c829",
+      "size": 246384080
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "de5e0bb28e2b32409444ed4c1431e2931001c05ed270a3dc96c6706b0693867f",
-      "size": 258587376
+      "checksum": "c37256a8c3998b8675e8385f1ae4677d69bdff1e717c389296eec70e02e317ef",
+      "size": 253344496
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "71590202249892db3805ecd5b867f831f04b8129eaabd3f9a5bd4ba16b52c839",
-      "size": 261786424
+      "checksum": "c8ee1ea69154533c691a68f46abb645196fe7339d26e6fc204cc7f08220139d3",
+      "size": 256535352
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "80405fead329dd67d786b2a3d49bb121797a157937c99dedae2e36fcc77b55e6",
-      "size": 251835576
+      "checksum": "d87a3b19f01bbf28d05e7ff7c449923fc520f2d64c4227373ccbf24dec6438f3",
+      "size": 246592696
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "bd62d47b677b8867e34f32642ee13f9fb87ad31b8acfdd326307eeffec02ec89",
-      "size": 256471424
+      "checksum": "b2d7a23342e315f8dd0d253b14f394bffb5ba04d434b7631c9837e38d99fde35",
+      "size": 251224448
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "7ff0787ebdc19fc509ccea8886ebf6a53ad8213407fa3a2b7c6d1446efc419f6",
-      "size": 252038816
+      "checksum": "e1d82bf346d99db3e611b75a4afc5fdf1530d8d8c546389cf45ac8250bce4af1",
+      "size": 246707360
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "67a437feb7489620063f57e3bb073b8b7b82252d9373c9edc1d4969e42796be4",
-      "size": 246505120
+      "checksum": "085f7d5c98dfec2681996cacbf6185d1439fdc7208087afa99c22c07132b9a56",
+      "size": 241173664
     }
   }
 }

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,47 +1,68 @@
 {
-  "version": "2.1.206",
-  "commit": "edc8ebf7f852d3abffad32a5bf8e49e439f92afb",
-  "buildDate": "2026-07-09T01:48:20Z",
+  "version": "2.1.207",
+  "commit": "bc512d56332530b2be3f5079e29ec17aa20b8553",
+  "buildDate": "2026-07-10T21:39:38Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "3197aba4442dbd5b3df42b6f35e6d7bd03b5e48ce18b7a3c5c6f5f8c28e03b7f",
-      "size": 240395024
+      "checksum": "1397a062c6889675055e3314dd956376ac51262a7734ad9e819c26975d71547a",
+      "size": 241237136
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "b1e1636917a12c7d4e1fa54cd13f7f76ba3779fb988180610b6ca483258c2f46",
-      "size": 248431568
+      "checksum": "8a4355d251a60c90d8cf08f32fdb22a8157dd3d085542f95d0da0475f9a2c57c",
+      "size": 249273680
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "cb8ccaf4ae6beb558747227a362010c6b32b4f4a5868c3a7e96aa9972fc6ef58",
-      "size": 255376112
+      "checksum": "8bc14a284065383460f37981d724b8f7aa7ca93c9849d2fe367e08f03383f454",
+      "size": 256228080
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "d131494be407ff56a62f4e99a96ba60102002d01e3b6b1494db16bef4b7f060f",
-      "size": 258566968
+      "checksum": "85e7e988a392d859f90802ca21fb26e89d3c9ab527f5ed0b08df3955e34d5c83",
+      "size": 259402552
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "b1920556c3b077694d52397f4e5221df2419ad9b44af641be0f49647b51f87ad",
-      "size": 248624312
+      "checksum": "ec3b657344dcf6693f434fe11ffe4592381d31d4e6a7976649c1a610770dcc74",
+      "size": 249476280
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "b0d780783401de979024c25f14a2cae665873afbcfe718c090b73e13c4cd08a0",
-      "size": 253251968
+      "checksum": "09a43ff41e33cbb0c4903a4939353933ee8f0d1964abab4b837004a951edb9ee",
+      "size": 254091648
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "d5072b25b9a20bffb24625d36129a05ed2be4d2eb7e35625aad6aa35596892c2",
-      "size": 248682144
+      "checksum": "781fdc2c89868b1cb05cc22c253ef142a0b44e7cc36236aecd6335745c7d42d0",
+      "size": 249485472
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "c17ac3a5a8edf5cfa658e82bd41fcf83170af21538e51cc9d4cbaeefe382aba3",
-      "size": 243149984
+      "checksum": "fa0c887a3f944ba1915766b525538b82b029ca8078ed6ee180c3b83c1b862521",
+      "size": 243952800
     }
+  },
+  "sdkCompat": {
+    "testedWrapperVersions": [
+      "0.3.181",
+      "0.3.182",
+      "0.3.183",
+      "0.3.185",
+      "0.3.186",
+      "0.3.187",
+      "0.3.190",
+      "0.3.191",
+      "0.3.195",
+      "0.3.196",
+      "0.3.197",
+      "0.3.198",
+      "0.3.201",
+      "0.3.202",
+      "0.3.204",
+      "0.3.205"
+    ],
+    "harnessSchema": 1
   }
 }

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.212",
-  "commit": "8b2783a8f907ce5c5ad1241ecdbab0ff3301c617",
-  "buildDate": "2026-07-16T16:50:33Z",
+  "version": "2.1.214",
+  "commit": "e158e55a79995c80ed463a5d2de322bc0ac2f711",
+  "buildDate": "2026-07-17T23:32:51Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "09ecba2ab2df9b6ee5b0695e26f65dea60fb3b6af3d3542ee09f466838d1e574",
-      "size": 244530512
+      "checksum": "59796dd18e9d77f1256f367db6d28ce4bd9cd5968e402ad3a327aac36abc6dec",
+      "size": 247091504
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "7681a0634c89fa4474e53c0c794e992944aebf3409a7a2b87ea9f9b0194ea341",
-      "size": 254080272
+      "checksum": "d979ba15662828969e5d0f39f1367798a07ef6e031b524efdad37fe7caf84010",
+      "size": 256507024
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "66e88634a8573a002702e6a9de0d80cb9bb7c9072f9e6f4486778539057dfd3c",
-      "size": 260946672
+      "checksum": "4c38f26a57a42619ee813f15dc39fc1fa4fe0bb403215c3cdc342b58fa689c3c",
+      "size": 261995424
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "044a88cf3a5180776617fd3da1238dcbf9141ddec449a39cf7d2af1ac78e684e",
-      "size": 264096568
+      "checksum": "3c029136f7c81f54ed4a38e9d52e655aad536433dbbde50519c8c31bb646ad14",
+      "size": 265210864
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "6996b65fc90aa1e0b8f80824df77295d93fa43b12388915a762b58fd982a1d16",
-      "size": 254194872
+      "checksum": "bbcdec27500f1c7f04a8697fa1d55cdae183ba9054b984ac95d82ccdcccaec3e",
+      "size": 255243624
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "a17757970a1f7ef0c47a31ea8fa40798fd7796854ba9422e1a4175f3f149de2c",
-      "size": 258756992
+      "checksum": "1744afe6baa7d5321917bc6f807883daf4f0abda8e9e5d006c03356eb3df8945",
+      "size": 259838544
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "fe639693fd7e9a881c799867711abb7666dec2a5fefbaba41af6a09e71bcbefa",
-      "size": 255334560
+      "checksum": "da26afacbc58d6f569d0921ff6825772220c734327f5f976c0c73bd0b7dd3cf8",
+      "size": 256220832
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "adaa6e3dadb8016755ccd1907a5f249c1bc9bdb6c71d3f7dcea7d5db8f72d0a5",
-      "size": 249684640
+      "checksum": "4c62218523c562991ef05985af3cffa1a69a588bbcfb3b3bf7b59e9bcb69e963",
+      "size": 250596512
     }
   },
   "sdkCompat": {
@@ -58,6 +58,7 @@
       "0.3.196",
       "0.3.197",
       "0.3.198",
+      "0.3.200",
       "0.3.201",
       "0.3.202",
       "0.3.204",

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.198",
-  "commit": "b80c496480ebf28e6dfe755cf0b8e3dd1d7cba1f",
-  "buildDate": "2026-07-01T06:17:25Z",
+  "version": "2.1.199",
+  "commit": "968b0c4118bde7c998acd97511e68daecacd8507",
+  "buildDate": "2026-07-02T01:58:04Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "ab6f7ee109816ede414f7c285446633f805b623aa609f425609a64266451d61e",
-      "size": 229328464
+      "checksum": "e3cb61abc8a2ec7b98976cee1ffdde5a3fa755c9990bc8d688cd89290e0dcec0",
+      "size": 232155536
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "280b6cfc60dacc4caed31af1249e53c259c01759556e60633944c02405c82dd0",
-      "size": 238706000
+      "checksum": "e64853ff3bc2ae6ed8115581c851e1176762d445d0b8b9e0dd37d0d560224a88",
+      "size": 240192080
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "99b50a6f2b1f3ef07bcaf1e58a2f9883c470c84e428afa321972b1aa20372e9a",
-      "size": 245742320
+      "checksum": "14851b5170b154b01baca09bba970172e70cdd768b5a012bf347ba0f594b4ad3",
+      "size": 247184112
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "7066af42a5fe93038c13af5072d4c034dc3928092cb121fdd892c76b94b6b84d",
-      "size": 248900408
+      "checksum": "b31dfd5e3dee23b51c42e0d8ddb405148978237d3aabc8cbbf77c5cf83367e27",
+      "size": 250383160
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "88cb391085e419457569bcc57a672f734f30b424e17df7323f3bbb421238e801",
-      "size": 238990520
+      "checksum": "4115c07bc6dfa71affff595400599032b70b4ab25b7a2dae982341ef4da47b38",
+      "size": 240432312
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "42892159a03bee492926b616b1270313544f7a52b68d32cb680e91984a4c6659",
-      "size": 243589504
+      "checksum": "22c8b0861078cef1b572023e7eda4ce0dda7e12cc2e3060858eaa3de010bee21",
+      "size": 245068160
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "6afd07cb03aa981c5e918808f53a1e2b729015b695122a944f6e41aaf5393933",
-      "size": 239292064
+      "checksum": "63de670613bb74594564a2125cb54e0e2e78192c5696e396adfae093b9132eec",
+      "size": 240716448
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "10a6d21332f674c87f52b1dc09926945d0169f1bb82aced84ada100639ab70bc",
-      "size": 233758880
+      "checksum": "7e4900b1ce5588003e0ade6caa0aaef1e2b8efd903c5a86c671d0de258b7a4d4",
+      "size": 235182752
     }
   }
 }

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.199",
-  "commit": "968b0c4118bde7c998acd97511e68daecacd8507",
-  "buildDate": "2026-07-02T01:58:04Z",
+  "version": "2.1.201",
+  "commit": "5bb45156ece6b12214696c88adec695b2dca1338",
+  "buildDate": "2026-07-03T20:01:44Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "e3cb61abc8a2ec7b98976cee1ffdde5a3fa755c9990bc8d688cd89290e0dcec0",
-      "size": 232155536
+      "checksum": "a0852d76afc47b30f5cb0b7625ec9a7714cb189f2eeef6c28c77e2be954fb7fd",
+      "size": 231708784
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "e64853ff3bc2ae6ed8115581c851e1176762d445d0b8b9e0dd37d0d560224a88",
-      "size": 240192080
+      "checksum": "1889287a92d25356ae8bd8d8e67b11456015516ee8ba4277a0c7074786c49bb6",
+      "size": 241100240
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "14851b5170b154b01baca09bba970172e70cdd768b5a012bf347ba0f594b4ad3",
-      "size": 247184112
+      "checksum": "86b2eab34d382c7b428fc2e9f4c97f04e46805e950582472a13eb7d48de60516",
+      "size": 248101616
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "b31dfd5e3dee23b51c42e0d8ddb405148978237d3aabc8cbbf77c5cf83367e27",
-      "size": 250383160
+      "checksum": "a34809a6839fdefff21b9347d7fb5b6b58e6a9cc208a5e62853f29c83eb107a3",
+      "size": 251300664
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "4115c07bc6dfa71affff595400599032b70b4ab25b7a2dae982341ef4da47b38",
-      "size": 240432312
+      "checksum": "5b4cde588b0196c8f88654ca9652c4703788f4d9fbab32a17ab3c444830085ae",
+      "size": 241349816
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "22c8b0861078cef1b572023e7eda4ce0dda7e12cc2e3060858eaa3de010bee21",
-      "size": 245068160
+      "checksum": "a0f81ec99ac65e8c5919e7aae54b8a496488e0f1311884fc9ffd05c7cbf6bd2f",
+      "size": 245985664
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "63de670613bb74594564a2125cb54e0e2e78192c5696e396adfae093b9132eec",
-      "size": 240716448
+      "checksum": "fb804ee019bfbb8d7e85abf965e528e53b5aa5a4e4ebc0f164139dc10a9e0320",
+      "size": 241591968
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "7e4900b1ce5588003e0ade6caa0aaef1e2b8efd903c5a86c671d0de258b7a4d4",
-      "size": 235182752
+      "checksum": "a3ad78a0b593dea94c3ee787b1f5b17a173a7679203a296acf9aae7ef4705d42",
+      "size": 236058784
     }
   }
 }

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.217",
-  "commit": "9963b018d22c3e6659c99e135e687870301b5c67",
-  "buildDate": "2026-07-21T18:45:36Z",
+  "version": "2.1.218",
+  "commit": "bce61b433bc397ce68686368abd12f545b0a013a",
+  "buildDate": "2026-07-22T18:42:19Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "5840c777fd47115e9ca276e165563c6e121e7c7e2b4d86598e0025f8cc37de56",
-      "size": 250456784
+      "checksum": "71abaff59312c9a9b6a1d818365048b42e4e95cc521a823660eded3e0880d9b7",
+      "size": 255069680
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "8387a6fd44edfd40d7e74c5fdc3270a15f5e6b1b58c7c6fee560e70d3d1943da",
-      "size": 259908496
+      "checksum": "9862b74a083e8a4ed572f99cbd4895185e0dd5a0a601affb0fb8e43d8d1f40e6",
+      "size": 264548368
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "40c53507ac669c1d438366c19760c22f52748a06e50e0fc0e353d2cb73425597",
-      "size": 265337760
+      "checksum": "295fd30481bd03b38450fdec2a6e25bb6472c2074f04b0c4a566cd5988f230bf",
+      "size": 269990816
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "2630fc5dc6db61bc03f86b95daf47766e5ed5b61873f7bb7cfea764c5ac5a9ba",
-      "size": 268573680
+      "checksum": "e12071751a9336b8af1012c103358ff04ac18f9aaff4a738cff7ba5cdfaf63f2",
+      "size": 273177584
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "e219a631e194e71bccbea2f81f5678c75f745aa6e7a74e8a407610c906d1299b",
-      "size": 258585960
+      "checksum": "efcaae48f8f537a0e9a47b4317a5f8c184706c99ddd8ca0a9a21391e2a766ef8",
+      "size": 263239016
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "7c44188927edbf7b918b41bc7a284292359b1ad556b7802db0148adb4b395732",
-      "size": 263197264
+      "checksum": "62986293277153f5db97404cf7e3e96de136f02c28f79ccd5c7bc99766224db4",
+      "size": 267801168
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "6e4a3a4679f381178a90cf741de9ce924a3274304b09277695ac3a679628ca17",
-      "size": 259460768
+      "checksum": "81fcf59bb7abb558aedc6f2361f4723b3d757d28e799962d88b18b4520df66ca",
+      "size": 263931552
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "f0128e1a50b8d7dec5bb4dbdff0ef622f617e798df61ebb009ed3f03d2afe613",
-      "size": 253836448
+      "checksum": "a7959fd87feb9557d56f4e5752f7ed1ddf405f3bea91b2571bf93af636efd193",
+      "size": 258307232
     }
   },
   "sdkCompat": {
@@ -67,7 +67,8 @@
       "0.3.207",
       "0.3.208",
       "0.3.209",
-      "0.3.215"
+      "0.3.215",
+      "0.3.217"
     ],
     "harnessSchema": 1
   }

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.197",
-  "commit": "c8fd8048f30950a21d28734718275aa7e97f5143",
-  "buildDate": "2026-06-29T19:16:30Z",
+  "version": "2.1.198",
+  "commit": "b80c496480ebf28e6dfe755cf0b8e3dd1d7cba1f",
+  "buildDate": "2026-07-01T06:17:25Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "8cc0c4d1e4eb1dca3b0cc92ab02ee3505de764e023f8c901761c167b72041fb8",
-      "size": 227251472
+      "checksum": "ab6f7ee109816ede414f7c285446633f805b623aa609f425609a64266451d61e",
+      "size": 229328464
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "5e8a57cc7a92377f0744fa4c79191cf93d4b26c79cb919b07a407511fed1be26",
-      "size": 235288016
+      "checksum": "280b6cfc60dacc4caed31af1249e53c259c01759556e60633944c02405c82dd0",
+      "size": 238706000
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "fb48473c467c27615ac799a754f4ef0b68c363e4596cefbb59c3815d51a0cc8a",
-      "size": 242334448
+      "checksum": "99b50a6f2b1f3ef07bcaf1e58a2f9883c470c84e428afa321972b1aa20372e9a",
+      "size": 245742320
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "f54e69cbc89b2da61a415700af7ff52a147e862517d4f1b0eecf768448cf7f83",
-      "size": 245517112
+      "checksum": "7066af42a5fe93038c13af5072d4c034dc3928092cb121fdd892c76b94b6b84d",
+      "size": 248900408
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "acb885610ba06d90c46206ded9b14121bc30e96affecbfb3c37d511bf02af2bd",
-      "size": 235582648
+      "checksum": "88cb391085e419457569bcc57a672f734f30b424e17df7323f3bbb421238e801",
+      "size": 238990520
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "2f610c0f81341052426981b5dc59277a33e6ec3df924071b24edbc05e6a096dc",
-      "size": 240202112
+      "checksum": "42892159a03bee492926b616b1270313544f7a52b68d32cb680e91984a4c6659",
+      "size": 243589504
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "038bd9fe90c60304601e19751269a50d62925c541dd6a2b3da5274549e9416ee",
-      "size": 236121248
+      "checksum": "6afd07cb03aa981c5e918808f53a1e2b729015b695122a944f6e41aaf5393933",
+      "size": 239292064
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "8d2baeaf77b0e79ea33cf5ce78a37e64804c3a26d63d35355a830fda404a4f61",
-      "size": 230588064
+      "checksum": "10a6d21332f674c87f52b1dc09926945d0169f1bb82aced84ada100639ab70bc",
+      "size": 233758880
     }
   }
 }

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.218",
-  "commit": "bce61b433bc397ce68686368abd12f545b0a013a",
-  "buildDate": "2026-07-22T18:42:19Z",
+  "version": "2.1.219",
+  "commit": "7006c4c3acac98e554d3997baeda6a7fa4d1ff7c",
+  "buildDate": "2026-07-24T03:34:26Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "71abaff59312c9a9b6a1d818365048b42e4e95cc521a823660eded3e0880d9b7",
-      "size": 255069680
+      "checksum": "a8e806faaefac53c7a0f26523d8a45c60dbef3407b14ef990c75765d08febc82",
+      "size": 256908272
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "9862b74a083e8a4ed572f99cbd4895185e0dd5a0a601affb0fb8e43d8d1f40e6",
-      "size": 264548368
+      "checksum": "03be9f988ed88391b4a5f08e4c5dc317ce2fffa4a9dc66c01106326e7698ee76",
+      "size": 266381200
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "295fd30481bd03b38450fdec2a6e25bb6472c2074f04b0c4a566cd5988f230bf",
-      "size": 269990816
+      "checksum": "1f834b322ba9d1291cc7ffeff16a6795a59145bda279dbd59cd7ecebc7b7f15a",
+      "size": 271825824
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "e12071751a9336b8af1012c103358ff04ac18f9aaff4a738cff7ba5cdfaf63f2",
-      "size": 273177584
+      "checksum": "22cfd6f5b3061c0391ba84e9cf8c9deaa37783aac18b004d42ec061e98f00691",
+      "size": 275004400
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "efcaae48f8f537a0e9a47b4317a5f8c184706c99ddd8ca0a9a21391e2a766ef8",
-      "size": 263239016
+      "checksum": "22b2c2e0f41ab0b7c7b8845be9c49fe6f27e4c344aab1bd174bdf84a4e6b0570",
+      "size": 265074024
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "62986293277153f5db97404cf7e3e96de136f02c28f79ccd5c7bc99766224db4",
-      "size": 267801168
+      "checksum": "487008769dd69599adb779205b6b371de27b4245f0ad2ad70f15baf4eac5f81e",
+      "size": 269627984
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "81fcf59bb7abb558aedc6f2361f4723b3d757d28e799962d88b18b4520df66ca",
-      "size": 263931552
+      "checksum": "10f4c1f85b07f3cf6b8fff930fd26ecd475bd146a378acfafa559a6db9d89637",
+      "size": 265714848
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "a7959fd87feb9557d56f4e5752f7ed1ddf405f3bea91b2571bf93af636efd193",
-      "size": 258307232
+      "checksum": "6a1db10161b93e81ac55537feeae8a299f0bf67601c1c0f2016e79c850302baa",
+      "size": 260090016
     }
   },
   "sdkCompat": {
@@ -68,7 +68,8 @@
       "0.3.208",
       "0.3.209",
       "0.3.215",
-      "0.3.217"
+      "0.3.217",
+      "0.3.218"
     ],
     "harnessSchema": 1
   }

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,52 +1,51 @@
 {
-  "version": "2.1.221",
-  "commit": "6efaf12e8b43dc7dbe50e0955c76dc4174a15876",
-  "buildDate": "2026-08-03T21:08:11Z",
+  "version": "2.1.222",
+  "commit": "fbf49312c28437bf9c2546b9ace3bd7b34eb6ff6",
+  "buildDate": "2026-08-04T01:46:04Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "7a181f36ed0fc4fbac6cee4ecf2b615eff93d8b434221fff5d7c878dc5ebf380",
-      "size": 270518240
+      "checksum": "c66a6cc6fa2e8145bb1a6e77831f2caf4b83690ff04650500dfa6e2c05ca997c",
+      "size": 271289792
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "f408b9f7e46439f6e34a3687ff67433fc6bc189f40220ce4f0a1e829e58f0a52",
-      "size": 280087584
+      "checksum": "36bfc6482a25730dbb1cee72589e522c66c45a4dc9ebfdd8a76a8113b01b6188",
+      "size": 280847136
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "d3c59d6bcc4adcf4cd85abca3bc13fa1131a34cb32f982bdf030d83a3b11e700",
-      "size": 285457336
+      "checksum": "a04be0a8d7fe0259571ab7411d51d85658d71a4a26ce62b60c908290372e6016",
+      "size": 286178232
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "60db8e88d42c24b5199c92cfd56ec88370c510c3789c6f364af748354f087ada",
-      "size": 288705544
+      "checksum": "10caae8f22b915c26bfff0e013a4d45608c4f1ae287583626569156f447730e5",
+      "size": 289467400
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "85985afd58d33578efd217788dd9e5cbbc0177ad00e638d9316c6fd89640f3ff",
-      "size": 278771048
+      "checksum": "a3c3e3202ae8842a5e9d2b4ce1dcea9fa00d4e0ae27b5b3e8d778332ba3bb23c",
+      "size": 279491944
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "15b068e06eafff9b64583b46cdc065ac18b0d0d13950c2a83c6ee854f301a32f",
-      "size": 283312720
+      "checksum": "e0b0fb4005e1ac0ebcee136254c638722f1c49e171a23d0843c605d72aac9029",
+      "size": 284074576
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "0f73196359a07f9ad435a8c83ca7c741b9f2adbc0ad9b05f71a0c2f4aabe906a",
-      "size": 278279328
+      "checksum": "032cb799d2abfaa6ca440f6458304b9a2a250521063d21ebcea7f3c77c443db7",
+      "size": 279014048
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "1407585e0c33a70061d6ea7cb873b8582dcedbe928d2118982676f1951576a58",
-      "size": 272952480
+      "checksum": "f760aa2782019e55b1e44fda9eddec85ca8499429da87efddd47ab18d4a716a2",
+      "size": 273687200
     }
   },
   "sdkCompat": {
     "testedWrapperVersions": [
-      "0.3.181",
       "0.3.182",
       "0.3.183",
       "0.3.185",
@@ -75,7 +74,8 @@
       "0.3.215",
       "0.3.217",
       "0.3.218",
-      "0.3.220"
+      "0.3.220",
+      "0.3.221"
     ],
     "harnessSchema": 1
   }

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.222",
-  "commit": "fbf49312c28437bf9c2546b9ace3bd7b34eb6ff6",
-  "buildDate": "2026-08-04T01:46:04Z",
+  "version": "2.1.223",
+  "commit": "4535f69721056abf01650c73ee8a91c69ba00838",
+  "buildDate": "2026-08-05T21:55:19Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "c66a6cc6fa2e8145bb1a6e77831f2caf4b83690ff04650500dfa6e2c05ca997c",
-      "size": 271289792
+      "checksum": "fcbe0b8d47570c501302dd1ad31cc26ac2810f022c45fa253936a6961dee32bf",
+      "size": 272553824
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "36bfc6482a25730dbb1cee72589e522c66c45a4dc9ebfdd8a76a8113b01b6188",
-      "size": 280847136
+      "checksum": "350e657428a6d34f7cf71f6738c5ebb6a1952ccb12fc1747f64297e065b1846f",
+      "size": 282118560
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "a04be0a8d7fe0259571ab7411d51d85658d71a4a26ce62b60c908290372e6016",
-      "size": 286178232
+      "checksum": "60e83d8db0e894d0e54413e5e7daa256d180db660f51e139a51b614fc30cf3ac",
+      "size": 287423416
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "10caae8f22b915c26bfff0e013a4d45608c4f1ae287583626569156f447730e5",
-      "size": 289467400
+      "checksum": "98226474f802e3094d6a86c5ade8883c16206d0fcb5c400b7401c800063e99d7",
+      "size": 290728968
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "a3c3e3202ae8842a5e9d2b4ce1dcea9fa00d4e0ae27b5b3e8d778332ba3bb23c",
-      "size": 279491944
+      "checksum": "f41692eab23ebcd836d342fbc494d8783b1f19efb13d04fbf8461d2806ccb586",
+      "size": 280737128
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "e0b0fb4005e1ac0ebcee136254c638722f1c49e171a23d0843c605d72aac9029",
-      "size": 284074576
+      "checksum": "8a4e561e8af19746d2defcf1a5661f5c0384c9c26dadd87d45e11b67802ad147",
+      "size": 285336144
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "032cb799d2abfaa6ca440f6458304b9a2a250521063d21ebcea7f3c77c443db7",
-      "size": 279014048
+      "checksum": "a708ba811c4cc46907df358e22f2aa6da3dbc28192747e4d3c4a0869752fe722",
+      "size": 280233632
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "f760aa2782019e55b1e44fda9eddec85ca8499429da87efddd47ab18d4a716a2",
-      "size": 273687200
+      "checksum": "8efb44f04fda50fac3c7602276903e44ff82d48f1a29a41f1a5d98891a01864b",
+      "size": 274906784
     }
   },
   "sdkCompat": {

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.220",
-  "commit": "4073f59596e272f39393db4f96abc5f4b10eff21",
-  "buildDate": "2026-07-24T22:28:51Z",
+  "version": "2.1.221",
+  "commit": "6efaf12e8b43dc7dbe50e0955c76dc4174a15876",
+  "buildDate": "2026-08-03T21:08:11Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "8addc857f3fe64d5a0368af9ee50321b50afb4a6918ba3ef018ab84f5dbbe081",
-      "size": 256908272
+      "checksum": "7a181f36ed0fc4fbac6cee4ecf2b615eff93d8b434221fff5d7c878dc5ebf380",
+      "size": 270518240
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "dca7be0aa7d3d924836d440e0c6d8e3d47ef3c8e61fa5809b54b9017170ce2f3",
-      "size": 266397712
+      "checksum": "f408b9f7e46439f6e34a3687ff67433fc6bc189f40220ce4f0a1e829e58f0a52",
+      "size": 280087584
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "159e4a51d796f3bf14677577100f7efb845611b1ceaf0c30cbd8d4650d942185",
-      "size": 271825824
+      "checksum": "d3c59d6bcc4adcf4cd85abca3bc13fa1131a34cb32f982bdf030d83a3b11e700",
+      "size": 285457336
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "674f61f20ff306f3100cf9200e4c36c4b70278b5bef2884549819b942a89c863",
-      "size": 275012592
+      "checksum": "60db8e88d42c24b5199c92cfd56ec88370c510c3789c6f364af748354f087ada",
+      "size": 288705544
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "5eb2697a1500c1b8736e53fd696392196dc6758cf1d470c64d8d2a2fd1629eeb",
-      "size": 265074024
+      "checksum": "85985afd58d33578efd217788dd9e5cbbc0177ad00e638d9316c6fd89640f3ff",
+      "size": 278771048
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "f1c20514a3571cdf9982e25c490042d740ed7cfed3f00c64ba92dc7ec47c3c5b",
-      "size": 269636176
+      "checksum": "15b068e06eafff9b64583b46cdc065ac18b0d0d13950c2a83c6ee854f301a32f",
+      "size": 283312720
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "af5bf1f1b2aadffc768eccd787084c6fdf9ba81624cbe96c1c6d9ac1a1550231",
-      "size": 265720480
+      "checksum": "0f73196359a07f9ad435a8c83ca7c741b9f2adbc0ad9b05f71a0c2f4aabe906a",
+      "size": 278279328
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "07343ace8a2e9ba87eed716e9c0261ce4bda8954c316695e4cb26fd0605de13c",
-      "size": 260095648
+      "checksum": "1407585e0c33a70061d6ea7cb873b8582dcedbe928d2118982676f1951576a58",
+      "size": 272952480
     }
   },
   "sdkCompat": {
@@ -68,9 +68,14 @@
       "0.3.207",
       "0.3.208",
       "0.3.209",
+      "0.3.210",
+      "0.3.211",
+      "0.3.212",
+      "0.3.214",
       "0.3.215",
       "0.3.217",
-      "0.3.218"
+      "0.3.218",
+      "0.3.220"
     ],
     "harnessSchema": 1
   }

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.219",
-  "commit": "7006c4c3acac98e554d3997baeda6a7fa4d1ff7c",
-  "buildDate": "2026-07-24T03:34:26Z",
+  "version": "2.1.220",
+  "commit": "4073f59596e272f39393db4f96abc5f4b10eff21",
+  "buildDate": "2026-07-24T22:28:51Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "a8e806faaefac53c7a0f26523d8a45c60dbef3407b14ef990c75765d08febc82",
+      "checksum": "8addc857f3fe64d5a0368af9ee50321b50afb4a6918ba3ef018ab84f5dbbe081",
       "size": 256908272
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "03be9f988ed88391b4a5f08e4c5dc317ce2fffa4a9dc66c01106326e7698ee76",
-      "size": 266381200
+      "checksum": "dca7be0aa7d3d924836d440e0c6d8e3d47ef3c8e61fa5809b54b9017170ce2f3",
+      "size": 266397712
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "1f834b322ba9d1291cc7ffeff16a6795a59145bda279dbd59cd7ecebc7b7f15a",
+      "checksum": "159e4a51d796f3bf14677577100f7efb845611b1ceaf0c30cbd8d4650d942185",
       "size": 271825824
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "22cfd6f5b3061c0391ba84e9cf8c9deaa37783aac18b004d42ec061e98f00691",
-      "size": 275004400
+      "checksum": "674f61f20ff306f3100cf9200e4c36c4b70278b5bef2884549819b942a89c863",
+      "size": 275012592
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "22b2c2e0f41ab0b7c7b8845be9c49fe6f27e4c344aab1bd174bdf84a4e6b0570",
+      "checksum": "5eb2697a1500c1b8736e53fd696392196dc6758cf1d470c64d8d2a2fd1629eeb",
       "size": 265074024
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "487008769dd69599adb779205b6b371de27b4245f0ad2ad70f15baf4eac5f81e",
-      "size": 269627984
+      "checksum": "f1c20514a3571cdf9982e25c490042d740ed7cfed3f00c64ba92dc7ec47c3c5b",
+      "size": 269636176
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "10f4c1f85b07f3cf6b8fff930fd26ecd475bd146a378acfafa559a6db9d89637",
-      "size": 265714848
+      "checksum": "af5bf1f1b2aadffc768eccd787084c6fdf9ba81624cbe96c1c6d9ac1a1550231",
+      "size": 265720480
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "6a1db10161b93e81ac55537feeae8a299f0bf67601c1c0f2016e79c850302baa",
-      "size": 260090016
+      "checksum": "07343ace8a2e9ba87eed716e9c0261ce4bda8954c316695e4cb26fd0605de13c",
+      "size": 260095648
     }
   },
   "sdkCompat": {
@@ -64,6 +64,7 @@
       "0.3.202",
       "0.3.204",
       "0.3.205",
+      "0.3.206",
       "0.3.207",
       "0.3.208",
       "0.3.209",

--- a/pkgs/by-name/cl/claude-code/package.nix
+++ b/pkgs/by-name/cl/claude-code/package.nix
@@ -16,11 +16,11 @@
   socat,
   versionCheckHook,
   writableTmpDirAsHomeHook,
+  manifest ? lib.importJSON ./manifest.json,
 }:
 let
   stdenv = stdenvNoCC;
   baseUrl = "https://downloads.claude.ai/claude-code-releases";
-  manifest = lib.importJSON ./manifest.json;
   platformKey = "${stdenv.hostPlatform.node.platform}-${stdenv.hostPlatform.node.arch}";
   platformManifestEntry = manifest.platforms.${platformKey};
 in


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I wanted to automate a minimum release age against the stable branch, but will do this manually for now. The x86_64-darwin drop in unstable makes it not simple cherry-picks (for the vscode extension anyway), and 2.1.223 fixes a bash permission bypass.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
