### PR TITLE
oxyromon: init at 0.22.0

### DIFF
--- a/pkgs/by-name/ox/oxyromon/package.nix
+++ b/pkgs/by-name/ox/oxyromon/package.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  fetchFromGitHub,
+  bchunk,
+  cdrkit,
+  ctrtool,
+  dolphin-emu,
+  flips,
+  makeWrapper,
+  mame,
+  maxcso,
+  nsz,
+  p7zip,
+  pkg-config,
+  rustPlatform,
+  versionCheckHook,
+  wiimms-iso-tools,
+  xdelta,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "oxyromon";
+  version = "0.22.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "alucryd";
+    repo = "oxyromon";
+    tag = finalAttrs.version;
+    hash = "sha256-m5LxTsqfNdr6sgKxK1kLBOT7QGfFLc8GQUqATsL1a38=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    pkg-config
+  ];
+
+  cargoHash = "sha256-MbaK2HuIep5Yp4pNRs5X7moSzdP/Kj7jZ/zakok9oIU=";
+
+  # Requires internet access
+  doCheck = false;
+
+  postFixup =
+    let
+      runtimeDeps = [
+        # disc images
+        bchunk
+        cdrkit
+        p7zip
+        # rom patching
+        flips
+        xdelta
+        # console-specific tools
+        ctrtool
+        dolphin-emu
+        mame.tools
+        maxcso
+        nsz
+        wiimms-iso-tools
+      ];
+    in
+    ''
+      wrapProgram $out/bin/oxyromon \
+        --prefix PATH : ${lib.makeBinPath runtimeDeps}
+    '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    description = "Rusty ROM organizer";
+    longDescription = ''
+      oxyROMon is a cross-platform opinionated CLI ROM organizer written in Rust.
+      Like most ROM managers, it checks ROM files against known good databases.
+      It is designed with archiving in mind, as such it only supports original and lossless ROM formats.
+      It can however export in various popular lossy formats, leaving the lossless ROM files untouched.
+      Sorting can be done in regions mode, in so-called 1G1R mode, or both.
+      Console, computer and arcade (WIP) systems are supported using Logiqx DAT files.
+      The first two require No-Intro or Redump DAT files, while the latter makes use MAME or FBNeo DAT files.
+    '';
+    homepage = "https://github.com/alucryd/oxyromon";
+    changelog = "https://github.com/alucryd/oxyromon/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ dansbandit ];
+    platforms = lib.platforms.unix;
+    mainProgram = "oxyromon";
+  };
+})


### PR DESCRIPTION
https://github.com/alucryd/oxyromon

oxyROMon is a cross-platform opinionated CLI ROM organizer written in Rust. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
