### PR TITLE
moji: init at 0.7.0

### DIFF
--- a/pkgs/by-name/mo/moji/package.nix
+++ b/pkgs/by-name/mo/moji/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "moji";
+  version = "0.7.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "Microck";
+    repo = "moji";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-qt5eNxXm30QMmryolfRObogMQwtxXuI3ylIRy+YEaho=";
+  };
+
+  vendorHash = "sha256-cCCwL7bqn+23YeLMiDEyCv+Gcu0xw068DgJDgaMb2tY=";
+
+  subPackages = [ "cmd/moji" ];
+  excludedPackages = [ "e2e" ];
+
+  preCheck = ''
+    unset subPackages
+  '';
+
+  checkFlags =
+    let
+      skippedTests = [
+        "TestConfigCompactLayoutPutsValuesBelowLabels"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/microck/moji/internal/app.Version=${finalAttrs.version}"
+    "-X github.com/microck/moji/internal/app.ReleaseMarker=moji-release-version:${finalAttrs.version}:moji-marker-end"
+  ];
+
+  meta = {
+    description = "Find and download fonts from the terminal";
+    homepage = "https://github.com/Microck/moji";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yarn ];
+    mainProgram = "moji";
+  };
+})


### PR DESCRIPTION
https://github.com/Microck/moji
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
