### PR TITLE
nixos-container: forward --show-trace to nix

### DIFF
--- a/pkgs/by-name/ni/nixos-container/nixos-container.pl
+++ b/pkgs/by-name/ni/nixos-container/nixos-container.pl
@@ -124,6 +124,7 @@ GetOptions(
     "no-allow-dirty" => \&copyNixFlags0,
     "recreate-lock-file" => \&copyNixFlags0,
     "refresh" => \&copyNixFlags0,
+    "show-trace" => \&copyNixFlags0,
     ) or exit 1;
 
 push @nixFlags, @nixFlags2;


### PR DESCRIPTION
Fixed a bug in nixos-container during creating/updating where --show-trace option was offered when crashed but it did not actually work when passed, responding with "unknown option: show-trace".

## Things done

Added "show-trace" => \&copyNixFlags0," to the options list to pass nix flags, which passes show trace.
Fixes #8970

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
