### PR TITLE
lib.lists.findFirstIndex: reimplement without indexing

### DIFF
--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -646,11 +646,28 @@ rec {
     :::
   */
   findFirst =
+    let
+      init = {
+        found = false;
+      };
+    in
     pred: default: list:
     let
-      index = findFirstIndex pred null list;
+      result = foldl' (
+        acc: el:
+        if !acc.found && pred el then
+          # We haven't found a match yet, and the current element passes the
+          # predicate!
+          {
+            found = true;
+            value = el;
+          }
+        else
+          # There's already a match, or the current element fails the predicate
+          acc
+      ) init list;
     in
-    if index == null then default else elemAt list index;
+    if result.found then result.value else default;
 
   /**
     Returns true if function `pred` returns true for at least one


### PR DESCRIPTION
@adisbladis rewrote an instance of `findFirstIndex` in lib.fileset to instead iterate over the elements directly, since indexing logic is actually relatively expensive in the dogshit language that is Nix. This made me realize that we could move this optimization to `lib.findIndex` itself.

Tested with this benchmark script:
```nix
let
  inherit (builtins)
    elemAt
    foldl'
    genList
    mapAttrs
    ;

  findFirstIndex =
    pred: default: list:
    let
      resultIndex = foldl' (
        index: el: if index < 0 then if pred el then -index - 1 else index - 1 else index
      ) (-1) list;
    in
    if resultIndex < 0 then default else resultIndex;

  init = {
    found = false;
  };

  functions.before =
    pred: default: list:
    let
      index = findFirstIndex pred null list;
    in
    if index == null then default else elemAt list index;

  functions.after =
    pred: default: list:
    let
      result = foldl' (
        acc: el:
        if !acc.found && pred el then
          {
            found = true;
            value = el;
          }
        else
          acc
      ) init list;
    in
    if result.found then result.value else default;

  data = genList (i: i) 10000000;
in
mapAttrs (_: f: f (x: x == 9999999) null data) functions
```

And comparing real-time performance:
```
Benchmark 1: nix eval -f benchmark.nix before
  Time (mean ± σ):      2.029 s ±  0.051 s    [User: 2.422 s, System: 0.301 s]
  Range (min … max):    1.987 s …  2.152 s    10 runs

Benchmark 2: nix eval -f benchmark.nix after
  Time (mean ± σ):      1.776 s ±  0.045 s    [User: 2.187 s, System: 0.304 s]
  Range (min … max):    1.734 s …  1.865 s    10 runs
```

Stats aren't that meaningful, because `<`, subtraction, and negation don't show up there. Here they are for posterity:
```json
{
  "attrset": {
    "lookups": "+250000025%",
    "merges": false,
    "mergeCopies": false
  },
  "list": {
    "concats": false
  },
  "parser": {
    "expressions": null
  },
  "memoryBytes": {
    "envs": "-0%",
    "list": null,
    "sets": "+4.18%",
    "symbols": null,
    "values": "-0%",
    "total": "-0%"
  },
  "speed": {
    "primops": "-100%",
    "functionCalls": "-0%",
    "thunksMade": "-18.75%",
    "thunksAvoided": "-80%"
  }
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
