### PR TITLE
stalwart_0_15.webadmin: fixes wasm-bindgen deplicate exports

### DIFF
--- a/pkgs/by-name/st/stalwart_0_15/webadmin.nix
+++ b/pkgs/by-name/st/stalwart_0_15/webadmin.nix
@@ -3,6 +3,7 @@
   rustPlatform,
   stalwart_0_15,
   fetchFromGitHub,
+  fetchpatch,
   trunk,
   tailwindcss_3,
   fetchNpmDeps,
@@ -15,6 +16,24 @@
   zip,
 }:
 
+let
+
+  # apply upstream fix https://github.com/wasm-bindgen/wasm-bindgen/pull/4380,
+  # as we cannot change the wasm-bindgen version, as it's pinned to 0.2.93.
+  wasmBindgenCliPatched =
+    let
+      wasmBindgenCliDedupExportsPatch = fetchpatch {
+        url = "https://github.com/wasm-bindgen/wasm-bindgen/commit/b375e974cf30a203f1ea7f6320ad32759c5cb9e6.patch";
+        relative = "crates/cli-support";
+        hash = "sha256-pejDKqNbtlpLLqNcdpwgxDSxsGxyv5V8/QeK+OCY3qw=";
+      };
+    in
+    wasm-bindgen-cli_0_2_93.overrideAttrs (old: {
+      postPatch = (old.postPatch or "") + ''
+        patch -p1 -d "$cargoDepsCopy"/*/wasm-bindgen-cli-support-* < ${wasmBindgenCliDedupExportsPatch}
+      '';
+    });
+in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "webadmin";
   version = "0.1.37";
@@ -46,7 +65,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     tailwindcss_3
     trunk
     # needs to match with wasm-bindgen version in upstreams Cargo.lock
-    wasm-bindgen-cli_0_2_93
+    wasmBindgenCliPatched
 
     zip
   ];


### PR DESCRIPTION
## Things done
stalwart webadmin fails to build as described in https://github.com/NixOS/nixpkgs/issues/549417 , this PR pulls in the upstream fix and patches wasm-bindgen for the version we need.

It should fix the issue described.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
