### PR TITLE
meters-lv2: 0.9.20 -> 0.9.28, drop gtk2 dependency

### DIFF
--- a/pkgs/by-name/me/meters-lv2/package.nix
+++ b/pkgs/by-name/me/meters-lv2/package.nix
@@ -13,17 +13,16 @@
   libjack2,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "meters-lv2";
-  version = "0.9.20";
-  robtkVersion = "0.7.5";
+  version = "0.9.28";
+  robtkVersion = "0.8.6";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
     lv2
     libGLU
     libGL
-    gtk2
     cairo
     pango
     fftwFloat
@@ -33,27 +32,27 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "x42";
     repo = "meters.lv2";
-    rev = "v${version}";
-    sha256 = "sha256-eGXTbE83bJEDqTBltL6ZX9qa/OotCFmUxpE/aLqGELU=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-vNLo16ZFBrbV5AYDGu9CIb+pXW7fAzc8IDDryuAeeLM=";
   };
 
   robtkSrc = fetchFromGitHub {
     owner = "x42";
     repo = "robtk";
-    rev = "v${robtkVersion}";
-    sha256 = "sha256-L1meipOco8esZl+Pgqgi/oYVbhimgh9n8p9Iqj3dZr0=";
+    tag = "v${finalAttrs.robtkVersion}";
+    hash = "sha256-/X7+oZh25IIbji6THwDGcP+SlGIPi/T4HnFtVx/PcZ0=";
   };
 
   postUnpack = ''
     rm -rf $sourceRoot/robtk/
-    ln -s ${robtkSrc} $sourceRoot/robtk
+    ln -s ${finalAttrs.robtkSrc} $sourceRoot/robtk
   '';
 
   postPatch = ''
     substituteInPlace Makefile --replace "-msse -msse2 -mfpmath=sse" ""
   ''; # remove x86-specific flags
 
-  meter_VERSION = version;
+  meter_VERSION = finalAttrs.version;
   enableParallelBuilding = true;
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
@@ -64,4 +63,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2;
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
diff: https://github.com/x42/meters.lv2/compare/v0.9.20..v0.9.28

it doesn't seem to me that this project actually uses gtk 2 at all (ref: #410814). it has checks for several other libraries (cairo, pango, etc.) in the Makefile, but not gtk itself, and robtk seems like an *alternative* to gtk.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (the ui seems to work, though i don't really have a great idea of what this program *is* and thus cannot give a great review)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
