### PR TITLE
nixos/step-ca: add user, group options

### DIFF
--- a/nixos/modules/services/security/step-ca.nix
+++ b/nixos/modules/services/security/step-ca.nix
@@ -16,6 +16,16 @@ in
       enable = lib.mkEnableOption "the smallstep certificate authority server";
       openFirewall = lib.mkEnableOption "opening the certificate authority server port";
       package = lib.mkPackageOption pkgs "step-ca" { };
+      user = lib.mkOption {
+        type = lib.types.nonEmptyStr;
+        default = "step-ca";
+        description = "User to run step-ca as.";
+      };
+      group = lib.mkOption {
+        type = lib.types.nonEmptyStr;
+        default = "step-ca";
+        description = "Primary group for the step-ca user.";
+      };
       address = lib.mkOption {
         type = lib.types.str;
         example = "127.0.0.1";
@@ -95,8 +105,8 @@ in
         };
         serviceConfig = {
           Type = "notify";
-          User = "step-ca";
-          Group = "step-ca";
+          User = cfg.user;
+          Group = cfg.group;
           UMask = "0077";
           Environment = "HOME=%S/step-ca";
           WorkingDirectory = ""; # override upstream
@@ -126,13 +136,17 @@ in
         };
       };
 
-      users.users.step-ca = {
-        home = "/var/lib/step-ca";
-        group = "step-ca";
-        isSystemUser = true;
+      users.users = lib.mkIf (cfg.user == "step-ca") {
+        step-ca = {
+          home = "/var/lib/step-ca";
+          group = "step-ca";
+          isSystemUser = true;
+        };
       };
 
-      users.groups.step-ca = { };
+      users.groups = lib.mkIf (cfg.group == "step-ca") {
+        step-ca = { };
+      };
 
       networking.firewall = lib.mkIf cfg.openFirewall {
         allowedTCPPorts = [ cfg.port ];


### PR DESCRIPTION
User and group options are common among several modules, but step-ca did not have them.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
