### PR TITLE
generic-stack-builder: fix error when using default extraArgs with buildStackProject

### DIFF
--- a/pkgs/development/haskell-modules/generic-stack-builder.nix
+++ b/pkgs/development/haskell-modules/generic-stack-builder.nix
@@ -12,7 +12,7 @@
 {
   buildInputs ? [ ],
   nativeBuildInputs ? [ ],
-  extraArgs ? [ ],
+  extraArgs ? "",
   LD_LIBRARY_PATH ? [ ],
   ghc ? depArgs.ghc,
   stack ? depArgs.stack,

--- a/pkgs/test/haskell/default.nix
+++ b/pkgs/test/haskell/default.nix
@@ -2,6 +2,7 @@
 
 lib.recurseIntoAttrs {
   cabalSdist = callPackage ./cabalSdist { };
+  stack = callPackage ./stack { };
   documentationTarball = callPackage ./documentationTarball { };
   env = callPackage ./env { };
   ghcWithPackages = callPackage ./ghcWithPackages { };

--- a/pkgs/test/haskell/stack/default.nix
+++ b/pkgs/test/haskell/stack/default.nix
@@ -1,0 +1,18 @@
+{
+  lib,
+  haskell,
+}:
+
+lib.recurseIntoAttrs {
+  simpleStackProject = haskell.lib.buildStackProject {
+    pname = "stack-test-simple-project";
+    version = "0.1.0.0";
+    src = ./local;
+
+    meta = {
+      description = "Nixpkgs stack test case";
+      license = lib.licenses.mit;
+      mainProgram = "local";
+    };
+  };
+}

--- a/pkgs/test/haskell/stack/local/.gitignore
+++ b/pkgs/test/haskell/stack/local/.gitignore
@@ -1,0 +1,1 @@
+.stack-work/

--- a/pkgs/test/haskell/stack/local/Setup.hs
+++ b/pkgs/test/haskell/stack/local/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/pkgs/test/haskell/stack/local/app/Main.hs
+++ b/pkgs/test/haskell/stack/local/app/Main.hs
@@ -1,0 +1,5 @@
+module Main (main) where
+
+main :: IO ()
+main = do
+  putStrLn "hello world"

--- a/pkgs/test/haskell/stack/local/local.cabal
+++ b/pkgs/test/haskell/stack/local/local.cabal
@@ -1,0 +1,12 @@
+cabal-version:      2.4
+name:               local
+version:            0.1.0.0
+
+synopsis: Nixpkgs test case
+license:  MIT
+
+executable local
+    main-is:          Main.hs
+    build-depends:    base
+    hs-source-dirs:   app
+    default-language: Haskell2010

--- a/pkgs/test/haskell/stack/local/stack.yaml
+++ b/pkgs/test/haskell/stack/local/stack.yaml
@@ -1,0 +1,5 @@
+snapshot: ghc-9.10.3
+packages:
+  - .
+nix:
+  enable: true


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Currently, simple use of `buildStackProject` throws an error. Take for example this `shell.nix` with a stack project located at `./test`:

```nix
{ ... }: let
  pkgs = import <nixpkgs> {};
in
pkgs.haskell.lib.buildStackProject {
  name = "test";
  src = ./test;
}

```

When invoking `nix-shell`:
```
error:
       … while calling the 'derivationStrict' builtin
         at «nix-internal»/derivation-internal.nix:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'test'
         whose name attribute is located at /nix/store/3534kmswzarh1x778kw7n57vacwqa751-nixos-26.05/nixos/pkgs/stdenv/generic/make-derivation.nix:647:11

       … while evaluating attribute 'STACK_IN_NIX_EXTRA_ARGS' of derivation 'test'

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: The `env` attribute set can only contain derivation, string, boolean or integer attributes. The `STACK_IN_NIX_EXTRA_ARGS` attribute is of type list.
```

This is because the default value for `extraArgs` is `[]`, which is not permitted in `env`. Without this PR, the problem can be worked around by setting `extraArgs = "";` in the derivation.

The reason why this has gone unnoticed is because there are no actual [packages depending on `buildStackProject`](https://github.com/search?q=repo%3ANixOS%2Fnixpkgs+buildStackProject&type=code). Therefore I have written a test `tests.haskell.stack` which tries to build a simple empty project. I made it a global test in case anyone wishes to add more stack-related tests in the future, but I can move it to `passthru.tests` on `generic-stack-builder` if preferred.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
    * Ran `nix-build -A tests.haskell`.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  * Ran test stack project.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
   * No AI usage.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
