### PR TITLE
nixos/wireless: add pkcs11 option for smartcard/TPM EAP-TLS

### DIFF
--- a/nixos/doc/manual/configuration/wireless.section.md
+++ b/nixos/doc/manual/configuration/wireless.section.md
@@ -214,8 +214,15 @@ Certificates and other files supplied here need to be readable by the
 `wpa_supplicant` user; it is therefore recommended to store them in the
 `/etc/wpa_supplicant` directory.
 
-If your network authentication protocol requires write access to files, smart
-cards or TPM devices, you may have to disable security hardening with
+With [](#opt-networking.wireless.pkcs11.enable), the default tpm2-pkcs11
+database directory `/etc/tpm2_pkcs11` is available inside the sandbox. A
+database in another location must be added explicitly:
+```nix
+{ systemd.services.wpa_supplicant.serviceConfig.BindPaths = [ "/var/lib/tpm2_pkcs11" ]; }
+```
+
+If your network authentication protocol requires other access that cannot be
+granted explicitly, you may have to disable security hardening with
 ```nix
 { networking.wireless.enableHardening = false; }
 ```

--- a/nixos/modules/security/tpm2.nix
+++ b/nixos/modules/security/tpm2.nix
@@ -290,6 +290,13 @@ in
           '';
         };
 
+        # Give rw access for tss group to tpm2-pkcs11's system-wide token store.
+        # Consumers like tpm2-pkcs11 refuses to use a store they cannot lock and update.
+        systemd.tmpfiles.rules = lib.mkIf (cfg.pkcs11.enable && cfg.tssGroup != null) [
+          "d /etc/tpm2_pkcs11 2770 root ${cfg.tssGroup} -"
+          "Z /etc/tpm2_pkcs11 ~2770 - ${cfg.tssGroup} -"
+        ];
+
         services.udev.extraRules = lib.mkIf cfg.applyUdevRules (udevRules cfg.tssUser cfg.tssGroup);
 
         # Create the tss user and group only if the default value is used

--- a/nixos/modules/services/networking/wpa_supplicant.nix
+++ b/nixos/modules/services/networking/wpa_supplicant.nix
@@ -115,6 +115,22 @@ let
       stopIfChanged = false;
       restartTriggers = [ config.environment.etc."wpa_supplicant/nixos.conf".source ];
 
+      # OpenSSL's dynamic engine loader only searches its own store path,
+      # which does not contain the pkcs11 engine (it is built separately,
+      # in libp11), so ENGINE_by_id("pkcs11") fails unless the search path
+      # is redirected to the libp11 package
+      environment = lib.optionalAttrs cfg.pkcs11.enable (
+        {
+          OPENSSL_ENGINES = "${cfg.pkcs11.package}/lib/engines";
+        }
+        # security.tpm2.tctiEnvironment exports its variables only to login
+        # shells, not to systemd units, so mirror the TCTI selection here for
+        # the TPM2 PKCS11 module
+        // lib.optionalAttrs config.security.tpm2.tctiEnvironment.enable {
+          inherit (config.environment.variables) TPM2_PKCS11_TCTI;
+        }
+      );
+
       path = [ pkgs.wpa_supplicant ];
       serviceConfig = {
         RuntimeDirectory = "wpa_supplicant";
@@ -615,6 +631,48 @@ in
           access to mutable files, smart cards or TPM devices).
           :::
         '';
