### PR TITLE
curl, curlFull, curlWithGnuTls: move to pkgs/by-name; curlFull: include c-ares support

### DIFF
--- a/pkgs/by-name/cu/curl/package.nix
+++ b/pkgs/by-name/cu/curl/package.nix
@@ -1,0 +1,15 @@
+{
+  curlMinimal,
+  ...
+}@args:
+
+curlMinimal.override (
+  {
+    brotliSupport = true;
+    http3Support = true;
+    idnSupport = true;
+    pslSupport = true;
+    zstdSupport = true;
+  }
+  // removeAttrs args [ "curlMinimal" ]
+)

--- a/pkgs/by-name/cu/curlFull/package.nix
+++ b/pkgs/by-name/cu/curlFull/package.nix
@@ -5,6 +5,7 @@
 
 curl.override (
   {
+    c-aresSupport = true;
     ldapSupport = true;
     gsaslSupport = true;
     rtmpSupport = true;

--- a/pkgs/by-name/cu/curlFull/package.nix
+++ b/pkgs/by-name/cu/curlFull/package.nix
@@ -1,0 +1,14 @@
+{
+  curl,
+  ...
+}@args:
+
+curl.override (
+  {
+    ldapSupport = true;
+    gsaslSupport = true;
+    rtmpSupport = true;
+    websocketSupport = true;
+  }
+  // removeAttrs args [ "curl" ]
+)

--- a/pkgs/by-name/cu/curlWithGnuTls/package.nix
+++ b/pkgs/by-name/cu/curlWithGnuTls/package.nix
@@ -1,0 +1,17 @@
+{
+  curl,
+  ngtcp2-gnutls,
+  ...
+}@args:
+
+curl.override (
+  {
+    gnutlsSupport = true;
+    opensslSupport = false;
+    ngtcp2 = ngtcp2-gnutls;
+  }
+  // removeAttrs args [
+    "curl"
+    "ngtcp2-gnutls"
+  ]
+)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1891,12 +1891,6 @@ with pkgs;
   # TODO: move to alias
   cudatoolkit = cudaPackages.cudatoolkit;
 
-  curlWithGnuTls = curl.override {
-    gnutlsSupport = true;
-    opensslSupport = false;
-    ngtcp2 = ngtcp2-gnutls;
-  };
-
   dconf2nix = callPackage ../development/tools/haskell/dconf2nix { };
 
   inherit (callPackages ../applications/networking/p2p/deluge { })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1899,14 +1899,6 @@ with pkgs;
     websocketSupport = true;
   };
 
-  curl = curlMinimal.override {
-    idnSupport = true;
-    pslSupport = true;
-    zstdSupport = true;
-    http3Support = true;
-    brotliSupport = true;
-  };
-
   curlWithGnuTls = curl.override {
     gnutlsSupport = true;
     opensslSupport = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1891,14 +1891,6 @@ with pkgs;
   # TODO: move to alias
   cudatoolkit = cudaPackages.cudatoolkit;
 
-  curlFull = curl.override {
-    ldapSupport = true;
-    gsaslSupport = true;
-    rtmpSupport = true;
-    pslSupport = true;
-    websocketSupport = true;
-  };
-
   curlWithGnuTls = curl.override {
     gnutlsSupport = true;
     opensslSupport = false;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

~~I took the liberty to place the `curl` package before the other curl* packages in `all-packages.nix`, to better convey that the latter are derived from the former.~~

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
