### PR TITLE
python3Packages.napalm-ros: fix build; python3Packages.napalm-hp-procurve: fix build

### DIFF
--- a/pkgs/development/python-modules/napalm/hp-procurve.nix
+++ b/pkgs/development/python-modules/napalm/hp-procurve.nix
@@ -11,7 +11,7 @@
   standard-telnetlib,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "napalm-procurve";
   version = "0.7.0";
   pyproject = true;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "napalm-automation-community";
     repo = "napalm-hp-procurve";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-cO4kxI90krj1knzixRKWxa77OAaxjO8dLTy02VpkV9M=";
   };
 
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     # Dependency installation in setup.py doesn't work
     echo -n > requirements.txt
     substituteInPlace setup.cfg \
-      --replace " --pylama" ""
+      --replace-fail " --pylama" ""
   '';
 
   build-system = [
@@ -62,8 +62,8 @@ buildPythonPackage rec {
   meta = {
     description = "HP ProCurve Driver for NAPALM automation frontend";
     homepage = "https://github.com/napalm-automation-community/napalm-hp-procurve";
-    changelog = "https://github.com/napalm-automation-community/napalm-hp-procurve/releases/tag/${src.tag}";
+    changelog = "https://github.com/napalm-automation-community/napalm-hp-procurve/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/napalm/hp-procurve.nix
+++ b/pkgs/development/python-modules/napalm/hp-procurve.nix
@@ -12,7 +12,7 @@
 }:
 
 buildPythonPackage rec {
-  pname = "napalm-hp-procurve";
+  pname = "napalm-procurve";
   version = "0.7.0";
   pyproject = true;
 

--- a/pkgs/development/python-modules/napalm/ros.nix
+++ b/pkgs/development/python-modules/napalm/ros.nix
@@ -2,11 +2,10 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  setuptools,
   napalm,
   librouteros,
   pytestCheckHook,
-  pythonAtLeast,
+  poetry-core,
 }:
 buildPythonPackage rec {
   pname = "napalm-ros";
@@ -20,14 +19,26 @@ buildPythonPackage rec {
     hash = "sha256-Fv11Blx44vZZ8NuhQQIFpDr+dH2gDJtQP7b0kAk3U/s=";
   };
 
-  build-system = [ setuptools ];
+  # Setuptools is wrong, upstream uses poetry
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'requires = ["setuptools>=56.0.0", "wheel"]' 'requires = ["poetry-core"]' \
+      --replace-fail 'build-backend = "setuptools.build_meta"' 'build-backend = "poetry.core.masonry.api"'
+  '';
 
-  dependencies = [ librouteros ];
+  build-system = [ poetry-core ];
 
-  nativeCheckInputs = [
+  dependencies = [
+    librouteros
     napalm
-    pytestCheckHook
   ];
+
+  pythonRelaxDeps = [
+    "librouteros"
+    "napalm"
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
 
   disabledTests = [
     # AssertionError: Some methods vary.

--- a/pkgs/development/python-modules/napalm/ros.nix
+++ b/pkgs/development/python-modules/napalm/ros.nix
@@ -7,7 +7,8 @@
   pytestCheckHook,
   poetry-core,
 }:
-buildPythonPackage rec {
+
+buildPythonPackage (finalAttrs: {
   pname = "napalm-ros";
   version = "1.2.6";
   pyproject = true;
@@ -15,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "napalm-automation-community";
     repo = "napalm-ros";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-Fv11Blx44vZZ8NuhQQIFpDr+dH2gDJtQP7b0kAk3U/s=";
   };
 
@@ -50,9 +51,9 @@ buildPythonPackage rec {
   meta = {
     description = "MikroTik RouterOS NAPALM driver";
     homepage = "https://github.com/napalm-automation-community/napalm-ros";
-    changelog = "https://github.com/napalm-automation-community/napalm-ros/releases/tag/${src.tag}";
+    changelog = "https://github.com/napalm-automation-community/napalm-ros/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ felbinger ];
   };
-}
+})


### PR DESCRIPTION
napalm-ros uses poetry to manage deps instead and was missing some deps
for napalm-hp-procurve the package name specified in setup.py is different https://github.com/napalm-automation-community/napalm-hp-procurve/blob/master/setup.py#L25C1-L25C2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
