### PR TITLE
python3Packages.itkwasm: 1.0b195 -> 1.0b200

### DIFF
--- a/pkgs/development/python-modules/itkwasm-downsample-emscripten/default.nix
+++ b/pkgs/development/python-modules/itkwasm-downsample-emscripten/default.nix
@@ -10,13 +10,13 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "itkwasm-downsample-emscripten";
-  version = "1.8.1";
+  version = "2.0.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "itkwasm_downsample_emscripten";
     inherit (finalAttrs) version;
-    hash = "sha256-kF851K6cy1jozPxd5zE8XVnBAHMljmOqtvpmfmQDZy4=";
+    hash = "sha256-Gz4sO6udvY/5AZzQcB5DE6+pk2cmSMmuQor7wNj9Wv8=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/itkwasm-downsample-wasi/default.nix
+++ b/pkgs/development/python-modules/itkwasm-downsample-wasi/default.nix
@@ -11,13 +11,13 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "itkwasm-downsample-wasi";
-  version = "1.8.1";
+  version = "2.0.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "itkwasm_downsample_wasi";
     inherit (finalAttrs) version;
-    hash = "sha256-OykKkZRlRGDw+SsK69z6dqh6LY7eUlyHGdZwmkKsMKQ=";
+    hash = "sha256-5vqw+sb9Zb0npYiDtzUla3JT5zEimOD5gAnwxcYi4cM=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/itkwasm-downsample/default.nix
+++ b/pkgs/development/python-modules/itkwasm-downsample/default.nix
@@ -12,13 +12,13 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "itkwasm-downsample";
-  version = "1.8.1";
+  version = "2.0.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "itkwasm_downsample";
     inherit (finalAttrs) version;
-    hash = "sha256-tKkct5+39p5jM/vBj3RTSM1YZZoLnajh85Eon4/wavs=";
+    hash = "sha256-LP9sg4VFc1/niioRzAR9cbwdl6fiEkrOpGT7vjj+6LQ=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/itkwasm/default.nix
+++ b/pkgs/development/python-modules/itkwasm/default.nix
@@ -13,12 +13,12 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "itkwasm";
-  version = "1.0b195";
+  version = "1.0b200";
   pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
-    hash = "sha256-1OQ0SieMEcrWiIgWT1dQxXdk9lCbWD+1xJ0jfIr0isU=";
+    hash = "sha256-vhN4Nm5tuGDRYYZKFyC+mH+LxW4UXmVxZDzsQI48U4s=";
   };
 
   build-system = [ hatchling ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
