### PR TITLE
k3s: update all packages

### DIFF
--- a/nixos/modules/services/cluster/rancher/default.nix
+++ b/nixos/modules/services/cluster/rancher/default.nix
@@ -29,7 +29,7 @@ let
       containerdConfigTemplateFile = "/var/lib/rancher/${name}/agent/etc/containerd/config.toml.tmpl";
       staticContentChartDir = "/var/lib/rancher/${name}/server/static/charts";
 
-      manifestFormat = if jsonManifests then pkgs.formats.json { } else pkgs.formats.yaml { };
+      manifestFormat = if jsonManifests then pkgs.formats.json { } else pkgs.formats.yaml_1_2 { };
       # Manifests need a valid suffix to be respected
       mkManifestTarget =
         name:

--- a/nixos/tests/rancher/auto-deploy.nix
+++ b/nixos/tests/rancher/auto-deploy.nix
@@ -104,6 +104,7 @@ let
 in
 {
   name = "${rancherPackage.name}-auto-deploy";
+  interactive.sshBackdoor.enable = true;
 
   nodes.machine =
     { pkgs, ... }:

--- a/nixos/tests/rancher/configuration.nix
+++ b/nixos/tests/rancher/configuration.nix
@@ -21,6 +21,8 @@ let
 in
 {
   name = "${rancherPackage.name}-configuration";
+  interactive.sshBackdoor.enable = true;
+
   nodes.machine =
     { ... }:
     {

--- a/nixos/tests/rancher/etcd.nix
+++ b/nixos/tests/rancher/etcd.nix
@@ -13,6 +13,7 @@
 
 {
   name = "${rancherPackage.name}-etcd";
+  interactive.sshBackdoor.enable = true;
 
   nodes = {
 

--- a/nixos/tests/rancher/multi-node.nix
+++ b/nixos/tests/rancher/multi-node.nix
@@ -68,6 +68,7 @@ let
 in
 {
   name = "${rancherPackage.name}-multi-node";
+  interactive.sshBackdoor.enable = true;
 
   nodes = {
     server =

--- a/nixos/tests/rancher/single-node.nix
+++ b/nixos/tests/rancher/single-node.nix
@@ -45,6 +45,7 @@ let
 in
 {
   name = "${rancherPackage.name}-single-node";
+  interactive.sshBackdoor.enable = true;
 
   nodes.machine =
     { config, pkgs, ... }:

--- a/pkgs/applications/networking/cluster/k3s/1_33/chart-versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_33/chart-versions.nix
@@ -1,10 +1,10 @@
 {
   traefik-crd = {
-    url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-40.1.3+up40.1.0.tgz";
-    sha256 = "0wrjc73w4h7bshm5lg6hb71h6s49wmxkmplrf6601zq400yr0m2y";
+    url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-40.1.4+up40.1.0.tgz";
+    sha256 = "0g79q6rb3n3i2v1qw3j5259pjfb9y1g4m9r9wpqrijhrsj2qjn6d";
   };
   traefik = {
-    url = "https://k3s.io/k3s-charts/assets/traefik/traefik-40.1.3+up40.1.0.tgz";
-    sha256 = "1sgc46xpc2vg5s5vbs7jk2y2bzylf34qcamx681jq0gfjaxs0cdz";
+    url = "https://k3s.io/k3s-charts/assets/traefik/traefik-40.1.4+up40.1.0.tgz";
+    sha256 = "0rvp9ch1rda4iv79hjc6236ldqv9xvzsfrqixbzz3ffmrppczsx9";
   };
 }

--- a/pkgs/applications/networking/cluster/k3s/1_33/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_33/images-versions.json
@@ -1,26 +1,26 @@
 {
   "airgap-images-amd64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.13%2Bk3s1/k3s-airgap-images-amd64.tar.gz",
-    "sha256": "2e96b421314df12b5a4b2168ae0a8f097a63b9826bf93fbb86f7b69a48551cd7"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.13%2Bk3s2/k3s-airgap-images-amd64.tar.gz",
+    "sha256": "49f2d99717503e1f9db527baedf7b4b3d0463f1ed3d4544940a234561c5651ba"
   },
   "airgap-images-amd64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.13%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
-    "sha256": "b01d1c0b5eeff414a405a423851e13575317831eec3f87f22d6a7038f9a1fdb7"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.13%2Bk3s2/k3s-airgap-images-amd64.tar.zst",
+    "sha256": "7e59087b6a72e00db45a3bcb4f144114b13eb72dc8947c2b7908a0e1482b42b3"
   },
   "airgap-images-arm-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.13%2Bk3s1/k3s-airgap-images-arm.tar.gz",
-    "sha256": "b0d3bbbb034fcb920124562ef115ede32c2269fa8f5c35342a7c801c1e3d8068"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.13%2Bk3s2/k3s-airgap-images-arm.tar.gz",
+    "sha256": "91e2deca0b39119d02c03495520542977712641ec142a81af0ad1fa1cbf4f362"
   },
   "airgap-images-arm-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.13%2Bk3s1/k3s-airgap-images-arm.tar.zst",
-    "sha256": "ce3ac7a19d4753d543063e8bc70425b289a4b0c5c1a9e5e23555f2c70c3053f8"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.13%2Bk3s2/k3s-airgap-images-arm.tar.zst",
+    "sha256": "b94244483badd6793f2e8d93de9d3125d4faf4a10b10047f289bee1e30bb1f44"
   },
   "airgap-images-arm64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.13%2Bk3s1/k3s-airgap-images-arm64.tar.gz",
-    "sha256": "e483093a7cfa530445405faa7496ac6dedd7cb51312afc5e0cd8455923bd661e"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.13%2Bk3s2/k3s-airgap-images-arm64.tar.gz",
+    "sha256": "35bbd4e5201c8c6a48776822b8e46d7067cff1875f86c3bde5de3bda37757584"
   },
   "airgap-images-arm64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.13%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
-    "sha256": "76103ee88986c05f858d3f0f92c5e42f6410e33a94b5ee528897c7d45e1bef74"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.13%2Bk3s2/k3s-airgap-images-arm64.tar.zst",
+    "sha256": "47bc05eb1b21f0f76530a927ec5e1c5c2dec457f0190bf423e7be1d49348b5e6"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_33/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_33/versions.nix
@@ -1,8 +1,8 @@
 {
-  k3sVersion = "1.33.13+k3s1";
-  k3sCommit = "86c2c10c51e4340bb8252fff312d74dcafaf39d5";
-  k3sRepoSha256 = "06m8rqarxii7ip4pjwyr25mskgnr00lp3xypr8ywq01akns8y2bg";
-  k3sVendorHash = "sha256-oshDuY+I4sdXvjxyrp7meI9XzXo9DUr9wdD6pvUT3fg=";
+  k3sVersion = "1.33.13+k3s2";
+  k3sCommit = "875e930d812e17f955cfb3a4817ad33cce3c6822";
+  k3sRepoSha256 = "1hk3z4s2hhzdha894aai4jpl8nc5mkqb2sf7hywi8b11h8ckhv8n";
+  k3sVendorHash = "sha256-jsGm6y94Kqd4SIDy00A5QpBylHIuTuirEbChpEKo2R8=";
   chartVersions = import ./chart-versions.nix;
   imagesVersions = builtins.fromJSON (builtins.readFile ./images-versions.json);
   k3sRootVersion = "0.15.2";
@@ -17,5 +17,5 @@
   flannelPluginVersion = "v1.9.0-flannel1";
   kubeRouterVersion = "v2.6.3-k3s1";
   criDockerdVersion = "v0.3.19-k3s2";
-  helmJobVersion = "v0.11.1-build20260615";
+  helmJobVersion = "v0.13.3-build20260727";
 }

--- a/pkgs/applications/networking/cluster/k3s/1_34/chart-versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_34/chart-versions.nix
@@ -1,10 +1,10 @@
 {
   traefik-crd = {
-    url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-40.1.3+up40.1.0.tgz";
-    sha256 = "0wrjc73w4h7bshm5lg6hb71h6s49wmxkmplrf6601zq400yr0m2y";
+    url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-40.1.4+up40.1.0.tgz";
+    sha256 = "0g79q6rb3n3i2v1qw3j5259pjfb9y1g4m9r9wpqrijhrsj2qjn6d";
   };
   traefik = {
-    url = "https://k3s.io/k3s-charts/assets/traefik/traefik-40.1.3+up40.1.0.tgz";
-    sha256 = "1sgc46xpc2vg5s5vbs7jk2y2bzylf34qcamx681jq0gfjaxs0cdz";
+    url = "https://k3s.io/k3s-charts/assets/traefik/traefik-40.1.4+up40.1.0.tgz";
+    sha256 = "0rvp9ch1rda4iv79hjc6236ldqv9xvzsfrqixbzz3ffmrppczsx9";
   };
 }

--- a/pkgs/applications/networking/cluster/k3s/1_34/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_34/images-versions.json
@@ -1,26 +1,26 @@
 {
   "airgap-images-amd64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.9%2Bk3s1/k3s-airgap-images-amd64.tar.gz",
-    "sha256": "87a83fb2db2883e427e3c2351c2d3bff7bd6d3ad2ab703aec22e81e326bd63cf"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.10%2Bk3s1/k3s-airgap-images-amd64.tar.gz",
+    "sha256": "e972a78ff6ba5a83ea80c36ac986e687ee2ce4181e0fe6104f98a48467094297"
   },
   "airgap-images-amd64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.9%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
-    "sha256": "b01d1c0b5eeff414a405a423851e13575317831eec3f87f22d6a7038f9a1fdb7"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.10%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
+    "sha256": "7e59087b6a72e00db45a3bcb4f144114b13eb72dc8947c2b7908a0e1482b42b3"
   },
   "airgap-images-arm-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.9%2Bk3s1/k3s-airgap-images-arm.tar.gz",
-    "sha256": "6063398406fca10cafb109a04967c42dfcfee7216e6c6ec49a2f8c3a3b51d80a"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.10%2Bk3s1/k3s-airgap-images-arm.tar.gz",
+    "sha256": "718b9bf069aff3ffc9c3dd769abc30decf301ae90d06e47f33ed48e4957b9b3b"
   },
   "airgap-images-arm-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.9%2Bk3s1/k3s-airgap-images-arm.tar.zst",
-    "sha256": "db42a4016d8ff1f98520613fd0f569723c7553063d1a3f9aa12f25bc68b19b2a"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.10%2Bk3s1/k3s-airgap-images-arm.tar.zst",
+    "sha256": "d24b30ad5536998219611cdb7ee20d2c821a9acb69fb3852dd892a1e082edf44"
   },
   "airgap-images-arm64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.9%2Bk3s1/k3s-airgap-images-arm64.tar.gz",
-    "sha256": "eedeab95e4e1f7f11bdd08b45555c591d6b35a59be9f476b9ac95d9940ab720d"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.10%2Bk3s1/k3s-airgap-images-arm64.tar.gz",
+    "sha256": "3040602c860a1827d11b6db19307e586300a271b2f5a7781909de47f32df4ea2"
   },
   "airgap-images-arm64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.9%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
