### PR TITLE
upki: init at 0.1.0-beta.3

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -346,6 +346,7 @@
   ./programs/tsm-client.nix
   ./programs/turbovnc.nix
   ./programs/udevil.nix
+  ./programs/upki.nix
   ./programs/usbtop.nix
   ./programs/vim.nix
   ./programs/virt-manager.nix

--- a/nixos/modules/programs/upki.nix
+++ b/nixos/modules/programs/upki.nix
@@ -1,0 +1,97 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.upki;
+  format = pkgs.formats.toml { };
+  configFile = format.generate "upki.toml" cfg.settings;
+in
+{
+  options.services.upki = {
+    enable = lib.mkEnableOption "upki certificate infrastructure cache updates";
+
+    package = lib.mkPackageOption pkgs "upki" { };
+
+    interval = lib.mkOption {
+      type = lib.types.str;
+      default = "2h";
+      example = "1h";
+      description = "How often to update the upki cache.";
+    };
+
+    settings = lib.mkOption {
+      inherit (format) type;
+      default = { };
+      description = "Settings written to the upki config file.";
+      example = lib.literalExpression ''
+        {
+          cache-dir = "/var/cache/upki";
+          revocation.fetch-url = "https://upki.rustls.dev/";
+        }
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    services.upki.settings = {
+      cache-dir = lib.mkDefault "/var/cache/upki";
+      revocation.fetch-url = lib.mkDefault "https://upki.rustls.dev/";
+    };
+
+    users.users.upki = {
+      isSystemUser = true;
+      group = "upki";
+    };
+    users.groups.upki = { };
+
+    systemd.services.upki-fetch = {
+      description = "Update the upki cache";
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${lib.getExe cfg.package} --config-file ${configFile} fetch";
+        User = "upki";
+        Group = "upki";
+        CacheDirectory = "upki";
+        CacheDirectoryMode = "0755";
+        UMask = "0022";
+
+        # Hardening
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectSystem = "strict";
+        RestrictAddressFamilies = [
+          "AF_UNIX"
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictRealtime = true;
+        SystemCallArchitectures = "native";
+        SystemCallErrorNumber = "EPERM";
+        SystemCallFilter = "@system-service";
+      };
+    };
+
+    systemd.timers.upki-fetch = {
+      description = "Update the upki cache every ${cfg.interval}";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnActiveSec = "0";
+        OnUnitActiveSec = cfg.interval;
+      };
+    };
+  };
+}

--- a/pkgs/by-name/up/upki/package.nix
+++ b/pkgs/by-name/up/upki/package.nix
@@ -1,0 +1,103 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  buildPackages,
+  stdenv,
+  testers,
+  versionCheckHook,
+  rustc,
+  cacert,
+  pkg-config,
+  openssl,
+  cargo-c,
+  validatePkgConfig,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "upki";
+  version = "1.0.0-beta.3";
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "rustls";
+    repo = "upki";
+    tag = "upki-${finalAttrs.version}";
+    hash = "sha256-GZkXxidIjG76yIzAcMRsRorMVYpImFN5Q2pe2YgiEUs=";
+  };
+
+  cargoHash = "sha256-/z11KuGP3A3fh/Jk2Kx26x7okh6brHs+t/XC7BuPgcA=";
+
+  cargoBuildFlags = [
+    "--package=upki-cli"
+    "--package=upki-openssl"
+  ];
+
+  cargoInstallFlags = [
+    "--package=upki-cli"
+  ];
+
+  nativeBuildInputs = [
+    cargo-c
+    pkg-config
+  ];
+  buildInputs = [ openssl ];
+
+  env.SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+
+  postBuild = ''
+    ${buildPackages.rust.envVars.setEnv} cargo cbuild --release --frozen \
+      --package=upki \
+      --prefix=$out \
+      --target=${stdenv.hostPlatform.rust.rustcTarget}
+    ${buildPackages.rust.envVars.setEnv} cargo cbuild --release --frozen \
+      --package=upki-openssl \
+      --prefix=$out \
+      --target=${stdenv.hostPlatform.rust.rustcTarget}
+  '';
+
+  postInstall = ''
+    ${buildPackages.rust.envVars.setEnv} cargo cinstall --release --frozen \
+      --package=upki \
+      --prefix=$out \
+      --target=${stdenv.hostPlatform.rust.rustcTarget}
+    ${buildPackages.rust.envVars.setEnv} cargo cinstall --release --frozen \
+      --package=upki-openssl \
+      --prefix=$out \
+      --target=${stdenv.hostPlatform.rust.rustcTarget}
+    cp $out/include/upki/upki.h $out/include/upki_openssl/upki.h
+  '';
+
+  nativeInstallCheckInputs = [
+    pkg-config
+    versionCheckHook
+    validatePkgConfig
+  ];
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [ "--version=unstable" ];
+    };
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Platform-independent browser-grade certificate infrastructure";
+    homepage = "https://github.com/rustls/upki";
+    changelog = "https://github.com/rustls/upki/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.OR [
+      lib.licenses.mit
+      lib.licenses.asl20
+    ];
+    maintainers = [ lib.maintainers.skyesoss ];
+    mainProgram = "upki";
+    pkgConfigModules = [
+      "upki"
+      "upki_openssl"
+    ];
+    platforms = rustc.meta.platforms;
+  };
+})


### PR DESCRIPTION
Adds [upki](https://github.com/rustls/upki), a service that periodically downloads certificate revocations.

### Differences from #492119

- This package also builds the `upki` and `upki_openssl` C libraries.
- The newer beta version of upki defaults to `/var/cache/upki` (instead of a user directory), which is what we want to be using anyways.
- This PR adds a basic NixOS module to setup the system service. The upstream documentation has guidance on doing this [here](https://github.com/rustls/upki/blob/main/PACKAGING.md).

Replaces: #492119

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [X] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
