### PR TITLE
sv-lang: fix build with fmt 12.2

### DIFF
--- a/pkgs/by-name/sv/sv-lang/package.nix
+++ b/pkgs/by-name/sv/sv-lang/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   boost,
   catch2_3,
   cmake,
@@ -21,6 +22,20 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-popHzwX0qwv2POAl7/qX3e//OwJRXGtSl9xogpSn2LI=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "fmt-12.2.patch";
+      url = "https://github.com/MikePopoloski/slang/commit/5a898b4b9225d281902fcd59fe4732b1561677d2.patch";
+      excludes = [ "tests/unittests/diagnostics/WaiverTests.cpp" ];
+      hash = "sha256-Y+GG8UINWXh7eTXEweM42oPY8ByP4DQYgTjSLukz4I4=";
+    })
+  ];
+
+  patchFlags = [
+    "-p1"
+    "-F3"
+  ];
 
   cmakeFlags = [
     # fix for https://github.com/NixOS/nixpkgs/issues/144170


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/341410372/step/1/log

From the [fmt 12.2 changelog](https://github.com/fmtlib/fmt/blob/60ccad511fd680cb91d8b60a315759f71c67bef9/ChangeLog.md#1220---2026-06-16):

> - Made the `<fmt/core.h>` header equivalent to `<fmt/base.h>` by default. Code that relied on `<fmt/core.h>` pulling in `<fmt/format.h>` must now either include `<fmt/format.h>` directly or define `FMT_DEPRECATED_HEAVY_CORE` to opt back in.

Upstream commit: https://github.com/MikePopoloski/slang/commit/5a898b4b9225d281902fcd59fe4732b1561677d2

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `sv-lang`, `yosys` (reverse dependency)
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
