### PR TITLE
python3Packages.dashscope: 1.25.9 -> 1.26.6

### DIFF
--- a/pkgs/development/python-modules/dashscope/default.nix
+++ b/pkgs/development/python-modules/dashscope/default.nix
@@ -11,21 +11,32 @@
   websocket-client,
   cryptography,
   certifi,
+  typer,
+  rich,
+  httpx,
+  httpx-sse,
+  pyyaml,
+  # Optional dependencies
+  tiktoken,
   # Test
   pytestCheckHook,
-  tiktoken,
+  pytest-asyncio,
+  pydantic,
+  tenacity,
 }:
 
 buildPythonPackage rec {
   pname = "dashscope";
-  version = "1.25.9";
+  version = "1.26.6";
   pyproject = true;
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "dashscope";
     repo = "dashscope-sdk-python";
     tag = "v${version}";
-    hash = "sha256-VR7Auso+0al9qAE3IDFAPl5zIX0Yp9OfJchR+Q9DB1o=";
+    hash = "sha256-4plniNvpRNIUquTRDJZonQsa4inktGS7AluxKsX+Mpg=";
   };
 
   build-system = [ setuptools ];
@@ -36,7 +47,17 @@ buildPythonPackage rec {
     websocket-client
     cryptography
     certifi
+    typer
+    rich
+    httpx
+    httpx-sse
+    # Not listed in requirements.txt
+    pyyaml
   ];
+
+  optional-dependencies = {
+    tokenizer = [ tiktoken ];
+  };
 
   # Specify the version explicitly
   postPatch = ''
@@ -46,8 +67,11 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    tiktoken
-  ];
+    pytest-asyncio
+    pydantic
+    tenacity
+  ]
+  ++ optional-dependencies.tokenizer;
 
   pythonImportsCheck = [ "dashscope" ];
 
@@ -55,6 +79,9 @@ buildPythonPackage rec {
     # Needs network access and/or API key
     "TestAsyncImageSynthesisRequest"
     "TestAsyncRequest"
+    "TestAsyncSessionLifecycle"
+    "TestAsyncSessionUsage"
+    "TestAsyncSessionWithDifferentMethods"
     "TestAsyncVideoSynthesisRequest"
     "TestEncryption"
     "TestSpeechRecognition"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

And also fix build failure.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
