### PR TITLE
akkuPackages: fixes

### DIFF
--- a/pkgs/tools/package-management/akku/overrides.nix
+++ b/pkgs/tools/package-management/akku/overrides.nix
@@ -104,6 +104,13 @@ in
   ufo-threaded-function = skipTests;
   ufo-timer = skipTests;
   ufo-try = skipTests;
+  srfi-19 = skipTests;
+  dataframe = skipTests;
+  surfage = skipTests;
+  fectors = skipTests;
+  gnuplot-pipe = skipTests;
+  wak-ssax = skipTests;
+  chez-stats = skipTests;
 
   # unsupported schemes, it seems.
   loko-srfi = broken;
@@ -121,7 +128,6 @@ in
   chibi-math-linalg = broken;
   chibi-mecab = broken;
   chibi-ssl = broken;
-  chibi-voting = broken;
   chibi-xgboost = broken;
   dockerfile = broken;
   in-progress-hash-bimaps = broken;
@@ -138,7 +144,6 @@ in
   rapid-syntax = broken;
   read-char-if = broken;
   shell-quote = broken;
-  srfi-19 = broken;
   srfi-64 = broken;
   srfi-179 = broken;
   string-inflection = broken;
@@ -148,30 +153,21 @@ in
   agave = broken;
   box2d-lite = broken;
   chez-soop = broken;
-  chez-stats = broken;
-  dataframe = broken;
-  dharmalab = broken;
   dorodango = broken;
-  fectors = broken;
   fs-fatfs = broken;
   fs-partitions = broken;
-  gnuplot-pipe = broken;
   http-pixiu = broken;
   influx-client = broken;
   linenoise = broken;
-  mpl = broken;
   mummel = broken;
-  ocelotl = broken;
   r6lint = broken;
   r6rs-clos = broken;
   r6rs-coap = broken;
   r6rs-msgpack = broken;
   scheme-bytestructures = broken;
-  surfage = broken;
   swish = broken;
   text-mode = broken;
   thunderchez = broken;
-  wak-ssax = broken;
   wak-sxml-tools = broken;
   yxskaft = broken;
 }


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
