### PR TITLE
fork: init at 2.66.7

### DIFF
--- a/pkgs/by-name/fo/fork/package.nix
+++ b/pkgs/by-name/fo/fork/package.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  undmg,
+  callPackage,
+  testers,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "fork";
+  version = "2.66.7";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchurl {
+    url = "https://cdn.fork.dev/mac/Fork-${finalAttrs.version}.dmg";
+    hash = "sha256-80T545Q80J+Dri62bj42CxUExO7HC/ihhf9tgU9i8Q0=";
+  };
+
+  nativeBuildInputs = [ undmg ];
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/Applications
+    cp -r Fork.app $out/Applications/
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    mkdir -p $out/bin
+    ln -s "$out/Applications/Fork.app/Contents/Resources/fork_cli" "$out/bin/fork"
+  '';
+
+  passthru = {
+    updateScript = lib.getExe (callPackage ./update.nix { });
+
+    tests = {
+      help = testers.runCommand {
+        name = "fork-help-test";
+        buildInputs = [ finalAttrs.finalPackage ];
+        script = ''
+          fork --help | grep "Fork Command Line Tools"
+          touch $out
+        '';
+      };
+    };
+  };
+
+  meta = {
+    mainProgram = "fork";
+    description = "A fast and friendly Git client";
+    longDescription = ''
+      Fork is a GUI Git client for macOS and Windows aimed at making everyday
+      Git workflows easier to reason about. It provides an interactive rebase
+      editor, a built-in merge tool, side-by-side diffs, commit search, Git
+      LFS locking support, and a CLI companion (`fork`) for opening
+      repositories straight from the terminal.
+    '';
+    homepage = "https://fork.dev";
+    downloadPage = "https://fork.dev";
+    changelog = "https://fork.dev/releasenotes";
+    license = lib.licenses.unfree;
+    platforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    identifiers = {
+      cpeParts = {
+        vendor = "danilpristupov";
+        product = "fork";
+        version = finalAttrs.version;
+        target_sw = "macos";
+      };
+      purlParts = {
+        type = "generic";
+        spec = "danilpristupov/fork@${finalAttrs.version}?download_url=https://cdn.fork.dev/mac/Fork-${finalAttrs.version}.dmg";
+      };
+    };
+    maintainers = with lib.maintainers; [ KristijanZic ];
+  };
+})

--- a/pkgs/by-name/fo/fork/update.nix
+++ b/pkgs/by-name/fo/fork/update.nix
@@ -1,0 +1,52 @@
+{
+  writeShellApplication,
+  common-updater-scripts,
+  curl,
+  jq,
+  nix,
+}:
+
+let
+  packageName = "fork";
+in
+writeShellApplication {
+  name = "update-${packageName}";
+  runtimeInputs = [
+    common-updater-scripts
+    curl
+    jq
+    nix
+  ];
+  text = ''
+    pname="''${UPDATE_NIX_PNAME:-${packageName}}"
+
+    main() {
+      old_version="''${UPDATE_NIX_OLD_VERSION:-$(get_version)}"
+      new_version="$(get_new_version)"
+
+      if [[ "$new_version" == "$old_version" ]]; then
+        exit 0
+      fi
+
+      update-source-version "$pname" "$new_version" --print-changes
+    }
+
+    get_version() {
+      nix-instantiate --raw --eval --strict -A "$pname.version"
+    }
+
+    get_new_version() {
+      cask_json=$(curl -sL https://formulae.brew.sh/api/cask/fork.json)
+
+      version=$(echo "$cask_json" | jq -r '.version')
+
+      if [[ ! "$version" =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
+        exit 1
+      fi
+
+      echo "$version"
+    }
+
+    main
+  '';
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added fork at 2.66.7 from https://fork.dev

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
