### PR TITLE
hyprmoncfg: 1.9.0 -> 1.9.1

### DIFF
--- a/pkgs/by-name/hy/hyprmoncfg/package.nix
+++ b/pkgs/by-name/hy/hyprmoncfg/package.nix
@@ -11,7 +11,7 @@
 
 buildGoModule (finalAttrs: {
   pname = "hyprmoncfg";
-  version = "1.9.0";
+  version = "1.9.1";
 
   __structuredAttrs = true;
 
@@ -19,7 +19,7 @@ buildGoModule (finalAttrs: {
     owner = "crmne";
     repo = "hyprmoncfg";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-YHJHW1ArHRhx4RKtwUmIrsMvEyTEZEjDuEXXgc98/ys=";
+    hash = "sha256-LCZ1F30Ix4NnWYPI3WkL03jke9XW1cB5CWxmVSrdYYI=";
   };
 
   vendorHash = "sha256-gQbjvdKtO0hCXrs9RnWo1s0YeHf5W9t+8AgS2ELXlPo=";


### PR DESCRIPTION
## Things done

Updates hyprmoncfg to 1.9.1, a safety patch that protects user-managed monitor configuration files and reliably rolls back unconfirmed previews.

- Built on platform(s): x86_64-linux
- Tested the 1.9.1 source and unchanged vendor hashes with `nix build` in `nixos/nix:latest` through the upstream packaging flake
- Checked the Nix expression as part of the packaging validation suite
- Upstream `go test ./...` passes

No NixOS module changes.

https://github.com/crmne/hyprmoncfg/releases/tag/v1.9.1