### PR TITLE
python3Packages.vizaio: init at 0.6.1

### DIFF
--- a/pkgs/development/python-modules/vizaio/default.nix
+++ b/pkgs/development/python-modules/vizaio/default.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  aiohttp,
+  aioresponses,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  platformdirs,
+  pyprojectVersionPatchHook,
+  pytest-asyncio,
+  pytestCheckHook,
+  rich,
+  tomlkit,
+  typer,
+  zeroconf,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "vizaio";
+  version = "0.6.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "raman325";
+    repo = "vizaio";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-u0ZHSHzkGna9ajmV7V3n8YKPuI598acnXhIEBXvnU2I=";
+  };
+
+  nativeBuildInputs = [ pyprojectVersionPatchHook ];
+
+  build-system = [ hatchling ];
+
+  dependencies = [ aiohttp ];
+
+  optional-dependencies = {
+    cli = [
+      platformdirs
+      rich
+      tomlkit
+      typer
+    ];
+    discovery = [ zeroconf ];
+  };
+
+  nativeCheckInputs = [
+    aioresponses
+    pytest-asyncio
+    pytestCheckHook
+  ]
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
+
+  pythonImportsCheck = [ "vizaio" ];
+
+  meta = {
+    description = "Modern async Python client and CLI for Vizio SmartCast devices";
+    homepage = "https://github.com/raman325/vizaio";
+    changelog = "https://github.com/raman325/vizaio/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+    mainProgram = "vizaio";
+  };
+})

--- a/pkgs/development/python-modules/vizaio/default.nix
+++ b/pkgs/development/python-modules/vizaio/default.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  aiohttp,
+  aioresponses,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  platformdirs,
+  pythonOlder,
+  pyprojectVersionPatchHook,
+  pytest-asyncio,
+  pytestCheckHook,
+  rich,
+  tomlkit,
+  typer,
+  zeroconf,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "vizaio";
+  version = "0.3.2";
+  pyproject = true;
+
+  disabled = pythonOlder "3.12";
+
+  src = fetchFromGitHub {
+    owner = "raman325";
+    repo = "vizaio";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-NgiSbADKscieLGK8tfTD8uXM1df4lnIDL5dP13puigQ=";
+  };
+
+  nativeBuildInputs = [ pyprojectVersionPatchHook ];
+
+  build-system = [ hatchling ];
+
+  dependencies = [ aiohttp ];
+
+  optional-dependencies = {
+    cli = [
+      platformdirs
+      rich
+      tomlkit
+      typer
+    ];
+    discovery = [ zeroconf ];
+  };
+
+  nativeCheckInputs = [
+    aioresponses
+    pytest-asyncio
+    pytestCheckHook
+  ]
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
+
+  pythonImportsCheck = [ "vizaio" ];
+
+  meta = {
+    description = "Modern async Python client and CLI for Vizio SmartCast devices";
+    homepage = "https://github.com/raman325/vizaio";
+    changelog = "https://github.com/raman325/vizaio/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+    mainProgram = "vizaio";
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -7451,7 +7451,8 @@
       ];
     "vizio" =
       ps: with ps; [
-      ]; # missing inputs: vizaio
+        vizaio
+      ];
     "vlc" =
       ps: with ps; [
         python-vlc
@@ -9053,6 +9054,7 @@
     "vilfo"
     "vistapool"
     "vivotek"
+    "vizio"
     "vlc_telnet"
     "vodafone_station"
     "voicerss"

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -7800,7 +7800,8 @@
       ];
     "vizio" =
       ps: with ps; [
-      ]; # missing inputs: vizaio
+        vizaio
+      ];
     "vlc_telnet" =
       ps: with ps; [
         aiovlc
@@ -9429,6 +9430,7 @@
     "vilfo"
     "vistapool"
     "vivotek"
+    "vizio"
     "vlc_telnet"
     "vodafone_station"
     "voicerss"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21925,6 +21925,8 @@ self: super: with self; {
     inherit (pkgs.libsForQt5) wrapQtAppsHook;
   };
 
+  vizaio = callPackage ../development/python-modules/vizaio { };
+
   vl-convert-python = callPackage ../development/python-modules/vl-convert-python {
     inherit (pkgs) protobuf;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22255,6 +22255,8 @@ self: super: with self; {
     inherit (pkgs.libsForQt5) wrapQtAppsHook;
   };
 
+  vizaio = callPackage ../development/python-modules/vizaio { };
+
   vl-convert-python = callPackage ../development/python-modules/vl-convert-python {
     inherit (pkgs) protobuf;
   };


### PR DESCRIPTION
- https://pypi.org/project/vizaio/
- https://github.com/raman325/vizaio
- https://www.home-assistant.io/integrations/vizio/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
