### PR TITLE
firefoxpwa: fix DRM

### DIFF
--- a/pkgs/by-name/fi/firefoxpwa-unwrapped/package.nix
+++ b/pkgs/by-name/fi/firefoxpwa-unwrapped/package.nix
@@ -95,6 +95,17 @@ rustPlatform.buildRustPackage rec {
     binaryName = "firefoxpwa";
     applicationName = "firefoxpwa";
     inherit (firefoxRuntime) gtk3;
+    # Inherit all variables that related for wrapping, since this derivation is
+    # wrapped similarly to `firefoxRuntime`, and these passthru variables are
+    # read when `wrapFirefox` wraps this derivation too.
+    inherit (firefoxRuntime)
+      ffmpegSupport
+      gssSupport
+      alsaSupport
+      pipewireSupport
+      sndioSupport
+      jackSupport
+      ;
   };
 
   meta = {


### PR DESCRIPTION
This is how the 3 diff looks like:

```
  after.txt | before.txt|  firefox.txt
+ +--  3 lines: /nix/store/hz2c9dgirq57csa0v0laas9cah5h49dl-systemd-min│+ +--  3 lines: /nix/store/hz2c9dgirq57csa0v0laas9cah5h49dl-systemd-mi│+ +--  3 lines: /nix/store/hz2c9dgirq57csa0v0laas9cah5h49dl-systemd-mi
  /nix/store/knlcss9wcq9wl1b4mxfzbn9zw23p41lc-libnotify-0.8.8/lib      │  /nix/store/knlcss9wcq9wl1b4mxfzbn9zw23p41lc-libnotify-0.8.8/lib     │  /nix/store/knlcss9wcq9wl1b4mxfzbn9zw23p41lc-libnotify-0.8.8/lib
  /nix/store/mgilpndnwz54gc6b8izrm0wyjww8klf4-libxscrnsaver-1.2.5/lib  │  /nix/store/mgilpndnwz54gc6b8izrm0wyjww8klf4-libxscrnsaver-1.2.5/lib │  /nix/store/mgilpndnwz54gc6b8izrm0wyjww8klf4-libxscrnsaver-1.2.5/lib
  /nix/store/3r10j3q6hdsglyq7dbxbjhw7abr26srn-cups-2.4.19-lib/lib      │  /nix/store/3r10j3q6hdsglyq7dbxbjhw7abr26srn-cups-2.4.19-lib/lib     │  /nix/store/3r10j3q6hdsglyq7dbxbjhw7abr26srn-cups-2.4.19-lib/lib
  /nix/store/bgxyb8y2fwf52f3y77y175bh8apshfv3-pciutils-3.15.0/lib      │  /nix/store/bgxyb8y2fwf52f3y77y175bh8apshfv3-pciutils-3.15.0/lib     │  /nix/store/bgxyb8y2fwf52f3y77y175bh8apshfv3-pciutils-3.15.0/lib
  /nix/store/i5p83jmafxzw98q980k8qwhdby5yf0i4-vulkan-loader-1.4.350.0/l│  /nix/store/i5p83jmafxzw98q980k8qwhdby5yf0i4-vulkan-loader-1.4.350.0/│  /nix/store/i5p83jmafxzw98q980k8qwhdby5yf0i4-vulkan-loader-1.4.350.0/
  /nix/store/90dwfpy19mxi536v98cjg3bibc3lnjgb-speech-dispatcher-0.12.1/│  /nix/store/90dwfpy19mxi536v98cjg3bibc3lnjgb-speech-dispatcher-0.12.1│  /nix/store/90dwfpy19mxi536v98cjg3bibc3lnjgb-speech-dispatcher-0.12.1
  /nix/store/4n1la41z3iqhq5nlrpkmd15k61rh0ch0-pipewire-1.6.8/lib       │  --------------------------------------------------------------------│  /nix/store/4n1la41z3iqhq5nlrpkmd15k61rh0ch0-pipewire-1.6.8/lib
  /nix/store/d4yyvx1d0p7041jz2zwvd7fx4xh8q5kh-ffmpeg-7.1.5-lib/lib     │  --------------------------------------------------------------------│  /nix/store/d4yyvx1d0p7041jz2zwvd7fx4xh8q5kh-ffmpeg-7.1.5-lib/lib
  /nix/store/qiwg67zp9w898zwr57g2lnhmhk0bifxa-krb5-1.22.2-lib/lib      │  --------------------------------------------------------------------│  /nix/store/qiwg67zp9w898zwr57g2lnhmhk0bifxa-krb5-1.22.2-lib/lib
  /nix/store/bcm3mwyfja8rd2y995vcnzq06b341nnz-libglvnd-1.7.0/lib       │  /nix/store/bcm3mwyfja8rd2y995vcnzq06b341nnz-libglvnd-1.7.0/lib      │  /nix/store/bcm3mwyfja8rd2y995vcnzq06b341nnz-libglvnd-1.7.0/lib
  /nix/store/c90fysvnhkyjwbyjxgbfz8lqq1alps76-libpulseaudio-17.0/lib   │  /nix/store/c90fysvnhkyjwbyjxgbfz8lqq1alps76-libpulseaudio-17.0/lib  │  /nix/store/c90fysvnhkyjwbyjxgbfz8lqq1alps76-libpulseaudio-17.0/lib
  /nix/store/71ng8shgss15xpxmjs935cjdxsq2jwxd-alsa-lib-1.2.16.1/lib    │  --------------------------------------------------------------------│  /nix/store/71ng8shgss15xpxmjs935cjdxsq2jwxd-alsa-lib-1.2.16.1/lib
  /nix/store/iz2aszflkdsx60wm3kqk14x7xln2rj7v-sndio-1.10.0/lib         │  --------------------------------------------------------------------│  /nix/store/iz2aszflkdsx60wm3kqk14x7xln2rj7v-sndio-1.10.0/lib
  /nix/store/pybnxrf7wgl94ssj5gs4ikv4ggpvkyq6-libjack2-1.9.22/lib      │  --------------------------------------------------------------------│  /nix/store/pybnxrf7wgl94ssj5gs4ikv4ggpvkyq6-libjack2-1.9.22/lib
  /nix/store/bngxc1jjnb57hcrnr5zrs690bggmq54a-libcanberra-0.30/lib     │  /nix/store/bngxc1jjnb57hcrnr5zrs690bggmq54a-libcanberra-0.30/lib    │  /nix/store/bngxc1jjnb57hcrnr5zrs690bggmq54a-libcanberra-0.30/lib
  /nix/store/hz2c9dgirq57csa0v0laas9cah5h49dl-systemd-minimal-libs-261.│  /nix/store/hz2c9dgirq57csa0v0laas9cah5h49dl-systemd-minimal-libs-261│  /nix/store/hz2c9dgirq57csa0v0laas9cah5h49dl-systemd-minimal-libs-261
  /nix/store/426bln8z8kcvxlhqwb1k85lw0y2bxcvz-libva-2.24.0/lib64       │  /nix/store/426bln8z8kcvxlhqwb1k85lw0y2bxcvz-libva-2.24.0/lib64      │  /nix/store/426bln8z8kcvxlhqwb1k85lw0y2bxcvz-libva-2.24.0/lib64
  /nix/store/m2r2yjknh4grrafd39j016c75rqlkp54-mesa-libgbm-26.1.3/lib64 │  /nix/store/m2r2yjknh4grrafd39j016c75rqlkp54-mesa-libgbm-26.1.3/lib64│  /nix/store/m2r2yjknh4grrafd39j016c75rqlkp54-mesa-libgbm-26.1.3/lib64
  /nix/store/knlcss9wcq9wl1b4mxfzbn9zw23p41lc-libnotify-0.8.8/lib64    │  /nix/store/knlcss9wcq9wl1b4mxfzbn9zw23p41lc-libnotify-0.8.8/lib64   │  /nix/store/knlcss9wcq9wl1b4mxfzbn9zw23p41lc-libnotify-0.8.8/lib64
  /nix/store/mgilpndnwz54gc6b8izrm0wyjww8klf4-libxscrnsaver-1.2.5/lib64│  /nix/store/mgilpndnwz54gc6b8izrm0wyjww8klf4-libxscrnsaver-1.2.5/lib6│  /nix/store/mgilpndnwz54gc6b8izrm0wyjww8klf4-libxscrnsaver-1.2.5/lib6
  /nix/store/3r10j3q6hdsglyq7dbxbjhw7abr26srn-cups-2.4.19-lib/lib64    │  /nix/store/3r10j3q6hdsglyq7dbxbjhw7abr26srn-cups-2.4.19-lib/lib64   │  /nix/store/3r10j3q6hdsglyq7dbxbjhw7abr26srn-cups-2.4.19-lib/lib64
  /nix/store/bgxyb8y2fwf52f3y77y175bh8apshfv3-pciutils-3.15.0/lib64    │  /nix/store/bgxyb8y2fwf52f3y77y175bh8apshfv3-pciutils-3.15.0/lib64   │  /nix/store/bgxyb8y2fwf52f3y77y175bh8apshfv3-pciutils-3.15.0/lib64
  /nix/store/i5p83jmafxzw98q980k8qwhdby5yf0i4-vulkan-loader-1.4.350.0/l│  /nix/store/i5p83jmafxzw98q980k8qwhdby5yf0i4-vulkan-loader-1.4.350.0/│  /nix/store/i5p83jmafxzw98q980k8qwhdby5yf0i4-vulkan-loader-1.4.350.0/
  /nix/store/90dwfpy19mxi536v98cjg3bibc3lnjgb-speech-dispatcher-0.12.1/│  /nix/store/90dwfpy19mxi536v98cjg3bibc3lnjgb-speech-dispatcher-0.12.1│  /nix/store/90dwfpy19mxi536v98cjg3bibc3lnjgb-speech-dispatcher-0.12.1
  /nix/store/4n1la41z3iqhq5nlrpkmd15k61rh0ch0-pipewire-1.6.8/lib64     │  --------------------------------------------------------------------│  /nix/store/4n1la41z3iqhq5nlrpkmd15k61rh0ch0-pipewire-1.6.8/lib64
  /nix/store/d4yyvx1d0p7041jz2zwvd7fx4xh8q5kh-ffmpeg-7.1.5-lib/lib64   │  --------------------------------------------------------------------│  /nix/store/d4yyvx1d0p7041jz2zwvd7fx4xh8q5kh-ffmpeg-7.1.5-lib/lib64
  /nix/store/qiwg67zp9w898zwr57g2lnhmhk0bifxa-krb5-1.22.2-lib/lib64    │  --------------------------------------------------------------------│  /nix/store/qiwg67zp9w898zwr57g2lnhmhk0bifxa-krb5-1.22.2-lib/lib64
  /nix/store/bcm3mwyfja8rd2y995vcnzq06b341nnz-libglvnd-1.7.0/lib64     │  /nix/store/bcm3mwyfja8rd2y995vcnzq06b341nnz-libglvnd-1.7.0/lib64    │  /nix/store/bcm3mwyfja8rd2y995vcnzq06b341nnz-libglvnd-1.7.0/lib64
  /nix/store/c90fysvnhkyjwbyjxgbfz8lqq1alps76-libpulseaudio-17.0/lib64 │  /nix/store/c90fysvnhkyjwbyjxgbfz8lqq1alps76-libpulseaudio-17.0/lib64│  /nix/store/c90fysvnhkyjwbyjxgbfz8lqq1alps76-libpulseaudio-17.0/lib64
  /nix/store/71ng8shgss15xpxmjs935cjdxsq2jwxd-alsa-lib-1.2.16.1/lib64  │  --------------------------------------------------------------------│  /nix/store/71ng8shgss15xpxmjs935cjdxsq2jwxd-alsa-lib-1.2.16.1/lib64
  /nix/store/iz2aszflkdsx60wm3kqk14x7xln2rj7v-sndio-1.10.0/lib64       │  --------------------------------------------------------------------│  /nix/store/iz2aszflkdsx60wm3kqk14x7xln2rj7v-sndio-1.10.0/lib64
  /nix/store/pybnxrf7wgl94ssj5gs4ikv4ggpvkyq6-libjack2-1.9.22/lib64    │  --------------------------------------------------------------------│  /nix/store/pybnxrf7wgl94ssj5gs4ikv4ggpvkyq6-libjack2-1.9.22/lib64
  /nix/store/bngxc1jjnb57hcrnr5zrs690bggmq54a-libcanberra-0.30/lib64   │  /nix/store/bngxc1jjnb57hcrnr5zrs690bggmq54a-libcanberra-0.30/lib64  │  /nix/store/bngxc1jjnb57hcrnr5zrs690bggmq54a-libcanberra-0.30/lib64
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test