### PR TITLE
hbkit: init at 0.4.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -31463,6 +31463,12 @@
     name = "Alvaro Viejo";
     matrix = "@yoquec.com:matrix.org";
   };
+  yordilorenzo = {
+    email = "yordilorenzo@gmail.com";
+    github = "YordiLorenzo";
+    githubId = 7012112;
+    name = "Yordi de Kleijn";
+  };
   yorickvp = {
     email = "yorickvanpelt@gmail.com";
     matrix = "@yorickvp:matrix.org";

--- a/pkgs/by-name/hb/hbkit/package.nix
+++ b/pkgs/by-name/hb/hbkit/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  python3Packages,
+  fetchFromGitHub,
+  lz4,
+  makeWrapper,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "hbkit";
+  version = "0.4.3";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "YordiLorenzo";
+    repo = "hbkit";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-F3LH5bvYbgdb3xOrb2FZcZ5vuS4KzFKvJvw6GlzsEgU=";
+  };
+
+  build-system = [ python3Packages.hatchling ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dependencies = with python3Packages; [
+    textual
+    pynacl
+    cryptography
+  ];
+
+  # hbkit dlopen()s liblz4 by name instead of linking it, and nothing is on a default
+  # library search path here, so point it straight at the store path.
+  postFixup = ''
+    for exe in hbk hbk-tui; do
+      wrapProgram "$out/bin/$exe" \
+        --set HBK_LZ4 "${lz4.lib}/lib/liblz4${stdenv.hostPlatform.extensions.sharedLibrary}"
+    done
+  '';
+
+  nativeCheckInputs = [ python3Packages.pytestCheckHook ];
+
+  pythonImportsCheck = [ "hbkit" ];
+
+  meta = {
+    description = "Recover files from Synology Hyper Backup (.hbk) archives";
+    longDescription = ''
+      hbkit reads Synology Hyper Backup archives directly, without a NAS or any
+      Synology software. It restores the original directory tree and mtimes,
+      verifies every chunk against the checksums stored in the archive, and can
+      read client-side encrypted archives given the password. Includes a
+      full-screen browser (hbk-tui) and can work against an archive kept in S3 or
+      R2 over an rclone mount.
+    '';
+    homepage = "https://github.com/YordiLorenzo/hbkit";
+    changelog = "https://github.com/YordiLorenzo/hbkit/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "hbk";
+    maintainers = with lib.maintainers; [ yordilorenzo ];
+  };
+})


### PR DESCRIPTION
## Description

`hbkit` recovers files from Synology Hyper Backup (`.hbk`) archives without a NAS or any Synology software. The on-disk format was reverse engineered and is [documented in the repo](https://github.com/YordiLorenzo/hbkit/blob/main/FORMAT.md); extraction verifies every chunk against the MD5/CRC32 stored in the archive itself, so a successful restore is byte-exact rather than merely the right length. Client-side encrypted archives are supported. It ships a CLI (`hbk`) and a Textual TUI (`hbk-tui`).

Upstream is MIT, has CI across Linux/macOS on Python 3.10–3.13, and I am the author.

### Note on the `postFixup` wrapper

hbkit `dlopen()`s `liblz4` rather than linking it. There is no default library search path in a Nix build, so `HBK_LZ4` is set to the store path explicitly. Without it the package builds and imports fine and only fails the first time someone extracts a file.

## Things done

- Built on platform(s): **aarch64-darwin**
- Built with `nix-build -A hbkit` from this branch
- `nixfmt` clean on both changed files
- Ran the package against a real encrypted `.hbk` archive: `hbk doctor` verified 11 sampled files chunk-by-chunk, and `hbk get` restored 9 files that check out as valid PNGs
- Tests run in `pytestCheckPhase` (25 passed, 9 skipped — the skipped ones need a backup archive that cannot ship in a tarball)
- `pythonImportsCheck` passes
- Not built on Linux; relying on ofborg for that
