### PR TITLE
treewide: replace misuses of lib.optional{,s} with lib.optionalString

### DIFF
--- a/pkgs/by-name/ce/centerpiece/package.nix
+++ b/pkgs/by-name/ce/centerpiece/package.nix
@@ -44,7 +44,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     libxrandr
   ];
 
-  postFixup = lib.optional stdenv.hostPlatform.isLinux ''
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
     rpath=$(patchelf --print-rpath $out/bin/centerpiece)
     patchelf --set-rpath "$rpath:${
       lib.makeLibraryPath [

--- a/pkgs/by-name/ch/chipsec/package.nix
+++ b/pkgs/by-name/ch/chipsec/package.nix
@@ -43,7 +43,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   ];
 
   # Marker file preventing driver from being built
-  preBuild = lib.optionals (!withDriver) ''
+  preBuild = lib.optionalString (!withDriver) ''
     touch README.NO_KERNEL_DRIVER
   '';
 

--- a/pkgs/by-name/co/corepack/package.nix
+++ b/pkgs/by-name/co/corepack/package.nix
@@ -88,7 +88,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     versionCheckHook
   ];
   # Built-in SQLite support is only available in Node.js 22+, and required to run the tests.
-  preInstallCheck = lib.optional (lib.versionAtLeast nodejs.version "22") ''
+  preInstallCheck = lib.optionalString (lib.versionAtLeast nodejs.version "22") ''
     # Exclude test files that require internet access.
     NOCK_ENV=replay yarn test --reporter tap --exclude tests/config.test.ts --exclude tests/Use.test.ts
   '';

--- a/pkgs/by-name/cs/csound/package.nix
+++ b/pkgs/by-name/cs/csound/package.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
     ]
   );
 
-  postInstall = lib.optional stdenv.hostPlatform.isDarwin ''
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     mkdir -p $out/Library/Frameworks
     ln -s $out/lib/CsoundLib64.framework $out/Library/Frameworks
   '';

--- a/pkgs/by-name/da/dash/package.nix
+++ b/pkgs/by-name/da/dash/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   hardeningDisable = [ "strictflexarrays3" ];
 
   configureFlags = [ "--with-libedit" ];
-  preConfigure = lib.optional stdenv.hostPlatform.isStatic ''
+  preConfigure = lib.optionalString stdenv.hostPlatform.isStatic ''
     export LIBS="$(''${PKG_CONFIG:-pkg-config} --libs --static libedit)"
   '';
 

--- a/pkgs/by-name/da/dashy-ui/package.nix
+++ b/pkgs/by-name/da/dashy-ui/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
   # the way the client parses things
   # - Instead, we use `remarshal` to convert it to yaml
   # Config validation needs to happen after yarnConfigHook, since it's what sets the yarn offline cache
-  preBuild = lib.optional (settings != { }) ''
+  preBuild = lib.optionalString (settings != { }) ''
     echo "Writing settings override..."
     json2yaml '${builtins.toFile "conf.json" (builtins.toJSON settings)}' user-data/conf.yml
     yarn validate-config --offline

--- a/pkgs/by-name/di/direwolf/package.nix
+++ b/pkgs/by-name/di/direwolf/package.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     ];
   nativeInstallCheckInputs = [ versionCheckHook ];
 
-  preConfigure = lib.optionals (!extraScripts) ''
+  preConfigure = lib.optionalString (!extraScripts) ''
     echo "" > scripts/CMakeLists.txt
   '';
 

--- a/pkgs/by-name/do/dovi-tool/package.nix
+++ b/pkgs/by-name/do/dovi-tool/package.nix
@@ -36,7 +36,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     fontconfig
   ];
 
-  preCheck = lib.optionals (!stdenv.hostPlatform.isDarwin) ''
+  preCheck = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     # Fontconfig error: Cannot load default config file: No such file: (null)
     export FONTCONFIG_FILE="${fontsConf}"
     # Fontconfig error: No writable cache directories

--- a/pkgs/by-name/dr/draco/package.nix
+++ b/pkgs/by-name/dr/draco/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   # ld: unknown option: --start-group
-  postPatch = lib.optional stdenv.hostPlatform.isDarwin ''
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace cmake/draco_targets.cmake \
       --replace-fail "^Clang" "^AppleClang"
   '';

