### PR TITLE
[staging-next] alsa-plugins: fix build with ffmpeg 9

### DIFF
--- a/pkgs/by-name/al/alsa-plugins/package.nix
+++ b/pkgs/by-name/al/alsa-plugins/package.nix
@@ -1,6 +1,7 @@
 {
   stdenv,
   fetchurl,
+  fetchpatch,
   lib,
   pkg-config,
   alsa-lib,
@@ -20,6 +21,14 @@ stdenv.mkDerivation (finalAttrs: {
     url = "mirror://alsa/plugins/alsa-plugins-${finalAttrs.version}.tar.bz2";
     hash = "sha256-e9ioPTBOji2GoliV2Nyw7wJFqN8y4nGVnNvcavObZvI=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "ffmpeg-9-compatibility.patch";
+      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/alsa-plugins/-/raw/7f250af93b76e9b3d552af509beb8ea1356114d1/ffmpeg9.patch";
+      hash = "sha256-heAl6Ym3iYI8mhuuQpwBpc0FeFYsQZRHx4UUvqiVtBo=";
+    })
+  ];
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/by-name/al/alsa-plugins/package.nix
+++ b/pkgs/by-name/al/alsa-plugins/package.nix
@@ -4,8 +4,7 @@
   lib,
   pkg-config,
   alsa-lib,
-  # FIXME: unpin when upstream supports ffmpeg 9
-  ffmpeg_8,
+  ffmpeg,
   libjack2,
   libogg,
   libpulseaudio,
@@ -26,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     alsa-lib
-    ffmpeg_8
+    ffmpeg
     libjack2
     libogg
     libpulseaudio


### PR DESCRIPTION
failing build logs: https://hydra.nixos.org/build/341407667

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
