### PR TITLE
workrave: 1.10.54 -> 1.11.1

### DIFF
--- a/pkgs/by-name/wo/workrave/fix-workrave-paths.patch
+++ b/pkgs/by-name/wo/workrave/fix-workrave-paths.patch
@@ -1,0 +1,171 @@
+diff -ru 1.11.0-rc.3.orig/libs/config/src/GSettingsConfigurator.cc 1.11.0-rc.3/libs/config/src/GSettingsConfigurator.cc
+--- 1.11.0-rc.3.orig/libs/config/src/GSettingsConfigurator.cc	2025-11-25 13:03:40.000000000 -0500
++++ 1.11.0-rc.3/libs/config/src/GSettingsConfigurator.cc	2025-11-25 19:34:09.334474401 -0500
+@@ -22,6 +22,8 @@
+ #include "GSettingsConfigurator.hh"
+ #include "IConfiguratorListener.hh"
+ 
++#include "utils/Exception.hh"
++
+ #include <array>
+ #include <boost/algorithm/string/replace.hpp>
+ 
+@@ -228,19 +230,38 @@
+   TRACE_ENTRY();
+   std::size_t len = schema_base.length();
+ 
++  GSettingsSchemaSource *global_schema_source =
++    g_settings_schema_source_new_from_directory("@workrave_schema_path@",
++                                                g_settings_schema_source_get_default(),
++                                                TRUE, nullptr);
++
+   gchar **schemas = nullptr;
+-  g_settings_schema_source_list_schemas(g_settings_schema_source_get_default(), TRUE, &schemas, nullptr);
++  g_settings_schema_source_list_schemas(global_schema_source, TRUE, &schemas, nullptr);
+ 
+   for (int i = 0; schemas[i] != nullptr; i++)
+     {
+       if (g_ascii_strncasecmp(schemas[i], schema_base.c_str(), len) == 0)
+         {
+-          GSettings *gsettings = g_settings_new(schemas[i]);
++	  GSettingsSchema *schema = g_settings_schema_source_lookup(global_schema_source,
++                                                                    schemas[i], FALSE);
++	  
++          if (schema == nullptr) {
++	    std::string err_msg = "schema for schema id ";
++            err_msg += schemas[i];
++            err_msg += " not found!";
++            
++            TRACE_MSG(err_msg);
++            throw workrave::utils::Exception(err_msg);
++          }
++          
++          GSettings *gsettings = g_settings_new_full(schema, nullptr, nullptr);
+ 
+           settings[schemas[i]] = gsettings;
+           g_signal_connect(gsettings, "changed", G_CALLBACK(on_settings_changed), this);
+         }
+     }
++
++  g_settings_schema_source_unref(global_schema_source);
+ }
+ 
+ void
+diff -ru 1.11.0-rc.3.orig/ui/applets/common/src/control.c 1.11.0-rc.3/ui/applets/common/src/control.c
+--- 1.11.0-rc.3.orig/ui/applets/common/src/control.c	2025-11-25 13:03:40.000000000 -0500
++++ 1.11.0-rc.3/ui/applets/common/src/control.c	2025-11-25 19:34:09.335474435 -0500
+@@ -510,9 +510,21 @@
+ workrave_timerbox_control_create_dbus(WorkraveTimerboxControl *self)
+ {
+   WorkraveTimerboxControlPrivate *priv = workrave_timerbox_control_get_instance_private(self);
+-  GSettings *settings = g_settings_new("org.workrave.gui");
++  
++  GSettingsSchemaSource *global_schema_source =
++    g_settings_schema_source_new_from_directory("@workrave_schema_path@",
++                                                g_settings_schema_source_get_default(),
++                                                TRUE, NULL);
++
++  GSettingsSchema *schema = g_settings_schema_source_lookup(global_schema_source,
++                                                            "org.workrave.gui", FALSE);
++  
++  GSettings *settings = g_settings_new_full(schema, NULL, NULL);
+   gboolean autostart = g_settings_get_boolean(settings, "autostart");
++  
+   g_object_unref(settings);
++  g_settings_schema_unref(schema);
++  g_settings_schema_source_unref(global_schema_source);
+ 
+   GDBusProxyFlags flags = autostart ? 0 : G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START;
+ 
+diff -ru 1.11.0-rc.3.orig/ui/applets/common/src/timerbox.c 1.11.0-rc.3/ui/applets/common/src/timerbox.c
+--- 1.11.0-rc.3.orig/ui/applets/common/src/timerbox.c	2025-11-25 13:03:40.000000000 -0500
++++ 1.11.0-rc.3/ui/applets/common/src/timerbox.c	2025-11-25 19:34:09.336474469 -0500
+@@ -104,13 +104,26 @@
+   priv->enabled = FALSE;
+   priv->force_icon = FALSE;
+   priv->mode = g_strdup("normal");
+-  priv->settings = g_settings_new("org.workrave.gui");
++  
++  GSettingsSchemaSource *global_schema_source =
++    g_settings_schema_source_new_from_directory("@workrave_schema_path@",
++                                                g_settings_schema_source_get_default(),
++                                                TRUE, NULL);
++
++  GSettingsSchema *schema = g_settings_schema_source_lookup(global_schema_source,
++                                                            "org.workrave.gui", FALSE);
++  
++  priv->settings = g_settings_new_full(schema, NULL, NULL);
++  
+   g_signal_connect(priv->settings, "changed", G_CALLBACK(workrave_on_settings_changed), self);
+ 
+   priv->normal_sheep_icon = NULL;
+   priv->quiet_sheep_icon = NULL;
+   priv->suspended_sheep_icon = NULL;
+ 
++  g_settings_schema_unref(schema);
++  g_settings_schema_source_unref(global_schema_source);
++
+   workrave_timerbox_init_images(self);
+ }
+ 
+diff -ru 1.11.0-rc.3.orig/ui/applets/gnome-shell-45/src/extension.js 1.11.0-rc.3/ui/applets/gnome-shell-45/src/extension.js
+--- 1.11.0-rc.3.orig/ui/applets/gnome-shell-45/src/extension.js	2025-11-25 13:03:40.000000000 -0500
++++ 1.11.0-rc.3/ui/applets/gnome-shell-45/src/extension.js	2025-12-02 18:59:41.150022164 -0500
+@@ -11,9 +11,13 @@
+   gettext as _,
+ } from "resource:///org/gnome/shell/extensions/extension.js";
+ 
+-import Workrave from "gi://Workrave?version=2.0";
++import GIRepository from 'gi://GIRepository';
+ import * as PreludeManager from "./prelude_manager.js";
+ 
++const repo = GIRepository.Repository.dup_default();
++repo.prepend_search_path('@workrave_typelib_path@');
++const Workrave = (await import("gi://Workrave?version=2.0")).default;
++
+ let start = GLib.get_monotonic_time();
+ console.log("workrave-applet: start @ " + start);
+ 
+diff -ru 1.11.0-rc.3.orig/ui/applets/gnome-shell-45/src/prelude_window.js 1.11.0-rc.3/ui/applets/gnome-shell-45/src/prelude_window.js
+--- 1.11.0-rc.3.orig/ui/applets/gnome-shell-45/src/prelude_window.js	2025-11-25 13:03:40.000000000 -0500
++++ 1.11.0-rc.3/ui/applets/gnome-shell-45/src/prelude_window.js	2025-12-02 18:58:40.185041678 -0500
+@@ -4,7 +4,11 @@
+ import GObject from "gi://GObject";
+ import St from "gi://St";
+ import { gettext as _ } from "resource:///org/gnome/shell/extensions/extension.js";
+-import Workrave from "gi://Workrave?version=2.0";
++import GIRepository from 'gi://GIRepository';
++
++const repo = GIRepository.Repository.dup_default();
++repo.prepend_search_path('@workrave_typelib_path@');
++const Workrave = (await import("gi://Workrave?version=2.0")).default;
+ 
+ var TimeBarConstraint = GObject.registerClass(
+   class TimeBarConstraint extends Clutter.Constraint {
+diff -ru 1.11.0-rc.3.orig/ui/applets/indicator/src/indicator-workrave.c 1.11.0-rc.3/ui/applets/indicator/src/indicator-workrave.c
+--- 1.11.0-rc.3.orig/ui/applets/indicator/src/indicator-workrave.c	2025-11-25 13:03:40.000000000 -0500
++++ 1.11.0-rc.3/ui/applets/indicator/src/indicator-workrave.c	2025-11-25 19:34:09.337474503 -0500
+@@ -462,9 +462,21 @@
+ indicator_workrave_create_dbus(IndicatorWorkrave *self)
+ {
+   IndicatorWorkravePrivate *priv = indicator_workrave_get_instance_private(self);
+-  GSettings *settings = g_settings_new("org.workrave.gui");
++  
++  GSettingsSchemaSource *global_schema_source =
++    g_settings_schema_source_new_from_directory("@workrave_schema_path@",
++                                                g_settings_schema_source_get_default(),
++                                                TRUE, NULL);
++
++  GSettingsSchema *schema = g_settings_schema_source_lookup(global_schema_source,
++                                                            "org.workrave.gui", FALSE);
++  
++  GSettings *settings = g_settings_new_full(schema, NULL, NULL);
+   gboolean autostart = g_settings_get_boolean(settings, "autostart");
++  
+   g_object_unref(settings);
++  g_settings_schema_unref(schema);
++  g_settings_schema_source_unref(global_schema_source);
+ 
+   GDBusProxyFlags flags = autostart ?: G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START;
+ 
+

--- a/pkgs/by-name/wo/workrave/package.nix
+++ b/pkgs/by-name/wo/workrave/package.nix
@@ -3,9 +3,7 @@
   stdenv,
   fetchFromGitHub,
   wrapGAppsHook3,
-  autoconf,
-  autoconf-archive,
-  automake,
+  cmake,
   gettext,
   intltool,
   libtool,
@@ -18,6 +16,7 @@
   glib,
   glibmm,
   gtkmm3,
+  gtk4,
   atk,
   pango,
   pangomm,
@@ -29,23 +28,26 @@
   libsigcxx,
   boost,
   python3Packages,
+  wayland,
+  wayland-scanner,
+  libayatana-appindicator,
+  fmt,
+  spdlog,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "workrave";
-  version = "1.10.54";
+  version = "1.11.1";
 
   src = fetchFromGitHub {
     repo = "workrave";
     owner = "rcaelers";
-    rev = "v" + lib.concatStringsSep "_" (lib.splitVersion finalAttrs.version);
-    sha256 = "sha256-pbMkzwxgKc4vjFhBeOf513hFytYiTPST19L8Nq4CVTg=";
+    tag = ("v" + (lib.replaceString "." "_" finalAttrs.version));
+    sha256 = "sha256-NfGgcJyTKokcAIffO7YrW3Zs8AHFJGyRaXOvw+n5KZk=";
   };
 
   nativeBuildInputs = [
-    autoconf
-    autoconf-archive
-    automake
+    cmake
     gettext
     intltool
     libtool
@@ -53,6 +55,8 @@ stdenv.mkDerivation (finalAttrs: {
     wrapGAppsHook3
     python3Packages.jinja2
     gobject-introspection
+    wayland-scanner
+    spdlog
   ];
 
   buildInputs = [
@@ -63,6 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
     glib
     glibmm
     gtkmm3
+    gtk4
     atk
     pango
     pangomm
@@ -75,9 +80,31 @@ stdenv.mkDerivation (finalAttrs: {
     gst_all_1.gst-plugins-good
     libsigcxx
     boost
+    wayland
+    libayatana-appindicator
+    fmt
   ];
 
-  preConfigure = "./autogen.sh";
+  cmakeFlags = [
+    "-DLOCALINSTALL:BOOL=TRUE"
+    "-DGSETTINGS_COMPILE:BOOL=ON"
+  ];
+
+  # patching gnome shell extension
+  # https://nixos.org/manual/nixpkgs/stable/#ssec-gnome-common-issues-unwrappable-package
+  patches = [ ./fix-workrave-paths.patch ];
+
+  postPatch = ''
+    substituteInPlace ui/applets/gnome-shell-45/src/extension.js \
+       ui/applets/gnome-shell-45/src/prelude_window.js \
+       --subst-var-by workrave_typelib_path "$out/lib/girepository-1.0"
+
+    substituteInPlace libs/config/src/GSettingsConfigurator.cc \
+       ui/applets/common/src/control.c \
+       ui/applets/common/src/timerbox.c \
+       ui/applets/indicator/src/indicator-workrave.c \
+       --subst-var-by workrave_schema_path ${glib.makeSchemaPath "$out" "${finalAttrs.pname}-${finalAttrs.version}"}
+  '';
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
## Things done
I've mixed https://github.com/NixOS/nixpkgs/pull/546163 and https://github.com/jjramsey/workrave-prerelease-nix-flake , and it seems to work just fine. The patch was made by @jjramsey.

I've been running this for ~1 week, and it work wonderfully on Wayland.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
