### PR TITLE
gzip: inline handling of `$GZIP_NO_TIMESTAMPS`

### DIFF
--- a/nixos/modules/profiles/bashless.nix
+++ b/nixos/modules/profiles/bashless.nix
@@ -31,8 +31,6 @@
   # Relies on bash scripts
   powerManagement.enable = lib.mkDefault false;
   users.manageLingering = lib.mkDefault false;
-  # Relies on the gzip command which depends on bash
-  services.logrotate.enable = lib.mkDefault false;
   # The resize helper pulls in bash
   services.lvm.resizeHelper.enable = false;
 

--- a/pkgs/stdenv/darwin/stdenv-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/stdenv-bootstrap-tools.nix
@@ -142,7 +142,7 @@ stdenv.mkDerivation (finalAttrs: {
       cp -d ${getBin bzip2}/bin/b{,un}zip2 $out/bin
       cp ${getBin cpio}/bin/cpio $out/bin
       cp ${getBin gnutar}/bin/tar $out/bin
-      cp ${getBin gzip}/bin/.gzip-wrapped $out/bin/gzip
+      cp ${getBin gzip}/bin/gzip $out/bin/gzip
       cp ${getBin pbzx}/bin/pbzx $out/bin
       cp ${getBin xz}/bin/xz $out/bin
       cp -d ${getLib bzip2}/lib/libbz2*.dylib $out/lib

--- a/pkgs/stdenv/linux/stdenv-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/stdenv-bootstrap-tools.nix
@@ -119,7 +119,7 @@ stdenv.mkDerivation (finalAttrs: {
     cp ${gawk.out}/bin/gawk $out/bin
     cp -d ${gawk.out}/bin/awk $out/bin
     cp ${tarMinimal.out}/bin/tar $out/bin
-    cp ${gzip.out}/bin/.gzip-wrapped $out/bin/gzip
+    cp ${gzip.out}/bin/gzip $out/bin/gzip
     cp ${bzip2.bin}/bin/bzip2 $out/bin
     cp -d ${gnumake.out}/bin/* $out/bin
     cp -d ${patch}/bin/* $out/bin

--- a/pkgs/tools/compression/gzip/0001-Don-t-add-timestamps-when-GZIP_NO_TIMESTAMPS-is-set.patch
+++ b/pkgs/tools/compression/gzip/0001-Don-t-add-timestamps-when-GZIP_NO_TIMESTAMPS-is-set.patch
@@ -1,0 +1,48 @@
+From 96c1a24911e6992ab4e98354b7ae9077b852cac3 Mon Sep 17 00:00:00 2001
+From: h7x4 <h7x4@nani.wtf>
+Date: Fri, 7 Aug 2026 16:24:51 +0900
+Subject: [PATCH] Don't add timestamps when `$GZIP_NO_TIMESTAMPS` is set
+
+This patch is a nixpkgs specific change that makes gzip set its `-n`
+flag whenever `$GZIP_NO_TIMESTAMPS` is set. This envvar is typically set
+by stdenv's `setup.sh` to stop gzip from adding timestamps to archive
+headers.
+
+See https://github.com/NixOS/nixpkgs/issues/86348
+
+Co-authored-by: Michael Daniels <mdaniels5757@gmail.com>
+---
+ gzip.c          | 4 ++--
+ tests/timestamp | 1 +
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/gzip.c b/gzip.c
+index 914247d..084b361 100644
+--- a/gzip.c
++++ b/gzip.c
+@@ -586,8 +586,8 @@ int main (int argc, char **argv)
+     /* By default, save name and timestamp on compression but do not
+      * restore them on decompression.
+      */
+-    if (no_time < 0) no_time = decompress;
+-    if (no_name < 0) no_name = decompress;
++    if (no_time < 0) no_time = decompress || getenv("GZIP_NO_TIMESTAMPS") != NULL;
++    if (no_name < 0) no_name = decompress || getenv("GZIP_NO_TIMESTAMPS") != NULL;
+ 
+     file_count = argc - optind;
+ 
+diff --git a/tests/timestamp b/tests/timestamp
+index ab1ca50..3a734ac 100755
+--- a/tests/timestamp
++++ b/tests/timestamp
+@@ -22,6 +22,7 @@
+ TZ=UTC0
+ export TZ
+ oldIFS=$IFS
++unset GZIP_NO_TIMESTAMPS
+ 
+ # On platforms supporting timestamps outside gzip's range,
+ # test that gzip warns when converting them to gzip format.
+-- 
+2.54.0
+

--- a/pkgs/tools/compression/gzip/default.nix
+++ b/pkgs/tools/compression/gzip/default.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  makeShellWrapper,
   updateAutotoolsGnuConfigScriptsHook,
   runtimeShellPackage,
   # Tests
@@ -26,6 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = [
+    ./0001-Don-t-add-timestamps-when-GZIP_NO_TIMESTAMPS-is-set.patch
     ./CVE-2026-41991.patch
     ./CVE-2026-41992.patch
   ];
@@ -38,10 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [
-    updateAutotoolsGnuConfigScriptsHook
-    makeShellWrapper
-  ];
+  nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook ];
   buildInputs = [ runtimeShellPackage ];
 
   makeFlags = [
@@ -76,13 +73,6 @@ stdenv.mkDerivation (finalAttrs: {
   + lib.optionalString stdenv.hostPlatform.isCygwin ''
     mv $out/bin/{,.}gzip.exe
     ln -s .gzip.exe $out/bin/gzip
-  ''
-  # run gzip with "-n" when $GZIP_NO_TIMESTAMPS (set by stdenv's setup.sh) is set to stop gzip from adding timestamps
-  # to archive headers: https://github.com/NixOS/nixpkgs/issues/86348
-  # if changing so that there's no longer a .gzip-wrapped then update copy in make-bootstrap-tools.nix
-  + ''
-    wrapProgram $out/bin/gzip \
-      --add-flags "\''${GZIP_NO_TIMESTAMPS:+-n}"
   '';
 
   passthru.tests.makecheck = gzip.overrideAttrs { doCheck = true; };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This removes the bash wrapper around `gzip`, which unlocks `services.logrotate` for the bashless profile.

Tested gzip interactively with and without the envvar to ensure it's still working as expected (both with and without the envvar and explicitly enabling timestamps via `-N`), and checked closures for these derivations:

- `gzip`
- `logrotate`
- `nixosTests.logrotate.nodes.machine.system.build.units."logrotate.service".unit` (after commenting out `sendmail` related config)
- `nixosTests.logrotate.nodes.machine.system.build.units."logrotate-checkconf.service".unit`

with `nix why-depends` to verify that the bash dependency is gone.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
