### PR TITLE
various: actually pass list to lib.optionals

### DIFF
--- a/pkgs/by-name/co/composefs/package.nix
+++ b/pkgs/by-name/co/composefs/package.nix
@@ -88,7 +88,7 @@ stdenv.mkDerivation (finalAttrs: {
     fsverity-utils
   ];
 
-  mesonCheckFlags = lib.optionals enableValgrindCheck "--setup=valgrind";
+  mesonCheckFlags = lib.optionals enableValgrindCheck [ "--setup=valgrind" ];
 
   preCheck = ''
     patchShebangs --build ../tests/*dir ../tests/*.sh

--- a/pkgs/by-name/di/digikam/package.nix
+++ b/pkgs/by-name/di/digikam/package.nix
@@ -174,7 +174,9 @@ stdenv.mkDerivation (finalAttrs: {
     #(lib.cmakeBool "ENABLE_AKONADICONTACTSUPPORT" true)
     (lib.cmakeBool "ENABLE_MEDIAPLAYER" true)
     (lib.cmakeBool "ENABLE_APPSTYLES" true)
-    (lib.optionals enableCuda "-DCUDA_TOOLKIT_ROOT_DIR=${cudaPackages.cudatoolkit}")
+  ]
+  ++ lib.optionals enableCuda [
+    "-DCUDA_TOOLKIT_ROOT_DIR=${cudaPackages.cudatoolkit}"
   ];
 
   # Tests segfault for some reason…

--- a/pkgs/by-name/im/imager/package.nix
+++ b/pkgs/by-name/im/imager/package.nix
@@ -64,10 +64,9 @@ stdenv.mkDerivation (finalAttrs: {
     ./numpy-header.patch
   ];
 
-  env.NIX_CFLAGS_COMPILE = toString [
-    (lib.optionals stdenv.cc.isClang "-Wno-unused-command-line-argument")
-    "-std=gnu17"
-  ];
+  env.NIX_CFLAGS_COMPILE = toString (
+    [ "-std=gnu17" ] ++ lib.optionals stdenv.cc.isClang [ "-Wno-unused-command-line-argument" ]
+  );
 
   # Workaround for https://github.com/NixOS/nixpkgs/issues/304528
   env.GAG_CPP = if stdenv.hostPlatform.isDarwin then "${gfortran.outPath}/bin/cpp" else "cpp";

--- a/pkgs/by-name/ke/keyutils/package.nix
+++ b/pkgs/by-name/ke/keyutils/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  makeFlags = lib.optionals stdenv.hostPlatform.isStatic "NO_SOLIB=1";
+  makeFlags = lib.optionals stdenv.hostPlatform.isStatic [ "NO_SOLIB=1" ];
 
   outputs = [
     "out"

--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -91,7 +91,9 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     (makeBool "LLAMA_CLBLAST" clblastSupport)
     (makeBool "LLAMA_VULKAN" vulkanSupport)
     (makeBool "LLAMA_METAL" metalSupport)
-    (lib.optionals cublasSupport "CUDA_DOCKER_ARCH=${builtins.head cudaArches}")
+  ]
+  ++ lib.optionals cublasSupport [
+    "CUDA_DOCKER_ARCH=${builtins.head cudaArches}"
   ];
 
   installPhase = ''

--- a/pkgs/by-name/li/libudev-zero/package.nix
+++ b/pkgs/by-name/li/libudev-zero/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   # non-install target that builds everything anyway.
   dontBuild = true;
 
-  installTargets = lib.optionals stdenv.hostPlatform.isStatic "install-static";
+  installTargets = lib.optionals stdenv.hostPlatform.isStatic [ "install-static" ];
 
   passthru.tests = {
     pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;

--- a/pkgs/by-name/mi/mixxc/package.nix
+++ b/pkgs/by-name/mi/mixxc/package.nix
@@ -28,11 +28,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoBuildFlags = [ "--locked" ];
 
-  buildFeatures = [
-    (lib.optionals enableWayland "Wayland")
-    (lib.optionals enableX11 "X11")
-    (lib.optionals enableSass "Sass")
-  ];
+  buildFeatures =
+    lib.optionals enableWayland [ "Wayland" ]
+    ++ lib.optionals enableX11 [ "X11" ]
+    ++ lib.optionals enableSass [ "Sass" ];
 
   nativeBuildInputs = [
     pkg-config
@@ -43,9 +42,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   buildInputs = [
     libpulseaudio
     gtk4
-    (lib.optionals enableWayland gtk4-layer-shell)
-    (lib.optionals enableX11 libxcb)
-  ];
+  ]
+  ++ lib.optionals enableWayland [ gtk4-layer-shell ]
+  ++ lib.optionals enableX11 [ libxcb ];
 
   outputs = [
     "out"

--- a/pkgs/by-name/pr/prometheus-postfix-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-postfix-exporter/package.nix
@@ -28,7 +28,7 @@ buildGoModule rec {
 
   nativeBuildInputs = lib.optionals withSystemdSupport [ makeWrapper ];
   buildInputs = lib.optionals withSystemdSupport [ systemdLibs ];
-  tags = lib.optionals (!withSystemdSupport) "nosystemd";
+  tags = lib.optionals (!withSystemdSupport) [ "nosystemd" ];
 
   postInstall = lib.optionals withSystemdSupport ''
     wrapProgram $out/bin/postfix_exporter \


### PR DESCRIPTION
Related: https://github.com/NixOS/nixpkgs/pull/550348

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
