### PR TITLE
python3Packages.cuda-core: add `cuda-bindings` to `dependencies`

### DIFF
--- a/pkgs/development/python-modules/cuda-core/default.nix
+++ b/pkgs/development/python-modules/cuda-core/default.nix
@@ -24,6 +24,8 @@
 
   # passthru
   cuda-core,
+  python,
+  runCommand,
 
   cudaSupport ? config.cudaSupport,
 }:
@@ -80,6 +82,7 @@ buildPythonPackage.override { stdenv = cudaPackages.backendStdenv; } (finalAttrs
   '';
 
   dependencies = [
+    cuda-bindings
     cuda-pathfinder
     numpy
   ];
@@ -118,9 +121,22 @@ buildPythonPackage.override { stdenv = cudaPackages.backendStdenv; } (finalAttrs
   # Tests require a GPU
   doCheck = false;
 
-  passthru.gpuCheck = cuda-core.overridePythonAttrs {
-    requiredSystemFeatures = [ "cuda" ];
-    doCheck = true;
+  passthru = {
+    tests = {
+      import-clean-env =
+        runCommand "import-clean-env-cuda-core"
+          {
+            nativeBuildInputs = [ (python.withPackages (_: [ finalAttrs.finalPackage ])) ];
+          }
+          ''
+            python -c 'import cuda.core'
+            touch $out
+          '';
+    };
+    gpuCheck = cuda-core.overridePythonAttrs {
+      requiredSystemFeatures = [ "cuda" ];
+      doCheck = true;
+    };
   };
 
   meta = {


### PR DESCRIPTION
Also added a `passthru.tests` for a real import test, which fails without adding `cuda-bindings` to the `dependencies`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
