### PR TITLE
nopass: init at 0.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26833,6 +26833,12 @@
     githubId = 20756843;
     name = "Sofi";
   };
+  souravsspace = {
+    email = "souravsspace@gmail.com";
+    github = "souravsspace";
+    githubId = 88476413;
+    name = "Sourav";
+  };
   soyouzpanda = {
     name = "soyouzpanda";
     email = "soyouzpanda@soyouzpanda.fr";

--- a/pkgs/by-name/no/nopass/package.nix
+++ b/pkgs/by-name/no/nopass/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  stdenv,
+  git,
+  pkg-config,
+  udev,
+  # The FIDO2 security-key slot pulls in a C HID stack. Off by default,
+  # exactly as in Cargo.toml.
+  withSecurityKey ? false,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "nopass";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "souravsspace";
+    repo = "nopass";
+    tag = "v${version}";
+    hash = "sha256-b2H7xPI5Nt2Zwe4YGpigvxh/OFfPw5Gq54dRKuB3lU8=";
+  };
+
+  cargoHash = "sha256-zmDWXbcjraMfizO4vYTVeH2gKWbb75FK7vACNV92qzo=";
+
+  cargoBuildFlags = [
+    "--package"
+    "nopass-cli"
+  ];
+  buildFeatures = lib.optional withSecurityKey "security-key";
+
+  nativeBuildInputs = lib.optionals withSecurityKey [ pkg-config ];
+  buildInputs = lib.optionals (withSecurityKey && stdenv.hostPlatform.isLinux) [ udev ];
+
+  # The history and sync tests drive a real git, and every test wants a HOME
+  # of its own to keep away from the one running the build.
+  nativeCheckInputs = [ git ];
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  meta = {
+    description = "Fast, self-contained password manager";
+    longDescription = ''
+      nopass keeps each password in its own age-encrypted file under one
+      directory. Every command that reads or changes the store asks for your
+      master passphrase; reads can reuse a cached one when you opt in.
+    '';
+    homepage = "https://github.com/souravsspace/nopass";
+    changelog = "https://github.com/souravsspace/nopass/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ souravsspace ];
+    mainProgram = "nopass";
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
nopass is a password manager that keeps each entry in its own age-encrypted
file under one directory. It is self-contained — the age implementation is a
Rust dependency, not an external binary — with gpg available as an optional
backend.

Homepage: https://github.com/souravsspace/nopass

Two commits: the maintainer entry, then the package.

Notes for reviewers:

- `nativeCheckInputs = [ git ]` and the `preCheck` HOME are load-bearing.
  The suite is hermetic (no network, temp dirs throughout) but the history
  and sync tests drive a real git, and every test wants a HOME away from the
  build user's.
- `withSecurityKey` is off by default, matching the crate's own default. The
  feature pulls in a C HID stack, and on Linux `udev`.
- `platforms = lib.platforms.unix`: the CLI uses unix sockets for its
  passphrase agent, `stty` for hidden prompts, and `/dev/shm` when present.

I am the upstream author. I have only built this on aarch64-darwin — a
Linux build and a `nixpkgs-review` run from someone with the hardware would
be welcome.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - the package's own test suite runs during the build (`doCheck`) — 162
    tests, all passing in the sandbox
  - `result/bin/nopass --version` and `--help` on aarch64-darwin
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
