### PR TITLE
nixos/home-assistant: remove frontend firewalling option

### DIFF
--- a/nixos/modules/services/home-automation/home-assistant.nix
+++ b/nixos/modules/services/home-automation/home-assistant.nix
@@ -29,7 +29,6 @@ let
     literalExpression
     mapAttrsToList
     mergeAttrsList
-    mkEnableOption
     mkIf
     mkMerge
     mkOption
@@ -298,9 +297,13 @@ in
       "home-assistant"
       "autoExtraComponents"
     ] "Components are now parsed from services.home-assistant.config unconditionally")
-    (mkRenamedOptionModule
-      [ "services" "home-assistant" "port" ]
-      [ "services" "home-assistant" "config" "http" "server_port" ]
+    (mkRemovedOptionModule
+      [
+        "services"
+        "home-assistant"
+        "openFirewall"
+      ]
+      "The frontend port is not configured in YAML any more and therefore cannot be determined at eval time any longer."
     )
   ];
 
@@ -767,27 +770,11 @@ in
       '';
     };
 
-    openFirewall = mkOption {
-      default = false;
-      type = types.bool;
-      description = ''
-        Whether to open the firewall for the specified frontend port
-
-        :::{.note}
-        For components specific ports see {option}`services.home-assistant.openFirewallForComponents`.
-        :::
-      '';
-    };
-
     openFirewallForComponents = mkOption {
       default = false;
       type = types.bool;
       description = ''
         Whether to open required firewall ports for enabled components.
-
-        :::{.note}
-        For the frontend see {option}`services.home-assistant.openFirewall`.
-        :::
       '';
     };
 
@@ -843,10 +830,6 @@ in
 
     assertions = [
       {
-        assertion = cfg.openFirewall -> cfg.config != null;
-        message = "openFirewall can only be used with a declarative config";
-      }
-      {
         assertion = !(cfg.lovelaceConfig != null && cfg.lovelaceConfigFile != null);
         message = "Only one of `lovelaceConfig` or `lovelaceConfigFile` can be configured at the same time.";
       }
@@ -856,15 +839,12 @@ in
       }
     ];
 
-    networking.firewall.allowedTCPPorts = mkMerge [
-      (mkIf cfg.openFirewall [ cfg.config.http.server_port ])
-      (mkIf cfg.openFirewallForComponents (
-        # https://www.home-assistant.io/integrations/homekit/#firewall
-        optionals (useComponent "homekit") [ 21063 ]
-        # https://www.home-assistant.io/integrations/sonos/#network-requirements
-        ++ optionals (useComponent "sonos") [ 1400 ]
-      ))
-    ];
+    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewallForComponents (
+      # https://www.home-assistant.io/integrations/homekit/#firewall
+      optionals (useComponent "homekit") [ 21063 ]
+      # https://www.home-assistant.io/integrations/sonos/#network-requirements
+      ++ optionals (useComponent "sonos") [ 1400 ]
+    );
 
     networking.firewall.allowedUDPPorts = mkIf cfg.openFirewallForComponents (
       # https://www.home-assistant.io/integrations/homekit/#firewall


### PR DESCRIPTION
With Home Assistant 2026.8.0 the frontend port now gets configured from within the frontend, which means we cannot infer the correct port at eval time any longer.

Fixes #550666

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
