### PR TITLE
_cuda.lib.allowUnfreeCudaPredicate: handle compound licenses

### DIFF
--- a/pkgs/development/cuda-modules/_cuda/lib/cuda.nix
+++ b/pkgs/development/cuda-modules/_cuda/lib/cuda.nix
@@ -115,13 +115,22 @@
   */
   allowUnfreeCudaPredicate =
     let
-      cudaLicenseNames = [
-        lib.licenses.nvidiaCuda.shortName
+      cudaLicenses = [
+        lib.licenses.nvidiaCuda
+        lib.licenses.nvidiaCudaRedist
       ]
-      ++ lib.map (license: license.shortName) (lib.attrValues _cuda.lib.licenses);
+      ++ lib.attrValues _cuda.lib.licenses;
+      cudaLicenseNames = lib.map (license: license.shortName) cudaLicenses;
     in
     package:
-    lib.all (license: license.free || lib.elem (license.shortName or null) cudaLicenseNames) (
-      lib.toList package.meta.license
-    );
+    # new compound licenses
+    if lib.isAttrs package.meta.license && lib.hasAttr "licenseType" package.meta.license then
+      lib.licenses.evaluateProperty (
+        license: (license.free or false) || lib.elem license cudaLicenses
+      ) true (package.meta.license or [ ])
+    else
+      # old license list
+      lib.all (
+        license: (license.free or false) || lib.elem (license.shortName or null) cudaLicenseNames
+      ) (lib.toList package.meta.license);
 }


### PR DESCRIPTION
Some package I use has a compound license (no idea which)

```
       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'free' missing
       at «git+https://github.com/SuperSandro2000/nixpkgs.git?ref=nixos-unstable&rev=1e70c06a4d3e661657a25ec2baf5919c24f3133e&shallow=1»/pkgs/development/cuda-modules/_cuda/lib/cuda.nix:124:23:
          123|     package:
          124|     lib.all (license: license.free || lib.elem (license.shortName or null) cudaLicenseNames) (
             |                       ^
          125|       lib.toList package.meta.license
```

I could only find out that it is this license:

```
nix-repl> :p license
{
  licenseType = "compound";
  licenses = [
    {
      deprecated = false;
      free = true;
      fullName = "GNU General Public License v2.0 or later";
      licenseType = "simple";
      redistributable = true;
      shortName = "gpl2Plus";
      spdxId = "GPL-2.0-or-later";
      url = "https://spdx.org/licenses/GPL-2.0-or-later.html";
    }
    {
      deprecated = false;
      free = true;
      fullName = "Apache License 2.0";
      licenseType = "simple";
      redistributable = true;
      shortName = "asl20";
      spdxId = "Apache-2.0";
      url = "https://spdx.org/licenses/Apache-2.0.html";
    }
  ];
  operator = "AND";
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
