### PR TITLE
netbird: fix ssh rule for multiple clients

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -164,6 +164,8 @@
 
 - [firefox-syncserver.database.type](#opt-services.firefox-syncserver.database.type) no longer defaults to `"mysql"`. You must now explicitly choose between `"mysql"` and `"postgresql"`. New deployments should prefer PostgreSQL.
 
+- `services.netbird` no longer lets the client daemon write {file}`/etc/ssh/ssh_config.d/99-netbird.conf` (`NB_DISABLE_SSH_CONFIG` now defaults to `true`); that file never took effect on NixOS, as {file}`/etc/ssh/ssh_config` does not include {file}`ssh_config.d`. Set [services.netbird.clients.\<name\>.ssh.enable](#opt-services.netbird.clients._name_.ssh.enable) if you relied on plain `ssh <netbird-peer>` using NetBird's JWT/SSO authentication; it adds a `Match` block gated on that client's own daemon reporting the target as a peer, and delegates host key verification for those hosts to the daemon.
+
 ## Other Notable Changes {#sec-release-26.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/services/networking/netbird.nix
+++ b/nixos/modules/services/networking/netbird.nix
@@ -200,6 +200,7 @@ in
                     NB_STATE_DIR = client.dir.state;
                     NB_CONFIG = "''${client.dir.state}/config.json";
                     NB_DAEMON_ADDR = "unix://''${client.dir.runtime}/sock";
+                    NB_DISABLE_SSH_CONFIG = mkOptionDefault "true";
                     NB_INTERFACE_NAME = client.interface;
                     NB_LOG_FILE = mkOptionDefault "console";
                     NB_LOG_LEVEL = client.logLevel;
@@ -296,6 +297,65 @@ in
                 ];
                 default = "info";
                 description = "Log level of the NetBird daemon.";
+              };
+
+              ssh.enable = mkOption {
+                type = bool;
+                default = false;
+                description = ''
+                  Routes `ssh <netbird-peer>` through NetBird's JWT/SSO authentication instead of
+                  letting it fall back to password authentication, by adding a `Match` block with
+                  `netbird ssh proxy` as a `ProxyCommand` to {file}`/etc/ssh/ssh_config`.
+
+                  The block applies only to hosts this client's own daemon reports as peers *and*
+                  which serve NetBird SSH, so it stays inert for everything else, including other
+                  clients' peers and peers running a plain `sshd`. Deciding that runs a subprocess
+                  and a daemon round trip on every `ssh` invocation on the machine - around 0.1s,
+                  capped at 2s per enabled client - which is why this is opt-in.
+
+                  Matched hosts get `StrictHostKeyChecking no` and `UserKnownHostsFile /dev/null`,
+                  as upstream's own snippet does. That is not a loss of verification: OpenSSH is
+                  talking to a local `netbird ssh proxy` process over stdio, and the real peer's
+                  host key is checked one hop further in, by the daemon.
+
+                  On a `hardened` client the daemon socket is restricted to `${client.user.group}`.
+                  Users outside that group cannot read it, so the check never matches for them:
+                  their `ssh` keeps its stock behaviour but does not get the SSO proxy either.
+                '';
+              };
+
+              ssh.matchScript = mkOption {
+                type = package;
+                internal = true;
+                default = pkgs.writeShellApplication {
+                  name = "${client.suffixedName}-ssh-match";
+                  runtimeInputs = with pkgs; [
+                    coreutils
+                    jq
+                  ];
+                  text = ''
+                    case "$1" in
+                      *[!a-zA-Z0-9.:_-]*) exit 1 ;;
+                    esac
+
+                    # runs on every ssh invocation: answer at once when the socket is missing
+                    # (daemon down) or unreadable (caller outside of ${client.user.group}),
+                    # rather than waiting out the `timeout` below
+                    test -S "${client.dir.runtime}/sock" || exit 1
+
+                    # ask this client's own daemon. `ssh detect` cannot answer this: it reads the
+                    # target's SSH banner, so the target decides, and it cannot tell two clients'
+                    # peers apart. ssh host names are case insensitive and may be fully qualified.
+                    NB_LOG_LEVEL=error timeout 2 ${getExe client.wrapper} status --json 2>/dev/null \
+                      | jq --exit-status --arg host "$1" \
+                        '($host | ascii_downcase | rtrimstr(".")) as $h
+                         | any(.peers.details[]?;
+                             ((.fqdn // "") | ascii_downcase | rtrimstr(".")) as $f
+                             | $f == $h or ($f | split(".")[0]) == $h
+                               or .netbirdIp == $h or .netbirdIpv6 == $h)' \
+                        >/dev/null
+                  '';
+                };
               };
 
               ui.enable = mkOption {
@@ -440,6 +500,10 @@ in
               NB_STATE_DIR = client.dir.state;
               NB_CONFIG = "${client.dir.state}/config.json";
               NB_DAEMON_ADDR = "unix://${client.dir.runtime}/sock";
+              # upstream's writer targets a hardcoded /etc path (read-only under
+              # `hardened = true`, shared by all clients) and the unwrapped binary,
+              # `clients.<name>.ssh.enable` replaces it
+              NB_DISABLE_SSH_CONFIG = mkOptionDefault "true";
               NB_INTERFACE_NAME = client.interface;
               NB_LOG_FILE = mkOptionDefault "console";
               NB_LOG_LEVEL = client.logLevel;
@@ -571,6 +635,39 @@ in
               ActivationPolicy = "manual";
             };
           }
