### PR TITLE
yadal: init at 0.3.0

### DIFF
--- a/pkgs/by-name/ya/yadal/package.nix
+++ b/pkgs/by-name/ya/yadal/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromCodeberg,
+
+  makeBinaryWrapper,
+  ffmpeg,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "yadal";
+  version = "0.3.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromCodeberg {
+    owner = "tomkoid";
+    repo = "yadal";
+    tag = finalAttrs.version;
+    hash = "sha256-TgM1xhk47x8Bl8gITCmM05ilZH9E29DuWBIg5bPbpyU=";
+  };
+
+  cargoHash = "sha256-pOmko/ec5YbZ47j+EnYKm5lYN1fDmmjAV62OV641Y+s=";
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/yadal \
+      --prefix PATH : ${lib.makeBinPath [ ffmpeg ]}
+  '';
+
+  meta = {
+    description = "Yet another TIDAL Hi-Res audio downloader for the CLI";
+    homepage = "https://codeberg.org/tomkoid/yadal";
+    license = lib.licenses.gpl3Only;
+    changelog = "https://codeberg.org/tomkoid/yadal/releases/tag/${finalAttrs.version}";
+    maintainers = with lib.maintainers; [ tomkoid ];
+    mainProgram = "yadal";
+  };
+})


### PR DESCRIPTION
Added Yadal from https://codeberg.org/tomkoid/yadal

Yadal is a simple command-line tool for downloading music from TIDAL. It supports downloading individual tracks, albums, and playlists in Hi-Res quality.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
