### PR TITLE
wayshot: 1.5.0 -> 1.6.0 & fix manpages & update packaging & update meta

### DIFF
--- a/pkgs/by-name/wa/wayshot/package.nix
+++ b/pkgs/by-name/wa/wayshot/package.nix
@@ -1,42 +1,63 @@
 {
   lib,
-  libgbm,
-  libjxl,
-  libGL,
   stdenv,
   fetchFromGitHub,
   nix-update-script,
   pango,
+  scdoc,
   pkg-config,
   installShellFiles,
   rustPlatform,
   wayland,
+  jpegSupport ? true,
+  pnmSupport ? true,
+  qoiSupport ? true,
+  webpSupport ? true,
+  avifSupport ? true,
+  jxlSupport ? true,
+  clipboardSupport ? true,
+  colorPickerSupport ? true,
+  completionsSupport ? true,
+  loggerSupport ? true,
+  notificationsSupport ? true,
+  selectorSupport ? true,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "wayshot";
-  version = "1.5.0";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "waycrate";
     repo = "wayshot";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-sbY3h3FoWxDmxSng9YvYpt3kyasVJGsykYC/7tblFn8=";
+    hash = "sha256-MihZAAZ+K95jBE1gp0kne/+Z3rBUDqlphmyBI0FI1jE=";
   };
   nativeBuildInputs = [
     pkg-config
     installShellFiles
+    scdoc
   ];
-  buildInputs = [
-    pango
-    libgbm
-    libjxl
-    libGL
-    wayland
-  ];
-  cargoHash = "sha256-J7ZKWx258bBCNBd061aCeKgTdcWMUF4yzAiIa9l8ZRA=";
+  buildInputs = [ wayland ] ++ lib.optional (selectorSupport || colorPickerSupport) pango;
+
+  cargoHash = "sha256-SAI+KXRV4E130ROmNyXraaO31D341CRWXGuIPV8depA=";
+
+  buildNoDefaultFeatures = true;
+  buildFeatures =
+    lib.optional jpegSupport "jpeg"
+    ++ lib.optional pnmSupport "pnm"
+    ++ lib.optional qoiSupport "qoi"
+    ++ lib.optional webpSupport "webp"
+    ++ lib.optional avifSupport "avif"
+    ++ lib.optional jxlSupport "jxl"
+    ++ lib.optional clipboardSupport "clipboard"
+    ++ lib.optional colorPickerSupport "color_picker"
+    ++ lib.optional completionsSupport "completions"
+    ++ lib.optional loggerSupport "logger"
+    ++ lib.optional notificationsSupport "notifications"
+    ++ lib.optional selectorSupport "selector";
 
   postInstall = ''
-    installManPage docs/wayshot.1.scd docs/wayshot.5.scd docs/wayshot.7.scd
+    installManPage docs/wayshot.1.gz docs/wayshot.5.gz docs/wayshot.7.gz
   ''
   + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd wayshot \
@@ -48,9 +69,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "Native, blazing-fast screenshot tool for wlroots based compositors such as sway and river";
-    homepage = "https://github.com/waycrate/wayshot";
-    license = lib.licenses.bsd2;
+    description = "Screenshot crate for wlroots based compositors implementing the zwlr_screencopy_v1 protocol.";
+    homepage = "https://crates.io/crates/wayshot";
+    license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
       id3v1669
       Subserial


### PR DESCRIPTION


## Things done

- Updated package and packaging(ditch deps that are meant for lib and not wayshot itself)
- Fix man pages generation
- Update meta

Why no default features with feature flags: 
otherwise we run checks for libwayshot that requires extra deps and we don't utilize all of them within the package

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

