### PR TITLE
rapidraw: 1.6.0 -> 1.6.1

### DIFF
--- a/pkgs/by-name/ra/rapidraw/package.nix
+++ b/pkgs/by-name/ra/rapidraw/package.nix
@@ -43,16 +43,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rapidraw";
-  version = "1.6.0";
+  version = "1.6.1";
 
   src = fetchFromGitHub {
     owner = "CyberTimon";
     repo = "RapidRAW";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-CxuoyscGiZmWz2P3i3tcKe0JIL2PIvCk6AicjgdyUzw=";
+    hash = "sha256-+sV8XRK+rBVKB6AdoGuz7q6bYtz8HwnVZghK3JjGFes=";
   };
 
-  cargoHash = "sha256-UEM5UG+0fh5StIVU8AIptX6bqwTqUA4SNOn1GmUPfow=";
+  cargoHash = "sha256-QItJQ7POtH+SRr5pyLJAWD4wx+fRpx1JI/KK6KIgNT8=";
 
   npmDeps = fetchNpmDeps {
     inherit (finalAttrs) src;
@@ -93,7 +93,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     zlib
     libGL
     dbus
-    gvfs
     libheif
     onnxruntime
     wrapGAppsHook4
@@ -101,6 +100,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     webkitgtk_4_1
     libappindicator
+    gvfs
   ];
 
   cargoRoot = "src-tauri";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Moved `gvfs` to the linux specific packages as it was causing a linking error on darwin

```
❯ nix run #rapidraw
warning: Git tree '/Users/kierank/code/github/nixpkgs' is dirty
error: builder for '/nix/store/w65rxjfygfgqrp3svnnkbhg61k4hyjjy-libgphoto2-2.5.34.drv' failed with exit code 2;
       last 25 log lines:
       >   CC       ax203/la-library.lo
       >   CC       ax203/la-ax203.lo
       >   CC       ax203/la-ax203_decode_yuv.lo
       >   CC       ax203/la-ax203_decode_yuv_delta.lo
       >   CC       ax203/la-ax203_compress_jpeg.lo
       >   CC       ax203/la-jpeg_memsrcdest.lo
       >   CC       ax203/la-tinyjpeg.lo
       >   CC       ax203/la-jidctflt.lo
       >   CCLD     ax203.la
       > Undefined symbols for architecture arm64:
       >   "_libintl_dgettext", referenced from:
       >       _camera_summary in la-library.o
       >       _camera_manual in la-library.o
       >       _camera_about in la-library.o
       >       _camera_get_config in la-library.o
       >       _camera_set_config in la-library.o
       > ld: symbol(s) not found for architecture arm64
       > clang: error: linker command failed with exit code 1 (use -v to see invocation)
       > make[3]: *** [Makefile:2214: ax203.la] Error 1
       > make[3]: Leaving directory '/nix/var/nix/b/16mq95gxfz5klm745x6m9x5qkn/source/camlibs'
       > make[2]: *** [Makefile:4944: all-recursive] Error 1
       > make[2]: Leaving directory '/nix/var/nix/b/16mq95gxfz5klm745x6m9x5qkn/source/camlibs'
       > make[1]: *** [Makefile:778: all-recursive] Error 1
       > make[1]: Leaving directory '/nix/var/nix/b/16mq95gxfz5klm745x6m9x5qkn/source'
       > make: *** [Makefile:602: all] Error 2
       For full logs, run:
              nix log /nix/store/w65rxjfygfgqrp3svnnkbhg61k4hyjjy-libgphoto2-2.5.34.drv
error: 1 dependencies of derivation '/nix/store/ym12lb2cz1z8n862x8f9dcci7skdr27m-gvfs-1.60.1.drv' failed to build
error: 1 dependencies of derivation '/nix/store/z2ny9d5ddis175vhmc9vwhwd0wsvjwjb-rapidraw-1.6.1.drv' failed to build
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
