### PR TITLE
bcachefs-tools: fix riscv build

### DIFF
--- a/pkgs/by-name/bc/bcachefs-tools/package.nix
+++ b/pkgs/by-name/bc/bcachefs-tools/package.nix
@@ -113,6 +113,12 @@ stdenv.mkDerivation (finalAttrs: {
     "CARGO_TARGET_${stdenv.hostPlatform.rust.cargoEnvVarTarget}_LINKER" = "${stdenv.cc.targetPrefix}cc";
   };
 
+  # Workaround for RISCV cross-compilation issue
+  # https://github.com/koverstreet/bcachefs-tools/issues/850
+  preBuild = lib.optionalString stdenv.hostPlatform.isRiscV ''
+    export BINDGEN_EXTRA_CLANG_ARGS="$BINDGEN_EXTRA_CLANG_ARGS --target=riscv64-unknown-linux-gnu -march=rv64gc"
+  '';
+
   # FIXME: Try enabling this once the default linux kernel is at least 6.7
   doCheck = false; # needs bcachefs module loaded on builder
 


### PR DESCRIPTION
Fixes cross-compilation for the `bcachefs-tools` package on RISCV.

Former error was:
```
nix build -L .#pkgsCross.riscv64.bcachefs-tools
[...]
bcachefs-tools-riscv64-unknown-linux-gnu>    Compiling serde_json v1.0.143
bcachefs-tools-riscv64-unknown-linux-gnu> error: failed to run custom build command for `bcachefs-kernel v0.1.0 (/build/source/fs)`
bcachefs-tools-riscv64-unknown-linux-gnu> Caused by:
bcachefs-tools-riscv64-unknown-linux-gnu>   process didn't exit successfully: `/build/source/target/release/build/bcachefs-kernel-e8c0ccdad112401b/build-script-build` (exit status: 1)
bcachefs-tools-riscv64-unknown-linux-gnu>   --- stdout
bcachefs-tools-riscv64-unknown-linux-gnu>   cargo::rustc-check-cfg=cfg(kernel)
bcachefs-tools-riscv64-unknown-linux-gnu>   cargo:rerun-if-changed=codegen.rs
bcachefs-tools-riscv64-unknown-linux-gnu>   cargo:rerun-if-changed=../doc/opts_macro.h
[...]
bcachefs-tools-riscv64-unknown-linux-gnu>   cargo:rerun-if-changed=../include/linux/seq_buf.h
bcachefs-tools-riscv64-unknown-linux-gnu>   --- stderr
bcachefs-tools-riscv64-unknown-linux-gnu>   warning: optimization flag '-fkeep-inline-functions' is not supported [-Wignored-optimization-argument]
bcachefs-tools-riscv64-unknown-linux-gnu>   error: unknown target triple 'riscv64gc-unknown-linux-gnu'
bcachefs-tools-riscv64-unknown-linux-gnu>   panicked at /build/rust-bindgen-unwrapped-0.72.1-vendor/source-registry-0/bindgen-0.72.1/ir/context.rs:562:15:
bcachefs-tools-riscv64-unknown-linux-gnu>   libclang error; possible causes include:
bcachefs-tools-riscv64-unknown-linux-gnu>   - Invalid flag syntax
bcachefs-tools-riscv64-unknown-linux-gnu>   - Unrecognized flags
bcachefs-tools-riscv64-unknown-linux-gnu>   - Invalid flag arguments
bcachefs-tools-riscv64-unknown-linux-gnu>   - File I/O errors
bcachefs-tools-riscv64-unknown-linux-gnu>   - Host vs. target architecture mismatch
bcachefs-tools-riscv64-unknown-linux-gnu>   If you encounter an error missing from this list, please file an issue or a PR!
```

Upstream issue https://github.com/koverstreet/bcachefs-tools/issues/850

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
