### PR TITLE
python3Packages.mpi4py: fix build on darwin

### DIFF
--- a/pkgs/development/python-modules/mpi4py/default.nix
+++ b/pkgs/development/python-modules/mpi4py/default.nix
@@ -13,7 +13,7 @@
   mpich,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "mpi4py";
   version = "4.1.2";
   pyproject = true;
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     repo = "mpi4py";
     owner = "mpi4py";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-h9RZr+xLmp+cVvrPkew3AOJLE8okd4A/2oqhsSmVBXU=";
   };
 
@@ -69,7 +69,7 @@ buildPythonPackage rec {
     mpiexec -n 1 python test/main.py -v
     echo 'Testing mpi4py (np=2)'
     mpiexec -n 2 python test/main.py -v -f -e spawn${
-      lib.concatMapStrings (test: " -x ${test}") disabledTests
+      lib.concatMapStrings (test: " -x ${test}") finalAttrs.disabledTests
     }
 
     runHook postCheck
@@ -86,8 +86,8 @@ buildPythonPackage rec {
   meta = {
     description = "Python bindings for the Message Passing Interface standard";
     homepage = "https://github.com/mpi4py/mpi4py";
-    changelog = "https://github.com/mpi4py/mpi4py/blob/${src.tag}/CHANGES.rst";
+    changelog = "https://github.com/mpi4py/mpi4py/blob/${finalAttrs.src.tag}/CHANGES.rst";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ doronbehar ];
   };
-}
+})

--- a/pkgs/development/python-modules/mpi4py/default.nix
+++ b/pkgs/development/python-modules/mpi4py/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   cython,
   setuptools,
+  stdenv,
   mpi,
   toPythonModule,
   pytest,
@@ -52,6 +53,13 @@ buildPythonPackage rec {
   # see https://github.com/mpi4py/mpi4py/issues/545#issuecomment-2343011460
   env.MPI4PY_TEST_SPAWN = if mpi.pname == "openmpi" then 0 else 1;
 
+  disabledTests = [
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # testJoin calls socket.getaddrinfo(socket.gethostname(), ...)
+    "test_dynproc.TestDPM.testJoin"
+  ];
+
   # follow upstream's checkPhase
   # see https://github.com/mpi4py/mpi4py/blob/4.1.0/.github/workflows/ci-test.yml#L92-L95
   checkPhase = ''
@@ -60,7 +68,9 @@ buildPythonPackage rec {
     echo 'Testing mpi4py (np=1)'
     mpiexec -n 1 python test/main.py -v
     echo 'Testing mpi4py (np=2)'
-    mpiexec -n 2 python test/main.py -v -f -e spawn
+    mpiexec -n 2 python test/main.py -v -f -e spawn${
+      lib.concatMapStrings (test: " -x ${test}") disabledTests
+    }
 
     runHook postCheck
   '';


### PR DESCRIPTION
Simply skip this test on darwin.
https://github.com/NixOS/nixpkgs/pull/449436#issuecomment-5033168284
https://hydra.nixos.org/build/340366917
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
