### PR TITLE
mediaharbor: init at 2.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11678,6 +11678,13 @@
     githubId = 12761234;
     name = "Ida Bzowska";
   };
+  idkdontaskm3 = {
+    name = "idkdontaskm3";
+    email = "idkdontaskm3@proton.me";
+    github = "idkdontaskm3";
+    githubId = 252943539;
+    matrix = "@idkdontaskm3:matrix.org";
+  };
   idlip = {
     name = "Dilip";
     email = "igoldlip@gmail.com";

--- a/pkgs/by-name/me/mediaharbor/package.nix
+++ b/pkgs/by-name/me/mediaharbor/package.nix
@@ -1,0 +1,107 @@
+{
+  atk,
+  cairo,
+  cargo-tauri,
+  dbus,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  ffmpeg,
+  gdk-pixbuf,
+  glib,
+  gst_all_1,
+  gtk3,
+  harfbuzz,
+  lib,
+  libgit2,
+  libsoup_3,
+  nodejs,
+  npmHooks,
+  openssl,
+  pango,
+  pkg-config,
+  rustPlatform,
+  typescript,
+  webkitgtk_4_1,
+  wrapGAppsHook4,
+  zlib,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "mediaharbor";
+  version = "2.1.0";
+
+  src = fetchFromGitHub {
+    owner = "MediaHarbor";
+    repo = "mediaharbor";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-XGND7sT099xg9lObtYiv4MTLsgZxoiUC1r9V7crxrt8=";
+  };
+
+  __structuredAttrs = true;
+  env.LIBGIT2_NO_VENDOR = true;
+
+  cargoHash = "sha256-GoyY4dSeDO3ue0c/5QdRGFFHegJID4DWGGbcuCAZeOc=";
+
+  cargoBuildFlags = [
+    "-p"
+    "mediaharbor"
+  ];
+
+  npmRebuildFlags = [ "--ignore-scripts" ];
+
+  npmDeps = fetchNpmDeps {
+    src = finalAttrs.src;
+    hash = "sha256-66Z42cZQ/bW5Dn0Wfz6MWbIgrI9NF3XsNj4j5KhIzBY=";
+  };
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    nodejs
+    npmHooks.npmConfigHook
+    pkg-config
+    typescript
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    atk
+    cairo
+    dbus
+    ffmpeg
+    gdk-pixbuf
+    glib
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gtk3
+    harfbuzz
+    libgit2
+    libsoup_3
+    nodejs
+    openssl
+    pango
+    webkitgtk_4_1
+    zlib
+  ];
+
+  preBuild = ''
+    npm run build:react
+  '';
+
+  dontUseCargoInstall = true;
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share
+    install -Dm755 target/x86_64-unknown-linux-gnu/release/mediaharbor $out/bin/
+    cp -r target/x86_64-unknown-linux-gnu/release/bundle/deb/MediaHarbor_*/data/usr/share/* $out/share/ || true
+  '';
+
+  meta = {
+    description = "Cross-platform Media Ripping and Browsing GUI";
+    homepage = "https://mediaharbor.org/";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ idkdontaskm3 ];
+    mainProgram = "mediaharbor";
+  };
+})


### PR DESCRIPTION
## Things done
Fetched and built MediaHarbor package. - Pulled Cargo.lock and github repo <br> (probably not the best way to do it but wtvr) and built with rustPlatform.buildRustPackage.

NOTE : i have not added any maintainers or maintainer list related stuff yet <br> because I have another active PR with the maintainer list, if this is not what I <br> be doing, please mention so. thx :3

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].