### PR TITLE
linphonePackages.linphone-desktop: 6.1.0 -> 6.2.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/linphone/bc-zxing-cpp/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/bc-zxing-cpp/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  cmake,
+  fetchFromGitLab,
+  stdenv,
+  libzint,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "zxing-cpp";
+  # Version taken from CMakeLists.txt - likely not actively updated
+  version = "1.4.0-unstable-2026-08-08";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.linphone.org";
+    group = "BC";
+    owner = "public/external";
+    repo = "zxing-cpp";
+    rev = "722123ad0cadee0e4c313f80eac5162a9f8d7d73";
+    sha256 = "sha256-GhrrIk2Kph6H5qs0g01b98F1Xzh/6vCS3+p+q0mhqcQ=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    libzint
+  ];
+
+  cmakeFlags = [
+    "-DZXING_BLACKBOX_TESTS=OFF"
+    "-DZXING_DEPENDENCIES=LOCAL"
+    "-DZXING_EXAMPLES=OFF"
+    "-DZXING_USE_BUNDLED_ZINT=OFF"
+  ];
+
+  # The BC fork's zxing.pc.in joins @CMAKE_INSTALL_LIBDIR@/INCLUDEDIR@ onto a
+  # hardcoded "/" prefix, and never includes GNUInstallDirs, causing us to run into
+  # https://github.com/NixOS/nixpkgs/issues/144170
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail '# PC file generation.' 'include (GNUInstallDirs)'
+    substituteInPlace zxing.pc.in \
+      --replace-fail 'libdir=''${exec_prefix}/@CMAKE_INSTALL_LIBDIR@' 'libdir=@CMAKE_INSTALL_FULL_LIBDIR@' \
+      --replace-fail 'includedir=''${prefix}/@CMAKE_INSTALL_INCLUDEDIR@' 'includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@'
+  '';
+
+  meta = {
+    homepage = "https://gitlab.linphone.org/BC/public/external/zxing-cpp";
+    description = "BelledonneCommunications' fork of zxing-cpp";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ naxdy ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/applications/networking/instant-messengers/linphone/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/default.nix
@@ -8,8 +8,8 @@ makeScopeWithSplicing' {
   extra = self: {
     mkLinphoneDerivation = self.mk-linphone-derivation;
 
-    linphoneSdkVersion = "5.4.85";
-    linphoneSdkHash = "sha256-mdJDCuCaZlcQ92P6oMgH/8iWgm8hGz8gTVUilC+yaSU=";
+    linphoneSdkVersion = "5.5.13";
+    linphoneSdkHash = "sha256-RsSMLO7wZ7azWF7/KcERkd5et73w0kUZpwsqj9QxZgc=";
   };
   f =
     self:

--- a/pkgs/applications/networking/instant-messengers/linphone/liblinphone/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/liblinphone/default.nix
@@ -11,7 +11,7 @@
   python3,
   sqlite,
   xercesc,
-  zxing-cpp,
+  bc-zxing-cpp,
   mkLinphoneDerivation,
 }:
 mkLinphoneDerivation {
@@ -39,7 +39,7 @@ mkLinphoneDerivation {
     libxml2
     sqlite
     xercesc
-    zxing-cpp
+    bc-zxing-cpp
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/applications/networking/instant-messengers/linphone/linphone-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/linphone-desktop/default.nix
@@ -3,6 +3,7 @@
   bc-soci,
   bctoolbox,
   belcard,
+  cacert,
   belle-sip,
   belr,
   boost,
@@ -40,7 +41,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "linphone-desktop";
-  version = "6.1.0";
+  version = "6.2.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
@@ -48,13 +49,14 @@ stdenv.mkDerivation (finalAttrs: {
     group = "BC";
     repo = "linphone-desktop";
     tag = finalAttrs.version;
-    hash = "sha256-jCnovCFdPJExD0+ZLhU9np1R5uN+mPlSPi/Nb1aOD0U=";
+    hash = "sha256-JtNYeMu174afzuWSVIuLyI5M16iC5XGr2qTcTsixRg8=";
   };
 
   patches = [
     ./do-not-override-install-prefix.patch
     ./do-not-manually-compute-sdk-version.patch
     ./always-install-desktop-files.patch
+    ./use-absolute-resource-paths.patch
 
     # .mkv recordings are broken in NixOS and other distros (see
     # https://github.com/NixOS/nixpkgs/issues/219551), and simply changing the
@@ -79,8 +81,10 @@ stdenv.mkDerivation (finalAttrs: {
     minizip-ng
     qt6Packages.qtbase
     qt6Packages.qtnetworkauth
+    qt6Packages.qtkeychain
     zxing-cpp
     boost
+    cacert
 
     python3Packages.pystache
     python3Packages.six
@@ -103,9 +107,6 @@ stdenv.mkDerivation (finalAttrs: {
     # RPATH of binary /nix/store/.../bin/... contains a forbidden reference to /build/
     "-DCMAKE_SKIP_BUILD_RPATH=ON"
 
-    # Requires EQt5Keychain
-    "-DENABLE_QT_KEYCHAIN=OFF"
-
     "-DCMAKE_INSTALL_BINDIR=bin"
     "-DCMAKE_INSTALL_INCLUDEDIR=include"
     "-DCMAKE_INSTALL_LIBDIR=lib"
@@ -114,7 +115,6 @@ stdenv.mkDerivation (finalAttrs: {
     "-DLINPHONEAPP_INSTALL_PREFIX=${placeholder "out"}"
     "-DLINPHONE_QML_DIR=${placeholder "out"}/${qt6Packages.qtbase.qtQmlPrefix}/ui"
     "-DLINPHONESDK_VERSION=${linphoneSdkVersion}"
-    "-DENABLE_APP_PACKAGE_ROOTCA=OFF"
 
     # normally set by the custom find modules, which we have disabled
     "-DLibLinphone_TARGET=liblinphone"
@@ -154,6 +154,12 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s ${msopenh264}/lib/mediastreamer/plugins/* $out/lib/mediastreamer/plugins/
     ln -s ${mediastreamer2}/lib/mediastreamer/plugins/* $out/lib/mediastreamer/plugins/
     ln -s ${grammars} $out/share/belr/grammars
+
+    # linphone looks for the TLS root CA bundle at `<dataResourcesDir>/rootca.pem`
+    # (with `<dataResourcesDir>` made absolute by `use-absolute-resource-paths.patch`).
+    # Provide nixpkgs' cacert bundle there instead of shipping the stale one
+    # bundled with linphone-sdk.
+    ln -s ${cacert}/etc/ssl/certs/ca-bundle.crt $out/share/linphone/rootca.pem
 
     mkdir -p $out/share/sounds/linphone/
     ln -s ${liblinphone}/share/sounds/linphone/rings $out/share/sounds/linphone/rings

--- a/pkgs/applications/networking/instant-messengers/linphone/linphone-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/linphone-desktop/default.nix
@@ -57,6 +57,9 @@ stdenv.mkDerivation (finalAttrs: {
     ./do-not-manually-compute-sdk-version.patch
     ./always-install-desktop-files.patch
     ./use-absolute-resource-paths.patch
+    # Linphone creates a broken desktop file.
+    # See: https://github.com/NixOS/nixpkgs/issues/551204
+    ./no-user-desktop-file.patch
 
     # .mkv recordings are broken in NixOS and other distros (see
     # https://github.com/NixOS/nixpkgs/issues/219551), and simply changing the

--- a/pkgs/applications/networking/instant-messengers/linphone/linphone-desktop/no-user-desktop-file.patch
+++ b/pkgs/applications/networking/instant-messengers/linphone/linphone-desktop/no-user-desktop-file.patch
@@ -1,0 +1,19 @@
+diff --git a/Linphone/core/App.cpp b/Linphone/core/App.cpp
+index 315632d..78eba8b 100644
+--- a/Linphone/core/App.cpp
++++ b/Linphone/core/App.cpp
+@@ -1567,14 +1567,7 @@ QString App::getApplicationPath() const {
+ }
+ 
+ void App::exportDesktopFile() {
+-	QDir dir(ApplicationsDirectory);
+-	if (!dir.exists() && !dir.mkpath(ApplicationsDirectory)) {
+-		qWarning() << QStringLiteral("Unable to build applications dir path: `%1`.").arg(ApplicationsDirectory);
+-		return;
+-	}
+-
+ 	const QString confPath(ApplicationsDirectory + EXECUTABLE_NAME ".desktop");
+-	if (generateDesktopFile(confPath, true, false)) generateDesktopFile(confPath, false, false);
+ }
+ 
+ bool App::generateDesktopFile(const QString &confPath, bool remove, bool openInBackground) {

--- a/pkgs/applications/networking/instant-messengers/linphone/linphone-desktop/use-absolute-resource-paths.patch
+++ b/pkgs/applications/networking/instant-messengers/linphone/linphone-desktop/use-absolute-resource-paths.patch
@@ -1,0 +1,38 @@
+diff --git a/Linphone/core/path/Paths.cpp b/Linphone/core/path/Paths.cpp
+index 33449dc..734ba51 100644
+--- a/Linphone/core/path/Paths.cpp
++++ b/Linphone/core/path/Paths.cpp
+@@ -115,7 +115,6 @@ static inline QDir getAppPackageDir() {
+ }
+ 
+ static inline QString getAppPackageDataDirPath() {
+-	QDir executableDir(QCoreApplication::applicationDirPath());
+ 	QDir dir = getAppPackageDir();
+ #ifdef __APPLE__
+ 	if (!dir.cd("Resources")) {
+@@ -127,22 +126,17 @@ static inline QString getAppPackageDataDirPath() {
+ 		dir.mkdir("share");
+ 		dir.cd("share");
+ 	}
+-	lInfo() << executableDir.absolutePath() << " VS " << dir.absolutePath()
+-	        << " == " << executableDir.relativeFilePath(dir.absolutePath());
+-	return executableDir.relativeFilePath(dir.absolutePath());
++	return dir.absolutePath();
+ }
+ 
+ static inline QString getAppPackageMsPluginsDirPath() {
+-	QDir executableDir(QCoreApplication::applicationDirPath());
+ 	QDir dir = getAppPackageDir();
+ 	dir.cd(MSPLUGINS_DIR);
+-	return executableDir.relativeFilePath(dir.absolutePath());
++	return dir.absolutePath();
+ }
+ 
+ static inline QString getAppPackagePluginsDirPath() {
+-	QDir executableDir(QCoreApplication::applicationDirPath());
+-	QDir packageDir = getAppPackageDir();
+-	return executableDir.relativeFilePath(packageDir.absolutePath() + Constants::PathPlugins);
++	return getAppPackageDir().absolutePath() + Constants::PathPlugins;
+ }
+ 
+ static inline QString getAppBinDirPath() {


### PR DESCRIPTION
## Things done

BC's Gitlab is somewhat stable right now, which means I was finally able to update Linphone to 6.2.0!

Couple things of note:
- we're now also rolling BC's fork of `zxing-cpp`, since `liblinphone` refuses to build with `zxing-cpp>=3.0.0`
- we update `linphone-sdk` to 5.5.13 instead of 5.5.15 (current latest version), since `linphone-desktop` actually doesn't build cleanly against 5.5.14 onwards, as they deprecated a function that `linphone-desktop` uses

---

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Note for reviewers: You may need to re-run the builds multiple times if FOD fetching fails, since BC's Gitlab is notoriously unstable and may refuse connections on a whim :melting_face: 

---

LLM / AI use disclosure: I used DeepSeek V4 Flash 0731 to produce the `postPatch` phase to get `bc-zxing-cpp` to build. Tool use has been included in the relevant commit, all other changes are from me directly (including any research done).