### PR TITLE
fish: add functions to fish module

### DIFF
--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -19,6 +19,21 @@ let
     )
   );
 
+  fishFunctions = lib.mapAttrs' (
+    name: value: {
+      name = "fish/functions/${name}.fish";
+      value.source =
+        let
+          body = if lib.isPath value then lib.readFile value else value;
+        in
+        indentFishFile "${name}.fish" ''
+          function ${name}
+            ${lib.strings.removeSuffix "\n" body}
+          end
+        '';
+    }
+  );
+
   envShellInit = pkgs.writeText "shellInit" cfge.shellInit;
   envLoginShellInit = pkgs.writeText "loginShellInit" cfge.loginShellInit;
   envInteractiveShellInit = pkgs.writeText "interactiveShellInit" cfge.interactiveShellInit;
@@ -131,6 +146,58 @@ in
         type = with lib.types; attrsOf (nullOr (either str path));
       };
 
+      shellFunctions = lib.mkOption {
+        description = ''
+          A set of fish functions, with the attribute name being the function name. Function names cannot be reserved
+          words or have spaces. These are elements of fish syntax or builtin commands which are essential for the
+          operations of the shell.
+
+          See the documentation for [fish functions](https://fishshell.com/docs/current/cmds/function.html) for further information.
+        '';
+        example = {
+          ll.body = "ls -l $argv";
+          mcd = {
+            modifiers = {
+              description = "Create a directory and set CWD";
+            };
+            body = ''
+              command mkdir $argv
+              if test $status = 0
+                switch $argv[(count $argv)]
+                  case '-*'
+
+                  case '*'
+                    cd $argv[(count $argv)]
+                    return
+                end
+              end
+            '';
+          };
+        };
+        type = lib.types.attrsOf (
+          lib.types.submodule {
+            options = {
+              body = lib.mkOption {
+                type = lib.types.str;
+                description = ''
+                  The function body. You may provide a path or a string containing the fish function body.
+                '';
+              };
+
+              modifiers = lib.mkOption {
+                type = lib.types.attrsOf lib.types.anything;
+                default = { };
+                defaultText = "input for 'lib.cli.toCommandLine'";
+                description = ''
+                  Modifiers to be applied to the function. This is a string, concatenated with a space after the function nane
+                '';
+              };
+            };
+
+          }
+        );
+      };
+
       shellInit = lib.mkOption {
         default = "";
         description = ''
@@ -223,6 +290,9 @@ in
 
             ${cfg.shellInit}
 
+            # Add the search path for global fish functions
+            set fish_function_path /etc/fish/functions/ $fish_function_path
+
             # and leave a note so we don't source this config section again from
             # this very shell (children will source the general config anew)
             set -g __fish_nixos_general_config_sourced 1
@@ -257,6 +327,21 @@ in
             set -g __fish_nixos_interactive_config_sourced 1
           end
         '';
+      }
+
+      {
+        etc = lib.mapAttrs' (name: value: {
+          name = "fish/functions/${name}.fish";
+          value.source =
+            let
+              modifiers = lib.cli.toCommandLineShellGNU { } value.modifiers;
+            in
+            indentFishFile "${name}.fish" ''
+              function ${name} ${modifiers}
+                ${lib.trim value.body}
+              end
+            '';
+        }) cfg.shellFunctions;
       }
 
       (lib.mkIf cfg.generateCompletions {


### PR DESCRIPTION
Adds `programs.fish.shellFunctions` for configuring global fish functions. 


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