--- a/pkgs/by-name/es/esdm/package.nix
+++ b/pkgs/by-name/es/esdm/package.nix
@@ -137,7 +137,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonOption "drng_max_reseed_bits" (toString drngMaxReseedBits))
   ];
 
-  postFixup = lib.optionals fips140 ''
+  postFixup = lib.optionalString fips140 ''
     $out/bin/esdm-tool --fips-checkfile $out/bin/.esdm-server.hmac \
                        --fips-targetfile $out/bin/esdm-server
   '';

--- a/pkgs/by-name/gg/gg-jj/package.nix
+++ b/pkgs/by-name/gg/gg-jj/package.nix
@@ -67,7 +67,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   env.OPENSSL_NO_VENDOR = true;
 
-  postInstall = lib.optionals stdenv.hostPlatform.isDarwin ''
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     mkdir -p $out/bin
     ln -s $out/Applications/gg.app/Contents/MacOS/gg $out/bin/gg
   '';

--- a/pkgs/by-name/he/heimdall/package.nix
+++ b/pkgs/by-name/he/heimdall/package.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
   doInstallCheck = true;
 
   # heimdall cli looked up from PATH by gui
-  preFixup = lib.optional enableGUI ''
+  preFixup = lib.optionalString enableGUI ''
     qtWrapperArgs+=(--prefix PATH : "$out/bin")
   '';
 

--- a/pkgs/by-name/ht/htslib/package.nix
+++ b/pkgs/by-name/ht/htslib/package.nix
@@ -48,12 +48,12 @@ stdenv.mkDerivation (finalAttrs: {
       ];
 
   # In the case of static builds, we need to replace the build and install phases
-  buildPhase = lib.optional stdenv.hostPlatform.isStatic ''
+  buildPhase = lib.optionalString stdenv.hostPlatform.isStatic ''
     make AR=$AR lib-static
     make LDFLAGS=-static bgzip htsfile tabix
   '';
 
-  installPhase = lib.optional stdenv.hostPlatform.isStatic ''
+  installPhase = lib.optionalString stdenv.hostPlatform.isStatic ''
     install -d $out/bin
     install -d $out/lib
     install -d $out/include/htslib

--- a/pkgs/by-name/kc/kcollectd/package.nix
+++ b/pkgs/by-name/kc/kcollectd/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-35zb5Kx0tRP5l0hILdomCu2YSQfng02mbyyAClm4uZs=";
   };
 
-  postPatch = lib.optional (!lib.versionOlder rrdtool.version "1.9.0") ''
+  postPatch = lib.optionalString (!lib.versionOlder rrdtool.version "1.9.0") ''
     substituteInPlace kcollectd/rrd_interface.cc --replace-fail 'char *arg[] =' 'const char *arg[] ='
   '';
 

--- a/pkgs/by-name/li/libsbml/package.nix
+++ b/pkgs/by-name/li/libsbml/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optional withPython "-DWITH_PYTHON=ON";
 
-  postInstall = lib.optional withPython ''
+  postInstall = lib.optionalString withPython ''
     mv $out/${python.sitePackages}/libsbml/libsbml.py $out/${python.sitePackages}/libsbml/__init__.py
   '';
 

