### PR TITLE
space-rabbit: init at 2.1.1

### DIFF
--- a/pkgs/by-name/sp/space-rabbit/package.nix
+++ b/pkgs/by-name/sp/space-rabbit/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  swiftPackages,
+}:
+
+let
+  inherit (swiftPackages) stdenv swift;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "space-rabbit";
+  version = "2.1.5";
+
+  src = fetchFromGitHub {
+    owner = "tahul";
+    repo = "space-rabbit";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-RGA0/BiMoDnIqD3gr+jxBthny1+BKlVUC6hs7rrApyY=";
+  };
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    swift
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  postPatch = ''
+    # The upstream icon is generated at build time by an AppKit script that
+    # needs a graphical session, so it cannot run in the headless sandbox.
+    # Remove the icon reference; the app is a menu bar agent (LSUIElement)
+    # and needs no bundle icon.
+    sed --in-place \
+      '/<key>CFBundleIconFile<\/key>/,+1d' \
+      App/Info.plist
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    swiftTarget=${stdenv.hostPlatform.darwinArch}-apple-macosx15.0
+
+    make \
+      VERSION=${finalAttrs.version} \
+      SWIFT_TARGET="$swiftTarget" \
+      spacerabbit verify-macos-min
+
+    swiftc -O -target "$swiftTarget" \
+      -o validate-localizations \
+      Tools/Localization/Validate.swift
+    ./validate-localizations App/Resources App
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    app="$out/Applications/Space Rabbit.app"
+
+    mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources" "$out/bin"
+    install -Dm755 spacerabbit "$app/Contents/MacOS/spacerabbit"
+    cp -R App/Resources/*.lproj "$app/Contents/Resources/"
+
+    substitute App/Info.plist "$app/Contents/Info.plist" \
+      --replace-fail "__VERSION__" "${finalAttrs.version}" \
+      --replace-fail "__MACOS_MIN__" "15.0"
+
+    printf 'APPL????' > "$app/Contents/PkgInfo"
+
+    # Launch through a wrapper that execs the bundle executable, so
+    # `Bundle.main` resolves to the .app. A bare symlink into $out/bin would
+    # make `Bundle.main` the bin directory, which has no .lproj resources, so
+    # every localized string would fall back to its raw key.
+    makeWrapper "$app/Contents/MacOS/spacerabbit" "$out/bin/space-rabbit"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Instant space switching on macOS";
+    homepage = "https://github.com/tahul/space-rabbit";
+    changelog = "https://github.com/tahul/space-rabbit/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mpl20;
+    mainProgram = "space-rabbit";
+    maintainers = with lib.maintainers; [ sheeeng ];
+    platforms = lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
