### PR TITLE
pkgs/nixos-render-docs: fix included content should be 'page' 

### DIFF
--- a/doc/style.css
+++ b/doc/style.css
@@ -465,7 +465,8 @@ div.appendix .variablelist .term {
   font-display: swap;
 }
 
-.chapter {
+div.chapter,
+div.page {
   content-visibility: auto;
 }
 

--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/manual.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/manual.py
@@ -236,7 +236,7 @@ class RendererMixin(Renderer):
             'included_preface': lambda *args: self._included_thing("preface", *args),
             'included_parts': lambda *args: self._included_thing("part", *args),
             'included_appendix': lambda *args: self._included_thing("appendix", *args),
-            'included_content': lambda *args: self._included_thing("content", *args),
+            'included_page': lambda *args: self._included_thing("page", *args),
             'included_options': self.included_options,
         }
 
@@ -396,7 +396,7 @@ class ManualHTMLRenderer(RendererMixin, HTMLRenderer):
         intersection_observer_js = """
 //<![CDATA[
 function createObserver() {
-  const content = document.querySelector(".content");
+  const content = document.querySelector("main.content");
   const headings = content.querySelectorAll("h1, h2, h3, h4, h5, h6");
 
   const links = new Map();
@@ -739,7 +739,7 @@ class HTMLConverter(BaseConverter[ManualHTMLRenderer]):
 
     def _build_config_include(self, nodes: list[ConfigNode], config_file: Path) -> Token:
         included = [self._build_config_item(node, config_file) for node in nodes]
-        token = Token('included_content', '', 0, map=[0, 1])
+        token = Token('included_page', '', 0, map=[0, 1])
         token.meta['included'] = included
         token.meta['include-args'] = {}
         return token
@@ -749,7 +749,7 @@ class HTMLConverter(BaseConverter[ManualHTMLRenderer]):
             path = (config_file.parent / node.file).resolve()
             leaf_src = path.read_text()
             self._base_paths.append(path)
-            self._current_type.append('content')
+            self._current_type.append('page')
             try:
                 fragment = self._parse(leaf_src)
             finally:
@@ -884,7 +884,7 @@ class HTMLConverter(BaseConverter[ManualHTMLRenderer]):
             title_html = (
                 f"<em>{title_html}</em>"
                 if typ == 'chapter'
-                else title_html if typ in [ 'book', 'part', 'content' ]
+                else title_html if typ in [ 'book', 'part', 'page' ]
                 else f'the section called “{title_html}”'
             )
         return XrefTarget(id, title_html, toc_html, re.sub('<.*?>', '', title), path, drop_fragment)

--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/manual_structure.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/manual_structure.py
@@ -15,8 +15,8 @@ FragmentType = Literal['preface', 'part', 'chapter', 'section', 'appendix']
 
 # the TOC allows every fragment type. it also allows the enclosing book.
 # it allows 'example' and 'figure'.
-# --experimental-config adds a generic 'content' kind.
-TocEntryType = Literal['book', 'preface', 'part', 'chapter', 'section', 'appendix', 'example', 'figure', 'content']
+# --experimental-config adds a generic 'page' kind.
+TocEntryType = Literal['book', 'preface', 'part', 'chapter', 'section', 'appendix', 'example', 'figure', 'page']
 
 def is_include(token: Token) -> bool:
     return token.type == "fence" and token.info.startswith("{=include=} ")


### PR DESCRIPTION
Unfortunately the term and the `<main class="content">` collide.

Most notably this bricks the intersection observer silently so this cannot be caught in tests.

I noticed this while trying to add the first content to `nav.json` and the query selector of the observer didn't select the new content.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
