### PR TITLE
libmysofa: 1.3.4 -> 1.3.5, adopt

### DIFF
--- a/pkgs/by-name/li/libmysofa/package.nix
+++ b/pkgs/by-name/li/libmysofa/package.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libmysofa";
-  version = "1.3.4";
+  version = "1.3.5";
 
   src = fetchFromGitHub {
     owner = "hoene";
     repo = "libmysofa";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-gP/RjKzMx8JIYcyiivBGvy3kIdwHMEKY6abssyVUKNQ=";
+    hash = "sha256-HxYSQNk7V0IQaZn/K1MdtSgL+7mxBNNPn7HNors5Vkk=";
   };
 
   outputs = [

--- a/pkgs/by-name/li/libmysofa/package.nix
+++ b/pkgs/by-name/li/libmysofa/package.nix
@@ -38,6 +38,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/hoene/libmysofa";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.all;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ hythera ];
   };
 })

--- a/pkgs/by-name/li/libmysofa/package.nix
+++ b/pkgs/by-name/li/libmysofa/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "hoene";
     repo = "libmysofa";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-HxYSQNk7V0IQaZn/K1MdtSgL+7mxBNNPn7HNors5Vkk=";
   };
 
@@ -23,12 +23,15 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   nativeBuildInputs = [ cmake ];
+
   buildInputs = [ zlib ];
 
   cmakeFlags = [
-    "-DBUILD_TESTS=OFF"
-    "-DCODE_COVERAGE=OFF"
+    (lib.cmakeBool "BUILD_TESTS" false)
   ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   meta = {
     description = "Reader for AES SOFA files to get better HRTFs";


### PR DESCRIPTION
changelog: https://github.com/hoene/libmysofa/releases/tag/v1.3.5
diff: https://github.com/hoene/libmysofa/compare/v1.3.4...v1.3.5

Also proposing myself as a maintainer since https://github.com/NixOS/nixpkgs/pull/486773#issuecomment-5010084912.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
