### PR TITLE
rmatrix: init at 0.3.3

### DIFF
--- a/pkgs/by-name/rm/rmatrix/package.nix
+++ b/pkgs/by-name/rm/rmatrix/package.nix
@@ -1,0 +1,33 @@
+{
+  rustPlatform,
+  fetchFromGitHub,
+  lib,
+  versionCheckHook,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rmatrix";
+  version = "0.3.3";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Tripstack-Corp";
+    repo = "rmatrix";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-sViNj7paMY/3x9u6dKHKf+XQRgv+EYsYsooZSTAwrA4=";
+  };
+
+  cargoHash = "sha256-em16fNb4BZeTsZuaT5Bu/u2cc75iSjOcSDYU0qazefM=";
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    description = "Digital rain for modern terminals";
+    maintainers = with lib.maintainers; [ yarn ];
+    platforms = lib.platforms.all;
+    license = lib.licenses.mit;
+    homepage = "https://github.com/Tripstack-Corp/rmatrix";
+    mainProgram = "rmatrix";
+  };
+})


### PR DESCRIPTION
https://github.com/Tripstack-Corp/rmatrix
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
