### PR TITLE
widelands: add explicit libx11 dependency for Wayland compatibility

### DIFF
--- a/pkgs/by-name/wi/widelands/package.nix
+++ b/pkgs/by-name/wi/widelands/package.nix
@@ -26,6 +26,7 @@
   libsm,
   libice,
   libxext,
+  libx11,
 }:
 
 stdenv.mkDerivation rec {
@@ -79,6 +80,7 @@ stdenv.mkDerivation rec {
     asio
     libsm # XXX: these should be propagated by SDL2?
     libice
+    libx11
   ]
   ++ lib.optional stdenv.hostPlatform.isLinux libxext;
 


### PR DESCRIPTION
Trying to run the binary on a Wayland system failed with `ld` not finding `libx11.so.6`. It seems the package either envisioned it being bundled as a transitive dependency or Wayland-only systems were not tested.

This PR adds `libx11` as an explicit dependency, which fixes the problem.

There were no package tests -- at least I couldn't find any. Could be my fault, this is my first PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable: (*not applicable, no tests*)
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
