### PR TITLE
mistral-vibe: 2.23.3 -> 2.24.0

### DIFF
--- a/pkgs/by-name/mi/mistral-vibe/package.nix
+++ b/pkgs/by-name/mi/mistral-vibe/package.nix
@@ -13,7 +13,7 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "mistral-vibe";
-  version = "2.23.3";
+  version = "2.24.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -21,7 +21,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     owner = "mistralai";
     repo = "mistral-vibe";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-VvrLcotRl3nyjb0c1sipDMSEpbIGWF2T0rCA0adgSww=";
+    hash = "sha256-Ux5W+9mtvAdlINQfr58Fft4OtpqjoYQrQe3XZwhvovc=";
   };
 
   build-system = with python3Packages; [
@@ -165,47 +165,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
     # TypeError: cannot pickle 'itertools.count' object (Python 3.14 compatibility)
     "test_orchestrator_deepcopies_and_stays_functional"
-
-    # Fail in the sandbox
-    # vibe.core.audio_recorder.audio_recorder_port.NoAudioInputDeviceError: No audio input device available
-    "test_audio_stream_yields_chunks"
-    "test_auto_stops_after_max_duration"
-    "test_buffer_mode_audio_stream_yields_nothing"
-    "test_callback_feeds_audio_data"
-    "test_callback_pads_silence_at_end"
-    "test_can_play_multiple_times"
-    "test_can_record_multiple_times"
-    "test_cancel_discards_audio"
-    "test_creates_stream_with_correct_params"
-    "test_finished_callback_resets_state"
-    "test_manual_stop_prevents_on_expire"
-    "test_on_expire_receives_audio"
-    "test_on_finished_called_after_natural_completion"
-    "test_peak_clamps_to_one"
-    "test_peak_updates_from_callback"
-    "test_play_sets_playing_state"
-    "test_play_when_already_playing_raises"
-    "test_silent_audio_has_zero_peak"
-    "test_start_sets_recording_state"
-    "test_start_when_already_recording_raises"
-    "test_stop_closes_stream"
-    "test_stop_from_event_loop_does_not_block"
-    "test_stop_returns_empty_data_in_stream_mode"
-    "test_stop_returns_positive_duration"
-    "test_stop_returns_valid_wav"
-    "test_stop_triggers_on_finished_via_callback"
-    "test_stop_without_drain_returns_promptly"
-    "test_stream_audio_does_not_leak_into_buffer_recording"
-    "test_unsupported_format_raises"
-
-    # AssertionError: assert True is False
-    #  +  where True = VibeApp(title='VibeApp', ...)._rewind_mode
-    "test_rewind_confirm_edits_message_and_prefills_input"
-    "test_rewind_option_selection_with_number_keys"
-
-    # AssertionError: assert 3 == 1
-    # +  where 3 = len([UserMessage(classes='user-message'), UserMessage(classes='...
-    "test_rewind_removes_messages_after_selected"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # AssertionError
@@ -225,8 +184,18 @@ python3Packages.buildPythonApplication (finalAttrs: {
     # All snapshot tests fail with AssertionError
     "tests/snapshots/"
 
-    # Try to invoke `uv run vibe`
-    "tests/e2e/"
+    # These tests invoke uv run and fail to import the packaged pydantic extension.
+    "tests/e2e/agent_loop_characterization/test_resume.py"
+    "tests/e2e/agent_loop_characterization/test_subagents.py"
+    "tests/e2e/agent_loop_characterization/test_tool_execution.py"
+    "tests/e2e/agent_loop_characterization/test_tool_permissions.py"
+    "tests/e2e/agent_loop_characterization/test_user_interaction.py"
+    "tests/e2e/test_cli_tui_fresh_install.py"
+    "tests/e2e/test_cli_tui_hooks.py"
+    "tests/e2e/test_cli_tui_onboarding.py"
+    "tests/e2e/test_cli_tui_session_exit.py"
+    "tests/e2e/test_cli_tui_streaming.py"
+    "tests/e2e/test_cli_tui_tool_approval.py"
 
     # ACP tests require network access
     "tests/acp/test_acp_entrypoint_smoke.py"

--- a/pkgs/development/python-modules/agent-client-protocol/default.nix
+++ b/pkgs/development/python-modules/agent-client-protocol/default.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "agent-client-protocol";
-  version = "0.11.1";
+  version = "0.12.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -27,7 +27,7 @@ buildPythonPackage (finalAttrs: {
     owner = "agentclientprotocol";
     repo = "python-sdk";
     tag = finalAttrs.version;
-    hash = "sha256-R4DYTUuy7vs4c+8k4nF7IjOWVjICGe/Zf9/QlyXu94U=";
+    hash = "sha256-IJJ4zgwkLP7CnU330X1K6p/We3A+tm/Veu64C2XhPS8=";
   };
 
   build-system = [
@@ -55,6 +55,11 @@ buildPythonPackage (finalAttrs: {
   disabledTests = [
     # Hangs forever
     "test_spawn_agent_process_roundtrip"
+  ];
+
+  disabledTestPaths = [
+    # Optional HTTP transport dependencies are not packaged here.
+    "tests/http"
   ];
 
   __darwinAllowLocalNetworking = true;

--- a/pkgs/development/python-modules/mistralai/default.nix
+++ b/pkgs/development/python-modules/mistralai/default.nix
@@ -33,7 +33,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "mistralai";
-  version = "2.8.0";
+  version = "2.9.1";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -41,7 +41,7 @@ buildPythonPackage (finalAttrs: {
     owner = "mistralai";
     repo = "client-python";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-3RMev6XdxIU1PVWIoZsGzHEqzmd+VZPR1baL39q1CLE=";
+    hash = "sha256-liWCT2ArXdRmyB+oPwSLJRRyfossW+jfSNpWgeSfvb0=";
   };
 
   preBuild = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Diff: [mistralai/mistral-vibe@v2.23.3...v2.24.0](https://github.com/mistralai/mistral-vibe/compare/v2.23.3...v2.24.0)
Changelog: [https://github.com/mistralai/mistral-vibe/blob/v2.24.0/CHANGELOG.md](https://github.com/mistralai/mistral-vibe/blob/v2.24.0/CHANGELOG.md)

Diff: [mistralai/client-python@v2.8.0...v2.9.1](https://github.com/mistralai/client-python/compare/v2.8.0...v2.9.1)
Changelog: [https://github.com/mistralai/client-python/blob/v2.9.1/RELEASES.md](https://github.com/mistralai/client-python/blob/v2.9.1/RELEASES.md)

Diff: [agentclientprotocol/python-sdk@0.11.1...0.12.0](https://github.com/agentclientprotocol/python-sdk/compare/0.11.1...0.12.0)
Changelog: [https://github.com/agentclientprotocol/python-sdk/releases/tag/0.12.0](https://github.com/agentclientprotocol/python-sdk/releases/tag/0.12.0)

The Mistral Vibe test exclusions were narrowed to only failures reproduced in the Nix sandbox.

cc @GaetanLepage @shikanime @mana-byte

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at passthru.tests.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and core functionality.
- [x] Ran [nixpkgs-review](https://github.com/Mic92/nixpkgs-review#usage). See [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage).
- [x] Tested basic functionality of all binary files, usually in ./result/bin/.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.
- [ ] Follows the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy).
