### PR TITLE
mposplit: init at v0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1949,6 +1949,13 @@
     githubId = 143312793;
     name = "Annin";
   };
+  annoyingrains = {
+    email = "avali@avali.zone";
+    matrix = "@avali:avali.zone";
+    github = "AnnoyingRain5";
+    githubId = 35289650;
+    name = "AnnoyingRains";
+  };
   anntnzrb = {
     github = "anntnzrb";
     githubId = 51257127;

--- a/pkgs/by-name/mp/mposplit/package.nix
+++ b/pkgs/by-name/mp/mposplit/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mposplit";
+  version = "v0.1";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "AlbrechtL";
+    repo = "mposplit";
+    rev = "v0.1";
+    hash = "sha256-nrW9yceqdGRHtOs2V4iNHLinVf8cB/QBNzx33FAvB8E=";
+  };
+
+  buildPhase = "gcc -o mposplit mposplit.c";
+  installPhase = "mkdir -p $out/bin; mv mposplit $out/bin/mposplit";
+
+  meta = {
+    description = "A small tool to convert a 3D MPO-file into two JPEG-files.";
+    homepage = "https://github.com/AlbrechtL/mposplit";
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.linux;
+    mainProgram = "mposplit";
+    maintainers = with lib.maintainers; [ annoyingrains ];
+  };
+})


### PR DESCRIPTION
`mposplit` is a very simple program that splits `.mpo` files into multiple JPEGs. MPO is a common format for older 3D cameras (Fujifilm Real 3D W1, Ricoh CX5, Nintendo 3DS, etc), and (to my knowledge) there is no program in nixpkgs that can correctly split or display these files.

Example MPO files for testing: [MPOs.zip](https://github.com/user-attachments/files/30813786/MPOs.zip)

You can also make an MPO by adapting the following bash script:

```bash
cat orig1.jpg > final.mpo
printf '\0' >> final.mpo
cat orig2.jpg >> final.mpo
```

Note that this only works for EXIF JPEG files. JPEGs using JFIF metadata can't be converted using this method.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
