### PR TITLE
postico: init at 2.3.3-9804

### DIFF
--- a/pkgs/by-name/po/postico/package.nix
+++ b/pkgs/by-name/po/postico/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  undmg,
+  makeWrapper,
+  callPackage,
+}:
+
+let
+  # Upstream / Homebrew's cask feed expose this as "<version>,<build>";
+  # joined with a dash instead since commas aren't valid in Nix store names.
+  version = "2.3.3-9804";
+  releaseVersion = lib.head (lib.splitString "-" version);
+  build = lib.last (lib.splitString "-" version);
+  appNameWithMajorVersion = "Postico ${builtins.head (lib.splitString "." version)}.app";
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "postico";
+  inherit version;
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchurl {
+    url = "https://downloads.eggerapps.at/postico/postico-${build}.dmg";
+    hash = "sha256-NH/gbP8b4dypMPNLWxMkK0VfjiK8hc+m80+Jrkg98R4=";
+  };
+
+  nativeBuildInputs = [
+    undmg
+    makeWrapper
+  ];
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/Applications
+    cp -r "${appNameWithMajorVersion}" $out/Applications/
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    mkdir -p $out/bin
+    makeWrapper "$out/Applications/Postico 2.app/Contents/MacOS/Postico" $out/bin/${finalAttrs.pname}
+  '';
+
+  passthru.updateScript = lib.getExe (callPackage ./update.nix { });
+
+  meta = {
+    mainProgram = "postico";
+    description = "A modern PostgreSQL client for macOS";
+    longDescription = ''
+      Postico 2 is a database app with a very strong focus on its core audience:
+      people who use databases. Our customers range from researchers and analysts
+      to app developers and students. Whether you want to enter data, search data,
+      or perform SQL queries, Postico has you covered.
+    '';
+    homepage = "https://eggerapps.at/postico";
+    downloadPage = "https://eggerapps.at/postico";
+    changelog = "https://eggerapps.at/postico2/changelog";
+    license = lib.licenses.unfree;
+    platforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    identifiers = {
+      cpeParts = {
+        vendor = "eggerapps";
+        product = "postico";
+        version = releaseVersion;
+        update = build;
+        target_sw = "macos";
+      };
+      purlParts = {
+        type = "generic";
+        spec = "eggerapps/postico@${version}?download_url=https://downloads.eggerapps.at/postico/postico-${build}.dmg";
+      };
+    };
+    maintainers = with lib.maintainers; [ KristijanZic ];
+  };
+})

--- a/pkgs/by-name/po/postico/update.nix
+++ b/pkgs/by-name/po/postico/update.nix
@@ -1,0 +1,50 @@
+{
+  writeShellApplication,
+  common-updater-scripts,
+  curl,
+  jq,
+  nix,
+}:
+let
+  packageName = "postico";
+in
+writeShellApplication {
+  name = "update-${packageName}";
+  runtimeInputs = [
+    common-updater-scripts
+    curl
+    jq
+    nix
+  ];
+  text = ''
+    pname="''${UPDATE_NIX_PNAME:-${packageName}}"
+
+    main() {
+      old_version="''${UPDATE_NIX_OLD_VERSION:-$(get_version)}"
+      new_version="$(get_new_version)"
+
+      if [[ "$new_version" == "$old_version" ]]; then
+        exit 0
+      fi
+
+      update-source-version "$pname" "$new_version" --print-changes
+    }
+
+    get_version() {
+      nix-instantiate --raw --eval --strict -A "$pname.version"
+    }
+
+    get_new_version() {
+      cask_json=$(curl -sL https://formulae.brew.sh/api/cask/postico.json)
+      full_version=$(echo "$cask_json" | jq -r '.version')
+
+      if [[ ! "$full_version" =~ ^[0-9.]+,[0-9]+$ ]]; then
+        exit 1
+      fi
+
+      echo "''${full_version/,/-}"
+    }
+
+    main
+  '';
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added postico at 2.3.3-9804 from https://eggerapps.at/postico

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
