### PR TITLE
cudaPackages.nccl-ep: init at 2.30.7-1

### DIFF
--- a/pkgs/development/cuda-modules/packages/nccl-ep.nix
+++ b/pkgs/development/cuda-modules/packages/nccl-ep.nix
@@ -1,0 +1,91 @@
+{
+  _cuda,
+  backendStdenv,
+  cudaAtLeast,
+  cudaNamePrefix,
+  cudaOlder,
+  lib,
+
+  # nativeBuildInputs
+  python3Packages,
+  autoAddDriverRunpath,
+  cuda_nvcc,
+  which,
+
+  # buildInputs
+  cccl,
+  cuda_crt ? null, # only exists in cudaPackages with CUDA >= 13.0
+  cuda_cudart,
+  nccl,
+}:
+
+let
+  epFlags = _cuda.lib.formatCapabilities {
+    inherit (_cuda.db) cudaCapabilityToInfo;
+    inherit (backendStdenv) cudaForwardCompat;
+    cudaCapabilities = lib.filter (
+      cudaCapability: lib.versionAtLeast cudaCapability "9.0"
+    ) backendStdenv.cudaCapabilities;
+  };
+in
+
+backendStdenv.mkDerivation (finalAttrs: {
+  name = "${cudaNamePrefix}-${finalAttrs.pname}-${finalAttrs.version}";
+  pname = "nccl-ep";
+  inherit (nccl) src version;
+  sourceRoot = "${finalAttrs.src.name}/contrib/nccl_ep";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoAddDriverRunpath
+    cuda_nvcc
+    which
+  ];
+
+  buildInputs = [
+    cccl
+    cuda_cudart
+    (lib.getLib nccl)
+  ]
+
+  ++ lib.optionals (cudaOlder "13.0") [ (lib.getInclude cuda_nvcc) ]
+  ++ lib.optionals (cudaAtLeast "13.0") [ cuda_crt ];
+
+  makeFlags = [
+    "CUDA_HOME=${lib.getBin cuda_nvcc}"
+    "CUDA_INC=${lib.getInclude cuda_cudart}/include"
+    "CUDA_LIB=${lib.getLib cuda_cudart}/lib"
+    "LDFLAGS=-L${lib.getLib cuda_cudart}/lib/stubs"
+    "NCCL_INCDIR=${lib.getInclude nccl}/include"
+    "NCCL_LIBDIR=${lib.getLib nccl}/lib"
+    "NCCL_EP_BUILDDIR=${placeholder "out"}"
+  ]
+  ++ lib.optionals (epFlags.cudaCapabilities != [ ]) [ "NVCC_GENCODE=${epFlags.gencodeString}" ];
+  buildFlags = [ "lib" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    rm -rf "$out/obj"
+
+    ln -s ${lib.getInclude nccl}/include/nccl.h "$out/include/nccl.h"
+    ln -s ${lib.getInclude nccl}/include/nccl_device.h "$out/include/nccl_device.h"
+    ln -s ${lib.getInclude nccl}/include/nccl_device "$out/include/nccl_device"
+
+    runHook postInstall
+  '';
+
+  passthru.tests = {
+    inherit (python3Packages) nccl4py;
+  };
+
+  meta = {
+    description = "Expert-parallelism (MoE dispatch/combine) extension library for NCCL";
+    homepage = "https://github.com/NVIDIA/nccl/blob/master/contrib/nccl_ep/README.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ thefossguy ];
+    inherit (nccl.meta) platforms badPlatforms;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
