### PR TITLE
ocamlPackages.odoc: remove `cmdliner_1` override for 3.2 and newer

### DIFF
--- a/pkgs/development/ocaml-modules/odoc/default.nix
+++ b/pkgs/development/ocaml-modules/odoc/default.nix
@@ -4,9 +4,9 @@
   ocaml-crunch,
   astring,
   cmdliner,
+  cmdliner_1,
   cppo,
   fpath,
-  result,
   tyxml,
   markup,
   yojson,
@@ -18,7 +18,7 @@
   fmt,
 }:
 
-buildDunePackage {
+buildDunePackage (self: {
   pname = "odoc";
   inherit (odoc-parser) version src;
 
@@ -28,7 +28,7 @@ buildDunePackage {
   ];
   buildInputs = [
     astring
-    cmdliner
+    (if lib.versionAtLeast self.version "3.2.0" then cmdliner else cmdliner_1)
     fpath
     tyxml
     odoc-parser
@@ -63,4 +63,4 @@ buildDunePackage {
     homepage = "https://github.com/ocaml/odoc";
     changelog = "https://github.com/ocaml/odoc/blob/${odoc-parser.version}/CHANGES.md";
   };
-}
+})

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1649,9 +1649,7 @@ let
 
         odig = callPackage ../development/ocaml-modules/odig { };
 
-        odoc = callPackage ../development/ocaml-modules/odoc {
-          cmdliner = cmdliner_1;
-        };
+        odoc = callPackage ../development/ocaml-modules/odoc { };
 
         odoc-parser = callPackage ../development/ocaml-modules/odoc-parser { };
 


### PR DESCRIPTION
It's no longer needed after the fixes in 3.2: https://github.com/ocaml/odoc/commit/4fa086b11d14962f41d9717f03a9d8413a8c20dd

This moves the override into the `default.nix` so we can conditionally apply the override for versions below 3.2.0.

Tested:

    nix-build -A ocamlPackages.odoc


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