--- a/pkgs/by-name/li/lightgbm/package.nix
+++ b/pkgs/by-name/li/lightgbm/package.nix
@@ -152,13 +152,13 @@ stdenv.mkDerivation (finalAttrs: {
       (lib.cmakeBool "__BUILD_FOR_PYTHON" true)
     ];
 
-  configurePhase = lib.optionals rLibrary ''
+  configurePhase = lib.optionalString rLibrary ''
     export R_LIBS_SITE="$out/library:$R_LIBS_SITE''${R_LIBS_SITE:+:}"
   '';
 
   # set the R package buildPhase to null because lightgbm has a
   # custom builder script that builds and installs in one step
-  buildPhase = lib.optionals rLibrary "";
+  buildPhase = lib.optionalString rLibrary "";
 
   inherit doCheck;
 

--- a/pkgs/by-name/mc/mcrl2/package.nix
+++ b/pkgs/by-name/mc/mcrl2/package.nix
@@ -21,14 +21,14 @@ stdenv.mkDerivation rec {
     hash = "sha256-Ur7GGXbYvVmrEUq/CTRyuVNLDHKfFrYHJibo0JvYhyM=";
   };
 
-  postInstall = lib.optional stdenv.hostPlatform.isDarwin ''
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     mkdir $out/Applications
     mv $out/mCRL2.app $out/Applications
     mkdir $out/bin
     makeWrapper "$out/Applications/mCRL2.app/Contents/MacOS/mCRL2" "$out/bin/mcrl2ide"
   '';
 
-  postFixup = lib.optional stdenv.hostPlatform.isDarwin ''
+  postFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
     APP_DIR="$out/Applications/mCRL2.app/Contents"
     find "$APP_DIR/lib" -name "*.dylib" | while read lib; do
       install_name_tool -id "@rpath/$(basename "$lib")" "$lib" || true

--- a/pkgs/by-name/ms/mstflint/package.nix
+++ b/pkgs/by-name/ms/mstflint/package.nix
@@ -76,29 +76,27 @@ stdenv.mkDerivation (finalAttrs: {
   #
   # Remove patch for regex check, after https://github.com/Mellanox/mstflint/pull/871
   # got merged.
-  prePatch = [
-    ''
-      patchShebangs eval_git_sha.sh
-      substituteInPlace configure.ac \
-          --replace "build_cpu" "host_cpu"
-      substituteInPlace common/compatibility.h \
-          --replace "#define ROOT_PATH \"/\"" "#define ROOT_PATH \"$out/\""
-      substituteInPlace configure.ac \
-          --replace 'Whether to use GNU C regex])' 'Whether to use GNU C regex])],[AC_MSG_RESULT([yes])'
-    ''
-    (lib.optionals (!onlyFirmwareUpdater) ''
-      substituteInPlace common/python_wrapper.sh \
-        --replace \
-        'exec $PYTHON_EXEC $SCRIPT_PATH "$@"' \
-        'export PATH=$PATH:${
-          lib.makeBinPath [
-            (placeholder "out")
-            pciutils
-            busybox
-          ]
-        }; exec ${python3}/bin/python3 $SCRIPT_PATH "$@"'
-    '')
-  ];
+  prePatch = ''
+    patchShebangs eval_git_sha.sh
+    substituteInPlace configure.ac \
+        --replace "build_cpu" "host_cpu"
+    substituteInPlace common/compatibility.h \
+        --replace "#define ROOT_PATH \"/\"" "#define ROOT_PATH \"$out/\""
+    substituteInPlace configure.ac \
+        --replace 'Whether to use GNU C regex])' 'Whether to use GNU C regex])],[AC_MSG_RESULT([yes])'
+  ''
+  + lib.optionalString (!onlyFirmwareUpdater) ''
+    substituteInPlace common/python_wrapper.sh \
+      --replace \
+      'exec $PYTHON_EXEC $SCRIPT_PATH "$@"' \
+      'export PATH=$PATH:${
+        lib.makeBinPath [
+          (placeholder "out")
+          pciutils
+          busybox
+        ]
+      }; exec ${python3}/bin/python3 $SCRIPT_PATH "$@"'
+  '';
 
   configureFlags = [
     "--enable-xml2"

--- a/pkgs/by-name/na/nanoboyadvance/package.nix
+++ b/pkgs/by-name/na/nanoboyadvance/package.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # Make it runnable from the terminal on Darwin
-  postInstall = lib.optionals stdenv.hostPlatform.isDarwin ''
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     mkdir "$out/bin"
     ln -s "$out/Applications/NanoBoyAdvance.app/Contents/MacOS/NanoBoyAdvance" "$out/bin/NanoBoyAdvance"
   '';

--- a/pkgs/by-name/nf/nfd/package.nix
+++ b/pkgs/by-name/nf/nfd/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-HbKPO3gwQWOZf4QZE+N7tAiqsNl1GrcwE4EUGjWmf5s=";
   };
 
-  prePatch = lib.optional withWebSocket ''
+  prePatch = lib.optionalString withWebSocket ''
     ln -s ${websocketpp}/include/websocketpp websocketpp
   '';
 

--- a/pkgs/by-name/op/opencpn/package.nix
+++ b/pkgs/by-name/op/opencpn/package.nix
@@ -142,7 +142,7 @@ stdenv.mkDerivation (finalAttrs: {
     ]
   );
 
-  postInstall = lib.optionals stdenv.hostPlatform.isDarwin ''
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     mkdir -p $out/Applications
     mv $out/bin/OpenCPN.app $out/Applications
     makeWrapper $out/Applications/OpenCPN.app/Contents/MacOS/OpenCPN $out/bin/opencpn

--- a/pkgs/by-name/op/ophcrack/package.nix
+++ b/pkgs/by-name/op/ophcrack/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
       [ "--disable-gui" ]
   );
 
