### PR TITLE
Truffleruby metadata fix

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20800,6 +20800,12 @@
     github = "nipeharefa";
     githubId = 12620257;
   };
+  nirvdrum = {
+    name = "Kevin Menard";
+    email = "kevin@nirvdrum.com";
+    github = "nirvdrum";
+    githubId = 12584;
+  };
   NIS = {
     name = "NSC IT Solutions";
     github = "dev-nis";

--- a/pkgs/development/compilers/graalvm/community-edition/truffleruby/default.nix
+++ b/pkgs/development/compilers/graalvm/community-edition/truffleruby/default.nix
@@ -38,4 +38,19 @@ graalvmPackages.buildGraalvmProduct {
       ''
     }
   '';
+
+  meta = {
+    description = "High-performance implementation of Ruby built on GraalVM";
+    homepage = "https://truffleruby.dev/";
+    mainProgram = "ruby";
+    maintainers = with lib.maintainers; [ nirvdrum ];
+
+    license =
+      with lib.licenses;
+      OR [
+        epl20
+        gpl2Only
+        lgpl21Only
+      ];
+  };
 }


### PR DESCRIPTION
This PR fixes an issue with the metadata for the TruffleRuby package. It's currently packaged as part of GraalVM, which includes other Truffle/Graal languages and that metadata was being inherited incorrectly by the TruffleRuby package.

I've corrected:

* Description
* Homepage
* License(s)
* Main program

And I've added myself as maintainer for future updates. For context, I'm a maintainer of the upstream TruffleRuby project.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
