### PR TITLE
python3Packages.python-kadmin-rs: remove explicit pythonImportsCheckHook, modernize

### DIFF
--- a/pkgs/development/python-modules/python-kadmin-rs/default.nix
+++ b/pkgs/development/python-modules/python-kadmin-rs/default.nix
@@ -3,12 +3,11 @@
   pkgs,
   fetchFromGitHub,
   rustPlatform,
-  pythonImportsCheckHook,
   buildPythonPackage,
   pkg-config,
   heimdal,
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "python-kadmin-rs";
   version = "0.7.2";
   pyproject = true;
@@ -16,12 +15,12 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "authentik-community";
     repo = "kadmin-rs";
-    rev = "kadmin/version/${version}";
+    tag = "kadmin/version/${finalAttrs.version}";
     hash = "sha256-zl0N6cIcRFsShKOc3aazYsTlEBXpnymP9nsdaBky1OE=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
+    inherit (finalAttrs) src;
     hash = "sha256-NXPc8hssmMXcmuK15oF5CIV+cUAmRoml6BXYhIkRdvI=";
   };
 
@@ -60,7 +59,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     pkg-config
-    pythonImportsCheckHook
     rustPlatform.bindgenHook
     rustPlatform.cargoSetupHook
     rustPlatform.maturinBuildHook
@@ -73,11 +71,11 @@ buildPythonPackage rec {
   meta = {
     description = "Rust and Python interfaces to the Kerberos administration interface (kadm5)";
     homepage = "https://github.com/authentik-community/kadmin-rs";
-    changelog = "https://github.com/authentik-community/kadmin-rs/releases/tag/kadmin%2Fversion%2F${version}";
+    changelog = "https://github.com/authentik-community/kadmin-rs/releases/tag/kadmin%2Fversion%2F${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       jvanbruegge
       risson
     ];
   };
-}
+})


### PR DESCRIPTION
pythonImportsCheckHook is automatically added via buildPythonPackage.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
