### PR TITLE
sbcl.pkgs.cffi-c2ffi: init as override of cffi

### DIFF
--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -625,6 +625,21 @@ let
         };
       });
 
+      cffi-c2ffi = self.cffi.overrideLispAttrs (old: {
+        systems = old.systems ++ [
+          "cffi/c2ffi"
+          "cffi/c2ffi-generator"
+        ];
+        lispLibs = old.lispLibs ++ [
+          self.cl-ppcre
+          self.cl-json
+        ];
+        postPatch = (old.postPatch or "") + ''
+          echo '(unless (ignore-errors (c2ffi-executable-available?))
+              (setf *c2ffi-executable* "${pkgs.lib.getExe pkgs.c2ffi}"))' \
+          >> src/c2ffi/c2ffi.lisp
+        '';
+      });
     }
     // optionalAttrs pkgs.config.allowAliases {
       cl-glib_dot_gio = throw "cl-glib_dot_gio was replaced by cl-gio";


### PR DESCRIPTION
make it a separate package to auto-reference c2ffi when needed, but not by default as c2ffi is heavy

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
