### PR TITLE
spec-kit: 0.0.90 -> 0.16.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -63,6 +63,12 @@
 {
   # keep-sorted start case=no numeric=no block=yes
 
+  "3mp3ri0r" = {
+    email = "christoforus@xendit.co";
+    github = "3mp3ri0r";
+    githubId = 3140815;
+    name = "Christoforus Surjoputro";
+  };
   _0b11stan = {
     name = "Tristan Auvinet Pinaudeau";
     email = "tristan@tic.sh";

--- a/pkgs/by-name/sp/spec-kit/package.nix
+++ b/pkgs/by-name/sp/spec-kit/package.nix
@@ -7,13 +7,13 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "spec-kit";
-  version = "0.0.90";
+  version = "0.16.1";
 
   src = fetchFromGitHub {
     owner = "github";
     repo = "spec-kit";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ulAii6//DT9uqLxYk6qmX6dwWWjhuARbBmjH5u1YGGM=";
+    hash = "sha256-Js/yEO63OG4rZ32Vm5qGDOFlVnitxqr/NIIQS6kwdRs=";
   };
 
   pyproject = true;
@@ -22,17 +22,17 @@ python3Packages.buildPythonApplication (finalAttrs: {
     hatchling
   ];
 
-  dependencies =
-    with python3Packages;
-    [
-      typer
-      rich
-      httpx
-      platformdirs
-      readchar
-      truststore
-    ]
-    ++ httpx.optional-dependencies.socks;
+  dependencies = with python3Packages; [
+    click
+    json5
+    packaging
+    pathspec
+    platformdirs
+    pyyaml
+    readchar
+    rich
+    typer
+  ];
 
   pythonImportsCheck = [
     "specify_cli"
@@ -45,7 +45,10 @@ python3Packages.buildPythonApplication (finalAttrs: {
     homepage = "https://github.com/github/spec-kit";
     changelog = "https://github.com/github/spec-kit/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ luochen1990 ];
+    maintainers = [
+      lib.maintainers.luochen1990
+      lib.maintainers."3mp3ri0r"
+    ];
     mainProgram = "specify";
   };
 })


### PR DESCRIPTION
Upgrade version from v0.090 to 0.16.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

## Test Result

<img width="1512" height="295" alt="image" src="https://github.com/user-attachments/assets/b0ab5dee-a0f8-4882-99d8-a8b1d794b5bd" />

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
