### PR TITLE
beamPackages.lfe: 2.2.0 -> 2.2.2

### DIFF
--- a/pkgs/development/interpreters/lfe/default.nix
+++ b/pkgs/development/interpreters/lfe/default.nix
@@ -1,6 +1,5 @@
 {
   bash,
-  fetchHex,
   buildRebar3,
   config,
   coreutils,
@@ -19,23 +18,12 @@ let
     versions
     ;
 
-  version = "2.2.0";
-  hash = "sha256-47lEUVU9Api1Yj1q+Ch8aIV8kaALhst1ty8RHTwMVcI=";
+  version = "2.2.2";
+  hash = "sha256-krUjWu+wWv2+22m+YEE66myRIb7dm5ecaMm07hIlHgA=";
 
-  maximumOTPVersion = "27";
+  maximumOTPVersion = "29";
   mainVersion = versions.major (getVersion erlang);
   maxAssert = versionAtLeast maximumOTPVersion mainVersion;
-
-  proper = buildRebar3 rec {
-    name = "proper";
-    version = "1.4.0";
-
-    src = fetchHex {
-      pkg = name;
-      inherit version;
-      sha256 = "sha256-GChYQhhb0z772pfRNKXLWgiEOE2zYRn+4OPPpIhWjLs=";
-    };
-  };
 
 in
 if !config.allowAliases && !maxAssert then
@@ -65,8 +53,6 @@ else
       makeWrapper
       erlang
     ];
-
-    beamDeps = [ proper ];
 
     # override buildRebar3's install to let the builder use make install
     installPhase = ''


### PR DESCRIPTION
Diff: https://github.com/lfe/lfe/compare/v2.2.0...v2.2.2

Changelog: https://github.com/lfe/lfe/releases/tag/v2.2.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
