### PR TITLE
gnu-smalltalk: remove gtk2 support

### DIFF
--- a/pkgs/by-name/gn/gnu-smalltalk/package.nix
+++ b/pkgs/by-name/gn/gnu-smalltalk/package.nix
@@ -11,7 +11,6 @@
   readline,
   gmp,
   gnutls,
-  gtk2,
   cairo,
   SDL,
   sqlite,
@@ -63,14 +62,13 @@ stdenv.mkDerivation (finalAttrs: {
     readline
     gmp
     gnutls
-    gtk2
     cairo
     SDL
     sqlite
   ]
   ++ lib.optional emacsSupport emacs;
 
-  configureFlags = lib.optional (!emacsSupport) "--without-emacs";
+  configureFlags = [ "--enable-gtk=no" ] ++ lib.optionals (!emacsSupport) [ "--without-emacs" ];
 
   hardeningDisable = [ "format" ];
 


### PR DESCRIPTION
Means the gtk2 `gst-browser` feature of this package will not be available, but at least keeps it available for users who do not depend on that. May be a candidate for dropping in the future.

Part of https://github.com/NixOS/nixpkgs/issues/410814


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
