### PR TITLE
python3Packages.nccl4py: add support for `cudaPackages.nccl-ep`

### DIFF
--- a/pkgs/development/python-modules/nccl4py/default.nix
+++ b/pkgs/development/python-modules/nccl4py/default.nix
@@ -14,6 +14,10 @@
   packaging,
   pythonOlder,
   typing-extensions,
+
+  # passthru
+  runCommand,
+  python,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -50,6 +54,21 @@ buildPythonPackage (finalAttrs: {
         --replace-fail \
           'cdef uintptr_t handle = load_nvidia_dynamic_lib("nccl")._handle_uint' \
           'cdef uintptr_t handle = <uintptr_t>dlopen("${lib.getLib cudaPackages.nccl}/lib/libnccl.so.2", RTLD_NOW | RTLD_GLOBAL)'
+
+      substituteInPlace nccl/bindings/_internal/nccl_ep_linux.pyx \
+        --replace-fail \
+          "handle = dlopen('libcuda.so.1'" \
+          "handle = dlopen('${libCudaPath}/lib/libcuda.so.1'"
+
+      substituteInPlace nccl/bindings/_internal/nccl_ep_linux.pyx \
+        --replace-fail \
+          'load_nvidia_dynamic_lib("nccl")' \
+          'dlopen("${lib.getLib cudaPackages.nccl}/lib/libnccl.so.2", RTLD_NOW | RTLD_GLOBAL)'
+
+      substituteInPlace nccl/bindings/_internal/nccl_ep_linux.pyx \
+        --replace-fail \
+          'cdef bytes path_bytes = _resolve_library_path().encode()' \
+          'cdef bytes path_bytes = b"${lib.getLib cudaPackages.nccl-ep}/lib/libnccl_ep.so"'
     '';
 
   build-system = [
@@ -60,6 +79,10 @@ buildPythonPackage (finalAttrs: {
   env = {
     # `${sourceRoot}/setup.py` insists on reading only from $CUDA_HOME/include
     CUDA_HOME = (lib.getInclude cudaPackages.cuda_cudart).outPath;
+    # Since `cudaPackages.nccl-ep` is used as a byte string, it gets
+    # compressed and no dependency is created. Disable string
+    # compression for Nix to correctly detect the dependency.
+    NIX_CLFAGS_COMPILE = "-DCYTHON_COMPRESS_STRINGS=0";
   };
 
   buildInputs =
@@ -83,6 +106,19 @@ buildPythonPackage (finalAttrs: {
     "nccl"
     "nccl.bindings"
   ];
+
+  passthru.tests = {
+    import-clean-env =
+      runCommand "import-clean-env-nccl4py-ep"
+        {
+          nativeBuildInputs = [ (python.withPackages (_: [ finalAttrs.finalPackage ])) ];
+        }
+        ''
+          LD_LIBRARY_PATH="${lib.getLib cudaPackages.cuda_cudart}/lib/stubs" \
+              python -c 'import nccl.ep'
+          touch $out
+        '';
+  };
 
   # Upstream doesn't ship any tests.
   doCheck = false;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
