### PR TITLE
stellar-core: fix build with rustc 1.97

### DIFF
--- a/pkgs/by-name/st/stellar-core/package.nix
+++ b/pkgs/by-name/st/stellar-core/package.nix
@@ -2,7 +2,9 @@
   autoconf,
   automake,
   bison,
+  cargo,
   fetchFromGitHub,
+  fetchpatch2,
   flex,
   gitMinimal,
   lib,
@@ -16,7 +18,6 @@
   rustPlatform,
   stdenv,
   symlinkJoin,
-  cargo,
 }:
 
 let
@@ -103,6 +104,23 @@ stdenv.mkDerivation (finalAttrs: {
         done
       '';
     };
+
+  # ethnum <= 1.5.2 fails on rustc 1.97+ (TryFromIntError is no longer ZST).
+  # Protocols p21-p26 pin ethnum 1.5.0 in Cargo.lock / dep-tree expects, so keep
+  # that version and apply the upstream 1.5.3 source fix in the vendored crate.
+  # https://github.com/nlordell/ethnum-rs/pull/58
+  postPatch = ''
+    shopt -s nullglob
+    for crate in "$cargoDepsCopy"/source-registry-*/ethnum-1.5.0; do
+      patch -p1 -d "$crate" < ${
+        fetchpatch2 {
+          name = "ethnum-1.5.0-rustc-1.97.patch";
+          url = "https://github.com/nlordell/ethnum-rs/commit/87e3457c095c98fcac554548ee80f56e0cfb80ae.patch?full_index=1";
+          hash = "sha256-xG3RQg2vF+XW9IiYWaNyOF39WipSeoZGrygsOJ3XgIs=";
+        }
+      }
+    done
+  '';
 
   strictDeps = true;
 


### PR DESCRIPTION
fix build with rustc 1.97
https://hydra.nixos.org/build/340192422

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
