### PR TITLE
python3Packages.nccl4py: init at 0.3.0

### DIFF
--- a/pkgs/development/python-modules/nccl4py/default.nix
+++ b/pkgs/development/python-modules/nccl4py/default.nix
@@ -1,0 +1,102 @@
+{
+  lib,
+  buildPythonPackage,
+  cudaPackages,
+  addDriverRunpath,
+
+  # build-system
+  cython,
+  setuptools,
+
+  # dependencies
+  cuda-core,
+  numpy,
+  packaging,
+  pythonOlder,
+  typing-extensions,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "nccl4py";
+  # `nccl4py` is versioned independently of `nccl` and should be the
+  # same as the contents of
+  # `${cudaPackages.nccl.src}/bindings/nccl4py/nccl/_version.py`
+  version = "0.3.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  inherit (cudaPackages.nccl) src;
+  sourceRoot = "${finalAttrs.src.name}/bindings/nccl4py";
+
+  postPatch =
+    let
+      # taken from `cuda-bindings`'s `postPatch`
+      libCudaPath =
+        # Use cuda_compat to provide libcuda.so on pre-Thor Jetsons
+        if (cudaPackages.cuda_compat.meta.available or false) then
+          cudaPackages.cuda_compat
+
+        # Else, use the host CUDA driver library
+        else
+          addDriverRunpath.driverLink;
+    in
+    ''
+      substituteInPlace nccl/bindings/_internal/nccl_linux.pyx \
+        --replace-fail \
+          "handle = dlopen('libcuda.so.1'" \
+          "handle = dlopen('${libCudaPath}/lib/libcuda.so.1'"
+
+      substituteInPlace nccl/bindings/_internal/nccl_linux.pyx \
+        --replace-fail \
+          'cdef uintptr_t handle = load_nvidia_dynamic_lib("nccl")._handle_uint' \
+          'cdef uintptr_t handle = <uintptr_t>dlopen("${lib.getLib cudaPackages.nccl}/lib/libnccl.so.2", RTLD_NOW | RTLD_GLOBAL)'
+    '';
+
+  build-system = [
+    cython
+    setuptools
+  ];
+
+  env = {
+    # `${sourceRoot}/setup.py` insists on reading only from $CUDA_HOME/include
+    CUDA_HOME = (lib.getInclude cudaPackages.cuda_cudart).outPath;
+  };
+
+  buildInputs =
+    lib.optionals (cudaPackages.cudaOlder "13.0") [
+      cudaPackages.cuda_nvcc
+    ]
+    ++ lib.optionals (cudaPackages.cudaAtLeast "13.0") [
+      cudaPackages.cuda_crt
+    ];
+
+  dependencies = [
+    cuda-core
+    numpy
+    packaging
+  ]
+  ++ lib.optionals (pythonOlder "3.13") [
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [
+    "nccl"
+    "nccl.bindings"
+  ];
+
+  # Upstream doesn't ship any tests.
+  doCheck = false;
+
+  meta = {
+    description = "Python bindings for NCCL";
+    homepage = "https://github.com/NVIDIA/nccl/blob/master/bindings/nccl4py/README.md";
+    # `cudaPackages.nccl` is BSD3 but the bindings are licensed under
+    # Apache License 2.0
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [
+      GaetanLepage
+      thefossguy
+    ];
+    inherit (cudaPackages.nccl.meta) platforms badPlatforms;
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11591,6 +11591,8 @@ self: super: with self; {
 
   nc-dnsapi = callPackage ../development/python-modules/nc-dnsapi { };
 
+  nccl4py = callPackage ../development/python-modules/nccl4py { };
+
   ncclient = callPackage ../development/python-modules/ncclient { };
 
   nclib = callPackage ../development/python-modules/nclib { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
