### PR TITLE
throne: 1.2.2 -> 1.2.4

### DIFF
--- a/pkgs/by-name/th/throne/nixos-disable-setuid-request.patch
+++ b/pkgs/by-name/th/throne/nixos-disable-setuid-request.patch
@@ -1,5 +1,5 @@
 diff --git a/src/global/Configs.cpp b/src/global/Configs.cpp
-index 37b69be..2d458f3 100644
+index 9600a95..ee38aaa 100644
 --- a/src/global/Configs.cpp
 +++ b/src/global/Configs.cpp
 @@ -45,6 +45,12 @@ namespace Configs {
@@ -15,11 +15,11 @@ index 37b69be..2d458f3 100644
          auto fn = QApplication::applicationDirPath() + "/ThroneCore";
  #ifdef Q_OS_WIN
          fn += ".exe";
-diff --git a/src/ui/mainwindow.cpp b/src/ui/mainwindow.cpp
-index 9acfee4..c0c313a 100644
---- a/src/ui/mainwindow.cpp
-+++ b/src/ui/mainwindow.cpp
-@@ -163,8 +163,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
+diff --git a/src/ui/mainWindow/mainwindow_setup.cpp b/src/ui/mainWindow/mainwindow_setup.cpp
+index 7bec187..0f04cc8 100644
+--- a/src/ui/mainWindow/mainwindow_setup.cpp
++++ b/src/ui/mainWindow/mainwindow_setup.cpp
+@@ -207,8 +207,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
      runOnNewThread([=, this] {GetDeviceDetails(); });
  
      // Prepare core
@@ -29,7 +29,11 @@ index 9acfee4..c0c313a 100644
  
      bool coreDebugMode = (Configs::dataManager->settingsRepo->log_level == "debug");
  
-@@ -1296,6 +1295,15 @@ bool MainWindow::get_elevated_permissions(int reason) {
+diff --git a/src/ui/mainWindow/mainwindow_system.cpp b/src/ui/mainWindow/mainwindow_system.cpp
+index f1a7504..efffd4a 100644
+--- a/src/ui/mainWindow/mainwindow_system.cpp
++++ b/src/ui/mainWindow/mainwindow_system.cpp
+@@ -193,6 +193,15 @@ bool MainWindow::get_elevated_permissions(ExitReason reason) {
          return true;
      }
      if (Configs::IsAdmin()) return true;

--- a/pkgs/by-name/th/throne/package.nix
+++ b/pkgs/by-name/th/throne/package.nix
@@ -21,20 +21,20 @@
   # To get the latest revision go to the rule-set branch and get the revision of the last commit
   # Link: https://github.com/throneproj/routeprofiles/tree/rule-set
   throne-srslist-info ? {
-    rev = "ef80dfa41c3ba2d32c9c79b8ac930c4962cb589d";
-    hash = "sha256-GKlrla/Zy+IE+V5zwDHw6oqzWBND/w7uUntnuJx5BJg=";
+    rev = "bf5016b114a2dee6a31aa269093de38892fb9df4";
+    hash = "sha256-RfyFSCecfY1SfvO62nW72+4JLAP7qX8KmmWFGhRrC8I=";
   },
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "throne";
-  version = "1.2.2";
+  version = "1.2.4";
 
   src = fetchFromGitHub {
     owner = "throneproj";
     repo = "Throne";
     tag = finalAttrs.version;
-    hash = "sha256-b0iLGQjG+Iz9ZQeR1El907SPIzXiwrgJt8oZHIDhABc=";
+    hash = "sha256-fDaU3xjrpjeW8MePBaj5aNGJ2GrNQ3/M3LhtBoU+I/A=";
   };
 
   strictDeps = true;
@@ -120,7 +120,7 @@ stdenv.mkDerivation (finalAttrs: {
       ./dont-check-parent.patch
     ];
 
-    vendorHash = "sha256-oJE3xrFKBOtdFcZgpJNTe2xiAJfmiJTfnxaYZKM9a+w=";
+    vendorHash = "sha256-qr45kA/xw3NARNUAj5OMjNE1JUeYQXkEXArsyc9K5jA=";
 
     nativeBuildInputs = [
       protobuf


### PR DESCRIPTION
See changes at https://github.com/throneproj/Throne/releases

One of the patches had to be adjusted due to upstream splitting up mainwindow.cpp into multiple parts.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
