### PR TITLE
frankenphp: 1.12.6 -> 1.12.7

### DIFF
--- a/pkgs/by-name/fr/frankenphp/package.nix
+++ b/pkgs/by-name/fr/frankenphp/package.nix
@@ -30,13 +30,13 @@ let
 in
 buildGoModule (finalAttrs: {
   pname = "frankenphp";
-  version = "1.12.6";
+  version = "1.12.7";
 
   src = fetchFromGitHub {
     owner = "php";
     repo = "frankenphp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Rj4ClbTP0vqHtCZZNQQHFIVZ/Ep6F7W4MY6CztVV9LQ=";
+    hash = "sha256-UDxtI/+QSBRLZouHD3Lxdg4GFpU8tqybyPMvWpP/FA0=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/caddy";
@@ -44,7 +44,7 @@ buildGoModule (finalAttrs: {
   # frankenphp requires C code that would be removed with `go mod tidy`
   # https://github.com/golang/go/issues/26366
   proxyVendor = true;
-  vendorHash = "sha256-28CWF9AUweUoCBDWtG10XGACpkslEPrVvkj1VDCrTiM=";
+  vendorHash = "sha256-RXD7mJIV7cgo1YG8ECepuWtvIiOHbcZ1by/noaQZVFI=";
 
   buildInputs = [
     phpUnwrapped


### PR DESCRIPTION
Update frankenphp to 1.12.7, based on information from https://github.com/php/frankenphp/releases.

meta.description for frankenphp is: Modern PHP app server

meta.homepage for frankenphp is: https://github.com/php/frankenphp

meta.changelog for frankenphp is: https://github.com/php/frankenphp/releases/tag/v1.12.7


###### Updates performed
- Version update: 1.12.6 -> 1.12.7 (manual, bot was not aware of the release yet)

###### To inspect upstream changes

https://github.com/php/frankenphp/compare/v1.12.6...v1.12.7


###### Impact

<b>Checks done</b>

---

- built on NixOS
- The tests defined in `passthru.tests`, if any, passed
- found 1.12.7 with grep in /nix/store/zhqf4v1mcp885d153d6b3yn90vnayxkk-frankenphp-1.12.7
- found 1.12.7 in filename of file in /nix/store/zhqf4v1mcp885d153d6b3yn90vnayxkk-frankenphp-1.12.7

---

<details>
<summary>
<b>Rebuild report</b> (if merged into master) (click to expand)
</summary>

```
2 package rebuild(s)

frankenphp
tests.config-nix-unit
```

</details>

<details>
<summary>
<b>Instructions to test this update</b> (click to expand)
</summary>

---

Or, **build yourself**:
```
nix build github:vasilvestre/nixpkgs/441e94001#frankenphp
```

After you've downloaded or built it, look at the files and if there are any, run the binaries:
```
frankenphp version
```
which should output `FrankenPHP 1.12.7`.

---

</details>
<br/>



### Pre-merge build results

We have automatically built all packages that will get rebuilt due to
this change.

This gives evidence on whether the upgrade will break dependent packages.
Note sometimes packages show up as _failed to build_ independent of the
change, simply because they are already broken on the target branch.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 550145`
Commit: `441e94001`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>frankenphp</li>
    <li>tests.config-nix-unit</li>
  </ul>
</details>

---

###### Maintainer pings

cc @piotrkwiecinski for [testing](https://github.com/nix-community/nixpkgs-update/blob/main/doc/nixpkgs-maintainer-faq.md#r-ryantm-opened-a-pr-for-my-package-what-do-i-do).

> [!TIP]
> As a maintainer, if your package is located under `pkgs/by-name/*`, you can comment **`@NixOS/nixpkgs-merge-bot merge`** to automatically merge this update using the [`nixpkgs-merge-bot`](https://github.com/NixOS/nixpkgs/blob/master/ci/README.md#nixpkgs-merge-bot).