### PR TITLE
nixos/esphome: convert to new device builder

### DIFF
--- a/nixos/modules/services/home-automation/esphome.nix
+++ b/nixos/modules/services/home-automation/esphome.nix
@@ -11,6 +11,7 @@ let
     mkEnableOption
     mkIf
     mkOption
+    mkRemovedOptionModule
     types
     ;
 
@@ -18,19 +19,31 @@ let
 
   stateDir = "/var/lib/esphome";
 
-  esphomeParams =
+  esphomeHttpParams =
     if cfg.enableUnixSocket then
       "--socket /run/esphome/esphome.sock"
     else
-      "--address ${cfg.address} --port ${toString cfg.port}";
+      "--host ${cfg.address} --port ${toString cfg.port}";
+
+  esphomeParams = [
+    esphomeHttpParams
+    "--log-level ${cfg.logLevel}"
+    "--remote-build-host ${cfg.remoteBuildAddress}"
+    "--remote-build-port ${toString cfg.remoteBuildPort}"
+  ]
+  ++ lib.optional cfg.remoteBuildOnly "--remote-build-only"
+  ++ lib.optional (
+    cfg.trustedDomains != [ ]
+  ) "--trusted-domains ${lib.concatStringsSep "," cfg.trustedDomains}"
+  ++ cfg.extraArgs;
 in
 {
   meta.maintainers = with maintainers; [ oddlama ];
 
   options.services.esphome = {
-    enable = mkEnableOption "esphome, for making custom firmwares for ESP32/ESP8266";
+    enable = mkEnableOption "ESPHome Device Builder, for making custom firmwares for ESP32/ESP8266";
 
-    package = lib.mkPackageOption pkgs "esphome" { };
+    package = lib.mkPackageOption pkgs "esphome-device-builder" { };
 
     enableUnixSocket = mkOption {
       type = types.bool;
@@ -41,19 +54,54 @@ in
     address = mkOption {
       type = types.str;
       default = "localhost";
-      description = "esphome address";
+      description = "ESPHome Device Builder HTTP address";
     };
 
     port = mkOption {
       type = types.port;
       default = 6052;
-      description = "esphome port";
+      description = "ESPHome Device Builder HTTP port";
+    };
+
+    remoteBuildOnly = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Unconditionally only run the remote build server";
+    };
+
+    remoteBuildAddress = mkOption {
+      type = types.str;
+      default = "localhost";
+      description = "Address of the remote build server";
+    };
+
+    remoteBuildPort = mkOption {
+      type = types.port;
+      default = 6055;
+      description = "Port of the remote build server";
+    };
+
+    logLevel = mkOption {
+      type = types.enum [
+        "debug"
+        "info"
+        "warning"
+        "error"
+      ];
+      default = "info";
+      description = "Log level of the ESPHome Device Builder";
     };
 
     openFirewall = mkOption {
       default = false;
       type = types.bool;
       description = "Whether to open the firewall for the specified port.";
+    };
+
+    trustedDomains = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = "Hostnames the WebSocket handshake trusts (case-insensitive, port-tolerant)";
     };
 
     allowedDevices = mkOption {
@@ -65,18 +113,12 @@ in
         "/dev/serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_0001-if00-port0"
       ];
       description = ''
-        A list of device nodes to which {command}`esphome` has access to.
+        A list of device nodes to which {command}`esphome-device-builder` has access to.
         Refer to DeviceAllow in {manpage}`systemd.resource-control(5)` for more information.
         Beware that if a device is referred to by an absolute path instead of a device category,
         it will only allow devices that already are plugged in when the service is started.
       '';
       type = types.listOf types.str;
-    };
-
-    usePing = mkOption {
-      default = false;
-      type = types.bool;
-      description = "Use ping to check online status of devices instead of mDNS";
     };
 
     environment = mkOption {
@@ -87,8 +129,8 @@ in
         using the {option}`services.esphome.environmentFile` option.
       '';
       example = {
-        USERNAME = "reimu";
-        PASSWORD = "gensokyo9";
+        ESPHOME_TRUSTED_DOMAINS = "dashboard.example.com";
+        ESPHOME_REMOTE_BUILD_PORT = "6055";
       };
     };
 
@@ -100,10 +142,27 @@ in
         Use this option for setting the dashboard password.
       '';
     };
+
+    extraArgs = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = ''
+        Extra command line arguments for the ESPHome Device Builder.
+      '';
+    };
   };
 