-    "sha256": "26a5528bb00c7beac8c88399af77c71123e74fedbba5b03c1c5ae003c838880f"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.10%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
+    "sha256": "dc1a8c0d10a40f2d0dc1d53c5c42f2b4e00a996b1573227bcbf2855c644d3025"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_34/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_34/versions.nix
@@ -1,8 +1,8 @@
 {
-  k3sVersion = "1.34.9+k3s1";
-  k3sCommit = "5f72184f2d188f75171bbd21953b1c16268e425f";
-  k3sRepoSha256 = "0z9c98f02ixvfjlm6yj3i93pvplnfc52l54lyfrb40d1b9wgrsdw";
-  k3sVendorHash = "sha256-JAOi23vFIYoTxB7g5Fyr+91dEX0lqChJMHCNW3q8O/g=";
+  k3sVersion = "1.34.10+k3s1";
+  k3sCommit = "39a4509ed98145d4f1eb8e15a8ca8362ca018afa";
+  k3sRepoSha256 = "1r0far01pxbjvlrz7pjmx11k1hmvwr6xmkdcpf9iph64qlnwr4s3";
+  k3sVendorHash = "sha256-ypwsQOkbda18/YLqM4v88RH4aKAxsagiocukYFnQHSw=";
   chartVersions = import ./chart-versions.nix;
   imagesVersions = builtins.fromJSON (builtins.readFile ./images-versions.json);
   k3sRootVersion = "0.15.2";
@@ -17,5 +17,5 @@
   flannelPluginVersion = "v1.9.0-flannel1";
   kubeRouterVersion = "v2.6.3-k3s1";
   criDockerdVersion = "v0.3.19-k3s3";
-  helmJobVersion = "v0.11.1-build20260615";
+  helmJobVersion = "v0.13.3-build20260727";
 }

