### PR TITLE
stirling-pdf: 2.14.2 -> 2.14.3

### DIFF
--- a/pkgs/by-name/st/stirling-pdf/deps.json
+++ b/pkgs/by-name/st/stirling-pdf/deps.json
@@ -854,35 +854,35 @@
    "module": "sha256-yEQahybbGk+dTzngaOu0LfalnWR+MqnGHBW1OQ7VklI=",
    "pom": "sha256-CPvpfh4ugVoUyvFv9ayHCFEb713ec51gwHE5UYdtomM="
   },
-  "com/stirling#jpdfium-natives-darwin-arm64/1.0.2": {
-   "jar": "sha256-Jy3uCtUMP9v7CnP0Ax223rRCMG5uxUHpl4JcOR+c4WY=",
-   "module": "sha256-x1gci7X676q26K4oKG1P/1THjPVo8ofwT/c2Zxb5OkY=",
-   "pom": "sha256-4BlPDsF6qNpIsPt1sGe3PDoDXeTNPIR/KJ2nZKVdtlQ="
+  "com/stirling#jpdfium-natives-darwin-arm64/1.0.4": {
+   "jar": "sha256-GP8LORIvh0q82cihKer3fYKmD0uBk4hCONfB+zwipLY=",
+   "module": "sha256-VOWBvq3xzyb/6jtJ+GUvaUl0uIup6erhQfuhfabFs34=",
+   "pom": "sha256-aC3bwLjzZoQtABhpK7zcZ7iJVyztOA2NjjHRC7OjF7Q="
   },
-  "com/stirling#jpdfium-natives-darwin-x64/1.0.2": {
-   "jar": "sha256-MOknHnAXXSuX9EicEI02bxeD0CZ7u5RD4uPfuMUa7JQ=",
-   "module": "sha256-ftSn7FE43X1Daf5S3JtKdV5Z284/wIVayo5dXlOVH0g=",
-   "pom": "sha256-Niue51BiUHVNrKTOWoYlX5JvR2KVkSrZK09LlfkDrv4="
+  "com/stirling#jpdfium-natives-darwin-x64/1.0.4": {
+   "jar": "sha256-0fvs/AmgOOrp4plMvxiMoh704aTQIk2nE0SxM/IV8+k=",
+   "module": "sha256-sJvmpLzTuXOfU1pdiL2EKCWA2RQ1FxEH2Nj1SYM6VGw=",
+   "pom": "sha256-s+tVZQ2TRMtaHLNK2fFY8o+xHbWNhOBW+R0oLwDRL1c="
   },
-  "com/stirling#jpdfium-natives-linux-arm64/1.0.2": {
-   "jar": "sha256-PyV9SSpu26fjnBVSjWPk7ZdeqNd+w84to80fyB6RJJQ=",
-   "module": "sha256-PehWG6orSRJ/x/TMaTH7E0nSclIQFc5apD6Tzg1rtPk=",
-   "pom": "sha256-vkeoUt2Ol7DbFPuRqA3bfv3RHhmefEQctCfnBGu0PiM="
+  "com/stirling#jpdfium-natives-linux-arm64/1.0.4": {
+   "jar": "sha256-gD/T/vKIIHPldxUZ+Q038Z/qJxmloSQBjb9tsVrXtSU=",
+   "module": "sha256-VMzWnMRzQyulqQa+WrT1mOqgM/bjE3aGrhLdvtmsUsU=",
+   "pom": "sha256-KG4b/zMv4EkQkJ8Lqhfs8A2YXORJHFElIrTpBLRZNoc="
   },
-  "com/stirling#jpdfium-natives-linux-x64/1.0.2": {
-   "jar": "sha256-SL8w09JO+B07MMq0/I9zNf11YcoiyIHOzVw+bkOa2fY=",
-   "module": "sha256-8mm3odjyo8gozfNk8YaFBGP17Wggr1QfY89zoIa6REE=",
-   "pom": "sha256-0YRWllBTpznT+9RfdlyseRMezCs3JxtEEWHkNMCSTLg="
+  "com/stirling#jpdfium-natives-linux-x64/1.0.4": {
+   "jar": "sha256-u0tnfzEDISd2SmScZhV4Bn/Ucxb5Pm//65kVJHMDtf0=",
+   "module": "sha256-ad5CtEBwXHBGQWZntVz8JhMuSv2yKj4SPHqRAV5NS+g=",
+   "pom": "sha256-kn/kj5Rb2p2o/dn8IiOMXbIMh9emYopuGceU8X2qbL4="
   },
-  "com/stirling#jpdfium-natives-windows-x64/1.0.2": {
-   "jar": "sha256-x+zlqBIhD+qUBFbYNQIYiSsDgKLYZFoObz8h5QaYbv8=",
-   "module": "sha256-B8lrv5noknHeZGIO2spu4fDzJ+KD7MpQSGuz5jW/BEo=",
-   "pom": "sha256-h5aXa6biCbWGtWe+Z7sbOBVU8fjfDshdBusdpvPoiOw="
+  "com/stirling#jpdfium-natives-windows-x64/1.0.4": {
+   "jar": "sha256-R1KlxhnNXsQ3jaS89XlEKvH9Eaob6HHSRiwt7nZYYYg=",
+   "module": "sha256-GK1CPKIIGydZUPtMM/5d8HmbfbANC/TYlLG9M3YF1Z0=",
+   "pom": "sha256-d+vYh31gpx840YXxi/YglZlZ9k6e3QfSkIYI7V//5L8="
   },
-  "com/stirling#jpdfium/1.0.2": {
-   "jar": "sha256-m5vQo+K1whZs+3LV8etFnT047pTIayWhCB98lZ636+Y=",
-   "module": "sha256-iLo6iB9ancv1mXJFZ1oNBMRwZrx5vDEcmCGFm+Ti07U=",
-   "pom": "sha256-d6xFgvn13+/ancvKfseKA+cDSckKlHXYmI6bNNbv0KU="
+  "com/stirling#jpdfium/1.0.4": {
+   "jar": "sha256-Jh+davgVoFtvYrwXy+j9I84gLu+eP8G/P9PxE0Zc4eM=",
+   "module": "sha256-IDofIvoyWKJZJT3ZKjCAUba+ExE5Gm+FJh6If93qUoA=",
+   "pom": "sha256-SBDAt8EqzZjPETiHDbNaNy6idJmNdtvi5Q+kXhNg8/M="
   },
   "com/sun/activation#all/1.2.0": {
    "pom": "sha256-HYUY46x1MqEE5Pe+d97zfJguUwcjxr2z1ncIzOKwwsQ="
@@ -1586,6 +1586,9 @@
   "org/apache#apache/37": {
    "pom": "sha256-Uk7EeHr/c69rOp+voVTH8YgbZIKZtmP9v8rdoShvI1M="
   },
+  "org/apache#apache/39": {
+   "pom": "sha256-cXUu1MJDWh2Dhf4KTTMPOdBO/sifDRul0VmNOfc5ekQ="
+  },
   "org/apache/activemq#activemq-bom/6.1.8": {
    "pom": "sha256-qUF6jlh2GhfWVwzZClBokbUfd03TKZ7IC4Uxr/TlMHw="
   },
@@ -1776,9 +1779,9 @@
   "org/apache/logging/log4j#log4j/2.25.4": {
    "pom": "sha256-+K6JBKKONPoEw103QGGdroNjJAG6HjE7r9fM9aMADew="
   },
-  "org/apache/pdfbox#fontbox/3.0.7": {
-   "jar": "sha256-gUnZiXq1BPej83l9VSzYkl71gUm03j+0cOtG10fmj4Y=",
-   "pom": "sha256-o/xYnFZLQbybtLty0XPM5fjCM10uZtY0SJtqiwS/63o="
+  "org/apache/pdfbox#fontbox/3.0.8": {
+   "jar": "sha256-oZFcJOPtvg7OyTiW379tQUJ4ELZjrel71Oi66G7D/as=",
+   "pom": "sha256-F4Bd6Nrp6AUZZh3RwKYj1plZDyEs7M2x3JhScz8a6W8="
   },
   "org/apache/pdfbox#jbig2-imageio/3.0.3": {
    "jar": "sha256-yAEQ/aVxKFY9PQZWv/eNqL81qTTPVO36EOi3b8Y4mSk=",
@@ -1788,24 +1791,24 @@
    "jar": "sha256-KcspUWIvEKz2H9BlbE5vpVYhlKkJX3odJqpCbi9rF+s=",
    "pom": "sha256-KOp8SskuCYX3lqi8aJCnvviSZwetrf0eLIVsmwvho4s="
   },
-  "org/apache/pdfbox#pdfbox-io/3.0.7": {
-   "jar": "sha256-uag4KRl4BpCG77zR9iuBueSmAW5h3SxoEE7p9ML/mXs=",
-   "pom": "sha256-dCz9VwGuLNV6HS7mG+z+G9FUm6dwTH+xcZN/rQECFLY="
+  "org/apache/pdfbox#pdfbox-io/3.0.8": {
+   "jar": "sha256-NqDgQAEBC0x2SFeBdBK5YzmTCxl1XnKJWYBcwDUgYbI=",
+   "pom": "sha256-ytjpKa+CSTlHcTsDpE0Iwcm3g5qok17Gl5PaWbBrBPc="
   },
-  "org/apache/pdfbox#pdfbox-parent/3.0.7": {
-   "pom": "sha256-z60fFpQrxTkWiDsxQ/JRfseUc3Es1yNKWopxwQsPrnQ="
+  "org/apache/pdfbox#pdfbox-parent/3.0.8": {
+   "pom": "sha256-8DE3PwPA+S+05JIQZFzVPkDpV5IZZVNjzhlkT/d5KD4="
   },
-  "org/apache/pdfbox#pdfbox/3.0.7": {
-   "jar": "sha256-fO+nF2IjMJUbQ0Or8eXTa8yxH0uiRdeKqnMlHQj+xiM=",
-   "pom": "sha256-3nkpJ2LYVd1pqOVVyeDm3kD1OP+9l9AS0bs6TQRa0Ec="
+  "org/apache/pdfbox#pdfbox/3.0.8": {
+   "jar": "sha256-l2R8+95h68/Aa0z4ybD/yq7gczluzrSn9oNqm5EokDw=",
+   "pom": "sha256-Gs/OcY7ckA3/dbF6/UQnKwIqTw6RStvnZTHfVoYkA90="
   },
-  "org/apache/pdfbox#preflight/3.0.7": {
-   "jar": "sha256-ae3MeMB9ZSe6oAYCzn/X+WcoJHVV7xpNmp0LytBSVpM=",
-   "pom": "sha256-sXRZcjGLrEGdHbpf9RvTh5hUHe9/vlNzIN3B+Bhf9Jw="
+  "org/apache/pdfbox#preflight/3.0.8": {
+   "jar": "sha256-N1pdLJPKxIk0NU8UbfkQdOrsnAGBY0bl6VZUNUHofmk=",
+   "pom": "sha256-qGdPrcs8berlpCr4cidcsEdJOPqUYTBmto12iXl0Q0g="
   },
-  "org/apache/pdfbox#xmpbox/3.0.7": {
-   "jar": "sha256-pTB9h3ZBA+YZS7+4AKj3msutLfMtWdq8oiUqv5I8QBo=",
-   "pom": "sha256-fnE6xU8e5I9oIwDC6yft4ZEe9vVZRit38rkS6gPCm1E="
+  "org/apache/pdfbox#xmpbox/3.0.8": {
+   "jar": "sha256-8ETS4xbldxSgrfJyrYq/SoY7iXj9F9xbhtz6gTVGmxA=",
+   "pom": "sha256-KT0RLIe2aDxWAMHy0TmQYE/dtaRPf+AEMNB0ZJ+7d2g="
   },
   "org/apache/poi#poi-ooxml-lite/5.5.1": {
    "jar": "sha256-5uN63rbW7otA7Eka2VXZNNj5mCerBQ8QWxgoblmx2ec=",

--- a/pkgs/by-name/st/stirling-pdf/package.nix
+++ b/pkgs/by-name/st/stirling-pdf/package.nix
@@ -12,11 +12,8 @@
   makeBinaryWrapper,
   nodejs,
   npmHooks,
-  pax-utils,
   pkg-config,
-  unzip,
   wrapGAppsHook3,
-  zip,
 
   glib-networking,
   jdk25,
@@ -38,56 +35,18 @@ assert isDesktopVariant -> !buildWithFrontend;
 let
   gradle = gradle_8;
   jre = jdk25;
-  # jpdfium 1.0.2's bundled x86_64 libicudata.so.74 has an erroneous executable
-  # PT_GNU_STACK; the arm64 archive was checked and already has a non-executable stack.
-  # Fixed upstream for the next natives release; remove when Stirling-PDF updates jpdfium.
-  # https://github.com/Stirling-Tools/Stirling-PDF/issues/6869
-  # https://github.com/Stirling-Tools/JPDFium/pull/19
-  patchJpdfium = lib.optionalString (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64) ''
-    nativeJars=(
-      "$GRADLE_USER_HOME"/caches/modules-2/files-2.1/com.stirling/jpdfium-natives-linux-x64/*/*/jpdfium-natives-linux-x64-*.jar
-    )
-    if (( ''${#nativeJars[@]} != 1 )); then
-      echo "expected exactly one jpdfium native JAR, found ''${#nativeJars[@]}" >&2
-      exit 1
-    fi
-    nativeJar="''${nativeJars[0]}"
-
-    patchDir="$(mktemp -d)"
-    unzip -q "$nativeJar" natives/linux-x64/libicudata.so.74 -d "$patchDir"
-    scanelf -X -e "$patchDir/natives/linux-x64/libicudata.so.74"
-    touch --date=@315532800 "$patchDir/natives/linux-x64/libicudata.so.74"
-
-    chmod u+w "$nativeJar"
-    (cd "$patchDir" && zip -q -X "$nativeJar" natives/linux-x64/libicudata.so.74)
-
-    bootJars=( ./app/core/build/libs/stirling-pdf-*.jar )
-    if (( ''${#bootJars[@]} != 1 )); then
-      echo "expected exactly one Stirling-PDF JAR, found ''${#bootJars[@]}" >&2
-      exit 1
-    fi
-    bootJar="$(realpath "''${bootJars[0]}")"
-    nestedJar="BOOT-INF/lib/$(basename "$nativeJar")"
-    mkdir -p "$patchDir/$(dirname "$nestedJar")"
-    cp "$nativeJar" "$patchDir/$nestedJar"
-    touch --date=@315532800 "$patchDir/$nestedJar"
-
-    chmod u+w "$bootJar"
-    (cd "$patchDir" && zip -q -X -0 "$bootJar" "$nestedJar")
-    rm -rf "$patchDir"
-  '';
 in
 stdenv.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
 
   pname = "stirling-pdf" + lib.optionalString isDesktopVariant "-desktop";
-  version = "2.14.2";
+  version = "2.14.3";
 
   src = fetchFromGitHub {
     owner = "Stirling-Tools";
     repo = "Stirling-PDF";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-2u4d9K4OEuOw9qE4YgpGXDvVLExVGUKAeXYNCySqy1c=";
+    hash = "sha256-Jh7F3e7Zho3BlaBZD8xfXSCjwXyF5qQk4VSm8DIwIBY=";
   };
 
   patches = [
@@ -111,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
     name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
     inherit (finalAttrs) src patches;
     postPatch = "cd ${finalAttrs.npmRoot}";
-    hash = "sha256-ujvSzang7n6DJZbNU/lDlG0x1265N5LJ6prkPbBYEic=";
+    hash = "sha256-3JYcOtX0pBMIgUtcK6LoejIhoSR2jpnQRzhePdCfJzI=";
   };
 
   cargoRoot = "frontend/editor/src-tauri";
@@ -152,9 +111,6 @@ stdenv.mkDerivation (finalAttrs: {
     gradle
     jre # one of the tests also require that the `java` command is available on the command line
     makeBinaryWrapper
-    pax-utils
-    unzip
-    zip
   ]
   ++ lib.optionals (buildWithFrontend || isDesktopVariant) [
     nodejs
@@ -185,7 +141,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     # this simulates what the desktop:jlink:jar would do
     gradle bootJar
-    ${patchJpdfium}
     install -Dm644 ./app/core/build/libs/stirling-pdf-*.jar -t ./frontend/editor/src-tauri/libs
 
     # creates as minimal jre via jlink
@@ -194,8 +149,6 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace frontend/editor/src-tauri/stirling-pdf.desktop \
       --replace-fail 'MimeType=application/pdf;' 'MimeType=application/pdf;x-scheme-handler/stirlingpdf;'
   '';
-
-  postBuild = lib.optionalString (!isDesktopVariant) patchJpdfium;
 
   # we use the installPhase from cargo-tauri-hook when we're building the desktop variant
   installPhase = lib.optionalString (!isDesktopVariant) ''


### PR DESCRIPTION
Updates both `stirling-pdf` and `stirling-pdf-desktop` to 2.14.3.

Release notes: https://github.com/Stirling-Tools/Stirling-PDF/releases/tag/v2.14.3

The Gradle dependency manifest and npm dependency hash were regenerated. JPDFium is updated to 1.0.4; all bundled Linux x86_64 ELF objects report a non-executable `GNU_STACK` (`RW-`), so the previous executable-stack rewrite and its build-only tools are removed.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests]. Attempted twice; the local test-driver guest shell timed out before the first assertion, although `stirling-pdf.service` started. A forced package-independent test-driver VM test passed but needed 201 seconds to establish its shell.
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Both server and desktop derivations build with their full upstream check phases.
  - The built server started as v2.14.3 and returned HTTP 200 with the Stirling page.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

`nixpkgs-vet` passes against current `master`.

Assisted-by: OpenCode, GPT-5.6 Sol

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/tree/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/tree/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/tree/master/pkgs/test