### PR TITLE
nixos/wpa_supplicant: replace `script`, remove dependency on bash

### DIFF
--- a/nixos/modules/services/networking/wpa_supplicant.nix
+++ b/nixos/modules/services/networking/wpa_supplicant.nix
@@ -102,6 +102,8 @@ let
             "-c /etc/wpa_supplicant/imperative.conf"
         )
         + lib.concatMapStrings (p: " -I " + p) cfg.extraConfigFiles;
+
+      enableAutoDetection = iface == null && cfg.autoDetectInterfaces;
     in
     {
       description = "WPA Supplicant instance" + optionalString (iface != null) " for interface ${iface}";
@@ -115,7 +117,8 @@ let
       stopIfChanged = false;
       restartTriggers = [ config.environment.etc."wpa_supplicant/nixos.conf".source ];
 
-      path = [ pkgs.wpa_supplicant ];
+      unitConfig.StartLimitIntervalSec = lib.mkIf enableAutoDetection 0;
+
       serviceConfig = {
         RuntimeDirectory = "wpa_supplicant";
         ExecStartPre =
@@ -131,7 +134,23 @@ let
             "+${pkgs.coreutils}/bin/mkdir -p /run/wpa_supplicant/client"
             "+${pkgs.coreutils}/bin/chown wpa_supplicant:wpa_supplicant /run/wpa_supplicant/client"
             "+${pkgs.coreutils}/bin/chmod g=u /run/wpa_supplicant/client"
+          ]
+          # auto-detect interfaces, and render arguments for wpa_supplicant to use.
+          ++ lib.optionals enableAutoDetection [
+            ''${lib.getExe' pkgs.findutils "find"} /sys/class/net -mindepth 1 -maxdepth 1 -exec ${lib.getExe' pkgs.coreutils "test"} -e {}/wireless \; -fprintf /run/wpa_supplicant/interface-args "-N -i%%f -s ${optionalString cfg.dbusControlled "-u"} -D${cfg.driver} ${configStr} "''
+            ''${lib.getExe' pkgs.gnused "sed"} -i -e "1s/^-N //" -e "1s/^/IFACE_ARGS=/" /run/wpa_supplicant/interface-args''
           ];
+        EnvironmentFile = optionals enableAutoDetection [ "-/run/wpa_supplicant/interface-args" ];
+        ExecStart =
+          if enableAutoDetection then
+            "${lib.getExe' pkgs.wpa_supplicant "wpa_supplicant"} $IFACE_ARGS"
+          else
+            "${lib.getExe' pkgs.wpa_supplicant "wpa_supplicant"} -s ${optionalString cfg.dbusControlled "-u"} -D${cfg.driver} ${configStr}"
+            + optionalString (iface != null) " -i${iface}";
+      }
+      // lib.optionalAttrs enableAutoDetection {
+        Restart = "on-failure";
+        RestartSec = "1s";
       }
       // lib.optionalAttrs cfg.enableHardening {
         User = "wpa_supplicant";
@@ -198,46 +217,6 @@ let
         SystemCallArchitectures = "native";
         UMask = "0077";
       };
-
-      script = ''
-        iface_args="-s ${optionalString cfg.dbusControlled "-u"} -D${cfg.driver} ${configStr}"
-        ${
-          if iface != null then
-            ''
-              # add known interface to the daemon arguments
-              args="-i${iface} $iface_args"
-            ''
-          else if cfg.autoDetectInterfaces then
-            ''
-              # detect interfaces automatically
-
-              # check if there are no wireless interfaces
-              if ! find -H /sys/class/net/* -name wireless | grep -q .; then
-                # if so, wait until one appears
-                echo "Waiting for wireless interfaces"
-                grep -q '^ACTION=add' < <(stdbuf -oL -- udevadm monitor -s net/wlan -pu)
-                # Note: the above line has been carefully written:
-                # 1. The process substitution avoids udevadm hanging (after grep has quit)
-                #    until it tries to write to the pipe again. Not even pipefail works here.
-                # 2. stdbuf is needed because udevadm output is buffered by default and grep
-                #    may hang until more udev events enter the pipe.
-              fi
-
-              # add any interface found to the daemon arguments
-              for name in $(find -H /sys/class/net/* -name wireless | cut -d/ -f 5); do
-                echo "Adding interface $name"
-                args+="''${args:+ -N} -i$name $iface_args"
-              done
-            ''
-          else
-            "args=$iface_args"
-        }
-
-        # finally start daemon
-        # shellcheck disable=SC2086
-        exec wpa_supplicant $args
-      '';
-      enableStrictShellChecks = true;
     };
 
   systemctl = "/run/current-system/systemd/bin/systemctl";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The main goal of this PR is to replace the `script` attribute from the wpa_supplicant systemd service(s) with other systemd directives , in order to make it usable with the bashless profile.

The hard part to solve here was the autodetection loop. The intended replacement logic is as following:

- We use `find` and `sed` to shape the argument string for `wpa_supplicant`, similar to what was being done in the bash for loop in the previous implementation. The flags will be picked up on `ExecStart` through `EnvironmentFile`.
- We use `Restart=on-failure` with `StartLimitIntervalSec=0` to loop endlessly to handle missing devices during boot.

I've spent some time looking at #127595 and the related issues. The replacement solution I'm proposing is arguably worse, as it changes service from reacting to udev events to essentially polling for devices. However, I haven't found any good way to await udev events without resorting to using the shell (apart from maybe making a different type of wrapper). I played around with path activation, but fsnotify is no good on sysfs. Using a restart loop removes a potential race condition of having the udev event appear inbetween the `find` and the `grep` for what it's worth (I haven't verified this is a real bug, it just seems likely from looking at the code).

All NixOS tests are passing (`nix build .#nixosTests.wpa_supplicant.{basic,imperative,saeOnly,mixedUsingSae,mixedUsingWpa2,legacy,bssidGuard} -L`)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
