### PR TITLE
karton: init at unstable-2026-08-04

### DIFF
--- a/pkgs/kde/default.nix
+++ b/pkgs/kde/default.nix
@@ -70,6 +70,7 @@ let
         alpaka = self.callPackage ./misc/alpaka { };
         cxx-rust-cssparser = self.callPackage ./misc/cxx-rust-cssparser { };
         glaxnimate = self.callPackage ./misc/glaxnimate { };
+        karton = self.callPackage ./misc/karton { };
         kdiagram = self.callPackage ./misc/kdiagram { };
         kdevelop-pg-qt = self.callPackage ./misc/kdevelop-pg-qt { };
         kdsoap-ws-discovery-client = self.callPackage ./misc/kdsoap-ws-discovery-client { };

--- a/pkgs/kde/misc/karton/default.nix
+++ b/pkgs/kde/misc/karton/default.nix
@@ -1,0 +1,27 @@
+{ mkKdeDerivation, lib, fetchFromGitLab, libvirt, spice, libosinfo, pkg-config
+, qtmultimedia, kirigami-addons
+, spice-gtk, spice-protocol }:
+
+mkKdeDerivation {
+  pname = "karton";
+  version = "unstable-2026-08-04";
+
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "system";
+    repo = "karton";
+    rev = "bd0e933af452ee4fe11b697c7a0d337fb6a24254";
+    hash = "sha256-238qKEzhePfX/GG9WWsy7Qd+Y5SGTXxTt4AGVJCqDjU=";
+  };
+
+  extraBuildInputs = [
+    libvirt libosinfo
+    qtmultimedia kirigami-addons
+    spice spice-gtk spice-protocol
+  ];
+
+  extraNativeBuildInputs = [ pkg-config ];
+
+  meta.mainProgram = "karton";
+  meta.license = lib.licenses.gpl3Plus;
+}


### PR DESCRIPTION
Add Karton, a KDE frontend to libvirt. The project is currently work-in-progress and hasn't had major releases, hence the unstable version.

## Things done

Add a new package.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
