### PR TITLE
qgis{,-ltr}: drop reference to src

### DIFF
--- a/pkgs/applications/gis/qgis/default.nix
+++ b/pkgs/applications/gis/qgis/default.nix
@@ -21,7 +21,7 @@ let
 in
 symlinkJoin {
 
-  inherit (qgis-unwrapped) version outputs src;
+  inherit (qgis-unwrapped) version outputs;
   pname = "qgis";
 
   paths = [ qgis-unwrapped ];

--- a/pkgs/applications/gis/qgis/ltr.nix
+++ b/pkgs/applications/gis/qgis/ltr.nix
@@ -20,7 +20,7 @@ let
 in
 
 symlinkJoin {
-  inherit (qgis-ltr-unwrapped) version outputs src;
+  inherit (qgis-ltr-unwrapped) version outputs;
   pname = "qgis-ltr";
 
   paths = [ qgis-ltr-unwrapped ];

--- a/pkgs/applications/gis/qgis/update.sh
+++ b/pkgs/applications/gis/qgis/update.sh
@@ -17,4 +17,4 @@ elif [ "$package" == "qgis-ltr" ]; then
     version="$(curl --silent $url | jq '.ltr' | make_version)"
 fi
 
-update-source-version "$package" "$version"
+update-source-version "$package.unwrapped" "$version"


### PR DESCRIPTION
The src attribute in the wrapped derivation is only required by the update script, however the presence of this reference causes the source code to be downloaded whenever the wrapped derivation is realised, even if the unwrapped derivation is already realised or can be substituted.  Referencing the unwrapped derivation in the update script avoids this problem.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 550193`
Commit: `cc3decea477397e6a07ea3f84949a2942e5c5f1b`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 3 packages built:</summary>
  <ul>
    <li>qgis</li>
    <li>qgis-ltr</li>
    <li>tests.config-nix-unit</li>
  </ul>
</details>


---
### `aarch64-linux`
<details>
  <summary>:white_check_mark: 3 packages built:</summary>
  <ul>
    <li>qgis</li>
    <li>qgis-ltr</li>
    <li>tests.config-nix-unit</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test