### PR TITLE
epiphany: fix CVE-2026-18487

### DIFF
--- a/pkgs/by-name/ep/epiphany/CVE-2026-18487.patch
+++ b/pkgs/by-name/ep/epiphany/CVE-2026-18487.patch
@@ -1,0 +1,85 @@
+From cecdea95801630c87ef1cc502437fedc608631bd Mon Sep 17 00:00:00 2001
+From: Michael Catanzaro <mcatanzaro@gnome.org>
+Date: Fri, 10 Jul 2026 08:55:09 -0500
+Subject: [PATCH] Fix address bar spoofing when userinfo contains : character
+
+Our algorithm for finding the host component of the URL without using a
+URL parser is easily defeated by a colon in the userinfo section.
+Tighten this up.
+
+It's a real shame that we cannot use a normal URL parser here. But the
+goal is to return a pointer into the original string, without mutating
+it, so that's not an option.
+
+Fixes #2897
+
+
+(cherry picked from commit 0dde1d369458ac5c44b74b5ad3c433f825f6f8af)
+
+Co-authored-by: Michael Catanzaro <mcatanzaro@gnome.org>
+---
+ lib/ephy-uri-helpers.c        |  7 ++++---
+ tests/ephy-uri-helpers-test.c | 16 +++++++++++++++-
+ 2 files changed, 19 insertions(+), 4 deletions(-)
+
+diff --git a/lib/ephy-uri-helpers.c b/lib/ephy-uri-helpers.c
+index aa11edb43..a67005741 100644
+--- a/lib/ephy-uri-helpers.c
++++ b/lib/ephy-uri-helpers.c
+@@ -96,11 +96,12 @@ ephy_uri_get_base_domain (const char *hostname)
+ static const char *
+ get_first_colon_after_host (const char *authority_start)
+ {
+-  const char *search_start = authority_start;
++  const char *userinfo_end = strchr (authority_start, '@');
++  const char *search_start = userinfo_end ? userinfo_end + 1 : authority_start;
+ 
+   /* Skip colons in IPv6 addresses */
+-  if (authority_start[0] == '[') {
+-    const char *bracket_close = strchr (authority_start, ']');
++  if (search_start[0] == '[') {
++    const char *bracket_close = strchr (search_start, ']');
+     if (bracket_close)
+       search_start = bracket_close;
+   }
+diff --git a/tests/ephy-uri-helpers-test.c b/tests/ephy-uri-helpers-test.c
+index daf5b7180..b800419db 100644
+--- a/tests/ephy-uri-helpers-test.c
++++ b/tests/ephy-uri-helpers-test.c
+@@ -30,12 +30,25 @@ test_ephy_uri_decode (void)
+ 
+   result = ephy_uri_decode ("https://ja.wikipedia.org/wiki/%E3%83%A1%E3%82%A4%E3%83%B3%E3%83%9A%E3%83%BC%E3%82%B8");
+   g_assert_cmpstr (result, ==, "https://ja.wikipedia.org/wiki/メインページ");
+-
+   g_clear_pointer (&result, g_free);
++
+   result = ephy_uri_decode ("https://xn--9dbaqfu.xn--4dbrk0ce/");
+   g_assert_cmpstr (result, ==, "https://כולנו.ישראל/");
+ }
+ 
++static void
++test_ephy_uri_get_decoded_host (void)
++{
++  g_autofree char *result = NULL;
++
++  result = ephy_uri_get_decoded_host ("https://example.com:80@www.gnome.org/");
++  g_assert_cmpstr (result, ==, "www.gnome.org");
++  g_clear_pointer (&result, g_free);
++
++  result = ephy_uri_get_decoded_host ("https://[::1]:8080/");
++  g_assert_cmpstr (result, ==, "[::1]");
++}
++
+ int
+ main (int   argc,
+       char *argv[])
+@@ -45,6 +58,7 @@ main (int   argc,
+   g_test_init (&argc, &argv, NULL);
+ 
+   g_test_add_func ("/lib/ephy-uri-helpers/decode", test_ephy_uri_decode);
++  g_test_add_func ("/lib/ephy-uri-helpers/get-decoded-host", test_ephy_uri_get_decoded_host);
+ 
+   ret = g_test_run ();
+ 
+-- 
+GitLab

--- a/pkgs/by-name/ep/epiphany/package.nix
+++ b/pkgs/by-name/ep/epiphany/package.nix
@@ -5,6 +5,7 @@
   meson,
   ninja,
   gettext,
+  fetchpatch,
   fetchurl,
   pkg-config,
   gtk4,
@@ -45,6 +46,18 @@ stdenv.mkDerivation (finalAttrs: {
     url = "mirror://gnome/sources/epiphany/${lib.versions.major finalAttrs.version}/epiphany-${finalAttrs.version}.tar.xz";
     hash = "sha256-Hib5kB8PCL/pQ6pwFjyVMzTH7D1K78jTVOipwUCzNKc=";
   };
+
+  patches = [
+    # Required for `CVE-2026-18487.patch` to apply
+    (fetchpatch {
+      name = "fix-ipv6-address-prettification.patch";
+      url = "https://gitlab.gnome.org/GNOME/epiphany/-/commit/e63bfdc7f117c9b60ea54b5760363ab256b9ff2b.patch";
+      hash = "sha256-9m8R5GUOBCm3xDXVHBDrV/HbjfIDL+D3wUGkkqc4RmA==";
+    })
+    # Upstream issue: https://gitlab.gnome.org/GNOME/epiphany/-/work_items/2897
+    # Upstream PR: https://gitlab.gnome.org/GNOME/epiphany/-/merge_requests/2123
+    ./CVE-2026-18487.patch
+  ];
 
   nativeBuildInputs = [
     blueprint-compiler


### PR DESCRIPTION
Reproduced the issue before the changes in this PR and couldn't reproduce it after the changes in this PR.

https://github.com/advisories/GHSA-5w7g-jqwx-788x

Upstream issue: https://gitlab.gnome.org/GNOME/epiphany/-/work_items/2897
Upstream PR: https://gitlab.gnome.org/GNOME/epiphany/-/merge_requests/2123

Closes https://github.com/NixOS/nixpkgs/issues/550211

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
