### PR TITLE
nexus-shell: init at 1.6.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29956,6 +29956,12 @@
     githubId = 94648307;
     name = "Thanh Viet Nguyen";
   };
+  viewer12 = {
+    email = "marketing@nexusshell.app";
+    github = "viewer12";
+    githubId = 25808434;
+    name = "Sameral";
+  };
   vifino = {
     email = "vifino@tty.sh";
     github = "vifino";

--- a/pkgs/by-name/ne/nexus-shell/package.nix
+++ b/pkgs/by-name/ne/nexus-shell/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  _7zz,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "nexus-shell";
+  version = "1.6.9";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchurl {
+    url = "https://github.com/viewer12/Nexus-Shell-Releases/releases/download/v${finalAttrs.version}/Nexus-Shell-v${finalAttrs.version}.dmg";
+    hash = "sha256-CIk465AXYKMSO+fI3xikHUgPI0NYo6VvJI3oi8yDph0=";
+  };
+
+  # The image uses APFS. Avoid extracting macOS extended attributes as files,
+  # since that would corrupt the signed application bundle.
+  unpackCmd = "7zz x -snld -xr'!*:com.apple.*' $curSrc";
+
+  nativeBuildInputs = [ _7zz ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications"
+    cp -R "Nexus Shell.app" "$out/Applications/"
+
+    runHook postInstall
+  '';
+
+  # Preserve the notarized signatures of the bundled binaries and resources.
+  dontFixup = true;
+
+  meta = {
+    description = "Native macOS SSH workspace for terminal, SFTP, Docker, and server monitoring";
+    homepage = "https://nexusshell.app/";
+    changelog = "https://github.com/viewer12/Nexus-Shell-Releases/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ viewer12 ];
+    platforms = [ "aarch64-darwin" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
Adds Nexus Shell, a native macOS SSH workspace distributed as a signed and notarized Apple Silicon DMG. The package installs the app bundle without fixups so the upstream code signature remains intact.

Homepage: https://nexusshell.app/
Release: https://github.com/viewer12/Nexus-Shell-Releases/releases/tag/v1.6.9

### Validation

Fork-only Apple Silicon workflows built the package with Nix and verified that:

- `result/Applications/Nexus Shell.app` exists
- `CFBundleShortVersionString` is `1.6.9`
- the main executable is `arm64`
- `codesign --verify --deep --strict` succeeds
- LaunchServices can start the app from the Nix output and the `Nexus Shell` process remains alive during the smoke-test window

Build and metadata validation: https://github.com/viewer12/nixpkgs/actions/runs/31308131687

Launch smoke test: https://github.com/viewer12/nixpkgs/actions/runs/31308905367

The application has not yet been interactively inspected by the responsible developer from the Nix store, so this remains a draft pending final human review and UI smoke testing.

### Automation/AI disclosure

This package definition, validation workflow, commit message, and pull request text were prepared with assistance from OpenAI Codex (GPT-5.6). The deterministic validation workflows and their successful results are linked above. This PR is intentionally marked draft until the developer performs the responsible-person review required by the Nixpkgs automation/AI policy. The commit includes the required `Assisted-by:` trailer.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [ ] Tested basic functionality of all binary files.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits `CONTRIBUTING.md`, `pkgs/README.md`, `maintainers/README.md` and other READMEs.
- [x] Follows the automation/AI policy for a draft contribution.
