### PR TITLE
archon-lite: 9.4.36 -> 9.5.0

### DIFF
--- a/pkgs/by-name/ar/archon-lite/package.nix
+++ b/pkgs/by-name/ar/archon-lite/package.nix
@@ -7,23 +7,22 @@
 
 appimageTools.wrapType2 (finalAttrs: {
   pname = "archon-lite";
-  version = "9.4.36";
+  version = "9.5.0";
 
   src = fetchurl {
     url = "https://github.com/RPGLogs/Uploaders-archon-lite/releases/download/v${finalAttrs.version}/archon-lite-v${finalAttrs.version}.AppImage";
-    hash = "sha256-th48nSDIi2iugtiqjgkI7/QZtBq+BRQjRs1pKweDArI=";
+    hash = "sha256-ZuALgVtqsYtvnSq8hkJL4A+i4UaEpk+2L3bpSEXrhRM=";
   };
 
   extraInstallCommands = ''
     mkdir -p $out/share/applications
     mkdir -p $out/share/icons/hicolor/512x512/apps
-    cp -r ${finalAttrs.contents}/usr/share/icons/hicolor/512x512/apps/'Archon App Lite.png' $out/share/icons/hicolor/512x512/apps/archon-lite.png
+    cp -r ${finalAttrs.contents}/usr/share/icons/hicolor/512x512/apps/archon-lite.png $out/share/icons/hicolor/512x512/apps/archon-lite.png
     chmod -R +w $out/share/
     test ! -e $out/share/icons/hicolor/0x0 # check for regression of https://github.com/electron-userland/electron-builder/issues/5294
-    cp ${finalAttrs.contents}/'Archon App Lite.desktop' $out/share/applications/archon-lite.desktop
+    cp ${finalAttrs.contents}/archon-lite.desktop $out/share/applications/archon-lite.desktop
     substituteInPlace $out/share/applications/archon-lite.desktop \
-      --replace-fail "Exec=AppRun --no-sandbox" "Exec=archon-lite" \
-      --replace-fail "Icon=Archon App Lite" "Icon=archon-lite"
+      --replace-fail "Exec=AppRun --no-sandbox" "Exec=archon-lite"
   '';
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
updated archon-lite to 9.5.0. the icon and desktop entry were renamed in the appimage, which needed to be accounted for, and was why the auto-updater failed

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
