### PR TITLE
libcanberra: replace systemd dependency with systemdLibs

### DIFF
--- a/pkgs/by-name/li/libcanberra/package.nix
+++ b/pkgs/by-name/li/libcanberra/package.nix
@@ -12,8 +12,8 @@
   gst_all_1,
   libvorbis,
   libcap,
-  withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
-  systemd,
+  withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
+  systemdLibs,
   withAlsa ? stdenv.hostPlatform.isLinux,
   alsa-lib,
 }:
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional (gtkSupport == "gtk2") gtk2-x11
   ++ lib.optional (gtkSupport == "gtk3") gtk3-x11
   ++ lib.optional stdenv.hostPlatform.isLinux libcap
-  ++ lib.optional withSystemd systemd
+  ++ lib.optional withSystemd systemdLibs
   ++ lib.optional withAlsa alsa-lib;
 
   configureFlags = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

the dependency should be `udev` aka `systemdLibs`, not the full `systemd` suite

```
libcanberra>  ---{ libcanberra 0.30 }---
libcanberra>
libcanberra>     prefix:                 /nix/store/6c1nhkvx6chp6007vfa91hi94j8da95a-libcanberra-0.30
libcanberra>     sysconfdir:             ${prefix}/etc
libcanberra>     localstatedir:          ${prefix}/var
libcanberra>     Compiler:               gcc
libcanberra>     CFLAGS:                 -g -O2
libcanberra>     C++-Compiler:           g++
libcanberra>     CXXFLAGS:               -g -O2
libcanberra>     Builtin DSO:            yes
libcanberra>     Enable PulseAudio:      yes
libcanberra>     Builtin PulseAudio:     no
libcanberra>     Enable ALSA:            yes
libcanberra>     Builtin ALSA:           no
libcanberra>     Enable OSS:             no
libcanberra>     Builtin OSS:            no
libcanberra>     Enable GStreamer:       yes
libcanberra>     Builtin GStreamer:      no
libcanberra>     Enable Null Output:     yes
libcanberra>     Builtin Null Output:    no
libcanberra>     Enable tdb:             no
libcanberra>     Enable lookup cache:    no
libcanberra>     Enable GTK+:            no
libcanberra>     GTK Modules Directory:
libcanberra>     Enable GTK3+:           no
libcanberra>     GTK3 Modules Directory:
libcanberra>     Enable udev:            yes
libcanberra>     systemd Unit Directory: /nix/store/6c1nhkvx6chp6007vfa91hi94j8da95a-libcanberra-0.30/lib/systemd/system
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
