### PR TITLE
lx: init at 0.40.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4962,6 +4962,12 @@
     githubId = 33503784;
     name = "Yucheng Zhang";
   };
+  chengjilai = {
+    email = "chengjilai@sjtu.edu.cn";
+    github = "chengjilai";
+    githubId = 191971401;
+    name = "Jilai Cheng";
+  };
   cheriimoya = {
     email = "github@hausch.xyz";
     github = "cheriimoya";

--- a/pkgs/by-name/lx/lx/package.nix
+++ b/pkgs/by-name/lx/lx/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  openssl,
+  pkg-config,
+  libgpg-error,
+  gpgme,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "lx";
+  version = "0.40.2";
+
+  src = fetchFromGitHub {
+    owner = "lumen-oss";
+    repo = "lux";
+    rev = "v${version}";
+    hash = "sha256-UOvVH/YnKI04is88FJpB04PG0umG/4ejSPhvALpv7tA=";
+  };
+
+  cargoHash = "sha256-RmWFFrHgb4EPwfJHCP4kbBKyLCNdSvKOfj5TaJLacSM=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    openssl
+    libgpg-error
+    gpgme
+  ];
+
+  env = {
+    # openssl-sys must use the system OpenSSL, not build its vendored copy
+    # (which fails in the nixpkgs build sandbox).
+    OPENSSL_NO_VENDOR = 1;
+  };
+
+  # Unit tests require network access (they download Lua from lua.org at
+  # test time), which is unavailable in the build sandbox.
+  doCheck = false;
+
+  meta = {
+    description = "A luxurious package manager for Lua";
+    homepage = "https://lux.lumen-labs.org";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ chengjilai ];
+    mainProgram = "lx";
+  };
+}

--- a/pkgs/by-name/lx/lx/package.nix
+++ b/pkgs/by-name/lx/lx/package.nix
@@ -12,6 +12,8 @@ rustPlatform.buildRustPackage rec {
   pname = "lx";
   version = "0.40.2";
 
+  __structuredAttrs = true; # required for new packages (NPV-166)
+
   src = fetchFromGitHub {
     owner = "lumen-oss";
     repo = "lux";


### PR DESCRIPTION
## Description of changes

Adds **lx**, the CLI for [Lux](https://lux.lumen-labs.org) — "a luxurious package manager for Lua". It manages Lua toolchains (installing the right Lua version for a project, 5.1–5.5 and LuaJIT) and dependencies.

- `pkgs/by-name/lx/lx/package.nix`
- adds `chengjilai` to maintainers

## Things done

- Built successfully on `x86_64-linux` (via `callPackage`)
- Verified `lx --version` → `lux-cli 0.40.2`
- `nixfmt-rfc-style` formatted

Notes:
- `doCheck = false`: unit tests require network access (they download Lua from lua.org at test time), unavailable in the sandbox.
- `OPENSSL_NO_VENDOR = 1`: openssl-sys must use the system OpenSSL; its vendored build fails in the sandbox.

cc @lumen-oss