### PR TITLE
wordpress_7_0: 7.0.2 -> 7.0.3, wordpress_6_9: 6.9.5 -> 6.9.6, wordpress_6_8: 6.8.6 -> 6.8.7, wordpressPackages: update plugins and languages

### DIFF
--- a/pkgs/servers/web-apps/wordpress/default.nix
+++ b/pkgs/servers/web-apps/wordpress/default.nix
@@ -6,8 +6,8 @@ builtins.mapAttrs (_: callPackage ./generic.nix) rec {
     hash = "sha256-Fu0P83henBEdNbXXVb7cKc69zcLrGyRMx7LcTea+if0=";
   };
   wordpress_6_9 = {
-    version = "6.9.5";
-    hash = "sha256-01h7VJpvXZDG5PQmj/xsI2cUY2Jc+ImiyBWnB86fXEE=";
+    version = "6.9.6";
+    hash = "sha256-kyTKCV/z5RtKmrEcAdb8lPtutloBCjOHCSFTNwFCGH8=";
   };
   wordpress_7_0 = {
     version = "7.0.2";

--- a/pkgs/servers/web-apps/wordpress/default.nix
+++ b/pkgs/servers/web-apps/wordpress/default.nix
@@ -2,8 +2,8 @@
 builtins.mapAttrs (_: callPackage ./generic.nix) rec {
   wordpress = wordpress_7_0;
   wordpress_6_8 = {
-    version = "6.8.6";
-    hash = "sha256-ID5C12xn+GprUynX8WLS5dl9iJyv13yDxYbqMDPB8P4=";
+    version = "6.8.7";
+    hash = "sha256-Fu0P83henBEdNbXXVb7cKc69zcLrGyRMx7LcTea+if0=";
   };
   wordpress_6_9 = {
     version = "6.9.5";

--- a/pkgs/servers/web-apps/wordpress/default.nix
+++ b/pkgs/servers/web-apps/wordpress/default.nix
@@ -10,7 +10,7 @@ builtins.mapAttrs (_: callPackage ./generic.nix) rec {
     hash = "sha256-kyTKCV/z5RtKmrEcAdb8lPtutloBCjOHCSFTNwFCGH8=";
   };
   wordpress_7_0 = {
-    version = "7.0.2";
-    hash = "sha256-1KTSGd6mTGxo5i8v/D8zHFR1UQJG1sRPYftS83fSlbk=";
+    version = "7.0.3";
+    hash = "sha256-OOTH15WW1Y9g+lSWojVHFAfETcN6b5xNMdRgcJhei8Q=";
   };
 }

--- a/pkgs/servers/web-apps/wordpress/packages/languages.json
+++ b/pkgs/servers/web-apps/wordpress/packages/languages.json
@@ -1,20 +1,20 @@
 {
   "de_DE": {
     "path": "de_DE",
-    "rev": "2214206",
-    "sha256": "03yrqgk0r6lin1hlq6lib4g5h358ckxf9g7rp0h3sfj6yb9l9b88",
+    "rev": "2262763",
+    "sha256": "1pdgpafpjbzqa4xwcqs5pxyrklxa4vl7g0115bl1nr64alcdpgk4",
     "version": "7.0"
   },
   "fr_FR": {
     "path": "fr_FR",
-    "rev": "2212303",
-    "sha256": "0ac31iy80qd3bd42k8454zmgsvl93sqvrb391y8l3bzk6k5h692r",
+    "rev": "2247121",
+    "sha256": "02gn5cjpfwhcbfxwx4dkg6b5ngzk40hylaw8rzqqa80w7pd4lcr2",
     "version": "7.0"
   },
   "ro_RO": {
     "path": "ro_RO",
-    "rev": "2213066",
-    "sha256": "033dnjrjwnssl8a8izx5v94sdpfgyhx90pb5lfm340a6fgqk9j21",
+    "rev": "2259356",
+    "sha256": "18rr9fymf0859nkrgpb406jzk51n63wg0gfs0wva5yrxq6pa5hiz",
     "version": "7.0"
   },
   "ru_RU": {

--- a/pkgs/servers/web-apps/wordpress/packages/plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/plugins.json
@@ -1,9 +1,9 @@
 {
   "add-widget-after-content": {
-    "path": "add-widget-after-content/tags/2.5.3",
-    "rev": "3405529",
-    "sha256": "13aa8zw553cf855j33mf8ldhakhhnngqgfj7f0b21xaaysw973pb",
-    "version": "2.5.3"
+    "path": "add-widget-after-content/tags/2.5.4",
+    "rev": "3548285",
+    "sha256": "0ba5xgk1mixdazpi2mw0n9x5nb3zsnvaxkwc9pddb3kr6mbl8hi9",
+    "version": "2.5.4"
   },
   "akismet": {
     "path": "akismet/tags/5.7",
@@ -12,10 +12,10 @@
     "version": "5.7"
   },
   "antispam-bee": {
-    "path": "antispam-bee/tags/2.11.11",
-    "rev": "3515277",
-    "sha256": "1hp7jhrhvrdqrdabkbd15b5paaycxqqqxjvzi23lcss9fcxh2rh4",
-    "version": "2.11.11"
+    "path": "antispam-bee/tags/2.11.12",
+    "rev": "3554094",
+    "sha256": "0y3xnj51zadja2am6xif3jacyyqvg3z06gz49d8w710a088sdk1y",
+    "version": "2.11.12"
   },
   "async-javascript": {
     "path": "async-javascript/tags/2.21.08.31",
@@ -24,16 +24,16 @@
     "version": "2.21.08.31"
   },
   "breeze": {
-    "path": "breeze/tags/2.5.3",
-    "rev": "3541694",
-    "sha256": "1fbfypv8gajpk2rkds8g8ama1235m3vx5na42wyjlkbkag0mcdm4",
-    "version": "2.5.3"
+    "path": "breeze/tags/2.5.12",
+    "rev": "3635295",
+    "sha256": "1nl89b0y3jbzbxn4p5jbhznlyjcvaxmfnm0z19g5na0f2z56afa7",
+    "version": "2.5.12"
   },
   "co-authors-plus": {
-    "path": "co-authors-plus/tags/4.0.2",
-    "rev": "3518612",
-    "sha256": "0bmxpkwdm84zsy29wvzdki4ss06bgpviwgjn44fzmlbjnr09ffjm",
-    "version": "4.0.2"
+    "path": "co-authors-plus/tags/4.1.1",
+    "rev": "3587259",
+    "sha256": "0akrpclq5fqab21859x1ydny99mjkihbbsvd5jifd7vbb0jjl4vn",
+    "version": "4.1.1"
   },
   "code-syntax-block": {
     "path": "code-syntax-block/tags/3.2.1",
@@ -42,15 +42,15 @@
     "version": "3.2.1"
   },
   "cookie-notice": {
-    "path": "cookie-notice/tags/3.0.6",
-    "rev": "3539409",
-    "sha256": "0c5r0zi45nb62yb82ywd0532m41jgj2k218v8gbj285lmx9imly6",
-    "version": "3.0.6"
+    "path": "cookie-notice/tags/3.1.4",
+    "rev": "3617278",
+    "sha256": "0cbpw4g7ny2wz08r0y8cpy5m1lyqvahq8lcv17ds8l478z3g6d70",
+    "version": "3.1.4"
   },
   "disable-xml-rpc": {
     "path": "disable-xml-rpc/tags/1.0.1",
-    "rev": "3408666",
-    "sha256": "10yx47s82wfczy4nlhv5ck9wprxvawj320k55rpn5kx8zmrbakwv",
+    "rev": "3551367",
+    "sha256": "0bdc371p9mjpv499d83a7zyx6llrqhz5y61fdjfljqymd3gmvclm",
     "version": "1.0.1"
   },
   "embed-extended": {
@@ -60,16 +60,16 @@
     "version": "1.4.0"
   },
   "gutenberg": {
-    "path": "gutenberg/tags/23.2.2",
-    "rev": "3542978",
-    "sha256": "0w71p6yng9k7lkg5lfys087xr9fkca96gyabh3c2mh5i1c5qa6wf",
-    "version": "23.2.2"
+    "path": "gutenberg/tags/23.7.1",
+    "rev": "3637146",
+    "sha256": "14fcbrd5g7dmfcjmn1klk8yvy5rzkxqxkxrpxnkzws4zwih6rrr5",
+    "version": "23.7.1"
   },
   "hcaptcha-for-forms-and-more": {
-    "path": "hcaptcha-for-forms-and-more/tags/4.26.0",
-    "rev": "3524788",
-    "sha256": "0l2942in25dpgpr7n57l9x99kbhlxlz1qfcg2j1lgp8fvjlv9xb8",
-    "version": "4.26.0"
+    "path": "hcaptcha-for-forms-and-more/tags/5.2.0",
+    "rev": "3636642",
+    "sha256": "1r96j4ygacifcjpx07fqx8h5drxl8djcvhddgznn8r64v00fl92f",
+    "version": "5.2.0"
   },
   "hello-dolly": {
     "path": "hello-dolly/tags/1.7.2",
@@ -78,16 +78,16 @@
     "version": "1.7.2"
   },
   "hkdev-maintenance-mode": {
-    "path": "hkdev-maintenance-mode/tags/3.1.3",
-    "rev": "3252095",
-    "sha256": "1znf09ld180qkfzyxigm5xhzqvfrlvx4g4j0f66a9fny4kpfk9jq",
-    "version": "3.1.3"
+    "path": "hkdev-maintenance-mode/tags/3.2.1",
+    "rev": "3632916",
+    "sha256": "175vb87xv04bygw6iqz391xbnjcp88wr234wxj3yy6ifj1rsnvdi",
+    "version": "3.2.1"
   },
   "jetpack": {
-    "path": "jetpack/tags/15.8",
-    "rev": "3523625",
-    "sha256": "0cf9iqwcwh86vbqsh8863p6ph8bzf7n9a6vcqg73hzhkkzmpiv9j",
-    "version": "15.8"
+    "path": "jetpack/tags/16.0.1",
+    "rev": "3609285",
+    "sha256": "0w1i4vbk0xsa0nm49gbhbggyh9lx8124yfxqikydf2dc3fiph4am",
+    "version": "16.0.1"
   },
   "jetpack-lite": {
     "path": "jetpack-lite/tags/3.0.3",
@@ -96,39 +96,39 @@
     "version": "3.0.3"
   },
   "lightbox-photoswipe": {
-    "path": "lightbox-photoswipe/tags/5.8.3",
-    "rev": "3470492",
-    "sha256": "003lbsx2jssvw7pbka96amfwqa3ir46jf40yly4h65xs2l588r58",
-    "version": "5.8.3"
+    "path": "lightbox-photoswipe/tags/5.10.1",
+    "rev": "3631617",
+    "sha256": "02xf9zc7612xd7h4jsypgrg55s9xqzh8b4bgr9zsyshx2al7xf74",
+    "version": "5.10.1"
   },
   "login-lockdown": {
-    "path": "login-lockdown/tags/2.16",
-    "rev": "3506152",
-    "sha256": "16xflxfsajkw8fvfllvnmnirks3x0i8dsr4k5p46swm810rjwm4y",
-    "version": "2.16"
+    "path": "login-lockdown/tags/2.17",
+    "rev": "3620442",
+    "sha256": "0lih4a3y4s4dyl767n6532sywg281znbsqvhk15rs9nhnsklgcmc",
+    "version": "2.17"
   },
   "mailpoet": {
-    "path": "mailpoet/tags/5.27.0",
-    "rev": "3537320",
-    "sha256": "0x9kwi6ynk22pw2m5gh0229ff0r4k0n3k02dh3ii664l2y9hy35q",
-    "version": "5.27.0"
+    "path": "mailpoet/tags/5.35.0",
+    "rev": "3634163",
+    "sha256": "1lijmkfaiyim0akr2m3rg4jd4ixv211mw9klghnirn4vmdh93bgd",
+    "version": "5.35.0"
   },
   "merge-minify-refresh": {
-    "path": "merge-minify-refresh/tags/2.15",
-    "rev": "3432380",
-    "sha256": "13p324apg3rpb3ssr8d1kmbm51i2bmpn4z6xzardsl10nw79yy1f",
-    "version": "2.15"
+    "path": "merge-minify-refresh/tags/2.16",
+    "rev": "3623221",
+    "sha256": "0vi72hpsk6idhkd2jx9l5pgwk7knh6vj2vl6s89rbmgrcv6ipdny",
+    "version": "2.16"
   },
   "opengraph": {
     "path": "opengraph/tags/2.0.2",
-    "rev": "3413644",
-    "sha256": "0v95kc0iavdr44dkx6ykyhcqgbhz7klvwdgg8b9a6gx8qna5wbyi",
+    "rev": "3574673",
+    "sha256": "0g98qgl1svf6jcybbqih466hp2w0ckjgbgwz6cl6ljr6fghk68k8",
     "version": "2.0.2"
   },
   "simple-login-captcha": {
     "path": "simple-login-captcha/tags/1.3.6",
-    "rev": "3411124",
-    "sha256": "1nnyfqbf8clclnvam8z13kdbkr3kzwv97gyqca9rqk28pwvciapi",
+    "rev": "3549724",
+    "sha256": "0ql908qfp8gy2b06hf4j2q6axaab1rs10p1fkzni7xdwy41q7qn3",
     "version": "1.3.6"
   },
   "simple-mastodon-verification": {
@@ -162,28 +162,28 @@
     "version": "1.2.3"
   },
   "webp-converter-for-media": {
-    "path": "webp-converter-for-media/tags/6.6.0",
-    "rev": "3538008",
-    "sha256": "004x7xyzbmbqh9lwnb6bz2s8a1599kjqpg4prbccjmapz80l4jvk",
-    "version": "6.6.0"
+    "path": "webp-converter-for-media/tags/6.6.4",
+    "rev": "3635161",
+    "sha256": "0fvi2jy0x5blyskf4jsidh2f2x00b6jfpmigx9qh2s1rph4rgzps",
+    "version": "6.6.4"
   },
   "webp-express": {
-    "path": "webp-express/tags/0.25.14",
-    "rev": "3439201",
-    "sha256": "0w3nx6piablib95cjn6lvfzxlhfgc2vnjxrx97d6hg33137kpj3m",
-    "version": "0.25.14"
+    "path": "webp-express/tags/0.25.15",
+    "rev": "3578701",
+    "sha256": "08izk3dw4y3mnwzfxmg9h69gk6y3xm5yss03s0igdgj9d8j7a1yw",
+    "version": "0.25.15"
   },
   "wordpress-seo": {
-    "path": "wordpress-seo/tags/27.6",
-    "rev": "3529588",
-    "sha256": "1cnvmzrrnf5f0z6c0drjv935yn43pnbmxmbj27sd0ffmmdv9c9r6",
-    "version": "27.6"
+    "path": "wordpress-seo/tags/28.2",
+    "rev": "3633714",
+    "sha256": "0k4ssa4davz9426pnvqz4sicgki4ja78h1awwjhj0qpqr4ja2fgx",
+    "version": "28.2"
   },
   "worker": {
-    "path": "worker/tags/4.9.34",
-    "rev": "3528692",
-    "sha256": "1836v703qyk49r74ym1xc9wbwj1d0sdd7z4s5w4vv9zgng5jg0s5",
-    "version": "4.9.34"
+    "path": "worker/tags/4.9.35",
+    "rev": "3609742",
+    "sha256": "0asfaqp8sbkmibc5hixf9qv991s6lmcd6a1av117gcas5f3ca3ph",
+    "version": "4.9.35"
   },
   "wp-change-email-sender": {
     "path": "wp-change-email-sender/tags/3.3.1",
@@ -204,10 +204,10 @@
     "version": "2.0.0"
   },
   "wp-fastest-cache": {
-    "path": "wp-fastest-cache/tags/1.4.9",
-    "rev": "3540132",
-    "sha256": "1jd2sma8y3lzsqw36zzhal8xf3ksn9v7c6bzdpdimaz4ddhcwqsq",
-    "version": "1.4.9"
+    "path": "wp-fastest-cache/tags/1.5.0",
+    "rev": "3633253",
+    "sha256": "0acax3lizx3ff6fillwwpn63wzxax8h7ci8rq1004gj4zb4088n6",
+    "version": "1.5.0"
   },
   "wp-gdpr-compliance": {
     "path": "wp-gdpr-compliance/tags/2.0.22",
@@ -216,28 +216,28 @@
     "version": "2.0.22"
   },
   "wp-import-export-lite": {
-    "path": "wp-import-export-lite/tags/3.9.30",
-    "rev": "3338702",
-    "sha256": "10caiankigsyghw59xvd3mf3ys0xra7ch5qyzvl3g05va7qki0km",
-    "version": "3.9.30"
+    "path": "wp-import-export-lite/tags/3.9.32",
+    "rev": "3587815",
+    "sha256": "0f36kmfsafrfdszj442ihg7yzks3f07y7fga1j2r0mmgr4l12nrd",
+    "version": "3.9.32"
   },
   "wp-mail-smtp": {
-    "path": "wp-mail-smtp/tags/4.8.0",
-    "rev": "3508233",
-    "sha256": "1wm4vv303rapbw61hlb12h8y1vxs1sh7ak7xajq1vzlwyfkab3h8",
-    "version": "4.8.0"
+    "path": "wp-mail-smtp/tags/4.9.0",
+    "rev": "3585907",
+    "sha256": "0nd8cdhl0cmmh7kz9hbf3fb8w9fms8df71996665yxppds8pi6gs",
+    "version": "4.9.0"
   },
   "wp-statistics": {
-    "path": "wp-statistics/tags/14.16.8",
-    "rev": "3537179",
-    "sha256": "19sv54i8r5v5lvq7mxfm2gqvy68pw95jx2zv3izls15zl868qcal",
-    "version": "14.16.8"
+    "path": "wp-statistics/tags/14.16.10",
+    "rev": "3622133",
+    "sha256": "116vxg4z310x8arc38n3nhi2j3fizxl2jcrf9qj8cdmzki5cfrmn",
+    "version": "14.16.10"
   },
   "wp-swiper": {
-    "path": "wp-swiper/trunk",
-    "rev": "3448359",
-    "sha256": "1gllxbz3k49nklfrh4ldkn17fgmscv1dd9r58jfx90p4pqgabd44",
-    "version": "1.4.3"
+    "path": "wp-swiper/tags/1.5.0",
+    "rev": "3634016",
+    "sha256": "0g7cax3bb7nk2bab19q9f9wlaj1dm0psn0xs0r4ir5rvjz8fsg06",
+    "version": "1.5.0"
   },
   "wp-user-avatars": {
     "path": "wp-user-avatars/tags/1.4.1",
@@ -246,9 +246,9 @@
     "version": "1.4.1"
   },
   "wpforms-lite": {
-    "path": "wpforms-lite/tags/1.10.0.5",
-    "rev": "3532389",
-    "sha256": "1gcglajl782mx8rr5196mlp42avlcqnw4riy4fnj0dcfvbi8jlmv",
-    "version": "1.10.0.5"
+    "path": "wpforms-lite/tags/2.0.0.2",
+    "rev": "3610719",
+    "sha256": "1qgzjhkrbrxhpx14mfcm4fycc0z8gsly5xvlyhjg6p0ngnphl4bh",
+    "version": "2.0.0.2"
   }
 }


### PR DESCRIPTION
- **wordpress_6_8: 6.8.6 -> 6.8.7**
- **wordpress_6_9: 6.9.5 -> 6.9.6**
- **wordpress_7_0: 7.0.2 -> 7.0.3**
- **wordpressPackages: update plugins and languages**

Fixes (high-severity) security vulnerabilities, of which a priviledge escalation and a multitude of XSS vulnerabilities.

Fixes: GHSA-52p2-r8wf-jcrf
Fixes: CVE-2026-64638
Announcement: https://wordpress.org/news/2026/08/wordpress-7-0-3-release/

Closes: https://github.com/NixOS/nixpkgs/issues/532248
Closes: https://github.com/NixOS/nixpkgs/issues/527024
Closes: https://github.com/NixOS/nixpkgs/issues/532252
Closes: https://github.com/NixOS/nixpkgs/issues/500147
Fixes: GHSA-hmqg-cxww-wqhq
Fixes: GHSA-3pwp-g2mj-5p3v
See also: https://github.com/WordPress/gutenberg/pull/81279

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
