### PR TITLE
scummvm: 2026.1.0 -> 2026.3.0, modernize

### DIFF
--- a/pkgs/by-name/sc/scummvm/package.nix
+++ b/pkgs/by-name/sc/scummvm/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   nasm,
+  pkg-config,
   alsa-lib,
   curl,
   flac,
@@ -31,11 +32,17 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "scummvm";
     repo = "scummvm";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-wFEYg3hRVNVlxpw3xP8O8s4ILKy487k5hyWENaLiOlw=";
   };
 
-  nativeBuildInputs = [ nasm ];
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    nasm
+    pkg-config
+  ];
 
   buildInputs =
     lib.optionals stdenv.hostPlatform.isLinux [
@@ -68,6 +75,10 @@ stdenv.mkDerivation (finalAttrs: {
     "--enable-release"
   ];
 
+  preConfigure = ''
+    PATH="${lib.getDev SDL2}/bin:$PATH"
+  '';
+
   # They use 'install -s', that calls the native strip instead of the cross
   postConfigure = ''
     sed -i "s/-c -s/-c -s --strip-program=''${STRIP@Q}/" ports.mk
@@ -93,10 +104,18 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Program to run certain classic graphical point-and-click adventure games (such as Monkey Island)";
-    mainProgram = "scummvm";
+    longDescription = ''
+      ScummVM is a program which allows you to run a variety of classic
+      graphical point-and-click adventure games and role-playing games,
+      provided you already have their data files. It reimplements the original
+      engines (SCUMM, SCI, AGS, and many more) so those games can be played
+      on systems and hardware they were never designed for.
+    '';
     homepage = "https://www.scummvm.org/";
+    changelog = "https://github.com/scummvm/scummvm/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ peterhoeg ];
+    mainProgram = "scummvm";
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/sc/scummvm/package.nix
+++ b/pkgs/by-name/sc/scummvm/package.nix
@@ -20,18 +20,19 @@
   SDL2,
   zlib,
   cctools,
+  fetchpatch,
   nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "scummvm";
-  version = "2026.1.0";
+  version = "2026.3.0";
 
   src = fetchFromGitHub {
     owner = "scummvm";
     repo = "scummvm";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-wgMOhQ6yHk4dG94J4EdHTxsaCqapyFhJU1GjRuQY8TY=";
+    hash = "sha256-wFEYg3hRVNVlxpw3xP8O8s4ILKy487k5hyWENaLiOlw=";
   };
 
   nativeBuildInputs = [ nasm ];
@@ -75,6 +76,14 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace config.mk \
       --replace-fail ${stdenv.hostPlatform.config}-ranlib ${cctools}/bin/ranlib
   '';
+
+  patches = [
+    # Nancy Drew build error. Remove after next release.
+    (fetchpatch {
+      url = "https://github.com/scummvm/scummvm/commit/e2ef63e84123c199ab55de445e406aa626147e10.patch";
+      hash = "sha256-sdabI0W6Apav/pgGBxY+usHUakxECZtYu2tdyi8gojk=";
+    })
+  ];
 
   env.NIX_CFLAGS_COMPILE = toString [ "-fpermissive" ];
 


### PR DESCRIPTION
Supersedes https://github.com/NixOS/nixpkgs/pull/506742

Bot is currently failing to build on its own: https://nixpkgs-update-logs.nix-community.org/scummvm/

Changelog:

- https://github.com/scummvm/scummvm/releases#release-v2026.3.0
- https://github.com/scummvm/scummvm/releases#release-v2026.2.0

Diff: https://github.com/scummvm/scummvm/compare/v2026.1.0...v2026.3.0

- Bump to latest version
- Modernize the package. Tag, changelog, longDescription. structuredAttrs, strictDeps. 
- Changed build to accommodate for strictDeps. Add pkg-config, add a preConfigure.
- ~Temporarily disable hardening. See comment. This can also be `substituteInPlace` if that's preferred.~ Swapped to fetchpatch.
 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
