### PR TITLE
libtexprintf: init at 1.31

### DIFF
--- a/pkgs/by-name/li/libtexprintf/package.nix
+++ b/pkgs/by-name/li/libtexprintf/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  autoreconfHook,
+  fetchFromGitHub,
+  gitUpdater,
+  stdenv,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "libtexprintf";
+  version = "1.31";
+
+  src = fetchFromGitHub {
+    owner = "bartp5";
+    repo = "libtexprintf";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-OXDcohfSfik0H1MpoznN267OVTYkW75N+TIF6lRRvZ0=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  strictDeps = true;
+
+  enableParallelBuilding = true;
+
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+
+  meta = {
+    homepage = "https://github.com/bartp5/libtexprintf";
+    description = "Printf-style formatted output routines with TeX-like syntax support";
+    longDescription = ''
+      libtexprintf provides tools to pretty-print math in mono-space fonts
+      using TeX-like syntax, producing UTF-8 encoded output. It includes the
+      utftex command-line program and a C library that applications can link
+      against for printf-style formatted math output. Inspired by asciiTeX,
+      it supports substantially more TeX syntax via extensive Unicode tables
+      mapping LaTeX commands to Unicode symbols.
+    '';
+    changelog = "https://github.com/bartp5/libtexprintf/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "utftex";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Summary:
The package [libtexprintf](https://github.com/bartp5/libtexprintf/) provides a library and command line utilities to print latex expression in the terminal. It is used by Neovim's [render-makdown plugin](https://github.com/MeanderingProgrammer/render-markdown.nvim) for latex rendering. For example
```bash
$ utftex '\int_0^1 \frac{1}{x^2+1} dx= \frac{\pi}{4}'
⌠¹  1       π
⎮  ──── dx= ─
⌡₀ x²+1     4
```
P.S. This is my first contribution to nixpkgs. Your feedback is appreciated if there is needed that needs to be changed/improved. 



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