--- a/pkgs/applications/networking/cluster/k3s/1_35/chart-versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_35/chart-versions.nix
@@ -1,10 +1,10 @@
 {
   traefik-crd = {
-    url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-40.1.3+up40.1.0.tgz";
-    sha256 = "0wrjc73w4h7bshm5lg6hb71h6s49wmxkmplrf6601zq400yr0m2y";
+    url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-40.1.4+up40.1.0.tgz";
+    sha256 = "0g79q6rb3n3i2v1qw3j5259pjfb9y1g4m9r9wpqrijhrsj2qjn6d";
   };
   traefik = {
-    url = "https://k3s.io/k3s-charts/assets/traefik/traefik-40.1.3+up40.1.0.tgz";
-    sha256 = "1sgc46xpc2vg5s5vbs7jk2y2bzylf34qcamx681jq0gfjaxs0cdz";
+    url = "https://k3s.io/k3s-charts/assets/traefik/traefik-40.1.4+up40.1.0.tgz";
+    sha256 = "0rvp9ch1rda4iv79hjc6236ldqv9xvzsfrqixbzz3ffmrppczsx9";
   };
 }

--- a/pkgs/applications/networking/cluster/k3s/1_35/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_35/images-versions.json
@@ -1,26 +1,26 @@
 {
   "airgap-images-amd64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.6%2Bk3s1/k3s-airgap-images-amd64.tar.gz",
-    "sha256": "0ffcf255abd68eb4a321c9b13e1b596c1d32a59c5b9bbcaa4d415f213ba34cf1"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.7%2Bk3s1/k3s-airgap-images-amd64.tar.gz",
+    "sha256": "c109b42bce8de6f258be41f3f83393ff2693b7ede95bce0e80a1ff394b590507"
   },
   "airgap-images-amd64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.6%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
