### PR TITLE
linuxPackages.drbd: mark as not broken

### DIFF
--- a/pkgs/by-name/dr/drbd/driver.nix
+++ b/pkgs/by-name/dr/drbd/driver.nix
@@ -56,6 +56,5 @@ stdenv.mkDerivation (finalAttrs: {
       DRBD is a software-based, shared-nothing, replicated storage solution
       mirroring the content of block devices (hard disks, partitions, logical volumes, and so on) between hosts.
     '';
-    broken = kernel.kernelOlder "6.19" && kernel.kernelAtLeast "6.18";
   };
 })


### PR DESCRIPTION
this was marked as universally broken for 6.18, but builds+works fine now

amends #527222 (rebase of #515561)

~~not sure if it's even worth to keep the version filter in this form, or just drop it because nobody using kernel pkgs from nixpkgs would ever run into this again. lmk what you think~~
Since nixpkgs ships 6.18.43 for 6.18 now, we can drop the conditional

cc from previous PR(s): @birkb @SuperSandro2000 @samestep 

Analysis on which specific kernel version fixes this by opus 5 via claude code. relevant changelog is https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.18.39 (backport commit: `2dca62902eb3501432ee9bd098fce878cfbb2c1a`) but beyond my comprehension. I do actively use drbd and it seems fine on 6.18.42 via nixos-unstable, so I'm inclined to believe it.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
