### PR TITLE
unixtools: set licenses

### DIFF
--- a/pkgs/by-name/ge/getopt/package.nix
+++ b/pkgs/by-name/ge/getopt/package.nix
@@ -28,5 +28,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "http://frodo.looijaard.name/project/getopt";
     description = "Parses command-line arguments from shell scripts";
     mainProgram = "getopt";
+    license = lib.licenses.gpl2Plus;
   };
 })

--- a/pkgs/by-name/ti/tinyxxd/package.nix
+++ b/pkgs/by-name/ti/tinyxxd/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     homepage = "https://github.com/xyproto/tinyxxd";
     description = "Drop-in replacement and standalone version of the hex dump utility that comes with ViM";
-    license = [
+    license = lib.licenses.OR [
       lib.licenses.mit # or
       lib.licenses.gpl2Only
     ];

--- a/pkgs/os-specific/darwin/by-name/ad/adv_cmds/package.nix
+++ b/pkgs/os-specific/darwin/by-name/ad/adv_cmds/package.nix
@@ -95,7 +95,7 @@ mkAppleDerivation {
 
   meta = {
     description = "Advanced commands package for Darwin";
-    license = [
+    license = lib.licenses.AND [
       lib.licenses.apsl10
       lib.licenses.apsl20
     ];

--- a/pkgs/os-specific/darwin/by-name/ba/basic_cmds/package.nix
+++ b/pkgs/os-specific/darwin/by-name/ba/basic_cmds/package.nix
@@ -12,7 +12,7 @@ mkAppleDerivation {
 
   meta = {
     description = "Basic commands for Darwin";
-    license = [
+    license = lib.licenses.AND [
       lib.licenses.isc
       lib.licenses.bsd3
     ];

--- a/pkgs/os-specific/darwin/by-name/sh/shell_cmds/package.nix
+++ b/pkgs/os-specific/darwin/by-name/sh/shell_cmds/package.nix
@@ -63,7 +63,7 @@ mkAppleDerivation {
 
   meta = {
     description = "Darwin shell commands and the Almquist shell";
-    license = [
+    license = lib.licenses.AND [
       lib.licenses.bsd2
       lib.licenses.bsd3
     ];

--- a/pkgs/top-level/unixtools.nix
+++ b/pkgs/top-level/unixtools.nix
@@ -41,6 +41,7 @@ let
           mainProgram = cmd;
           priority = 10;
           platforms = platforms.${stdenv.hostPlatform.parsed.kernel.name} or platforms.all;
+          inherit (provider.meta) license;
         };
         inherit (provider) version pname;
         passthru = {
@@ -75,6 +76,9 @@ let
     runCommand pkgs.less.name
       {
         inherit (pkgs.less) version pname;
+        meta = {
+          inherit (pkgs.less.meta) license;
+        };
       }
       ''
         mkdir -p $out/bin
@@ -268,6 +272,9 @@ let
     pname: paths:
     buildEnv {
       inherit paths pname version;
+      meta = {
+        license = lib.licenses.AND (lib.unique (lib.map (x: x.meta.license) paths));
+      };
     };
 
   # Compatibility derivations


### PR DESCRIPTION
working towards #43716
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
