### PR TITLE
python3Packages.unittestCheckHook: make discover optional

### DIFF
--- a/pkgs/development/interpreters/python/hooks/unittest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/unittest-check-hook.sh
@@ -10,11 +10,16 @@ unittestCheckPhase() {
     local -a flagsArray=()
 
     # Compatibility layer to the obsolete unittestFlagsArray
+    if [[ -z "${dontUseUnittestDiscover-}" ]]; then
+      flagsArray+=("discover")
+    fi
+
     eval "flagsArray+=(${unittestFlagsArray[*]-})"
 
     concatTo flagsArray unittestFlags
+
     echoCmd 'unittest flags' "${flagsArray[@]}"
-    @pythonCheckInterpreter@ -m unittest discover "${flagsArray[@]}"
+    @pythonCheckInterpreter@ -m unittest "${flagsArray[@]}"
 
     runHook postCheck
     echo "Finished executing unittestCheckPhase"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Example of use: https://github.com/NixOS/nixpkgs/commit/21154af9a16d0f9e3e9679c1253ffec07dce2227, see [why discover dont work in this scenario](https://github.com/NixOS/nixpkgs/pull/530486#discussion_r3740942598)

(removed from staging, due to conflicts)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
