### PR TITLE
celld: init at 0.1.0

### DIFF
--- a/pkgs/by-name/ce/celld/librusty_v8.nix
+++ b/pkgs/by-name/ce/celld/librusty_v8.nix
@@ -1,0 +1,27 @@
+# auto-generated file -- DO NOT EDIT!
+{
+  lib,
+  stdenv,
+  fetchurl,
+}:
+
+let
+  version = "152.0.0";
+in
+fetchurl {
+  name = "librusty_v8-${version}";
+  url = "https://github.com/denoland/rusty_v8/releases/download/v${version}/librusty_v8_release_${stdenv.hostPlatform.rust.rustcTarget}.a.gz";
+  hash =
+    {
+      x86_64-linux = "sha256-nS++EYCa01QTDVw3gmNqE89YaNptLAAtqIJ7hT01x+w=";
+      aarch64-linux = "sha256-pTVYAE1/5QIGX1ucQrUHl5MLMM42DokTeZ2+wK7upA8=";
+      aarch64-darwin = "sha256-q5Rw4GxkJlSae1lBIMTg8GAS5wEFzcOi9CGiv9YJqiA=";
+    }
+    .${stdenv.hostPlatform.system}
+      or (throw "librusty_v8 ${version} is not available for ${stdenv.hostPlatform.system}");
+
+  meta = {
+    inherit version;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/by-name/ce/celld/package.nix
+++ b/pkgs/by-name/ce/celld/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  callPackage,
+  fetchFromGitHub,
+  rustPlatform,
+  esbuild,
+  makeWrapper,
+  versionCheckHook,
+  librusty_v8 ? callPackage ./librusty_v8.nix { },
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "celld";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "denoland";
+    repo = "celld";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Iew3/ugHftS1Ui6tiVRPj3FguYmGx9vwMfS6pY00CWQ=";
+  };
+
+  cargoHash = "sha256-g3b2gFeHkqlUVLydWs/HiieK2dtw7BC2o9eNwCGAHT0=";
+
+  __structuredAttrs = true;
+
+  __darwinAllowLocalNetworking = true;
+
+  env.RUSTY_V8_ARCHIVE = librusty_v8;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/celld \
+      --set-default CELLD_ESBUILD ${lib.getExe esbuild}
+  '';
+
+  doInstallCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru = {
+    inherit librusty_v8;
+    updateScript = ./update.sh;
+  };
+
+  meta = {
+    description = "Self-hosted, distributed Durable Objects runtime";
+    homepage = "https://celld.dev";
+    changelog = "https://github.com/denoland/celld/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ akosseres ];
+    mainProgram = "celld";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+  };
+})

