### PR TITLE
codex: 0.146.0 -> 0.147.0

### DIFF
--- a/pkgs/by-name/co/codex/fetchers.nix
+++ b/pkgs/by-name/co/codex/fetchers.nix
@@ -17,4 +17,16 @@
         sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
       };
     };
+
+  fetchLibrustyV8SrcBinding =
+    args:
+    fetchurl {
+      name = "src_binding-${args.version}";
+      url = "https://github.com/denoland/rusty_v8/releases/download/v${args.version}/src_binding_release_${stdenv.hostPlatform.rust.rustcTarget}.rs";
+      sha256 = args.shas.${stdenv.hostPlatform.system};
+      meta = {
+        inherit (args) version;
+        sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+      };
+    };
 }

--- a/pkgs/by-name/co/codex/librusty_v8.nix
+++ b/pkgs/by-name/co/codex/librusty_v8.nix
@@ -2,10 +2,10 @@
 { fetchLibrustyV8 }:
 
 fetchLibrustyV8 {
-  version = "146.4.0";
+  version = "150.4.0";
   shas = {
-    x86_64-linux = "sha256-5ktNmeSuKTouhGJEqJuAF4uhA4LBP7WRwfppaPUpEVM=";
-    aarch64-linux = "sha256-2/FlsHyBvbBUvARrQ9I+afz3vMGkwbW0d2mDpxBi7Ng=";
-    aarch64-darwin = "sha256-v+LJvjKlbChUbw+WWCXuaPv2BkBfMQzE4XtEilaM+Yo=";
+    x86_64-linux = "0v5hi3s56b6yk7nh5n0wygh7fn0j41yyjz5903r227qv0yvzssaq";
+    aarch64-linux = "1lvx9xjzv7ibqvg5jnaxqaaim0lw4dwfgf6kw0pjfdrkmm97s5xp";
+    aarch64-darwin = "043bgs3hcvrn1yzknrxchqnki8r9p7ggk9zbiaqwa8mqhlagin6c";
   };
 }

--- a/pkgs/by-name/co/codex/librusty_v8_src_binding.nix
+++ b/pkgs/by-name/co/codex/librusty_v8_src_binding.nix
@@ -1,0 +1,11 @@
+# auto-generated file -- DO NOT EDIT!
+{ fetchLibrustyV8SrcBinding }:
+
+fetchLibrustyV8SrcBinding {
+  version = "150.4.0";
+  shas = {
+    x86_64-linux = "01l53l6nk4p5brpz2v3svqijx3hz5nqry8q7x12vdgbrwim849vp";
+    aarch64-linux = "01l53l6nk4p5brpz2v3svqijx3hz5nqry8q7x12vdgbrwim849vp";
+    aarch64-darwin = "0krrb2vh4skvfmzwpcqkl55bg2gyn943drqa8snp16lwz06dynna";
+  };
+}

--- a/pkgs/by-name/co/codex/package.nix
+++ b/pkgs/by-name/co/codex/package.nix
@@ -14,6 +14,9 @@
   librusty_v8 ? callPackage ./librusty_v8.nix {
     inherit (callPackage ./fetchers.nix { }) fetchLibrustyV8;
   },
+  librusty_v8_src_binding ? callPackage ./librusty_v8_src_binding.nix {
+    inherit (callPackage ./fetchers.nix { }) fetchLibrustyV8SrcBinding;
+  },
   lld,
   makeBinaryWrapper,
   nix-update-script,
@@ -22,21 +25,22 @@
   ripgrep,
   versionCheckHook,
   installShellCompletions ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
+  _experimental-update-script-combinators,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "codex";
-  version = "0.146.0";
+  version = "0.147.0";
 
   src = fetchFromGitHub {
     owner = "openai";
     repo = "codex";
     tag = "rust-v${finalAttrs.version}";
-    hash = "sha256-/kTIOX/klxm1nq2bJsBqS8f1jZZp2ilaTeULQFPJgDk=";
+    hash = "sha256-NKeOxp9vLcx7tpghqhpS3ocPqUDP2PircNwkJNpHBPo=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/codex-rs";
 
-  cargoHash = "sha256-N9jbH/cgAyu2QxneSnpkdaF0MgV3ZtDmN9q6rr9u+hE=";
+  cargoHash = "sha256-MJuM2QLxvL+r/Gw8QXLjtsLS25QGVCqcqU5GJssSoQ4=";
 
   __structuredAttrs = true;
 
@@ -93,6 +97,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       ]
     );
     RUSTY_V8_ARCHIVE = librusty_v8;
+    RUSTY_V8_SRC_BINDING_PATH = librusty_v8_src_binding;
   }
   // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
     # Link with lld on Darwin. nixpkgs' classic open-source ld64 fails to insert
