### PR TITLE
formats.yaml_1_1,formats.yaml_1_2: add tags option

### DIFF
--- a/nixos/doc/manual/development/settings-options.section.md
+++ b/nixos/doc/manual/development/settings-options.section.md
@@ -291,10 +291,17 @@ have a predefined type and string generator already declared under
     and returning a set with JSON-specific attributes `type` and
     `generate` as specified [below](#pkgs-formats-result).
 
-`pkgs.formats.yaml` { }
+`pkgs.formats.yaml` { *`tags`* ? false }
 
-:   A function taking an empty attribute set (for future extensibility)
-    and returning a set with YAML-specific attributes `type` and
+:   A function taking an attribute set with values
+
+    `tags`
+
+    :   A boolean for controlling whether YAML tags can be generated.
+        If set, attribute sets with a single key that starts with a "!"
+        will be interpreted as a YAML tag.
+
+    It returns a set with YAML-specific attributes `type` and
     `generate` as specified [below](#pkgs-formats-result).
 
 `pkgs.formats.ini` { *`listsAsDuplicateKeys`* ? false, *`listToValue`* ? null, \.\.\. }

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -162,7 +162,9 @@ optionalAttrs allowAliases aliases
   yaml = yaml_1_1;
 
   yaml_1_1 =
-    { }:
+    {
+      tags ? false,
+    }:
     {
       generate =
         name: value:
@@ -176,7 +178,7 @@ optionalAttrs allowAliases aliases
               __structuredAttrs = true;
             }
             ''
-              remarshal --from json --to yaml-1.1 ${
+              remarshal --from json --to yaml-1.1${lib.optionalString tags " --yaml-tags"} ${
                 # attributes with null values are omitted from the JSON with structured attrs
                 # yaml_1_1Null test keeps this in check
                 if value == null then ''<(echo "null")'' else ''--unwrap value "$NIX_ATTRS_JSON_FILE"''
@@ -189,7 +191,9 @@ optionalAttrs allowAliases aliases
     };
 
   yaml_1_2 =
-    { }:
+    {
+      tags ? false,
+    }:
     {
       generate =
         name: value:
@@ -203,7 +207,7 @@ optionalAttrs allowAliases aliases
               __structuredAttrs = true;
             }
             ''
-              json2yaml ${
+              json2yaml${lib.optionalString tags " --yaml-tags"} ${
                 # attributes with null values are omitted from the JSON with structured attrs
                 # yaml_1_2Null test keeps this in check
                 if value == null then ''<(echo "null")'' else ''--unwrap value "$NIX_ATTRS_JSON_FILE"''

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -240,6 +240,46 @@ runBuildTests {
     '';
   };
 
+  yaml_1_1Tags = shouldPass {
+    format = formats.yaml_1_1 { tags = true; };
+    input = {
+      tag1 = {
+        "!mytag" = {
+          k1 = "v1";
+        };
+      };
+      tag2 = {
+        "!anothertag" = true;
+      };
+    };
+    expected = ''
+      %YAML 1.1
+      ---
+      tag1: !mytag
+        k1: v1
+      tag2: !anothertag true
+    '';
+  };
+
+  yaml_1_2Tags = shouldPass {
+    format = formats.yaml_1_2 { tags = true; };
+    input = {
+      tag1 = {
+        "!mytag" = {
+          k1 = "v1";
+        };
+      };
+      tag2 = {
+        "!anothertag" = true;
+      };
+    };
+    expected = ''
+      tag1: !mytag
+        k1: v1
+      tag2: !anothertag true
+    '';
+  };
+
   iniAtoms = shouldPass {
     format = formats.ini { };
     input = {


### PR DESCRIPTION
When the `tags` option is set to `true`, the formatters will translate singleton attrsets with a key starting with '!' into a YAML tag.

```nix
let format = formats.yaml_1_1 { tags = true; };
in  format.generate {test = {"!foo" = { bar = "baz"; }; }; };
```

```yaml
test: !foo
  bar: baz
```

This feature is designed to be used in modules such as `home-assistant`, which requires the use of the `!secret` YAML tag.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [X] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

Due to relevance to the Home Assistant service: @dotlambda @mweinelt

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