+      };
+
+      pkcs11 = {
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Whether to make the OpenSSL pkcs11 engine available to
+            wpa_supplicant, for EAP-TLS authentication with client keys on
+            PKCS#11 tokens such as smartcards or a TPM.
+
+            ::: {.note}
+            Hardware-backed tokens usually also require disabling
+            {option}`networking.wireless.enableHardening`, since the hardened
+            service cannot access device nodes such as the TPM.
+            :::
+
+            ::: {.note}
+            wpa_supplicant loads the engine through OpenSSL's dynamic engine
+            mechanism, which only searches OpenSSL's own store path;
+            This option points the search path (the `OPENSSL_ENGINES` environment
+            variable) at the configured libp11 package instead,
+            which shadows OpenSSL's built-in engine directory rather than extending it.
+
+            wpa_supplicant never requests the engines shipped there (afalg,
+            capi, loader_attic, padlock), so this is normally invisible.
+            A configuration that nevertheless loads one of them by name
+            inside this service (e.g. through a custom `OPENSSL_CONF`) can
+            restore the union of both directories:
+
+            ```nix
+            networking.wireless.pkcs11.package = pkgs.symlinkJoin {
+              name = "wpa-supplicant-engines";
+              paths = [ pkgs.libp11 ];
+              postBuild = "ln -s ''${pkgs.openssl.out}/lib/engines-3/*.so $out/lib/engines/";
+            };
+            ```
+            :::
+          '';
+        };
+
+        package = mkPackageOption pkgs "libp11" { };
       };
 
       extraConfig = mkOption {

--- a/nixos/modules/services/networking/wpa_supplicant.nix
+++ b/nixos/modules/services/networking/wpa_supplicant.nix
@@ -170,14 +170,27 @@ let
           "/dev/rfkill"
         ]
         ++ lib.optional cfg.dbusControlled "/run/dbus"
-        ++ lib.optional cfg.allowAuxiliaryImperativeNetworks "/etc/wpa_supplicant";
+        ++ lib.optional cfg.allowAuxiliaryImperativeNetworks "/etc/wpa_supplicant"
+        # token access for the PKCS#11 backends
+        ++ lib.optionals cfg.pkcs11.enable [
+          "-${config.security.tpm2.tctiEnvironment.deviceConf}"
+          "-/run/pcscd"
+          "-/etc/tpm2_pkcs11"
+        ];
         BindReadOnlyPaths = [
           builtins.storeDir
           "/etc/"
         ]
         ++ cfg.extraConfigFiles
         ++ lib.optional (cfg.secretsFile != null) cfg.secretsFile;
-        DeviceAllow = "/dev/rfkill rw";
+        DeviceAllow = [
+          "/dev/rfkill rw"
+        ]
+        ++ lib.optional cfg.pkcs11.enable "${config.security.tpm2.tctiEnvironment.deviceConf} rw";
+        # Grant tss group for tpm2 access if pkcs11 is enabled.
+        SupplementaryGroups = lib.optional (
+          cfg.pkcs11.enable && config.security.tpm2.enable && config.security.tpm2.tssGroup != null
+        ) config.security.tpm2.tssGroup;
         LockPersonality = true;
         MemoryDenyWriteExecute = true;
         NoNewPrivileges = true;
@@ -643,9 +656,19 @@ in
             PKCS#11 tokens such as smartcards or a TPM.
 
             ::: {.note}
-            Hardware-backed tokens usually also require disabling
-            {option}`networking.wireless.enableHardening`, since the hardened
-            service cannot access device nodes such as the TPM.
+            With {option}`networking.wireless.enableHardening` enabled,
+            the service is additionally granted:
+              - Membership in {option}`security.tpm2.tssGroup`.
+              - Access to the TPM device configured by
+                {option}`security.tpm2.tctiEnvironment.deviceConf`.
+              - pcscd socket for smartcard readers.
+              - Access to default system-wide token store `/etc/tpm2_pkcs11`.
+                Note that the hardened service by default has no home directory,
+                so only the system store location applies.
+
+            The store must be writable by {option}`security.tpm2.tssGroup`.
+            Enable {option}`security.tpm2.pkcs11.enable` option to grant
+            tss group access to the store.
             :::
 
             ::: {.note}

