### PR TITLE
prometheus-snowflake-exporter: init at 0-unstable-2026-07-02

### DIFF
--- a/pkgs/by-name/pr/prometheus-snowflake-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-snowflake-exporter/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "prometheus-snowflake-exporter";
+  # No tagged release upstream (only a moving `latest` tag), so pin the commit and
+  # use nixpkgs' unstable versioning. Bump the date + rev on update.
+  version = "0-unstable-2026-07-02";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "grafana";
+    repo = "snowflake-prometheus-exporter";
+    rev = "d9447d3401aa81b26c091775606c502bf8e2d7cd";
+    hash = "sha256-3yaZ2kk2k5ivUNgRNazYjA38zY4dvsTOrkvftQpCW5A=";
+  };
+
+  vendorHash = "sha256-HvlZ5g1LqAoXuFuidmHCMTeFfivqUR2ryAh0hQayxnc=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/prometheus/common/version.Version=${finalAttrs.version}"
+    "-X github.com/prometheus/common/version.Branch=master"
+    "-X github.com/prometheus/common/version.BuildUser=nixbld@nixpkgs"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = "Prometheus exporter for Snowflake metrics";
+    homepage = "https://github.com/grafana/snowflake-prometheus-exporter";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ rhousand ];
+    mainProgram = "snowflake-exporter";
+  };
+})


### PR DESCRIPTION
Adds `prometheus-snowflake-exporter` — Grafana's Prometheus exporter for Snowflake metrics (https://github.com/grafana/snowflake-prometheus-exporter). New leaf package, no mass rebuild.

Notes for reviewers:
- **Unstable versioning**: upstream has no tagged release (only a moving `latest` tag), so the package pins a commit and uses `0-unstable-2026-07-02` per nixpkgs' unreleased-versioning convention. `passthru.updateScript` tracks the branch.
- **Naming**: follows the `prometheus-<subject>-exporter` convention. The upstream repo is `snowflake-prometheus-exporter`; the built binary / `mainProgram` is `snowflake-exporter`.
- **Go**: `go.mod` requires Go 1.26.4; the default `buildGoModule` (Go 1.26.5) satisfies it.
- The `maintainers: add rhousand` commit duplicates the same addition in my open #547172; whichever lands second I will rebase to drop the duplicate.
- Builds: x86_64-linux and aarch64-darwin built locally via `nixpkgs-review` (`versionCheckHook` runs `snowflake-exporter --version`). aarch64-linux left to ofborg — I have no aarch64-linux builder wired locally.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
