### PR TITLE
hwall: init at 1.0.5

### DIFF
--- a/pkgs/by-name/hw/hwall/package.nix
+++ b/pkgs/by-name/hw/hwall/package.nix
@@ -74,3 +74,4 @@ rustPlatform.buildRustPackage (finalAttrs: {
     platforms = platforms.linux;
   };
 }
+)

--- a/pkgs/by-name/hw/hwall/package.nix
+++ b/pkgs/by-name/hw/hwall/package.nix
@@ -10,7 +10,7 @@
   hicolor-icon-theme,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs:  {
   pname = "hwall";
   version = "1.0.5";
 

--- a/pkgs/by-name/hw/hwall/package.nix
+++ b/pkgs/by-name/hw/hwall/package.nix
@@ -10,14 +10,14 @@
   hicolor-icon-theme,
 }:
 
-rustPlatform.buildRustPackage (finalAttrs:  {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "hwall";
   version = "1.0.5";
 
   src = fetchFromGitHub {
+    tag = "v${finalAttrs.version}";
     owner = "pulpul-s";
     repo = "HWall";
-    tag = ${finalAttrs.version};
     hash = "sha256-4xl4WUgfa86YWoLxD0L7zVxzMddlDvNKbCi8z8JwqKo=";
   };
 

--- a/pkgs/by-name/hw/hwall/package.nix
+++ b/pkgs/by-name/hw/hwall/package.nix
@@ -10,6 +10,8 @@
   hicolor-icon-theme,
 }:
 
+__structuredAttrs = true;
+
 rustPlatform.buildRustPackage rec {
   pname = "hwall";
   version = "1.0.5";

--- a/pkgs/by-name/hw/hwall/package.nix
+++ b/pkgs/by-name/hw/hwall/package.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "pulpul-s";
     repo = "HWall";
-    rev = "d27a5e2d1a690c45ce4c05b3ddc39c9281728e7d";
+    tag = ${finalAttrs.version};
     hash = "sha256-4xl4WUgfa86YWoLxD0L7zVxzMddlDvNKbCi8z8JwqKo=";
   };
 

--- a/pkgs/by-name/hw/hwall/package.nix
+++ b/pkgs/by-name/hw/hwall/package.nix
@@ -10,8 +10,6 @@
   hicolor-icon-theme,
 }:
 
-__structuredAttrs = true;
-
 rustPlatform.buildRustPackage rec {
   pname = "hwall";
   version = "1.0.5";
@@ -25,6 +23,8 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-zQ4bbPV+ApX0Uq+BLLbqaCki9VZF1c5i8u160QBAAsY=";
 
+  __structuredAttrs = true;
+ 
   nativeBuildInputs = [
     pkg-config
     wrapGAppsHook4 # sets XDG_DATA_DIRS, GDK_PIXBUF_MODULE_FILE, GIO_EXTRA_MODULES

--- a/pkgs/by-name/hw/hwall/package.nix
+++ b/pkgs/by-name/hw/hwall/package.nix
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-zQ4bbPV+ApX0Uq+BLLbqaCki9VZF1c5i8u160QBAAsY=";
 
   __structuredAttrs = true;
- 
+
   nativeBuildInputs = [
     pkg-config
     wrapGAppsHook4 # sets XDG_DATA_DIRS, GDK_PIXBUF_MODULE_FILE, GIO_EXTRA_MODULES
@@ -73,5 +73,4 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mainProgram = "hwall";
     platforms = platforms.linux;
   };
-}
-)
+})

--- a/pkgs/by-name/hw/hwall/package.nix
+++ b/pkgs/by-name/hw/hwall/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  wrapGAppsHook4,
+  gtk4,
+  librsvg,
+  gsettings-desktop-schemas,
+  hicolor-icon-theme,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "hwall";
+  version = "1.0.5";
+
+  src = fetchFromGitHub {
+    owner = "pulpul-s";
+    repo = "HWall";
+    rev = "d27a5e2d1a690c45ce4c05b3ddc39c9281728e7d";
+    hash = "sha256-4xl4WUgfa86YWoLxD0L7zVxzMddlDvNKbCi8z8JwqKo=";
+  };
+
+  cargoHash = "sha256-zQ4bbPV+ApX0Uq+BLLbqaCki9VZF1c5i8u160QBAAsY=";
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook4 # sets XDG_DATA_DIRS, GDK_PIXBUF_MODULE_FILE, GIO_EXTRA_MODULES
+  ];
+
+  buildInputs = [
+    gtk4 # propagates glib, pango, cairo, gdk-pixbuf, graphene, harfbuzz, ...
+    librsvg # SVG loader for gdk-pixbuf (app icon)
+    gsettings-desktop-schemas
+    hicolor-icon-theme
+  ];
+
+  # The workspace produces both binaries: hwall (GTK) and hwall-cli (TUI).
+  cargoBuildFlags = [
+    "--workspace"
+    "--locked"
+  ];
+
+  # Skip the helper-timeout test: it spawns /bin/sleep, which does not exist
+  # inside the Nix build sandbox (only /bin/sh is provided).
+  checkFlags = [
+    "--skip"
+    "times_out_and_reaps_slow_helpers"
+  ];
+
+  # Default cargoInstallHook copies the two built binaries (hwall, hwall-cli)
+  # into $out/bin; here we add the desktop integration files.
+  postInstall = ''
+    install -Dm644 packaging/io.github.hwall.HWall.desktop \
+      $out/share/applications/io.github.hwall.HWall.desktop
+    install -Dm644 packaging/io.github.hwall.HWall.metainfo.xml \
+      $out/share/metainfo/io.github.hwall.HWall.metainfo.xml
+    install -Dm644 packaging/icons/hicolor/scalable/apps/io.github.hwall.HWall.svg \
+      $out/share/icons/hicolor/scalable/apps/io.github.hwall.HWall.svg
+    for size in 32 48 64; do
+      install -Dm644 packaging/icons/hicolor/''${size}x''${size}/apps/io.github.hwall.HWall.png \
+        $out/share/icons/hicolor/''${size}x''${size}/apps/io.github.hwall.HWall.png
+    done
+  '';
+
+  meta = with lib; {
+    description = "Linux hardware inventory and live sensor monitor";
+    homepage = "https://github.com/pulpul-s/HWall";
+    license = licenses.mit;
+    maintainers = [ ];
+    mainProgram = "hwall";
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
Assisted-by: freebuff coding agent using LLM model Deepseek V4 Flash 07/31

Add hwall package for Linux hardware inventory and monitoring.

Currently only built and tested on x86_64-linux platform.

<!--

Link to homepage: https://github.com/pulpul-s/HWall

Package description: HWall is a read-only Linux hardware monitor and inventory application written in Rust. It provides native GTK 4 and terminal interfaces, with a hierarchical sensor view inspired by HWiNFO64. HWall reports information exposed by Linux, firmware, hardware drivers, and installed read-only helper tools.

`packages/hwall/package.nix` is a **function** that nixpkgs fills with the right tools. It downloads HWall at a pinned, hash-verified commit, pre-fetches all cargo dependencies (also hash-verified), compiles the whole workspace with `rustc 1.97.1`, runs the test suite (skipping one test that needs `/bin/sleep`), installs both binaries (`hwall` and `hwall-cli`) plus the desktop/icon files, and wraps the GUI with GTK's runtime environment — producing a fully self-contained, reproducible `hwall-1.0.5` that any NixOS machine can install

-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