-    "sha256": "b3af3ad5f8faaaf5deb3e875815f0805f2abd31f8c2f4d566cc2d9e6bb7e688a"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.7%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
+    "sha256": "d28bbfef8a86b740e8235b6b2cfa6e29ecb0da457a55275d788a18d09142ee1f"
   },
   "airgap-images-arm-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.6%2Bk3s1/k3s-airgap-images-arm.tar.gz",
-    "sha256": "1e5747971cc382ef44b3f0b0aa640da45642c2bec330fd6daae28d61c90f0eca"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.7%2Bk3s1/k3s-airgap-images-arm.tar.gz",
+    "sha256": "589150e3493a5cd29bf7b8b57f9e3f7968c1b2d1f79e8a072352d63abb59e978"
   },
   "airgap-images-arm-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.6%2Bk3s1/k3s-airgap-images-arm.tar.zst",
-    "sha256": "29eae298befd23f13426443ccc049921874dd4e4987c4e5e15a1e63b816177fd"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.7%2Bk3s1/k3s-airgap-images-arm.tar.zst",
+    "sha256": "c6d57e5fb17ba142464bc8db9debfa701f560b4defa70c2e06981bf52cb9e26b"
   },
   "airgap-images-arm64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.6%2Bk3s1/k3s-airgap-images-arm64.tar.gz",
