### PR TITLE
ungoogled-chromium: 151.0.7922.71-1 -> 151.0.7922.75-1

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -837,7 +837,7 @@
     }
   },
   "ungoogled-chromium": {
-    "version": "151.0.7922.71",
+    "version": "151.0.7922.75",
     "deps": {
       "depot_tools": {
         "rev": "94e89b10b92cc9d6e58fc8d1b6474b7d29e8a114",
@@ -849,16 +849,16 @@
         "hash": "sha256-T2LdISIkp8fcUli5ZetTqrESBAc7coJhWdJv7I+o9kk="
       },
       "ungoogled-patches": {
-        "rev": "151.0.7922.71-1",
-        "hash": "sha256-u9SqDpb4yT7N6DUtFxVb4a0yYYGELC0qWYYyRuVD8K8="
+        "rev": "151.0.7922.75-1",
+        "hash": "sha256-zpW7AGN9VrdlNg+q6BzwN3XW2TACQ07i2IwodSEi3CQ="
       },
       "npmHash": "sha256-pF0JtwFpPC4/fodbhSJnQKkczA9WlDg4VqEAy9aDVLg="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "ef35003457e93c278f911a334b06e4a5f8967e06",
-        "hash": "sha256-t6j280DSQQQwwcD41ldN3uLmOihW/Q2674+rR5qMkGU=",
+        "rev": "1ddc0a2003eb30c3990568d74ed0437451e9c374",
+        "hash": "sha256-QKVYipzVK/TUVdI4k8LLNmmhwAR6xP/Bgc1ZmNjySjo=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -1493,8 +1493,8 @@
       },
       "src/third_party/skia": {
         "url": "https://skia.googlesource.com/skia.git",
-        "rev": "14c2431eaed7c0a097d197caa3669cda996c63b7",
-        "hash": "sha256-i3rLTKer13xHzpiEdMlNS5rQOYSDFmvAVvdYUiizDzA="
+        "rev": "f4eee5c6735d33a829ab2cfbf3fe23d0376e7992",
+        "hash": "sha256-UKewcYGGJrWA+ZJAp5TA3gGQpns+/5L6PlFxpEHWfG8="
       },
       "src/third_party/smhasher/src": {
         "url": "https://chromium.googlesource.com/external/smhasher.git",


### PR DESCRIPTION
https://chromereleases.googleblog.com/2026/08/stable-channel-update-for-desktop.html

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests] (`nix-build -A ungoogled nixos/tests/chromium.nix`).
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
