### PR TITLE
python3Packages.transformer-engine: 2.16.1 -> 2.17.1

### DIFF
--- a/pkgs/development/python-modules/transformer-engine/default.nix
+++ b/pkgs/development/python-modules/transformer-engine/default.nix
@@ -44,12 +44,14 @@
   withJax ? true,
   withNvshmem ? false,
   withCusolvermp ? false,
+  withNcclEp ? true,
 }:
 
 let
   inherit (lib)
     cmakeFeature
     concatStringsSep
+    getBin
     getInclude
     getLib
     optional
@@ -80,7 +82,7 @@ let
 in
 buildPythonPackage.override { stdenv = backendStdenv; } (finalAttrs: {
   pname = "transformer-engine";
-  version = "2.16.1";
+  version = "2.17.1";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -90,7 +92,7 @@ buildPythonPackage.override { stdenv = backendStdenv; } (finalAttrs: {
     tag = "v${finalAttrs.version}";
     # Their CMakeLists.txt does not easily let us inject dependencies
     fetchSubmodules = true;
-    hash = "sha256-jYQZwgBedpCALhXYw2qH7PwIoSz6ttUje78xjdF+CYc=";
+    hash = "sha256-W9aWSmYCV7wYrLSAlYE2prfPfucXkPjWGA7NAMfBJ9E=";
   };
 
   patches = optionals cudaSupport [
@@ -124,6 +126,17 @@ buildPythonPackage.override { stdenv = backendStdenv; } (finalAttrs: {
         --replace-fail \
           'te_path = Path(importlib.util.find_spec("transformer_engine").origin).parent.parent' \
           'te_path = Path("${placeholder "out"}/${python.sitePackages}")'
+    ''
+    # nccl-ep is built from the vendored `3rdparty/nccl` submodule (see the NCCL_EP_* CMake
+    # variables in `transformer_engine/common/CMakeLists.txt`), which pins a newer NCCL than
+    # `cudaPackages.nccl-ep` provides.
+    # Only `libnccl_ep.a` is consumed (whole-archive), so skip the shared library, which would
+    # otherwise need `-lnccl -lcuda` on the link line.
+    + optionalString withNcclEp ''
+      substituteInPlace 3rdparty/nccl/contrib/nccl_ep/Makefile \
+        --replace-fail \
+          'lib: $(LIBTARGET) $(SOLIBTARGET) $(SOLIBLINKS) $(HEADER_TARGETS)' \
+          'lib: $(LIBTARGET) $(HEADER_TARGETS)'
     '';
 
   # https://github.com/NVIDIA/TransformerEngine/blob/main/docs/envvars.rst
@@ -143,6 +156,15 @@ buildPythonPackage.override { stdenv = backendStdenv; } (finalAttrs: {
     NVTE_CMAKE_EXTRA_ARGS = toString [
       (cmakeFeature "CUDNN_FRONTEND_INCLUDE_DIR" "${getInclude cudaPackages.cudnn-frontend}/include")
     ];
+
+    NVTE_WITH_NCCL_EP = if withNcclEp then 1 else 0;
+    # Consumed by `3rdparty/nccl/makefiles/common.mk`, which otherwise defaults to
+    # `CUDA_HOME = /usr/local/cuda`. Only the nccl-ep headers are needed, so `NCCL_HOME`
+    # can point at the `include` output alone.
+    NCCL_HOME = optionalString withNcclEp (getInclude cudaPackages.nccl).outPath;
+    CUDA_HOME = optionalString withNcclEp (getBin cudaPackages.cuda_nvcc).outPath;
+    CUDA_INC = optionalString withNcclEp "${getInclude cudaPackages.cuda_cudart}/include";
+    CUDA_LIB = optionalString withNcclEp "${getLib cudaPackages.cuda_cudart}/lib";
 
     NVTE_UB_WITH_MPI = if withMpi then 1 else 0;
     # NOTE: Make sure to use mpi from buildPackages to match the spliced version created through nativeBuildInputs.
@@ -184,6 +206,7 @@ buildPythonPackage.override { stdenv = backendStdenv; } (finalAttrs: {
 
   buildInputs = [
     cudaPackages.cuda_cudart # cuda_runtime.h
+    cudaPackages.cuda_nvcc # crt/host_config.h; even though we include this in nativeBuildInputs, it's needed here too
     cudaPackages.cuda_nvml_dev # nvml.h
     cudaPackages.cuda_nvrtc # nvrtc.h
     cudaPackages.cuda_nvtx # nvToolsExt.h
@@ -239,7 +262,13 @@ buildPythonPackage.override { stdenv = backendStdenv; } (finalAttrs: {
     # When built with nvshmem support `dlopen`ing libtransformer_engine.so `dlopen`s
     # libnvidia-ml.so.1 which is provided by the GPU driver at run time:
     # OSError: libnvidia-ml.so.1: cannot open shared object file: No such file or directory
-    || withNvshmem;
+    || withNvshmem
+
+    # nccl-ep links `CUDA::cuda_driver` after the `libnccl_ep.a` whole-archive, so
+    # libtransformer_engine.so gets a `DT_NEEDED` on libcuda.so.1, provided by the GPU driver at
+    # run time:
+    # OSError: libcuda.so.1: cannot open shared object file: No such file or directory
+    || withNcclEp;
 
   pythonImportsCheck = [
     "transformer_engine"
@@ -255,6 +284,7 @@ buildPythonPackage.override { stdenv = backendStdenv; } (finalAttrs: {
   doCheck = false;
 
   passthru.tests = {
+    withOutNcclEp = transformer-engine.override { withNcclEp = false; };
     withMpi = transformer-engine.override { withMpi = true; };
     withPytorch = transformer-engine.override { withPytorch = true; };
     withJax = transformer-engine.override { withJax = true; };


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/NVIDIA/TransformerEngine/compare/v2.16.1...v2.17.1
Changelog: https://github.com/NVIDIA/TransformerEngine/releases/tag/v2.17.1

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test