@@ -124,15 +129,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
 
-  passthru = {
-    updateScript = nix-update-script {
+  passthru.updateScript = _experimental-update-script-combinators.sequence [
+    (nix-update-script {
       extraArgs = [
         "--use-github-releases"
         "--version-regex"
         "^rust-v(\\d+\\.\\d+\\.\\d+)$"
       ];
-    };
-  };
+    })
+    ./update-librusty.sh
+  ];
 
   meta = {
     description = "Lightweight coding agent that runs in your terminal";

--- a/pkgs/by-name/co/codex/update-librusty.sh
+++ b/pkgs/by-name/co/codex/update-librusty.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p gnugrep gnused nix jq
+# shellcheck shell=bash
+
+set -eu -o pipefail
+
+echo "librusty_v8: UPDATING"
+
+# ASSUMES; The Cargo.lock file is located at <REPO>/codex-rs/Cargo.toml
+
+CODEX_LATEST_VERSION=$(curl ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} --silent --fail --location "https://api.github.com/repos/openai/codex/releases/latest" | jq --raw-output .tag_name)
+CARGO_LOCK=$(curl ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} --silent --fail --location "https://github.com/openai/codex/raw/$CODEX_LATEST_VERSION/codex-rs/Cargo.lock")
+
+PACKAGE_DIR=$(dirname "$(readlink --canonicalize-existing "${BASH_SOURCE[0]}")")
+OUTPUT_FILE="$PACKAGE_DIR/librusty_v8.nix"
+NEW_VERSION=$(echo "$CARGO_LOCK" | grep --after-context 5 'name = "v8"' | grep 'version =' | sed -E 's/version = "//;s/"//')
+
+CURRENT_VERSION=""
+if [ -f "$OUTPUT_FILE" ]; then
+  CURRENT_VERSION="$(grep 'version =' "$OUTPUT_FILE" | sed -E 's/version = "//;s/"//')"
+fi
+
+if [ "$CURRENT_VERSION" == "$NEW_VERSION" ]; then
+  echo "No update needed, $CURRENT_VERSION is already latest"
+  exit 0
+fi
+
+TEMP_FILE="$OUTPUT_FILE.tmp"
+cat >"$TEMP_FILE" <<EOF
+# auto-generated file -- DO NOT EDIT!
+{ fetchLibrustyV8 }:
+
+fetchLibrustyV8 {
+  version = "$NEW_VERSION";
+  shas = {
+    x86_64-linux = "$(nix-prefetch-url --type sha256 https://github.com/denoland/rusty_v8/releases/download/v"$NEW_VERSION"/librusty_v8_release_x86_64-unknown-linux-gnu.a.gz)";
+    aarch64-linux = "$(nix-prefetch-url --type sha256 https://github.com/denoland/rusty_v8/releases/download/v"$NEW_VERSION"/librusty_v8_release_aarch64-unknown-linux-gnu.a.gz)";
+    aarch64-darwin = "$(nix-prefetch-url --type sha256 https://github.com/denoland/rusty_v8/releases/download/v"$NEW_VERSION"/librusty_v8_release_aarch64-apple-darwin.a.gz)";
+  };
+}
+EOF
+
+mv "$TEMP_FILE" "$OUTPUT_FILE"
+
+OUTPUT_FILE="$PACKAGE_DIR/librusty_v8_src_binding.nix"
+TEMP_FILE="$OUTPUT_FILE.tmp"
+cat >"$TEMP_FILE" <<EOF
+# auto-generated file -- DO NOT EDIT!
+{ fetchLibrustyV8SrcBinding }:
+
+fetchLibrustyV8SrcBinding {
+  version = "$NEW_VERSION";
+  shas = {
+    x86_64-linux = "$(nix-prefetch-url --type sha256 https://github.com/denoland/rusty_v8/releases/download/v"$NEW_VERSION"/src_binding_release_x86_64-unknown-linux-gnu.rs)";
+    aarch64-linux = "$(nix-prefetch-url --type sha256 https://github.com/denoland/rusty_v8/releases/download/v"$NEW_VERSION"/src_binding_release_aarch64-unknown-linux-gnu.rs)";
+    aarch64-darwin = "$(nix-prefetch-url --type sha256 https://github.com/denoland/rusty_v8/releases/download/v"$NEW_VERSION"/src_binding_release_aarch64-apple-darwin.rs)";
+  };
+}
+EOF
+
+mv "$TEMP_FILE" "$OUTPUT_FILE"
+
+echo "librusty_v8: UPDATE DONE"


### PR DESCRIPTION
https://github.com/openai/codex/releases/tag/rust-v0.147.0

Codex now also requires the source bindings of librusty_v8. I took and adapted windmill's update script to automatically update librusty_v8 as well.

Resolves #550421

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
