### PR TITLE
bmputil: 1.0.0 -> 1.1.0

### DIFF
--- a/pkgs/by-name/bm/bmputil/package.nix
+++ b/pkgs/by-name/bm/bmputil/package.nix
@@ -1,30 +1,31 @@
 {
   blackmagic,
   lib,
-  fetchFromGitHub,
+  stdenv,
+  fetchFromCodeberg,
   rustPlatform,
   versionCheckHook,
   udevCheckHook,
   pkg-config,
-  openssl,
+  udev,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "bmputil";
-  version = "1.0.0";
+  version = "1.1.0";
 
-  src = fetchFromGitHub {
+  src = fetchFromCodeberg {
     owner = "blackmagic-debug";
     repo = "bmputil";
     tag = "v${version}";
-    hash = "sha256-5BHnh1/6DqjvT0ptOoGqDqVGU0coVPdnZPDQPT9fVFk=";
+    hash = "sha256-ZD/JXsx52U+O3FazRc9xnShx34fxTXcD2zhW5mgSYtU=";
   };
 
-  cargoHash = "sha256-JoqNEesozr4ahyenZeeAMf0m8M+sxvbF+A6t23Gcz+4=";
+  cargoHash = "sha256-/I1chzqnhgky/+cKGhFrdgZvoLGM9P75ga5UDTMOI3Q=";
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [
-    openssl # can be removed once https://github.com/blackmagic-debug/bmputil/commit/5fa01c20902a3f2570fed58ee66f2241546dd6d7 is released
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    udev
   ];
 
   postInstall = ''


### PR DESCRIPTION
Addressing changes requested in https://github.com/NixOS/nixpkgs/pull/512433 (seems to have gone stale)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