--- a/pkgs/by-name/ce/celld/update.sh
+++ b/pkgs/by-name/ce/celld/update.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash cacert common-updater-scripts coreutils curl gawk gnused gnutar jq nix-update
+# shellcheck shell=bash
+
+set -euo pipefail
+
+PACKAGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NIXPKGS_ROOT="$(realpath "$PACKAGE_DIR/../../../..")"
+LIBRUSTY_V8_NIX="$PACKAGE_DIR/librusty_v8.nix"
+ATTR_PATH=celld
+OWNER=denoland
+REPO=celld
+
+github_api_get() {
+  local url="$1"
+  local curl_args=(
+    --fail
+    --silent
+    --show-error
+    -H "Accept: application/vnd.github+json"
+  )
+
+  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    curl_args+=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+  fi
+
+  curl "${curl_args[@]}" "$url"
+}
+
+normalize_version() {
+  local version="$1"
+  echo "${version#v}"
+}
+
+prefetch_sri() {
+  local url="$1"
+  local unpack="${2:-false}"
+  local raw_hash
+  local args=(--type sha256)
+
+  if [[ "$unpack" == "true" ]]; then
+    args+=(--unpack)
+  fi
+
+  raw_hash="$(nix-prefetch-url "${args[@]}" "$url")"
+  nix hash convert --to sri --hash-algo sha256 "$raw_hash"
+}
+
+parse_v8_version() {
+  local cargo_lock="$1"
+  local v8_version
+
+  v8_version="$(
+    awk '
+      /^\[\[package\]\]$/ { in_pkg = 1; is_v8 = 0; next }
+      in_pkg && /^name = "v8"$/ { is_v8 = 1; next }
+      in_pkg && is_v8 && /^version = "/ {
+        gsub(/^version = "/, "")
+        gsub(/"$/, "")
+        print
+        exit
+      }
+    ' "$cargo_lock"
+  )"
+
+  if [[ -z "$v8_version" ]]; then
+    echo "Could not find the v8 package version in Cargo.lock" >&2
+    return 1
+  fi
+
+  printf '%s\n' "$v8_version"
+}
+
+write_librusty_v8_nix() {
+  cat >"$LIBRUSTY_V8_NIX" <<EOF
+# auto-generated file -- DO NOT EDIT!
+{
+  lib,
+  stdenv,
+  fetchurl,
+}:
+
+let
+  version = "${V8_VERSION}";
+in
+fetchurl {
+  name = "librusty_v8-\${version}";
+  url = "https://github.com/denoland/rusty_v8/releases/download/v\${version}/librusty_v8_release_\${stdenv.hostPlatform.rust.rustcTarget}.a.gz";
+  hash =
+    {
+      x86_64-linux = "${V8_HASH_X86_64_LINUX}";
+      aarch64-linux = "${V8_HASH_AARCH64_LINUX}";
+      aarch64-darwin = "${V8_HASH_AARCH64_DARWIN}";
+    }
+    .\${stdenv.hostPlatform.system}
+      or (throw "librusty_v8 \${version} is not available for \${stdenv.hostPlatform.system}");
+
+  meta = {
+    inherit version;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}
+EOF
+}
+
+cd "$NIXPKGS_ROOT"
+
+current_version="$(nix eval --raw -f . "${ATTR_PATH}.version")"
+latest_version="${CELLD_LATEST_VERSION_OVERRIDE:-}"
+if [[ -z "$latest_version" ]]; then
+  latest_version="$(github_api_get "https://api.github.com/repos/${OWNER}/${REPO}/releases/latest" | jq --raw-output '.tag_name')"
+fi
+latest_version="$(normalize_version "$latest_version")"
+
+if [[ -z "$latest_version" || "$latest_version" == "null" ]]; then
+  echo "Could not determine the latest celld version" >&2
+  exit 1
+fi
+
+echo "latest  version: $latest_version"
+echo "current version: $current_version"
+
+if [[ "$latest_version" == "$current_version" && "${CELLD_FORCE_UPDATE:-0}" != "1" ]]; then
+  echo "celld is already up to date"
+  exit 0
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+source_tarball="$tmpdir/celld-${latest_version}.tar.gz"
+source_root="$tmpdir/celld-${latest_version}"
+source_url="https://github.com/${OWNER}/${REPO}/archive/refs/tags/v${latest_version}.tar.gz"
+
+curl --fail --silent --show-error --location \
+  "$source_url" \
+  --output "$source_tarball"
+tar -xzf "$source_tarball" -C "$tmpdir"
+
+V8_VERSION="$(parse_v8_version "$source_root/Cargo.lock")"
+echo "pinned v8 version: $V8_VERSION"
+
+src_hash="$(prefetch_sri "$source_url" true)"
+V8_HASH_X86_64_LINUX="$(prefetch_sri "https://github.com/denoland/rusty_v8/releases/download/v${V8_VERSION}/librusty_v8_release_x86_64-unknown-linux-gnu.a.gz")"
+V8_HASH_AARCH64_LINUX="$(prefetch_sri "https://github.com/denoland/rusty_v8/releases/download/v${V8_VERSION}/librusty_v8_release_aarch64-unknown-linux-gnu.a.gz")"
+V8_HASH_AARCH64_DARWIN="$(prefetch_sri "https://github.com/denoland/rusty_v8/releases/download/v${V8_VERSION}/librusty_v8_release_aarch64-apple-darwin.a.gz")"
+export V8_VERSION V8_HASH_X86_64_LINUX V8_HASH_AARCH64_LINUX V8_HASH_AARCH64_DARWIN
+
+update-source-version "$ATTR_PATH" "$latest_version" "$src_hash" --ignore-same-version
+write_librusty_v8_nix
+nix-update "$ATTR_PATH" --version skip
+
+echo "updated celld to $latest_version"


### PR DESCRIPTION
This PR packages [celld](https://github.com/denoland/celld), a self-hosted Cloudflare Workers and Durable Objects implementation.

The package builds celld from source and links it against the official Rusty V8
release archive matching the exact `v8` version pinned by celld. There's also an update script that parses that version and updates the hashes to match it. This is based on the pattern used for `codex-acp`: https://github.com/NixOS/nixpkgs/tree/e189cf1e3d05026646496be23f9be5a6014a74e3/pkgs/by-name/co/codex-acp

esbuild is used by `celld deploy`, so celld is wrapped to use nixpkgs esbuild.

## Things done

- Build and tested on all relevant platforms
  - Tested basic functionality
  - Confirmed `celld deploy --dry-run` can make use of the bundled esbuild
- Update script also tested

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

LLM usage: the available packaging options were researched and first draft of the derivation was generated using GPT-5.6 Sol.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
