### PR TITLE
quill-linux: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3661,6 +3661,12 @@
     githubId = 47600778;
     name = "Arnav Vijaywargiya";
   };
+  bindusara-reddy = {
+    email = "business@waterfly.blue";
+    github = "bindusara-reddy";
+    githubId = 43317025;
+    name = "Bindusara";
+  };
   binsky = {
     email = "timo@binsky.org";
     github = "binsky08";

--- a/pkgs/by-name/qu/quill-linux/package.nix
+++ b/pkgs/by-name/qu/quill-linux/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  makeWrapper,
+  bash,
+  coreutils,
+  util-linux,
+  findutils,
+  gnused,
+  jq,
+  curl,
+  pulseaudio,
+  python3,
+  systemd,
+  whisper-cpp,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "quill-linux";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "bindusara-reddy";
+    repo = "quill-linux";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-OvvwXAPgF9jmkQ1Ez1t2/gvVp1i/MtiMaNi/VKqBmmg=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 quill $out/bin/quill
+    install -Dm644 share/applications/quill.desktop \
+      $out/share/applications/quill.desktop
+
+    wrapProgram $out/bin/quill \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          bash
+          coreutils
+          util-linux
+          findutils
+          gnused
+          jq
+          curl
+          pulseaudio
+          (python3.withPackages (ps: [ ps.sherpa-onnx ]))
+          systemd
+          whisper-cpp
+        ]
+      }
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Minimal local meeting recorder and transcriber (PipeWire + Parakeet TDT)";
+    longDescription = ''
+      quill records the microphone and system audio as two separate tracks via
+      PipeWire's PulseAudio layer, transcribes both locally with NVIDIA
+      Parakeet TDT 0.6B v3 through whisper.cpp's parakeet-cli, splits each
+      track by voice with sherpa-onnx speaker diarization, and writes a
+      speaker-tagged (me/them-1/them-2/...) transcript. Audio is deleted after
+      successful transcription. Override whisper-cpp with whisper-cpp-vulkan
+      for GPU transcription.
+    '';
+    homepage = "https://github.com/bindusara-reddy/quill-linux";
+    changelog = "https://github.com/bindusara-reddy/quill-linux/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "quill";
+    maintainers = with lib.maintainers; [ bindusara-reddy ];
+  };
+})


### PR DESCRIPTION
## Description

New package: **quill-linux 0.1.0** — a minimal local meeting recorder and transcriber for Linux.

Records microphone and system audio as two separate tracks via PipeWire's PulseAudio layer, transcribes both locally with NVIDIA Parakeet TDT 0.6B v3 through whisper.cpp's `parakeet-cli` (packaged `whisper-cpp` ≥ 1.9.2 ships it), and writes a speaker-tagged me/them transcript. Audio is deleted after successful transcription. GPU transcription via `.override { whisper-cpp = whisper-cpp-vulkan; }`.

Linux counterpart of [digimata/quill](https://github.com/digimata/quill) (macOS). Upstream: https://github.com/bindusara-reddy/quill-linux

Includes a `maintainers: add bindusara-reddy` commit (first contribution).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html#conf-sandbox))
- Tested, as applicable:
  - [x] Ran the binary (`quill doctor`) from the built output
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)