### PR TITLE
libp11: set p11-kit proxy as default PKCS#11 module

### DIFF
--- a/pkgs/by-name/li/libp11/package.nix
+++ b/pkgs/by-name/li/libp11/package.nix
@@ -6,6 +6,7 @@
   libtool,
   pkg-config,
   openssl,
+  p11-kit,
 }:
 
 stdenv.mkDerivation rec {
@@ -22,6 +23,12 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--with-enginesdir=${placeholder "out"}/lib/engines"
     "--with-modulesdir=${placeholder "out"}/lib/ossl-module"
+    # Without a default module, the pkcs11 engine/provider is useless unless the
+    # application explicitly configures a PKCS#11 module path, which most don't
+    # (e.g. wpa_supplicant with EAP-TLS client certificates on a smartcard/TPM).
+    # Upstream defaults to the p11-kit proxy, which in turn loads the modules
+    # configured system-wide; it is only skipped when p11-kit is not found.
+    "--with-pkcs11-module=${lib.getLib p11-kit}/lib/p11-kit-proxy.so"
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libp11/package.nix
+++ b/pkgs/by-name/li/libp11/package.nix
@@ -7,6 +7,8 @@
   pkg-config,
   openssl,
   p11-kit,
+  runCommand,
+  libp11,
 }:
 
 stdenv.mkDerivation rec {
@@ -41,7 +43,35 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  passthru = { inherit openssl; };
+  passthru = {
+    inherit openssl;
+
+    tests.default-pkcs11-module =
+      runCommand "libp11-default-pkcs11-module" { nativeBuildInputs = [ (lib.getBin openssl) ]; }
+        ''
+          # The default module path is baked into both the engine and the provider.
+          grep -q "${lib.getLib p11-kit}/lib/p11-kit-proxy.so" ${libp11}/lib/engines/pkcs11.so
+          grep -q "${lib.getLib p11-kit}/lib/p11-kit-proxy.so" ${libp11}/lib/ossl-module/pkcs11prov.so
+
+          export OPENSSL_ENGINES=${libp11}/lib/engines
+          openssl engine -t pkcs11 | grep -F "[ available ]"
+
+          # Loading a key forces the engine to load its PKCS#11 module.
+          # No token is present in the sandbox, so the command fails either way;
+          # assert that the failure is a key lookup failure (the p11-kit proxy
+          # loaded, with zero modules configured) and not a module load failure.
+          openssl pkeyutl -engine pkcs11 -keyform engine \
+            -inkey "pkcs11:object=missing" -sign 2>stderr.log || true
+          cat stderr.log
+          grep -qF "Could not find private key" stderr.log
+          if grep -qF "Unable to load PKCS#11 module" stderr.log; then
+            echo "the pkcs11 engine failed to load its default PKCS#11 module" >&2
+            exit 1
+          fi
+
+          touch $out
+        '';
+  };
 
   meta = {
     description = "Small layer on top of PKCS#11 API to make PKCS#11 implementations easier";


### PR DESCRIPTION
`libp11` is currently built without a default PKCS#11 module. That makes the
pkcs11 engine and provider unusable unless the application passes a module path
explicitly, which most don't — for example `wpa_supplicant` doing EAP-TLS with a
client certificate on a smartcard or TPM has to be rebuilt with
`CONFIG_PKCS11_MODULE_PATH` pointing at one specific module.

Upstream's default is the p11-kit proxy, which is skipped only when p11-kit is
not found at configure time — which is what happens in our sandbox. This sets it
explicitly, so the engine and provider load whatever modules are registered
system-wide via p11-kit instead of nothing.

No new runtime dependency in practice: p11-kit is already in the closure of
most systems using this, and the proxy loads zero modules when none are
registered, so behaviour for existing users is unchanged unless they have a
PKCS#11 module registered — in which case it starts working.

Adds `passthru.tests.default-pkcs11-module`, which checks that the path is baked
into both `pkcs11.so` and `pkcs11prov.so`, that the engine loads, and that
loading a key fails with "Could not find private key" (proxy loaded, no tokens)
rather than "Unable to load PKCS#11 module".

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
