### PR TITLE
mill: fix updateScript to skip pre-release versions

### DIFF
--- a/pkgs/by-name/mi/mill/package.nix
+++ b/pkgs/by-name/mi/mill/package.nix
@@ -8,8 +8,10 @@
   zlib,
   writeScript,
   stdenv,
+  coreutils,
   curl,
-  libxml2,
+  gnugrep,
+  gnused,
   common-updater-scripts,
 }:
 
@@ -68,13 +70,24 @@ stdenvNoCC.mkDerivation rec {
     set -eu -o pipefail
     PATH=${
       lib.makeBinPath [
+        coreutils
         curl
-        libxml2 # xmllint
+        gnugrep
+        gnused
         common-updater-scripts
       ]
     }:$PATH
     metadataUrl="https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/maven-metadata.xml"
-    latestVersion="$(curl -sS $metadataUrl | xmllint --xpath '/metadata/versioning/release/text()' -)"
+    # Maven's <release>/<latest> just reflect whatever was published most recently, which
+    # for mill includes milestone (-M1, -M2, ...) and per-commit dev builds (-N-<sha>).
+    # Filter the full <version> list down to plain X.Y.Z semver and take the highest.
+    latestVersion="$(
+      curl -sS $metadataUrl \
+        | grep -oE '<version>[0-9]+\.[0-9]+\.[0-9]+</version>' \
+        | sed -E 's#</?version>##g' \
+        | sort -V \
+        | tail -n1
+    )"
 
     ${lib.strings.concatStrings (
       builtins.map (


### PR DESCRIPTION
Maven's <release>/<latest> fields in maven-metadata.xml just reflect whatever was published most recently, which for mill includes milestone builds (-M1, -M2, ...) and per-commit dev builds (-N-<sha>). This caused the updateScript to pick those up instead of the latest stable release.

Filter the full <version> list down to plain X.Y.Z semver strings and pick the highest via `sort -V` instead.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
