### PR TITLE
[staging-next] rocmPackages.rocprofiler-register: fix build with fmt 12.2.0

### DIFF
--- a/pkgs/development/rocm-modules/rocprofiler-register/default.nix
+++ b/pkgs/development/rocm-modules/rocprofiler-register/default.nix
@@ -44,6 +44,14 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-VloRKV6kUzIfIInltx/bV1EM0FUfeQZrVAx6qgdsLyg=";
       relative = "projects/rocprofiler-register";
     })
+    (fetchpatch {
+      # fix(rocprofiler-sdk): include fmt/format.h instead of fmt/core.h for fmt::format
+      # fmt 12.2.0 changes the meaning of fmt/core.h so it no longer includes
+      # fmt::format, so this upstream commit switches to the correct header.
+      url = "https://github.com/ROCm/rocm-systems/commit/e2f588592ecfb0653ed5b3078753186325adf70a.patch";
+      hash = "sha256-ip/s7tmUptcXMen3fyQJYKiZKwoe3SH0XqTVb0YBA7k=";
+      relative = "projects/rocprofiler-register";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
fmt 12.2.0 changes the meaning of fmt/core.h so it no longer includes fmt::format, so this upstream commit switches to the correct header.

see https://hydra.nixos.org/build/341249671

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
