### PR TITLE
obd-drift-monitor: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20284,6 +20284,11 @@
     github = "NickCao";
     githubId = 15247171;
   };
+  nickdom1 = {
+    name = "Nicholas DeTello";
+    github = "Nickdom1";
+    githubId = 48835536;
+  };
   nickhu = {
     email = "me@nickhu.co.uk";
     github = "NickHu";

--- a/pkgs/by-name/ob/obd-drift-monitor/package.nix
+++ b/pkgs/by-name/ob/obd-drift-monitor/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "obd-drift-monitor";
+  version = "0.1.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Nickdom1";
+    repo = "obd-drift-monitor";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-1BKXwmPFb1DSYm81/d70kP4hatyCPNEJKPkcK2ZBpOo=";
+  };
+
+  # The decoder is a Cargo workspace living in a subdirectory of the project repo.
+  sourceRoot = "${finalAttrs.src.name}/pkgs/decode-rs";
+
+  cargoHash = "sha256-XVuhSIUQymWbqjwcOvQN5TcWBB3DluyFNEtRGC1JZSg=";
+
+  meta = {
+    description = "Monitor OBD-II self-diagnostic sensor readings over time to reveal drift";
+    longDescription = ''
+      OBD Drift Monitor turns the results of a vehicle's built-in self-diagnostics
+      (OBD-II Mode 06 on-board monitor tests, plus Mode 01 live PIDs) into a time
+      series, so a sensor slowly drifting toward its pass/fail limits over weeks or
+      months becomes visible as a trend long before it trips a fault code. It
+      answers "how has this sensor changed over the last six months?" rather than
+      only "how is the car doing right now?" that a snapshot scan tool provides.
+
+      Readings are captured at the CAN-bus level and turned into structured,
+      limit-scaled values by decoderd, the project's small native decode engine
+      (JSON lines in, decoded monitor/PID values out) — the executable this
+      package provides and the same one deployed in the monitor's pipeline.
+    '';
+    homepage = "https://github.com/Nickdom1/obd-drift-monitor";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nickdom1 ];
+    mainProgram = "decoderd";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Description

Adds **`obd-drift-monitor`** — a monitor that turns a vehicle's built-in OBD-II
self-diagnostics into a **time series**, so a sensor slowly drifting toward its
pass/fail limits over weeks or months shows up as a *trend* long before it trips a
fault code. Where a normal scan tool only answers "how is the car doing right
now?", this answers "how has this sensor changed over the last six months?".

It captures OBD-II **Mode 06** on-board monitor test results (and Mode 01 live
PIDs) at the CAN-bus level and turns them into structured, limit-scaled values.
This package provides **`decoderd`**, the project's small native Rust decode
engine — JSON lines in, decoded monitor/PID values (test values, scaled limits,
units, pass/fail) out — the same executable deployed in the monitor's pipeline.
Decode correctness is gated by frozen golden vectors run in the check phase.

Upstream: https://github.com/Nickdom1/obd-drift-monitor (tag `v0.1.0`)

Example:

```console
$ echo '{"mode":"06","hex":"4601010c0100000001f4"}' | decoderd
{"mode":"06","records":[{"mid":1,"tid":1,"uasid":12,"test_value_raw":256,"min_limit_raw":0,"max_limit_raw":500,"test_value":2.56,"min_limit":0.0,"max_limit":5.0,"unit":"V","name":null,"is_manufacturer_defined":false,"passed":true}]}
```

Builds with `nix-build -A obd-drift-monitor`; `cargo test` (golden vectors) passes
in the check phase.

> Nix Vegas CTF team: **Nicholas DeTello**

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Ran `nix-build` on the package and verified the `decoderd` binary works
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)
- [x] Package meta is complete (description, longDescription, homepage, license, maintainers, mainProgram, platforms)
- [x] Formatted with `nixfmt`; placed under `pkgs/by-name/`
- [x] Added self as maintainer

## Automation disclosure

Per the Nixpkgs [contribution standards](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), disclosed separately for the commit and this summary:

- **Commit:** carries an `Assisted-by: Claude Code (Anthropic), primary model Claude Opus 4.8 (claude-opus-4-8)` trailer.
- **This PR summary** was likewise drafted with Claude Code (Anthropic Claude Opus 4.8).

The packaged software (the `decoderd` decode engine and its golden-vector tests) is my own work; the Nix packaging and this summary were produced with the above assistance and **reviewed and understood by me** before submission. I am the responsible person accountable for this contribution.
