### PR TITLE
doasedit: init at 1.0.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2979,6 +2979,13 @@
     githubId = 2998834;
     name = "Bruno Rodrigues";
   };
+  b-swist = {
+    email = "bswist@protonmail.com";
+    github = "b-swist";
+    githubId = 187181291;
+    name = "Bartosz Świst";
+    keys = [ { fingerprint = "A601 ABB3 1BFC AA4E B7A0  BB02 AEF5 F296 583F B763"; } ];
+  };
   b4dm4n = {
     email = "fabianm88@gmail.com";
     github = "B4dM4n";

--- a/pkgs/by-name/do/doasedit/package.nix
+++ b/pkgs/by-name/do/doasedit/package.nix
@@ -1,0 +1,55 @@
+{
+  stdenv,
+  lib,
+  fetchFromCodeberg,
+  makeWrapper,
+  bash,
+  coreutils,
+  gnugrep,
+  findutils,
+  diffutils,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "doasedit";
+  version = "1.0.9";
+
+  src = fetchFromCodeberg {
+    owner = "TotallyLeGIT";
+    repo = "doasedit";
+    rev = finalAttrs.version;
+    hash = "sha256-gXwAgchcjp+bq9TC0SavmXOkzpJnqTC9InZIREs9fSo=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  installFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  postInstall = ''
+    wrapProgram $out/bin/doasedit \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          bash
+          coreutils
+          gnugrep
+          findutils
+          diffutils
+        ]
+      }
+  '';
+
+  meta = {
+    description = "Edit files as root using an unprivileged editor";
+    mainProgram = "doasedit";
+    homepage = "https://codeberg.org/TotallyLeGIT/doasedit";
+    changelog = "https://codeberg.org/TotallyLeGIT/doasedit/src/tag/${finalAttrs.version}/CHANGELOG.md";
+    maintainers = with lib.maintainers; [ b-swist ];
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added doasedit https://codeberg.org/TotallyLeGIT/doasedit

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
