### PR TITLE
[release-26.05] kitty-img: 1.1.0 -> 1.1.1

### DIFF
--- a/pkgs/by-name/ki/kitty-img/package.nix
+++ b/pkgs/by-name/ki/kitty-img/package.nix
@@ -1,26 +1,26 @@
 {
   lib,
   rustPlatform,
-  fetchFromSourcehut,
+  fetchFromCodeberg,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "kitty-img";
-  version = "1.1.0";
+  version = "1.1.1";
 
-  src = fetchFromSourcehut {
-    owner = "~zethra";
+  src = fetchFromCodeberg {
+    owner = "sashanoraa";
     repo = "kitty-img";
     rev = finalAttrs.version;
-    hash = "sha256-liqLocNIIOmkVWI8H9WU7T352sK7sceVtOX+R0BQ/uk=";
+    hash = "sha256-r5gt5ESQ/2Z//k6rZtPSp1dnQOYvB6+7T7LUcSryrHY=";
   };
 
-  cargoHash = "sha256-50M1TUGvjELARt/gvtyAPNL0hG1ekKwdefI9nMEsTo0=";
+  cargoHash = "sha256-S/f2Q9SpPuAJLr8QkdWjRGwcuE64AhXJMcXMvwAMIUw=";
 
   meta = {
     description = "Print images inline in kitty";
-    homepage = "https://git.sr.ht/~zethra/kitty-img";
-    changelog = "https://git.sr.ht/~zethra/kitty-img/refs/${finalAttrs.version}";
+    homepage = "https://codeberg.org/sashanoraa/kitty-img";
+    changelog = "https://codeberg.org/sashanoraa/kitty-img/releases/tag/${finalAttrs.version}";
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [ gaykitty ];
     mainProgram = "kitty-img";


### PR DESCRIPTION
(cherry picked from commit b05e9b0ab1d2f439a6e0275496c2afa8815f26c2)

Backport #514505
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
