### PR TITLE
marktext: 0.17.0-unstable-2025-11-19 -> 0.19.1 (migrating from yarn to pnpm)

### DIFF
--- a/pkgs/by-name/ma/marktext/package.nix
+++ b/pkgs/by-name/ma/marktext/package.nix
@@ -2,11 +2,10 @@
   stdenv,
   fetchFromGitHub,
   lib,
-  fetchYarnDeps,
-  yarn,
-  fixup-yarn-lock,
+  fetchPnpmDeps,
+  pnpm_10,
+  pnpmConfigHook,
   nodejs,
-  electron,
   python3,
   node-gyp,
   libx11,
@@ -14,168 +13,135 @@
   libxkbfile,
   fontconfig,
   node-gyp-build,
-  ripgrep,
   pkg-config,
   libsecret,
-  yarnBuildHook,
-  makeShellWrapper,
-  unstableGitUpdater,
-  xcbuild,
-  libtool,
+  makeWrapper,
+  electron,
+  nix-update-script,
 }:
-
+let
+  pnpm = pnpm_10;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "marktext";
-  version = "0.17.0-unstable-2025-11-19";
+  version = "0.19.1";
 
   src = fetchFromGitHub {
     owner = "marktext";
     repo = "marktext";
-    rev = "aa71e33e07845419533d767ad0d260a7c267cec7";
-    hash = "sha256-c/MxYGFFCfC5KcvtBYuxSqeZ4WuAq5zPuBfYqXczicU=";
-    postFetch = ''
-      cd $out
-      patch -p1 < ${./0001-update-electron.patch}
-    ''; # Need for offlineCache
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-i1CjwRndcDUNpoMUPZ9U2TI/OsSX/WH8zXgEMHy338k=";
   };
 
