### PR TITLE
python3Packages.sentence-transformers: 5.6.1 -> 5.7.0

### DIFF
--- a/pkgs/development/python-modules/sentence-transformers/default.nix
+++ b/pkgs/development/python-modules/sentence-transformers/default.nix
@@ -13,6 +13,7 @@
   numpy,
   scikit-learn,
   scipy,
+  tokenizers,
   torch,
   tqdm,
   transformers,
@@ -33,7 +34,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "sentence-transformers";
-  version = "5.6.1";
+  version = "5.7.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -41,7 +42,7 @@ buildPythonPackage (finalAttrs: {
     owner = "huggingface";
     repo = "sentence-transformers";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-nV378rNxaIdPjshxkgqCpQuUQmh7/Z7xhhD5u9KT81A=";
+    hash = "sha256-0H/sgSxEcDnZkDEtAroSV9zVLfLF04AsjSV0m0Csyk0=";
   };
 
   build-system = [ setuptools ];
@@ -51,6 +52,7 @@ buildPythonPackage (finalAttrs: {
     numpy
     scikit-learn
     scipy
+    tokenizers
     torch
     tqdm
     transformers
@@ -119,6 +121,7 @@ buildPythonPackage (finalAttrs: {
     "test_save_and_load"
     "test_simple"
     "test_simple_encode"
+    "test_sparse_cosent_loss_default_matches_explicit_pairwise"
     "test_tokenize"
     "test_train_stsb"
     "test_trainer"
@@ -161,17 +164,27 @@ buildPythonPackage (finalAttrs: {
     "tests/base/test_model_card.py"
     "tests/base/test_model_type_subclass.py"
     "tests/cross_encoder/evaluation/test_reranking.py"
-    "tests/cross_encoder/losses/test_rerank_losses_dtype.py"
+    "tests/cross_encoder/losses/test_cached_multiple_negatives_ranking.py"
+    "tests/cross_encoder/losses/test_misc.py"
+    "tests/cross_encoder/losses/test_misc.py"
     "tests/cross_encoder/test_model.py"
     "tests/cross_encoder/test_model_card.py"
     "tests/cross_encoder/test_train_stsb.py"
+    "tests/sentence_transformer/evaluation/test_binary_classification_evaluator.py"
     "tests/sentence_transformer/losses/test_adaptive_layer.py"
+    "tests/sentence_transformer/losses/test_cached_gist_embed.py"
+    "tests/sentence_transformer/losses/test_cached_mnsrl.py"
+    "tests/sentence_transformer/losses/test_cmnrl.py"
     "tests/sentence_transformer/losses/test_denoising_auto_encoder.py"
     "tests/sentence_transformer/losses/test_embed_distill.py"
+    "tests/sentence_transformer/losses/test_gradcache.py"
+    "tests/sentence_transformer/losses/test_gradcache.py"
+    "tests/sentence_transformer/losses/test_mega_batch_margin.py"
     "tests/sentence_transformer/test_compute_embeddings.py"
     "tests/sentence_transformer/test_model.py"
     "tests/sentence_transformer/test_model_card.py"
     "tests/sentence_transformer/test_model_card_data.py"
+    "tests/sparse_encoder/losses/test_cached_splade.py"
     "tests/sparse_encoder/modules/test_csr.py"
     "tests/sparse_encoder/modules/test_sparse_static_embedding.py"
     "tests/sparse_encoder/test_model.py"


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/huggingface/sentence-transformers/compare/v5.6.1...v5.7.0
Changelog: https://github.com/huggingface/sentence-transformers/releases/tag/v5.7.0

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test