### PR TITLE
Ioquake3: fix riscv cross-compiation

### DIFF
--- a/pkgs/by-name/io/ioquake3/package.nix
+++ b/pkgs/by-name/io/ioquake3/package.nix
@@ -17,7 +17,6 @@
   libjpeg,
   makeDesktopItem,
   freetype,
-  mumble,
   unstableGitUpdater,
   bc,
   cmake,
@@ -54,7 +53,6 @@ stdenv.mkDerivation (finalAttrs: {
     libjpeg
     libogg
     libvorbis
-    mumble
     openal
     opusfile
     speex


### PR DESCRIPTION
Remove `mumble` buildInput since its not required for build or runtime. `mumble` won't cross-compile to RISCV currently.

No `mumble` reference in the final build, even when setting `USE_MUMBLE=true`.
```
[onny@nixos:~/projects/nixpkgs]$ nix-store -q --references ./result
/nix/store/qqiqd3ah10x8hzsif4j1y4xc1miw23nx-glibc-2.42-67
/nix/store/0mcj4s4rf8h755230vd3nh3v4v8bqdz4-libjpeg-turbo-3.1.4.1
/nix/store/7lz2zkz3lnpk1cz54bg03dr6qmgpnf3g-openal-soft-1.24.3
/nix/store/9gg2kw74rag1sjl2jl6qaddaisllpdip-curl-8.21.0
/nix/store/a5z68qrqk6mw26a0pw9slpn0nh3f3gxw-libogg-1.3.6
/nix/store/jgq86hmm9jv6c62ja0p6fd596d3ap0aw-libvorbis-1.3.7
/nix/store/m3fklrivqli4arqqc600m4iv6ialc091-freetype-2.14.3
/nix/store/qd707z3py0n0qws77j9ydm8xc5imjb96-sdl2-compat-2.32.70
/nix/store/qx470axrcikywh1xb4v5pw5h3ir4nb5f-libopus-1.6.1
/nix/store/y5h1sgi7rjvan33kyd3nvc1gq28z80j3-opusfile-0.12
/nix/store/kbbxcp5r0gwwblk7jp8kl8j03pai3lpk-ioquake3-0-unstable-2025-05-15
```

ioquake3 uses a file link to communicate with mumble and doesn't require any additional libraries https://github.com/ioquake/ioq3/blob/588393618dbc82e7207c21c6ddecca229944a03a/code/client/libmumblelink.c#L103

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
