### PR TITLE
claude-powerline: init at 1.30.1

### DIFF
--- a/pkgs/by-name/cl/claude-powerline/package.nix
+++ b/pkgs/by-name/cl/claude-powerline/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "claude-powerline";
+  version = "1.30.1";
+
+  src = fetchFromGitHub {
+    owner = "Owloops";
+    repo = "claude-powerline";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Kevx+gZULenAPKe0LYov+v4byCJHoauf58Xkxd53Xyw=";
+  };
+
+  npmDepsHash = "sha256-D3Z5tb4phZUMPQaXvfYiIWuwaX5YGI8ubgyV7sSJqQk=";
+
+  __structuredAttrs = true;
+
+  doCheck = true;
+  # jest forks its worker children with FORCE_COLOR=1, which fails the terminal
+  # detection cases in test/colors.test.ts. --runInBand keeps them in-process.
+  checkPhase = ''
+    runHook preCheck
+
+    npm test -- --runInBand
+
+    runHook postCheck
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Beautiful vim-style powerline for Claude Code";
+    homepage = "https://github.com/Owloops/claude-powerline";
+    changelog = "https://github.com/Owloops/claude-powerline/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ cohei ];
+    mainProgram = "claude-powerline";
+  };
+})


### PR DESCRIPTION
Beautiful vim-style powerline for Claude Code
https://github.com/Owloops/claude-powerline

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
