### PR TITLE
odin: dev-2026-07a -> dev-2026-09, ols: dev-2026-06 -> dev-2026-08, temp fix for new asm syntax

### DIFF
--- a/pkgs/by-name/od/odin/package.nix
+++ b/pkgs/by-name/od/odin/package.nix
@@ -12,13 +12,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "odin";
-  version = "dev-2026-07a";
+  version = "dev-2026-09";
 
   src = fetchFromGitHub {
     owner = "odin-lang";
     repo = "Odin";
     tag = finalAttrs.version;
-    hash = "sha256-sjL6mj2zfUVpiwkooTTBCVkPRoPWR7ci/hb9TYF+J/I=";
+    hash = "sha256-wJm7J1DU9XxUGrh4AKqHtDJEzxSSVKqOVKWEhckl94Q=";
   };
 
   patches = [
@@ -77,9 +77,12 @@ stdenv.mkDerivation (finalAttrs: {
       } \
       --set-default ODIN_ROOT $out/share
 
-    make -C "$out/share/vendor/cgltf/src/"
-    make -C "$out/share/vendor/stb/src/"
-    make -C "$out/share/vendor/miniaudio/src/"
+    patchShebangs $out/share/vendor/
+
+    $out/share/vendor/cgltf/src/build_cgltf.sh
+    $out/share/vendor/stb/src/build_stb.sh
+    $out/share/vendor/miniaudio/src/build_miniaudio.sh
+    $out/share/vendor/kb_text_shape/src/build_unix.sh
 
     runHook postInstall
   '';

--- a/pkgs/by-name/od/odin/system-raylib.patch
+++ b/pkgs/by-name/od/odin/system-raylib.patch
@@ -5,7 +5,7 @@ index b02fa4438..23e8704ed 100644
 @@ -5,31 +5,7 @@ import "core:c"
  RAYGUI_SHARED :: #config(RAYGUI_SHARED, false)
  RAYGUI_WASM_LIB :: #config(RAYGUI_WASM_LIB, "wasm/libraygui.a")
-
+ 
 -when ODIN_OS == .Windows {
 -	foreign import lib {
 -		"windows/rayguidll.lib" when RAYGUI_SHARED else "windows/raygui.lib",
@@ -32,17 +32,17 @@ index b02fa4438..23e8704ed 100644
 -	foreign import lib "system:raygui"
 -}
 +foreign import lib "system:raygui"
-
+ 
  RAYGUI_VERSION :: "4.0"
-
+ 
 diff --git a/vendor/raylib/raylib.odin b/vendor/raylib/raylib.odin
-index 0a30fd72b..91a2b8bac 100644
+index 01235b6ec..3d1361945 100644
 --- a/vendor/raylib/raylib.odin
 +++ b/vendor/raylib/raylib.odin
 @@ -99,53 +99,7 @@ MAX_MATERIAL_MAPS      :: #config(RAYLIB_MAX_MATERIAL_MAPS, 12)
  RAYLIB_SHARED :: #config(RAYLIB_SHARED, false)
  RAYLIB_WASM_LIB :: #config(RAYLIB_WASM_LIB, "wasm/libraylib.web.a")
-
+ 
 -when ODIN_OS == .Windows {
 -	@(extra_linker_flags="/NODEFAULTLIB:" + ("msvcrt" when RAYLIB_SHARED else "libcmt"))
 -	foreign import lib {
@@ -59,7 +59,7 @@ index 0a30fd72b..91a2b8bac 100644
 -			// multiple copies of raylib.so, but since these bindings are for
 -			// particular version of the library, I better specify it. Ideally,
 -			// though, it's best specified in terms of major (.so.4)
--			"linux-arm64/libraylib.so.600" when RAYLIB_SHARED else "linux-arm/libraylib.a",
+-			"linux-arm64/libraylib.so.600" when RAYLIB_SHARED else "linux-arm64/libraylib.a",
 -			"system:dl",
 -			"system:pthread",
 -			"system:X11",
@@ -91,6 +91,6 @@ index 0a30fd72b..91a2b8bac 100644
 -	foreign import lib "system:raylib"
 -}
 +foreign import lib "system:raylib"
-
+ 
  VERSION_MAJOR :: 6
  VERSION_MINOR :: 0

--- a/pkgs/by-name/ol/ols/package.nix
+++ b/pkgs/by-name/ol/ols/package.nix
@@ -8,14 +8,18 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ols";
-  version = "dev-2026-06";
+  version = "dev-2026-08";
 
   src = fetchFromGitHub {
     owner = "DanielGavin";
     repo = "ols";
     tag = finalAttrs.version;
-    hash = "sha256-BqLaPVntNzK5N3lffjn4umLhqSM0bOcAVgzk+f13BKM=";
+    hash = "sha256-dRMDb5RO0yCSOcLeDXk1nkAXaj1mqliuhktpKq4XwUI=";
   };
+
+  patches = [
+    ./temp-fix-asm-syntax.diff
+  ];
 
   postPatch = ''
     substituteInPlace build.sh \

--- a/pkgs/by-name/ol/ols/temp-fix-asm-syntax.diff
+++ b/pkgs/by-name/ol/ols/temp-fix-asm-syntax.diff
@@ -1,0 +1,27 @@
+diff --git a/src/odin/printer/visit.odin b/src/odin/printer/visit.odin
+index 8c22780f..144d8ba4 100644
+--- a/src/odin/printer/visit.odin
++++ b/src/odin/printer/visit.odin
+@@ -1464,19 +1464,9 @@ visit_expr :: proc(
+ 	document := empty()
+
+ 	#partial switch v in expr.derived {
+-	case ^ast.Inline_Asm_Expr:
+-		document = cons(text_token(p, v.tok), text("("), visit_exprs(p, v.param_types, {.Add_Comma}), text(")"))
+-		document = cons_with_opl(document, cons(text("-"), text(">")))
+-		document = cons_with_opl(document, visit_expr(p, v.return_type))
+-
+-		document = cons(
+-			document,
+-			text("{"),
+-			visit_expr(p, v.asm_string),
+-			text(","),
+-			visit_expr(p, v.constraints_string),
+-			text("}"),
+-		)
++	case ^ast.Asm_Template:
++		// TODO: new `asm` syntax support
++		document = text(p.src[v.pos.offset:v.end.offset])
+ 	case ^ast.Undef:
+ 		document = text("---")
+ 	case ^ast.Auto_Cast:


### PR DESCRIPTION
## Things done

Updated Odin dev-2026-07a to dev-2026-09
Also updates ols dev-2026-06 to dev-2026-08 with a patch applied so that it builds again

Patch is from the master branch of ols: https://github.com/DanielGavin/ols/commit/5f1b4d773b05d98dc9533521490096cf1a06a6d3

Release Notes: 
- https://github.com/odin-lang/Odin/releases/tag/dev-2026-08
- https://github.com/odin-lang/Odin/releases/tag/dev-2026-09
- https://github.com/DanielGavin/ols/releases/tag/dev-2026-07
- https://github.com/DanielGavin/ols/releases/tag/dev-2026-08

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
