### PR TITLE
nixos/getty: remove dash from closure if autologinOnce is disabled

### DIFF
--- a/nixos/modules/services/ttys/getty.nix
+++ b/nixos/modules/services/ttys/getty.nix
@@ -28,16 +28,13 @@ let
 
   gettyCmd = args: "${lib.getExe' pkgs.util-linux "agetty"} ${escapeShellArgs baseArgs} ${args}";
 
-  autologinScript = ''
-    otherArgs="--noclear --keep-baud $TTY 115200,38400,9600 $TERM";
-    ${lib.optionalString cfg.autologinOnce ''
-      autologged="/run/agetty.autologged"
-      if test "$TTY" = tty1 && ! test -f "$autologged"; then
-        touch "$autologged"
-        exec ${gettyCmd "$otherArgs --autologin ${cfg.autologinUser}"}
-      fi
-    ''}
-    exec ${gettyCmd "$otherArgs"}
+  autologinOnceScript = otherArgs: ''
+    autologged="/run/agetty.autologged"
+    if test "$TTY" = tty1 && ! test -f "$autologged"; then
+      touch "$autologged"
+      exec ${gettyCmd "${otherArgs} --autologin ${cfg.autologinUser}"}
+    fi
+    exec ${gettyCmd otherArgs}
   '';
 
 in
@@ -179,7 +176,15 @@ in
       serviceConfig.ExecStart = [
         # override upstream default with an empty ExecStart
         ""
-        (pkgs.writers.writeDash "getty" autologinScript)
+        (
+          let
+            args = "--noclear --keep-baud $TTY 115200,38400,9600 $TERM";
+          in
+          if cfg.autologinOnce then
+            (pkgs.writers.writeDash "getty" (autologinOnceScript args))
+          else
+            gettyCmd args
+        )
       ];
       environment.TTY = "%I";
       restartIfChanged = false;

--- a/nixos/modules/services/ttys/getty.nix
+++ b/nixos/modules/services/ttys/getty.nix
@@ -28,14 +28,19 @@ let
 
   gettyCmd = args: "${lib.getExe' pkgs.util-linux "agetty"} ${escapeShellArgs baseArgs} ${args}";
 
-  autologinOnceScript = otherArgs: ''
-    autologged="/run/agetty.autologged"
-    if test "$TTY" = tty1 && ! test -f "$autologged"; then
-      touch "$autologged"
-      exec ${gettyCmd "${otherArgs} --autologin ${cfg.autologinUser}"}
-    fi
-    exec ${gettyCmd otherArgs}
-  '';
+  autologinOnceScript =
+    otherArgs:
+    pkgs.writeShellApplication {
+      name = "autologin-once";
+      text = ''
+        autologged="/run/agetty.autologged"
+        if test "$TTY" = tty1 && ! test -f "$autologged"; then
+          touch "$autologged"
+          exec ${gettyCmd "${otherArgs} --autologin ${cfg.autologinUser}"}
+        fi
+        exec ${gettyCmd otherArgs}
+      '';
+    };
 
 in
 
@@ -177,13 +182,10 @@ in
         # override upstream default with an empty ExecStart
         ""
         (
-          let
-            args = "--noclear --keep-baud $TTY 115200,38400,9600 $TERM";
-          in
           if cfg.autologinOnce then
-            (pkgs.writers.writeDash "getty" (autologinOnceScript args))
+            lib.getExe (autologinOnceScript ''--noclear --keep-baud "$TTY" 115200,38400,9600 "$TERM"'')
           else
-            gettyCmd args
+            gettyCmd "--noclear --keep-baud %I 115200,38400,9600 $TERM"
         )
       ];
       environment.TTY = "%I";


### PR DESCRIPTION
autologinOnce sets up a lock file in /run to prevent later automatic logins. This needs some extra logic to check wether the lock exists already, and then logging in a user. This extra check is implemented in `dash` and skipped entirely if autologinOnce is disabled, yet dash was still used.

Instead, if autologinOnce is disabled, getty should just start immediately from ExecStart, without additional script interpreters on the way.

cc @nikstur. This isn't `bash`, this is `dash`, but i know you are interested in interpreter-less systems.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
