### PR TITLE
rustfs: 1.0.0-beta.12 -> 1.0.0-rc.1

### DIFF
--- a/pkgs/by-name/ru/rustfs/package.nix
+++ b/pkgs/by-name/ru/rustfs/package.nix
@@ -9,13 +9,14 @@
   rustPlatform,
   protobuf,
   cacert,
+  tzdata,
   nixosTests,
 }:
 
 let
   console = stdenv.mkDerivation (finalAttrs: {
     pname = "rustfs-console";
-    version = "0.1.17";
+    version = "0.1.20";
     __structuredAttrs = true;
     __darwinAllowLocalNetworking = true;
 
@@ -23,13 +24,13 @@ let
       owner = "rustfs";
       repo = "console";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-t1NYCSdhCYSRjQ/qp+lFP43/N9UXapGiLN7a0gcUaYU=";
+      hash = "sha256-EUyjYPDkHmD8RRmusFnWsWiKbRRSzZ0c4pbMr+2PJdE=";
     };
 
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname version src;
       fetcherVersion = 4;
-      hash = "sha256-+U4HRaThEeC6jA6dA4UmhJLvANq0IMySOW5ua9m5Q6A=";
+      hash = "sha256-ox4hKm3f4QVpxfx4g0uNDRY7w6O3L3AVz2nmHhs8UHM=";
     };
 
     nativeBuildInputs = [
@@ -51,14 +52,14 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "rustfs";
-  version = "1.0.0-beta.12";
+  version = "1.0.0-rc.1";
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "rustfs";
     repo = "rustfs";
     tag = version;
-    hash = "sha256-u5DhPg0e42IvP5lNyLVh2kBQLEYQz3J5crnTs8mfFms=";
+    hash = "sha256-iVAIsq/SAabdBjnNYLF7oQRagUILRN5HEUumnVqp1CM=";
   };
 
   postPatch = ''
@@ -66,7 +67,7 @@ rustPlatform.buildRustPackage rec {
     cp -rL ${console} ./rustfs/static
   '';
 
-  cargoHash = "sha256-5QpSWlGN0zV6BW6joRyP+Ly6QEVTkHTJUSBBnyYx+EQ=";
+  cargoHash = "sha256-W6+6Ypw9WTbprQbDVbhdvB+hEW71oPOHYQV5bZKtJhc=";
 
   nativeBuildInputs = [
     protobuf
@@ -77,6 +78,8 @@ rustPlatform.buildRustPackage rec {
     RUSTFLAGS = "--cfg tokio_unstable";
     # reqwest loads CA certs even if not used during tests
     SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+    # jiff needs a time zone database to resolve zones like UTC during tests
+    TZDIR = "${tzdata}/share/zoneinfo";
   };
 
   # Only build the main rustfs binary


### PR DESCRIPTION
Diff: https://github.com/rustfs/rustfs/compare/1.0.0-beta.12...1.0.0-rc.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
