### PR TITLE
unimatrix: 0-unstable-2023-04-25 -> 0-unstable-2026-05-20

### DIFF
--- a/pkgs/by-name/un/unimatrix/package.nix
+++ b/pkgs/by-name/un/unimatrix/package.nix
@@ -6,14 +6,14 @@
 
 python3Packages.buildPythonApplication {
   pname = "unimatrix";
-  version = "0-unstable-2023-04-25";
+  version = "0-unstable-2026-05-20";
   pyproject = false;
 
   src = fetchFromGitHub {
     owner = "will8211";
     repo = "unimatrix";
-    rev = "65793c237553bf657af2f2248d2a2dc84169f5c4";
-    hash = "sha256-fiaVEc0rtZarUQlUwe1V817qWRx4LnUyRD/j2vWX5NM=";
+    rev = "dff519f972103f91384f360f270614184de8aa92";
+    hash = "sha256-g5/Hrk/coq8d7pNwE5juMQhxYSZBXwlGbqikiI9eGvg=";
   };
 
   installPhase = ''


### PR DESCRIPTION
Updates unimatrix to the latest upstream commit.

Notable changes since the previous pin:
- Fixes Python 3.12+ `SyntaxWarning: invalid escape sequence '\;'` ([upstream #56](https://github.com/will8211/unimatrix/issues/56), [#60](https://github.com/will8211/unimatrix/pull/60))
- Adds Glagolitic character sets and other upstream updates

https://github.com/will8211/unimatrix/compare/65793c237553bf657af2f2248d2a2dc84169f5c4...dff519f972103f91384f360f270614184de8aa92

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Assisted by Cursor (Grok 4.5); changes and tests were manually reviewed.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md