### PR TITLE
silo: 2026-08-04T00-00-00Z -> 2026-08-06T00-00-00Z

### DIFF
--- a/pkgs/by-name/si/silo/package.nix
+++ b/pkgs/by-name/si/silo/package.nix
@@ -30,16 +30,16 @@ buildGoModule (finalAttrs: {
   __structuredAttrs = true;
 
   pname = "silo";
-  version = "2026-08-04T00-00-00Z";
+  version = "2026-08-06T00-00-00Z";
 
   src = fetchFromGitHub {
     owner = "pgsty";
-    repo = "minio";
+    repo = "silo";
     tag = "RELEASE.${finalAttrs.version}";
-    hash = "sha256-F5gyhSBVH4RUoOyo+8UQ0RXuraXkGVO/mGkuFIi0hoc=";
+    hash = "sha256-mFHgeetimgSgztA39oP4TcxdlFpI+Usjg7cvhyjsYRI=";
   };
 
-  vendorHash = "sha256-gDcO0q6beKEGSs6MM/C3iKC2+eFk1o6Ug5KLMmK12ek=";
+  vendorHash = "sha256-7uXfM10x5ouCLNuk204AUi9up5oXVesPdNAbbGFyQ6U=";
 
   subPackages = [ "." ];
 
@@ -60,6 +60,7 @@ buildGoModule (finalAttrs: {
       "-X ${t}.CopyrightYear=${versionToYear finalAttrs.version}"
     ];
 
+  # Despite the renaming, the binary result comes out as minio. Upstream's goreleaser pipeline passes an explicit -o silo. The buildGoModule does not.
   postInstall = ''
     ln -s "$out/bin/minio" "$out/bin/silo"
   '';
@@ -71,8 +72,8 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Community-maintained fork of MinIO packaged as silo";
-    homepage = "https://github.com/pgsty/minio";
-    changelog = "https://github.com/pgsty/minio/releases/tag/${finalAttrs.src.tag}";
+    homepage = "https://github.com/pgsty/silo";
+    changelog = "https://github.com/pgsty/silo/releases/tag/${finalAttrs.src.tag}";
     maintainers = with lib.maintainers; [ randoneering ];
     license = lib.licenses.agpl3Plus;
     mainProgram = "silo";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The following PR brings in the latest version of Silo. Upstream officially changed the name to 'silo', which required a few updates to the nixpkg. In addition, it looks like we will still need to use the symlink as the binary still lands as 'minio' after the package builds. I believe this is do to upstream's goreleaser pipeline passing an explicit -o silo. The buildGoModule does not support this natively, unless I am wrong? Either way, the symlink stays.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