--- a/nixos/modules/services/networking/wpa_supplicant.nix
+++ b/nixos/modules/services/networking/wpa_supplicant.nix
@@ -147,6 +147,11 @@ let
             "+${pkgs.coreutils}/bin/mkdir -p /run/wpa_supplicant/client"
             "+${pkgs.coreutils}/bin/chown wpa_supplicant:wpa_supplicant /run/wpa_supplicant/client"
             "+${pkgs.coreutils}/bin/chmod g=u /run/wpa_supplicant/client"
+          ]
+          ++ lib.optionals (cfg.enableHardening && cfg.pkcs11.enable) [
+            # tpm2-pkcs11 refuses to use a token store it cannot write.
+            "-+${pkgs.coreutils}/bin/chgrp --recursive wpa_supplicant /etc/tpm2_pkcs11"
+            "-+${pkgs.coreutils}/bin/chmod --recursive g+w /etc/tpm2_pkcs11"
           ];
       }
       // lib.optionalAttrs cfg.enableHardening {
@@ -170,14 +175,27 @@ let
           "/dev/rfkill"
         ]
         ++ lib.optional cfg.dbusControlled "/run/dbus"
-        ++ lib.optional cfg.allowAuxiliaryImperativeNetworks "/etc/wpa_supplicant";
+        ++ lib.optional cfg.allowAuxiliaryImperativeNetworks "/etc/wpa_supplicant"
+        # token access for the PKCS#11 backends
+        ++ lib.optionals cfg.pkcs11.enable [
+          "-/dev/tpmrm0"
+          "-/run/pcscd"
+          "-/etc/tpm2_pkcs11"
+        ];
         BindReadOnlyPaths = [
           builtins.storeDir
           "/etc/"
         ]
         ++ cfg.extraConfigFiles
         ++ lib.optional (cfg.secretsFile != null) cfg.secretsFile;
-        DeviceAllow = "/dev/rfkill rw";
+        DeviceAllow = [
+          "/dev/rfkill rw"
+        ]
+        ++ lib.optional cfg.pkcs11.enable "/dev/tpmrm0 rw";
+        # Grant tss group for tpm2 access if pkcs11 is enabled.
+        SupplementaryGroups = lib.optional (
+          cfg.pkcs11.enable && config.security.tpm2.enable && config.security.tpm2.tssGroup != null
+        ) config.security.tpm2.tssGroup;
         LockPersonality = true;
         MemoryDenyWriteExecute = true;
         NoNewPrivileges = true;
@@ -643,9 +661,15 @@ in
             PKCS#11 tokens such as smartcards or a TPM.
 
             ::: {.note}
-            Hardware-backed tokens usually also require disabling
-            {option}`networking.wireless.enableHardening`, since the hardened
-            service cannot access device nodes such as the TPM.
+            With {option}`networking.wireless.enableHardening` enabled, the
+            service is additionally granted access to the kernel TPM resource
+            manager (`/dev/tpmrm0`, including membership in
+            {option}`security.tpm2.tssGroup`) and to the pcscd socket for
+            smartcard readers. The hardened service has no home directory,
+            so a tpm2-pkcs11 token store must reside at tpm2-pkcs11's
+            built-in fallback location `/etc/tpm2_pkcs11`. The store is made
+            group-writable to the service at each start: tpm2-pkcs11 refuses
+            to use a store it cannot lock and update.
             :::
 
             ::: {.note}

--- a/nixos/tests/networking/networkmanager.nix
+++ b/nixos/tests/networking/networkmanager.nix
@@ -32,6 +32,9 @@ let
     openssl x509 -req -in client1.csr -CA $out/ca.cert -CAkey $out/ca.key \
       -days 365000 -set_serial 101 -out $out/client1.cert
   '';
+  eapWifiSsid = "NixOS EAP";
+  vwifiPort = 8212;
+  vwifiServerAddress = "192.168.1.2";
 
   # this is intended as a client test since you shouldn't use NetworkManager for a router or server
   # so using systemd-networkd for the router vm is fine in these tests.
