### PR TITLE
kubernetes-helmPlugins: add helm-secrets-getter and post-renderer

### DIFF
--- a/pkgs/applications/networking/cluster/helm/plugins/default.nix
+++ b/pkgs/applications/networking/cluster/helm/plugins/default.nix
@@ -15,6 +15,10 @@
 
   helm-secrets = callPackage ./helm-secrets.nix { };
 
+  helm-secrets-getter = callPackage ./helm-secrets-getter.nix { };
+
+  helm-secrets-post-renderer = callPackage ./helm-secrets-post-renderer.nix { };
+
   helm-schema = callPackage ./helm-schema.nix { };
 
   helm-unittest = callPackage ./helm-unittest.nix { };

--- a/pkgs/applications/networking/cluster/helm/plugins/default.nix
+++ b/pkgs/applications/networking/cluster/helm/plugins/default.nix
@@ -1,5 +1,8 @@
 { callPackage }:
 
+let
+  helm-secrets = callPackage ./helm-secrets.nix { };
+in
 {
   helm-cm-push = callPackage ./helm-cm-push.nix { };
 
@@ -13,11 +16,13 @@
 
   helm-s3 = callPackage ./helm-s3.nix { };
 
-  helm-secrets = callPackage ./helm-secrets.nix { };
+  inherit helm-secrets;
 
   helm-secrets-getter = callPackage ./helm-secrets-getter.nix { };
 
-  helm-secrets-post-renderer = callPackage ./helm-secrets-post-renderer.nix { };
+  helm-secrets-post-renderer = callPackage ./helm-secrets-post-renderer.nix {
+    inherit helm-secrets;
+  };
 
   helm-schema = callPackage ./helm-schema.nix { };
 

--- a/pkgs/applications/networking/cluster/helm/plugins/helm-secrets-getter.nix
+++ b/pkgs/applications/networking/cluster/helm/plugins/helm-secrets-getter.nix
@@ -12,7 +12,7 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  pname = "helm-secrets";
+  pname = "helm-secrets-getter";
   version = "4.7.7";
 
   src = fetchFromGitHub {
@@ -31,16 +31,16 @@ stdenv.mkDerivation (finalAttrs: {
   # NOTE: helm-secrets is comprised of shell scripts.
   dontBuild = true;
 
-  # NOTE: Fix version string in the Helm 4 CLI plugin manifest.
+  # NOTE: Fix version string in the Helm 4 getter plugin manifest.
   postPatch = ''
-    sed -i 's/^version:.*/version: "${finalAttrs.version}"/' plugins/helm-secrets-cli/plugin.yaml
+    sed -i 's/^version:.*/version: "${finalAttrs.version}"/' plugins/helm-secrets-getter/plugin.yaml
   '';
 
   installPhase = ''
     runHook preInstall
 
     install -dm755 $out/${finalAttrs.pname} $out/${finalAttrs.pname}/scripts
-    install -m644 -Dt $out/${finalAttrs.pname} plugins/helm-secrets-cli/plugin.yaml
+    install -m644 -Dt $out/${finalAttrs.pname} plugins/helm-secrets-getter/plugin.yaml
     cp -rL scripts/* $out/${finalAttrs.pname}/scripts
     wrapProgram $out/${finalAttrs.pname}/scripts/run.sh \
         --prefix PATH : ${
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "Helm plugin that helps manage secrets";
+    description = "Helm secrets getter plugin for secrets:// protocol support";
     homepage = "https://github.com/jkroepke/helm-secrets";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ yurrriq ];

--- a/pkgs/applications/networking/cluster/helm/plugins/helm-secrets-post-renderer.nix
+++ b/pkgs/applications/networking/cluster/helm/plugins/helm-secrets-post-renderer.nix
@@ -12,7 +12,7 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  pname = "helm-secrets";
+  pname = "helm-secrets-post-renderer";
   version = "4.7.7";
 
   src = fetchFromGitHub {
@@ -31,16 +31,16 @@ stdenv.mkDerivation (finalAttrs: {
   # NOTE: helm-secrets is comprised of shell scripts.
   dontBuild = true;
 
-  # NOTE: Fix version string in the Helm 4 CLI plugin manifest.
+  # NOTE: Fix version string in the Helm 4 post-renderer plugin manifest.
   postPatch = ''
-    sed -i 's/^version:.*/version: "${finalAttrs.version}"/' plugins/helm-secrets-cli/plugin.yaml
+    sed -i 's/^version:.*/version: "${finalAttrs.version}"/' plugins/helm-secrets-post-renderer/plugin.yaml
   '';
 
   installPhase = ''
     runHook preInstall
 
     install -dm755 $out/${finalAttrs.pname} $out/${finalAttrs.pname}/scripts
-    install -m644 -Dt $out/${finalAttrs.pname} plugins/helm-secrets-cli/plugin.yaml
+    install -m644 -Dt $out/${finalAttrs.pname} plugins/helm-secrets-post-renderer/plugin.yaml
     cp -rL scripts/* $out/${finalAttrs.pname}/scripts
     wrapProgram $out/${finalAttrs.pname}/scripts/run.sh \
         --prefix PATH : ${
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "Helm plugin that helps manage secrets";
+    description = "Helm secrets post-renderer plugin for evaluate-templates support";
     homepage = "https://github.com/jkroepke/helm-secrets";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ yurrriq ];

--- a/pkgs/applications/networking/cluster/helm/plugins/helm-secrets-post-renderer.nix
+++ b/pkgs/applications/networking/cluster/helm/plugins/helm-secrets-post-renderer.nix
@@ -9,6 +9,13 @@
   gnugrep,
   gnused,
   sops,
+  vals,
+
+  helm-secrets,
+  kubernetes-helm,
+  runCommand,
+  wrapHelm,
+  writableTmpDirAsHomeHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -26,6 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     getopt
     sops
+    vals
   ];
 
   # NOTE: helm-secrets is comprised of shell scripts.
@@ -42,6 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     install -dm755 $out/${finalAttrs.pname} $out/${finalAttrs.pname}/scripts
     install -m644 -Dt $out/${finalAttrs.pname} plugins/helm-secrets-post-renderer/plugin.yaml
     cp -rL scripts/* $out/${finalAttrs.pname}/scripts
+    # NOTE: The Helm 4 post-renderer always runs `vals eval` for --evaluate-templates.
     wrapProgram $out/${finalAttrs.pname}/scripts/run.sh \
         --prefix PATH : ${
           lib.makeBinPath [
@@ -51,11 +60,41 @@ stdenv.mkDerivation (finalAttrs: {
             gnugrep
             gnused
             sops
+            vals
           ]
         }
 
     runHook postInstall
   '';
+
+  passthru.tests.evaluate-templates =
+    let
+      helm = wrapHelm kubernetes-helm {
+        plugins = [
+          helm-secrets
+          finalAttrs.finalPackage
+        ];
+      };
+    in
+    runCommand "helm-secrets-post-renderer-evaluate-templates"
+      {
+        nativeBuildInputs = [
+          helm
+          writableTmpDirAsHomeHook
+        ];
+      }
+      ''
+        cp -r ${./tests/helm-secrets/evaluate-templates} chart
+        chmod -R u+w chart
+        rendered=$(helm secrets --evaluate-templates template smoke chart)
+        echo "$rendered"
+        echo "$rendered" | grep -F 'secret: hunter2'
+        if echo "$rendered" | grep -F 'ref+echo'; then
+          echo "vals expression was not evaluated" >&2
+          exit 1
+        fi
+        touch $out
+      '';
 
   meta = {
     description = "Helm secrets post-renderer plugin for evaluate-templates support";

--- a/pkgs/applications/networking/cluster/helm/plugins/tests/helm-secrets/evaluate-templates/Chart.yaml
+++ b/pkgs/applications/networking/cluster/helm/plugins/tests/helm-secrets/evaluate-templates/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: smoke
+version: 0.1.0

--- a/pkgs/applications/networking/cluster/helm/plugins/tests/helm-secrets/evaluate-templates/templates/configmap.yaml
+++ b/pkgs/applications/networking/cluster/helm/plugins/tests/helm-secrets/evaluate-templates/templates/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ .Release.Name }}-smoke"
+data:
+  secret: "ref+echo://hunter2"


### PR DESCRIPTION
Add Helm 4 getter and post-renderer plugins for helm-secrets, and bump the CLI plugin to 4.7.7.

Helm 4 requires separate plugins for CLI, getter (`secrets://`), and post-renderer (`--evaluate-templates`) capabilities. #542211 restored the CLI only; this PR packages the remaining two plugins.

https://github.com/jkroepke/helm-secrets/releases/tag/v4.7.7
https://github.com/jkroepke/helm-secrets/wiki/Installation#helm-4

Related: #536239
Supersedes: #531207

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
