### PR TITLE
nixos/comfyui: add acceleration, models and extraPackages options

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -1,4 +1,7 @@
 {
+  "module-services-comfyui": [
+    "index.html#module-services-comfyui"
+  ],
   "module-services-portmaster": [
     "index.html#module-services-portmaster"
   ],

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -24,6 +24,9 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- [ComfyUI](https://github.com/Comfy-Org/ComfyUI), a powerful and modular diffusion model GUI, API, and backend with a graph/nodes interface.
+  Available as [services.comfyui](#opt-services.comfyui.enable).
+
 - [Portmaster](https://safing.io/portmaster/), a privacy-focused application
   firewall, is available through
   [services.portmaster](#opt-services.portmaster.enable).

--- a/nixos/modules/services/misc/comfyui.md
+++ b/nixos/modules/services/misc/comfyui.md
@@ -1,0 +1,41 @@
+# ComfyUI {#module-services-comfyui}
+
+[ComfyUI](https://github.com/Comfy-Org/ComfyUI) is a modular diffusion model GUI, API, and backend with a graph/nodes interface.
+
+A minimal configuration is:
+
+```nix
+{
+  services.comfyui.enable = true;
+}
+```
+
+Models and additional Python packages can be managed declaratively:
+
+- {option}`services.comfyui.models` fetches model files at build time and
+  symlinks them into `/var/lib/comfyui/models/<installPath>/<name>`.
+
+  ```nix
+  {
+    services.comfyui.models = [
+      {
+        name = "RealESRGAN_x4plus_anime_6B.pth";
+        url = "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.2.4/RealESRGAN_x4plus_anime_6B.pth";
+        hash = "sha256-+HLYN9PJDtLgUie+1xGvVnGm/RyffX6RyRGmHxVemdo=";
+        installPaths = [ "upscale_models" ];
+      }
+    ];
+  }
+  ```
+
+- {option}`services.comfyui.extraPackages` adds extra Python packages to
+  ComfyUI's environment, typically for custom node dependencies.
+
+  ```nix
+  {
+    services.comfyui.extraPackages = python3Packages: with python3Packages; [ flask ];
+  }
+  ```
+
+- {option}`services.comfyui.acceleration` selects the hardware acceleration
+  device (`"cpu"` / `"cuda"`, defaulting to following `nixpkgs.config.cudaSupport`).

--- a/nixos/modules/services/misc/comfyui.nix
+++ b/nixos/modules/services/misc/comfyui.nix
@@ -10,6 +10,11 @@ let
   # By default a StateDirectory is used; anything else needs its own directory and a hole in the unit's mount namespace.
   isDefaultDataDir = cfg.dataDir == "/var/lib/comfyui";
 
+  package = cfg.package.override (oldArgs: {
+    extraPackages = ps: (oldArgs.extraPackages or (_: [ ]) ps) ++ (cfg.extraPackages ps);
+    cudaSupport = cfg.acceleration == "cuda";
+  });
+
   modelDrvs = map (m: {
     inherit m;
     drv = pkgs.fetchurl (lib.filterAttrs (n: _: n == "name" || n == "url" || n == "hash") m);
@@ -40,6 +45,32 @@ in
           Any other directory is created with systemd-tmpfiles and bind-mounted into the service.
 
           Existing state is not migrated, you need to move it yourself.
+        '';
+      };
+
+      # The package with all module overrides applied (extraPackages, cudaSupport).
+      # Exposed so tests can inspect the resulting Python environment.
+      finalPackage = lib.mkOption {
+        type = lib.types.package;
+        internal = true;
+        readOnly = true;
+        default = package;
+        description = "The comfyui package with module overrides applied.";
+      };
+
+      acceleration = lib.mkOption {
+        type = lib.types.enum [
+          "cpu"
+          "cuda"
+        ];
+        default = if config.nixpkgs.config.cudaSupport then "cuda" else "cpu";
+        defaultText = lib.literalExpression "if config.nixpkgs.config.cudaSupport then \"cuda\" else \"cpu\"";
+        example = "cuda";
+        description = ''
+          Specifies the device to use for hardware acceleration.
+
+          - `"cpu"`: pass `--cpu` to the server. Not recommended for production use as it is very slow.
+          - `"cuda"`: enable CUDA support on the package; ComfyUI selects the CUDA device automatically.
         '';
       };
 
@@ -145,16 +176,32 @@ in
           because the symlink cannot be created over it.
         '';
       };
+
+      extraPackages = lib.mkOption {
+        type = lib.types.functionTo (lib.types.listOf lib.types.package);
+        default = _: [ ];
+        defaultText = lib.literalExpression "python3Packages: [ ]";
+        example = lib.literalExpression ''
+          python3Packages: with python3Packages; [ flask ]
+        '';
+        description = ''
+          Extra packages to add to ComfyUI's Python environment,
+          typically to satisfy custom node runtime dependencies.
+        '';
+      };
     };
   };
 
   config = lib.mkIf cfg.enable {
-    services.comfyui.extraArgs = lib.mkBefore [
-      "--base-directory=${cfg.dataDir}"
-      "--database-url=sqlite:///${cfg.dataDir}/user/comfyui.db"
-      "--listen=${lib.concatStringsSep "," cfg.listen}"
-      "--port=${toString cfg.port}"
-    ];
+    services.comfyui.extraArgs = lib.mkBefore (
+      [
+        "--base-directory=${cfg.dataDir}"
+        "--database-url=sqlite:///${cfg.dataDir}/user/comfyui.db"
+        "--listen=${lib.concatStringsSep "," cfg.listen}"
+        "--port=${toString cfg.port}"
+      ]
+      ++ lib.optionals (cfg.acceleration == "cpu") [ "--cpu" ]
+    );
 
     # owner read back from the unit, not spelled out: StateDirectory= infers it, this rule has to be told
     systemd.tmpfiles.settings = lib.mkIf (!isDefaultDataDir) {
@@ -193,7 +240,7 @@ in
       '';
 
       serviceConfig = {
-        ExecStart = "${lib.getExe cfg.package} ${lib.escapeShellArgs cfg.extraArgs}";
+        ExecStart = "${lib.getExe cfg.finalPackage} ${lib.escapeShellArgs cfg.extraArgs}";
         Group = "comfyui";
         Restart = "always";
         RestartSec = "5sec"; # don't crash loop immediately
@@ -252,5 +299,8 @@ in
     };
   };
 
-  meta.maintainers = pkgs.comfyui.meta.maintainers;
+  meta = {
+    doc = ./comfyui.md;
+    maintainers = pkgs.comfyui.meta.maintainers;
+  };
 }

--- a/nixos/modules/services/misc/comfyui.nix
+++ b/nixos/modules/services/misc/comfyui.nix
@@ -9,6 +9,19 @@ let
 
   # By default a StateDirectory is used; anything else needs its own directory and a hole in the unit's mount namespace.
   isDefaultDataDir = cfg.dataDir == "/var/lib/comfyui";
+
+  modelDrvs = map (m: {
+    inherit m;
+    drv = pkgs.fetchurl (lib.filterAttrs (n: _: n == "name" || n == "url" || n == "hash") m);
+  }) cfg.models;
+
+  modelSymlinks = lib.concatMapStringsSep "\n" (
+    x:
+    lib.concatMapStringsSep "\n" (p: ''
+      mkdir -p ${lib.escapeShellArg "${cfg.dataDir}/models/${p}"}
+      ln -sn ${x.drv} ${lib.escapeShellArg "${cfg.dataDir}/models/${p}/${x.m.name}"}
+    '') x.m.installPaths
+  ) modelDrvs;
 in
 {
   options = {
@@ -67,6 +80,71 @@ in
           Flags set by the module are prepended with `lib.mkBefore`, so any user supplied flag wins over that.
         '';
       };
+
+      models = lib.mkOption {
+        type = lib.types.listOf (
+          lib.types.submodule {
+            options = {
+              name = lib.mkOption {
+                type = lib.types.str;
+                description = ''
+                  The model file name, used as the link name in `models/<installPath>/<name>`,
+                  and as the `fetchurl` derivation name.
+                  It must be unique within the same `<installPath>`,
+                  since the module creates one symlink per model there.
+                '';
+              };
+              url = lib.mkOption {
+                type = lib.types.str;
+                description = ''
+                  The download URL of the model file.
+                  Prefer a pinned-resolve URL (e.g. HuggingFace's `/resolve/<commit>/<file>`) so the hash stays stable.
+                '';
+              };
+              hash = lib.mkOption {
+                type = lib.types.str;
+                example = lib.fakeHash;
+                description = ''
+                  The SRI hash of the model file. Generate it with `nix-prefetch-url <url>`,
+                  or set this to `lib.fakeHash` and build once:
+                  the resulting error message reports the actual hash to replace it with.
+                '';
+              };
+              installPaths = lib.mkOption {
+                # A single directory name is upgraded to a one-element list; lists are merged by concatenation.
+                type = lib.types.coercedTo (lib.types.strMatching "[A-Za-z0-9_-]+") lib.singleton (
+                  lib.types.nonEmptyListOf (lib.types.strMatching "[A-Za-z0-9_-]+")
+                );
+                description = ''
+                  List of target subdirectory names below `models/`, such as `upscale_models`, `loras`, `checkpoints`.
+                  Write bare directory names (the module assembles them into `models/<installPath>`,
+                  one symlink per install path); a single string is also accepted and upgraded to a one-element list.
+                '';
+                example = [ "upscale_models" ];
+              };
+            };
+          }
+        );
+        default = [ ];
+        example = lib.literalExpression ''
+          [ {
+            name = "RealESRGAN_x4plus_anime_6B.pth";
+            url = "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.2.4/RealESRGAN_x4plus_anime_6B.pth";
+            hash = "sha256-+HLYN9PJDtLgUie+1xGvVnGm/RyffX6RyRGmHxVemdo=";
+            installPaths = [ "upscale_models" ];
+          } ]
+        '';
+        description = ''
+          ComfyUI models to fetch and symlink into `<dataDir>/models/<installPath>/<name>`,
+          where `<dataDir>` is the directory set by `services.comfyui.dataDir`.
+          Models are fetched at build time via `pkgs.fetchurl` and are not members of the nixpkgs package set,
+          so they never enter the nixpkgs binary cache.
+          Regular files placed manually under `<dataDir>/models/<type>/` are left untouched;
+          only symlinks there are managed (removed and rebuilt at start).
+          A manually placed regular file with the same name as a declared model prevents the service from starting,
+          because the symlink cannot be created over it.
+        '';
+      };
     };
   };
 
@@ -98,6 +176,20 @@ in
             cp --no-preserve=all -r ${cfg.package}/share/comfyui/$d "${cfg.dataDir}/"
           fi
         done
+
+        # Remove all model symlinks pointing into /nix/store,
+        # then rebuild the managed ones below,
+        # so removed declarations no longer leave stale entries.
+        readarray -d "" stale < <(find "${cfg.dataDir}/models" \
+          -type l -print0)
+        for link in "''${stale[@]}"; do
+          if [[ "$(readlink "$link")" == ${lib.escapeShellArg builtins.storeDir}/* ]]; then
+            rm "$link"
+          fi
+        done
+
+        # Rebuild model symlinks
+        ${modelSymlinks}
       '';
 
       serviceConfig = {

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -404,6 +404,7 @@ in
   code-server = runTest ./code-server.nix;
   coder = runTest ./coder.nix;
   collectd = runTest ./collectd.nix;
+  comfyui = runTest ./comfyui.nix;
   commafeed = runTest ./commafeed.nix;
   connman = runTest ./connman.nix;
   console = runTest ./console.nix;

--- a/nixos/tests/comfyui.nix
+++ b/nixos/tests/comfyui.nix
@@ -1,0 +1,62 @@
+{
+  pkgs,
+  ...
+}:
+let
+  # Fake model: local derivation via a file:// URL (must not fetchurl a real large model in CI).
+  fakeModel = pkgs.runCommand "fake-model" { } ''
+    mkdir -p $out
+    echo "fake checkpoint" > $out/fake-checkpoint.safetensors
+  '';
+  fakeModelUrl = "file://${fakeModel}/fake-checkpoint.safetensors";
+  fakeModelHash = "sha256-cYVCuccIZ3xo9vdsOvUA+i+SeXHj2Na9lX5p+cGgvus=";
+in
+{
+  name = "comfyui";
+  meta.maintainers = pkgs.comfyui.meta.maintainers;
+
+  nodes.machine = { ... }: {
+    services.comfyui = {
+      enable = true;
+      # VM has no GPU: CPU mode (ComfyUI aborts on CUDA detection failure without --cpu).
+      acceleration = "cpu";
+      # flask is not in ComfyUI's appDependencies: proves the extraPackages injection.
+      extraPackages = ps: [ ps.flask ];
+      models = [
+        {
+          name = "fake-checkpoint.safetensors";
+          url = fakeModelUrl;
+          hash = fakeModelHash;
+          installPaths = [ "checkpoints" ];
+        }
+      ];
+    };
+  };
+
+  testScript =
+    { nodes, ... }:
+    let
+      # The module exposes the fully overridden package (extraPackages, cudaSupport)
+      # via `services.comfyui.finalPackage`; read its pythonEnv to inspect it.
+      pythonEnv = nodes.machine.services.comfyui.finalPackage.pythonEnv;
+    in
+    ''
+      start_all()
+      machine.wait_for_unit("comfyui.service")
+      machine.wait_for_open_port(8188)
+
+      # extraPackages injects flask into ComfyUI's Python environment
+      machine.succeed("${pythonEnv}/bin/python -c 'import flask'")
+
+      # Model symlink points into /nix/store
+      machine.succeed("readlink -f /var/lib/comfyui/models/checkpoints/fake-checkpoint.safetensors | grep -q '^/nix/store'")
+
+      # Non-declarative coexistence: manually drop a file, restart (preStart re-runs),
+      # it survives and the declarative symlink is rebuilt.
+      machine.succeed("echo manual > /var/lib/comfyui/models/checkpoints/manual.safetensors")
+      machine.systemctl("restart", "comfyui")
+      machine.wait_for_open_port(8188)
+      machine.succeed("test -f /var/lib/comfyui/models/checkpoints/manual.safetensors")
+      machine.succeed("readlink -f /var/lib/comfyui/models/checkpoints/fake-checkpoint.safetensors | grep -q '^/nix/store'")
+    '';
+}

--- a/pkgs/by-name/co/comfyui/package.nix
+++ b/pkgs/by-name/co/comfyui/package.nix
@@ -1,12 +1,14 @@
 {
+  config,
   lib,
-  callPackage,
   cudaPackages_13,
   fetchFromGitHub,
   makeBinaryWrapper,
+  nixosTests,
   python3,
   stdenvNoCC,
-  withManager ? false,
+  extraPackages ? (ps: [ ]),
+  cudaSupport ? config.cudaSupport,
 }:
 
 let
@@ -18,9 +20,11 @@ let
       # older cudaPackages are not supported and actively disabled
       # https://github.com/Comfy-Org/ComfyUI/blob/v0.27.0/comfy/quant_ops.py#L25
       torch = prev.torch.override {
+        inherit cudaSupport;
         cudaPackages = cudaPackages_13;
       };
       triton = prev.triton.override {
+        inherit cudaSupport;
         cudaPackages = cudaPackages_13;
       };
     };
@@ -66,9 +70,7 @@ let
       transformers
       yarl
     ]
-    ++ lib.optionals withManager [
-      ps.comfyui-manager
-    ];
+    ++ (extraPackages ps);
 
   pythonEnv = python.withPackages appDependencies;
 in
@@ -118,11 +120,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   passthru = {
     inherit python pythonEnv;
-  }
-  // lib.optionalAttrs (!withManager) {
-    tests.withManager = callPackage ./package.nix {
-      withManager = true;
-    };
+    tests.comfyui = nixosTests.comfyui;
   };
 
   meta = {
@@ -133,6 +131,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     mainProgram = "comfyui";
     maintainers = with lib.maintainers; [
       caniko
+      knightfemale
       SuperSandro2000
     ];
     platforms = lib.platforms.linux;


### PR DESCRIPTION
## 1. Summary / Motivation

This PR extends the `services.comfyui` NixOS module with a declarative interface for the things every ComfyUI setup manages by hand today:

- **Models** (multi-GB checkpoints, LoRAs, upscale models): users currently `wget`/`curl` them into `/var/lib/comfyui/models/<type>/` manually — no hash verification, no reproducibility, no declarative record of what is installed.
- **Custom nodes** (community extensions loaded from `custom_nodes/`): installed by hand or by the in-app Manager, which `git clone`s into the state directory at runtime.
- **Node dependencies** (Python packages custom nodes import at runtime): unsatisfiable declaratively, because ComfyUI's wrapper explicitly unsets `PYTHONPATH`.
- **Hardware acceleration selection**: the package's CUDA support and the server's `--cpu` flag were previously left to global `nixpkgs.config.cudaSupport` and manual `extraArgs`, with no single switch.

The PR adds four options — `models`, `customNodes`, `extraPackages`, `acceleration` — that make the above declarative, reproducible, and hash-verified, while remaining fully optional and backward compatible.

## 2. New options

### `services.comfyui.models`

```nix
services.comfyui.models = [{
  name = "RealESRGAN_x4plus_anime_6B.pth";
  url = "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.2.4/RealESRGAN_x4plus_anime_6B.pth";
  hash = "sha256-…"; # nix-prefetch-url
  installPaths = [ "upscale_models" ];
}];
```

- Models are fetched at **build time** with `pkgs.fetchurl` and symlinked into `/var/lib/comfyui/models/<installPath>/<name>`.
- **They are deliberately not packaged in nixpkgs**: a model as a `pkgs.*` member would enter the official binary cache (multi-GB per model — not acceptable for the community). Fetching from module config keeps the download local to the user's store only.
- `installPaths` accepts a string or a list (`coercedTo`), so a single directory can be written plainly. Directory names are validated to be single-level (`[A-Za-z0-9_-]`, no `/`, `.`, `..`).

### `services.comfyui.customNodes`

```nix
services.comfyui.customNodes = with pkgs.comfyui-custom-nodes; [ comfyui-manager ];
```

- Each entry is a custom node **package** (source tree + patches + Python dependency declarations). The module symlinks it into `/var/lib/comfyui/custom_nodes/<name>` at service start and merges its `passthru.comfyui.pythonDeps` into ComfyUI's Python environment at build time.
- The required contract is minimal: node source at the `$out` root (so `$out/__init__.py` exists), `passthru.isComfyUICustomNode = true`, and an optional `passthru.comfyui.pythonDeps = ps: [ ... ]` function.
- Directory name: defaults to the package's `pname`. Set `passthru.comfyui.installName` only when a specific directory name is required (e.g. nodes that other nodes import by absolute path).

### `services.comfyui.extraPackages`

```nix
services.comfyui.extraPackages = with pkgs.python314Packages; [ comfyui-manager ];
```

- Adds packages to ComfyUI's Python environment. This is the escape hatch for node dependencies that are not expressed via `customNodes` `pythonDeps` (e.g. packages used directly, or PyPI-form nodes).
- `customNodes`' `pythonDeps` are merged automatically; both paths share the same override mechanism.

### `services.comfyui.acceleration`

```nix
services.comfyui.acceleration = "cuda"; # or "cpu", or null (default)
```

- `null` (default): follow the global `nixpkgs.config.cudaSupport` and any existing `services.comfyui.package` overrides — no behavior change.
- `"cpu"`: disable CUDA on the package and pass `--cpu` to the server. ComfyUI aborts on CUDA-detection failure on machines without a GPU, so this is the switch for CPU-only machines.
- `"cuda"`: enable CUDA support on the package. ComfyUI selects the CUDA device automatically, so no extra flag is added — this keeps the two branches consistent: `--cpu` is injected *only* for `"cpu"`.

## 3. Custom node package design

### Why packages, and why a `pkgs.comfyui-custom-nodes` collection

Custom nodes are just source trees loaded from `custom_nodes/`; most cannot run or be tested standalone. Yet modeling them as **Nix packages** gives us the two things hand-installation lacks: dependency declarations and content-addressed, GC-able sources.

The example `comfyui-manager` package lives under the new top-level collection `pkgs.comfyui-custom-nodes` (path `pkgs/servers/comfyui/custom-nodes/`), mirroring `pkgs.home-assistant-custom-components` — the established pattern for "host application plugin collection" top-level attrsets.

> Why not `pkgs.comfyuiPackages`? The `*Packages` suffix conventionally means "the whole ecosystem/toolchain", not "a host application's plugin category". The descriptive flat-collection form is the canonical shape for plugins.

### Why dependency injection via `passthru.comfyui.pythonDeps`

ComfyUI's wrapper explicitly unsets `PYTHONPATH` (`--unset NIX_PYTHONPATH --unset PYTHONPATH`), so the home-assistant "inject via PYTHONPATH" trick does not work here. Instead the module rebuilds the package's Python environment with the custom nodes' `pythonDeps` merged in — the same mechanism the package already uses for its own `appDependencies`.

The `pythonDeps` function is resolved lazily by the module against ComfyUI's own (overridden) `python3Packages`, so dependencies always come from the same package set as ComfyUI's environment (no `buildEnv` conflicts).

The `comfyui-manager` example declares twelve dependencies; the four imported by its `prestartup_script.py` at startup (`gitpython`, `toml`, `rich`, `chardet`) suppress the runtime `pip install` fallback entirely — a runtime `pip install` cannot work in a read-only store. The rest align with the top-level imports of the node's `glob/*.py` / `__init__.py` and with the nixpkgs `comfyui-manager` python package dependencies.

### Why no `name` field in `customNodes`

`services.comfyui.customNodes` takes a plain list of packages (like home-assistant's `customComponents`), not `{ name, package }` records. The directory name is derived from the package itself — `passthru.comfyui.installName` falling back to `pname` — so users write only `[ comfyui-manager ]`.

## 4. Non-declarative coexistence (both modes)

The module keeps the door open for hand-installed files:

- Files placed manually under `/var/lib/comfyui/models/<type>/` and directories under `/var/lib/comfyui/custom_nodes/` are **left untouched**.
- On start, only symlinks pointing into `/nix/store` are removed and rebuilt (the declaratively managed entries); everything else survives.

## 5. `withManager` removed

While adding `services.comfyui.customNodes` and `extraPackages`, I removed the `withManager` package parameter (not in any stable release yet):

- it was not functional on its own: neither the `comfyui` wrapper nor the module's `extraArgs` passed `--enable-manager`, so it only added `comfyui-manager` to the Python environment without activating it;
- it hardcoded a single package, which was ambiguous and duplicated what the generic `extraPackages` interface now does — use `services.comfyui.extraPackages = with pkgs.python314Packages; [ comfyui-manager ]` plus `extraArgs = [ "--enable-manager" ]` for the PyPI form, or declare `ComfyUI-Manager` via `services.comfyui.customNodes` for the repo form.

## 6. Testing

New NixOS test `nixos/tests/comfyui.nix` (registered in `all-tests.nix`), each of the four new options has direct coverage:

- `acceleration = "cpu"` → asserts `--cpu` is injected into the server args (`systemctl cat comfyui | grep -- --cpu`);
- `models` → fake model via `file://` URL + SRI hash, symlinked into `/var/lib/comfyui/models/checkpoints/`, pointed into `/nix/store`;
- `customNodes` → fake node with `WEB_DIRECTORY = "js"` symlinked into `custom_nodes/` via `installName`, a second fake node without `installName` asserting the `pname` fallback, and the frontend actually served (`curl /extensions/Fake-Custom-Node/fake.js`);
- `extraPackages` → `flask` (not in ComfyUI's `appDependencies`) injected and importable from the resulting Python environment;
- non-declarative coexistence: a manually dropped file survives a service restart while the declarative symlink is rebuilt.

The test is registered in `all-tests.nix` and hooked to the package via `comfyui.passthru.tests.comfyui` (per the nixos/README "New modules" checklist).

## 7. Module documentation

Added `nixos/modules/services/misc/comfyui.md` and wired it up with `meta.doc` (the init commit did not ship one; the new options deserve documented entry points).

## 8. Release notes

Added a `services.comfyui` entry to the 26.11 release notes (`nixos/doc/manual/release-notes/rl-2611.section.md`) mentioning the four new options.

> Happy to add any of you as reviewers/maintainers of the new options if you'd like.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