@@ -296,6 +299,261 @@ let
         router.wait_for_unit("hostapd.service")
         router.wait_until_succeeds("journalctl -b --unit freeradius.service --grep='Sent Access-Accept'")
         router.wait_until_succeeds("journalctl -b --unit freeradius.service --grep='TLS-Client-Cert-Common-Name = \"client1.example.com\"'")
+      '';
+    };
+    eapPkcs11 = {
+      name = "eap / 802.1x over vwifi with a TPM-backed PKCS#11 private key";
+      nodes = {
+        airgap = {
+          networking = {
+            useDHCP = false;
+            interfaces.eth1.ipv4.addresses = lib.mkForce [
+              {
+                address = vwifiServerAddress;
+                prefixLength = 24;
+              }
+            ];
+          };
+          services.vwifi.server = {
+            enable = true;
+            ports.tcp = vwifiPort;
+            openFirewall = true;
+          };
+          virtualisation.vlans = [ 1 ];
+        };
+        router = {
+          imports = [
+            (import ./router-eap.nix {
+              inherit eapCerts;
+              wifi = {
+                interface = "wlan0";
+                ssid = eapWifiSsid;
+              };
+            })
+          ];
+          services.vwifi = {
+            module = {
+              enable = true;
+              macPrefix = "74:F8:F6:00:01";
+            };
+            client = {
+              enable = true;
+              serverAddress = vwifiServerAddress;
+              serverPort = vwifiPort;
+            };
+          };
+        };
+        client = clientConfig {
+          environment = {
+            etc = {
+              "wpa_supplicant/ca.cert" = {
+                source = "${eapCerts}/ca.cert";
+                user = "wpa_supplicant";
+                mode = "0400";
+              };
+              "wpa_supplicant/client1.cert" = {
+                source = "${eapCerts}/client1.cert";
+                user = "wpa_supplicant";
+                mode = "0400";
+              };
+            };
+            systemPackages = [
+              pkgs.opensc
+              pkgs.p11-kit
+            ];
+          };
+
+          networking = {
+            interfaces = lib.mkForce {
+              eth1.ipv4.addresses = [
+                {
+                  address = "192.168.1.3";
+                  prefixLength = 24;
+                }
+              ];
+            };
+            networkmanager = {
+              unmanaged = [ "eth1" ];
+              ensureProfiles.profiles.default = {
+                connection = {
+                  type = "wifi";
+                  interface-name = "wlan0";
+                };
+                wifi = {
+                  ssid = eapWifiSsid;
+                  mode = "infrastructure";
+                };
+                wifi-security.key-mgmt = "wpa-eap";
+                ipv4.method = "disabled";
+                ipv6.method = "disabled";
+                "802-1x" = {
+                  eap = "tls";
+                  identity = "client1.example.com";
+                  ca-cert = "/etc/wpa_supplicant/ca.cert";
+                  client-cert = "/etc/wpa_supplicant/client1.cert";
+                  private-key = "pkcs11:token=eap;object=client1;type=private";
+                  private-key-password = "userpin";
+                };
+              };
+            };
+            wireless = {
+              enable = lib.mkOverride 9 true;
+              driver = "nl80211";
+              pkcs11 = {
+                enable = true;
+                package = pkgs.libp11.overrideAttrs {
+                  # TODO: Remove this override once a libp11 release includes the fix for
+                  # https://github.com/OpenSC/libp11/issues/672
+                  version = "0.4.21-unstable-2026-08-19";
+                  src = pkgs.fetchFromGitHub {
+                    owner = "OpenSC";
+                    repo = "libp11";
+                    rev = "e72a2014eb078c7b784e2a9be3e7abd3dce8fd5a";
+                    hash = "sha256-V9ZRPUJp2FkK+Zb/qYC13SDE7+oyJ/hlnO/XEN2zDD8=";
+                  };
+                };
+              };
+            };
+          };
+
+          security.tpm2 = {
+            enable = true;
+            pkcs11.enable = true;
+            tctiEnvironment = {
+              enable = true;
+              deviceConf = "/dev/tpmrm-test";
+            };
+          };
+
+          services.udev.extraRules = ''
+            KERNEL=="tpmrm0", SYMLINK+="tpmrm-test"
+          '';
+
+          services.vwifi = {
+            module = {
+              enable = true;
+              macPrefix = "74:F8:F6:00:02";
+            };
+            client = {
+              enable = true;
+              serverAddress = vwifiServerAddress;
+              serverPort = vwifiPort;
+            };
+          };
+
+          systemd.services.tpm2-pkcs11-provision = {
+            description = "Provision the TPM2 PKCS#11 token for EAP-TLS";
+            requiredBy = [
+              "NetworkManager.service"
+              "wpa_supplicant.service"
+            ];
+            before = [
+              "NetworkManager.service"
+              "wpa_supplicant.service"
+            ];
+            requires = [ "dev-tpmrm0.device" ];
+            after = [
+              "dev-tpmrm0.device"
+              "systemd-tmpfiles-setup.service"
+            ];
+            path = [
+              pkgs.tpm2-pkcs11
+              pkgs.tpm2-tools
+            ];
+            environment = {
+              TPM2TOOLS_TCTI = "device:/dev/tpmrm-test";
+              TPM2_PKCS11_STORE = "/etc/tpm2_pkcs11";
+            };
+            serviceConfig = {
+              Type = "oneshot";
+              RemainAfterExit = true;
+              User = "wpa_supplicant";
+              Group = "wpa_supplicant";
+              SupplementaryGroups = [ "tss" ];
+            };
+            script = ''
+              test -c /dev/tpmrm-test
+              tpm2_ptool init \
+                --transient-parent=tpm2-tools-ecc-default \
+                --path="$TPM2_PKCS11_STORE"
+              tpm2_ptool addtoken \
+                --pid=1 \
+                --sopin=sopin \
+                --userpin=userpin \
+                --label=eap \
+                --path="$TPM2_PKCS11_STORE"
+              tpm2_ptool import \
+                --privkey=${eapCerts}/client1.key \
+                --algorithm=rsa \
+                --label=eap \
+                --key-label=client1 \
+                --userpin=userpin \
+                --path="$TPM2_PKCS11_STORE"
+            '';
+          };
+
+          virtualisation = {
+            tpm.enable = true;
+            vlans = [ 1 ];
+          };
+        };
+      };
+
+      testScript = ''
+        from datetime import timedelta
+
+        airgap.start()
+        airgap.wait_for_unit("vwifi-server.service")
+        airgap.wait_for_open_port(${toString vwifiPort})
+
+        router.start()
+        router.wait_for_unit("vwifi-client.service")
+        router.wait_for_unit("freeradius.service")
+        router.wait_for_unit("hostapd.service")
+
+        client.start()
+        client.wait_for_unit("vwifi-client.service")
+        client.wait_for_unit("tpm2-pkcs11-provision.service")
+        client.wait_for_unit("NetworkManager.service")
+        client.wait_for_unit("wpa_supplicant.service")
+
+        with subtest("The hardened supplicant can access the configured TPM device"):
+            client.succeed("systemctl cat wpa_supplicant.service | grep -F -- '-/dev/tpmrm-test'")
+            client.succeed("systemctl cat wpa_supplicant.service | grep -F 'DeviceAllow=/dev/tpmrm-test rw'")
+            client.succeed("systemctl show wpa_supplicant.service --property=SupplementaryGroups --value | grep -qw tss")
+
+        with subtest("The supplicant receives the PKCS#11 environment"):
+            client.succeed("systemctl show wpa_supplicant.service --property=Environment --value | grep -F 'OPENSSL_ENGINES='")
+            client.succeed("systemctl show wpa_supplicant.service --property=Environment --value | grep -F 'TPM2_PKCS11_TCTI=device:/dev/tpmrm-test'")
+
+        with subtest("The TPM-backed private key is available through p11-kit"):
+            client.succeed(
+                "TPM2_PKCS11_STORE=/etc/tpm2_pkcs11 "
+                "TPM2_PKCS11_TCTI=device:/dev/tpmrm-test "
+                "pkcs11-tool --module ${lib.getLib pkgs.p11-kit}/lib/p11-kit-proxy.so "
+                "--token-label=eap --login --pin=userpin --list-objects --type=privkey "
+                "| grep -F client1"
+            )
+
+        with subtest("The station connects to the hostapd access point over vwifi"):
+            client.wait_until_succeeds(
+                "journalctl -b --unit wpa_supplicant.service --grep='wlan0: CTRL-EVENT-CONNECTED'",
+                timeout=timedelta(seconds=120),
+            )
+            client.succeed(
+                "nmcli --terse --fields NAME,DEVICE connection show --active "
+                "| grep -Fx 'default:wlan0'"
+            )
+
+        with subtest("EAP-TLS authenticates with the TPM-backed private key"):
+            router.wait_until_succeeds(
+                "journalctl -b --unit freeradius.service --grep='Sent Access-Accept'",
+                timeout=timedelta(seconds=120),
+            )
+            router.wait_until_succeeds(
+                "journalctl -b --unit freeradius.service --grep='TLS-Client-Cert-Common-Name = \"client1.example.com\"'",
+                timeout=timedelta(seconds=120),
+            )
       '';
     };
   };

