### PR TITLE
pinnacle: install shell completions

### DIFF
--- a/pkgs/by-name/pi/pinnacle/package.nix
+++ b/pkgs/by-name/pi/pinnacle/package.nix
@@ -1,5 +1,6 @@
 {
   rustPlatform,
+  stdenv,
   lib,
   pkg-config,
   wayland,
@@ -22,11 +23,13 @@
   callPackage,
   libglvnd,
   autoPatchelfHook,
+  installShellFiles,
   libxcursor,
   libxi,
   libxrandr,
   libx11,
   fetchFromGitHub,
+  writableTmpDirAsHomeHook,
 }:
 let
   version = "0.2.4";
@@ -121,6 +124,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     wayland
     makeWrapper
     autoPatchelfHook
+    installShellFiles
+    writableTmpDirAsHomeHook
   ];
 
   checkFeatures = [ "testing" ];
@@ -155,6 +160,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mkdir -p $out/share/xdg-desktop-portal
     install -m644 ./resources/pinnacle-portals.conf $out/share/xdg-desktop-portal/pinnacle-portals.conf
     install -m644 ./resources/pinnacle-portals.conf $out/share/xdg-desktop-portal/pinnacle-uwsm-portals.conf
+  ''
+  + lib.optionalString (stdenv.hostPlatform.canExecute stdenv.buildPlatform) ''
+    installShellCompletion --cmd pinnacle \
+      --bash <($out/bin/pinnacle gen-completions --shell bash) \
+      --fish <($out/bin/pinnacle gen-completions --shell fish) \
+      --zsh <($out/bin/pinnacle gen-completions --shell zsh)
   '';
 
   runtimeDependencies = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
