### PR TITLE
firefox: do not allow lossy silent downgrades

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -95,6 +95,11 @@
   - The full-text search backend changed from Whoosh to Tantivy. The search index is rebuilt automatically on the first start after upgrading, which can take a while for large document sets.
   - Some settings changed or were removed (for example, an external database now needs an explicit `PAPERLESS_DBENGINE`); review your `services.paperless.settings` against the migration guide.
 
+- `firefox` no longer defaults to allowing silent downgrades that can lead to loss of important browser state.
+  This matches the behaviour which upstream Firefox has intended since version 67.
+  In case of an intended or necessary downgrade, users are advised to use the [`-allow-downgrade` CLI argument](https://wiki.mozilla.org/Firefox/CommandLineOptions#-allow-downgrade) or `MOZ_ALLOW_DOWNGRADE=1` environment variable to accept the risk of data loss and continue using the profile.
+  Users who frequently downgrade Firefox versions can use the `allowDowngrade` override to restore the previous behaviour of setting the environment variable by default.
+
 - `services.alps` has been rewritten, see [upstream repository](https://github.com/migadu/alps) for configuration.
 
 - Support for the legacy U‐Boot image format has been removed from the initrd generators, as it is deprecated upstream and no longer used by any platform in Nixpkgs.

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -85,6 +85,10 @@ let
       libName ? browser.libName or applicationName, # Important for tor package or the like
       nixExtensions ? null,
       hasMozSystemDirPatch ? (lib.hasPrefix "firefox" pname && !lib.hasSuffix "-bin" pname),
+      # Using a profile last written to by a newer version of firefox is
+      # possible in many cases but can lead to partial data loss without
+      # warning. This flag allows opting into that behaviour.
+      allowDowngrade ? false,
     }:
 
     let
@@ -329,7 +333,8 @@ let
         "--set"
         "MOZ_LEGACY_PROFILES"
         "1"
-
+      ]
+      ++ lib.optionals allowDowngrade [
         "--set"
         "MOZ_ALLOW_DOWNGRADE"
         "1"


### PR DESCRIPTION
I just lost my cookies and container state due to accidental rollback of Firefox. I had snapshots, so I'm fine, but firefox should *not* be doing that. The user should explicitly opt into this by either setting that env var themselves or by using `-allow-downgrade`; as upstream intends.

This partially reverts 87e261843c4236c541ee0113988286f77d2fa1ee.

I made this an overrideable option since this would be quite annoying to override otherwise in case people actually want it to behave like that.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
