### PR TITLE
python3Packages.msgspec: Fix tests & runtime behaviour on big-endian

### DIFF
--- a/pkgs/development/python-modules/msgspec/default.nix
+++ b/pkgs/development/python-modules/msgspec/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   attrs,
   coverage,
   furo,
@@ -36,6 +37,19 @@ buildPythonPackage rec {
     # https://github.com/NixOS/nixpkgs/issues/84312
     hash = "sha256-mjABnKhZeLLbSQPelZmi+UKZDEIiXi3c9shC8EG6tfE=";
   };
+
+  patches = [
+    # Ext.code is backed by a long, not an int. int (with sizeof(int) < sizeof(long)) makes it return the high half
+    # of the long on big-endian, so every code turns 0 or -1 when read.
+    # Fixes TestExt suite, and runtime usage of msgpack.Ext(), on big-endian.
+    # https://github.com/msgspec/msgspec/pull/1135
+    # Remove when version >= 0.22.0
+    (fetchpatch {
+      name = "0001-msgspec-Fix-backing-type-declaration-of-Ext.code.patch";
+      url = "https://github.com/msgspec/msgspec/commit/c24bc7025cbf153edc7d32256ea1279f49f422ea.patch";
+      hash = "sha256-JypmnX55s+wbWzBDsZjsQbkqpE6Cg61GpJ9lSvNrAgY=";
+    })
+  ];
 
   build-system = [
     setuptools


### PR DESCRIPTION
See https://github.com/msgspec/msgspec/pull/1135 / the vendored patch file for details. Fixes the tests (and likely some runtime behaviour somewhere) on big-endian systems.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] powerpc64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
