### PR TITLE
imlib2Full: enable JPEG 2000 support

### DIFF
--- a/pkgs/by-name/im/imlib2/package.nix
+++ b/pkgs/by-name/im/imlib2/package.nix
@@ -10,6 +10,7 @@
   libwebp,
   libjxl,
   libspectre,
+  openjpeg,
   # imlib2 can load images from ID3 tags.
   libid3tag,
   librsvg,
@@ -23,6 +24,7 @@
   heifSupport ? false,
   jxlSupport ? false,
   psSupport ? false,
+  j2kSupport ? false,
 
   # for passthru.tests
   libcaca,
@@ -68,7 +70,8 @@ stdenv.mkDerivation (finalAttrs: {
   ++ optional svgSupport librsvg
   ++ optional webpSupport libwebp
   ++ optional jxlSupport libjxl
-  ++ optional psSupport libspectre;
+  ++ optional psSupport libspectre
+  ++ optional j2kSupport openjpeg;
 
   nativeBuildInputs = [ pkg-config ];
 
@@ -80,6 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
     optional stdenv.hostPlatform.isDarwin "--enable-amd64=no"
     ++ optional (!svgSupport) "--without-svg"
     ++ optional (!heifSupport) "--without-heif"
+    ++ optional (!j2kSupport) "--without-j2k"
     ++ optional (!x11Support) "--without-x";
 
   outputs = [

--- a/pkgs/by-name/im/imlib2Full/package.nix
+++ b/pkgs/by-name/im/imlib2Full/package.nix
@@ -1,0 +1,12 @@
+{ imlib2, stdenv }:
+
+imlib2.override {
+  # Compilation error on Darwin with librsvg. For more information see:
+  # https://github.com/NixOS/nixpkgs/pull/166452#issuecomment-1090725613
+  svgSupport = !stdenv.hostPlatform.isDarwin;
+  heifSupport = !stdenv.hostPlatform.isDarwin;
+  webpSupport = true;
+  jxlSupport = true;
+  psSupport = true;
+  j2kSupport = true;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5891,6 +5891,7 @@ with pkgs;
     webpSupport = true;
     jxlSupport = true;
     psSupport = true;
+    j2kSupport = true;
   };
   imlib2-nox = imlib2.override {
     x11Support = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5883,16 +5883,6 @@ with pkgs;
 
   idasen = with python3Packages; toPythonApplication idasen;
 
-  imlib2Full = imlib2.override {
-    # Compilation error on Darwin with librsvg. For more information see:
-    # https://github.com/NixOS/nixpkgs/pull/166452#issuecomment-1090725613
-    svgSupport = !stdenv.hostPlatform.isDarwin;
-    heifSupport = !stdenv.hostPlatform.isDarwin;
-    webpSupport = true;
-    jxlSupport = true;
-    psSupport = true;
-    j2kSupport = true;
-  };
   imlib2-nox = imlib2.override {
     x11Support = false;
   };


### PR DESCRIPTION
Upstream Imlib2 supports JP2/J2K files through its optional OpenJPEG-based
loader. However this loader was not enabled for the imlib2Full package attribute set.

This pull request adds a j2kSupport option and enables it by default in the imlib2Full package attribute set.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