--- a/nixos/tests/networking/router-eap.nix
+++ b/nixos/tests/networking/router-eap.nix
@@ -70,6 +70,37 @@ let
     };
   inherit (pkgs) lib;
   vlanIfs = lib.range 1 (lib.length config.virtualisation.vlans);
+  # The hostapd module is Wi-Fi focused, so retain a custom service for wired EAP tests.
+  wiredHostapdService =
+    let
+      hostapdConfig = builtins.toFile "hostapd.conf" ''
+        interface=eth1
+        driver=wired
+        logger_stdout=-1
+        logger_stdout_level=1
+        debug=2
+        dump_file=/tmp/hostapd.dump
+        ieee8021x=1
+        eap_reauth_period=3600
+        use_pae_group_addr=1
+        ##### RADIUS configuration ####################################################
+        own_ip_addr=127.0.0.1
+        nas_identifier=ap.example.com
+        auth_server_addr=127.0.0.1
+        auth_server_port=1812
+        auth_server_shared_secret=insecure
+      '';
+    in
+    {
+      description = "IEEE 802.11 Host Access-Point Daemon";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = "${pkgs.hostapd}/bin/hostapd ${hostapdConfig}";
+        Restart = "always";
+        ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+        RuntimeDirectory = "hostapd";
+      };
+    };
 in
 {
   virtualisation.vlans = [
@@ -112,35 +143,5 @@ in
     debug = true;
   };
 
-  # upstream nixpkgs hostapd is focused on Wifi
-  systemd.services.hostapd =
-    let
-      hostapdConfig = builtins.toFile "hostapd.conf" ''
-        interface=eth1
-        driver=wired
-        logger_stdout=-1
-        logger_stdout_level=1
-        debug=2
-        dump_file=/tmp/hostapd.dump
-        ieee8021x=1
-        eap_reauth_period=3600
-        use_pae_group_addr=1
-        ##### RADIUS configuration ####################################################
-        own_ip_addr=127.0.0.1
-        nas_identifier=ap.example.com
-        auth_server_addr=127.0.0.1
-        auth_server_port=1812
-        auth_server_shared_secret=insecure
-      '';
-    in
-    {
-      description = "IEEE 802.11 Host Access-Point Daemon";
-      wantedBy = [ "multi-user.target" ];
-      serviceConfig = {
-        ExecStart = "${pkgs.hostapd}/bin/hostapd ${hostapdConfig}";
-        Restart = "always";
-        ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
-        RuntimeDirectory = "hostapd";
-      };
-    };
+  systemd.services.hostapd = wiredHostapdService;
 }