+        )
+      );
+
+      # `/etc/ssh/ssh_config` does not include `ssh_config.d` on NixOS, so the snippet goes in
+      # directly.
+      #
+      # Both criteria must hold, and ssh evaluates them left to right, stopping at the first
+      # failure: the daemon lookup answers "is this one of my peers", then `ssh detect` answers
+      # "does it actually serve NetBird SSH" - which is off by default upstream, so without it the
+      # proxy would engage for plain-sshd peers and replace a working connection with an SSO
+      # prompt. `detect` alone would not do: it reads the target's own banner, so a lying host
+      # could select itself. Ordered this way a lying host can only fail the second criterion and
+      # opt itself out, which is the safe direction.
+      #
+      # The closing `Match all` restores global scope: `extraConfig` is shared, and without it this
+      # block would swallow whatever another module happens to append after it.
+      #
+      # Quoting `%h` covers ordinary host names. It is not a security boundary: ssh_config has no
+      # escaping, so a `Hostname` directive containing a single quote still reaches the shell.
+      # Host names from the command line are rejected by ssh itself (OpenSSH >= 9.6).
+      programs.ssh.extraConfig = concatStringsSep "" (
+        toClientList (
+          client:
+          optionalString client.ssh.enable ''
+            # NetBird JWT/SSO authentication for ${client.service.name}
+            Match exec "${getExe client.ssh.matchScript} '%h'" exec "${getExe client.wrapper} ssh detect '%h' '%p'"
+                ProxyCommand ${getExe client.wrapper} ssh proxy %h %p
+                UserKnownHostsFile /dev/null
+                StrictHostKeyChecking no
+                # otherwise every proxied connection warns about /dev/null known hosts
+                LogLevel ERROR
+            Match all
+          ''
         )
       );
 

--- a/nixos/tests/netbird.nix
+++ b/nixos/tests/netbird.nix
@@ -11,6 +11,7 @@
       services.netbird = {
         enable = true;
         clients.custom.port = 51819;
+        clients.custom.ssh.enable = true;
         ui.enable = true;
       };
     };
@@ -87,6 +88,29 @@
 
     for name in instances:
       wait_until_rcode(node, f"{name} status |& grep -C20 Disconnected", 0, retries=5)