-  offlineCache = fetchYarnDeps {
-    yarnLock = "${finalAttrs.src}/yarn.lock";
-    hash = "sha256-mr79FV/LHkoY3vX9B5yv95IQIJQ9akwfslKndKYmwCo=";
+  pnpmDeps = fetchPnpmDeps {
+    inherit pnpm;
+    inherit (finalAttrs) src version;
+    pname = "marktext-monorepo";
+
+    fetcherVersion = 4;
+    hash = "sha256-PNFWviNG77Bfs0R08jCUDVQ/1O/1Q82iLWK+2tYLHg0=";
+    pnpmInstallFlags = [ "--no-frozen-lockfile" ];
   };
 
   nativeBuildInputs = [
-    yarn
-    fixup-yarn-lock
-    makeShellWrapper
-    yarnBuildHook
+    pnpmConfigHook
+    makeWrapper
     (python3.withPackages (ps: with ps; [ packaging ]))
     pkg-config
+    electron
     nodejs
     node-gyp
     node-gyp-build
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    xcbuild
-    libtool
   ];
 
   buildInputs = [
+    fontconfig
+    xorgproto
     libsecret
     libx11
     libxkbfile
-    fontconfig
-    xorgproto
+    pnpm
   ];
 
-  postPatch = ''
-    substituteInPlace src/common/filesystem/paths.js \
-      --replace-fail "process.resourcesPath" "'$out/opt/marktext/resources'"
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
-    substituteInPlace src/main/cli/index.js \
-      --replace-fail "process.argv.slice(1)" "process.argv.slice(2)"
+  # Patch i18n.ts before building
+  postPatch = ''
+    # Fix static/locales folder location
+    substituteInPlace packages/desktop/src/common/i18n.ts \
+      --replace-fail \
+        "process.resourcesPath, 'static', 'locales'" \
+        "__dirname, '..', '..', 'static', 'locales'"
   '';
 
-  configurePhase = ''
-    runHook preConfigure
+  buildPhase = ''
+    runHook preBuild
 
-    export HOME=$(mktemp -d)
-    yarn config --offline set yarn-offline-mirror ${finalAttrs.offlineCache}
-    fixup-yarn-lock yarn.lock
-
-    # set nodedir to prevent node-gyp from downloading headers
-    # taken from https://nixos.org/manual/nixpkgs/stable/#javascript-tool-specific
-    mkdir -p $HOME/.node-gyp/${nodejs.version}
-    echo 9 > $HOME/.node-gyp/${nodejs.version}/installVersion
-    ln -sfv ${nodejs}/include $HOME/.node-gyp/${nodejs.version}
+    # Need for electron-rebuild
     export npm_config_nodedir=${nodejs}
 
-    yarn --offline --frozen-lockfile install --ignore-scripts --no-progress --non-interactive
+    # Generate minified locale files
+    pnpm run minify-locales
 
-    patchShebangs node_modules
+    pnpm run build
 
-    substituteInPlace node_modules/node-gyp/gyp/pylib/gyp/input.py \
-      --replace-fail "from distutils.version import StrictVersion" "from packaging.version import Version as StrictVersion"
+    # Rebuild native modules
+    pnpm exec electron-rebuild -f --module-dir packages/desktop
 
-    ./node_modules/.bin/electron-rebuild -f
+    pnpm exec electron-builder \
+      --dir \
+      --projectDir packages/desktop \
+      --config electron-builder.yml \
+      -c.electronDist=${electron.dist} \
+      -c.electronVersion=${electron.version}
 
-    substituteInPlace package.json \
-      --replace-fail "electron-rebuild -f" "echo 0" \
-      --replace-fail "&& yarn run lint:fix" ""
+    # Inject static folder into the asar
+    pushd dist/*-unpacked
+    pnpm exec asar extract resources/app.asar app-tmp
+    cp -a ../../packages/desktop/static app-tmp/static
+    pnpm exec asar pack app-tmp resources/app.asar
+    rm -rf app-tmp
+    popd
 
-    mkdir -p node_modules/vscode-ripgrep/bin
-
-    yarn --offline --frozen-lockfile install --no-progress
-    patchShebangs node_modules
-
-    substituteInPlace node_modules/node-gyp/gyp/pylib/gyp/input.py \
-      --replace-fail "from distutils.version import StrictVersion" "from packaging.version import Version as StrictVersion"
-
-    sed -i -e 's|path.join(.*);|"${lib.getExe ripgrep}";|' \
-      node_modules/vscode-ripgrep/lib/index.js
-
-    runHook postConfigure
+    runHook postBuild
   '';
-
-  yarnBuildScript = "electron-builder";
-
-  yarnBuildFlags = [
-    "--dir"
-    "-c.electronDist=${electron.dist}"
-    "-c.electronVersion=${electron.version}"
-  ];
-
-  env = {
-    ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
-    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
-  };
-
-  preBuild = ''
-    node .electron-vue/build.js
-  ''; # From package.json
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/opt/marktext $out/bin
+    mkdir -p $out/lib/marktext $out/{bin,share}
 
-    install -Dm644 resources/linux/marktext.desktop $out/share/applications/marktext.desktop
+    install -Dm644 packages/desktop/build/linux/marktext.desktop \
+      $out/share/applications/marktext.desktop
 
-    pushd resources/icons/
+    # Copy the built app
+    cp -r dist/*-unpacked/{locales,resources{,.pak}} $out/lib/marktext
 
+    pushd packages/desktop/build/icons/
     find -maxdepth 1 -mindepth 1 -type d -exec install -DT {}/marktext.png $out/share/icons/hicolor/{}/apps/marktext.png \;
-
     find -maxdepth 1 -mindepth 1 -type d -exec install -DT {}/md.png $out/share/icons/hicolor/{}/apps/md.png \;
-
     popd
 
-    cp -r build/*-unpacked/{locales,resources{,.pak}} $out/opt/marktext
-
-    makeWrapper ${lib.getExe electron} $out/bin/marktext \
-      --add-flags $out/opt/marktext/resources/app.asar \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
+    makeWrapper ${lib.getExe electron} "$out/bin/marktext" \
+      --add-flags "$out/lib/marktext/resources/app.asar" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+      --inherit-argv0
 
     runHook postInstall
   '';
 
-  passthru.updateScript = unstableGitUpdater {
-    tagPrefix = "v";
-    branch = "develop";
-  };
+  passthru.updateScript = nix-update-script { extraArgs = [ "--use-github-releases" ]; };
 
   meta = {
     description = "Simple and elegant markdown editor, available for Linux, macOS and Windows";
-    homepage = "https://www.marktext.cc";
+    homepage = "https://www.marktext.me";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       nh2
       eduarrrd
       bot-wxt1221
     ];
-    badPlatforms = [
-      "aarch64-darwin"
-    ];
-    platforms = lib.platforms.unix;
+    platforms = lib.platforms.linux;
     mainProgram = "marktext";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->



## Things done
Probably fix #525483
That i do:
1. Updated version to 0.19.1 and replaced unstableGitUpdater with nix-update-script.
2. Migrated from yarn to pnpm. This allowed removing old offline cache workarounds and node-gyp header hacks.
3. Updated homepage URL from .cc to .me.
4. Remove darwin support

Tested basic functionality, but need improvements.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
