### PR TITLE
`rust-jemalloc-sys`: fix soname conflict with system-wide `jemalloc`

### DIFF
--- a/pkgs/by-name/ru/rust-jemalloc-sys/package.nix
+++ b/pkgs/by-name/ru/rust-jemalloc-sys/package.nix
@@ -28,6 +28,7 @@ jemalloc.overrideAttrs (oldAttrs: {
     ];
 
   setupHook = writeText "setup-hook.sh" ''
-    export JEMALLOC_OVERRIDE="@out@/lib/libjemalloc${stdenv.hostPlatform.extensions.library}"
+    # Use PIC static to prevent soname conflict with system-wide jemalloc
+    export JEMALLOC_OVERRIDE="@out@/lib/libjemalloc_pic${stdenv.hostPlatform.extensions.staticLibrary}"
   '';
 })


### PR DESCRIPTION
### Motivation

Currently, when enabling `environment.memoryAllocator.provider = "jemalloc"` in NixOS, running any Rust application built with `rust-jemalloc-sys` (like `ruff`, `yazi`, etc.) fails immediately with errors like:

```
ruff: symbol lookup error: ruff: undefined symbol: _rjem_malloc
```

This happens because `rust-jemalloc-sys` outputs `libjemalloc.so.2` (with prefix `_rjem_` configured) but keeps the standard soname. When NixOS preloads the standard `libjemalloc.so.2` via `/etc/ld.so.preload`, the dynamic linker skips loading the custom `_rjem_` version because of the matching soname, leading to unresolved symbols.

This PR changes `rust-jemalloc-sys` to use the static PIC library (`libjemalloc_pic.a`) instead of the shared library to isolate Rust apps from the system environment.

### Test Case

I've tested this change locally via an overlay in my NixOS configuration:

```nix
rust-jemalloc-sys = prev.rust-jemalloc-sys.overrideAttrs (prevAttrs: {
  setupHook = pkgs.writeText "setup-hook.sh" ''
    export JEMALLOC_OVERRIDE="@out@/lib/libjemalloc_pic.a"
  '';
});
```

`ruff` and `yazi` then became normal.

fix #550450

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
