### PR TITLE
ocamlPackages.cohttp-async: fix build on darwin

### DIFF
--- a/pkgs/development/ocaml-modules/cohttp/async.nix
+++ b/pkgs/development/ocaml-modules/cohttp/async.nix
@@ -51,6 +51,8 @@ buildDunePackage {
     ipaddr
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   doCheck = true;
   checkInputs = [
     ounit

--- a/pkgs/development/ocaml-modules/cohttp/eio.nix
+++ b/pkgs/development/ocaml-modules/cohttp/eio.nix
@@ -33,6 +33,8 @@ buildDunePackage {
     uri
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   doCheck = true;
   checkInputs = [
     alcotest

--- a/pkgs/development/ocaml-modules/ctypes/foreign.nix
+++ b/pkgs/development/ocaml-modules/ctypes/foreign.nix
@@ -1,4 +1,7 @@
 {
+  lib,
+  stdenv,
+  ocaml,
   buildDunePackage,
   ctypes,
   dune-configurator,
@@ -10,7 +13,7 @@
 buildDunePackage {
   pname = "ctypes-foreign";
 
-  inherit (ctypes) version src doCheck;
+  inherit (ctypes) version src;
 
   buildInputs = [ dune-configurator ];
 
@@ -26,6 +29,9 @@ buildDunePackage {
 
   # Fix build with gcc 14
   env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
+
+  # closure lifetime tests crash on darwin ocaml 5.5
+  doCheck = !(stdenv.hostPlatform.isDarwin && lib.versionAtLeast ocaml.version "5.5");
 
   meta = ctypes.meta // {
     description = "Dynamic access to foreign C libraries using Ctypes";

--- a/pkgs/development/ocaml-modules/janestreet/0.17.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.17.nix
@@ -445,6 +445,7 @@ with self;
     hash = "sha256-RB/sUq1tL8A3m9YhHHx2LFqoExTX187VeZI9MRb1NeA=";
     meta.description = "Library for easily creating a cohttp handler for static files";
     propagatedBuildInputs = [ cohttp-async_5_3 ];
+    __darwinAllowLocalNetworking = true;
   };
 
   content_security_policy = janePackage {

--- a/pkgs/development/ocaml-modules/janestreet/0.17.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.17.nix
@@ -177,6 +177,7 @@ with self;
       async_websocket
       cohttp_async_websocket
     ];
+    __darwinAllowLocalNetworking = true;
   };
 
   async_sendfile = janePackage {

--- a/pkgs/development/ocaml-modules/janestreet/0.17.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.17.nix
@@ -438,6 +438,7 @@ with self;
       ppx_jane
       uri-sexp
     ];
+    __darwinAllowLocalNetworking = true;
   };
 
   cohttp_static_handler = janePackage {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

follow up on https://github.com/NixOS/nixpkgs/pull/550127

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
