### PR TITLE
python3Packages.django-scim2: 0.20.0 -> 0.21.0, fix build

### DIFF
--- a/pkgs/development/python-modules/django-scim2/default.nix
+++ b/pkgs/development/python-modules/django-scim2/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
 
   # build-system
   poetry-core,
@@ -18,15 +19,34 @@
 
 buildPythonPackage rec {
   pname = "django-scim2";
-  version = "0.20.0";
+  version = "0.21.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "15five";
     repo = "django-scim2";
     tag = version;
-    hash = "sha256-OsfC6Jc/oQl6nzy3Nr3vkY+XicRxUoV62hK8MHa3LJ8=";
+    hash = "sha256-8zPUlvVHVowzPU+sfQGoOrJ+Vdm8zVKI5V+wTJnIBZ0=";
   };
+
+  patches = [
+    # These two patches update dependencies & the min. python version.
+    # They're applied such that the third can be applied trivially.
+    (fetchpatch {
+      url = "https://github.com/15five/django-scim2/commit/df3bd25d477928ceecdd02410babf9b59e67c595.patch";
+      hash = "sha256-BkBBbxImCKfSBDY7hTmKX6z/+l7H2MRmIJ4VHKxFtnM=";
+    })
+    (fetchpatch {
+      url = "https://github.com/15five/django-scim2/commit/be4e67f158b50fd216d723024d975d8b15f4031a.patch";
+      hash = "sha256-IE8yg7qdv5UWla5T1erAM3KK7TAb3qYBqjNJdV4+8C0=";
+    })
+    # Python 3.14 compat
+    # Includes support for newer Django.
+    (fetchpatch {
+      url = "https://github.com/15five/django-scim2/commit/131ec58a94c66f2f1b205a96e9405c76828de7db.patch";
+      hash = "sha256-KafF2I6CFCVz96NVHBoGmJLB6ejdLJaWBx2F0EoEwrI=";
+    })
+  ];
 
   build-system = [ poetry-core ];
 


### PR DESCRIPTION
Also applies patches for Python 3.14 compat.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
