### PR TITLE
zola: 0.22.1 -> 0.23.4

### DIFF
--- a/pkgs/by-name/zo/zola/package.nix
+++ b/pkgs/by-name/zo/zola/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   rustPlatform,
+  cacert,
   pkg-config,
   oniguruma,
   installShellFiles,
@@ -12,16 +13,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "zola";
-  version = "0.22.1";
+  version = "0.23.4";
 
   src = fetchFromGitHub {
     owner = "getzola";
     repo = "zola";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-mynoXNJE7IcP/0bMLUr/pJQbaEVEj2q/488Z4c9Tr5A=";
+    hash = "sha256-9lSl4/vM+mO2YQA1uq6knVZ6uENhxPPjJ9a8z2A5aRc=";
   };
 
-  cargoHash = "sha256-AEgyaKenTMKAoJjzcklFFWjy5H5hkNZvVnlMZmqQxlM=";
+  cargoHash = "sha256-LsnnX8zyyJexmc+aGiI3Lwbrb/rjtKiL15CSM/cEFOY=";
 
   nativeBuildInputs = [
     pkg-config
@@ -30,6 +31,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   buildInputs = [
     oniguruma
+  ];
+
+  checkInputs = [
+    cacert
   ];
 
   env.RUSTONIG_SYSTEM_LIBONIG = true;

--- a/pkgs/by-name/zo/zola/package.nix
+++ b/pkgs/by-name/zo/zola/package.nix
@@ -7,7 +7,6 @@
   pkg-config,
   oniguruma,
   installShellFiles,
-  zola,
   testers,
 }:
 
@@ -46,7 +45,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --zsh <($out/bin/zola completion zsh)
   '';
 
-  passthru.tests.version = testers.testVersion { package = zola; };
+  passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
 
   meta = {
     description = "Fast static site generator with everything built-in";


### PR DESCRIPTION
https://github.com/getzola/zola/releases/tag/v0.23.0
https://github.com/getzola/zola/releases/tag/v0.23.1
https://github.com/getzola/zola/releases/tag/v0.23.2
https://github.com/getzola/zola/releases/tag/v0.23.3
https://github.com/getzola/zola/releases/tag/v0.23.4

Had to add `cacert` due to a failing test: https://r.ryantm.com/log/zola/2026-08-05.log

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