+  imports = [
+    (mkRemovedOptionModule [ "services" "esphome" "usePing" ] ''
+      This option is no longer used by the ESPHome Device Builder which replaced the legacy ESPHome dashboard.
+    '')
+  ];
+
   config = mkIf cfg.enable {
-    networking.firewall.allowedTCPPorts = mkIf (cfg.openFirewall && !cfg.enableUnixSocket) [ cfg.port ];
+    networking.firewall.allowedTCPPorts = mkIf (cfg.openFirewall && !cfg.enableUnixSocket) [
+      cfg.port
+      cfg.remoteBuildPort
+    ];
 
     # Use a static system user instead of DynamicUser.
     # DynamicUser creates a /var/lib/esphome -> /var/lib/private/esphome symlink
@@ -118,7 +177,7 @@ in
     users.groups.esphome = { };
 
     systemd.services.esphome = {
-      description = "ESPHome dashboard";
+      description = "ESPHome Device Builder";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
       path = [ cfg.package ];
@@ -130,11 +189,10 @@ in
         # platformio needs a writable HOME for its configuration
         HOME = stateDir;
       }
-      // lib.optionalAttrs cfg.usePing { ESPHOME_DASHBOARD_USE_PING = "true"; }
       // cfg.environment;
 
       serviceConfig = {
-        ExecStart = "${cfg.package}/bin/esphome dashboard ${esphomeParams} ${stateDir}";
+        ExecStart = "${lib.getExe cfg.package} ${lib.concatStringsSep " " esphomeParams} ${stateDir}";
         User = "esphome";
         Group = "esphome";
         WorkingDirectory = stateDir;

--- a/nixos/modules/services/home-automation/esphome.nix
+++ b/nixos/modules/services/home-automation/esphome.nix
@@ -38,7 +38,10 @@ let
   ++ cfg.extraArgs;
 in
 {
-  meta.maintainers = with maintainers; [ oddlama ];
+  meta.maintainers = with maintainers; [
+    oddlama
+    tmarkus
+  ];
 
   options.services.esphome = {
     enable = mkEnableOption "ESPHome Device Builder, for making custom firmwares for ESP32/ESP8266";

--- a/nixos/tests/esphome.nix
+++ b/nixos/tests/esphome.nix
@@ -7,7 +7,10 @@ let
 in
 {
   name = "esphome";
-  meta.maintainers = with lib.maintainers; [ oddlama ];
+  meta.maintainers = with lib.maintainers; [
+    oddlama
+    tmarkus
+  ];
 
   nodes = {
     esphomeTcp =

--- a/nixos/tests/esphome.nix
+++ b/nixos/tests/esphome.nix
@@ -2,6 +2,7 @@
 
 let
   testPort = 6052;
+  remoteBuildPort = 6055;
   unixSocket = "/run/esphome/esphome.sock";
 in
 {
@@ -28,6 +29,17 @@ in
           enableUnixSocket = true;
         };
       };
+
+    esphomeRemoteBuild =
+      { ... }:
+      {
+        services.esphome = {
+          enable = true;
+          remoteBuildOnly = true;
+          inherit remoteBuildPort;
+          openFirewall = true;
+        };
+      };
   };
 
   testScript = ''
@@ -38,5 +50,8 @@ in
     esphomeUnix.wait_for_unit("esphome.service")
     esphomeUnix.wait_for_file("${unixSocket}")
     esphomeUnix.succeed("curl --fail --unix-socket ${unixSocket} http://localhost/")
+
+    esphomeRemoteBuild.wait_for_unit("esphome.service")
+    esphomeRemoteBuild.wait_for_open_port(${toString remoteBuildPort})
   '';
 }

--- a/pkgs/by-name/es/esphome-device-builder/package.nix
+++ b/pkgs/by-name/es/esphome-device-builder/package.nix
@@ -7,6 +7,7 @@
   versionCheckHook,
   esptool,
   esphome,
+  nixosTests,
 }:
 
 let
@@ -134,6 +135,10 @@ pythonPackages.buildPythonApplication (finalAttrs: {
   ];
 
   passthru = {
+    tests = {
+      inherit (nixosTests) esphome;
+    };
+
     frontend = pythonPackages.esphome-device-builder-frontend;
     updateScript = callPackage ./update.nix { };
   };


### PR DESCRIPTION
See #549709.
Haven't be able to exhaustively test this, it's more of a baseline PR to switch over to the device builder.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
