### PR TITLE
pocket-id: fix test

### DIFF
--- a/pkgs/by-name/po/pocket-id/package.nix
+++ b/pkgs/by-name/po/pocket-id/package.nix
@@ -39,8 +39,6 @@ buildGo127Module (finalAttrs: {
 
   checkFlags = [
     "-tags=unit"
-    # requires networking
-    "-skip=TestOidcService_downloadAndSaveLogoFromURL"
   ];
 
   # required for TestIsURLPrivate

--- a/pkgs/by-name/po/pocket-id/package.nix
+++ b/pkgs/by-name/po/pocket-id/package.nix
@@ -38,6 +38,7 @@ buildGo127Module (finalAttrs: {
   '';
 
   checkFlags = [
+    "-tags=unit"
     # requires networking
     "-skip=TestOidcService_downloadAndSaveLogoFromURL"
   ];


### PR DESCRIPTION
Since pocket-id v 2.11.0, there were some failed go tests, because upstream recently hid the test-only files behind a "unit" tag, so now we specify that we want to include those files.
It's weird that the test failure didn't result in a build failure, in https://github.com/NixOS/nixpkgs/blob/0b90ce9682919e77c34802b1babb2e71b0c32d09/pkgs/build-support/go/module.nix#L310-L319 it searches for some strings including "build constraints exclude", and ignores the errors if it found any, I'm not sure why this was added.

Also an other test was fixed a few version earlier, we can re-enable that.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