+
+    with subtest("ssh.enable gates the ProxyCommand on a daemon-backed peer lookup"):
+      node.succeed("grep -F 'netbird-custom ssh proxy %h %p' /etc/ssh/ssh_config")
+
+      # this VM never logs in, so the daemon reports no peers and the block must stay inert.
+      # `ssh -G` prints no `proxycommand` line at all unless one is configured; don't grep for
+      # "netbird", which a peer-shaped hostname echoes back on its own `hostname` line.
+      # `timeout` catches a lost fail-fast guard, `succeed` a Match block that breaks all ssh.
+      out = node.succeed("timeout 5 ssh -G node.netbird.cloud 2>/dev/null")
+      assert "proxycommand" not in out, f"block engaged for a non-peer:\n{out}"
+
+      # the other fail-closed path: no daemon to ask at all
+      node.succeed("systemctl stop netbird-custom.service")
+      node.wait_until_fails("test -S /var/run/netbird-custom/sock")
+      out = node.succeed("timeout 5 ssh -G node.netbird.cloud 2>/dev/null")
+      assert "proxycommand" not in out, f"block engaged without a daemon:\n{out}"
+
+    with subtest("the Match block does not capture later ssh_config directives"):
+      # `programs.ssh.extraConfig` is shared; an unterminated Match would silently scope
+      # whatever another module appends after it.
+      # `ssh_config` ends without a newline, so lead with one or the lines run together.
+      node.succeed("{ cat /etc/ssh/ssh_config; printf '\\nCompression yes\\n'; } >/tmp/after.conf")
+      node.succeed("ssh -G -F /tmp/after.conf nonmatching.example.org | grep -qx 'compression yes'")
   ''
   # The status used to turn into `NeedsLogin`, but recently started crashing instead.
   # leaving the snippets in here, in case some update goes back to the old behavior and can be tested again


### PR DESCRIPTION
> [!NOTE]
> **Automation disclosure.** The design and decisions here are mine. I used Claude Code
> (`claude-opus-5`) as a writing and verification aid for the code
> the commits carry `Assisted-by:` trailers.

The NetBird client daemon tries to maintain `/etc/ssh/ssh_config.d/99-netbird.conf`, the file carrying `ProxyCommand <netbird> ssh proxy %h %p`. That is how upstream wires NetBird's JWT/SSO authentication into stock OpenSSH (`netbird ssh proxy --help`: *"Internal command used by SSH ProxyCommand to handle JWT authentication"*). Without it, `ssh <netbird-peer>` never gets SSO and falls through to password auth, while `netbird-<client> ssh <peer>` works:

```
$ ssh -vv peer-01
debug1: Remote protocol version 2.0, remote software version NetBird-SSH-Server-0.76.1 NetBird-JWT-Required
debug1: Authentications that can continue: password
```

On NixOS the daemon's writer cannot work, for three independent reasons:

1. **The unit cannot write the file.** `hardened = true`, the default for every suffixed client, and for every setup not using `services.netbird.enable`, sets `ProtectSystem = "strict"` with no `ReadWritePaths`, so `/etc` is read-only:

   ```
   $ journalctl -u netbird-work
   WARN client/internal/engine_ssh.go:118: failed to update SSH client config:
        create temp SSH config: open /etc/ssh/ssh_config.d/99-netbird.conf.<rand>.tmp:
        read-only file system
   ```

   Not transient, it retries and fails on every management reconnect, spamming the journal.

2. **The file name is a hardcoded constant** in the binary. The only related env vars are `NB_DISABLE_SSH_CONFIG` and `NB_FORCE_SSH_CONFIG`; there is no override for the directory or name. With N suffixed clients, all N daemons write the same path and clobber each other, the per-client suffixing this module applies everywhere else (`suffixedName`, `dir.baseName`, `bin.suffix`) has no upstream counterpart here.

3. **The generated `ProxyCommand` names the wrong binary.** The daemon writes its own `os.Executable()`. `client.wrapper` is a `makeWrapper` script that `--set-default`s `NB_CONFIG` and `NB_DAEMON_ADDR` before `exec`ing `lib.getExe cfg.package`, so `os.Executable()` is the *unwrapped* store path. `netbird ssh proxy` then resolves its profile from the defaults (`/var/lib/netbird/default.json`, `unix:///var/run/netbird/sock`), the default client, which on a suffixed-only host does not exist.

And regardless of all three: **`/etc/ssh/ssh_config` on NixOS never includes `ssh_config.d`.** `nixos/modules/programs/ssh.nix` emits only two hardcoded store-path includes (libvirt, systemd-ssh-proxy), so a file dropped in that directory is read by nothing.

## Changes

- `NB_DISABLE_SSH_CONFIG` now defaults to `"true"` for every client, stopping the failed writes and the journal spam. It is a `mkOptionDefault`, so it stays overridable.
- New opt-in `services.netbird.clients.<name>.ssh.enable` adds the equivalent block to `programs.ssh.extraConfig`, pointing at that client's wrapper. Several clients can enable it side by side. `programs/gnupg.nix` already uses the same `Match … exec` mechanism.

