### PR TITLE
unifont: build from src

### DIFF
--- a/pkgs/by-name/un/unifont/package.nix
+++ b/pkgs/by-name/un/unifont/package.nix
@@ -2,65 +2,58 @@
   lib,
   stdenv,
   fetchurl,
-  mkfontscale,
-  fonttosfnt,
-  libfaketime,
+  perl,
+  bdftopcf,
+  bdf2psf,
+  imagemagick,
 }:
 
+let
+  perlenv = perl.withPackages (ps: [ ps.GD ]);
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "unifont";
   version = "17.0.05";
 
-  otf = fetchurl {
-    url = "mirror://gnu/unifont/unifont-${finalAttrs.version}/unifont-${finalAttrs.version}.otf";
-    hash = "sha256-hXAaubHiUe4W9N8AsT8i6sMR1yt9q0J6fZdf5/UGRwI=";
+  strictDeps = true;
+
+  src = fetchurl {
+    url = "mirror://gnu/unifont/unifont-${finalAttrs.version}/unifont-${finalAttrs.version}.tar.gz";
+    hash = "sha256-8ofP+ybiJyOqNuZoSGmw8/87+4IsSwEAi9hHkR7BtjE=";
   };
 
-  pcf = fetchurl {
-    url = "mirror://gnu/unifont/unifont-${finalAttrs.version}/unifont-${finalAttrs.version}.pcf.gz";
-    hash = "sha256-kld9gZ/QPhsu7IcqtFghB4qed4B6+Gp9IbbaOP72HNw=";
-  };
-
-  bdf = fetchurl {
-    url = "mirror://gnu/unifont/unifont-${finalAttrs.version}/unifont-${finalAttrs.version}.bdf.gz";
-    hash = "sha256-2wERwGbt/nWD8Nd62+y7pGPwBkOjfcO5ZRrpNJVDSH8=";
-  };
+  postPatch = ''
+    rm -r font/precompiled
+    patchShebangs ./src
+  '';
 
   nativeBuildInputs = [
-    libfaketime
-    fonttosfnt
-    mkfontscale
+    perlenv
+    bdftopcf
+    bdf2psf
+    imagemagick
   ];
 
-  dontUnpack = true;
+  buildInputs = [
+    perlenv
+  ];
 
-  buildPhase = ''
-    runHook preBuild
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
-    # convert pcf font to otb
-    faketime -f "1970-01-01 00:00:01" \
-    fonttosfnt -g 2 -m 2 -v -o "unifont.otb" "${finalAttrs.pcf}"
+  buildFlags = [ "BUILDFONT=1" ];
 
-    runHook postBuild
+  postInstall = ''
+    moveToOutput bin "$bin"
+    moveToOutput share/unifont "$doc"
   '';
 
-  installPhase = ''
-    runHook preInstall
-
-    # install otb fonts
-    install -m 644 -D unifont.otb "$out/share/fonts/unifont.otb"
-    mkfontdir "$out/share/fonts"
-
-    # install pcf, otf, and bdf fonts
-    install -m 644 -D ${finalAttrs.pcf} $out/share/fonts/unifont.pcf.gz
-    install -m 644 -D ${finalAttrs.otf} $out/share/fonts/opentype/unifont.otf
-    gunzip -c ${finalAttrs.bdf} > $out/share/fonts/unifont.bdf
-    cd "$out/share/fonts"
-    mkfontdir
-    mkfontscale
-
-    runHook postInstall
-  '';
+  outputs = [
+    "out"
+    "bin"
+    "doc"
+    "man"
+    "info"
+  ];
 
   passthru.updateScript = ./update.sh;
 

--- a/pkgs/by-name/un/unifont/update.sh
+++ b/pkgs/by-name/un/unifont/update.sh
@@ -5,6 +5,4 @@ set -euo pipefail
 
 latest=$(curl -sL "https://ftp.gnu.org/gnu/unifont/" | grep -oP 'unifont-\K\d+\.\d+\.\d+' | sort -V | tail -1)
 
-update-source-version unifont "$latest" --ignore-same-version --source-key=otf
-update-source-version unifont "$latest" --ignore-same-version --source-key=pcf
-update-source-version unifont "$latest" --ignore-same-version --source-key=bdf
+update-source-version unifont "$latest" --ignore-same-version --source-key=src


### PR DESCRIPTION
Also build tools and include documentation.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
