### PR TITLE
ocamlPackages.{eio-ssl,piaf}: fix build

### DIFF
--- a/pkgs/development/ocaml-modules/eio-ssl/default.nix
+++ b/pkgs/development/ocaml-modules/eio-ssl/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildDunePackage,
   fetchurl,
+  fetchpatch,
   eio,
   ssl,
 }:
@@ -14,6 +15,13 @@ buildDunePackage (finalAttrs: {
     url = "https://github.com/anmonteiro/eio-ssl/releases/download/${finalAttrs.version}/eio-ssl-${finalAttrs.version}.tbz";
     hash = "sha256-m4CiUQtXVSMfLthbDsAftpiOsr24I5IGiU1vv7Rz8go=";
   };
+
+  patches =
+    # Compatibility with eio 1.4
+    lib.optional (lib.versionAtLeast eio.version "1.4") (fetchpatch {
+      url = "https://github.com/anmonteiro/eio-ssl/commit/8cf6bccd2c272445d1dc93eb1d65e965f95646d4.patch";
+      hash = "sha256-NnwWDhr5H70EFVK+1/qbIA+srJHjxSvtWvakBXnrZMI=";
+    });
 
   propagatedBuildInputs = [
     eio

--- a/pkgs/development/ocaml-modules/eio/default.nix
+++ b/pkgs/development/ocaml-modules/eio/default.nix
@@ -77,7 +77,7 @@ buildDunePackage (finalAttrs: {
     mdx.bin
   ];
 
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "5.1";
 
   meta = {
     homepage = "https://github.com/ocaml-multicore/eio";

--- a/pkgs/development/ocaml-modules/piaf/default.nix
+++ b/pkgs/development/ocaml-modules/piaf/default.nix
@@ -2,6 +2,7 @@
   alcotest,
   buildDunePackage,
   fetchurl,
+  fetchpatch,
   eio-ssl,
   faraday,
   h2-eio,
@@ -29,6 +30,21 @@ buildDunePackage (finalAttrs: {
     url = "https://github.com/anmonteiro/piaf/releases/download/${finalAttrs.version}/piaf-${finalAttrs.version}.tbz";
     hash = "sha256-B/qQCaUvrqrm2GEW51AH9SebGFx7x8laq5RV8hBzcPs=";
   };
+
+  patches =
+    # Compatibility with eio 1.4
+    lib.optionals (lib.versionAtLeast eio_main.version "1.4") [
+      (fetchpatch {
+        url = "https://github.com/anmonteiro/piaf/commit/5b2f44683fb7eabdb78f43848c9e0a448e741fc3.patch";
+        includes = [ "lib/*.ml" ];
+        hash = "sha256-/Y3OQtqoA4DCgs3Ai2EPCipMb/xSwDAN7+6MTFoHKXI=";
+      })
+      (fetchpatch {
+        url = "https://github.com/anmonteiro/piaf/commit/b8f5e94deea6e653025c37131bbf6833dc4c4c85.patch";
+        includes = [ "lib/*.ml" ];
+        hash = "sha256-gazYJFlM9OeuixpJnLwANZj/DVqdc8vacd1a6v35SpM=";
+      })
+    ];
 
   propagatedBuildInputs = [
     eio-ssl


### PR DESCRIPTION
Fixes regressions due to the `eio` update (#524459).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
