### PR TITLE
Revert "rPackages: strip dynamic libraries"

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -25,7 +25,7 @@ let
 
   buildRPackage = pkgs.callPackage ./generic-builder.nix {
     inherit R;
-    inherit (pkgs) gettext;
+    inherit (pkgs) gettext gfortran;
   };
 
   # Generates package templates given per-repository settings

--- a/pkgs/development/r-modules/generic-builder.nix
+++ b/pkgs/development/r-modules/generic-builder.nix
@@ -5,6 +5,7 @@
   xvfb-run,
   util-linux,
   gettext,
+  gfortran,
   libiconv,
 }:
 
@@ -16,12 +17,6 @@
 
 stdenv.mkDerivation (
   {
-    __structuredAttrs = true;
-    outputChecks.out.disallowedReferences = [
-      stdenv.cc
-      stdenv.cc.cc
-    ];
-
     buildInputs =
       buildInputs
       ++ [
@@ -33,6 +28,7 @@ stdenv.mkDerivation (
         xvfb-run
       ]
       ++ lib.optionals stdenv.hostPlatform.isDarwin [
+        gfortran
         libiconv
       ];
 
@@ -74,8 +70,6 @@ stdenv.mkDerivation (
       $rCommand CMD INSTALL --built-timestamp='1970-01-01 00:00:00 UTC' $installFlags --configure-args="$configureFlags" -l $out/library .
       runHook postInstall
     '';
-
-    stripDebugList = [ "library/${attrs.pname}/libs" ];
 
     postFixup = ''
       if test -e $out/nix-support/propagated-build-inputs; then


### PR DESCRIPTION
This reverts commit 21020ff8377e7d0edc6909600d4aea45f4918811 (pr https://github.com/NixOS/nixpkgs/pull/542871). Closes #549906.


We'll merge this back in through r-updates next package bump. 