### PR TITLE
everforest-gtk-theme: reinit with no gtk-engine-murrine dependency

### DIFF
--- a/pkgs/by-name/ev/everforest-gtk-theme/fix-install-script.patch
+++ b/pkgs/by-name/ev/everforest-gtk-theme/fix-install-script.patch
@@ -1,0 +1,34 @@
+From f9be45b024e29efa6082cdfe6f47ca6b1110f20a Mon Sep 17 00:00:00 2001
+From: poz <poz@poz.pet>
+Date: Fri, 9 Jan 2026 03:25:01 +0100
+Subject: [PATCH] fix install script
+
+---
+ themes/install.sh | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/themes/install.sh b/themes/install.sh
+index 1dc573f1..b1657b62 100755
+--- a/themes/install.sh
++++ b/themes/install.sh
+@@ -130,6 +130,7 @@ install() {
+ 	ln -s assets/no-events.svg no-events.svg
+ 	ln -s assets/process-working.svg process-working.svg
+ 	ln -s assets/no-notifications.svg no-notifications.svg
++	cd - > /dev/null
+ 
+ 	# GTK2 Themes
+ 	mkdir -p                                                                      		 "${THEME_DIR}/gtk-2.0"
+@@ -166,7 +167,11 @@ install() {
+ 	cp -r "${SRC_DIR}/main/metacity-1/metacity-theme-3${window}${color}.xml"             "${THEME_DIR}/metacity-1/metacity-theme-3.xml"
+ 	cp -r "${SRC_DIR}/assets/metacity-1/assets${window}"                                 "${THEME_DIR}/metacity-1/assets"
+ 	cp -r "${SRC_DIR}/assets/metacity-1/thumbnail${ELSE_DARK:-}.png"                     "${THEME_DIR}/metacity-1/thumbnail.png"
+-	cd "${THEME_DIR}/metacity-1" && ln -s metacity-theme-3.xml metacity-theme-1.xml && ln -s metacity-theme-3.xml metacity-theme-2.xml
++
++	cd "${THEME_DIR}/metacity-1"
++	ln -s metacity-theme-3.xml metacity-theme-1.xml
++	ln -s metacity-theme-3.xml metacity-theme-2.xml
++	cd - > /dev/null
+ 
+ 	# XFWM4 Themes
+ 	mkdir -p                                                                             "${THEME_DIR}/xfwm4"

--- a/pkgs/by-name/ev/everforest-gtk-theme/gtk3-remove-border-spacing.patch
+++ b/pkgs/by-name/ev/everforest-gtk-theme/gtk3-remove-border-spacing.patch
@@ -1,0 +1,12 @@
+diff --git a/themes/src/sass/gtk/_common-3.0.scss b/themes/src/sass/gtk/_common-3.0.scss
+index 4148a1b4..735905e9 100644
+--- a/themes/src/sass/gtk/_common-3.0.scss
++++ b/themes/src/sass/gtk/_common-3.0.scss
+@@ -1119,7 +1119,6 @@ dropdown {
+ 
+ 	> button > box {
+ 		border-radius: 0 $modal-radius $modal-radius 0;
+-		border-spacing: $space-size;
+ 
+ 		> stack > row.activatable {
+ 			&:hover,

--- a/pkgs/by-name/ev/everforest-gtk-theme/package.nix
+++ b/pkgs/by-name/ev/everforest-gtk-theme/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  gnome-themes-extra,
+  gtk3,
+  sassc,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "everforest-gtk-theme";
+  version = "0-unstable-2025-10-23";
+
+  src = fetchFromGitHub {
+    owner = "Fausto-Korpsvart";
+    repo = "Everforest-GTK-Theme";
+    rev = "9b8be4d6648ae9eaae3dd550105081f8c9054825";
+    hash = "sha256-XHO6NoXJwwZ8gBzZV/hJnVq5BvkEKYWvqLBQT00dGdE=";
+  };
+
+  patches = [
+    # remove when merged
+    # https://github.com/Fausto-Korpsvart/Everforest-GTK-Theme/pull/34
+    ./fix-install-script.patch
+    # remove when merged
+    # https://github.com/Fausto-Korpsvart/Everforest-GTK-Theme/pull/35
+    ./gtk3-remove-border-spacing.patch
+  ];
+
+  buildInputs = [
+    gnome-themes-extra
+  ];
+
+  nativeBuildInputs = [
+    gtk3
+    sassc
+  ];
+
+  dontBuild = true;
+  dontFixup = true;
+  dontDropIconThemeCache = true;
+
+  postPatch = ''
+    patchShebangs themes/install.sh
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/share/"{themes,icons}
+
+    cp -a icons/* "$out/share/icons/"
+
+    for theme in "$out/share/icons/"*; do
+      gtk-update-icon-cache "$theme"
+    done
+
+    cd themes
+    ./install.sh --name Everforest --theme all --dest "$out/share/themes"
+    cd ..
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Everforest colour palette for GTK";
+    homepage = "https://github.com/Fausto-Korpsvart/Everforest-GTK-Theme";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ poz ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -781,7 +781,6 @@ mapAliases {
   ethercalc = throw "'ethercalc' has been removed from nixpkgs as the project was old, unmaintained, and could not be packaged well in nixpkgs"; # Added 2025-11-28
   ethersync = warnAlias "'ethersync' has been renamed to 'teamtype'" teamtype; # Added 2025-10-31
   eureka-ideas = throw "'eureka-ideas' has been removed as it has been unmaintained upstream since April 2023"; # Added 2026-02-07
-  everforest-gtk-theme = throw "'everforest-gtk-theme' has been removed because it depended on 'gtk-engine-murrine', which was removed because it was unmaintained upstream and depended on GTK 2."; # Added 2026-07-22
   everspace = throw "'everspace' has been removed, as it relies on gtk2 libraries"; # Added 2026-06-15
   evolve-core = throw "'evolve-core' has been removed, as it hindered the removal of flutter329"; # Added 2026-01-25
   eww-wayland = throw "'eww-wayland' has been renamed to/replaced by 'eww'"; # Converted to throw 2025-10-27


### PR DESCRIPTION
reverts 4a68b971401e27eaffcbf82a5b9501d0e6db0383 and adds myself as maintainer

running this on my system right now and it works with no issues, even without `gtk-engine-murrine` in dependencies

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
