### PR TITLE
terminal-space-program: init at 0.38.0

### DIFF
--- a/pkgs/by-name/te/terminal-space-program/package.nix
+++ b/pkgs/by-name/te/terminal-space-program/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+}:
+buildGoModule (finalAttrs: {
+  pname = "terminal-space-program";
+  version = "0.38.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "jasonfen";
+    repo = "terminal-space-program";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-pOJZ0qvR97gBz85lKAOpPvnYBWiX8mETtSLFi/OYU9o=";
+  };
+
+  vendorHash = "sha256-5bhIP7It6rqOFvXRBUIP6/nGz4X+dzm3/BjVeo3nw4I=";
+
+  ldflags = [
+    "-X github.com/jasonfen/terminal-space-program/internal/version.Version=${finalAttrs.version}"
+  ];
+
+  env.CGO_ENABLED = 0;
+
+  __darwinAllowLocalNetworking = true; # the server/multiplayer tests need local networking
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Terminal-native orbital-mechanics rocket simulator";
+    homepage = "https://terminalspaceprogram.com";
+    changelog = "https://github.com/jasonfen/terminal-space-program/blob/main/docs/version-history.md";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ tomasrivera ];
+    mainProgram = "terminal-space-program";
+  };
+})


### PR DESCRIPTION
Part of #380688

[terminal-space-program](https://terminalspaceprogram.com) : 
> Terminal-native orbital-mechanics rocket simulator. KSP-in-your-terminal, distributed as a single static Go binary.

Everything I tested seems fine, including multiplayer
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
