### PR TITLE
switch-to-configuration-ng: derive user GID/runtime from filesystem

### DIFF
--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
@@ -6,7 +6,8 @@ use std::{
     cell::RefCell,
     collections::HashMap,
     io::{BufRead, Read, Write},
-    os::unix::{fs::PermissionsExt, process::CommandExt},
+    os::unix::fs::{MetadataExt, PermissionsExt},
+    os::unix::process::CommandExt,
     path::{Path, PathBuf},
     rc::Rc,
     str::FromStr,
@@ -2384,19 +2385,33 @@ won't take effect until you reboot the system.
             exit_code = 4;
         }
         Ok(users) => {
-            for (uid, name, user_dbus_path) in users {
-                let proxy = dbus_conn.with_proxy(
-                    "org.freedesktop.login1",
-                    &user_dbus_path,
-                    Duration::from_millis(5000),
-                );
-                let gid: u32 = proxy
-                    .get("org.freedesktop.login1.User", "GID")
-                    .with_context(|| format!("Failed to get GID for {name}"))?;
-
-                let runtime_path: String = proxy
-                    .get("org.freedesktop.login1.User", "RuntimePath")
-                    .with_context(|| format!("Failed to get runtime directory for {name}"))?;
+            for (uid, name, _user_dbus_path) in users {
+                // Derive GID and runtime path from the filesystem instead of querying
+                // logind via D-Bus, which races against logind's async GC of user
+                // objects (list_users snapshot → Properties::get hits UnknownObject).
+                // /run/user/<uid> exists iff the user manager is active (BindsTo= on
+                // user@.service), so stat() is an atomic, race-free liveness check.
+                let runtime_path = PathBuf::from(format!("/run/user/{uid}"));
+                let metadata = match std::fs::metadata(&runtime_path) {
+                    Ok(m) => m,
+                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                        eprintln!(
+                            "skipping user {name}: {} not found \
+                             (user manager not running)",
+                            runtime_path.display()
+                        );
+                        continue;
+                    }
+                    Err(err) => {
+                        eprintln!(
+                            "warning: failed to stat {} for user {name}; \
+                             skipping: {err}",
+                            runtime_path.display()
+                        );
+                        exit_code = 4;
+                        continue;
+                    }
+                };
 
                 eprintln!("reloading user units for {name}...");
                 let myself = Path::new("/proc/self/exe")
@@ -2406,7 +2421,7 @@ won't take effect until you reboot the system.
                 log::debug!("Performing user switch for {name}");
                 let status = std::process::Command::new(&myself)
                     .uid(uid)
-                    .gid(gid)
+                    .gid(metadata.gid())
                     .env_clear()
                     .env("XDG_RUNTIME_DIR", runtime_path)
                     .env("__NIXOS_SWITCH_TO_CONFIGURATION_PARENT_EXE", &myself)


### PR DESCRIPTION
<!-- `logind.list_users()` returns a snapshot of logind's internal user hashmap, which is garbage-collected asynchronously. Between that snapshot and the D-Bus `Properties::get` for each user's GID and RuntimePath, the user's D-Bus object may already be gone, causing `Unknown object` errors that abort the entire switch mid-flight — after services have been stopped but before they are restarted, leaving the system in a half-switched state. -->

## Motivation

`logind.list_users()` returns a snapshot of logind's internal user hashmap, which is garbage-collected asynchronously. Between that snapshot and the subsequent `Properties::get` for each user's GID and RuntimePath, the user's D-Bus object may already be gone, causing `Unknown object` errors that abort the entire switch mid-flight — after services have been stopped but before they are restarted, leaving the system in a half-switched state.

The race fires whenever a short-lived system user (UID < 1000, e.g. `gitea`, `forgejo`) briefly appears in logind and disappears again while `switch-to-configuration` is running — typically a `git pull` over SSH that opens a PAM session under the service account, which logind tracks as a user session for the ~10 seconds the git operation takes.

## What

Instead of querying logind for GID and RuntimePath via D-Bus (which races against logind GC), derive them from the filesystem:

- `/run/user/<uid>` is created/removed atomically by `user-runtime-dir@.service`; `user@.service` has `BindsTo=user-runtime-dir@.service`, so the path exists **iff** the user manager is active.
- GID: `stat(/run/user/<uid>).st_gid` — the runtime dir is owned by uid:gid.

A single `stat()` syscall is an atomic, race-free liveness check that also yields the GID. If the path is already gone, the user manager has stopped and there are no user units to reload, so we skip silently.

We keep `list_users()` for the uid+name mapping (avoids an extra round-trip to list `user@*.service` units via `ListUnitsByPatterns` and parse UIDs out of unit names); the local `stat()` is cheaper than any D-Bus call.

<!-- A residual microsecond-scale window remains between `stat()` and `spawn()`, but if the runtime dir disappears in that window, the child process fails to connect to the user bus and the existing `exit_code = 4` fallback handles it gracefully. -->

## Things done

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`. (`switchTest`, `activation-template-dropin`)
- [x] Ran `nix-build -A switch-to-configuration-ng` on this PR (includes clippy `preCheck` with `-Dwarnings`)
- [x] Tested basic functionality of all binary files (`./result/bin/switch-to-configuration --help`)
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Relates: #429884

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test