### PR TITLE
python3Packages.pytweening: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/pytweening/default.nix
+++ b/pkgs/development/python-modules/pytweening/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchPypi,
   setuptools,
+  unittestCheckHook,
 }:
 buildPythonPackage rec {
   pname = "pytweening";
@@ -17,9 +18,15 @@ buildPythonPackage rec {
   build-system = [ setuptools ];
 
   pythonImportsCheck = [ "pytweening" ];
-  checkPhase = ''
-    python -m unittest tests.basicTests
-  '';
+
+  unittestFlags = [
+    "-s"
+    "tests"
+    "-p"
+    "basicTests.py"
+  ];
+
+  nativeCheckInputs = [ unittestCheckHook ];
 
   meta = {
     description = "Set of tweening / easing functions implemented in Python";

--- a/pkgs/development/python-modules/pytweening/default.nix
+++ b/pkgs/development/python-modules/pytweening/default.nix
@@ -5,13 +5,15 @@
   setuptools,
   unittestCheckHook,
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pytweening";
   version = "1.2.0";
+
+  __structuredAttrs = true;
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-JDMYt3NmmAZsXzYuxcK2Q07PQpfDyOfKqKv+avTKxxs=";
   };
 
@@ -34,4 +36,4 @@ buildPythonPackage rec {
     license = lib.licenses.bsd3;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/pytweening/default.nix
+++ b/pkgs/development/python-modules/pytweening/default.nix
@@ -2,16 +2,19 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
 }:
 buildPythonPackage rec {
   pname = "pytweening";
   version = "1.2.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-JDMYt3NmmAZsXzYuxcK2Q07PQpfDyOfKqKv+avTKxxs=";
   };
+
+  build-system = [ setuptools ];
 
   pythonImportsCheck = [ "pytweening" ];
   checkPhase = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- https://github.com/NixOS/nixpkgs/issues/515974
- https://github.com/NixOS/nixpkgs/issues/550532

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
