### PR TITLE
firecrawl-cli: init at 1.20.0

### DIFF
--- a/pkgs/by-name/fi/firecrawl-cli/default-disable-telemetry.patch
+++ b/pkgs/by-name/fi/firecrawl-cli/default-disable-telemetry.patch
@@ -1,0 +1,13 @@
+diff --git a/src/utils/auth.ts b/src/utils/auth.ts
+index 94f02c3..bd7fb00 100644
+--- a/src/utils/auth.ts
++++ b/src/utils/auth.ts
+@@ -408,7 +408,7 @@ function detectCodingAgents(): string[] {
+  * Check if telemetry is disabled via environment variable
+  */
+ function isTelemetryDisabled(): boolean {
+-  const noTelemetry = process.env.FIRECRAWL_NO_TELEMETRY;
++  const noTelemetry = process.env.FIRECRAWL_NO_TELEMETRY ?? 'true';
+   return noTelemetry === '1' || noTelemetry === 'true';
+ }
+ 

--- a/pkgs/by-name/fi/firecrawl-cli/package.nix
+++ b/pkgs/by-name/fi/firecrawl-cli/package.nix
@@ -1,0 +1,102 @@
+{
+  lib,
+  stdenvNoCC,
+
+  fetchFromGitHub,
+  fetchPnpmDeps,
+
+  makeWrapper,
+  nodejs,
+  pnpm_11,
+  pnpmConfigHook,
+
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "firecrawl-cli";
+  version = "1.20.0";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  outputs = [
+    "out"
+    "skills"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "firecrawl";
+    repo = "cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-w+U+WBiGv5F9AQcU+ItUzyBj1f51O7U5tNfOvs58L+g=";
+  };
+
+  patches = [
+    ./default-disable-telemetry.patch
+  ];
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm_11;
+    fetcherVersion = 4;
+    hash = "sha256-R59OM/4zZF3+JGMG3URe60I+Vs5x9WPeQfuZjuHDodc=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    nodejs
+    pnpmConfigHook
+    pnpm_11
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/lib/firecrawl-cli
+
+    # `pnpm build` doesn't bundle dependencies so we'll need to keep node_modules
+    # - remove unnecessary files
+    CI=true pnpm --ignore-scripts --prod prune
+    find -type f \( -name "*.ts" -o -name "*.map" \) -exec rm -rf {} +
+    # https://github.com/pnpm/pnpm/issues/3645
+    find node_modules -xtype l -delete
+    # - remove non-deterministic files
+    rm node_modules/{.modules.yaml,.pnpm-workspace-state-v1.json}
+    # - copy over node modules
+    cp -r dist node_modules $out/lib/firecrawl-cli
+    cp package.json $out/lib/firecrawl-cli
+
+    cp -r skills $skills
+    ln -s $skills $out/lib/firecrawl-cli/skills
+
+    # patch executable index.js just in-case
+    patchShebangs $out/lib/firecrawl-cli/dist/index.js
+    # prepare an entrypoint in /bin
+    makeWrapper ${lib.getExe nodejs} "$out/bin/firecrawl" --add-flags "$out/lib/firecrawl-cli/dist/index.js"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI and Agent Skill for Firecrawl - Add scrape, search, and browsing capabilities to your AI agents";
+    homepage = "https://github.com/firecrawl/cli";
+    changelog = "https://github.com/firecrawl/cli/releases/tag/${finalAttrs.src.tag}";
+    # https://github.com/firecrawl/cli/blob/main/package.json#L48
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      jk
+    ];
+    mainProgram = "firecrawl";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Packages https://github.com/firecrawl/cli @ `1.20.0` for nixpkgs.
The cli by default has telemetry enabled so a small patch is applied to default to opted-out. Users can still manually opt-in to telemetry.

Using the cli to search `nixpkgs` via a local firecrawl instance
<img width="814" height="362" alt="image" src="https://github.com/user-attachments/assets/4e1f17e3-d6cf-461c-9fc2-298fdadaca00" />


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].
  - Just human hands and good ol `nix-init` for a skeleton

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
