### PR TITLE
filemonitor: init at 1.3.0

### DIFF
--- a/pkgs/by-name/fi/filemonitor/package.nix
+++ b/pkgs/by-name/fi/filemonitor/package.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  makeWrapper,
+  writeShellApplication,
+  testers,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "filemonitor";
+  version = "1.3.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchzip {
+    url = "https://bitbucket.org/objective-see/deploy/downloads/FileMonitor_${finalAttrs.version}.zip";
+    hash = "sha256-ycC2MySfsnW6JicQRlWtuAqI887+0TlnD6PtlWewuog=";
+
+    stripRoot = false;
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    cp -R FileMonitor.app $out/Applications/
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    mkdir -p $out/bin
+    makeWrapper $out/Applications/FileMonitor.app/Contents/MacOS/FileMonitor $out/bin/${finalAttrs.pname}
+  '';
+
+  passthru = {
+    updateScript = lib.getExe (writeShellApplication {
+      name = "update-filemonitor";
+      text = ''
+        latest_version=$(curl -s https://objective-see.org/products/changelogs/FileMonitor.txt | grep -m1 -oE '[0-9]+\.[0-9]+\.[0-9]+')
+        update-source-version ${finalAttrs.pname} "$latest_version"
+      '';
+    });
+
+    tests = {
+      help = testers.runCommand {
+        name = "filemonitor-help-test";
+        buildInputs = [ finalAttrs.finalPackage ];
+        script = ''
+          # Capture both stdout and stderr, and use `|| true` to suppress the 255 exit code
+          # which occurs because of the wrong help exit code imlementation in filemonitor
+          # Fix when this is merged: https://github.com/objective-see/FileMonitor/pull/14
+          output=$(filemonitor -h 2>&1 || true)
+
+          echo "$output" | grep -F "FileMonitor (v${finalAttrs.version})"
+
+          touch $out
+        '';
+      };
+    };
+  };
+
+  meta = {
+    mainProgram = "filemonitor";
+    description = "Advanced utility that monitors file events on macOS";
+    longDescription = ''
+      Leveraging Apple's Endpoint Security Framework,
+      this utility monitors file events (such as creation, modifications, and deletions)
+      providing detailed information about such events.
+    '';
+    homepage = "https://objective-see.org/products/utilities.html#FileMonitor";
+    downloadPage = "https://objective-see.org/products/utilities.html#FileMonitor";
+    changelog = "https://objective-see.org/products/changelogs/FileMonitor.txt";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    identifiers = {
+      cpeParts = {
+        vendor = "objective-see";
+        product = "filemonitor";
+        version = finalAttrs.version;
+        target_sw = "macos";
+      };
+      purlParts = {
+        type = "generic";
+        spec = "objective-see/filemonitor@${finalAttrs.version}?download_url=https://bitbucket.org/objective-see/deploy/downloads/FileMonitor_${finalAttrs.version}.zip";
+      };
+    };
+    maintainers = with lib.maintainers; [ KristijanZic ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added filemonitor at 1.3.0 from https://objective-see.org/products/utilities.html#FileMonitor

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