-    "sha256": "14d4b33fd5dbc60c47d2c025b9a0cb1fa617e3ff351cc9c284ad9da3caf0263b"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.7%2Bk3s1/k3s-airgap-images-arm64.tar.gz",
+    "sha256": "b686b4c09dc335535889d5630ae5b0283d421d40af1029b271938cfd3b358f11"
   },
   "airgap-images-arm64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.6%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
-    "sha256": "850056a90a804ae95977bed34bcaf7d0cbc9fcb794700a25f34454c2b2fd6b50"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.7%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
+    "sha256": "47bc05eb1b21f0f76530a927ec5e1c5c2dec457f0190bf423e7be1d49348b5e6"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_35/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_35/versions.nix
@@ -1,8 +1,8 @@
 {
-  k3sVersion = "1.35.6+k3s1";
-  k3sCommit = "87243446a2c2fe958c31ad552fe38ebf96757b06";
-  k3sRepoSha256 = "0hcd2pyd66isnii7x6nbw420n0sc7rwrbws4aayakas1xi0yrkzq";
-  k3sVendorHash = "sha256-U8JM3CKLGUMWLntMyczrHCW+WMAeiDy2xwzR39InvCM=";
+  k3sVersion = "1.35.7+k3s1";
+  k3sCommit = "cd43afc7151132bac92feacd3e4d2127ea1e70d0";
+  k3sRepoSha256 = "1m9kwz8i1sqjgmc71qknmr87c9g8z7r2wl9440r32lfzxq8a6g1b";
+  k3sVendorHash = "sha256-0MVOVrRWZ/xyTaRq5Nw5ogxIGZLArDVA1wiHmiwKqFA=";
   chartVersions = import ./chart-versions.nix;
   imagesVersions = builtins.fromJSON (builtins.readFile ./images-versions.json);
   k3sRootVersion = "0.15.2";
@@ -17,5 +17,5 @@
   flannelPluginVersion = "v1.9.0-flannel1";
   kubeRouterVersion = "v2.6.3-k3s1";
   criDockerdVersion = "v0.3.19-k3s3";
-  helmJobVersion = "v0.11.1-build20260615";
+  helmJobVersion = "v0.13.3-build20260727";
 }

--- a/pkgs/applications/networking/cluster/k3s/1_36/chart-versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_36/chart-versions.nix
@@ -1,10 +1,10 @@
 {
   traefik-crd = {
-    url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-40.1.3+up40.1.0.tgz";
-    sha256 = "0wrjc73w4h7bshm5lg6hb71h6s49wmxkmplrf6601zq400yr0m2y";
+    url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-40.1.4+up40.1.0.tgz";
+    sha256 = "0g79q6rb3n3i2v1qw3j5259pjfb9y1g4m9r9wpqrijhrsj2qjn6d";
   };
   traefik = {
-    url = "https://k3s.io/k3s-charts/assets/traefik/traefik-40.1.3+up40.1.0.tgz";
-    sha256 = "1sgc46xpc2vg5s5vbs7jk2y2bzylf34qcamx681jq0gfjaxs0cdz";
+    url = "https://k3s.io/k3s-charts/assets/traefik/traefik-40.1.4+up40.1.0.tgz";
+    sha256 = "0rvp9ch1rda4iv79hjc6236ldqv9xvzsfrqixbzz3ffmrppczsx9";
   };
 }

--- a/pkgs/applications/networking/cluster/k3s/1_36/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_36/images-versions.json
@@ -1,26 +1,26 @@
 {
   "airgap-images-amd64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.36.2%2Bk3s1/k3s-airgap-images-amd64.tar.gz",
-    "sha256": "6065608edb70f061570fa15c4cce4eeb31e5218eadbacad65de4a75d1de4dad6"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.36.3%2Bk3s1/k3s-airgap-images-amd64.tar.gz",
+    "sha256": "e09e718f931ef094294781d3c35e58b84e2170acd5cc2edae075a20f58d1f89d"
   },
   "airgap-images-amd64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.36.2%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
-    "sha256": "da6a3b2dbd55cc368d930078ae8814ed22eb9c92247f7b9b46bf073445ff55b3"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.36.3%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
+    "sha256": "a197d79e979cc3f4fa9bca8f500bd70092b25c1b5ebda68b35a25f792abd42b0"
   },
   "airgap-images-arm-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.36.2%2Bk3s1/k3s-airgap-images-arm.tar.gz",