--- a/nixos/tests/networking/router-eap.nix
+++ b/nixos/tests/networking/router-eap.nix
@@ -1,4 +1,7 @@
-{ eapCerts }:
+{
+  eapCerts,
+  wifi ? null,
+}:
 { config, pkgs, ... }:
 let
   radiusDir =
@@ -143,5 +146,41 @@ in
     debug = true;
   };
 
-  systemd.services.hostapd = wiredHostapdService;
+  services.hostapd = lib.mkIf (wifi != null) {
+    enable = true;
+    radios.${wifi.interface} = {
+      channel = 1;
+      networks.${wifi.interface} = {
+        inherit (wifi) ssid;
+        authentication.mode = "none";
+        settings = {
+          ieee8021x = true;
+          wpa = 2;
+          wpa_key_mgmt = "WPA-EAP";
+          rsn_pairwise = "CCMP";
+          eap_reauth_period = 3600;
+          own_ip_addr = "127.0.0.1";
+          nas_identifier = "ap.example.com";
+          auth_server_addr = "127.0.0.1";
+          auth_server_port = 1812;
+          auth_server_shared_secret = "insecure";
+        };
+      };
+    };
+  };
+
+  systemd.services.hostapd =
+    if wifi == null then
+      wiredHostapdService
+    else
+      {
+        after = [
+          "freeradius.service"
+          "vwifi-client.service"
+        ];
+        wants = [
+          "freeradius.service"
+          "vwifi-client.service"
+        ];
+      };
 }


