### PR TITLE
python3Packages.diffimg: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/diffimg/default.nix
+++ b/pkgs/development/python-modules/diffimg/default.nix
@@ -11,6 +11,8 @@
 buildPythonPackage {
   pname = "diffimg";
   version = "0.3.0"; # github recognized 0.1.3, there's a v0.1.5 tag and setup.py says 0.3.0
+
+  __structureAttrs = true;
   pyproject = true;
 
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/diffimg/default.nix
+++ b/pkgs/development/python-modules/diffimg/default.nix
@@ -3,7 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   pillow,
-  unittestCheckHook,
+  pytestCheckHook,
   pythonAtLeast,
   setuptools,
 }:
@@ -39,7 +39,9 @@ buildPythonPackage {
 
   pythonImportsCheck = [ "diffimg" ];
 
-  nativeCheckInputs = [ unittestCheckHook ];
+  enabledTestPaths = [ "diffimg/test.py" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
 
   meta = {
     description = "Differentiate images in python - get a ratio or percentage difference, and generate a diff image";

--- a/pkgs/development/python-modules/diffimg/default.nix
+++ b/pkgs/development/python-modules/diffimg/default.nix
@@ -5,12 +5,13 @@
   pillow,
   unittestCheckHook,
   pythonAtLeast,
+  setuptools,
 }:
 
 buildPythonPackage {
   pname = "diffimg";
   version = "0.3.0"; # github recognized 0.1.3, there's a v0.1.5 tag and setup.py says 0.3.0
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "nicolashahn";
@@ -30,7 +31,9 @@ buildPythonPackage {
       --replace-warn "3503192421617232" "3503192421617233"
   '';
 
-  propagatedBuildInputs = [ pillow ];
+  build-system = [ setuptools ];
+
+  dependencies = [ pillow ];
 
   pythonImportsCheck = [ "diffimg" ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- https://github.com/NixOS/nixpkgs/issues/515974

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
