### PR TITLE
home-assistant-custom-components.localthings: init at 0.20.0

### DIFF
--- a/pkgs/development/python-modules/smartthings-local/default.nix
+++ b/pkgs/development/python-modules/smartthings-local/default.nix
@@ -1,0 +1,60 @@
+{
+  buildPythonPackage,
+  cbor2,
+  fetchFromGitHub,
+  git,
+  hatch-vcs,
+  hatchling,
+  lib,
+  nix-update-script,
+  pyopenssl,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "smartthings-local";
+  version = "0.1.3";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "QuiteYellow";
+    repo = "SmartThings-Local";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-HR9S4QE4gp3JxLAFHaPeSqzcP4HPShO1FAgEuQis7AA=";
+  };
+
+  build-system = [
+    hatch-vcs
+    hatchling
+  ];
+
+  dependencies = [
+    cbor2
+    pyopenssl
+  ];
+
+  nativeCheckInputs = [
+    git
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # import can't find pyopenssl for some reason
+    "test_smartthings_local_imports_without_mqtt_demo_present"
+  ];
+
+  pythonImportsCheck = [
+    "smartthings_local"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Local control of Samsung SmartThings appliances over cert-authenticated CoAP-DTLS. No cloud! Python library + Home Assistant MQTT bridge demo";
+    homepage = "https://github.com/QuiteYellow/SmartThings-Local";
+    changelog = "https://github.com/QuiteYellow/SmartThings-Local/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ Scrumplex ];
+  };
+})

--- a/pkgs/servers/home-assistant/custom-components/localthings/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/localthings/package.nix
@@ -1,0 +1,42 @@
+{
+  buildHomeAssistantComponent,
+  cbor2,
+  fetchFromGitHub,
+  lib,
+  pyopenssl,
+  pytest-homeassistant-custom-component,
+  pytestCheckHook,
+  smartthings-local,
+}:
+
+buildHomeAssistantComponent (finalAttrs: {
+  owner = "mbillow";
+  domain = "localthings";
+  version = "0.20.0";
+
+  src = fetchFromGitHub {
+    owner = "mbillow";
+    repo = "localthings";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-aRmKp+1M8QaMe3xBp8FcdNRPgI8faW+7870K2ffLCwY=";
+  };
+
+  dependencies = [
+    cbor2
+    pyopenssl
+    smartthings-local
+  ];
+
+  nativeCheckInputs = [
+    pytest-homeassistant-custom-component
+    pytestCheckHook
+  ];
+
+  meta = {
+    changelog = "https://github.com/mbillow/localthings/releases/tag/${finalAttrs.src.tag}";
+    description = "Local-control Home Assistant component that authenticates to newer-firmware Samsung devices and talks over CoAP-DTLS";
+    homepage = "https://github.com/mbillow/localthings";
+    maintainers = with lib.maintainers; [ Scrumplex ];
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18872,6 +18872,8 @@ self: super: with self; {
 
   smarthab = callPackage ../development/python-modules/smarthab { };
 
+  smartthings-local = callPackage ../development/python-modules/smartthings-local { };
+
   smartypants = callPackage ../development/python-modules/smartypants { };
 
   smbprotocol = callPackage ../development/python-modules/smbprotocol { };


### PR DESCRIPTION
Adds [LocalThings](https://github.com/mbillow/localthings) and its dependency [smartthings-local](https://github.com/QuiteYellow/SmartThings-Local) to allow controlling Samsung appliances without need for their cloud, as API access will be restricted in a few months.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