```nix
services.netbird.clients.work = {
  port = 51821;
  ssh.enable = true;
};
```

emits, ahead of the generated `Host *`:

```
# NetBird JWT/SSO authentication for netbird-work
Match exec "…/netbird-work-ssh-match '%h'" exec "…/netbird-work ssh detect '%h' '%p'"
    ProxyCommand …/netbird-work ssh proxy %h %p
    UserKnownHostsFile /dev/null
    StrictHostKeyChecking no
    LogLevel ERROR
Match all
```

### Why the `Match` is not gated on `netbird ssh detect` alone

Upstream scopes its snippet with `Match host * exec "<netbird> ssh detect %h %p"`. `detect` decides **purely from the target's self-advertised SSH banner**. With a fake listener and no netbird daemon at all (`NB_DAEMON_ADDR=unix:///nonexistent/sock`):

```
banner "SSH-2.0-NetBird-SSH-Server-0.76.1 NetBird-JWT-Required"  -> detect exit=0  (match)
banner "SSH-2.0-OpenSSH_9.6"                                    -> detect exit=2  (no match)
```

The block turns off host key verification for matched hosts, and `programs.ssh.extraConfig` is system-wide, so gating that on a value the target controls would let any on-path host switch the defense off.

So `ssh.enable` generates a small per-client script that asks the **local daemon** whether the target is one of *its* peers (`netbird status --json`), and requires **both** criteria. ssh evaluates them left to right and stops at the first failure, so the cheap daemon lookup runs first and `detect` only runs for confirmed peers.

Both are needed. Dropping `detect` would break `ssh <peer>` for peers not running NetBird's SSH server, off by default upstream (`ServerSSHAllowed`), turning a working WireGuard connection into an SSO prompt and then a failure. Dropping the daemon lookup is the spoofing hole above. Ordered this way a lying host can only *fail* the second criterion and opt itself out, which is the safe direction; it can never satisfy the first.

Measured on a two-client host:

| client daemon | target | result |
|---|---|---|
| A | a peer of A (short name, FQDN, uppercase, trailing dot, peer IP) | match |
| B | that same peer of A | no match |
| A or B | `github.com`, `evil.example.com` | no match |
| daemon up but logged out | anything | no match |

The B row is a bonus the banner probe could never deliver: two clients on one host no longer collide, because each daemon only knows its own peers.

It fails **closed and fast**. A `test -S <runtime>/sock` guard short-circuits when the daemon is down or the caller is outside a `hardened` client's group (the runtime dir is `0750`), 0.00 s in both cases, rather than waiting out the timeout. In-group steady state is ~0.1 s, capped by `timeout 2` per enabled client. It runs on every `ssh` invocation on the machine, which is why the option is opt-in and off by default.

`StrictHostKeyChecking no` / `UserKnownHostsFile /dev/null` mirror upstream's snippet and are not a loss of verification: OpenSSH is talking to a local `netbird ssh proxy` process over stdio, and the real peer's host key is checked one hop further in, by the daemon. The closing `Match all` restores global scope, without it the block would silently capture whatever another module appends to the shared `extraConfig` (verified: a following `Compression yes` was swallowed).

## Reproducer

```nix
services.netbird.enable = false;
services.netbird.clients.work = { port = 51822; autoStart = false; };
```

Start `netbird-work`, log in, then `journalctl -u netbird-work | grep 'update SSH client config'`.

## Worth fixing upstream too

This module can drop its own snippet once either lands:

- `99-netbird.conf`'s path/name should be configurable (env or flag), mirroring the existing `NB_CONFIG` / `NB_DAEMON_ADDR` / `NB_STATE_DIR` pattern, so multiple profiles on one host can coexist.
- The generated `ProxyCommand` should carry `--config` / `--daemon-addr` (or use `os.Args[0]`) so it reconnects to the profile that generated it, and `ssh detect` should consult the daemon's peer list rather than the target's banner.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

`nixosTests.netbird` is extended with `ssh.enable` coverage and passes. No package expression is touched, so `passthru.tests` and `nixpkgs-review` are not applicable here.

cc @nazarewk (module maintainer)

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

This is not as critical as it seems, people people NOT using the `services.netbird.(client|tunnel).<name>...` as profiles now exists as an alternative. 