### PR TITLE
python3Packages.zbar: fix and rename from python3Packages.python-zbar

### DIFF
--- a/pkgs/by-name/co/cobang/package.nix
+++ b/pkgs/by-name/co/cobang/package.nix
@@ -57,7 +57,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     gst-python
     pillow
     pygobject3
-    python-zbar
+    zbar
     qrcode
     typing-extensions
   ];

--- a/pkgs/development/python-modules/python-zbar/default.nix
+++ b/pkgs/development/python-modules/python-zbar/default.nix
@@ -9,7 +9,7 @@
 }:
 
 buildPythonPackage rec {
-  pname = "python-zbar";
+  pname = "zbar";
   version = "0.23.93";
   pyproject = true;
 
@@ -22,6 +22,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     cd python
+    substituteInPlace ./setup.py \
+      --replace-fail "version = '0.22.2'" "version = '0.23.93'"
   '';
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/pyzbar/default.nix
+++ b/pkgs/development/python-modules/pyzbar/default.nix
@@ -1,17 +1,17 @@
 {
   lib,
+  pkgs,
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   numpy,
   pillow,
-  zbar,
   pytestCheckHook,
   setuptools,
 }:
 
 let
-  zbar' = zbar.override {
+  zbar' = pkgs.zbar.override {
     enableVideo = false;
     withXorg = false;
   };

--- a/pkgs/development/python-modules/zbar/default.nix
+++ b/pkgs/development/python-modules/zbar/default.nix
@@ -1,10 +1,10 @@
 {
   lib,
+  pkgs,
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
   pillow,
-  zbar,
   pytestCheckHook,
 }:
 
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   dependencies = [ pillow ];
 
-  buildInputs = [ zbar ];
+  buildInputs = [ pkgs.zbar ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -572,6 +572,7 @@ mapAliases {
   python-subunit = throw "'python-subunit' has been renamed to/replaced by 'subunit'"; # Converted to throw 2025-10-29
   python-u2flib-server = throw "'python-u2flib-server' has been removed, since it was broken and archived upstream"; # added 2025-11-08
   python-unshare = throw "python-unshare was removed as unmaintained since 2016"; # added 2025-05-25
+  python-zbar = zbar; # Added 2026-08-08
   python_docs_theme = throw "'python_docs_theme' has been renamed to/replaced by 'python-docs-theme'"; # Converted to throw 2025-10-29
   python_fedora = throw "'python_fedora' has been renamed to/replaced by 'python-fedora'"; # Converted to throw 2025-10-29
   python_magic = throw "'python_magic' has been renamed to/replaced by 'python-magic'"; # Converted to throw 2025-10-29

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16956,8 +16956,6 @@ self: super: with self; {
 
   python-zaqarclient = callPackage ../development/python-modules/python-zaqarclient { };
 
-  python-zbar = callPackage ../development/python-modules/python-zbar { };
-
   python-zunclient = callPackage ../development/python-modules/python-zunclient { };
 
   python3-application = callPackage ../development/python-modules/python3-application { };
@@ -22632,6 +22630,8 @@ self: super: with self; {
   zammad-py = callPackage ../development/python-modules/zammad-py { };
 
   zarr = callPackage ../development/python-modules/zarr { };
+
+  zbar = callPackage ../development/python-modules/zbar { };
 
   zc-buildout = callPackage ../development/python-modules/zc-buildout { };
 


### PR DESCRIPTION
Rename of zbar, as update of setuptools to version 83 broke python-zbar complaining about mismatch in metadata.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
