### PR TITLE
nixos/redmine: remove `preStart`, replace imperative dir setup with bindmounts

### DIFF
--- a/nixos/modules/services/misc/redmine.nix
+++ b/nixos/modules/services/misc/redmine.nix
@@ -48,9 +48,9 @@ let
         name = "redmine-${id}-${name}";
         nativeBuildInputs = [ pkgs.unzip ];
         buildCommand = ''
-          mkdir -p $out
-          cd $out
-          unpackFile ${source}
+          mkdir -p "$out/share/redmine/${name}s.dist"
+          cd "$out/share/redmine/${name}s.dist"
+          unpackFile '${source}'
         '';
       }
     );
@@ -359,14 +359,22 @@ in
       "d '${cfg.stateDir}/public/plugin_assets' 0750 ${cfg.user} ${cfg.group} - -"
       "d '${cfg.stateDir}/themes' 0750 ${cfg.user} ${cfg.group} - -"
       "d '${cfg.stateDir}/tmp' 0750 ${cfg.user} ${cfg.group} - -"
+      "L+ '${cfg.stateDir}/config/configuration.yml' 0640 ${cfg.user} ${cfg.group} - '${configurationYml}'"
+      "L+ '${cfg.stateDir}/config/additional_environment.rb' 0640 ${cfg.user} ${cfg.group} - '${additionalEnvironment}'"
     ];
 
     systemd.services.redmine = {
       after = [
         "network.target"
+        "systemd-tmpfiles-setup.service"
+        "systemd-tmpfiles-resetup.service"
       ]
       ++ lib.optional mysqlLocal "mysql.service"
       ++ lib.optional pgsqlLocal "postgresql.target";
+      wants = [
+        "systemd-tmpfiles-setup.service"
+        "systemd-tmpfiles-resetup.service"
+      ];
       wantedBy = [ "multi-user.target" ];
       environment.RAILS_ENV = "production";
       environment.RAILS_CACHE = "${cfg.stateDir}/cache";
@@ -384,85 +392,80 @@ in
         ++ lib.optional cfg.components.imagemagick imagemagick
         ++ lib.optional cfg.components.ghostscript ghostscript;
 
-      preStart = ''
-        # Create symlinks for the basic directory layout the redmine package
-        # expects. This part must be done in preStart rather than tmpfiles,
-        # because /run/redmine is re-created when the service is restarted
-        mkdir /run/redmine/public
-        ln -s "${cfg.stateDir}/config" /run/redmine/config
-        ln -s "${cfg.stateDir}/files" /run/redmine/files
-        ln -s "${cfg.stateDir}/log" /run/redmine/log
-        ln -s "${cfg.stateDir}/plugins" /run/redmine/plugins
-        ln -s "${cfg.stateDir}/public/assets" /run/redmine/public/assets
-        ln -s "${cfg.stateDir}/public/plugin_assets" /run/redmine/public/plugin_assets
-        ln -s "${cfg.stateDir}/themes" /run/redmine/themes
-        ln -s "${cfg.stateDir}/tmp" /run/redmine/tmp
-
-        rm -rf "${cfg.stateDir}/plugins/"*
-        rm -rf "${cfg.stateDir}/themes/"*
-
-        # start with a fresh config directory
-        # the config directory is copied instead of linked as some mutable data is stored in there
-        find "${cfg.stateDir}/config" ! -name "secret_token.rb" -type f -exec rm -f {} +
-        cp -r ${cfg.package}/share/redmine/config.dist/* "${cfg.stateDir}/config/"
-
-        chmod -R u+w "${cfg.stateDir}/config"
-
-        # link in the application configuration
-        ln -fs ${configurationYml} "${cfg.stateDir}/config/configuration.yml"
-
-        # link in the additional environment configuration
-        ln -fs ${additionalEnvironment} "${cfg.stateDir}/config/additional_environment.rb"
-
-
-        # link in all user specified themes
-        for theme in ${lib.concatStringsSep " " (lib.mapAttrsToList unpackTheme cfg.themes)}; do
-          ln -fs $theme/* "${cfg.stateDir}/themes"
-        done
-
-        # link in redmine provided themes
-        ln -sf ${cfg.package}/share/redmine/themes.dist/* "${cfg.stateDir}/themes/"
-
-
-        # link in all user specified plugins
-        for plugin in ${lib.concatStringsSep " " (lib.mapAttrsToList unpackPlugin cfg.plugins)}; do
-          ln -fs $plugin/* "${cfg.stateDir}/plugins/''${plugin##*-redmine-plugin-}"
-        done
-
-
-        # handle database.passwordFile & permissions
-        cp -f ${databaseYml} "${cfg.stateDir}/config/database.yml"
-
-        ${lib.optionalString ((cfg.database.type != "sqlite3") && (cfg.database.passwordFile != null)) ''
-          DBPASS="$(head -n1 ${cfg.database.passwordFile})"
-          sed -e "s,#dbpass#,$DBPASS,g" -i "${cfg.stateDir}/config/database.yml"
-        ''}
-
-        chmod 440 "${cfg.stateDir}/config/database.yml"
-
-
-        # generate a secret token if required
-        if ! test -e "${cfg.stateDir}/config/initializers/secret_token.rb"; then
-          ${bundle} exec rake generate_secret_token
-          chmod 440 "${cfg.stateDir}/config/initializers/secret_token.rb"
-        fi
-
-        # execute redmine required commands prior to starting the application
-        ${bundle} exec rake db:migrate
-        ${bundle} exec rake redmine:plugins:migrate
-        ${bundle} exec rake redmine:load_default_data
-        ${bundle} exec rake assets:precompile
-      '';
-
       serviceConfig = {
         Type = "simple";
         User = cfg.user;
         Group = cfg.group;
         TimeoutSec = "300";
         WorkingDirectory = "${cfg.package}/share/redmine";
+
+        ExecStartPre = [
+          # start with a fresh config directory
+          # the config directory is copied instead of linked as some mutable data is stored in there
+          "${lib.getExe' pkgs.findutils "find"} '${cfg.stateDir}/config' ! -name 'secret_token.rb' -type f -exec ${lib.getExe' pkgs.coreutils "rm"} -f {} +"
+          "${lib.getExe' pkgs.findutils "find"} '${cfg.package}/share/redmine/config.dist' -mindepth 1 -maxdepth 1 -exec ${lib.getExe' pkgs.coreutils "cp"} -rt '${cfg.stateDir}/config/' {} +"
+          "${lib.getExe' pkgs.coreutils "chmod"} -R u+w '${cfg.stateDir}/config'"
+
+          # handle database.passwordFile & permissions
+          "${lib.getExe' pkgs.coreutils "install"} -Dm640 ${databaseYml} '${cfg.stateDir}/config/database.yml'"
+        ]
+        ++ lib.optionals ((cfg.database.type != "sqlite3") && (cfg.database.passwordFile != null)) [
+          "${lib.getExe pkgs.replace-secret} '#dbpass#' '${cfg.database.passwordFile}' ${cfg.stateDir}/config/database.yml"
+        ]
+        ++ [
+          # This step only has an effect if the token is not already present
+          "${bundle} exec rake generate_secret_token"
+
+          # execute redmine required commands prior to starting the application
+          "${bundle} exec rake db:migrate"
+          "${bundle} exec rake redmine:plugins:migrate"
+          "${bundle} exec rake redmine:load_default_data"
+          "${bundle} exec rake assets:precompile"
+        ];
+
         ExecStart = "${bundle} exec rails server -u webrick -e production -b ${toString cfg.address} -p ${toString cfg.port}";
-        RuntimeDirectory = "redmine";
+
         RuntimeDirectoryMode = "0750";
+        RuntimeDirectory = [
+          "redmine"
+          "redmine/config"
+          "redmine/files"
+          "redmine/log"
+          "redmine/plugins"
+          "redmine/public"
+          "redmine/public/assets"
+          "redmine/public/plugin_assets"
+          "redmine/themes"
+          "redmine/tmp"
+        ];
+        BindReadOnlyPaths = [
+          "${
+            pkgs.symlinkJoin {
+              name = "redmine-combined-themes";
+              stripPrefix = "/share/redmine/themes.dist";
+              paths = [
+                cfg.package
+              ]
+              ++ lib.mapAttrsToList unpackTheme cfg.themes;
+            }
+          }:/run/redmine/themes"
+          "${
+            pkgs.symlinkJoin {
+              name = "redmine-combined-plugins";
+              stripPrefix = "/share/redmine/plugins.dist";
+              paths = lib.mapAttrsToList unpackPlugin cfg.plugins;
+            }
+          }:/run/redmine/plugins"
+        ];
+        BindPaths = [
+          "${cfg.stateDir}/config:/run/redmine/config"
+          "${cfg.stateDir}/files:/run/redmine/files"
+          "${cfg.stateDir}/log:/run/redmine/log"
+          "${cfg.stateDir}/public/assets:/run/redmine/public/assets"
+          "${cfg.stateDir}/public/plugin_assets:/run/redmine/public/plugin_assets"
+          "${cfg.stateDir}/tmp:/run/redmine/tmp"
+        ];
+
         AmbientCapabilities = "";
         CapabilityBoundingSet = "";
         LockPersonality = true;

--- a/nixos/modules/services/misc/redmine.nix
+++ b/nixos/modules/services/misc/redmine.nix
@@ -351,16 +351,13 @@ in
       "d '${cfg.stateDir}' 0750 ${cfg.user} ${cfg.group} - -"
       "d '${cfg.stateDir}/cache' 0750 ${cfg.user} ${cfg.group} - -"
       "d '${cfg.stateDir}/config' 0750 ${cfg.user} ${cfg.group} - -"
+      "d '${cfg.stateDir}/config/initializers' 0750 ${cfg.user} ${cfg.group} - -"
       "d '${cfg.stateDir}/files' 0750 ${cfg.user} ${cfg.group} - -"
       "d '${cfg.stateDir}/log' 0750 ${cfg.user} ${cfg.group} - -"
-      "d '${cfg.stateDir}/plugins' 0750 ${cfg.user} ${cfg.group} - -"
       "d '${cfg.stateDir}/public' 0750 ${cfg.user} ${cfg.group} - -"
       "d '${cfg.stateDir}/public/assets' 0750 ${cfg.user} ${cfg.group} - -"
       "d '${cfg.stateDir}/public/plugin_assets' 0750 ${cfg.user} ${cfg.group} - -"
-      "d '${cfg.stateDir}/themes' 0750 ${cfg.user} ${cfg.group} - -"
       "d '${cfg.stateDir}/tmp' 0750 ${cfg.user} ${cfg.group} - -"
-      "L+ '${cfg.stateDir}/config/configuration.yml' 0640 ${cfg.user} ${cfg.group} - '${configurationYml}'"
-      "L+ '${cfg.stateDir}/config/additional_environment.rb' 0640 ${cfg.user} ${cfg.group} - '${additionalEnvironment}'"
     ];
 
     systemd.services.redmine = {
@@ -399,29 +396,22 @@ in
         TimeoutSec = "300";
         WorkingDirectory = "${cfg.package}/share/redmine";
 
-        ExecStartPre = [
-          # start with a fresh config directory
-          # the config directory is copied instead of linked as some mutable data is stored in there
-          "${lib.getExe' pkgs.findutils "find"} '${cfg.stateDir}/config' ! -name 'secret_token.rb' -type f -exec ${lib.getExe' pkgs.coreutils "rm"} -f {} +"
-          "${lib.getExe' pkgs.findutils "find"} '${cfg.package}/share/redmine/config.dist' -mindepth 1 -maxdepth 1 -exec ${lib.getExe' pkgs.coreutils "cp"} -rt '${cfg.stateDir}/config/' {} +"
-          "${lib.getExe' pkgs.coreutils "chmod"} -R u+w '${cfg.stateDir}/config'"
+        ExecStartPre =
+          lib.optionals ((cfg.database.type != "sqlite3") && (cfg.database.passwordFile != null)) [
+            # handle database.passwordFile & permissions
+            "${lib.getExe' pkgs.coreutils "install"} -Dm640 ${databaseYml} '/run/redmine/database.yml'"
+            "${lib.getExe pkgs.replace-secret} '#dbpass#' '${cfg.database.passwordFile}' /run/redmine/database.yml"
+          ]
+          ++ [
+            # This step only has an effect if the token is not already present
+            "${bundle} exec rake generate_secret_token"
 
-          # handle database.passwordFile & permissions
-          "${lib.getExe' pkgs.coreutils "install"} -Dm640 ${databaseYml} '${cfg.stateDir}/config/database.yml'"
-        ]
-        ++ lib.optionals ((cfg.database.type != "sqlite3") && (cfg.database.passwordFile != null)) [
-          "${lib.getExe pkgs.replace-secret} '#dbpass#' '${cfg.database.passwordFile}' ${cfg.stateDir}/config/database.yml"
-        ]
-        ++ [
-          # This step only has an effect if the token is not already present
-          "${bundle} exec rake generate_secret_token"
-
-          # execute redmine required commands prior to starting the application
-          "${bundle} exec rake db:migrate"
-          "${bundle} exec rake redmine:plugins:migrate"
-          "${bundle} exec rake redmine:load_default_data"
-          "${bundle} exec rake assets:precompile"
-        ];
+            # execute redmine required commands prior to starting the application
+            "${bundle} exec rake db:migrate"
+            "${bundle} exec rake redmine:plugins:migrate"
+            "${bundle} exec rake redmine:load_default_data"
+            "${bundle} exec rake assets:precompile"
+          ];
 
         ExecStart = "${bundle} exec rails server -u webrick -e production -b ${toString cfg.address} -p ${toString cfg.port}";
 
@@ -441,6 +431,23 @@ in
         BindReadOnlyPaths = [
           "${
             pkgs.symlinkJoin {
+              name = "redmine-config";
+              paths = [ "${cfg.package}/share/redmine/config.dist" ];
+              postBuild = ''
+                ln -s ${configurationYml} "$out/configuration.yml"
+                ln -s ${additionalEnvironment} "$out/additional_environment.rb"
+                ln -s ${
+                  if ((cfg.database.type != "sqlite3") && (cfg.database.passwordFile != null)) then
+                    "/run/redmine/database.yml"
+                  else
+                    lib.escapeShellArg databaseYml
+                } "$out/database.yml"
+                ln -s "${cfg.stateDir}/config/initializers/secret_token.rb" "$out/initializers/secret_token.rb"
+              '';
+            }
+          }:/run/redmine/config"
+          "${
+            pkgs.symlinkJoin {
               name = "redmine-combined-themes";
               stripPrefix = "/share/redmine/themes.dist";
               paths = [
@@ -458,7 +465,6 @@ in
           }:/run/redmine/plugins"
         ];
         BindPaths = [
-          "${cfg.stateDir}/config:/run/redmine/config"
           "${cfg.stateDir}/files:/run/redmine/files"
           "${cfg.stateDir}/log:/run/redmine/log"
           "${cfg.stateDir}/public/assets:/run/redmine/public/assets"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR replaces the `preStart` script with various other systemd mechanisms.

Most of the directory setup has been offloaded to the `RuntimeDirectory` directive, and the linking between `cfg.stateDirectory` and `/run` is done through a series of bindmounts. This is particularly neat for `${cfg.stateDirectory}/config`, because it removes the need for deleting and recopying the same files over and over.

Lucky situtation with the `generate_secret_token` task - after following a chain of abstractions through rake's [`FileCreationTask`](https://github.com/ruby/rake/blob/master/lib/rake/file_creation_task.rb) I found that the task not only checks whether the file exists or not, but [uses `stat` under the hood](https://ruby-doc.org/core-2.2.0/File.html#exist-3F-method) which considers the file nonexistent when met with a dangling symlink. So `generate_secret_token` will create the `secret_token.rb` file at the location pointed to by the symlink if not present (i.e. `{cfg.stateDir}/config/initializers/secret_token.rb`). We can get rid of all shell branching around the tool and just call it unconditionally. 

All NixOS tests run successfully, and I did some interactive testing through a NixOS VM just to verify that it behaves sane in the browser too.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
