### PR TITLE
nixos/tpm2: register pkcs11 module with p11-kit

### DIFF
--- a/nixos/modules/security/tpm2.nix
+++ b/nixos/modules/security/tpm2.nix
@@ -273,6 +273,23 @@ in
           (lib.getLib cfg.pkcs11.package)
         ];
 
+        # Register the module with p11-kit, so that PKCS#11 consumers going
+        # through the p11-kit proxy (e.g. the OpenSSL pkcs11 engine/provider
+        # from libp11, GnuTLS, Firefox) discover the TPM2 token without
+        # per-application module path configuration.
+        # Upstream ships this registration and installs it into p11-kit's
+        # module config directory, as queried from p11-kit's pkg-config; see
+        # https://github.com/tpm2-software/tpm2-pkcs11/blob/1.10.1/misc/p11-kit/tpm2_pkcs11.module
+        # On NixOS that directory is p11-kit's own immutable store path, so
+        # the file never reaches the p11-kit actually in use. Register the
+        # module in the system config directory instead (/etc/pkcs11, from
+        # p11-kit's --sysconfdir=/etc), which p11-kit reads at runtime.
+        environment.etc."pkcs11/modules/tpm2_pkcs11.module" = lib.mkIf cfg.pkcs11.enable {
+          text = ''
+            module: ${lib.getLib cfg.pkcs11.package}/lib/libtpm2_pkcs11.so
+          '';
+        };
+
         services.udev.extraRules = lib.mkIf cfg.applyUdevRules (udevRules cfg.tssUser cfg.tssGroup);
 
         # Create the tss user and group only if the default value is used

--- a/nixos/tests/tpm2/tpm2-abrmd.nix
+++ b/nixos/tests/tpm2/tpm2-abrmd.nix
@@ -32,12 +32,23 @@
       environment.systemPackages = [
         pkgs.tpm2-tools
         pkgs.openssl
+        pkgs.p11-kit
+        pkgs.opensc
       ];
     };
 
   testScript = ''
     machine.start()
     machine.wait_for_unit("multi-user.target")
+
+    with subtest("p11-kit discovers the tpm2_pkcs11 module"):
+        machine.succeed("p11-kit list-modules | grep 'library-description: TPM2.0 Cryptoki'")
+
+    with subtest("TPM2 token is reachable through the p11-kit proxy"):
+        machine.succeed(
+            "pkcs11-tool --module ${lib.getLib pkgs.p11-kit}/lib/p11-kit-proxy.so --list-slots"
+            " | grep 'token state'"
+        )
 
     with subtest("/dev/tpmrm0 has correct ownership"):
         machine.succeed('[ `stat -c "%U" /dev/tpmrm0` = "tss" ]')

--- a/nixos/tests/tpm2/tpm2-tpmrm.nix
+++ b/nixos/tests/tpm2/tpm2-tpmrm.nix
@@ -30,12 +30,23 @@
       environment.systemPackages = [
         pkgs.tpm2-tools
         pkgs.openssl
+        pkgs.p11-kit
+        pkgs.opensc
       ];
     };
 
   testScript = ''
     machine.start()
     machine.wait_for_unit("multi-user.target")
+
+    with subtest("p11-kit discovers the tpm2_pkcs11 module"):
+        machine.succeed("p11-kit list-modules | grep 'library-description: TPM2.0 Cryptoki'")
+
+    with subtest("TPM2 token is reachable through the p11-kit proxy"):
+        machine.succeed(
+            "pkcs11-tool --module ${lib.getLib pkgs.p11-kit}/lib/p11-kit-proxy.so --list-slots"
+            " | grep 'token state'"
+        )
 
     with subtest("/dev/tpmrm0 has correct ownership"):
         machine.succeed('[ `stat -c "%U" /dev/tpmrm0` = "root" ]')


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

Related: https://github.com/NixOS/nixpkgs/pull/550646

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
