### PR TITLE
pid-fan-controller: 0.1.3 -> 0.1.5

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -103,6 +103,8 @@
 
 - Support for the legacy U‐Boot image format has been removed from the initrd generators, as it is deprecated upstream and no longer used by any platform in Nixpkgs.
 
+- `services.pid-fan-controller` no longer provides deep configuration rewriting and adheres now fully to RFC42.
+
 - The `extraArgs` and `check` arguments to `nixos/lib/eval-config.nix` (and therefore to `lib.nixosSystem`) have been removed after being deprecated with a warning since 2021. Passing them is now an evaluation error. Instead of `extraArgs`, set `config._module.args`; instead of `check = false`, set `config._module.check = false`. The `extraArgs` attribute on the resulting configuration has been removed as well.
 
 - Rustical migrates from `settings.http.host` and `settings.http.port` to `settings.http.bind` to support UNIX domain sockets as well as TCP sockets in one setting.

--- a/nixos/modules/services/hardware/pid-fan-controller.nix
+++ b/nixos/modules/services/hardware/pid-fan-controller.nix
@@ -30,26 +30,10 @@ in
       oldConfig = cfg.settings ? heatSources;
       configFile = settingsFormat.generate "pid-fan-settings.json" (
         if oldConfig then
-          {
-            interval = cfg.settings.interval or 500;
-            heat_srcs = map (heatSrc: {
-              name = heatSrc.name or "";
-              wildcard_path = heatSrc.wildcardPath;
-              PID_params = {
-                set_point = heatSrc.pidParams.setPoint;
-                P = heatSrc.pidParams.P;
-                I = heatSrc.pidParams.I;
-                D = heatSrc.pidParams.D;
-              };
-            }) cfg.settings.heatSources;
-            fans = map (fan: {
-              wildcard_path = fan.wildcardPath;
-              min_pwm = fan.minPwm;
-              max_pwm = fan.maxPwm;
-              cutoff = fan.cutoff or false;
-              heat_pressure_srcs = fan.heatPressureSrcs;
-            }) cfg.settings.fans;
-          }
+          throw ''
+            `pid-fan-controller` is no longer deeply configured.
+            Please switch to using underscore case as shown in the upstream documentation.
+          ''
         else
           cfg.settings
       );
@@ -58,18 +42,6 @@ in
       systemd.packages = [ cfg.package ];
       systemd.services.pid-fan-controller.environment.PID_FAN_CONFIG = toString configFile;
       systemd.services.pid-fan-controller.wantedBy = [ "multi-user.target" ];
-      systemd.services.pid-fan-controller-sleep.wantedBy = [ "sleep.target" ];
-
-      warnings =
-        if oldConfig then
-          [
-            ''
-              The configuration of `pid-fan-controller` is no longer deeply configured and the rewriting will be removed in 26.11!
-              Please switch to using underscore case as shown in the upstream documentation.
-            ''
-          ]
-        else
-          [ ];
     };
   meta.maintainers = with lib.maintainers; [ zimward ];
 }

--- a/pkgs/by-name/pi/pid-fan-controller/package.nix
+++ b/pkgs/by-name/pi/pid-fan-controller/package.nix
@@ -4,7 +4,7 @@
   lib,
 }:
 let
-  version = "0.1.3";
+  version = "0.1.5";
 in
 rustPlatform.buildRustPackage {
   pname = "pid-fan-controller";
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage {
     owner = "zimward";
     repo = "pid-fan-controller";
     tag = version;
-    hash = "sha256-BgBFX4x1gMSMla7lhkFk1n5fBC1TFK0Z5Z3mFH2oBF0=";
+    hash = "sha256-2LylkjhWYMHGG/dSkbBoKv2Dpf6yNqfvsUdmJlwqPzU=";
   };
   cargoHash = "sha256-AN7EbjKZBxb8UP0MEbJUw5Y8E/rE35MByKVmxX2ctko=";
 
@@ -24,7 +24,6 @@ rustPlatform.buildRustPackage {
   '';
   postInstall = ''
     install -Dm0644 resources/pid-fan-controller.service $out/lib/systemd/system/pid-fan-controller.service
-    install -Dm0644 resources/pid-fan-controller-sleep.service $out/lib/systemd/system/pid-fan-controller-sleep.service
   '';
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