-  installPhase = lib.optional (stdenv.hostPlatform.isDarwin && enableGui) ''
+  installPhase = lib.optionalString (stdenv.hostPlatform.isDarwin && enableGui) ''
     mkdir -p $out/Applications
     cp -R src/ophcrack.app $out/Applications/ophcrack.app
   '';

--- a/pkgs/by-name/pr/prometheus-postfix-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-postfix-exporter/package.nix
@@ -30,7 +30,7 @@ buildGoModule rec {
   buildInputs = lib.optionals withSystemdSupport [ systemdLibs ];
   tags = lib.optionals (!withSystemdSupport) "nosystemd";
 
-  postInstall = lib.optionals withSystemdSupport ''
+  postInstall = lib.optionalString withSystemdSupport ''
     wrapProgram $out/bin/postfix_exporter \
       --prefix LD_LIBRARY_PATH : "${lib.getLib systemdLibs}/lib"
   '';

--- a/pkgs/by-name/rm/rmfakecloud/package.nix
+++ b/pkgs/by-name/rm/rmfakecloud/package.nix
@@ -37,7 +37,7 @@ buildGoModule rec {
     fetcherVersion = 4;
     hash = "sha256-UQT6uYusDw7Hd+1URrSQkyorajih6oF0LSMpPZy9K1w=";
   };
-  preBuild = lib.optionals enableWebui ''
+  preBuild = lib.optionalString enableWebui ''
     # using sass-embedded fails at executing node_modules/sass-embedded-linux-x64/dart-sass/src/dart
     rm -r ui/node_modules/sass-embedded ui/node_modules/.pnpm/sass-embedded*
 
@@ -53,7 +53,7 @@ buildGoModule rec {
   ];
 
   # ... or don't embed it in the server
-  postPatch = lib.optionals (!enableWebui) ''
+  postPatch = lib.optionalString (!enableWebui) ''
     sed -i '/go:/d' ui/assets.go
   '';
 

--- a/pkgs/by-name/sa/samtools/package.nix
+++ b/pkgs/by-name/sa/samtools/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
     htslib
   ];
 
-  preConfigure = lib.optional stdenv.hostPlatform.isStatic ''
+  preConfigure = lib.optionalString stdenv.hostPlatform.isStatic ''
     export LIBS="-lz -lbz2 -llzma"
   '';
   makeFlags = lib.optional stdenv.hostPlatform.isStatic "AR=${stdenv.cc.targetPrefix}ar";

--- a/pkgs/by-name/sn/snowcrash/package.nix
+++ b/pkgs/by-name/sn/snowcrash/package.nix
@@ -20,7 +20,7 @@ buildGoModule rec {
 
   subPackages = [ "." ];
 
-  postFixup = lib.optionals (!stdenv.hostPlatform.isDarwin) ''
+  postFixup = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     mv $out/bin/SNOWCRASH $out/bin/${pname}
   '';
 

--- a/pkgs/by-name/sq/sqlitebrowser/package.nix
+++ b/pkgs/by-name/sq/sqlitebrowser/package.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "QSCINTILLA_INCLUDE_DIR" "${lib.getDev qt'.qscintilla}/include")
   ];
 
-  postInstall = lib.optional stdenv.hostPlatform.isDarwin ''
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     # Copy the icon file to the app bundle
     target="$(find . -name "*.app")"
     mkdir -p "$target/Contents/Resources/"

