### PR TITLE
cloud-hypervisor: backport musl 1.2.6 fix

### DIFF
--- a/pkgs/by-name/cl/cloud-hypervisor/musl-1.2.6.patch
+++ b/pkgs/by-name/cl/cloud-hypervisor/musl-1.2.6.patch
@@ -1,0 +1,50 @@
+From b28ec4cda06af1afe378783bb505e1d9d62a4e4c Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Tue, 4 Aug 2026 01:45:12 +0200
+Subject: [PATCH] seccomp: allow pwritev2
+
+Since the latest release, musl preferentially uses this syscall in its
+pwrite and pwritev implementations.
+
+Signed-off-by: Alyssa Ross <hi@alyssa.is>
+(cherry picked from commit 3e8d2dac6f83ee8e741e88ac5d4298050d17693e)
+---
+ virtio-devices/src/seccomp_filters.rs | 1 +
+ vmm/src/seccomp_filters.rs            | 2 ++
+ 2 files changed, 3 insertions(+)
+
+diff --git a/virtio-devices/src/seccomp_filters.rs b/virtio-devices/src/seccomp_filters.rs
+index 75f493448..cbde59ea3 100644
+--- a/virtio-devices/src/seccomp_filters.rs
++++ b/virtio-devices/src/seccomp_filters.rs
+@@ -128,6 +128,7 @@ fn virtio_block_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
+         (libc::SYS_pread64, vec![]),
+         (libc::SYS_preadv, vec![]),
+         (libc::SYS_pwritev, vec![]),
++        (libc::SYS_pwritev2, vec![]),
+         (libc::SYS_pwrite64, vec![]),
+         (libc::SYS_sched_getaffinity, vec![]),
+         (libc::SYS_sched_setaffinity, vec![]),
+diff --git a/vmm/src/seccomp_filters.rs b/vmm/src/seccomp_filters.rs
+index 308cfa6bf..cfbde2866 100644
+--- a/vmm/src/seccomp_filters.rs
++++ b/vmm/src/seccomp_filters.rs
+@@ -725,6 +725,7 @@ fn vmm_thread_rules(
+         (libc::SYS_prlimit64, vec![]),
+         (libc::SYS_pwrite64, vec![]),
+         (libc::SYS_pwritev, vec![]),
++        (libc::SYS_pwritev2, vec![]),
+         (libc::SYS_read, vec![]),
+         (libc::SYS_readv, vec![]),
+         #[cfg(target_arch = "x86_64")]
+@@ -934,6 +935,7 @@ fn vcpu_thread_rules(
+         (libc::SYS_openat, vec![]),
+         (libc::SYS_pread64, vec![]),
+         (libc::SYS_pwrite64, vec![]),
++        (libc::SYS_pwritev2, vec![]),
+         (libc::SYS_read, vec![]),
+         #[cfg(target_arch = "x86_64")]
+         (libc::SYS_readlink, vec![]),
+-- 
+2.55.0
+

--- a/pkgs/by-name/cl/cloud-hypervisor/package.nix
+++ b/pkgs/by-name/cl/cloud-hypervisor/package.nix
@@ -23,6 +23,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-+RbW/9ap/69MyODUk/bHBlH6ZuqYYIyKaarYSMQ2G7w=";
 
+  patches = [
+    ./musl-1.2.6.patch
+  ];
+
   separateDebugInfo = true;
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
We recently upgraded to musl 1.2.6, and since then Cloud Hypervisor crashes with the sandbox enabled.  Backport my fix, which has been merged upstream.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
