### PR TITLE
gst_all_1.gst-plugins-bad: enable Vulkan support

### DIFF
--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -112,6 +112,10 @@
   guiSupport ? false,
   gst-plugins-bad,
   apple-sdk_gstreamer,
+  vulkanSupport ? stdenv.hostPlatform.isLinux,
+  vulkan-headers,
+  vulkan-loader,
+  shaderc,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -156,6 +160,9 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals (gst-plugins-base.waylandEnabled && stdenv.hostPlatform.isLinux) [
     wayland-scanner
+  ]
+  ++ lib.optionals vulkanSupport [
+    shaderc
   ];
 
   buildInputs = [
@@ -275,6 +282,10 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     apple-sdk_gstreamer
+  ]
+  ++ lib.optionals vulkanSupport [
+    vulkan-headers
+    vulkan-loader
   ];
 
   mesonFlags = [
@@ -314,7 +325,6 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dteletext=disabled" # required `zvbi` library not packaged in nixpkgs as of writing
     "-Dtinyalsa=disabled" # not packaged in nixpkgs as of writing
     "-Dvoamrwbenc=disabled" # required `vo-amrwbenc` library not packaged in nixpkgs as of writing
-    "-Dvulkan=disabled" # Linux-only, and we haven't figured out yet which of the vulkan nixpkgs it needs
     "-Dwasapi=disabled" # not packaged in nixpkgs as of writing / no Windows support
     "-Dwasapi2=disabled" # not packaged in nixpkgs as of writing / no Windows support
     "-Dwpe=disabled" # required `wpe-webkit` library not packaged in nixpkgs as of writing
@@ -333,6 +343,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonEnable "ldac" ldacbtSupport)
     (lib.mesonEnable "webrtcdsp" webrtcAudioProcessingSupport)
     (lib.mesonEnable "isac" webrtcAudioProcessingSupport)
+    (lib.mesonEnable "vulkan" vulkanSupport)
   ]
   ++ lib.mapAttrsToList lib.mesonEnable {
     mpeghdec = false; # mpeghdec not packaged
@@ -401,7 +412,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     patchShebangs \
-      scripts/extract-release-date-from-doap-file.py
+      scripts/extract-release-date-from-doap-file.py \
+      ext/vulkan/shaders/bin2array.py
   '';
 
   # This package has some `_("string literal")` string formats


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I was interested in Vulkan support in GStreamer, but it turns out to not be enabled in NixOS. It wasn't that difficult to wire up, just requires a bunch of dependencies and a build option.

To test, run `nix-shell -I nixpkgs=. -p gst_all_1.gstreamer gst_all_1.gst-plugins-bad gst_all_1.gst-plugins-base`. If you have a Vulkan driver installed, `gst-inspect-1.0 vulkan` should return some plugin details. Additionally, something like `gst-launch-1.0 videotestsrc ! "video/x-raw,format=RGBA" ! vulkanupload ! vulkancolorconvert ! vulkansink` should work.

I've enabled vulkanSupport by default on Linux.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
