### PR TITLE
podcast-dl: init at 12.0.1

### DIFF
--- a/pkgs/by-name/po/podcast-dl/package.nix
+++ b/pkgs/by-name/po/podcast-dl/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "podcast-dl";
+  version = "12.0.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "lightpohl";
+    repo = "podcast-dl";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-35JhO66biCxf5t6B+9pM8O67sohU6h5SLSHIJ1pP8vY=";
+  };
+
+  npmDepsHash = "sha256-0rN7DaWHIHOUY1a45Ee16UGFGble2oUv0ktpVVRDLM8=";
+
+  dontNpmBuild = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A CLI for downloading podcasts";
+    homepage = "https://github.com/lightpohl/podcast-dl";
+    changelog = "https://github.com/lightpohl/podcast-dl/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jecaro ];
+    mainProgram = "podcast-dl";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add the package `podcast-dl`, a CLI tool for downloading and archiving podcasts.

https://github.com/lightpohl/podcast-dl

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
