### PR TITLE
python3Packages.digi-xbee: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/digi-xbee/default.nix
+++ b/pkgs/development/python-modules/digi-xbee/default.nix
@@ -50,6 +50,7 @@ buildPythonPackage (finalAttrs: {
 
   meta = {
     description = "Python library to interact with Digi International's XBee radio frequency modules";
+    changelog = "https://github.com/digidotcom/xbee-python/blob/${finalAttrs.version}/CHANGELOG.rst";
     homepage = "https://github.com/digidotcom/xbee-python";
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [ jefflabonte ];

--- a/pkgs/development/python-modules/digi-xbee/default.nix
+++ b/pkgs/development/python-modules/digi-xbee/default.nix
@@ -4,12 +4,13 @@
   pyserial,
   srp,
   lib,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "digi-xbee";
   version = "1.5.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     pname = "digi_xbee";
@@ -17,7 +18,9 @@ buildPythonPackage rec {
     hash = "sha256-amUrhHIpeRHuShD0cxb2sbbRTpJQZ9/b8otsa1Bo+bI=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     pyserial
     srp
   ];

--- a/pkgs/development/python-modules/digi-xbee/default.nix
+++ b/pkgs/development/python-modules/digi-xbee/default.nix
@@ -7,14 +7,16 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "digi-xbee";
   version = "1.5.0";
+
+  __structuredAttrs = true;
   pyproject = true;
 
   src = fetchPypi {
     pname = "digi_xbee";
-    inherit version;
+    inherit (finalAttrs) version;
     hash = "sha256-amUrhHIpeRHuShD0cxb2sbbRTpJQZ9/b8otsa1Bo+bI=";
   };
 
@@ -52,4 +54,4 @@ buildPythonPackage rec {
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [ jefflabonte ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- https://github.com/NixOS/nixpkgs/issues/515974

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