### PR DESCRIPTION
Adds `networking.wireless.pkcs11.enable`, for EAP-TLS with the client private
key on a PKCS#11 token — a smartcard, or a TPM via tpm2-pkcs11.

wpa_supplicant already supports engine-backed keys (`engine=1`,
`engine_id="pkcs11"`, `key_id=` in a network block). What's missing is that it
cannot find the engine: it loads it through OpenSSL's dynamic engine mechanism,
which searches only OpenSSL's own store path, and the pkcs11 engine is built
separately in `libp11`. Today the only way out is rebuilding wpa_supplicant
with `CONFIG_PKCS11_ENGINE_PATH` pointed at libp11. This option instead sets
`OPENSSL_ENGINES` for the unit, so a stock wpa_supplicant works.

Two more things are needed for TPM keys, both handled by the option:

- `security.tpm2.tctiEnvironment` exports `TPM2_PKCS11_TCTI` to login shells
  only, never to systemd units, so the unit mirrors it.
- With `networking.wireless.enableHardening`, the service is sandboxed away
  from the token. It now additionally gets `/dev/tpmrm0` (plus membership in
  `security.tpm2.tssGroup`), the pcscd socket for readers, and
  `/etc/tpm2_pkcs11` — tpm2-pkcs11's built-in fallback store location, which
  is what applies here since the hardened service has no home directory.

Usage:

```nix
networking.wireless = {
  pkcs11.enable = true;
  networks."example".auth = ''
    key_mgmt=WPA-EAP
    eap=TLS
    engine=1
    engine_id="pkcs11"
    key_id="pkcs11:object=mykey;type=private"
    ...
  '';
};
```

Third of a series making this work out of the box: #550646 (give libp11 a
default PKCS#11 module) → #550647 (register the tpm2 module with p11-kit) →
this. With the first two in place, `key_id` above resolves through p11-kit
with no module path configured anywhere.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

Related: https://github.com/NixOS/nixpkgs/pull/550646 https://github.com/NixOS/nixpkgs/pull/550647

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
