### PR TITLE
processmonitor: init at 1.5.0

### DIFF
--- a/pkgs/by-name/pr/processmonitor/package.nix
+++ b/pkgs/by-name/pr/processmonitor/package.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  makeWrapper,
+  writeShellApplication,
+  testers,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "processmonitor";
+  version = "1.5.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchzip {
+    url = "https://bitbucket.org/objective-see/deploy/downloads/ProcessMonitor_${finalAttrs.version}.zip";
+    hash = "sha256-FQvQ80YVH6kSkAKKLWVaNdLCB5CqIBqG0vkD97KVEcs=";
+
+    stripRoot = false;
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    cp -R ProcessMonitor.app $out/Applications/
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    mkdir -p $out/bin
+    makeWrapper $out/Applications/ProcessMonitor.app/Contents/MacOS/ProcessMonitor $out/bin/processmonitor
+  '';
+
+  passthru = {
+    updateScript = lib.getExe (writeShellApplication {
+      name = "update-processmonitor";
+      text = ''
+        latest_version=$(curl -s https://objective-see.org/products/changelogs/ProcessMonitor.txt | grep -m1 -oE '[0-9]+\.[0-9]+\.[0-9]+')
+        update-source-version processmonitor "$latest_version"
+      '';
+    });
+
+    tests = {
+      help = testers.runCommand {
+        name = "processmonitor-help-test";
+        buildInputs = [ finalAttrs.finalPackage ];
+        script = ''
+          # Capture both stdout and stderr, and use `|| true` to suppress the 255 exit code
+          # which occurs because of the wrong help exit code imlementation in processmonitor
+          # Fix when this is merged: https://github.com/objective-see/ProcessMonitor/pull/11
+          output=$(processmonitor -h 2>&1 || true)
+
+          echo "$output" | grep -F "ProcessMonitor (v${finalAttrs.version})"
+
+          touch $out
+        '';
+      };
+    };
+  };
+
+  meta = {
+    mainProgram = "processmonitor";
+    description = "Advanced utility that monitors process creations and terminations on macOS";
+    longDescription = ''
+      ProcessMonitor leverages Apple's Endpoint Security Framework to capture system-wide process events.
+    '';
+    homepage = "https://objective-see.org/products/utilities.html#ProcessMonitor";
+    downloadPage = "https://objective-see.org/products/utilities.html#ProcessMonitor";
+    changelog = "https://objective-see.org/products/changelogs/ProcessMonitor.txt";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    identifiers = {
+      cpeParts = {
+        vendor = "objective-see";
+        product = "processmonitor";
+        version = finalAttrs.version;
+        target_sw = "macos";
+      };
+      purlParts = {
+        type = "generic";
+        spec = "objective-see/processmonitor@${finalAttrs.version}?download_url=https://bitbucket.org/objective-see/deploy/downloads/ProcessMonitor_${finalAttrs.version}.zip";
+      };
+    };
+    maintainers = with lib.maintainers; [ KristijanZic ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added processmonitor at 1.5.0 https://objective-see.org/products/utilities.html 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
