### PR TITLE
synfigstudio: 1.5.3 -> 1.5.5; modernize

### DIFF
--- a/pkgs/by-name/sy/synfigstudio/package.nix
+++ b/pkgs/by-name/sy/synfigstudio/package.nix
@@ -5,6 +5,7 @@
   pkg-config,
   autoreconfHook,
   wrapGAppsHook3,
+  gitUpdater,
 
   cairo,
   ffmpeg,
@@ -37,23 +38,29 @@ let
     hash = "sha256-5jVd+YqHVHKkePXBb3zjXEVlgdlU6Yb6LC4CurvsBtE=";
   };
 
-  ETL = stdenv.mkDerivation {
+  ETL = stdenv.mkDerivation (finalAttrs: {
     pname = "ETL";
     inherit version src;
 
     sourceRoot = "${src.name}/ETL";
 
+    __structuredAttrs = true;
+    strictDeps = true;
+
     nativeBuildInputs = [
       pkg-config
       autoreconfHook
     ];
-  };
+  });
 
-  synfig = stdenv.mkDerivation {
+  synfig = stdenv.mkDerivation (finalAttrs: {
     pname = "synfig";
     inherit version src;
 
     sourceRoot = "${src.name}/synfig-core";
+
+    __structuredAttrs = true;
+    strictDeps = true;
 
     configureFlags = lib.optionals stdenv.cc.isClang [
       # Newer versions of clang default to C++17, but synfig and some of its dependencies use deprecated APIs that
@@ -86,13 +93,16 @@ let
       ffmpeg
       libmng
     ];
-  };
+  });
 in
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "synfigstudio";
   inherit version src;
 
   sourceRoot = "${src.name}/synfig-studio";
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   postPatch = ''
     patchShebangs images/splash_screen_development.sh
@@ -140,13 +150,17 @@ stdenv.mkDerivation {
   passthru = {
     # Expose libraries and cli tools
     inherit ETL synfig;
+
+    updateScript = gitUpdater { rev-prefix = "v"; };
   };
 
   meta = {
     description = "2D animation program";
     homepage = "https://www.synfig.org";
+    changelog = "https://github.com/synfig/synfig/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;
+    mainProgram = "synfigstudio";
     maintainers = [ ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
-}
+})

--- a/pkgs/by-name/sy/synfigstudio/package.nix
+++ b/pkgs/by-name/sy/synfigstudio/package.nix
@@ -6,34 +6,35 @@
   autoreconfHook,
   wrapGAppsHook3,
 
-  boost,
   cairo,
+  ffmpeg,
   gettext,
   glibmm,
+  libmng,
   gtk3,
   gtkmm3,
   libjack2,
   libsigcxx,
   libxmlxx,
   mlt,
-  pango,
   imagemagick,
   intltool,
   adwaita-icon-theme,
   harfbuzz,
   freetype,
+  fontconfig,
   fribidi,
   openexr,
   fftw,
 }:
 
 let
-  version = "1.5.3";
+  version = "1.5.5";
   src = fetchFromGitHub {
     owner = "synfig";
     repo = "synfig";
     rev = "v${version}";
-    hash = "sha256-D+FUEyzJ74l0USq3V9HIRAfgyJfRP372aEKDqF8+hsQ=";
+    hash = "sha256-5jVd+YqHVHKkePXBb3zjXEVlgdlU6Yb6LC4CurvsBtE=";
   };
 
   ETL = stdenv.mkDerivation {
@@ -46,9 +47,6 @@ let
       pkg-config
       autoreconfHook
     ];
-    buildInputs = [
-      glibmm
-    ];
   };
 
   synfig = stdenv.mkDerivation {
@@ -57,11 +55,7 @@ let
 
     sourceRoot = "${src.name}/synfig-core";
 
-    configureFlags = [
-      "--with-boost=${boost.dev}"
-      "--with-boost-libdir=${boost.out}/lib"
-    ]
-    ++ lib.optionals stdenv.cc.isClang [
+    configureFlags = lib.optionals stdenv.cc.isClang [
       # Newer versions of clang default to C++17, but synfig and some of its dependencies use deprecated APIs that
       # are removed in C++17. Setting the language version to C++14 allows it to build.
       "CXXFLAGS=-std=c++14"
@@ -74,22 +68,23 @@ let
       autoreconfHook
       gettext
       intltool
+      imagemagick
     ];
     buildInputs = [
       ETL
-      boost
-      cairo
       glibmm
       mlt
       libsigcxx
       libxmlxx
-      pango
       imagemagick
       harfbuzz
       freetype
+      fontconfig
       fribidi
       openexr
       fftw
+      ffmpeg
+      libmng
     ];
   };
 in
@@ -119,11 +114,11 @@ stdenv.mkDerivation {
     gettext
     intltool
     wrapGAppsHook3
+    synfig
   ];
   buildInputs = [
     ETL
     synfig
-    boost
     cairo
     glibmm
     gtk3
@@ -133,6 +128,8 @@ stdenv.mkDerivation {
     libsigcxx
     libxmlxx
     mlt
+    fontconfig
+    ffmpeg
     adwaita-icon-theme
     openexr
     fftw


### PR DESCRIPTION
Diff: https://github.com/synfig/synfig/compare/v1.5.3...v1.5.5
Releases: https://github.com/synfig/synfig/releases/tag/v1.5.4 https://github.com/synfig/synfig/releases/tag/v1.5.5

Tested program on x86_64-linux and aarch64-darwin

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
