### PR TITLE
lib25519: update 20241004 -> 20260614

### DIFF
--- a/pkgs/by-name/li/lib25519/environment-variable-tools.patch
+++ b/pkgs/by-name/li/lib25519/environment-variable-tools.patch
@@ -1,8 +1,8 @@
 diff --git a/configure b/configure
-index 04042b2..30d1ea9 100755
+index 86b7e88..33c126f 100755
 --- a/configure
 +++ b/configure
-@@ -210,6 +210,17 @@ for arch in sorted(os.listdir('compilers')):
+@@ -255,6 +255,17 @@ for arch in sorted(os.listdir('compilers')):
      with open('compilers/%s' % arch) as f:
        for c in f.readlines():
          c = c.strip()
@@ -20,19 +20,32 @@ index 04042b2..30d1ea9 100755
          cv = compilerversion(c)
          if cv == None:
            log('skipping %s compiler %s' % (arch,c))
+diff --git a/scripts-build/checkinsns b/scripts-build/checkinsns
+index 039a0c5..4e64c96 100755
+--- a/scripts-build/checkinsns
++++ b/scripts-build/checkinsns
+@@ -5,7 +5,7 @@ import sys
+ import subprocess
+ import traceback
+ 
+-objdump = os.getenv('CROSS','')+'objdump'
++objdump = os.getenv('OBJDUMP', os.getenv('CROSS','')+'objdump')
+ 
+ host = sys.argv[1]
+ 
 diff --git a/scripts-build/checknamespace b/scripts-build/checknamespace
-index ae11bed..bd9cb85 100755
+index 2a599e4..d0ae563 100755
 --- a/scripts-build/checknamespace
 +++ b/scripts-build/checknamespace
-@@ -36,7 +36,7 @@ def doit(d):
-   obj2U = {}
+@@ -4,7 +4,7 @@ import os
+ import sys
+ import subprocess
  
-   try:
--    p = subprocess.Popen(['nm','-ApP']+objs,stdout=subprocess.PIPE,stderr=subprocess.STDOUT,universal_newlines=True)
-+    p = subprocess.Popen([os.getenv('NM', 'nm'),'-ApP']+objs,stdout=subprocess.PIPE,stderr=subprocess.STDOUT,universal_newlines=True)
-     out,err = p.communicate()
-   except Exception as e:
-     warn('nm failure: %s' % e)
+-nm = os.getenv('CROSS','')+'nm'
++nm = os.getenv('NM', os.getenv('CROSS','')+'nm')
+ 
+ topnamespace = sys.argv[1]
+ 
 diff --git a/scripts-build/staticlib b/scripts-build/staticlib
 index 7683233..0445bc3 100755
 --- a/scripts-build/staticlib

--- a/pkgs/by-name/li/lib25519/package.nix
+++ b/pkgs/by-name/li/lib25519/package.nix
@@ -5,16 +5,21 @@
   fetchzip,
   testers,
   valgrind,
+  valgrindSupport ?
+    lib.meta.availableOn stdenv.hostPlatform valgrind && !(valgrind.meta.broken or false),
   librandombytes,
   libcpucycles,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "lib25519";
-  version = "20241004";
+  version = "20260614";
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   src = fetchzip {
     url = "https://lib25519.cr.yp.to/lib25519-${finalAttrs.version}.tar.gz";
-    hash = "sha256-gKLMk+yZ/nDlwohZiCFurSZwHExX3Ge2W1O0JoGQf8M=";
+    hash = "sha256-k6hVfUckgrRGVmvbt5SW3Vg1woscGzPBpOYnfYx5t44=";
   };
 
   patches = [ ./environment-variable-tools.patch ];
@@ -22,6 +27,10 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     patchShebangs configure
     patchShebangs scripts-build
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    find . -name '*.S' -type f -exec \
+      sed -i '/^\.section\t\.note\.GNU-stack,"",@progbits/d' {} +
   '';
 
   # NOTE: lib25519 uses a custom Python `./configure`: it does not expect standard
@@ -29,23 +38,33 @@ stdenv.mkDerivation (finalAttrs: {
   # Pass the hostPlatform string
   configurePhase = ''
     runHook preConfigure
-    ./configure --host=${stdenv.buildPlatform.system} --prefix=$out
+    ./configure --host=${stdenv.buildPlatform.system} --prefix=$out ${
+      lib.optionalString (!valgrindSupport) "--no-valgrind"
+    }
     runHook postConfigure
   '';
 
   nativeBuildInputs = [
-    python3
+    (python3.withPackages (ps: [ ps.capstone ]))
+  ]
+  ++ lib.optionals valgrindSupport [
     valgrind
   ];
   buildInputs = [
     librandombytes
     libcpucycles
+  ]
+  ++ lib.optionals valgrindSupport [
+    valgrind
   ];
 
   preFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
     install_name_tool -id "$out/lib/lib25519.1.dylib" "$out/lib/lib25519.1.dylib"
     for f in $out/bin/*; do
-      install_name_tool -change "lib25519.1.dylib" "$out/lib/lib25519.1.dylib" "$f"
+      # Skip python script, fails on aarch64-darwin otherwise
+      if [[ "$f" != "$out/bin/lib25519-fulltest" ]]; then
+        install_name_tool -change "lib25519.1.dylib" "$out/lib/lib25519.1.dylib" "$f"
+      fi
     done
   '';
 


### PR DESCRIPTION
… and refresh the patch, which didn’t apply anymore:

Upstream has begun supporting an env var named `$CROSS` as a mechanism for
cross-compiling.  We now piggy-back on those points of the code the
check for the Nixpkgs stdenv environment vars relevant here (`$NM`,
`$OBJDUMP`).  `$CC` handling is left as it was, save for an offset
adjustment.  The patch now applies cleanly.

Also:
- Add `capstone` as a `nativeBuildInput`, which the project now requires

- Enable `strictDeps`, and register `valgrind` also as a `buildInput`

- Enable `__structuredAttrs`

- Restore build on `aarch64-darwin`:
  - `valgrind` is currently broken there, so gate its use
  - drop ELF-only assembly annotations
  - exclude python script from being processed by `install_name_tool`

Ref: https://github.com/ngi-nix/projects/issues/102

This work is done as part of Summer of Nix 2026.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
