### PR TITLE
home-assistant: 2026.8.0 -> 2026.8.1

### DIFF
--- a/pkgs/development/python-modules/aiowebostv/default.nix
+++ b/pkgs/development/python-modules/aiowebostv/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "aiowebostv";
-  version = "0.9.0";
+  version = "0.9.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "home-assistant-libs";
     repo = "aiowebostv";
     tag = "v${version}";
-    hash = "sha256-fdP5IfgjSFufHqbjujg68udF1mZTd1cHc5H0TogclUU=";
+    hash = "sha256-rHbGKJrEl/Rot7sW8KFK/a2bOF+XWfYbLlUs/1bqf2U=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/pyenphase/default.nix
+++ b/pkgs/development/python-modules/pyenphase/default.nix
@@ -22,14 +22,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pyenphase";
-  version = "3.1.0";
+  version = "3.2.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pyenphase";
     repo = "pyenphase";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-HV9cZW8lqdhkt+K7IWz2ExAheq7OoUrKRoVqmpqQ8Us=";
+    hash = "sha256-y/u1FmjA7lT4vTvH5wgnTgIbxd5EjjbBpl394GJo1ww=";
   };
 
   pythonRelaxDeps = [ "tenacity" ];

--- a/pkgs/development/python-modules/python-picnic-api2/default.nix
+++ b/pkgs/development/python-modules/python-picnic-api2/default.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   hatchling,
   lib,
+  pydantic,
   pytestCheckHook,
   pythonAtLeast,
   requests,
@@ -11,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "python-picnic-api2";
-  version = "1.3.4";
+  version = "2.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "codesalatdev";
     repo = "python-picnic-api";
     tag = "v${version}";
-    hash = "sha256-ytzzGr/z0jrsudtCBrcvGITo4DxxC8JCmSmQ8ybeomM=";
+    hash = "sha256-Ft/OEXkiXfsX1Kyi47PzycHk19jEIwYqyG+KP8q8x0I=";
   };
 
   postPatch = lib.optionalString (pythonAtLeast "3.14") ''
@@ -29,6 +30,7 @@ buildPythonPackage rec {
   build-system = [ hatchling ];
 
   dependencies = [
+    pydantic
     requests
     typing-extensions
   ];

--- a/pkgs/development/python-modules/pytrydan/default.nix
+++ b/pkgs/development/python-modules/pytrydan/default.nix
@@ -17,14 +17,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pytrydan";
-  version = "1.0.4";
+  version = "1.0.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "dgomes";
     repo = "pytrydan";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-4+bTRdU8XSxs9Lnh2tSp5i9px+2F80PnnULHYJVeEfE=";
+    hash = "sha256-sWGY7mfHJ+j2C8WAQYXD+cas+0gmsaRrt6PeetWWKV0=";
   };
 
   pythonRelaxDeps = [ "tenacity" ];

--- a/pkgs/development/python-modules/solaredge-web/default.nix
+++ b/pkgs/development/python-modules/solaredge-web/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "solaredge-web";
-  version = "0.3.0";
+  version = "0.3.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Solarlibs";
     repo = "solaredge-web";
     tag = "v${version}";
-    hash = "sha256-ptvONjdNBgdFWgxV2cRyfpa3rdvHjgTndhbmDzOfUZA=";
+    hash = "sha256-nhsY1/9ohT4CNLbDymNxSHex9AgeyZg+/Qka+L7vF3U=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2026.8.0";
+  version = "2026.8.1";
   components = {
     "3_day_blinds" =
       ps: with ps; [

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -270,7 +270,7 @@ let
   extraBuildInputs = extraPackages python3Packages;
 
   # Don't forget to run update-component-packages.py after updating
-  hassVersion = "2026.8.0";
+  hassVersion = "2026.8.1";
 
 in
 python3Packages.buildPythonApplication rec {
@@ -291,13 +291,13 @@ python3Packages.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     tag = version;
-    hash = "sha256-wFjH9i6SYt9ZGC3Ws4o121puz4rvReU/5zuxxLdCuKo=";
+    hash = "sha256-nR2VVEMoR5i2ZEnaL9wV0GiTv3NqxYAuEkgLL7iTiZ0=";
   };
 
   # Secondary source is pypi sdist for translations
   sdist = fetchPypi {
     inherit pname version;
-    hash = "sha256-LpZs8A7dproE/xxvcHwHO5315EgLUtvVlFHOyPMGEPk=";
+    hash = "sha256-YI1K1lIOXBbI2fQuqhWYTxq26ciWrIcvKjw4McycRb8=";
   };
 
   build-system = with python3Packages; [

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -8,7 +8,7 @@ buildPythonPackage (finalAttrs: {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20260729.5";
+  version = "20260729.6";
   format = "wheel";
 
   src = fetchPypi {
@@ -17,7 +17,7 @@ buildPythonPackage (finalAttrs: {
     pname = "home_assistant_frontend";
     dist = "py3";
     python = "py3";
-    hash = "sha256-LbFQ2MzXATsrswcRaigy3FSdys61uWnim42Aa6ilbtY=";
+    hash = "sha256-oBNTaN4rp1G/3gZ95PXYXYmBfj7aTiC17E6Rt+0911U=";
   };
 
   # there is nothing to strip in this package

--- a/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
+++ b/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "pytest-homeassistant-custom-component";
-  version = "0.13.354";
+  version = "0.13.355";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     owner = "MatthewFlamm";
     repo = "pytest-homeassistant-custom-component";
     tag = version;
-    hash = "sha256-odLMKgdhaG0Wd6Pi4pX4WtCosKxSDRIALhiVjah16no=";
+    hash = "sha256-urc+naai8VRkbNJ4Zu4GnLbkphPM+gbCh0fmtKaXYGI=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/servers/home-assistant/stubs.nix
+++ b/pkgs/servers/home-assistant/stubs.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "homeassistant-stubs";
-  version = "2026.8.0";
+  version = "2026.8.1";
   pyproject = true;
 
   disabled = python.version != home-assistant.python3Packages.python.version;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "KapJI";
     repo = "homeassistant-stubs";
     tag = version;
-    hash = "sha256-hUzC69fq4Q6NKxGrB03tWag4Wb9QNFjP2gvSj/K6hoQ=";
+    hash = "sha256-woTbzA7I4jl0XX46ZMdQFGhCd2c0H/p48PhoSvSTgCk=";
   };
 
   build-system = [


### PR DESCRIPTION
Diff: https://github.com/home-assistant/core/compare/2026.8.0...2026.8.1

Changelog: https://github.com/home-assistant/core/releases/tag/2026.8.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
