### PR TITLE
claude-code: 2.1.223 -> 2.1.224

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,22 +21,22 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-3V4N8zHj7nB987ImVtBS84LGxdQgkDp14kTPps72fHo=";
+          hash = "sha256-BE9YnAuEFyGrHCIWP0o+ddQ1lkcMhc5M+cIjAujQka0=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-6p09GcEfmSQs4nRuaFxQ1tKK25ENo2KOPkRQTPndNcw=";
+          hash = "sha256-bQR4WyDCbSYZG5YA/mytdKYQHqKc9NxgjWRVIfQPI6E=";
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-qbYE3f0fkxvfGyFAR8UPIFodOEYA0aJK6JK/r8PbI/k=";
+          hash = "sha256-kXm2c77lrCLq9MdzGcPijJuRDfLJxjMTDgIBCPMAy3U=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.223";
+      version = "2.1.224";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,52 +1,51 @@
 {
-  "version": "2.1.223",
-  "commit": "4535f69721056abf01650c73ee8a91c69ba00838",
-  "buildDate": "2026-08-05T21:55:19Z",
+  "version": "2.1.224",
+  "commit": "8a2a469b68f918917492973f3b16bd1682b9f82c",
+  "buildDate": "2026-08-06T01:47:12Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "fcbe0b8d47570c501302dd1ad31cc26ac2810f022c45fa253936a6961dee32bf",
-      "size": 272553824
+      "checksum": "391df9d2ab04e4cf32199335720ac7715a582e91eaecfd4d2198a16f57ea59b3",
+      "size": 277495040
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "350e657428a6d34f7cf71f6738c5ebb6a1952ccb12fc1747f64297e065b1846f",
-      "size": 282118560
+      "checksum": "7ae17a768a7270c7bd6c5484587c3c650dff425b4beeeb03addc1f2a4a7d702a",
+      "size": 287105184
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "60e83d8db0e894d0e54413e5e7daa256d180db660f51e139a51b614fc30cf3ac",
-      "size": 287423416
+      "checksum": "3e50836e227868746273653e0f8115cf5fc9cb34a081847c6040c81d80812c33",
+      "size": 292404152
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "98226474f802e3094d6a86c5ade8883c16206d0fcb5c400b7401c800063e99d7",
-      "size": 290728968
+      "checksum": "a2b5add7dc4bcd8eaa029f4e8bdac4df7769b4073698db7989d206baf9419c2d",
+      "size": 295676936
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "f41692eab23ebcd836d342fbc494d8783b1f19efb13d04fbf8461d2806ccb586",
-      "size": 280737128
+      "checksum": "5ab089acd0b8d56b08d9510aeecd96767a057fc7bc05221c968c81d8d21711f6",
+      "size": 285717864
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "8a4e561e8af19746d2defcf1a5661f5c0384c9c26dadd87d45e11b67802ad147",
-      "size": 285336144
+      "checksum": "979b08e51d814a4abaa36d8c3b570bdaa8c1dd2020b318c6f8334b631c2c4f19",
+      "size": 290284112
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "a708ba811c4cc46907df358e22f2aa6da3dbc28192747e4d3c4a0869752fe722",
-      "size": 280233632
+      "checksum": "879f0d7e7eee606095051c0c00772fc1de41778f34835a9de43ea8e1caad9afb",
+      "size": 284981920
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "8efb44f04fda50fac3c7602276903e44ff82d48f1a29a41f1a5d98891a01864b",
-      "size": 274906784
+      "checksum": "105b33963dfdcd58c52e90562fb03face32b7b7e0d9caba74bc06b9d7b45c102",
+      "size": 279654560
     }
   },
   "sdkCompat": {
     "testedWrapperVersions": [
-      "0.3.182",
       "0.3.183",
       "0.3.185",
       "0.3.186",
@@ -75,7 +74,8 @@
       "0.3.217",
       "0.3.218",
       "0.3.220",
-      "0.3.221"
+      "0.3.221",
+      "0.3.222"
     ],
     "harnessSchema": 1
   }


### PR DESCRIPTION
Update claude-code and vscode-extensions.anthropic.claude-code to 2.1.224.

https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md

> [!NOTE]
> Prepared with the assistance of Claude Code (Claude Opus 5). Version and hash bumps were produced by the standard `maintainers/scripts/update.nix` script; the change was built locally and validated across arches via `nixpkgs-review`, and reviewed by a human (@markus1189) before being marked ready.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
