### PR TITLE
python3Packages.exllamav3: 1.3.0 -> 1.4.1; tabbyapi: 0-unstable-2026-07-31 -> 0-unstable-2026-08-08

### DIFF
--- a/pkgs/by-name/ta/tabbyapi/package.nix
+++ b/pkgs/by-name/ta/tabbyapi/package.nix
@@ -7,14 +7,14 @@
 }:
 python3Packages.buildPythonApplication {
   pname = "tabbyapi";
-  version = "0-unstable-2026-07-31";
+  version = "0-unstable-2026-08-08";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "theroyallab";
     repo = "tabbyAPI";
-    rev = "29680f496b57e3ed1a496c580677d2d67ac729b8";
-    hash = "sha256-eB8Q4iVlNCrgHHWutuhxzD+bQfC5Yx3z2rSCCSFsrL4=";
+    rev = "3d2848d03184344664b9a8ed7685033e87744742";
+    hash = "sha256-gmvr8d0vGlkFcSbjSvECGiYWM69Y2c8ZWqL59+s34Yw=";
   };
 
   build-system = with python3Packages; [
@@ -44,8 +44,7 @@ python3Packages.buildPythonApplication {
       sse-starlette
       packaging
       tokenizers
-      formatron
-      kbnf
+      numpy
       aiofiles
       aiohttp
       async-lru

--- a/pkgs/development/python-modules/exllamav3/default.nix
+++ b/pkgs/development/python-modules/exllamav3/default.nix
@@ -8,8 +8,7 @@
   setuptools,
 
   flash-linear-attention,
-  formatron,
-  kbnf,
+  llguidance,
   marisa-trie,
   ninja,
   numpy,
@@ -27,14 +26,14 @@ let
 in
 buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
   pname = "exllamav3";
-  version = "1.3.0";
+  version = "1.4.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "turboderp-org";
     repo = "exllamav3";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-pWdh5fiGZEkdSLXvI5DAEdj6XmBFquzew57L1YIsEg8=";
+    hash = "sha256-6TzJbLGcp3rmlpIRiz26bYVbW2ZORrsJF3257Iv2QZc=";
   };
 
   pythonRelaxDeps = [
@@ -59,8 +58,7 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
 
   dependencies = [
     flash-linear-attention
-    formatron
-    kbnf
+    llguidance
     marisa-trie
     numpy
     pillow


### PR DESCRIPTION
https://github.com/turboderp-org/exllamav3/releases/tag/v1.4.0
https://github.com/turboderp-org/exllamav3/releases/tag/v1.4.1
https://github.com/turboderp-org/exllamav3/compare/v1.3.0...v1.4.1

https://github.com/theroyallab/tabbyAPI/compare/29680f496b57e3ed1a496c580677d2d67ac729b8...4deb5fdab7b4d26b3664533a992fd67acf2180ed
Tabbyapi had some relevant changes to new exllamav3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
