### PR TITLE
python3Packages.qtile: remove myself from maintainence

### DIFF
--- a/pkgs/development/python-modules/qtile/default.nix
+++ b/pkgs/development/python-modules/qtile/default.nix
@@ -218,7 +218,6 @@ buildPythonPackage (finalAttrs: {
     maintainers = with lib.maintainers; [
       arjan-s
       sigmanificient
-      doronbehar
     ];
   };
 })


### PR DESCRIPTION
Reasons:

- I'm not using it anymore
- Maintenance is hard, because:
  - In their last [0.37.0 release](https://github.com/qtile/qtile/releases/tag/v0.37.0), they included too much AI work which I find to be pretty wrong, see [this commit](https://github.com/qtile/qtile/commit/61e95beb0740f9ef005ce5a2cce8a06b9d1bb738#diff-0c425f8a2a097479df48392f8570510be7aabe75ad2f61f13706c6a86a33f612)
  - Too many tests fail and it becomes too much work to maintain that list of disabled tests. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test