### PR TITLE
lulu: 4.3.1 -> 4.5.1 and added metadata

### DIFF
--- a/pkgs/by-name/lu/lulu/package.nix
+++ b/pkgs/by-name/lu/lulu/package.nix
@@ -8,14 +8,14 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "lulu";
-  version = "4.3.1";
+  version = "4.5.1";
 
   __structuredAttrs = true;
   strictDeps = true;
 
   src = fetchurl {
     url = "https://github.com/objective-see/LuLu/releases/download/v${finalAttrs.version}/LuLu_${finalAttrs.version}.dmg";
-    hash = "sha256-zANmUn8fQSMpX9EzKaCAMaZgr9JWB23asD5gdDZc75M=";
+    hash = "sha256-mPTTQn9Mb8z5aA/tIoeb6Qpa6B6A64YWwddYdVtrtiQ=";
   };
 
   nativeBuildInputs = [ undmg ];
@@ -41,12 +41,34 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Free open-source macOS firewall that alerts you to outgoing network connections";
+    longDescription = ''
+      Nearly every application makes network connections. So does malware.
+      LuLu is a free, open-source firewall that blocks unknown outgoing
+      connections, protecting your privacy and your Mac.
+    '';
     homepage = "https://objective-see.org/products/lulu.html";
+    downloadPage = "https://objective-see.org/products/lulu.html";
     changelog = "https://github.com/objective-see/LuLu/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;
-    mainProgram = "LuLu";
-    maintainers = with lib.maintainers; [ philocalyst ];
     platforms = lib.platforms.darwin;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    identifiers = {
+      cpeParts = {
+        vendor = "objective-see";
+        product = "lulu";
+        version = finalAttrs.version;
+        target_sw = "macos";
+      };
+      purlParts = {
+        type = "github";
+        namespace = "objective-see";
+        name = "lulu";
+        version = finalAttrs.version;
+      };
+    };
+    maintainers = with lib.maintainers; [
+      KristijanZic
+      philocalyst
+    ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Updated lulu: 4.3.1 -> 4.5.1 and added metadata information, removed redundant mainProgram

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