--- a/pkgs/by-name/st/stirling-pdf/package.nix
+++ b/pkgs/by-name/st/stirling-pdf/package.nix
@@ -136,7 +136,7 @@ stdenv.mkDerivation (finalAttrs: {
   dontUseGradleBuild = isDesktopVariant; # we'll use the buildPhase from cargo-tauri-hook for the desktop app
 
   # prepare the resources before building the desktop app
-  preBuild = lib.optionals isDesktopVariant ''
+  preBuild = lib.optionalString isDesktopVariant ''
     MODE=desktop task frontend:prepare
 
     # this simulates what the desktop:jlink:jar would do

--- a/pkgs/by-name/sw/swayrbar/package.nix
+++ b/pkgs/by-name/sw/swayrbar/package.nix
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     export HOME=$TMPDIR
   '';
 
-  postInstall = lib.optionals withPulseaudio ''
+  postInstall = lib.optionalString withPulseaudio ''
     wrapProgram "$out/bin/swayrbar" \
       --prefix PATH : "$out/bin:${lib.makeBinPath [ pulseaudio ]}"
   '';

--- a/pkgs/by-name/te/temporal_capi/package.nix
+++ b/pkgs/by-name/te/temporal_capi/package.nix
@@ -65,7 +65,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     Cflags: -I\''${includedir}
     EOF
   '';
-  postFixup = lib.optional (stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isStatic) ''
+  postFixup = lib.optionalString (stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isStatic) ''
     ${stdenv.cc.targetPrefix}install_name_tool -id "$out/lib/libtemporal_capi.dylib" "$out/lib/libtemporal_capi.dylib"
   '';
 

--- a/pkgs/by-name/wa/waybar/package.nix
+++ b/pkgs/by-name/wa/waybar/package.nix
@@ -96,7 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-49ZKgK96a9uFip+svOdnw397xcEjiftXzd9gyv1H3sU=";
   };
 
-  postUnpack = lib.optional cavaSupport ''
+  postUnpack = lib.optionalString cavaSupport ''
     pushd "$sourceRoot"
     cp -R --no-preserve=mode,ownership ${libcava.src} subprojects/cava-${libcava.version}
     patchShebangs .

--- a/pkgs/by-name/wi/wivrn/package.nix
+++ b/pkgs/by-name/wi/wivrn/package.nix
@@ -178,7 +178,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   dontWrapQtApps = true;
 
-  preFixup = lib.optional (!clientLibOnly) ''
+  preFixup = lib.optionalString (!clientLibOnly) ''
     wrapProgram "$out/bin/wivrn-server" \
       --prefix LD_LIBRARY_PATH : ${
         lib.makeLibraryPath [

--- a/pkgs/by-name/xg/xgboost/package.nix
+++ b/pkgs/by-name/xg/xgboost/package.nix
@@ -90,7 +90,7 @@ effectiveStdenv.mkDerivation rec {
     ++ lib.optionals ncclSupport [ "-DUSE_NCCL=ON" ]
     ++ lib.optionals rLibrary [ "-DR_LIB=ON" ];
 
-  preConfigure = lib.optionals rLibrary ''
+  preConfigure = lib.optionalString rLibrary ''
     substituteInPlace cmake/RPackageInstall.cmake.in --replace "CMD INSTALL" "CMD INSTALL -l $out/library"
     export R_LIBS_SITE="$R_LIBS_SITE''${R_LIBS_SITE:+:}$out/library"
   '';

--- a/pkgs/desktops/lxqt/libfm-qt/default.nix
+++ b/pkgs/desktops/lxqt/libfm-qt/default.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = gitUpdater { };
 
-  postPatch = lib.optionals (version == "1.4.0") ''
+  postPatch = lib.optionalString (version == "1.4.0") ''
     substituteInPlace CMakeLists.txt \
       --replace-fail "cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)" "cmake_minimum_required(VERSION 3.10)"
   '';

--- a/pkgs/desktops/lxqt/libqtxdg/default.nix
+++ b/pkgs/desktops/lxqt/libqtxdg/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     )
   '';
 
-  postPatch = lib.optionals (version == "3.12.0") ''
+  postPatch = lib.optionalString (version == "3.12.0") ''
     substituteInPlace CMakeLists.txt \
       --replace-fail "cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)" "cmake_minimum_required(VERSION 3.10)"
   '';

--- a/pkgs/desktops/lxqt/qtermwidget/default.nix
+++ b/pkgs/desktops/lxqt/qtermwidget/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
 
   passthru.updateScript = gitUpdater { };
 
-  postPatch = lib.optionals (version == "1.4.0") ''
+  postPatch = lib.optionalString (version == "1.4.0") ''
     substituteInPlace CMakeLists.txt \
       --replace-fail "cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)" "cmake_minimum_required(VERSION 3.10)"
   '';

--- a/pkgs/development/libraries/itk/generic.nix
+++ b/pkgs/development/libraries/itk/generic.nix
@@ -189,7 +189,7 @@ stdenv.mkDerivation {
 
   # remove forbidden reference to /build which occur when building the Python wrapping
   # (also remove a copy of itkTestDriver with incorrect permissions/RPATH):
-  preFixup = lib.optionals enablePython ''
+  preFixup = lib.optionalString enablePython ''
     rm $out/${python.sitePackages}/itk/itkTestDriver
     find $out/${python.sitePackages}/itk -type f -name '*.so*' -exec \
       patchelf {} --shrink-rpath --allowed-rpath-prefixes "$NIX_STORE" \;

--- a/pkgs/development/libraries/maplibre-native-qt/default.nix
+++ b/pkgs/development/libraries/maplibre-native-qt/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  postPatch = lib.optionals (lib.versionAtLeast qtlocation.version "6.10") ''
+  postPatch = lib.optionalString (lib.versionAtLeast qtlocation.version "6.10") ''
     # fix build with Qt 6.10
     # included in https://github.com/maplibre/maplibre-native-qt/pull/216
     substituteInPlace CMakeLists.txt \

--- a/pkgs/development/ocaml-modules/bigstring/default.nix
+++ b/pkgs/development/ocaml-modules/bigstring/default.nix
@@ -13,7 +13,7 @@ buildDunePackage (finalAttrs: {
   minimalOCamlVersion = "4.03";
 
   # Ensure compatibility with OCaml ≥ 5.0
-  preConfigure = lib.optional (lib.versionAtLeast ocaml.version "4.08") ''
+  preConfigure = lib.optionalString (lib.versionAtLeast ocaml.version "4.08") ''
     substituteInPlace src/dune --replace '(libraries bytes bigarray)' ""
   '';
 

--- a/pkgs/development/python-modules/bloodyad/default.nix
+++ b/pkgs/development/python-modules/bloodyad/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage (finalAttrs: {
   # but this causes a FileAlreadyExists error during installation
   # on Darwin (case-insensitive filesystem).
   # https://github.com/CravateRouge/bloodyAD/issues/99
-  postPatch = lib.optionals stdenv.hostPlatform.isDarwin ''
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace pyproject.toml \
       --replace-fail "bloodyAD = \"bloodyAD.main:main\"" ""
   '';

--- a/pkgs/development/python-modules/torchaudio/bin.nix
+++ b/pkgs/development/python-modules/torchaudio/bin.nix
@@ -60,7 +60,7 @@ buildPythonPackage (finalAttrs: {
 
   dependencies = [ torch-bin ];
 
-  preInstall = lib.optionals stdenv.hostPlatform.isLinux ''
+  preInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
     addAutoPatchelfSearchPath "${torch-bin}/${python.sitePackages}/torch"
   '';
 

--- a/pkgs/development/rocm-modules/rocmlir/default.nix
+++ b/pkgs/development/rocm-modules/rocmlir/default.nix
@@ -139,7 +139,7 @@ stdenv.mkDerivation (finalAttrs: {
         stdenv.cc.cc
       ];
     in
-    lib.optionals (!buildRockCompiler) ''
+    lib.optionalString (!buildRockCompiler) ''
       mkdir -p $external/lib
       cp -a external/llvm-project/llvm/lib/{*.a*,*.so*} $external/lib
       patchelf --set-rpath $external/lib:$out/lib:${libPath} $external/lib/*.so*

--- a/pkgs/servers/web-apps/lemmy/server.nix
+++ b/pkgs/servers/web-apps/lemmy/server.nix
@@ -69,7 +69,7 @@ rustPlatform.buildRustPackage rec {
 
   # This gets installed automatically by cargoInstallHook,
   # but we don't actually need it, and it leaks a reference to rustc.
-  postInstall = lib.optionals (!stdenv.hostPlatform.isDarwin) ''
+  postInstall = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     rm $out/lib/libhtml2md.so
   '';
 


### PR DESCRIPTION
I'm surprised how many mistakes there were. (Though, 2 of them were made by me 🫤)

I have *NOT* tried building all of these packages! Nor did I trigger all conditionals.

`libxml2` is part of the darwin stdenv (?) so I split it out: https://github.com/NixOS/nixpkgs/pull/550359

I also opened https://github.com/NixOS/nixpkgs/pull/550369 which tackles the non-string version of this mistake. 

---

`lib.optionals cond "some string"` evals to `[]` or `"some string"`
`lib.optional cond "some string"` evals to `[]` or `[ "some string" ]`

however, derivations, when passed a non-string value, turn them into a string value via `toString`

So actually
`lib.optionals cond "some string"` turns into `""` or `"some string"`
`lib.optional cond "some string"` turns into `""` or `"some string"`

which is basically just `lib.optionalString cond "some string"` with extra steps


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
