### PR TITLE
python3Packages.qtile: 0.36.0 -> 0.37.0

### DIFF
--- a/pkgs/development/python-modules/qtile-extras/default.nix
+++ b/pkgs/development/python-modules/qtile-extras/default.nix
@@ -23,7 +23,7 @@
 }:
 buildPythonPackage (finalAttrs: {
   pname = "qtile-extras";
-  version = "0.36.0";
+  version = "0.37.0";
   # nixpkgs-update: no auto update
   # should be updated alongside with `qtile`
   pyproject = true;
@@ -32,7 +32,7 @@ buildPythonPackage (finalAttrs: {
     owner = "elParaguayo";
     repo = "qtile-extras";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-H2A5Y+ukTkUqjQB5eQVuOMYpf7T8RgQlNlQ25wlWwr8=";
+    hash = "sha256-gaBgB9ylC043EcNviAk/6ZfuocUISurbB4EO/fOhSo4=";
   };
 
   build-system = [ setuptools-scm ];
@@ -72,6 +72,8 @@ buildPythonPackage (finalAttrs: {
     # AttributeError: 'NoneType' object has no attribute 'theta'
     "test_image_size_horizontal"
     "test_image_size_vertical"
+    # Import error
+    "test_init_import_error_no_fallback"
   ];
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/qtile/default.nix
+++ b/pkgs/development/python-modules/qtile/default.nix
@@ -53,7 +53,6 @@
   pytest-asyncio,
   pytest-httpbin,
   pytest-rerunfailures,
-  pytest-xdist,
   writableTmpDirAsHomeHook,
   anyio,
   fontconfig,
@@ -71,7 +70,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "qtile";
-  version = "0.36.0";
+  version = "0.37.0";
   # nixpkgs-update: no auto update
   # should be updated alongside with `qtile-extras`
 
@@ -81,8 +80,12 @@ buildPythonPackage (finalAttrs: {
     owner = "qtile";
     repo = "qtile";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-yFh9h3djV52zdZjPYwOWaMzN9ZNhFdZYyxFJreoJBCk=";
+    hash = "sha256-04oSoqKzr9OKb7xOTmLzRUJl8x6aQzH7t9d4LYlgkO8=";
   };
+
+  patches = [
+    ./restore-generic-desktop-file.patch
+  ];
 
   build-system = [
     setuptools
@@ -154,7 +157,6 @@ buildPythonPackage (finalAttrs: {
     pytest-asyncio
     pytest-httpbin
     pytest-rerunfailures
-    pytest-xdist
     writableTmpDirAsHomeHook
     anyio
     gdk-pixbuf
@@ -176,26 +178,27 @@ buildPythonPackage (finalAttrs: {
   '';
 
   disabledTests = [
-    # caused by dbus-fast trying to read '/var/lib/dbus/machine-id'
-    "test_defaults"
-    "test_device_actions"
-    "test_adapter_actions"
-    "test_statusnotifier_defaults"
-    "test_custom_symbols"
-    "test_statusnotifier_defaults_vertical_bar"
-    "test_default_show_battery"
-    "test_statusnotifier_icon_size"
-    "test_missing_adapter"
-    "test_statusnotifier_left_click"
-    "test_default_text"
-    "test_statusnotifier_left_click_vertical_bar"
-    "test_default_device"
-
+    # Client disconnect prematurely
+    "test_repl_server_executes_code"
+    # Import Error
+    "test_init_import_error_no_fallback"
+    # Misising corresponding device (Headphone / BT)
+    "test_defaults[1-x11]"
+    "test_device_actions[1-x11]"
+    "test_adapter_actions[1-x11]"
+    "test_custom_symbols[1-x11-bluetooth_manager0]"
+    "test_default_show_battery[1-x11-bluetooth_manager0]"
+    "test_missing_adapter[1-x11-bluetooth_manager0]"
+    "test_default_text[1-x11-bluetooth_manager0]"
+    "test_default_device[1-x11-bluetooth_manager0]"
+    # Runtime window has not appeared yet
+    "test_statusnotifier_defaults[1-x11]"
+    "test_statusnotifier_defaults_vertical_bar[1-x11]"
+    "test_statusnotifier_icon_size[1-x11-sni_config0]"
+    "test_statusnotifier_left_click[1-x11]"
+    "test_statusnotifier_left_click_vertical_bar[1-x11]"
     # PermissionError: [Errno 13] Permission denied: '/var'
     "test_thermal_zone_getting_value"
-
-    # Probably won't work in the Nix sandbox due to `xcffib.ConnectionException`
-    "test_urgent_hook_fire"
   ];
 
   passthru = {
@@ -204,8 +207,8 @@ buildPythonPackage (finalAttrs: {
   };
 
   postInstall = ''
-    install resources/qtile.desktop -Dt $out/share/xsessions
-    install resources/qtile-wayland.desktop -Dt $out/share/wayland-sessions
+    install resources/qtile-generic.desktop -Dt $out/share/xsessions
+    install resources/qtile-generic.desktop -Dt $out/share/wayland-sessions
   '';
 
   meta = {

--- a/pkgs/development/python-modules/qtile/restore-generic-desktop-file.patch
+++ b/pkgs/development/python-modules/qtile/restore-generic-desktop-file.patch
@@ -1,0 +1,39 @@
+From 3c3cf5beb4557af2616f3e4e0bdc3d22e7fd1536 Mon Sep 17 00:00:00 2001
+From: Kai Stian Olstad <kai.stian.olstad@gmail.com>
+Date: Sat, 8 Aug 2026 23:47:56 +0200
+Subject: [PATCH] Plain desktop file for distro that does not use systemd
+
+---
+ resources/README                | 4 ++++
+ resources/qtile-generic.desktop | 6 ++++++
+ 2 files changed, 10 insertions(+)
+ create mode 100644 resources/qtile-generic.desktop
+
+diff --git a/resources/README b/resources/README
+index 3e12a454e8..0e4a34d65d 100644
+--- a/resources/README
++++ b/resources/README
+@@ -2,6 +2,10 @@ qtile.desktop: A desktop file for qtile telling session managers about qtile
+     and how to run it. Install it to /usr/share/xsessions (to offer an X11
+     session) and/or /usr/share/wayland-sessions (to offer a Wayland session).
+ 
++qtile-generic.desktop: A qtile desktop file for non sytemd users.
++    Install it to /usr/share/xsessions (to offer an X11 session) and/or
++    /usr/share/wayland-sessions (to offer a Wayland session).
++
+ 99-qtile.rules: udev rules for hardware that qtile can manage
+ 
+ qtile-session.target, qtile.service: systemd user units that start qtile as a
+diff --git a/resources/qtile-generic.desktop b/resources/qtile-generic.desktop
+new file mode 100644
+index 0000000000..0ea0a2fe62
+--- /dev/null
++++ b/resources/qtile-generic.desktop
+@@ -0,0 +1,6 @@
++[Desktop Entry]
++Name=Qtile
++Comment=Qtile Session
++Exec=qtile start
++Type=Application
++Keywords=wm;tiling
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17387,7 +17387,7 @@ self: super: with self; {
 
   qtconsole = callPackage ../development/python-modules/qtconsole { };
 
-  qtile = callPackage ../development/python-modules/qtile { wlroots = pkgs.wlroots_0_19; };
+  qtile = callPackage ../development/python-modules/qtile { wlroots = pkgs.wlroots_0_20; };
 
   qtile-bonsai = callPackage ../development/python-modules/qtile-bonsai { };
 


### PR DESCRIPTION
Incorporate qtile/qtile#6020 because we need it, to avoid doing a refactoring of the module. I have other thing to do than fight with the AI slop that is https://github.com/qtile/qtile/commit/61e95beb0740f9ef005ce5a2cce8a06b9d1bb738 systemd invocation in desktop files

I'll finish this when i have time to wait for the test suite

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
