### PR TITLE
knockknock: init at 4.0.3

### DIFF
--- a/pkgs/by-name/kn/knockknock/package.nix
+++ b/pkgs/by-name/kn/knockknock/package.nix
@@ -1,0 +1,107 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  makeWrapper,
+  nix-update-script,
+  testers,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "knockknock";
+  version = "4.0.3";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchzip {
+    url = "https://github.com/objective-see/KnockKnock/releases/download/v${finalAttrs.version}/KnockKnock_${finalAttrs.version}.zip";
+    hash = "sha256-KHXnjHY11UYHEztcEGIhVf+G34IKLN5mftjVUxnsLbM=";
+
+    stripRoot = false;
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    cp -R KnockKnock.app $out/Applications/
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    mkdir -p $out/bin
+    makeWrapper $out/Applications/KnockKnock.app/Contents/MacOS/KnockKnock $out/bin/${finalAttrs.pname}
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+
+    tests = {
+      version = testers.runCommand {
+        name = "knockknock-version-test";
+        buildInputs = [ finalAttrs.finalPackage ];
+        script = ''
+          # Capture both stdout and stderr, and use `|| true` to suppress the 255 exit code
+          # which occurs because of the wrong version exit code imlementation in knockknock
+          # Fix when this is merged: https://github.com/objective-see/KnockKnock/pull/53
+          output=$(knockknock -version 2>&1 || true)
+
+          echo "$output" | grep -F "KnockKnock Version: ${finalAttrs.version}"
+
+          touch $out
+        '';
+      };
+
+      help = testers.runCommand {
+        name = "knockknock-help-test";
+        buildInputs = [ finalAttrs.finalPackage ];
+        script = ''
+          # Capture both stdout and stderr, and use `|| true` to suppress the 255 exit code
+          # which occurs because of the wrong help exit code imlementation in knockknock
+          # Fix when this is merged: https://github.com/objective-see/KnockKnock/pull/53
+          output=$(knockknock -h 2>&1 || true)
+
+          echo "$output" | grep -F "KNOCKNOCK USAGE:"
+
+          touch $out
+        '';
+      };
+    };
+  };
+
+  meta = {
+    mainProgram = "knockknock";
+    description = "Advanced utility that shows what is persistently installed on the computer";
+    longDescription = ''
+      "Who's there?", See what's persistently installed on your Mac!
+      Malware often installs itself persistently, to ensure it is automatically
+      (re)executed each time a computer is restarted. KnockKnock uncovers persistently
+      installed software in order to generically reveal such malware.
+    '';
+    homepage = "https://objective-see.org/products/knockknock.html";
+    downloadPage = "https://github.com/objective-see/KnockKnock/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/objective-see/KnockKnock/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    identifiers = {
+      cpeParts = {
+        vendor = "objective-see";
+        product = "knockknock";
+        version = finalAttrs.version;
+        target_sw = "macos";
+      };
+      purlParts = {
+        type = "github";
+        namespace = "objective-see";
+        name = "knockknock";
+        version = finalAttrs.version;
+      };
+    };
+    maintainers = with lib.maintainers; [ KristijanZic ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added knockknock at 4.0.3 from https://objective-see.org/products/knockknock.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
