### PR TITLE
treewide: remove minijackson maintenanceship of some pkgs & modules

### DIFF
--- a/nixos/modules/config/xdg/portals/wlr.nix
+++ b/nixos/modules/config/xdg/portals/wlr.nix
@@ -12,7 +12,7 @@ let
 in
 {
   meta = {
-    maintainers = with lib.maintainers; [ minijackson ];
+    maintainers = [ ];
   };
 
   options.xdg.portal.wlr = {

--- a/nixos/modules/services/web-apps/mobilizon.nix
+++ b/nixos/modules/services/web-apps/mobilizon.nix
@@ -479,7 +479,6 @@ in
   };
 
   meta.maintainers = with lib.maintainers; [
-    minijackson
     erictapen
   ];
 }

--- a/nixos/tests/mobilizon.nix
+++ b/nixos/tests/mobilizon.nix
@@ -8,7 +8,6 @@ in
 {
   name = "mobilizon";
   meta.maintainers = with lib.maintainers; [
-    minijackson
     erictapen
   ];
 

--- a/pkgs/applications/editors/neovim/gnvim/default.nix
+++ b/pkgs/applications/editors/neovim/gnvim/default.nix
@@ -50,6 +50,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mainProgram = "gnvim";
     homepage = "https://github.com/vhakulinen/gnvim";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ minijackson ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/mo/mobilizon/frontend.nix
+++ b/pkgs/by-name/mo/mobilizon/frontend.nix
@@ -24,7 +24,6 @@ buildNpmPackage {
     homepage = "https://joinmobilizon.org/";
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [
-      minijackson
       erictapen
     ];
   };

--- a/pkgs/by-name/mo/mobilizon/package.nix
+++ b/pkgs/by-name/mo/mobilizon/package.nix
@@ -157,7 +157,6 @@ beamPackages.mixRelease rec {
     changelog = "https://framagit.org/framasoft/mobilizon/-/releases/${src.tag}";
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [
-      minijackson
       erictapen
     ];
   };

--- a/pkgs/by-name/os/ossia-score/package.nix
+++ b/pkgs/by-name/os/ossia-score/package.nix
@@ -163,7 +163,6 @@ clangStdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
       jcelerier
-      minijackson
     ];
   };
 })

--- a/pkgs/by-name/pa/pandoc-katex/package.nix
+++ b/pkgs/by-name/pa/pandoc-katex/package.nix
@@ -25,7 +25,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       mit
     ];
     maintainers = with lib.maintainers; [
-      minijackson
       euxane
     ];
     mainProgram = "pandoc-katex";

--- a/pkgs/by-name/qu/quarto/package.nix
+++ b/pkgs/by-name/qu/quarto/package.nix
@@ -106,7 +106,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/quarto-dev/quarto-cli/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
-      minijackson
       mrtarantoga
     ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/se/sequoia-sq/package.nix
+++ b/pkgs/by-name/se/sequoia-sq/package.nix
@@ -76,7 +76,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://gitlab.com/sequoia-pgp/sequoia-sq/-/blob/v${finalAttrs.version}/NEWS";
     license = lib.licenses.lgpl2Plus;
     maintainers = with lib.maintainers; [
-      minijackson
       doronbehar
       dvn0
       anish

--- a/pkgs/by-name/xd/xdg-desktop-portal-wlr/package.nix
+++ b/pkgs/by-name/xd/xdg-desktop-portal-wlr/package.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     homepage = "https://github.com/emersion/xdg-desktop-portal-wlr";
     description = "xdg-desktop-portal backend for wlroots";
-    maintainers = with lib.maintainers; [ minijackson ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
     license = lib.licenses.mit;
   };


### PR DESCRIPTION
Since I'm not personnaly using those packages & modules anymore, I haven't been active in maintening them…

Orphaned packages:

- `xdg-portal-wlr`
- `gnvim`

I've also removed myself from the BEAM GitHub team, since I haven't been active since forever. If I understood it correctly, the CI will update the team JSON file soon.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
