### PR TITLE
 nixos/tetragon: init module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1570,6 +1570,7 @@
   ./services/security/sslmate-agent.nix
   ./services/security/step-ca.nix
   ./services/security/tang.nix
+  ./services/security/tetragon.nix
   ./services/security/timekpr.nix
   ./services/security/tinyauth.nix
   ./services/security/tor.nix

--- a/nixos/modules/services/security/tetragon.nix
+++ b/nixos/modules/services/security/tetragon.nix
@@ -1,0 +1,153 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.tetragon;
+  filterEnabled = option: lib.filterAttrs (name: file: file.enable) option;
+  buildFilePath = name: file: lib.defaultTo (pkgs.writeText name file.text) file.source;
+in
+{
+  options = {
+    services.tetragon = {
+      enable = lib.mkEnableOption "Tetragon eBPF-based Security Observability and Runtime Enforcement";
+      package = lib.mkPackageOption pkgs "tetragon" { };
+
+      configs = lib.mkOption {
+        description = "Override default settings.";
+        example = lib.literalExpression ''
+          {
+            "enable-process-cred" = {
+              text = "true";
+            };
+          };
+        '';
+        type = lib.types.attrsOf (
+          lib.types.submodule {
+            options = {
+              enable = lib.mkOption {
+                description = ''
+                  Whether this config file should be generated. This
+                  option allows specific config files to be disabled.
+                '';
+                type = lib.types.bool;
+                default = true;
+              };
+
+              text = lib.mkOption {
+                description = "Text of the config file.";
+                type = lib.types.nullOr lib.types.lines;
+                default = null;
+              };
+
+              source = lib.mkOption {
+                description = "Path of the source config file.";
+                type = lib.types.nullOr lib.types.path;
+                default = null;
+              };
+            };
+          }
+        );
+        default = { };
+      };
+
+      tracingPolicies = lib.mkOption {
+        description = "Tracing policies.";
+        example = lib.literalExpression ''
+          {
+            "file_monitoring.yaml" = {
+              source = pkgs.fetchurl {
+                url = "https://raw.githubusercontent.com/cilium/tetragon/refs/heads/main/examples/quickstart/file_monitoring.yaml";
+                hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+              };
+            };
+          };
+        '';
+        type = lib.types.attrsOf (
+          lib.types.submodule {
+            options = {
+              enable = lib.mkOption {
+                description = ''
+                  Whether this policy file should be generated. This
+                  option allows specific policy files to be disabled.
+                '';
+                type = lib.types.bool;
+                default = true;
+              };
+
+              text = lib.mkOption {
+                description = "Text of the policy file.";
+                type = lib.types.nullOr lib.types.lines;
+                default = null;
+              };
+
+              source = lib.mkOption {
+                description = "Path of the source policy file.";
+                type = lib.types.nullOr lib.types.path;
+                default = null;
+              };
+            };
+          }
+        );
+        default = { };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+
+    environment.systemPackages = [ cfg.package ];
+
+    environment.etc = {
+      "tetragon/tetragon.conf.d".source = pkgs.linkFarm "tetragon.conf.d" (
+        lib.mapAttrsToList (name: file: {
+          inherit name;
+          path = buildFilePath name file;
+        }) (filterEnabled cfg.configs)
+      );
+
+      "tetragon/tetragon.tp.d".source = pkgs.linkFarm "tetragon.tp.d" (
+        lib.mapAttrsToList (name: file: {
+          inherit name;
+          path = buildFilePath name file;
+        }) (filterEnabled cfg.tracingPolicies)
+      );
+    };
+
+    systemd.services = {
+      tetragon = {
+        description = "Tetragon eBPF-based Security Observability and Runtime Enforcement";
+        unitConfig.DefaultDependencies = "no";
+        after = [
+          "network.target"
+          "local-fs.target"
+        ];
+        documentation = [ "https://tetragon.io/" ];
+
+        startLimitBurst = 10;
+        startLimitIntervalSec = 120;
+
+        serviceConfig = {
+          User = "root";
+          Group = "root";
+          ExecStart = [
+            "${lib.getExe cfg.package}"
+          ];
+          Restart = "on-failure";
+          RestartSec = 5;
+        };
+
+        wantedBy = [ "multi-user.target" ];
+
+        restartTriggers = [
+          config.environment.etc."tetragon/tetragon.conf.d".source
+          config.environment.etc."tetragon/tetragon.tp.d".source
+        ];
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ RoGreat ];
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

First time creating a module. Creates a service and can also create files for tracing policies and configuration files. Based that off the apparmor module, since it felt like a really good way of doing it.

The service file is basically the one used by the Tetragon repo: https://github.com/cilium/tetragon/blob/main/install/linux-tarball/systemd/tetragon.service. It might need to be more secure before it gets merged. There might be some way of securing it to a non-root user as shown with version 1.6.0 for Kubernetes: https://tetragon.io/docs/installation/configuration/#run-the-operator-as-non-root

@gngram tetragon maintainer for visibility.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test