### PR TITLE
redocly: 2.17.0 -> 2.46.0

### DIFF
--- a/pkgs/by-name/re/redocly/package.nix
+++ b/pkgs/by-name/re/redocly/package.nix
@@ -9,28 +9,25 @@
 
 buildNpmPackage rec {
   pname = "redocly";
-  version = "2.17.0";
+  version = "2.46.0";
 
   src = fetchFromGitHub {
     owner = "Redocly";
     repo = "redocly-cli";
     rev = "@redocly/cli@${version}";
-    hash = "sha256-bhM8CIKmZ3p96DViHVieMmUXOtkhs0+nhQs4naIgQVY=";
+    hash = "sha256-IdMeWY3MXHHoejWh2ZcskdzhUn0Ez3S9oxRx1uTKAWc=";
   };
 
-  npmDepsHash = "sha256-iWyFuyZJOW2/F1gE2nA601IlgXpYXeK31gwI+SfxRuY=";
+  npmDepsHash = "sha256-62S71SBbSSADzzHapCmY2r98bLmRbokaxZU5l1x1cFA=";
 
   npmBuildScript = "prepare";
 
-  postBuild = ''
-    npm --prefix packages/cli run copy-assets
-  '';
-
+  # The CLI is bundled into packages/cli/lib by the `prepare` script (esbuild,
+  # self-contained). That output directory is git-ignored, so `npm pack` drops
+  # it during install; copy it back into the installed package.
   postInstall = ''
-    rm $out/lib/node_modules/@redocly/cli/node_modules/@redocly/{cli,openapi-core,respect-core}
-    cp -R packages/cli $out/lib/node_modules/@redocly/cli/node_modules/@redocly/cli
-    cp -R packages/core $out/lib/node_modules/@redocly/cli/node_modules/@redocly/openapi-core
-    cp -R packages/respect-core $out/lib/node_modules/@redocly/cli/node_modules/@redocly/respect-core
+    cliDir="$out/lib/node_modules/@redocly/cli/packages/cli"
+    cp -R packages/cli/lib "$cliDir/lib"
 
     # Create a wrapper script to force the correct command name (Nodejs uses argv[1] for command name)
     mkdir -p $out/bin
@@ -43,7 +40,7 @@ buildNpmPackage rec {
     process.env.REDOCLY_TELEMETRY = process.env.REDOCLY_TELEMETRY || "off";
     process.env.REDOCLY_SUPPRESS_UPDATE_NOTICE = process.env.REDOCLY_SUPPRESS_UPDATE_NOTICE || "true";
 
-    require('$out/lib/node_modules/@redocly/cli/node_modules/@redocly/cli/bin/cli.js');
+    import('$cliDir/bin/cli.js');
     EOF
     chmod +x $out/bin/redocly
   '';


### PR DESCRIPTION
Bumps `redocly` from 2.17.0 to 2.46.0.

Changelog: https://redocly.com/docs/cli/changelog/

Upstream restructured the monorepo between these versions, so the build required a few adjustments:

- Dropped `postBuild` (the `copy-assets` npm script no longer exists). The `prepare` script now bundles the whole CLI into `packages/cli/lib` with esbuild, inlining `@redocly/openapi-core` and `@redocly/respect-core`.
- Rewrote `postInstall`: `packages/cli/lib` is git-ignored and therefore dropped by `npm pack`, so it is copied back into the installed package. The old per-package `node_modules` copying is no longer needed since everything is bundled.
- The CLI is now ESM, so the `redocly` wrapper uses a dynamic `import(...)` instead of `require(...)`.

## Things done

- Built on platform:
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] Package tests at `passthru.tests` (`redocly.tests.version` builds and reports 2.46.0).
  - [x] Tested basic functionality of the binary in `./result/bin/`: `lint`, `bundle`, `stats`, `split`, `join` and `build-docs` all work on a sample OpenAPI document (build-docs produces a 39 KiB HTML with the embedded redoc runtime).
- [x] `pkgs/by-name` structure validated with `nixpkgs-vet`.
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Fits CONTRIBUTING.md and pkgs/README.md.
- [x] Follows the automation/AI policy (see disclosure below).

---

**AI/automation disclosure:** This contribution was prepared with the assistance of an LLM-based tool (Claude Code). I authored, reviewed and verified all changes, and I am the responsible person accountable for this PR per the Nixpkgs automation/AI policy.