-    "sha256": "aaa7e592ba0b83e4e70741fc963358b87d57bb20a6daa09ef102db14995285e4"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.36.3%2Bk3s1/k3s-airgap-images-arm.tar.gz",
+    "sha256": "5e6b25d6cd2f6f25e663edf94a450e560a80b7a207c3d9f4d4646b688cceee5b"
   },
   "airgap-images-arm-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.36.2%2Bk3s1/k3s-airgap-images-arm.tar.zst",
-    "sha256": "9d1440d7fc88720f03b0e57d291e3a727a67a4f2e89bb5c4757d83a390635b2e"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.36.3%2Bk3s1/k3s-airgap-images-arm.tar.zst",
+    "sha256": "b94244483badd6793f2e8d93de9d3125d4faf4a10b10047f289bee1e30bb1f44"
   },
   "airgap-images-arm64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.36.2%2Bk3s1/k3s-airgap-images-arm64.tar.gz",
-    "sha256": "07766de91ed2bfa240e12b1d0b9c3af2257c8296bfa4ce17fba776243a2790fb"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.36.3%2Bk3s1/k3s-airgap-images-arm64.tar.gz",
+    "sha256": "75fc0f7a1f8a9babf00e4a6bd5fadfb6657a3af1289fe3611eaf56f01e5ce735"
   },
   "airgap-images-arm64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.36.2%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
-    "sha256": "26a5528bb00c7beac8c88399af77c71123e74fedbba5b03c1c5ae003c838880f"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.36.3%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
+    "sha256": "856feb047453cd697c2bc4dcf20127448554c8366be992a211558a13d830a038"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_36/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_36/versions.nix
@@ -1,8 +1,8 @@
 {
-  k3sVersion = "1.36.2+k3s1";
-  k3sCommit = "01b6f04aaa69e8b09303f0393d4b4f1811da23aa";
-  k3sRepoSha256 = "0iqh1hkqfgm9df3bnwi79zxcdk0a9621q451yibr19j58pb76pxv";
-  k3sVendorHash = "sha256-rwFC0bzUacl5kiQrnpRqqIam+9ADqaPuxLxNBX0wWXY=";
+  k3sVersion = "1.36.3+k3s1";
+  k3sCommit = "5aed4d7beddeb3e67120da477c876ac9efd70318";
+  k3sRepoSha256 = "0y5lc93f5pdvgm3mmk87mh50z7iway4cz99nskfh1600zfhia2s6";
+  k3sVendorHash = "sha256-pxYh1AJVZL8Xx23Nairoi5bSNNSVs+EqJbXF7ISN3wg=";
   chartVersions = import ./chart-versions.nix;
   imagesVersions = builtins.fromJSON (builtins.readFile ./images-versions.json);
   k3sRootVersion = "0.15.2";
@@ -17,5 +17,5 @@
   flannelPluginVersion = "v1.9.0-flannel1";
   kubeRouterVersion = "v2.6.3-k3s1";
   criDockerdVersion = "v0.3.19-k3s5";
-  helmJobVersion = "v0.11.1-build20260615";
+  helmJobVersion = "v0.13.3-build20260727";
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

The first commit fixes the YAML format of manifests by explicitly formatting with YAML 1.2. I think this was broken since https://github.com/NixOS/nixpkgs/commit/8f4dba19d16df4c5fe3a63739ae890bc04128664 due a a YAML directive (`%YAML 1.1`), which is added to the top of the document. See https://yaml.org/spec/1.1/#id895631. This lets the k3s parser fail with `did not find expected <document start>`.

The second commit enables the interactive SSH backdoor in all rancher tests and the rest are common version bumps.

Attention for all version bumps:

This releases upgrades Traefik chart to v40.x which includes a breaking change for the ingress-nginx migration: the provider name changes from kubernetesIngressNginx to kubernetesIngressNGINX. Check https://github.com/traefik/traefik-helm-chart/releases/tag/v40.0.0 for more details

@NixOS/k3s  

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
