### PR TITLE
Change networking.firewall.checkReversePath to "loose"

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -319,3 +319,6 @@
 - `nix` now supports running in "daemonless" mode by setting `nix.daemon.enable = false`. Under this mode all store operations must go through the [local store type](https://nix.dev/manual/nix/latest/store/types/local-store), which typically requires root permissions.
 
 - [Hister](https://github.com/asciimoo/hister), a web history service offering blazing fast, content-based search across visited websites. Available as [services.hister](#opt-services.hister.enable).
+
+- The default of [`networking.firewall.checkReversePath`](#opt-networking.firewall.checkReversePath) changed to `"loose"` to align with upstream systemd.
+  If your environment requires strict reverse path filtering, you must now explicitly configure it with `networking.firewall.checkReversePath = "strict";`.

--- a/nixos/modules/services/networking/firewall.nix
+++ b/nixos/modules/services/networking/firewall.nix
@@ -205,8 +205,8 @@ in
             "loose"
           ]
         );
-        default = true;
-        defaultText = lib.literalMD "`true` except if the iptables based firewall is in use and the kernel lacks rpfilter support";
+        default = "loose";
+        defaultText = "loose";
         example = "loose";
         description = ''
           Performs a reverse path filter test on a packet.  If a reply


### PR DESCRIPTION
This PR changes the default of [`networking.firewall.checkReversePath`](https://search.nixos.org/options?channel=unstable&query=reversepath&type=options#show=option%253Anetworking.firewall.checkReversePath) to `"loose"`.

Reasoning: the current default `strict` is neither the default of the linux kernel nor the default of systemd. Furthermore `strict` can break valid setups involving split DNS where the DNS resolver is not in the same broadcast domain as the client.

Systemd changed the default value in November 2018 from `strict` to `loose` so this PR aligns the module with upstream (see https://github.com/systemd/systemd/pull/10971).

The Kernel default is 0 (see https://sysctl-explorer.net/net/ipv4/rp_filter/). Note that such an option does not exist for IPV6.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
