### PR TITLE
python3Packages.paddlepaddle: fix build with cudaSupport

### DIFF
--- a/pkgs/development/python-modules/paddlepaddle/default.nix
+++ b/pkgs/development/python-modules/paddlepaddle/default.nix
@@ -77,6 +77,25 @@ buildPythonPackage {
     "opt_einsum"
   ];
 
+  pythonRemoveDeps = lib.optionals cudaSupport [
+    "cuda-python"
+    "nvidia-cublas-cu12"
+    "nvidia-cuda-cccl-cu12"
+    "nvidia-cuda-cupti-cu12"
+    "nvidia-cuda-nvrtc-cu12"
+    "nvidia-cuda-runtime-cu12"
+    "nvidia-cudnn-cu12"
+    "nvidia-cufile-cu12"
+    "nvidia-cufft-cu12"
+    "nvidia-curand-cu12"
+    "nvidia-cusolver-cu12"
+    "nvidia-cusparse-cu12"
+    "nvidia-cusparselt-cu12"
+    "nvidia-nccl-cu12"
+    "nvidia-nvjitlink-cu12"
+    "nvidia-nvtx-cu12"
+  ];
+
   dependencies = [
     setuptools
     httpx


### PR DESCRIPTION
When `cudaSupport = true`, the GPU wheel declares PyPI `nvidia-*-cu12` packages as dependencies. nixpkgs provides CUDA via system packages, so `pythonRuntimeDepsCheckHook` fails. Remove the 16 PyPI nvidia/cuda packages from the wheel metadata with `pythonRemoveDeps`, conditional on `cudaSupport`.

Assisted-by: OpenCode(1.18.4+411eff7)/ses_02881e43effeU5rUbrCeB05McK:zai-coding-plan/glm-5.2

Cc: @happysalada

Also see recent various build failures: https://hydra.nixos-cuda.org/search?query=paddlepaddle e.g. https://hydra.nixos-cuda.org/build/624898/nixlog/1

This fix uses the same mechanism as #502804.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
