### PR TITLE
rush-lyrics: 6.5.1 -> 6.5.2

### DIFF
--- a/pkgs/by-name/ru/rush-lyrics/deps.json
+++ b/pkgs/by-name/ru/rush-lyrics/deps.json
@@ -121,13 +121,13 @@
    "module": "sha256-I9rsvdWexb/rQmWRtBtSaqjWlj58xU8i0sIjktld50I=",
    "pom": "sha256-UeXUZwzRCtjGC9vD3cMHMFo7l+mh+ntAXI52QJa6CxU="
   },
-  "androidx/databinding#databinding-common/9.3.0": {
+  "androidx/databinding#databinding-common/9.3.1": {
    "jar": "sha256-goFjgqKp3sTwqxfHnO8IqeT+S5fYlqwg1/IVtt14ixg=",
-   "pom": "sha256-Ytl5Q9ObSJjS8GLZk6cfwkrlivjoSnPssuyTfSzM3E4="
+   "pom": "sha256-qdQ1bgKqKskFwFQOT1EHUDY/Ah4EN6QVTDO2ox5sXis="
   },
-  "androidx/databinding#databinding-compiler-common/9.3.0": {
-   "jar": "sha256-hTzCt0ZDcVXvSfN3nXYNU433cpR5yhN7U47qT25hras=",
-   "pom": "sha256-XD9vIopv3k7AJrDEpf+L4U0qqARS+3Focw+cFQvgBJ4="
+  "androidx/databinding#databinding-compiler-common/9.3.1": {
+   "jar": "sha256-j0LeOrbWyuH7U6FNM5bEmwHWpEkhznDP0WQXe65e07g=",
+   "pom": "sha256-ceJN+kTdsGtpuytUGR9PNm8VmfmJVnDcgseNisQcbnU="
   },
   "androidx/datastore#datastore-core-jvm/1.2.1": {
    "jar": "sha256-3S0ID8FusL6h4C5VUdQ0lvueUXeFXFtyxqr24WqxxcE=",
@@ -343,57 +343,57 @@
    "module": "sha256-7YnWBP05Hd0YMzf2S4b/ApCSk9dR6rLbyvWNIKM/kw8=",
    "pom": "sha256-nc0ZmUWCIEQj5D3H8zVswiJdzA9ttBMPkH+Kynck8Vw="
   },
-  "androidx/room3#androidx.room3.gradle.plugin/3.0.0": {
-   "pom": "sha256-u6y7SwDy20gFGj5zCDH7uKnYZegUCTL1lz4B5Xsl6Mc="
+  "androidx/room3#androidx.room3.gradle.plugin/3.0.1": {
+   "pom": "sha256-T2y6kkt/t20aOnFgSgFd0PCaGdN3tx8LvQHR+XfKWss="
   },
-  "androidx/room3#room3-common-jvm/3.0.0": {
+  "androidx/room3#room3-common-jvm/3.0.1": {
    "jar": "sha256-i77GUB/cRNxD4B1KpDsrUJwVfDPqG9IROZyk+CMlLcs=",
-   "module": "sha256-awWOtjMTH4fQ0kltkf9dxWhTbFT1pL5mo042nh5eP2I=",
-   "pom": "sha256-grY4yBemf2pQdHuA7ojuM39ZIjNyCbenehLjM00oqRk="
+   "module": "sha256-cq8kSf4uzS0BQqCQms2LOovpgPVtfMZjXAH1CelAPIA=",
+   "pom": "sha256-8zpU+QDTg6X9y1s3mKHvdl98bMD5QY7SDa2x8lWrFkc="
   },
-  "androidx/room3#room3-common/3.0.0": {
+  "androidx/room3#room3-common/3.0.1": {
    "jar": "sha256-CCM2YSe8+A/jBgWS5wKleltuKHIdHN0+RshwvwR2dyw=",
-   "module": "sha256-U1WR31+wj+f//8BOItpW+qu6HJCTXuZxn3aaji5ltkY=",
-   "pom": "sha256-9fmFAFmmGOWu10E/5xMOKW1cEBLW6LShBv8M7Jibh5w="
+   "module": "sha256-gwijWdK6mmYwiokvi9a+rYf8AQ2cXzYbGYXCU1miOy8=",
+   "pom": "sha256-1VFBtUVxGG32KlPabrrwU8k5srtg7+S8lyrGJmh4IMY="
   },
-  "androidx/room3#room3-compiler-processing/3.0.0": {
-   "jar": "sha256-4rloj1FZwZ2PLK522eT2E8rNZ8+mrtZ4sC6jQlauX/A=",
-   "module": "sha256-5umTpPHnF4rtgZdpYhG9aAFiaBxJ/4MMvb5Nqt0xh3k=",
-   "pom": "sha256-ZyVSXvnj/h2GC1+sAGBXh8tUI80DsTx3N1Zvk57Y030="
+  "androidx/room3#room3-compiler-processing/3.0.1": {
+   "jar": "sha256-1hIpDl3hvtwdSUmW36Cs4qcrVHXhOccjG+0j+7BO9S8=",
+   "module": "sha256-PL4c7PdAjSEu6Om1+m2iXmVyyr1xQIb1M+h4HtF0HCc=",
+   "pom": "sha256-Hj3hMkxBuSLtZC39YqRNX0Th5eZs1UeQZaB1lbC+h2U="
   },
-  "androidx/room3#room3-compiler/3.0.0": {
+  "androidx/room3#room3-compiler/3.0.1": {
    "jar": "sha256-VHWKrt4GARus8AuXV9AJqvxtBB/q1Cc8UFzDEzwpsRE=",
-   "module": "sha256-H6gFwVbadUYARUw5xYNUX0+OidBnjSxsZBPOaWwBQsA=",
-   "pom": "sha256-iPr0mGPvDyWtNgEZqGVVJehT/b9vBWeH9q28d1mJjco="
+   "module": "sha256-KK5w+zsQYjtq9GTvpQfDj2skrwL1Y0euFRjqq+SGqKU=",
+   "pom": "sha256-R4DpFVB90dFpR5jaNbj0a5w6p9wZaGqop2FWt3xgeqo="
   },
-  "androidx/room3#room3-external-antlr/3.0.0": {
+  "androidx/room3#room3-external-antlr/3.0.1": {
    "jar": "sha256-P7Ur3wf1JpltqNVOR4alda6OUweJV5K1O4muA/jbhbI=",
-   "module": "sha256-TzxjqQKQkwPz1fKmRtvlGbov8oBcMGK8KBjL9TuO8WE=",
-   "pom": "sha256-Vuaigw9fofmd24onhENVSTbtXS0QCoaWy9G3Wb+ODu0="
+   "module": "sha256-L9YhOHQK7t/BzfSjqPJCvSH992T0neb1HQ3V7Q6skIU=",
+   "pom": "sha256-0Dmtq26pVnJTYAO9fPo2lEedmJoOYcVgLmoB4gAEGxg="
   },
-  "androidx/room3#room3-gradle-plugin/3.0.0": {
+  "androidx/room3#room3-gradle-plugin/3.0.1": {
    "jar": "sha256-HlhgO219cXPO+Pj0Cb1034Lwf6fJNp8mi3KYPJHW7fQ=",
-   "module": "sha256-rxngZhRH8txzAQu32CnwpU1EoRyRh+sfFWiBQ0BwCUo=",
-   "pom": "sha256-6QYvlFMtb85Ab1YEqNKTkCKuxwGLbiap7ouRZ/XvD6A="
+   "module": "sha256-pOEviyTkOqGMF8d9rZZwvBrThgcIK5gZBTkutyfzRqg=",
+   "pom": "sha256-pYIs7NbiyoenOzgJLcKqqp0AGcgTQKHqP4tMPsqRv/U="
   },
-  "androidx/room3#room3-migration-jvm/3.0.0": {
+  "androidx/room3#room3-migration-jvm/3.0.1": {
    "jar": "sha256-mqoCKcvKbOxLmeu8R8YcjxEx+NwTjeWLlrKAtLrXAG8=",
-   "module": "sha256-6AGHY/lpJfsmw+Bf1fDszTDrrK7Kxx8LkRPtJ/8PK88=",
-   "pom": "sha256-HftKXw5NZTqz6KhxkLdayjWFmw/lSjvSp800pEuJlUQ="
+   "module": "sha256-Qj1Qz6U8i6lJab9Ju3tstR5E9iwLk5mg62tVo7xW3GI=",
+   "pom": "sha256-ngfT8ljUGG8kiF7Y7pmwfZEhBS/C3ku/f6+83x1TS+M="
   },
-  "androidx/room3#room3-migration/3.0.0": {
-   "module": "sha256-yR1nVucQg1/1eNsRthcx84vXdn2gVo7lC4Hr4jbaByQ=",
-   "pom": "sha256-oSHN+KnNx8tDZTgJbT+futMA7Ms4J2xeU9t4PU1/Fpo="
+  "androidx/room3#room3-migration/3.0.1": {
+   "module": "sha256-B77Omvzx7ZpZJBOD4MtoVcMgk1VbPs5WyMkJUATiMvA=",
+   "pom": "sha256-gIAiju09BWSb9RgjVo/UP+12VD7wFcIBKGK+hx7eAVY="
   },
-  "androidx/room3#room3-runtime-jvm/3.0.0": {
-   "jar": "sha256-r5WEzgAEWKx57REiOWTRAp2VmlncmTMgs4yiFfztRDM=",
-   "module": "sha256-dQVPFW0I867OaZovwSSzsfSRWA1y6Kys+w7Fpo4q4EM=",
-   "pom": "sha256-Mi10VBLfb+PlZzPDjOui46k47Ks7M8oKSsH8f9iQMeg="
+  "androidx/room3#room3-runtime-jvm/3.0.1": {
+   "jar": "sha256-fXJGUUpoX7a3UeblLZkglmACRGL6sdIW/YCBmpOWDB4=",
+   "module": "sha256-oCgbrxXDGJfhUiOaLulWUcaQg2ei2Wu8z6GlOklFWSM=",
+   "pom": "sha256-aVKLPkINC1yPbkf2IIyzvXTk/u+kdxvzAIMbHKpFeFk="
   },
-  "androidx/room3#room3-runtime/3.0.0": {
-   "jar": "sha256-E3axr6SsA7cBccbKAkrei1nvGy29G4xQDZMllT/A8PM=",
-   "module": "sha256-NRtmbMzQ1GDn9uDCF0bJMxAftsei1PRtPoJ5xMc2ygU=",
-   "pom": "sha256-eEKZ1hHt3DdzPXUTnJZdncqbkzkhrEdiVqDYcOq0UQo="
+  "androidx/room3#room3-runtime/3.0.1": {
+   "jar": "sha256-uJF4arO1+UDNMk2RswDIF24gLvc9J0WUMe5TOaWYCj0=",
+   "module": "sha256-Up8taG/1Bh4UgIAXfkeW6GFnET0NcJUBWBt1uV5UgJc=",
+   "pom": "sha256-yL1NDdUOMOPkhQZmJzGniwiYxdwIrrNUMkWw1N+5HmE="
   },
   "androidx/savedstate#savedstate-compose-desktop/1.4.0": {
    "jar": "sha256-wCqYsMKzXN3iRcC/5uf/RTx7bQal64aB0lt/VLh06kg=",
@@ -450,128 +450,128 @@
    "module": "sha256-FsWdq4FkIGUQJACIfn+AwxEXavy09g64Llr28ps/3FY=",
    "pom": "sha256-MaLLF88w29Al7VDyW50l4PzXkGCbIUc18PrJR4z3va8="
   },
-  "com/android#signflinger/9.3.0": {
+  "com/android#signflinger/9.3.1": {
    "jar": "sha256-fYISbJSDtUAXOmWwNU/ifwZ+yFyOZGdnlYc2QKBrKI0=",
-   "pom": "sha256-cqgIr/c2doQWueMD+IIJEac7QSJhAoiaXIAFPAygfAc="
+   "pom": "sha256-CSYW0eNrT/5fw1klNlR7erkRpgSIpDlbLmZuVVQNUqk="
   },
-  "com/android#zipflinger/9.3.0": {
+  "com/android#zipflinger/9.3.1": {
    "jar": "sha256-ChmE0UzIBw9zTdzFqUfxIt/uNkzb4YWVr7aRqoA4kOA=",
-   "pom": "sha256-dkTu0n49YWg+GOZeKqDZw2PbEoeEITJOSG/HWX4hm7Y="
+   "pom": "sha256-FGbpNWjSTGsySL/b5Mg7D1XgW2G5WAyJRYKf3kZgCr4="
   },
-  "com/android/application#com.android.application.gradle.plugin/9.3.0": {
-   "pom": "sha256-e5HWskuJdZwX/akiTrndlFArOEi3WKfo+EwLAeyPPSg="
+  "com/android/application#com.android.application.gradle.plugin/9.3.1": {
+   "pom": "sha256-lnT8wnuCmLIRWufuJYNtv1yZyKHcRzVhtRZ6GsK2a3o="
   },
-  "com/android/databinding#baseLibrary/9.3.0": {
+  "com/android/databinding#baseLibrary/9.3.1": {
    "jar": "sha256-lroqXwAIRtMXrN2Q3mp0KXAaxWVz3izMhCPSukBEb9k=",
-   "pom": "sha256-5ycRYt+SJdY/rmLbVCwfQ03FRz+y77UIKTQno50ePxU="
+   "pom": "sha256-EokmuyH/5wL4nsO8+Eplulg0dJDNWCUHLjyS+G+Od/8="
   },
-  "com/android/kotlin/multiplatform/library#com.android.kotlin.multiplatform.library.gradle.plugin/9.3.0": {
-   "pom": "sha256-zNFnXXTgrbS5MZkTAHxWJosNvB7EzseZIyO0W2l2ev0="
+  "com/android/kotlin/multiplatform/library#com.android.kotlin.multiplatform.library.gradle.plugin/9.3.1": {
+   "pom": "sha256-zA0uAddI+V0od8ZzLSzk/Rl2SGQbe6dj7KMVoy1rnRc="
   },
-  "com/android/library#com.android.library.gradle.plugin/9.3.0": {
-   "pom": "sha256-cSHG36YpO54sAqSTm5wXD/o/WNmt49h8MqHaFr4qi/0="
+  "com/android/library#com.android.library.gradle.plugin/9.3.1": {
+   "pom": "sha256-kKf14FXa2ErEOLBYmbxfHgRCQUkIm/HhrG+aS1ClTA4="
   },
-  "com/android/tools#annotations/32.3.0": {
+  "com/android/tools#annotations/32.3.1": {
    "jar": "sha256-MukCJq5Me1ntYbBmia6DVrqwgM159laUVf2SklQ5ozk=",
-   "pom": "sha256-Zjz9vM7vMD9OXwJNUgyYBpsmCYEM8FSPy4t3CS1jdj4="
+   "pom": "sha256-Su4/tPXrrJ20JGWiIHfsHmz7J5jZopeZljsgwkLyel4="
   },
-  "com/android/tools#common/32.3.0": {
-   "jar": "sha256-eNHaTkx3Bc4NyQI3Ae72gWEP8nVZI8GD/GNxkDaGzz0=",
-   "pom": "sha256-kB7cZIRZLaJkbABXsfsno4dwAgAtXYMnn58vbi+5MQ8="
+  "com/android/tools#common/32.3.1": {
+   "jar": "sha256-LLXftf/xRAiPGIh8Y8jnNoA07eMedBNAWsMlHR65oUc=",
+   "pom": "sha256-JrqSM5TvGcvT4qUxqIwBjR96hz7mG64YeAtccaqSmQM="
   },
-  "com/android/tools#dvlib/32.3.0": {
+  "com/android/tools#dvlib/32.3.1": {
    "jar": "sha256-UuJ/E2TNtdT1MfUuTuxa5I2gQNqpQX1PBt32oXmaBl4=",
-   "pom": "sha256-5Ek+s5+svo+tA4l3JajXBfCW+ynms9RsiNQ64yGs/HA="
+   "pom": "sha256-oWwMX99GotcWPF8MylNb/9VtxfLw4H5nTiPBmWUaqAY="
   },
-  "com/android/tools#repository/32.3.0": {
+  "com/android/tools#repository/32.3.1": {
    "jar": "sha256-uUcLsB+9j8rUhH4dEJZ7IPqTJVNhwNKyED/G3P8TsXc=",
-   "pom": "sha256-oQ2iaJA8uDMbClOgBxbEleTlIcnkNrcwwd6U9AsBJRY="
+   "pom": "sha256-I5WOK1KCf4u6/ffnRX9RHq6GqstfaXJXXWxKCCGf3wA="
   },
-  "com/android/tools#sdk-common/32.3.0": {
+  "com/android/tools#sdk-common/32.3.1": {
    "jar": "sha256-fTQwgkEHHkgvR8y3xbpT6DhYNmkFBhl5rk7UYjxtzdY=",
-   "pom": "sha256-cZSK/6BViGCYy7TtDv3BDq79CrDf+kKpOIiWZVf3I3g="
+   "pom": "sha256-p9Lii7VvfZWScm63lumPFicwRmxupyLM7Bi+19bC5n4="
   },
-  "com/android/tools#sdklib/32.3.0": {
-   "jar": "sha256-LL50p9LqdggJ1ll9Dx8mnmOfsFPKlkzyUpdxb/gnTqQ=",
-   "pom": "sha256-xTwW1DWI6h9KuagG5V/lQpLnoFKKPdnQbeLb+j+ZIMc="
+  "com/android/tools#sdklib/32.3.1": {
+   "jar": "sha256-RDPKN52wqfe9Cl1bkxsKxnF0exB5FwbcDUKjSNrLt4I=",
+   "pom": "sha256-6w/o5i36EakHdlmM57bxHj8XNRq3X0IgonHTVWbF+eg="
   },
-  "com/android/tools/analytics-library#crash/32.3.0": {
+  "com/android/tools/analytics-library#crash/32.3.1": {
    "jar": "sha256-ieM7Pq8F53V2yIyhSkWMR9/gc177+kjuGOX6hflfbyo=",
-   "pom": "sha256-ScsowAM+D3CLvvH69zW5ZoAhYzHKhmW9SlEG8ORMrVw="
+   "pom": "sha256-MXeJhfsOZK1mEGb0Ai0mtp7crCH9KBbr7b0zm2RCSAg="
   },
-  "com/android/tools/analytics-library#protos/32.3.0": {
+  "com/android/tools/analytics-library#protos/32.3.1": {
    "jar": "sha256-6eP1AhuOxkFpsumkkjK76LKiPi3PMSI/mCFjIWsy0w8=",
-   "pom": "sha256-re4wIjKGjBUav6G1XD191xMXshOfgAzJJSt1EOsJ1BQ="
+   "pom": "sha256-CKnyxaNvGJFOcpQYt6kZyhorqg3aN+JkLikHkE7NINs="
   },
-  "com/android/tools/analytics-library#shared/32.3.0": {
+  "com/android/tools/analytics-library#shared/32.3.1": {
    "jar": "sha256-FyoDexHa4PLLa1xHoAHJAa/PNjHGN1JvVF5FF7lztos=",
-   "pom": "sha256-lrWIUFCuHpnpeQqmJgCOOUt0kU2LJcx7a14Q0vHSEuA="
+   "pom": "sha256-lY0cItqasU4SOGkObKuhWOZqBRgKStJnL+1BOvcv6cw="
   },
-  "com/android/tools/analytics-library#tracker/32.3.0": {
+  "com/android/tools/analytics-library#tracker/32.3.1": {
    "jar": "sha256-8IPoJieYHb4TErXoBelHDSa0/1bQmuj93M6Phi0ugHo=",
-   "pom": "sha256-Rddcbid1BkO+o6n8PlAMtPx11NUgxAYSSfPDFcKOGUM="
+   "pom": "sha256-g48pgttR8kzTCJXEeBJCjwxYT83evL0G/1oSeDHktnE="
   },
-  "com/android/tools/build#aapt2-proto/9.3.0-15703166": {
+  "com/android/tools/build#aapt2-proto/9.3.1-15703166": {
    "jar": "sha256-W83XH954Y8aMZ+5Kac+GIG+9Oi3mb1o+RiXOX7Tq0rU=",
-   "module": "sha256-TLWRQW5tGXdLeo4z1jDBBnsY6V8hV4OwhzP8wwa3Bwo=",
-   "pom": "sha256-dPnXBa2fE+47QcQTUE1QRvhZo3ExnhqDe450K/lm/Y8="
+   "module": "sha256-o8WXbWWnh4IrQn0RQRDG5qt/qvuAcQeMM4BLskYDh4I=",
+   "pom": "sha256-+Baxu8UUqqY1UYZbNQQSs1OZRiYowdwLE4DsghYlKzI="
   },
-  "com/android/tools/build#aaptcompiler/9.3.0": {
+  "com/android/tools/build#aaptcompiler/9.3.1": {
    "jar": "sha256-qqPajpWKyUwzUihCJMgsDxU9y8k3bZ3cDY6TUIeEkwI=",
-   "module": "sha256-4QHZtVnvLDqT/mo4AvciiYhilkxRHz5dgwda/LkU508=",
-   "pom": "sha256-M3CUtKvQrVSqFTkxcqwfvdZt89sbUH++zEMTlRmU/Eo="
+   "module": "sha256-BxWgM637xsA0NJ5Fh/wSYy8vo/76hZF041CTnOko4DE=",
+   "pom": "sha256-kHDXzZm0mqeu4/3jogAZPEXCvdRkhaX5/p3/Og4OOJQ="
   },
-  "com/android/tools/build#apksig/9.3.0": {
+  "com/android/tools/build#apksig/9.3.1": {
    "jar": "sha256-VizQqIiQlg0uzkjhFsYfEociIvHcwwaJB5k4K8AZsgE=",
-   "pom": "sha256-qHXyBqJqhi8i4or0tbLJJluXbebEjS/t/v2dQPDWtdo="
+   "pom": "sha256-d++GaP+QFATu4vPowhI1D24yHu/ZCHVtJr+qVuPwNO4="
   },
-  "com/android/tools/build#apkzlib/9.3.0": {
+  "com/android/tools/build#apkzlib/9.3.1": {
    "jar": "sha256-pxRphRErupEYwEsOl0W6tzamZzqBQ/FGfC8+TCYr3iQ=",
-   "pom": "sha256-EOD4XbHss/9j8YK6ctRC924bFM4PWB0WnvEp7li0f/s="
+   "pom": "sha256-dGpOQfFztE+vSoFe+lD+ZtD3zCdiZjknZUsxBEc14FQ="
   },
-  "com/android/tools/build#builder-model/9.3.0": {
-   "jar": "sha256-obNh936T5CvyKhPX2GR3GkIx4Nm6Goa5s5nsZ63kMjo=",
-   "module": "sha256-7tBwSyNHhH4RJy10oPSn1AQQ6hCADdpWJhsg1ituYNw=",
-   "pom": "sha256-NL9h7Xl806UgXA1WcQYjGpuOi9qXvQQUYLglgmQN5pk="
+  "com/android/tools/build#builder-model/9.3.1": {
+   "jar": "sha256-8do5jdQNKJrlZgIrBXx8572Ttg0NdH+ZONtkXwyHK/w=",
+   "module": "sha256-FWVoWoCVsXD8jYu7nBGX3U9L3FUuVBrwbzySiIFSoOg=",
+   "pom": "sha256-rgtHtqCsI1SLoJaomFEKEVUAlK/+YJPVE1I1BDYV1R8="
   },
-  "com/android/tools/build#builder-test-api/9.3.0": {
+  "com/android/tools/build#builder-test-api/9.3.1": {
    "jar": "sha256-PN8Mr4sqEE62I51Oo+labCC6Lnb6CtETTI6T53V71DI=",
-   "module": "sha256-bN+5XFKerE5OYci7/Jmxjg0fzk7rVcWwDqoMPnRbXPI=",
-   "pom": "sha256-7muhkq2lOmt7Rb5YESTo9n31GsrAMBf6nCGRLtYW7xg="
+   "module": "sha256-IhOs5hBmNc8XDhw/aSznBT56oLJCBJDZgRfag7Evg8A=",
+   "pom": "sha256-yQNOMW1P+N79xh8dOgJB/SK01Wc5h/Qe+BooSWl/Vd8="
   },
-  "com/android/tools/build#builder/9.3.0": {
-   "jar": "sha256-3R87EMcxGgCY2nifXGaEj9kAsxFj9vfWbHvKAnY1N30=",
-   "module": "sha256-KESO9XB/XviP2+ak+oQnOJh/W+P/lxnOmDxT9GLlTbc=",
-   "pom": "sha256-guBvMDnwWzFcV6bRPaG3sHnRT8lc5XsOqQLWXP6AXkg="
+  "com/android/tools/build#builder/9.3.1": {
+   "jar": "sha256-hz4On+2odi6tD/HOYMMMwr8cCFnhOSRacjJI2ZiwCfo=",
+   "module": "sha256-LmEbS3sL6/33lJfM+JnnL2BThTcCVjcqSiLM6bTKUoU=",
+   "pom": "sha256-1uwopMlNEWJ/flwz53SGhZXqb3/dNUtrKYeptc6HUdA="
   },
   "com/android/tools/build#bundletool/1.18.3": {
    "jar": "sha256-zK0YUU/ZfbAQhWsrvtQPSB+LqTSTaMl65U1y41Z9AXE=",
    "pom": "sha256-+mdLOblsrpgBXzhQ82bP6wD+bHrqLZCyDAF7kOCZba4="
   },
-  "com/android/tools/build#gradle-api/9.3.0": {
-   "jar": "sha256-KqAjsvbBKWKzd5G8hr+q6xCSi4Dfu2kWVRJ/0xVlBQE=",
-   "module": "sha256-ppPYb2W+ww2vhpjF/0ASIFy5sFZ9Sf/RdhWWIuh5pag=",
-   "pom": "sha256-K4zMdYHwZ8qItVxHAS3GTr7xNF6n9o8x5vvYumLzVkU="
+  "com/android/tools/build#gradle-api/9.3.1": {
+   "jar": "sha256-Iv4StzDJElqDSo0Ax4RTzh+UtTiDMePTHXhAnXKYgS0=",
+   "module": "sha256-GrsKs4U3FN4h1YnUp6jXwB8siLenDnYE+WLwuCzfomg=",
+   "pom": "sha256-lpwraf+XSG7BGtcEbZxC01yRNTkZsLrtozxz/XdpuQY="
   },
-  "com/android/tools/build#gradle-common-api/9.3.0": {
+  "com/android/tools/build#gradle-common-api/9.3.1": {
    "jar": "sha256-X4zrFzgDdwfRZvebE73gUgJKY/xSuK0RrSy8eA77uNI=",
-   "module": "sha256-3Pc9sNlTqbYpti61KiXWhLfiPPOVbE/5iZky3gJ5VzE=",
-   "pom": "sha256-imdTo707dwOgnMJfppcv4YFxtoZ4g4O8GYzLOO8XzwU="
+   "module": "sha256-ZUQS6Y5s7ZQNPTCGKGYvwf7Heql5C6wpHEHQm+pqHB8=",
+   "pom": "sha256-npZjthy8rwlAJ7txjESy5pQsOdIsvAPH2kuqyxmKj7Q="
   },
-  "com/android/tools/build#gradle-settings-api/9.3.0": {
+  "com/android/tools/build#gradle-settings-api/9.3.1": {
    "jar": "sha256-IoR+ifElKUwwHVHuW2Ab9UGk4MU4MM3P6oMARs3GImc=",
-   "module": "sha256-QU8vV9PdJJ2W59P5IgCSaVe2aCyiUwVfwv2wIQSj8Cw=",
-   "pom": "sha256-HtiKzUwSCqX5Cu/9sZuUWwZuhWz0wMB9Ue9qs/VWZiU="
+   "module": "sha256-BKJlGiunlPSerC40HDCN2fTROJ9Hw1JiDaM7+DSHIm0=",
+   "pom": "sha256-f7G2OJ3uoHXqlVnJ33QSpALlobqp5iKE6fu5PzrEqUw="
   },
-  "com/android/tools/build#gradle/9.3.0": {
-   "jar": "sha256-GwFH7a5F1pDuN2CvDPV2WpC4+b8/8edDSUGrDUTiijk=",
-   "module": "sha256-AcyEaauUr1z7ATHzGhQbv95v/PzFBhetvyn5MIE3TUY=",
-   "pom": "sha256-VsC6wFSWDH4t5CwIP5EpxIv+IS2CPwAhL9kdAMQUztw="
+  "com/android/tools/build#gradle/9.3.1": {
+   "jar": "sha256-Sun1XO8RWXjef1AuSeoWPonHioq0CUNQSjfJSLlOrbU=",
+   "module": "sha256-YjfuJG0h/lxjeMsGGindxEJqTw3PG8ZuckVqSFvTIYI=",
+   "pom": "sha256-MQuHrVDZMsfOiKQk6YKNRgU2pSSi+RwrFlaRUYPEJt0="
   },
-  "com/android/tools/build#manifest-merger/32.3.0": {
+  "com/android/tools/build#manifest-merger/32.3.1": {
    "jar": "sha256-41/3qgpLKWYNWLCmZ997VDqoX38d1GKh3SsCGjoXWjA=",
-   "module": "sha256-qgxh8j1ecBs5mwg+EEzfweBoMVyOWIGToc5lXV75NSA=",
-   "pom": "sha256-U/F0xjz/L/cQv6+B45KCWD01oSYxZTnltotZPTdGqMI="
+   "module": "sha256-iyvToBePbjJfO5v36oe2kmVos49K0v9SXbWLvV7ZMS0=",
+   "pom": "sha256-bhBSu+KElFzeDHjodFct7+pNmXgkXMAMd0pqwO7zH/0="
   },
   "com/android/tools/build/jetifier#jetifier-core/1.0.0-beta10": {
    "jar": "sha256-Jqu0oTkn2QYhacUEyelP6A6a46T3tauIdasAdTapH14=",
@@ -583,31 +583,31 @@
    "module": "sha256-NsJVdrGZk982AXBSjMYrckbDd3bWFYFUpnzfj8LVjhM=",
    "pom": "sha256-M7F/OWmJQEpJF0dIVpvI7fTjmmKkKjXOk9ylwOS6CEI="
   },
-  "com/android/tools/ddms#ddmlib/32.3.0": {
+  "com/android/tools/ddms#ddmlib/32.3.1": {
    "jar": "sha256-i8jt8GN6m1IP6/g7ELV/MSDeX18ylcsjLJBGT2XUQxg=",
-   "pom": "sha256-/aabrkuIxIkrDyNScQ4mbuhwB5ubDw+h13kiHuLYnBQ="
+   "pom": "sha256-GTO4SU/N5LCx730I57Is53Nisx4w/lIq1AogfBWuZqQ="
   },
-  "com/android/tools/layoutlib#layoutlib-api/32.3.0": {
+  "com/android/tools/layoutlib#layoutlib-api/32.3.1": {
    "jar": "sha256-Ek8E66gAM+UIB0igV5cAOoHJBt61t2Zjq8KJ0AmUPoI=",
-   "pom": "sha256-xaY2O/ROKo/F8id+xMV1I7SbQSxtnYC2Jp3hdIrMwBY="
+   "pom": "sha256-dN3bgr+mYYG1jkynMoj3y5wnY3ADpb3sjEW2hZLZR8k="
   },
-  "com/android/tools/lint#lint-model/32.3.0": {
+  "com/android/tools/lint#lint-model/32.3.1": {
    "jar": "sha256-26dxnsK6n36AAUfdIftXvmXg7zFaNzVvaHjYEiLoL8Y=",
-   "pom": "sha256-V79SL1cLQcGo47QQA8bddAgECE8w23atHsSlA3cLLcY="
+   "pom": "sha256-6oSnaf3jICQmmMjqtQtM7TLKLgLLnpLu6pRvkBrlCKE="
   },
-  "com/android/tools/lint#lint-typedef-remover/32.3.0": {
+  "com/android/tools/lint#lint-typedef-remover/32.3.1": {
    "jar": "sha256-4oHpCm/8gxgA5kUXvo8bIwpjZ77CJvGwzhqA1Fc96t4=",
-   "pom": "sha256-du3cmDpbta+Y40xMzuewGLaT4KjIKI01ItRfG0i1zuw="
+   "pom": "sha256-UGyBfXGfsH0N8TXhiIjexXF8HJtwGlq5Eb2Ja1fLmEI="
   },
-  "com/android/tools/utp#gradle-work-action-api/32.3.0": {
+  "com/android/tools/utp#gradle-work-action-api/32.3.1": {
    "jar": "sha256-3od3Omd+h/YZx1HDBq9u5zoEp7JuXyBf/yh3KNivSs4=",
-   "module": "sha256-sMIHUKSTUZ2ed9+vWmR9jAPJd5ya8pRRkxiYxhW6evQ=",
-   "pom": "sha256-hcXif4hSnQnaJfKZr3aapgzktyHEI4WdTLLMNTqs09o="
+   "module": "sha256-Qz18BGs0B5EMKIPki6SUUekol8IDHavU34U+xalcGoA=",
+   "pom": "sha256-VzjG3Xe21wuEoO2Piowmweb/UbeLhq3my8Z75uTF6y4="
   }
  },
  "https://plugins.gradle.org/m2": {
-  "com/diffplug/spotless#com.diffplug.spotless.gradle.plugin/8.8.0": {
-   "pom": "sha256-rjIEDWCar8jpaUB9lB6OAJ+/vhmR1A4GdTe9vlxSNxo="
+  "com/diffplug/spotless#com.diffplug.spotless.gradle.plugin/8.9.0": {
+   "pom": "sha256-KiSidLMlcjuB1QGv6fjuNTNJK+WK2VIVukcEh39e4Y0="
   },
   "io/github/kdroidfilter#plugin/1.15.7": {
    "jar": "sha256-IvPp5/y8+e0Bcyi0Eb7VhDJhnawfX4TcLnDDH8EzPS4=",
@@ -674,20 +674,20 @@
    "module": "sha256-IFNqlfL+sr9DBRKMaq7Lb9idxFeYqchfJgK4qAnXUNs=",
    "pom": "sha256-Q1z/VXiZht7arXF/aPuo1UgklHhWLc2EsirU1lZvRAs="
   },
-  "com/diffplug/spotless#spotless-lib-extra/4.8.0": {
-   "jar": "sha256-vciax56nfFUzRzZDf6MuhsUW1aCbayIXgORXl2Pe6mw=",
-   "module": "sha256-fsJucDAxGawridZllXRA1d9cZ2/jMz8Vktc/lJodN10=",
-   "pom": "sha256-acayk+D14uHw0OiAyNZme8vsJ/Mudtw3+PFKaTw4Zis="
+  "com/diffplug/spotless#spotless-lib-extra/4.9.0": {
+   "jar": "sha256-HyB4zQvxKfI/aIGO8OrU6ZzrqKsAjmOKwDEbUHsBKZw=",
+   "module": "sha256-I50MaVyJBIeDyCJl4zMasKuy2R2M3KlK6mTFAn0trCs=",
+   "pom": "sha256-4wnu/KcMgWId/dV/l3tpBl8bLn/F1e5Ter3IWJqR7Js="
   },
-  "com/diffplug/spotless#spotless-lib/4.8.0": {
-   "jar": "sha256-/qJP2CUPcEnc+D6cU33KcNTu3fJ/ZWLMBbc5RdVYahU=",
-   "module": "sha256-x5qeZYQK3GICHDbY3j03FCXYZL+TSkWfzxQGxBBBSvc=",
-   "pom": "sha256-g1NaMOkgleCBTo4Y9mGvsc7Q7O/Mk+sI8iLXhiWBhYo="
+  "com/diffplug/spotless#spotless-lib/4.9.0": {
+   "jar": "sha256-kJBhy1A+7QEskhkMHZAXa7on65jVopAG6tFoGlkG8m8=",
+   "module": "sha256-5ev03bdRVVuCANvKHdvU32eoI7dR1b71/s+m2wiZoyw=",
+   "pom": "sha256-ieleUBzLXDxf9VR8iyR3/Clbl34Nj34OULWTrue9sL4="
   },
-  "com/diffplug/spotless#spotless-plugin-gradle/8.8.0": {
-   "jar": "sha256-4/v5wKvEIhru9DiGAA42oyMIvSNL9ntejx7B84MfVwc=",
-   "module": "sha256-NUNvS9pmAuS19I0Fer3fwb8+HY2kqJwdX8akTskkZcM=",
-   "pom": "sha256-oqjiUXekuEq40FutW8x6s8dbgWyibr2HC2jl+SMaJMY="
+  "com/diffplug/spotless#spotless-plugin-gradle/8.9.0": {
+   "jar": "sha256-quTS9fpQJs0gJ0xXYP0Be0mSMAMv6E39jkgquZYNN2Y=",
+   "module": "sha256-Rdxah2UCG19mXf3ilysGO5Zgt0tySYdVqUVDQ0PYAOc=",
+   "pom": "sha256-PNYQSZvqWU/zcOUC/g/oAAWXUNpyrGTsPlBnkM0hE0s="
   },
   "com/fleeksoft/charset#charset-jvm/0.0.8": {
    "jar": "sha256-DjFsMXYnKAwlM3LhwrxfA3CZLzz6omt2bu11ckOdnjs=",
@@ -831,32 +831,32 @@
    "jar": "sha256-8d0j+K40qOkTZnI5kerQ1kmdGj6RY85VDCALAtdqhys=",
    "pom": "sha256-JlupWajhPDoGEz8EtTkWnBAY2v/U0z9TxFOrTLOG9XA="
   },
-  "com/google/devtools/ksp#com.google.devtools.ksp.gradle.plugin/2.3.9": {
-   "pom": "sha256-uOx1tgDx9R8k5dPrtMFF3hPeP3XHXZ6twM1XnMDiBjA="
+  "com/google/devtools/ksp#com.google.devtools.ksp.gradle.plugin/2.3.10": {
+   "pom": "sha256-h1gWlHK3P1/m0ACDAyOAcegKLMocazdfVTjL0Y/JKsg="
   },
-  "com/google/devtools/ksp#symbol-processing-aa-embeddable/2.3.9": {
-   "jar": "sha256-s1NqDlmerxwVCkKrCJ2Ngq7sNfslRsk39NN/TF7LeZg=",
-   "pom": "sha256-1d1GunXfZcz0PAk/C3E0kD+daCmZdd0ghR3+sWALgpY="
+  "com/google/devtools/ksp#symbol-processing-aa-embeddable/2.3.10": {
+   "jar": "sha256-5+mHMlZuln/8ttw8NGF64sYapQrF3cWkrpoImGCbtpM=",
+   "pom": "sha256-nP0wBi1IV1mNidCwZMd79EWZ/oQ9ahuypXdO/UkOcD0="
   },
   "com/google/devtools/ksp#symbol-processing-api/2.0.10-1.0.24": {
    "jar": "sha256-3X3eBwvlTeZse91N4ExD+0KeDGK7EypkSM+jNlOvsik=",
    "module": "sha256-v8OiFHE2oHw5IP2mGeugc8uTgcVlf++xYc/ViZSPmVI=",
    "pom": "sha256-RSj+eY/v7sCVpz6GHBIG+oJUlqDntlInL0D/yWCBTmI="
   },
-  "com/google/devtools/ksp#symbol-processing-api/2.3.9": {
-   "jar": "sha256-U+S7dLfmXQZSInOXNfny9X7tuuu9MU+mkWe9Q9rctlk=",
-   "module": "sha256-g3e60trCIAdhsmbrkl0IasT+VoE0yCNgjvk16TrrxBg=",
-   "pom": "sha256-ULDusguRXq2LA9rx1aO2EWjvaXJ5Ir3s4cGNQBlodNw="
+  "com/google/devtools/ksp#symbol-processing-api/2.3.10": {
+   "jar": "sha256-iKIDJtvXlFyAWUqNA9jislO20+NUR9DG5t8rN4n9DI4=",
+   "module": "sha256-AbGZMezzCaZyolCeT4FPHW/5Tz1UGi5CS1dznUCdzHM=",
+   "pom": "sha256-yci9roQWVxPwe2s0zOJxNhMzOweWAOO+MbHSNW6Lw6M="
   },
-  "com/google/devtools/ksp#symbol-processing-common-deps/2.3.9": {
-   "jar": "sha256-71Hoja2Kg5rA3eoOZtGawUxWA/NQCZXbj8qx8b5f07k=",
-   "module": "sha256-mnJX6ejdI3NBBg8gNysqwqtAcuEDAWjMEMovLMZkGDU=",
-   "pom": "sha256-mx8qj7AhaaYjHIDK7oR9N93OJhdGODxF8VIDYS0sfTo="
+  "com/google/devtools/ksp#symbol-processing-common-deps/2.3.10": {
+   "jar": "sha256-MFEKQ2TgKIDOL78MTw71ZN6tOBju9PwFAMvO4j/DYq8=",
+   "module": "sha256-EqZXRUC7UEozmZhbBXWrMfShwEVWFakuwIXt8zcwNFA=",
+   "pom": "sha256-GvnsBnkMCCio5KzWzkCnRhryGHLx2k84qn5Lswwvq8M="
   },
-  "com/google/devtools/ksp#symbol-processing-gradle-plugin/2.3.9": {
-   "jar": "sha256-D6yceK1OD2n1vbCFAgP4K1vWP94FmawUIK7rA0UDhQ8=",
-   "module": "sha256-dfRI3nvmQdHxm8SRGyTxjQ+JkdgKO/kbWUb3RKG42lI=",
-   "pom": "sha256-3aypuMHpXv4oyOyH+wKEpd4V1RRpFXPLhuJnUSHhn/0="
+  "com/google/devtools/ksp#symbol-processing-gradle-plugin/2.3.10": {
+   "jar": "sha256-ldvaRGKRNAvrrvX+stWmSbUA+se/DIFoOMi8o44Lsko=",
+   "module": "sha256-xkbL/QOaYAHEBKuLtirlc3TDoRvQdbBaK4otuiYNLws=",
+   "pom": "sha256-CEU1qNaPg8RB1VwJLb4GFnFxsDOo9d2gbpwrSv+CKrg="
   },
   "com/google/errorprone#error_prone_annotations/2.18.0": {
    "pom": "sha256-kgE1eX3MpZF7WlwBdkKljTQKTNG80S9W+JKlZjvXvdw="
@@ -1354,15 +1354,15 @@
    "module": "sha256-2cXzDOE5EMq7unsobKnsELBBcyAy8TVHjHkg4Tdu7Jo=",
    "pom": "sha256-FtLTdAfQ91OyZajNnvacr3f+d4ZDUdplKji9ksJAL2g="
   },
-  "io/insert-koin#koin-compiler-gradle-plugin/1.0.2": {
-   "jar": "sha256-sIVF+opWPWOzZWf/rX321jNpSD2B9qy4fvsh3CAMQPM=",
-   "module": "sha256-0u99cn1YbnyxtXmdPQ26eNNBqRlEXCY+GBZCdV9B2/c=",
-   "pom": "sha256-j+Nh00hnd+n6qAcy7+2nc7DjUwLlWMedLotz9gnze3o="
+  "io/insert-koin#koin-compiler-gradle-plugin/1.1.0": {
+   "jar": "sha256-WRwGLd1qY2m3VL9Fm4oeOmz0fotyWrdxn8M2uGJHyfM=",
+   "module": "sha256-HOZslS5qNt4AZQ5ld4HyFJKUBy3wvRyzR1gDakflqHw=",
+   "pom": "sha256-4kYmR+u8V9s/TlH4D7jukorB08t62R2syVVV2cGj6Zw="
   },
-  "io/insert-koin#koin-compiler-plugin/1.0.2": {
-   "jar": "sha256-nHesE6Cib5SdqowxLX84vCrUgFX/05Cgmbv+2nCW6x8=",
-   "module": "sha256-pCa0+aNYuiwS1J3qVPuAbdRwn9l/3ilj3f85BRxI3f8=",
-   "pom": "sha256-BuTjOlGNaD3WuLwhVoX5OWzTW112YOhI9hpr1wszoJU="
+  "io/insert-koin#koin-compiler-plugin/1.1.0": {
+   "jar": "sha256-+4LZ44WEZRC4SFbEE7cLTPpN40b9Vr8O1lfKRoZXNTg=",
+   "module": "sha256-yxDz5tA3cI0x6QKnHECMVPGfB6+i2fzMFb8S6u2iQUw=",
+   "pom": "sha256-PfHzZ61iZMo11HwP8K46VG7S7YrzHzPWo1v9awzD6SE="
   },
   "io/insert-koin#koin-compose-jvm/4.2.2": {
    "jar": "sha256-O1x76W0z/ss3czczPI/5E9pjbFBtZu8MeXagvXJpSxw=",
@@ -1424,63 +1424,83 @@
    "module": "sha256-GCBqnfd/y+Hnx3gz3vxIEhHwz8ECQMyhJ7ea60Om2cg=",
    "pom": "sha256-avcxON4sYbBzgB+zxgPfD+CLISXBJYSol6O3pQ95jGU="
   },
-  "io/insert-koin/compiler/plugin#io.insert-koin.compiler.plugin.gradle.plugin/1.0.2": {
-   "pom": "sha256-eWVveQ2sv6Vou92/p6CKLtFwQa8bDCRjdj4n/3mdaZY="
+  "io/insert-koin/compiler/plugin#io.insert-koin.compiler.plugin.gradle.plugin/1.1.0": {
+   "pom": "sha256-xrRQl+GBODi5ySoAsgKZED8rTdOCU9/EL0Qwh43c0zU="
   },
-  "io/ktor#ktor-client-auth-jvm/3.5.1": {
-   "jar": "sha256-6LHPQfaGy00U74mciKZkGGFeeNBGcunRdY8FIFXYKXo=",
-   "module": "sha256-YAH4WyEeaGAI/5AttIlI4iYoSOOcQX5dQ/n/sX0dVsE=",
-   "pom": "sha256-0HUznhwc70zjskDyjeKi6j7kyxaM/esXgAU2ttrb9kw="
+  "io/ktor#ktor-client-auth-jvm/3.5.2": {
+   "jar": "sha256-IAFTH3SG5JMHRw67D5SDePyBrN594TWNZTzo0T/o+OY=",
+   "module": "sha256-/hzHrbINeVFyrCfUC9UgS1e9+1Xx1SK1ISSiKXXzTTQ=",
+   "pom": "sha256-dQe0t0ruI4Mg0fy7twlFedaMM2dEjNFRz6q3roMOsyk="
   },
-  "io/ktor#ktor-client-auth/3.5.1": {
+  "io/ktor#ktor-client-auth/3.5.2": {
    "jar": "sha256-ZvdTNWTmuf3q9n099GDdzxt3JS7SOHbCcGn6O9e5/9s=",
-   "module": "sha256-pTbzq5G2yQpjaWk/xEGlibreSf+7qWfE19j+BdqiZu0=",
-   "pom": "sha256-5NKmxkSCQhvk4vgYnyLCNZMMtAvpqIQKvaGjzjzT5h8="
+   "module": "sha256-XXiRBUCjDTwwgezqXEsYrB2NRlIpn0djjHQMFX24mDc=",
+   "pom": "sha256-VzMrQzpEK/11Anc35QVSAkX61WA3JI+y3GWs48KrgQ0="
   },
-  "io/ktor#ktor-client-content-negotiation-jvm/3.5.1": {
-   "jar": "sha256-SHx3J8P1v20j/HrmFZjZ3qoUawK4VkWMKM2ttElFHDE=",
-   "module": "sha256-W2LxKqnYQ6GxB+vhjb9h1/srWctwlSMkPzJoWFQp0Rc=",
-   "pom": "sha256-phehF7Pjc2Z8kEuNjwefGfRrYxy83nJnX9CbMv2HHpI="
+  "io/ktor#ktor-client-content-negotiation-jvm/3.5.2": {
+   "jar": "sha256-NzvI23rY6f3+jQtYKdaytSbWd3u5OhMcdWnS4CPlMuA=",
+   "module": "sha256-Xl4QlftShnG4s/aFu0wbzwMK1elFw6xQLH611WRF9VY=",
+   "pom": "sha256-tATqenr1BUQyOcZAbSO/CMHJZirGr/REtu3xvV7RKzw="
   },
-  "io/ktor#ktor-client-content-negotiation/3.5.1": {
-   "jar": "sha256-5eRVN7l7z193HN5V++KnANnDFxR5DsK6T1FbxQZeNyo=",
-   "module": "sha256-2KTPnXaCesSn8VE8Kaw+MuKhqE66a+5jP/O7oDOkyUc=",
-   "pom": "sha256-yvtfgEa3orr1AorB8wVtoCBhNQoPKm1pJhlhzR77GQU="
+  "io/ktor#ktor-client-content-negotiation/3.5.2": {
+   "jar": "sha256-UeMO+jd58uDTWigM1xusJc9uJxMHwOL8IkYhXJaD7So=",
+   "module": "sha256-P/Bq0PnTBMlIHfZrppXOHuDufrahbf4Ny/OP2wTGmZQ=",
+   "pom": "sha256-17LB1K7aE+jnw1pb4tWiY8SHmeOKLpRrTFTYJ9hoQjs="
   },
   "io/ktor#ktor-client-core-jvm/3.5.1": {
    "jar": "sha256-fWipfsyIPpPx1hp0EH5E7PY6X/vLq13AF3Pm2IQn6Fk=",
    "module": "sha256-IWYZarSoyT6lF2ixQtdjbMODz0C9Fy0UTi79G2Svohs=",
    "pom": "sha256-4wRHojFqx6Zki2yHARIZAhAg7E0k5HfmLYNvEoqLdEY="
   },
+  "io/ktor#ktor-client-core-jvm/3.5.2": {
+   "jar": "sha256-PgPXHFxjcNEo9IPPY8/mJijVwNGxrF5F2+Kmgl5pavQ=",
+   "module": "sha256-5Wd4i2WHWCiih9/Z1mx7L67a0YP2rH8mFO0/b8y00Qk=",
+   "pom": "sha256-OCnQqtatf187nXfKa97h3Vw/OJrItwSXp7EjCYDPP3o="
+  },
   "io/ktor#ktor-client-core/3.5.1": {
    "jar": "sha256-MBGNcaNs0QG1S+DBtt1Jtw4dKcGHgolIn256p9XYjzg=",
    "module": "sha256-tgQHBZyofCSyB4KTv3XPaYhU+EaBfKjrznO/EYrogCQ=",
    "pom": "sha256-fJud5b5bzbaqWrKRqxYkVL5MA8oJcd27BhMoPx/18Xg="
+  },
+  "io/ktor#ktor-client-core/3.5.2": {
+   "jar": "sha256-NYl86DJjCk4z8EFpUbiyYDpd6zvmUpqxeoUEPPASRjk=",
+   "module": "sha256-IcCLNdRFVpQZMFgldjUiCS4E+9su9eOvQ2e/B47AzXw=",
+   "pom": "sha256-ivRBpkstvC5MHwCNsqt6G9QglV4GH/iUQaDAViGbKCk="
   },
   "io/ktor#ktor-client-darwin/3.5.1": {
    "jar": "sha256-j8Zucfr1HjpVI6C8XNgH+conVWaK9awQcVHBg+s7484=",
    "module": "sha256-3gK2bac7FTyzXIjv/1o3Xq/dRxrpRE4shA0ZRRPqZ4A=",
    "pom": "sha256-bnckirF15S+1ju96AWeEpaa4hfYXXvUfRvtqMffUB1M="
   },
-  "io/ktor#ktor-client-logging-jvm/3.5.1": {
-   "jar": "sha256-TKhNxAofcy/zxmEyDenoe3Cufa+WQWtwXIR05qSGEKg=",
-   "module": "sha256-uucs+tTxfjtIK2gKvVWESiNy1Lyrbb4fIF+4fZZTnXw=",
-   "pom": "sha256-VfImhbdtDqNZs+hgbCGL7vKO3UaAzRaRqDYGoeQRAcQ="
+  "io/ktor#ktor-client-logging-jvm/3.5.2": {
+   "jar": "sha256-1WK1k2hm/843hBPm1jKG2RrUnmoAfBDNQFL2iNWOzOk=",
+   "module": "sha256-SGdsqLuffcT7wYdDWmADw5k/4sipnhAIEXG/xte4vFI=",
+   "pom": "sha256-zuyMZVgtTAs155Zk8OORVTcgKAn1iOrnAYCkWFz6aAU="
   },
-  "io/ktor#ktor-client-logging/3.5.1": {
+  "io/ktor#ktor-client-logging/3.5.2": {
    "jar": "sha256-Qg7cSJRLGFXAIRqD7/BtUt1/RyKMHG5EL+CCvP1Nw0w=",
-   "module": "sha256-abzwUy15D3B/uONLRl/o5VZpMx3F5cnjecxrDA5mutA=",
-   "pom": "sha256-ueJf/6FA4xva4VSSs6gI2/JE97DgO9AinPKNCwMWdAE="
+   "module": "sha256-IFPMvH50H+gF6AGLpoY+4dB/FRTHGYTg3WDJ//9Dmh0=",
+   "pom": "sha256-wLxTFeMhWD8V1y0L070jAk3kS3ltxQes9bp4OAjnbjE="
   },
   "io/ktor#ktor-client-okhttp-jvm/3.5.1": {
    "jar": "sha256-nVFYw4OQEzlZy2bKRqBUwXBSpjIGflYkP3/lDuBebhE=",
    "module": "sha256-dbSWvS7Du2fnXjy9cmrbfo7fUBZ3H+E+svQQQqEJef8=",
    "pom": "sha256-QXNJkNkHH1otra0CKFyfRXLbRb29vSZkVvy1GYuPSF4="
   },
+  "io/ktor#ktor-client-okhttp-jvm/3.5.2": {
+   "jar": "sha256-S/kXXd6++dvkJfnjCcas1vFgr2DDcL7h1aiQV3KyH3Q=",
+   "module": "sha256-ehxgt6PYaOoOdpQPBIzB9ve3AQ7iNnXDUWHjR8O/AkM=",
+   "pom": "sha256-1rlaweMyT+WPwbXICqKsTH4aS6kv1kMiPPLYXLqppBc="
+  },
   "io/ktor#ktor-client-okhttp/3.5.1": {
    "jar": "sha256-CJ4kQXv59sNO7Fcg7rssvMguooVezvkBM+sX4QedWGg=",
    "module": "sha256-LN+vr2alXQi+Gufkf3JzbvK8jtBYw4Vurn95gXIKPDc=",
    "pom": "sha256-rc9cEX3uBiHBnq97cRp4SkFMIU5P9visXpGwApWoNmU="
+  },
+  "io/ktor#ktor-client-okhttp/3.5.2": {
+   "jar": "sha256-CJ4kQXv59sNO7Fcg7rssvMguooVezvkBM+sX4QedWGg=",
+   "module": "sha256-ON4oTdrRsLV/g09GFXk5+0wqVSXmebL81q+oChLCpws=",
+   "pom": "sha256-gp4HOKA8rsNr+gPbr0dT+Lp43SC5VrM0i/l3ZlOuoOI="
   },
   "io/ktor#ktor-events-jvm/3.4.3": {
    "jar": "sha256-DwShuDgBMaFOlwW/HcvJ3yMvEkFTP8W40avYMHR93KQ=",
@@ -1492,6 +1512,11 @@
    "module": "sha256-ullALmQwBlR+Vk8/1gpexgWb/1ZrM4R6kRFGuWgLNdc=",
    "pom": "sha256-K15fKhcO9MrtQ+6C/cVpjGiiCAlvZ3iCZn2VQGWyGUE="
   },
+  "io/ktor#ktor-events-jvm/3.5.2": {
+   "jar": "sha256-dxLtHVFxYYCpZm/ojaXF7w5JEjSDrizRSuPpJS7nEUg=",
+   "module": "sha256-+sTDeXDiLRbWTbZodoRPxUjkUSPcUGqJOR5FR2drWPw=",
+   "pom": "sha256-3pbDg0qvmqwqhSGPIJGoZxKnjSrZ31BfsceliQaQQPI="
+  },
   "io/ktor#ktor-events/3.4.3": {
    "module": "sha256-iFOMVNRUJlYsI/dtPg0Xh5dQu2dJla0gERa4UrAIhdU=",
    "pom": "sha256-AMiqw04HLRxxjWn5e7Xaejg0YvaNiOoMHFp+3kd95+k="
@@ -1500,6 +1525,11 @@
    "jar": "sha256-y2t/GV/ZyDsXJxL7E2i7me5gHCM66+/7nt8XK2oQKkA=",
    "module": "sha256-pqrBWmUqtUSmwG5Yqd92HTFX1uZKwCOsO4ipb7bn06s=",
    "pom": "sha256-px4/NGB2xEuTNAWUU898l2Kg+XPYtwVspI2h2ixowcA="
+  },
+  "io/ktor#ktor-events/3.5.2": {
+   "jar": "sha256-y2t/GV/ZyDsXJxL7E2i7me5gHCM66+/7nt8XK2oQKkA=",
+   "module": "sha256-E8ITjdOBvsYoXxcKGqBf3XM6oVF2AR1WMOVSQzcqQVs=",
+   "pom": "sha256-2dBbwHE8A1CJXfc4Re0v0U+Ip8BnL7K6xw8dULpxYDU="
   },
   "io/ktor#ktor-http-cio-jvm/3.4.3": {
    "jar": "sha256-8ElYQSa29Nouk9fUMzYpYxLiqI1dUmPx0dJPG41m/zo=",
@@ -1511,6 +1541,11 @@
    "module": "sha256-2Hw5UmBIyVRilKKLk7XLvgO3g88OVjcW6woxmSbgWiQ=",
    "pom": "sha256-/L0pstFAhtxNlRrFIttOF15dYqMZSMQqDApK25sevx4="
   },
+  "io/ktor#ktor-http-cio-jvm/3.5.2": {
+   "jar": "sha256-PIej47NomUpIXi9i9Zy+IgHXZwlAGLcm6B/76bSXZVQ=",
+   "module": "sha256-kH8fGOehtb/tmI23iSsTYJTHAnilCTkXDqKsKO95teM=",
+   "pom": "sha256-MLo3kP6ddRV9OmzmhsRgYUX5e9Hd2XWdNpEpdkLXFRE="
+  },
   "io/ktor#ktor-http-cio/3.4.3": {
    "module": "sha256-bJGF/f35izzYbLpwez4NoUr7ihTePe20hccafwPMyuU=",
    "pom": "sha256-62gfWQOGEvNs8oXWt6bpyuWDBCTwrPmaAWUUu8nYjp8="
@@ -1519,6 +1554,11 @@
    "jar": "sha256-z+ZRVd4Smrx6O5bfYsizebK7Tj83ER+IQ8Fb8O+1Qc8=",
    "module": "sha256-WJEB+aecIcQkV8lWgWjL2vbYmwE6fXWw3j2GPxWklno=",
    "pom": "sha256-pdQ9uRQ3x4LSr4L5EYLCuvKZVzdiI/9YVdcyGG5VWqY="
+  },
+  "io/ktor#ktor-http-cio/3.5.2": {
+   "jar": "sha256-z+ZRVd4Smrx6O5bfYsizebK7Tj83ER+IQ8Fb8O+1Qc8=",
+   "module": "sha256-Jir8yxjcNckKTj5CqUpS0DjNg7P+4PXs22YzPF1EEzQ=",
+   "pom": "sha256-KEOq++mO0/BjjMQtRcYw7W/PtAU+P66zzz1Tg1W1pbA="
   },
   "io/ktor#ktor-http-jvm/3.4.3": {
    "jar": "sha256-sxNMLGxJvMl0ekJCeNByPtuiSiU7NkUOq8x/pWLirak=",
@@ -1530,6 +1570,11 @@
    "module": "sha256-abpgLhWntt9p1yay4wbGRvMxDB+KNVrY3sVzZJmstmE=",
    "pom": "sha256-VrGL9EIpNj0xM8NfgsvP99lVtchmbGDlSP66Y2N9PtQ="
   },
+  "io/ktor#ktor-http-jvm/3.5.2": {
+   "jar": "sha256-avyAdPYHMu1gzZBKPlK0aphCWzWhuURtLPpFfy7mO0E=",
+   "module": "sha256-cisd1GB8hrsFzsancIirFuug+aB5VE1usJMJ6A9ruZA=",
+   "pom": "sha256-DXHI6rXj+kD1Ow60WucRYFuxBWLbVWdfUYcNP+KrLvw="
+  },
   "io/ktor#ktor-http/3.4.3": {
    "module": "sha256-N0VSChyPVCRmCovRJ34JlqH/Ehp1aVJmqR7PEti5/iM=",
    "pom": "sha256-TRz1iMxd+vLlf1+yrnMjxA3pY22q2/5lLofqmPW8VkM="
@@ -1538,6 +1583,11 @@
    "jar": "sha256-Hf1GUk4bvz7XtPUjdlTYcY+RGGRYgoQlX7bLcv2FsnU=",
    "module": "sha256-d0T/s8aI4OVyAk0jsqGGdTFP/PGtL0sTune2Vwcwv0U=",
    "pom": "sha256-+lykK/QVxAoib9m3FhQyksgfbLzud6CWZ1CHI2IOs+8="
+  },
+  "io/ktor#ktor-http/3.5.2": {
+   "jar": "sha256-Hf1GUk4bvz7XtPUjdlTYcY+RGGRYgoQlX7bLcv2FsnU=",
+   "module": "sha256-LVImlZNGRAeVM9tEwjm+WtYU/b+XUDWYOjY5SWnWeq8=",
+   "pom": "sha256-hEwLmtymxHJS7/uXhP2s21Cv27L6q5hEffkj+wZImUY="
   },
   "io/ktor#ktor-io-jvm/3.4.3": {
    "jar": "sha256-RdpGKS4cKwWAxIfrp2fX28tQRg3y1uiTf0PoddkrRN8=",
@@ -1549,6 +1599,11 @@
    "module": "sha256-8Z2eyaP8RgJN/cuF1PI1Ac2m70JC+FbULiOClYrQU8I=",
    "pom": "sha256-BP5pMt3wZ9S2p6/4p60dpx5B8B9QQNzSMdeXfNl7WtQ="
   },
+  "io/ktor#ktor-io-jvm/3.5.2": {
+   "jar": "sha256-uZC0MZtxEhj7zuL5jh3PKJoloXGUg3mS77W5cLO2xkw=",
+   "module": "sha256-tk4XinhkcQworIWiOi9AHHlz1f186AI9aaqbxOWnCik=",
+   "pom": "sha256-IJbnf8HMo6gNk4QClGNIhRtBPTqR3BQ4Rv5i2jBpLPA="
+  },
   "io/ktor#ktor-io/3.4.3": {
    "module": "sha256-//2lHn3hMeIpcl+0IVMSi++p5rkRNAmxD4gZ0ehhdi0=",
    "pom": "sha256-vqyeo/zmS0cuMVI2afPLIX0xnqs8qd5LHq26ZBZV1Jo="
@@ -1557,6 +1612,11 @@
    "jar": "sha256-AMazAl/vGrdkkFGW2m5P8sZXD1NrWdgH3W2duSIj4Ns=",
    "module": "sha256-ETbvdQAErd2IzWheD0a3ldosmtUWI5baowRgRwcKmwI=",
    "pom": "sha256-B+TEkK62d/VzofwmAAv2hvtfYGhuqntR7axVRMBp2PA="
+  },
+  "io/ktor#ktor-io/3.5.2": {
+   "jar": "sha256-1O7MEIKpqCgOph3Z/PdTGa7XGqTlmm8cRrK/+s4dapw=",
+   "module": "sha256-jYyiWyCU/a75BQ5fAVbJfamBaUl3ZaBvXxvlqwoMyiY=",
+   "pom": "sha256-egddBpj08lPqsBiULP7O1cJt4EeCHlMUolcCEIWeEg4="
   },
   "io/ktor#ktor-network-jvm/3.4.3": {
    "jar": "sha256-pro+Kta7OKI7CPCO3DLjpgBArZUsbDqeCIctXZbdi0U=",
@@ -1567,6 +1627,11 @@
    "jar": "sha256-fJcsl67Mmyfbg3fjNH5vZvrUtSQRLAc77y1hUNEZRJI=",
    "module": "sha256-e/OKTaUlaJy1Zd6LlMafWJBev/xkM+ufTD+8RMMAIZs=",
    "pom": "sha256-4Q218LA8S4eaG8H31STVg0Hhhi2im3WbybxBwkRs9s4="
+  },
+  "io/ktor#ktor-network-jvm/3.5.2": {
+   "jar": "sha256-8dlm+vXprfkDqWhID2waQiPVllg6ly67rz+h/X+b510=",
+   "module": "sha256-cdkgxBtzep9wlsdvj7XzadvPaMXf5+P5CcuijMFL07Q=",
+   "pom": "sha256-oTdS54LS+mr2fVlbo9/1NZuOe/b5K7SJKjXT83Ut5ZA="
   },
   "io/ktor#ktor-network-tls/3.5.1": {
    "jar": "sha256-cu3Fh6DlhtyA9w2ipr9P4EGV9O4PgClpMF4quKQHVsk=",
@@ -1582,6 +1647,10 @@
    "module": "sha256-JGZ0q5f+xigrIoIgBNVe0H9WVgyo7/TGFFvjrk95RlM=",
    "pom": "sha256-bzFQ0n63rKeUpb7T1Dh4XcXFTyPm8B6ZJDNn5Mc9jFw="
   },
+  "io/ktor#ktor-network/3.5.2": {
+   "module": "sha256-Qmohe+8iuGW1LQYAIS8s+nKARil27OVMHeN/3X5AwsE=",
+   "pom": "sha256-8/+oqIvLu6poHERIAT1VgtTUbq2yzq9vvcvxAl4vJuI="
+  },
   "io/ktor#ktor-serialization-jvm/3.4.3": {
    "jar": "sha256-WH37qUYnL2W0El/QpoJCxC2E3jn/wrguN7q/N+QtaRk=",
    "module": "sha256-1tWshNysj1H91xB5cm0Wec8XSUxIF9VEfmY68pGgIMU=",
@@ -1592,43 +1661,48 @@
    "module": "sha256-WDMYMkFVu9ZfjPbDUjap9FXFnWzj+JMfd3JheC7zGyQ=",
    "pom": "sha256-I+wp6ORRn+Hzrj4qxIAA2sYME3htpPP8JrRCZxDloVY="
   },
+  "io/ktor#ktor-serialization-jvm/3.5.2": {
+   "jar": "sha256-t8hdCHFM456cF6I1A43m+cKxIeX7V86QxaNJpl9h6fY=",
+   "module": "sha256-CQtA2Ouf+GIu0BJUuDsGb5M08E07PEn2FCHqfJxbl8M=",
+   "pom": "sha256-0M4BAEnK4tLNr/KZF0p+5hlt2bAmKFlzoQy4jMiboPQ="
+  },
   "io/ktor#ktor-serialization-kotlinx-json-jvm/3.4.3": {
    "jar": "sha256-MoonKE5M3A0VVCFrfkrPhZ/jsM/UIcwgdcQ8E+PHYSc=",
    "module": "sha256-MdS+vO4zLw0wYFg5TSRmeyJ/TIqR2+8JCL1yFUsyUME=",
    "pom": "sha256-kPf60Llek/bdfZjmul/GPUdf4SXY1hK7toJ5/vBqaoE="
   },
-  "io/ktor#ktor-serialization-kotlinx-json-jvm/3.5.1": {
-   "jar": "sha256-aLkH+supyu2sW8+9bOMSOSD9dgZnMmfOEtU6jJpqo8M=",
-   "module": "sha256-LchRAKmepbf14H/UHDIHGulqAAtPzrSI+FGZBSXmLLg=",
-   "pom": "sha256-tq+aDn2zzoDqTZPXUGK4Zp2GAQhrksbcrki09eeg+b4="
+  "io/ktor#ktor-serialization-kotlinx-json-jvm/3.5.2": {
+   "jar": "sha256-tD5H0yCDuVBp0xys0NUoaq5Tkn57VVhtIMa/VU/7arU=",
+   "module": "sha256-UOXOmKOrMEr4127K7PZjPB7dfW5wRrxKLyzCvDMvTJE=",
+   "pom": "sha256-zIR73GWfS1fqqGgrgyUXcyomr1IP1fMbKLPBaYUk2v0="
   },
   "io/ktor#ktor-serialization-kotlinx-json/3.4.3": {
    "module": "sha256-Xqf6YGi9FiHHZD2ol3LT8yp6262XbVjEF9kZMFFV/3k=",
    "pom": "sha256-LsmwRLkeBitK8sMaEGnV619KanUo/JihjcU/u6wvWc8="
   },
-  "io/ktor#ktor-serialization-kotlinx-json/3.5.1": {
+  "io/ktor#ktor-serialization-kotlinx-json/3.5.2": {
    "jar": "sha256-3JdvaEhMDh7VkOrEWyEQJFSVyYVQSZB6w0F7qaZ62WA=",
-   "module": "sha256-Me9sGvXdG7+JsIkIwBA1TzqG8nqfW9/E2Kgv5YP3fx8=",
-   "pom": "sha256-lHDKG//9fw7HHmoHHSxtTbd/z7ymTTCyjYCk5W5D23M="
+   "module": "sha256-wYiL8D589kXb+Mxkqv1ORimGEX67nneeShMh6ehweBU=",
+   "pom": "sha256-39Ys5V06phUm4daA5CKzcWyFXshsqWs6Jp5hEXaGDS4="
   },
   "io/ktor#ktor-serialization-kotlinx-jvm/3.4.3": {
    "jar": "sha256-ofFrLcd4EpTbX0zKqM6Xr5QwUbXzwG7fYbr7ftGKmzE=",
    "module": "sha256-dqXUFXviiYYZgXlxQWrCi76gNEEkQCOKkthhxm+6RWQ=",
    "pom": "sha256-4MYuxs0qofFW3fSkagT6PSWNHLslNJOxf65ingatqP4="
   },
-  "io/ktor#ktor-serialization-kotlinx-jvm/3.5.1": {
-   "jar": "sha256-FIzVJmHC5MuxyIykzj5mIjNbQzmjs2kFQTnQ0Rpw9jA=",
-   "module": "sha256-sMcR+eEWvIFiMGPUXb5E0pbsHc/RUhg1wD2zG/FO8B4=",
-   "pom": "sha256-S+A8wXGqnQk5GjtW+8l6wbF1cXz3C4+BvaRA6rY+q58="
+  "io/ktor#ktor-serialization-kotlinx-jvm/3.5.2": {
+   "jar": "sha256-ji0S0M6+rbI7DFIRMxpVcWg2oGlRDMCzGEuHcnwb6co=",
+   "module": "sha256-+m9WL064CVWmA41PUFrnncOgTMnXJuiaOB9gCS6jP40=",
+   "pom": "sha256-uzxiaeQakwE6/3HBOjYr62DA/DPDNqpnpHmR9Rd7c4Y="
   },
   "io/ktor#ktor-serialization-kotlinx/3.4.3": {
    "module": "sha256-fDOe4//LBDkZfupS10VHibKG1ZF4YSmKSku29KREqho=",
    "pom": "sha256-JCJ5T8Q0kE78K13kB9X6EADvW7phQM3jMDtIxQ5skqY="
   },
-  "io/ktor#ktor-serialization-kotlinx/3.5.1": {
+  "io/ktor#ktor-serialization-kotlinx/3.5.2": {
    "jar": "sha256-QJyIUHTUQ6T5u7/pQo4fObVBpZgun2TY9Kl99tOfh+8=",
-   "module": "sha256-ndkRTCxhOPTSrkK0tkWgKmAx9HDi+CwDdqQaeIug9oA=",
-   "pom": "sha256-R7DC/ca/1fmDgrgJlpuaM9sK/2OsMbtLCV8FrCJ8A2M="
+   "module": "sha256-bQ/jxnc2yj1T9gb3dtrf7O+enIxAOJE64P3QJfYUHiw=",
+   "pom": "sha256-5L/Cq0zLSsyjMt5x+aHfElAbB7EYpFCSoXT4h89Q5gg="
   },
   "io/ktor#ktor-serialization/3.4.3": {
    "module": "sha256-T+4wl1yw6S4NYqMkioF0sfB7uI62DF1laKNRJedWCPs=",
@@ -1638,6 +1712,11 @@
    "jar": "sha256-/SrvFQlzPKSOhMeVPMdy52gWhCiVyTc6ctQqzPbBDlY=",
    "module": "sha256-hJZBlR4/KIc0Bdnh+/6KYu51YltN/dYE3pq5B4qgLPs=",
    "pom": "sha256-XWb0SdyWsK2LWCkSnJDaDW1NnWDwLgsKHYtmiv9CuUs="
+  },
+  "io/ktor#ktor-serialization/3.5.2": {
+   "jar": "sha256-/SrvFQlzPKSOhMeVPMdy52gWhCiVyTc6ctQqzPbBDlY=",
+   "module": "sha256-mrPpT/6r0rk4uSwGUDxG91041OUV0GSsWpQ156IlOZU=",
+   "pom": "sha256-Sm4Jqi+sS1JuMb+1t4viIBW2zDysI6jRnkacoqBSglM="
   },
   "io/ktor#ktor-server-content-negotiation-jvm/3.4.3": {
    "jar": "sha256-oEuI4lcu/C5+85bZ3kpDzwdeBt6iXhk7mS4SR4tCHBw=",
@@ -1685,6 +1764,11 @@
    "module": "sha256-mpZoxVTdup6jc5J9OoBB3jiPkwPm6u+PlWZVF9QR7js=",
    "pom": "sha256-ccKCNMxN3QmKF+L1xNvBqT+/gEyt0XHUdXUevx1T+QM="
   },
+  "io/ktor#ktor-sse-jvm/3.5.2": {
+   "jar": "sha256-xRCQT+Dn3Wud8vp8VHRpb9pk1zZhKc5fqazi6/RQ0og=",
+   "module": "sha256-Cqb+8A9qGxB2vq/JRD7osnv124ddIzjyTOgzAF4N/dE=",
+   "pom": "sha256-s0JeiUjrS0b9O1AdAGtpmH4Yiv14kDXjzNMfOm1uQjo="
+  },
   "io/ktor#ktor-sse/3.4.3": {
    "module": "sha256-44dTyTiU/6SGb2ftjhDjd9xwCdJPdsJ3aIsu6dEsTMs=",
    "pom": "sha256-iZfzk4e1n8qxvvFcfuQ7eymDJOs5U+MXOfDJ7hDDn4Q="
@@ -1693,6 +1777,11 @@
    "jar": "sha256-H0g43bfVfoS905E69LQGJ2Yqvbyi+6iSG4Z/GmLQv10=",
    "module": "sha256-bvsVtyHsuRhzMLz+/jcR4Owb6MZDRhB3G12Yzr48q6w=",
    "pom": "sha256-w0Tzjo9Vc3YZsEm4mYWdz+wAVqHAhh3tsoR1bnHrjDg="
+  },
+  "io/ktor#ktor-sse/3.5.2": {
+   "jar": "sha256-H0g43bfVfoS905E69LQGJ2Yqvbyi+6iSG4Z/GmLQv10=",
+   "module": "sha256-dtbg1OksUQE/kx5cjtisyEFO9SWJFbcQ82Pam1TSEE0=",
+   "pom": "sha256-xtqlT4TvVMpvXPIxYVYeDuTGuzlTQRRoUbb3nEzL1mM="
   },
   "io/ktor#ktor-utils-jvm/3.4.3": {
    "jar": "sha256-5Iuc5Rhw9BDHq1wEDI5tAmlIJ+v9/ForhPCGrQSbtWE=",
@@ -1704,6 +1793,11 @@
    "module": "sha256-eMBo0vpZZ2UbGcPzNrfM6PzZnyqpwa/Lhb4RyGr898E=",
    "pom": "sha256-rsA/Ek7gNaZnVq/Mv94QAkbjs8UOVxaYVnzX0Evy0xo="
   },
+  "io/ktor#ktor-utils-jvm/3.5.2": {
+   "jar": "sha256-XLnAQNKQqjHOXkkw2CXdpdJWJahgMHSymUPFGdWwIrs=",
+   "module": "sha256-/492fEhLgLlIwSn/qGhQdMk/FJRg7Q6QE7QqOi2kSQU=",
+   "pom": "sha256-I7hLPLfAFfRYlIZ7Y5IzCJRnqty7NZ8WoCHjo5OFnHE="
+  },
   "io/ktor#ktor-utils/3.4.3": {
    "module": "sha256-NRoL9TGXRIj0tH82hNfiMJK4+epGwWDw7TCl89NQgQE=",
    "pom": "sha256-nKnA3GjHIk2iLx4uM7LvPmXLBOtL8SaJwZcLX3JIzbs="
@@ -1712,6 +1806,11 @@
    "jar": "sha256-1syTBOx3QJllHiDG0y3kpn9t04FvkefJllN4PJKQ9Xo=",
    "module": "sha256-vCLy5m1u39RvKUu+xtBDh6tDnA8XmItt0YU+bg+Mf7g=",
    "pom": "sha256-FiH5x7wyKza7mD2R/nJxHAqui1avowT2nkbk0cDpVwI="
+  },
+  "io/ktor#ktor-utils/3.5.2": {
+   "jar": "sha256-1syTBOx3QJllHiDG0y3kpn9t04FvkefJllN4PJKQ9Xo=",
+   "module": "sha256-wRMwbaxsKoNXqJVnkoneB+aXDkUiYxwz2Cdt/jNkKa8=",
+   "pom": "sha256-ouwaroolZFKfkrtiUOjoDO3xech04+YJMoaghYalIFQ="
   },
   "io/ktor#ktor-websocket-serialization-jvm/3.4.3": {
    "jar": "sha256-2ZmnuQs9mtLvDRF8Ss5isQvXrBNFzRxqdoCkP/++DtA=",
@@ -1723,6 +1822,11 @@
    "module": "sha256-etQII/rOUt1/oMMzF0sFGjJaMk00MxAMWApKX60qDes=",
    "pom": "sha256-UXDCbW3H9l9vpgx3tvzw8KB3M5SnQHu64BMcvI39XAs="
   },
+  "io/ktor#ktor-websocket-serialization-jvm/3.5.2": {
+   "jar": "sha256-f/ysftPXI+C9M7IZuePfbVlT5bgQ9mxMjmhvVx9djmw=",
+   "module": "sha256-fk4SIFNfNJWTzoOln4M2pu5vXcuiFz9Xqgx1MgvQU7M=",
+   "pom": "sha256-O7qGgLJLeszwxTJkGX7rCkK81vOZH9bXCPwbtUul9s0="
+  },
   "io/ktor#ktor-websocket-serialization/3.4.3": {
    "module": "sha256-13WjyEC6DDt9WOtQZ33kG0OtZbBsrVlBAhF+XlxRXZc=",
    "pom": "sha256-QSPdZhKyV50uomw1TwhNJyxDkZw0ansWvUNedYK4hNA="
@@ -1731,6 +1835,11 @@
    "jar": "sha256-t0VVWddBP5wLMIiSCfgkQBokNNj1zF6grTiLSFQ7dTs=",
    "module": "sha256-4BsW3Hi7UUI0tVAcnVEYxnC1wNcbNNv4GLw0niA+UJw=",
    "pom": "sha256-npegSnFKtor/rK7Yu9zVE51bE8kcQqGs39d03nritPw="
+  },
+  "io/ktor#ktor-websocket-serialization/3.5.2": {
+   "jar": "sha256-t0VVWddBP5wLMIiSCfgkQBokNNj1zF6grTiLSFQ7dTs=",
+   "module": "sha256-8hzBBuoyBD/+XLSdODYRhZcgwFnJT7yXrlqljxbNerc=",
+   "pom": "sha256-seZOSnbwA6zcS27vILICFNefKrCtvJW7DYMrjSp5xpE="
   },
   "io/ktor#ktor-websockets-jvm/3.4.3": {
    "jar": "sha256-7S+/uB0wKc8FpirHttRbOKhzoC+O5gsErmU0btUpnuQ=",
@@ -1742,6 +1851,11 @@
    "module": "sha256-BfOvOo1JX4uKLmbF3tQprP0jXHGUizaY/nmNzNzgbHM=",
    "pom": "sha256-Gup9K5SacGVv6ZKq6YMCs8vcz2zm8uAk5cVk3H3YGMA="
   },
+  "io/ktor#ktor-websockets-jvm/3.5.2": {
+   "jar": "sha256-9a605u4QjoFWQ+LPBlgNTKGtxSn2z00waom2n7SIC0s=",
+   "module": "sha256-npwn+fyA26Ln3wjz2GeqJC96qA+5NFZZsX57odAZKkY=",
+   "pom": "sha256-KwD0ZZUWuc5A2s0oXxgLEZdjbvgOdPxZxErEpf6URvw="
+  },
   "io/ktor#ktor-websockets/3.4.3": {
    "module": "sha256-xTwREBNT5YY31k9EevyRPGVUHbgDOeB+q7PeWiGD8BI=",
    "pom": "sha256-UWoi9aLNpSqE9e4WFcfKtvKABy9GqYNY5bRjS2zh/mQ="
@@ -1750,6 +1864,11 @@
    "jar": "sha256-3vZ9V1vRQtHXXk8XWHlW9IPAlWJYapzAL5KaLyEcIEQ=",
    "module": "sha256-c46uXDjf5YJtRT7MOi7pjXO4LZBkaRVlmjb7qQvG4S8=",
    "pom": "sha256-LgqqcXqV5gSClwsZE9HbhgP/WI9k84HV8o1i/uLVzK0="
+  },
+  "io/ktor#ktor-websockets/3.5.2": {
+   "jar": "sha256-jQ/RtZ6wqspCLhmvHLid0I5l+Y1mhL4gkJYcTyG+qd4=",
+   "module": "sha256-IDcC1X3F44A0gwdDp0HmghRYC1b3KKLiwTlLWfBr3qo=",
+   "pom": "sha256-GAZwy/stapHbc6Kb70B0wA6/EnRmy8DWaFK99dZZNO0="
   },
   "io/modelcontextprotocol#kotlin-sdk-core-jvm/0.13.0": {
    "jar": "sha256-hT1iH4gmbDHtIcN0OvzVSR3dKjS5tabAixixpuoSXls=",
@@ -2219,18 +2338,18 @@
    "module": "sha256-5Z+aDYcs4zt44W18XqY2lgRuYXKTSozo1Cdyawd5GTQ=",
    "pom": "sha256-+01/UV0FOzQ9G+gAao4Ehw3SFbi1L89/DJvIv+7WgMY="
   },
-  "org/jetbrains/compose#compose-gradle-plugin/1.12.0-beta02": {
-   "jar": "sha256-JgjtpinQ3RSt2+lyk2vH8pI6veDHoVq7MEZPYbtcC1M=",
-   "module": "sha256-9tgY2YoOw98q9qJympz6EnrbxGkVAJjxMoaxQ5vXRM4=",
-   "pom": "sha256-Ynrm5giDqKPDhYdXpP3DwDxnjEaiEJbW+askKuPSwrg="
+  "org/jetbrains/compose#compose-gradle-plugin/1.12.0-beta03": {
+   "jar": "sha256-/STamWqkFCALSeRyFH1xqNSBeAScIx/qfwn2fbKkSAk=",
+   "module": "sha256-BsTgdCj1C34SSZv8kTiYIC1BzVsK2wIEzY9vMRBzIjw=",
+   "pom": "sha256-9pD1fTdBZbJiifGjFL2FEBAo4hN8JDI++DP44o5DeiM="
   },
   "org/jetbrains/compose#gradle-plugin-internal-jdk-version-probe/1.10.0": {
    "jar": "sha256-xJox16AUlF1BzaY8zpfbvbn+FOPScaTKfalmhKliDTY=",
    "module": "sha256-eoAK9PgqA9hgqpGo/7A7tqcK+1drO5hViYDYrS2PhZ0=",
    "pom": "sha256-L5XgUVmwXnU3x6doAaena/TqatKAlSc1KXtSWvAGtfc="
   },
-  "org/jetbrains/compose#org.jetbrains.compose.gradle.plugin/1.12.0-beta02": {
-   "pom": "sha256-F/IsIMXo5j7TrYz1Xe3tl+V1Ubw62Y+6fCv5xpNwrnU="
+  "org/jetbrains/compose#org.jetbrains.compose.gradle.plugin/1.12.0-beta03": {
+   "pom": "sha256-aPWCRlvhNwKsYMT0JAVtZxSkeoqQNXy1fKwXdz5GnBA="
   },
   "org/jetbrains/compose/animation#animation-core-desktop/1.10.0": {
    "module": "sha256-LfYlAI/0oZQVU5lSH/slEwODLHlOB8vSro9mh9wMYRE=",
@@ -2245,10 +2364,10 @@
    "module": "sha256-Rph/TL1iXppweU70V5TDaS6KL6xOrxzJOSa9jg/t1i0=",
    "pom": "sha256-cWWFXBJR8MnoSRECCH5K54CALp31g6XJDfHx5AmDN7E="
   },
-  "org/jetbrains/compose/animation#animation-core-desktop/1.12.0-beta02": {
+  "org/jetbrains/compose/animation#animation-core-desktop/1.12.0-beta03": {
    "jar": "sha256-2Yi2t9hnFGglqdo44VIvxQWAqhSYarIqi3JPzc7xeHU=",
-   "module": "sha256-I8wjxcbXHgxU0PgyDjmcp1q11RcEGYkFRIP94leV+jA=",
-   "pom": "sha256-GbsOB1LT/WeSBCWgGE7ZZjyt2jOp6THIY7yvzkJ8AO0="
+   "module": "sha256-miksXjwQ5uueuCxrYGuA5QE+i5poUVvH1Sx+DCJWvnw=",
+   "pom": "sha256-zUQonCHoh1yKGmuptE9S61m0rm+vvX464Y/fqTW+g0Y="
   },
   "org/jetbrains/compose/animation#animation-core-desktop/1.8.2": {
    "module": "sha256-qxOVOtDhVv+Au9EXooS4EVYN46LMXQKvjWGDKM5xbIg=",
@@ -2266,10 +2385,10 @@
    "module": "sha256-UjXClMvph99Nuij0S8HfZY8R42FNTf/vsoSAN3xmOHg=",
    "pom": "sha256-MSxoDMiKNSbVmM/XK49Ic7rEv+sCyCrGxkgIIpEecpM="
   },
-  "org/jetbrains/compose/animation#animation-core/1.12.0-beta02": {
+  "org/jetbrains/compose/animation#animation-core/1.12.0-beta03": {
    "jar": "sha256-hWAww02ErbD+6mUe9V0FMgOuvSANvbgZKBXFATExYzY=",
-   "module": "sha256-O9amf2RLwvdcvfFPEWHF/D13K8kHzCHNV+w62Wq1kQ0=",
-   "pom": "sha256-x2pQngjrTUqQmT8oox+CuL8iOPCc5TX4hVaQgZpyUWs="
+   "module": "sha256-21Eh1i39zxjAvwnHD8TfLzd6ItVWIKejUS52DJw9jMg=",
+   "pom": "sha256-rr0P+asZ0apR73S9Cx2CGleL9dYjUqiEvcXiEyHgQHs="
   },
   "org/jetbrains/compose/animation#animation-core/1.8.2": {
    "module": "sha256-tRGby7/TKMDcD8yKRynXk6g3vz4naSP1bRCtvifGSMk=",
@@ -2284,10 +2403,10 @@
    "module": "sha256-DEoL9Is7hj1v8jzT73kS97SpqHb3F3TPwiQKJ1YxKrg=",
    "pom": "sha256-o95ZtfTcd97jt5+shtFQ9gDiLORGcjj7WCIpX4UWKV8="
   },
-  "org/jetbrains/compose/animation#animation-desktop/1.12.0-beta02": {
+  "org/jetbrains/compose/animation#animation-desktop/1.12.0-beta03": {
    "jar": "sha256-RhfpSIA7q6/EZW0Vn7UZaTTj/vcax9xxvR3SnKTcLcE=",
-   "module": "sha256-1CszZZ15n6HA6V+1IDc18qC16zYyp0pySkrEjXL/iQM=",
-   "pom": "sha256-rHU6YjFnxwpMp8xL7A0aQ+mPjIwGBv01LMQWOeTrFDE="
+   "module": "sha256-N9c4y86LYHBGwrHK7Woukvd015AmKBpDKO1IZlIKluM=",
+   "pom": "sha256-SVU1AFIt2FgZYk56hB9D27qdr73r/bH2zh9rfcYxZNA="
   },
   "org/jetbrains/compose/animation#animation-desktop/1.8.2": {
    "module": "sha256-vPH6Ul9Vl5pujum2UCMjOhSnfrY/4byJQwiTZTJm2I0=",
@@ -2305,10 +2424,10 @@
    "module": "sha256-ulAXgUxeI6owCHJZRKVCCvJKikD7cJJ7AEwcif01xX8=",
    "pom": "sha256-P5ZN3fZBLtcGUwp7bUfo2BS1dAL+kcMFvbRN+gPo+nk="
   },
-  "org/jetbrains/compose/animation#animation/1.12.0-beta02": {
+  "org/jetbrains/compose/animation#animation/1.12.0-beta03": {
    "jar": "sha256-SpX7sTSn0Wz5I7DlcXbD7flxHo8jvH4NgQL0JgTx4/M=",
-   "module": "sha256-ovIHL32YmDQVrqyP/JDJ/1s3XEJOUkiOZOP+h94lLXc=",
-   "pom": "sha256-cZDkgfHhS/RUSaiR5pNCNv7YLDDGwRjr7dLo0UH+DBU="
+   "module": "sha256-vFd1ax9EI2RIiQXxBuspdGnN6KAsHPJtElmp9r9Qugs=",
+   "pom": "sha256-ozr+8UIZ8/W9Qa61fVia8j3yharqRfjpNu+Hg6Qxfhc="
   },
   "org/jetbrains/compose/animation#animation/1.8.2": {
    "module": "sha256-7RvWvOaffnnQdwZqUo1qKbH89/lh8CxTR5HrMl+BRmE=",
@@ -2324,28 +2443,28 @@
    "module": "sha256-C6k3s06FAnNf+ds1y0RpAs8RooVgyGqmSDNlu9/548I=",
    "pom": "sha256-5FdZGCjqC+2jhllNlNsB49nX3XcypgY4eZrlkxzyNqM="
   },
-  "org/jetbrains/compose/components#components-resources-desktop/1.12.0-beta02": {
+  "org/jetbrains/compose/components#components-resources-desktop/1.12.0-beta03": {
    "jar": "sha256-nVrQfQgv/8GccoUW6H1R0+Q5wACHzAZ/ghoRbyfosp4=",
-   "module": "sha256-UXOY0xPxf2zOAud8+YdhkKmDIJ1iUd31W8hgyRV/gdE=",
-   "pom": "sha256-2FQZB9l4HRmoP6ZoG7X2AFdIIx5xe2xShUYVqdgZle0="
+   "module": "sha256-V2EnMB57C/uBCPBooeR4PNU0gq1/jIlv8GPew2dpEtE=",
+   "pom": "sha256-5w/ie/O+fUmNg30xGxU4Y5IZuEGymepIpVqldZHzKQ0="
   },
-  "org/jetbrains/compose/components#components-resources/1.12.0-beta02": {
+  "org/jetbrains/compose/components#components-resources/1.12.0-beta03": {
    "jar": "sha256-+o6gv03BQllsOmWHXWELEv7W+JltPxhjzfOdP7vQywg=",
-   "module": "sha256-1tvDHszeLCJW1z3pnUoDnsEGZOXk52HOaimxk6VxBrM=",
-   "pom": "sha256-j16BP3n/LD7EC6Oxa8DwIwcFchQcyK43pixx4Msp9e0="
+   "module": "sha256-Tce1XkXrlmSlsPoQYwJie+DMQ7gZBRQA2MJXK9Fmcl4=",
+   "pom": "sha256-Sn4GbmRnH9iR3qDGIccFr0Feqr/8gMvCSCgjw8t5kLE="
   },
-  "org/jetbrains/compose/desktop#desktop-jvm-linux-x64/1.12.0-beta02": {
-   "pom": "sha256-/56zzbFpEKnr5etCxURz9lqQ14yDRMR6duWfePDjMzQ="
+  "org/jetbrains/compose/desktop#desktop-jvm-linux-x64/1.12.0-beta03": {
+   "pom": "sha256-h+U/zbZFVfpwga7H/kPRi9lJ6z01m1dmZRLB7ai3nWA="
   },
-  "org/jetbrains/compose/desktop#desktop-jvm/1.12.0-beta02": {
+  "org/jetbrains/compose/desktop#desktop-jvm/1.12.0-beta03": {
    "jar": "sha256-ra6m7GMEIHEtz9UqNWtGrvYDEpyn92y6IEVpES+oDhw=",
-   "module": "sha256-vbhOXCRLhp3lfMSDehLBg9ml5PDEGK8YiJJvcLaamtI=",
-   "pom": "sha256-KrFxOtEldZh07eXsmAmrw7SetBUjEQMC8iyd55PmTmk="
+   "module": "sha256-yL5sThflMkdtMimrcMVydAhxE7A7bo9druqguiv+BL8=",
+   "pom": "sha256-OXswlVEfw13gjQXmu3SV2DtC6ZkzDpJSt+3fU4Lc7p0="
   },
-  "org/jetbrains/compose/desktop#desktop/1.12.0-beta02": {
+  "org/jetbrains/compose/desktop#desktop/1.12.0-beta03": {
    "jar": "sha256-FYbciOwaF305iDF3Ini+Y1s/1QUGxOZ4HjJluFmyi8U=",
-   "module": "sha256-MMfLRsRVZRdat/+MGgm9bcblXhQUCFwR1bLuEOScsqo=",
-   "pom": "sha256-13yzYODT34vH4CP84wAgkYMLCnbIYY+IcswdKAlyHgw="
+   "module": "sha256-PLmFYj2i/aJ5iCsOAc2PYmGlUC2RcK9aoxnEIGepQOE=",
+   "pom": "sha256-8l9O/ct3x0bKWygxW31a+2Q/dKTDxDqk+xL4J4OgsDA="
   },
   "org/jetbrains/compose/foundation#foundation-desktop/1.10.2": {
    "jar": "sha256-Opt7+ucvGpKoEj0ykLt9f2HZLlzeh3r1Nzw+XCys6ys=",
@@ -2356,10 +2475,10 @@
    "module": "sha256-0WjpPqO2A7KWO68telm06t7EPhy5ME+4Sga18Ttloc8=",
    "pom": "sha256-bh8LZjBjHF+l60Wd75khISStYcF9jZMokOmiHB+docQ="
   },
-  "org/jetbrains/compose/foundation#foundation-desktop/1.12.0-beta02": {
+  "org/jetbrains/compose/foundation#foundation-desktop/1.12.0-beta03": {
    "jar": "sha256-IGDsEATO+r9iYbwdLjmWieLRX9sExnbjVdlrSo33Nco=",
-   "module": "sha256-qMcGtJK53+ywfDjnIMsgydODjHKEqxsq8kKLt+SpzU8=",
-   "pom": "sha256-Yf7epj9sF2fSg8lXpszNk9WFKLeTaBr2KDEy5QWOxLo="
+   "module": "sha256-1R+8k1bjjQ+5NPDywbR/RJpAHNDC/yeF7Qa+HkKccCA=",
+   "pom": "sha256-2mUTK5bOnh7L77DsWOjCU5JOAiJmdEd2qm5gLlUstJ8="
   },
   "org/jetbrains/compose/foundation#foundation-layout-desktop/1.10.2": {
    "jar": "sha256-jY4ABiqDoUdAn0L5F5g5TDwiHSKHeVPv99CoF2e10Pw=",
@@ -2370,10 +2489,10 @@
    "module": "sha256-pjOF4Z6L3JjB2V6Ovs6fYSd/erhFpjf7aTGEQQDorww=",
    "pom": "sha256-r51GM5B0KNs/wJTV8YrAH9hI/doadraNuJxQ8aKRzRk="
   },
-  "org/jetbrains/compose/foundation#foundation-layout-desktop/1.12.0-beta02": {
+  "org/jetbrains/compose/foundation#foundation-layout-desktop/1.12.0-beta03": {
    "jar": "sha256-V7VMEEuunuoOkLsmSH+LZOrQmkc/GzLL7YV5CE9IXns=",
-   "module": "sha256-KdJJXqo96O6U/mjZosHqOUCKMSK6Dj4ypVak97Or/7I=",
-   "pom": "sha256-eZ2FGKhMB5Qog9sd8A6qCTcnuedrcNwcgSW4C7YzEuQ="
+   "module": "sha256-QM0wr0zfMoTfeCa+63j+o93snZJYgPkJsebuyaascSY=",
+   "pom": "sha256-zGuyXIBnzWsoyRAt+sP495fCnZ2S5fiZ/7jwrf+4+t8="
   },
   "org/jetbrains/compose/foundation#foundation-layout/1.10.2": {
    "module": "sha256-z9jjcq0V1Wccv6bOg9DEDDiceJUNIZ66hYYRSrBXzig=",
@@ -2383,10 +2502,10 @@
    "module": "sha256-NEBGaZgZCwkMu6/5vsjgPcLu7k24BzooUhRZof5VIGE=",
    "pom": "sha256-FD3fSVUx1ispchkn1o1R6xkUSYPnJ+53UQ2BIg+7+Wo="
   },
-  "org/jetbrains/compose/foundation#foundation-layout/1.12.0-beta02": {
+  "org/jetbrains/compose/foundation#foundation-layout/1.12.0-beta03": {
    "jar": "sha256-7vah94vi86YyT3HpLUOW2/RaaTKKIiSUqf2Qj5J3Kzo=",
-   "module": "sha256-0C6n6fBaq9hjReS1k96JN7wgpObQgo/sCx0zJnLBAiI=",
-   "pom": "sha256-anyBDh7eHnrWUSCW34zhekQmEbtEMYba6rUuKGcfjhw="
+   "module": "sha256-/u+iYAWVOphrrPRYFGbAlzqzI47fCbDy0YgoPkbpASU=",
+   "pom": "sha256-L2+TahIbf1qFAYrQMGTMz4BRcwQBBRpNviifyv2SQmU="
   },
   "org/jetbrains/compose/foundation#foundation/1.10.2": {
    "module": "sha256-Smr5jULzXCALfuumMz1YBIrS/Y6tmWt6lPRe9Y99rZg=",
@@ -2396,65 +2515,65 @@
    "module": "sha256-rDHX0W1aWSsRZMlyFgWcEdIYrpcAMvrXb56Rs1cZ3pE=",
    "pom": "sha256-qNVdTiO5tH5XLRC5LHVfnIXHpleKnYRlgJ2ev4YV6pw="
   },
-  "org/jetbrains/compose/foundation#foundation/1.12.0-beta02": {
+  "org/jetbrains/compose/foundation#foundation/1.12.0-beta03": {
    "jar": "sha256-3KinopzOW9jNgUsvpDPgF1fqwMRVSMMAAB52dWn2U2g=",
-   "module": "sha256-tY2SvFyLFTVhakmF8kFxEAWUPzH1XLWwG2UVPKf0N00=",
-   "pom": "sha256-9TZ7fbtaKt3/XUjHP9ZqE5IHjwTw9zHnf37q0Qv7CAo="
+   "module": "sha256-N2KaszEF4daYLmPQr2DlWgj98CCiI+n8kCuKXuviT0U=",
+   "pom": "sha256-04n3dF2DNj/xqSYHpm8sRrsGxx6TsB4Rr/swD6Rfhmo="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-annotations-jvm/1.2.0-beta01": {
+  "org/jetbrains/compose/hot-reload#hot-reload-annotations-jvm/1.2.0-rc01": {
    "jar": "sha256-9QbjmAxn+HbJUUvgIJW8rTvv969P3tu/WXlD2G3wcPM=",
-   "module": "sha256-2hY6UzO3FHFoSkC0ZjeCQRLmNsq33HffnKS8qgYHZH8=",
-   "pom": "sha256-LMhwQsim2/lmuJd1/F3PdecFQjkCF/g8LIh9THr5VHc="
+   "module": "sha256-ZBsWzojDRJ81xo7VyZBxAyOt50DykgFrQrmyhm15Rmg=",
+   "pom": "sha256-8tPgbD7kmSU0QYZ5HVhj4cmCfRpX3ao27NE1NaOc8j4="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-annotations/1.2.0-beta01": {
+  "org/jetbrains/compose/hot-reload#hot-reload-annotations/1.2.0-rc01": {
    "jar": "sha256-pegeEYe6ut0xH5a8FJtMNqK013MTrA5+kTybmRR3wOk=",
-   "module": "sha256-rnaiiJ1Ibag4nqQt3p1Mez2BmjevP6IhZ9W1mCajsKE=",
-   "pom": "sha256-tX2F+ywVxh+CY1W4BZH97JiWL/Dv3F18SsAHKP7BgDk="
+   "module": "sha256-QlIiOA59dPIR8Nluv4Q73JtRIGV0/iAe+pyx51BUzPU=",
+   "pom": "sha256-NAsK2fIN3V8+x+T+6ZORtjyo34rzg5E7tAnsVvUBbyg="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-core/1.2.0-beta01": {
-   "jar": "sha256-lj/OHKDDLgjraEDaiNnFo9Fo3pqk7DtMBapI5IoNI64=",
-   "module": "sha256-W/JTUkCARVmsjtdmtlslvReLgirbsfMKyyn0tPocFSU=",
-   "pom": "sha256-sSXigpmWyXSjiodLzVtZalFkcugyMp1QWztPTgNgOVw="
+  "org/jetbrains/compose/hot-reload#hot-reload-core/1.2.0-rc01": {
+   "jar": "sha256-E5IwFGoa1DxJ9mVeH/qmCaXxpp5RJvRxQV72QOwgpkk=",
+   "module": "sha256-fr2aWegxt3Tzcq/R/eqAo8ZPNb9qDTNvUZetYvOoY8E=",
+   "pom": "sha256-qFDFeemSJ9ygoEcAwTHSbQqkApeW4QGgoBvwmykQftk="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-devtools-api/1.2.0-beta01": {
-   "jar": "sha256-NQHALK5wQ4DuG3J6Hf5AGENbzfMsmdifk37XfZx09lc=",
-   "module": "sha256-RzH6ks2uPn7UgTlc+pcZIGhK96HlH+egXlENNiM2t+s=",
-   "pom": "sha256-Vggk3J2j9GnWwqePvYD8ElPZwIVVqQyEH2q53x8LwZc="
+  "org/jetbrains/compose/hot-reload#hot-reload-devtools-api/1.2.0-rc01": {
+   "jar": "sha256-UPxQdWAXv95j16K9gRMpk4V+GTtJpLnsbTd7KkwP2sA=",
+   "module": "sha256-9PS9xyD0XLbkTU92KVBgHJJtDDzeKkYEJi/iSiSan/g=",
+   "pom": "sha256-rpTrZJdxNyY21CdTa53zekWv08Sm7zxGNw/aYvOaJHs="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-gradle-plugin/1.2.0-beta01": {
-   "jar": "sha256-5mg55iwPzGpExiOxg1fHitPxfXfJbsA4AJDD7HTz7cw=",
-   "module": "sha256-zlCzr8/GssECplRbfqCwl66xgXkhAj2LNlub8WV5ID0=",
-   "pom": "sha256-7mv89G7GQEcmExqj+Ifv/LqEcf6ZOPn+IcLa4QTJQMs="
+  "org/jetbrains/compose/hot-reload#hot-reload-gradle-plugin/1.2.0-rc01": {
+   "jar": "sha256-1WsV7bVcorf6fvUgJI8Ecdulk9gb3Z4Ry4CQuFiF6ys=",
+   "module": "sha256-UuTx8HrWjTRvPr8rOJ9pB/UjHQ0+D34kr6QrGeMeQ/k=",
+   "pom": "sha256-tIbrt+FCPL7n5qhtzZx5eATACEGcRYYcbtFy+KAenuE="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-mcp/1.2.0-beta01": {
-   "jar": "sha256-BcAvPmh6gXUPps+49SoI8dmy3mzDoXKx+NGcSYXGY+8=",
-   "module": "sha256-3pwagwtHtQBq6TM9EKVE/0dM8KEGQl5Ox6oQrcW8XdM=",
-   "pom": "sha256-DejIS0hcwBWASF8PjrJ3tgk42vH5A1jnb7ouELBfK68="
+  "org/jetbrains/compose/hot-reload#hot-reload-mcp/1.2.0-rc01": {
+   "jar": "sha256-82xIsgFRuAnDR6Wm3mr1Ei8NO6FZmYeA1ocoMCp+QRM=",
+   "module": "sha256-GHb6poPpV+p/JZJZYzyH1+TBhejjlUlPDe2sVVYjanw=",
+   "pom": "sha256-8+KNF4njIh7XtVdcnbc2TpSsb0zAglSbbB/qEPrEOwI="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-orchestration/1.2.0-beta01": {
-   "jar": "sha256-gp3Uynmm/kD7b4e5GIhWDHKbhu/8RIqsqRr8Ppe3H8k=",
-   "module": "sha256-l+hUdwY8QnuZuRIo/npQ1W8akCAcqHmtgHBsANvX3+0=",
-   "pom": "sha256-Yb+NFQHOMQvgiIoSbbCAzAK5sq0S3X0xyAMAtdzcBPU="
+  "org/jetbrains/compose/hot-reload#hot-reload-orchestration/1.2.0-rc01": {
+   "jar": "sha256-irI3rr/dpdUFM+rzfLYb/Ne1lAnLxzRdK8VO8zCu4Hc=",
+   "module": "sha256-aaxNJXh1QCv+ZV9ketrUSq4HBNr5C39YspQP6f33/sE=",
+   "pom": "sha256-aSov6mHZxYrrlAiOcm9CFlApYHijzbIvSpRMOjE0X/E="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-runtime-api-jvm/1.2.0-beta01": {
+  "org/jetbrains/compose/hot-reload#hot-reload-runtime-api-jvm/1.2.0-rc01": {
    "jar": "sha256-VZULFPN7q8+qofWwGuOnuSICaK5Qdz3C6yYGp5NFx8g=",
-   "module": "sha256-GLAmBDQOCW1W3XOkgOB+HHMRR6H7qJc/5TPf+sTJ73g=",
-   "pom": "sha256-Y0DHR5owt39EZ+ORdGeH9MEhyMov1eMD8kvv5OUNO8Y="
+   "module": "sha256-buAh2b1S50EscLDnJvxBf79yj2gZpsxZvl4rRzQF0ss=",
+   "pom": "sha256-c4YX34A7efrh+HdWPDOcPTzftw0lHLyTzqlvt1BDpn8="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-runtime-api/1.2.0-beta01": {
+  "org/jetbrains/compose/hot-reload#hot-reload-runtime-api/1.2.0-rc01": {
    "jar": "sha256-EbyT08rBkVwpgax6pBAFkrW9DqAD26CxRHh7ykirStY=",
-   "module": "sha256-QM6Z9I4HThPCv/oo+IL80HA572d/j3ssQTUa/uu8jrI=",
-   "pom": "sha256-861g6z0ssHlnUrIkyodbG7ehAEdEkxQoJCicDf9810o="
+   "module": "sha256-WEyJoLruweKgzh6prE09vR+HVMr1cu6A3Vc/vGRTxmE=",
+   "pom": "sha256-cAf+jdjKNfYUGr8Oe4+1cO9YnhjcWDm/YANSszJECVY="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-runtime-jvm/1.2.0-beta01": {
-   "jar": "sha256-+wkMZ+xzZnJZPMyoUCkozV0sCLtpZaQMs6E4IYN0Ldg=",
-   "module": "sha256-OtyuXqvUnwa+WI1bEPXhDCJSVhb35d0Du1a088m36Yg=",
-   "pom": "sha256-8U5YzpJQUhUE6k7T1bVobuaJVjnuC+sQGwu7c+cy4+U="
+  "org/jetbrains/compose/hot-reload#hot-reload-runtime-jvm/1.2.0-rc01": {
+   "jar": "sha256-bmJofzv2sihDNyK5FuTJxCSREPdQ4XCeH5zFO4hmzeo=",
+   "module": "sha256-79FFKXYw/a89yecDFrCnvt/q+CikXXI/zQvxdNdLHD0=",
+   "pom": "sha256-x3hQVm+SuzjKJTZe5w7YmfnJh17kTVmI4O6wasvbw58="
   },
-  "org/jetbrains/compose/material#material-desktop/1.12.0-beta02": {
+  "org/jetbrains/compose/material#material-desktop/1.12.0-beta03": {
    "jar": "sha256-DB3Tl7RafNgwI03fMNJTtYYlnnJqXNgWzKLnkRmkf6I=",
-   "module": "sha256-U5EmwDDNgt6zQZqA3n9JHqbCcmaNWP0917vZncYTfd8=",
-   "pom": "sha256-/4rNdWUSB1V9VSMYSo/BeKHBZEuN3p/pzm7idiMFTyk="
+   "module": "sha256-ZTvTbrmmsl8wlO7XFl99U+dBR/nPVCjw7gp9uZaKKpk=",
+   "pom": "sha256-nrIsJ5UFGEe6EZ6T/JeORKqFYFJDt+fkuoj6NYYZwZU="
   },
   "org/jetbrains/compose/material#material-icons-core-desktop/1.5.12": {
    "jar": "sha256-7jqTNDei3XlJ4NnFcTh8wpdtYaen9ZhJDblUVu2P8B8=",
@@ -2471,10 +2590,10 @@
    "module": "sha256-ihekSQIUm1I1ZRbxt4Ve+bmRtS5KsZJCdmxvJpgLxtg=",
    "pom": "sha256-moAEr4TjtQbC0bnnqPOeounvYlwKWAzOpDWrgVmZm1E="
   },
-  "org/jetbrains/compose/material#material-ripple-desktop/1.12.0-beta02": {
+  "org/jetbrains/compose/material#material-ripple-desktop/1.12.0-beta03": {
    "jar": "sha256-BqxypfV7LnJOoSnvvHGXOiep4c7rf1aCgdyw0e9ESP0=",
-   "module": "sha256-er0IvtBM2z7z3niZTWrXtAMCFKutQdii14xwuxU+ybA=",
-   "pom": "sha256-BELkk/9JUt32y3b8doJEqEHfvAfz0Iwp8bWUJJMOHfw="
+   "module": "sha256-x1xXJ9lHxPjNFDwZpZgAF9LlDDD0ubVT1tJug/h2Uw8=",
+   "pom": "sha256-/ahae8KMtfubYXO3XOK/EX2SPVGA9jDFPCk4ptoKNxM="
   },
   "org/jetbrains/compose/material#material-ripple-desktop/1.5.12": {
    "jar": "sha256-alADYML/sY6CmLKPuRJwoFyyQ8X1CUf1dOZc+Nk9Jok=",
@@ -2486,20 +2605,20 @@
    "module": "sha256-GgBmeKLPSpdGfXommv8BGbGuLnMnYhOcPTRb8v4p5Fo=",
    "pom": "sha256-kVWgu/MfSK5IRDowYVYEWdIyrjOhBM1XJTWCvHI2gpM="
   },
-  "org/jetbrains/compose/material#material-ripple/1.12.0-beta02": {
+  "org/jetbrains/compose/material#material-ripple/1.12.0-beta03": {
    "jar": "sha256-s/2P36bIzBZQaYimOK9jnMi3my2DabSUYKSHU+aMuRk=",
-   "module": "sha256-kdw6dPOmjBZ2L5FGSI7/MQ9vLEBY1ljh1eJWxtDoFaU=",
-   "pom": "sha256-IvagVn/aP4tpjXbVhuliu2Q3qIuKtXJ9D4I4SKvnLhY="
+   "module": "sha256-cuvxr0GZN6Xc28KuxV8NbEKW+11Cxw+TbjvDVXrcGt8=",
+   "pom": "sha256-VwtTOK5QLPSWdaMbdaCy1zu9wkBPYxQCSITpwM+M2do="
   },
   "org/jetbrains/compose/material#material-ripple/1.5.12": {
    "jar": "sha256-Y5HHORvwp+3X+QTKYiejB1F8csO7/KkuAANJ3RQhgQ8=",
    "module": "sha256-tlOm3j7g82ISgi0YtWTQ64tKb/bTh46FsOaxYTOoBUE=",
    "pom": "sha256-p9j9rHGRd39PxygiOT7GNytZstNv3WOf+8lAFtWnDaw="
   },
-  "org/jetbrains/compose/material#material/1.12.0-beta02": {
+  "org/jetbrains/compose/material#material/1.12.0-beta03": {
    "jar": "sha256-3PFkEq/mObT6V9adUaX8I4P5IyJz6DYcwHl/e9MDKEo=",
-   "module": "sha256-LYJ18F+2OGwyzt6x4I+4IyN5VkF9aD+rKy9LX69Zk78=",
-   "pom": "sha256-ZoPCpHv7vEeVpx6tL9WY+1vpWWnWQRH67Svc0pQN0yg="
+   "module": "sha256-mXT8XDBouWWs6GR7smq5K2VvvUBkRuuLnzVfgsXZ1Vs=",
+   "pom": "sha256-+LrAmv6/hqcm6Mdoe6r7KPR+LL+P5GjvQeSUXxN9R7c="
   },
   "org/jetbrains/compose/material3#material3-desktop/1.12.0-alpha03": {
    "jar": "sha256-J6yA2hw/ZbZzEb+uV9efEwt9TQrI4cW+HKfOiwS30Nc=",
@@ -2539,19 +2658,19 @@
    "module": "sha256-VN/axM8YPGpjtg6jcT4RNnlGqcsET4QH+yHNdA8/7OM=",
    "pom": "sha256-5uRZg/PpGIa2P1BLiM/VdiZdp6yzR/VyZ149sKVXGTY="
   },
-  "org/jetbrains/compose/runtime#runtime-desktop/1.12.0-beta02": {
+  "org/jetbrains/compose/runtime#runtime-desktop/1.12.0-beta03": {
    "jar": "sha256-mkD7msm5ihsti+Uc5X289zPnaPoGqeSFmhd1y1K/aAY=",
-   "module": "sha256-2pWLXc9CKdNB48OEqun8vi/k8s0S91zdG4uObuCfg5Y=",
-   "pom": "sha256-KoXQgRyVzbgX+CCNnWZ0Ms69WxNu3zBe52FbgGuxxW0="
+   "module": "sha256-IyQcN8w2d1SpSsFQiHdMV+dpAJorKoAE1o1OovoqAvI=",
+   "pom": "sha256-bTrlxoii2gxE8KzmqWjzfCi56ssNvJbqlTRUOw7ybJg="
   },
   "org/jetbrains/compose/runtime#runtime-saveable-desktop/1.10.0": {
    "module": "sha256-4y7c2cx6vAe/yA/F67aDp5uA2NhdRcWJUM7FvL8EZyU=",
    "pom": "sha256-7OTe747w7AS3p5VdQi8LOGFoId6ExWq+USc6xq3BcI8="
   },
-  "org/jetbrains/compose/runtime#runtime-saveable-desktop/1.12.0-beta02": {
+  "org/jetbrains/compose/runtime#runtime-saveable-desktop/1.12.0-beta03": {
    "jar": "sha256-2Blz3O0iPWrqe/n21OrShUlMZW6gA7WQcrq+/SVHDHs=",
-   "module": "sha256-7c0bH4UovouD+7DqHpk4NZbD7RERiHxz6rsPlSUWb6U=",
-   "pom": "sha256-Ky4D3+bdpcX21yHbP3RoWd6SRF8LIlBIFoGsdgPwp1Y="
+   "module": "sha256-9aIHNbhQLdP8Pa/IJW2BvED/pPdlEiRvaXp3TAj4nUU=",
+   "pom": "sha256-EOXdzqmk8+S0uttPC6I1/k2nKmhejwaGTzoIMC9J9MY="
   },
   "org/jetbrains/compose/runtime#runtime-saveable/1.10.0": {
    "module": "sha256-arj+tNQ/o5qZMoaY5NFHk+iu6nCcWmYc4bDfYkkbY+E=",
@@ -2561,10 +2680,10 @@
    "module": "sha256-A+ogrbSZX1clbMnGiwmnXjpB3DAjBHexhJKQ+2otUac=",
    "pom": "sha256-ERJhRxTk/r2QxLb7insKkStP93aA1by5gfSJWtvrk00="
   },
-  "org/jetbrains/compose/runtime#runtime-saveable/1.12.0-beta02": {
+  "org/jetbrains/compose/runtime#runtime-saveable/1.12.0-beta03": {
    "jar": "sha256-33BvOcsMzqsbWAwywLh9hVIkdY36wtmN3WJD4rpiijY=",
-   "module": "sha256-faGhq3EurKxM2a0TF32RZ3uoyG56c07vds9I8vps7iY=",
-   "pom": "sha256-YKcC004GB9d1NPPW+xclYIZPJ+4QltP+u3cO+cfjobk="
+   "module": "sha256-abNk8hZkuVpNsMVdyV2xlI1U4inuYicZrLKBZnQAf4A=",
+   "pom": "sha256-2ecp3MCTFxelbqIYTb6q4wgBj7IadsN1oevh+9Teflw="
   },
   "org/jetbrains/compose/runtime#runtime/1.10.2": {
    "module": "sha256-YVvm9uNuWeiDhCSGqspbi1NTFq+r8ltTi3nlyy74is8=",
@@ -2574,119 +2693,119 @@
    "module": "sha256-z9v1ZLTFXzLe4p+m+1v04zA+xdSwhcNoZ6Uz0l42ZEU=",
    "pom": "sha256-BI/26pMhJhvIUkUVOMImkjkCXZSiZDZSoeUB0qyI624="
   },
-  "org/jetbrains/compose/runtime#runtime/1.12.0-beta02": {
+  "org/jetbrains/compose/runtime#runtime/1.12.0-beta03": {
    "jar": "sha256-asCjxy8PIyQwi7sm0r83gftIIGsnVjgWj89UDmuljNQ=",
-   "module": "sha256-F1u0ajbi82Eq3oY4ozmpK3ne0nmNVTIygYvi+hiUi2s=",
-   "pom": "sha256-2f7OmQyIwywWI+bFOUjHpo471So2oh3DS08mNtOopto="
+   "module": "sha256-Xb08fn7yU4z2FU/vgL9Y9MctCyhpfDPuuveD3Le1bi0=",
+   "pom": "sha256-DXH0sayEXpX0vGzast3hVvyxhG1vqJNjPEKeSdB4x0Q="
   },
   "org/jetbrains/compose/runtime#runtime/1.9.3": {
    "module": "sha256-RoPOYaDjW2fnQuNTqNRlcXglAxwQgc+7+zojate9s9o=",
    "pom": "sha256-4yJMwKXBCThxJVp+fmcbXoXsxKLloEg1Q7o3Tc9awq4="
   },
-  "org/jetbrains/compose/ui#ui-backhandler-desktop/1.12.0-beta02": {
+  "org/jetbrains/compose/ui#ui-backhandler-desktop/1.12.0-beta03": {
    "jar": "sha256-C8AhrMxhbCqZr+DDnKHsKQgvp4p7mYaO0SLRYuq4KL0=",
-   "module": "sha256-Q8ALCsVEGMW9NXC/SBoZLcOJt6mVPV4VJQdDexud87U=",
-   "pom": "sha256-7jTbl4aHEQvvAywc3n9dMFZXCYFnT2ke/ZMnK04E7Cc="
+   "module": "sha256-L6FgBi5GOAnbOg1zurl9zit6yDCZr97ex30ttBpA96s=",
+   "pom": "sha256-XsNLZzaqwPOpi5xOmikpBbOoljhBnSL4TxS3E9OyB9c="
   },
   "org/jetbrains/compose/ui#ui-backhandler/1.12.0-beta01": {
    "module": "sha256-rxf4q7HNblwauAh28AzAFRJSsJKY+DmUDHIQySkB0sA=",
    "pom": "sha256-AqHIShqJBflEPUWloyalRv6QwOEVtgkLqeJwdyIhKig="
   },
-  "org/jetbrains/compose/ui#ui-backhandler/1.12.0-beta02": {
+  "org/jetbrains/compose/ui#ui-backhandler/1.12.0-beta03": {
    "jar": "sha256-HLx3/04wMfHX8dmuiuboLIHtCEuF+jjTU/FQVD1+jnc=",
-   "module": "sha256-OYdHcsXb468hqVs+XXnl5XbSP3R901em1vuOLsxWMgw=",
-   "pom": "sha256-kBsdrRFuq7XRcmh+Iy7cDB267LQc7iWkWiDExW9ZkQA="
+   "module": "sha256-zqdCOSmAlznSVJYHFUL0EVJ8wYbS1ALYjGwh1Dmxkes=",
+   "pom": "sha256-Xt/Gbzu6JVgqTRXmXoOW11TQ1ehNuxduGquqpfj/6FA="
   },
   "org/jetbrains/compose/ui#ui-desktop/1.12.0-beta01": {
    "module": "sha256-Zy56ti3kJXNMKiWlv2lfPZv47mP0ymAarbXsaZtuXGM=",
    "pom": "sha256-mEyG5WpR1xWTqvneamY014eXVGMCHQHL6NtifxOMUvw="
   },
-  "org/jetbrains/compose/ui#ui-desktop/1.12.0-beta02": {
+  "org/jetbrains/compose/ui#ui-desktop/1.12.0-beta03": {
    "jar": "sha256-q9H7UmmExjW5O1FZ6Axws7t4r+m1LNBwi60NPOy9FpI=",
-   "module": "sha256-4Fox5lkb2CMTzJdfglH01rOk3x0ixkbOTwT/+vBnDxE=",
-   "pom": "sha256-5wXLk/lgqOQVN19Z0WCg2g8rJivwhHviKx7EoXCcIlc="
+   "module": "sha256-mePfdglolhaXKM8dGLXbtjRo67AXhIb7XbQYhz54Tls=",
+   "pom": "sha256-8tndfwuznBdnbHcGEvd5YmKWoytkk81JwF8wMYml3l0="
   },
   "org/jetbrains/compose/ui#ui-geometry-desktop/1.12.0-beta01": {
    "module": "sha256-KyLCtcbUa8viZZ4KAyfItoJwadXBzEbC7wvIkI1lyLg=",
    "pom": "sha256-nXrRyo2h9zlBb5CPy176aNkCogMVPqlA7BZfMNabCfw="
   },
-  "org/jetbrains/compose/ui#ui-geometry-desktop/1.12.0-beta02": {
+  "org/jetbrains/compose/ui#ui-geometry-desktop/1.12.0-beta03": {
    "jar": "sha256-LN5E2VuiFlTcztOjCYvdFxs+9bF+9/xs7A0lmD28n6A=",
-   "module": "sha256-vxQvLZJVSc+7xsFPNO1DlMG/VVkRNWTv9Xtsv2I0j2U=",
-   "pom": "sha256-I8mg0tCx2pey0mFGFzGNo3hfVhoVNFnUDhz/gIRlLyw="
+   "module": "sha256-dkcppcmhn9oLzTpw9OusVqCMAJxLwhivM3mPt2/Ftn0=",
+   "pom": "sha256-6bJzs+lZpJci5tLD6heERhC5arWtzaj5tCVWCUvTbxE="
   },
   "org/jetbrains/compose/ui#ui-geometry/1.12.0-beta01": {
    "module": "sha256-aTXNXPQDzd0zdQbAc+CIvlmoAgyXRecCXwiN7YqNmfA=",
    "pom": "sha256-CRxaM9qCv3xmJnA+RKGDBw9hwbn5WhRU3zFPdGJFQNs="
   },
-  "org/jetbrains/compose/ui#ui-geometry/1.12.0-beta02": {
+  "org/jetbrains/compose/ui#ui-geometry/1.12.0-beta03": {
    "jar": "sha256-ucsT0NuZnVrT+42lptTwgTw5mM6vTeowMcIZZ3juPGA=",
-   "module": "sha256-qPhsdm1sklxvBfNEJUFfTiK3oQlbzBAw854wXZ+s8QE=",
-   "pom": "sha256-zL/uyalQE5RdSkxRj45CNkUXt3XpSKuc4PeAI1hpH9g="
+   "module": "sha256-ARA0g7ol3zghX8lpqIV1IG0hTZ2kwfEIRmQ2SEPTjv4=",
+   "pom": "sha256-HpyVurGL0t304oQ9syzZrtuLMgikQsGrZ11ZnT6ZdWY="
   },
   "org/jetbrains/compose/ui#ui-graphics-desktop/1.12.0-beta01": {
    "module": "sha256-X7WbjlbhiJH0MYHHeeZObtRof0pbIXwJt5LmH9SmKKs=",
    "pom": "sha256-Ulu9afB4WGYIHCTpptUloTAYTXo0j94Z8peO3jjVg+M="
   },
-  "org/jetbrains/compose/ui#ui-graphics-desktop/1.12.0-beta02": {
+  "org/jetbrains/compose/ui#ui-graphics-desktop/1.12.0-beta03": {
    "jar": "sha256-WuBG8HReT0hPOaAgLlVFuP/dGTDFUKYNdvbBypU06v8=",
-   "module": "sha256-HMh412hOyQYpeXR8dZ+WPEutqNgTnauDFTPD40m68jk=",
-   "pom": "sha256-Q3yQT0uTu+obICIR3LGYw/GtSlwrXpG7L61yoxgffOs="
+   "module": "sha256-lmeF6y+9lPCZpVUxNkmQIHvkkMqd8tKZ6eA5JieqJ3Q=",
+   "pom": "sha256-kHaruX1WdnN08Z1FGoCYTTRmx6Ee4TGP8Ej6sI5R1X8="
   },
   "org/jetbrains/compose/ui#ui-graphics/1.12.0-beta01": {
    "module": "sha256-D79TptfH8DerHxyf1eJqCuQoIQlzo+yCpglnxhqnP2o=",
    "pom": "sha256-FwSF9Frqv3isLsnWS45+7vAmJcwMUNeU0hr8aAl7qZQ="
   },
-  "org/jetbrains/compose/ui#ui-graphics/1.12.0-beta02": {
+  "org/jetbrains/compose/ui#ui-graphics/1.12.0-beta03": {
    "jar": "sha256-xmrKI1Z3cOAnnyTpDXBXv70SgnMSExvHxmTcwQB0iNY=",
-   "module": "sha256-F4qqM19kKs8LSorCygy//7Pz1pWAzL4Z6xHLPNG5LUw=",
-   "pom": "sha256-BotmCvXmK+pR1xkhANDUgkWJSVuO4N56TQQ6WUFiV4c="
+   "module": "sha256-36WYs1CodFy3eEqWJkMbOg6JvXOLHgRYvUfzxgJ+OjI=",
+   "pom": "sha256-FKpk4uap2S7uTa0fZdXbf5sqWtfzVMXA2/x52WciBMo="
   },
   "org/jetbrains/compose/ui#ui-text-desktop/1.12.0-beta01": {
    "module": "sha256-Z3KdxoPm+WnVRZsXujSp4mIXuJEGGHWNGAEhUv/vH0k=",
    "pom": "sha256-uz6Vwfiy8QVK7ZbYb1DyVFwd2h+fbCCMbc62fIgZR6w="
   },
-  "org/jetbrains/compose/ui#ui-text-desktop/1.12.0-beta02": {
+  "org/jetbrains/compose/ui#ui-text-desktop/1.12.0-beta03": {
    "jar": "sha256-ZyMx1+FEDyQG9qm209YUdTFs9iLQ276RDke9vWmGHDg=",
-   "module": "sha256-EGN2kHCGv1PywZ0f9Cye4Hk1ReBN5+bz0Z7EA2uxJ5c=",
-   "pom": "sha256-Ll+xE9ql493MI87/u7BeKHxPaZh/+lmDDG9bQR+6KX8="
+   "module": "sha256-QqgF20VPOIyTLRIdFnSpq8H5RE5fY9VPu6La7oTcFoI=",
+   "pom": "sha256-J/MkludOR22LXzO5YXidWxIfcjZA7xOGAWEdBpv0hCw="
   },
   "org/jetbrains/compose/ui#ui-text/1.12.0-beta01": {
    "module": "sha256-Q4UDw04lOzclHdBtiPABn0l7OHxIVNqIEdAbSqZM+W0=",
    "pom": "sha256-QFcPHSyBei3VaRzFAh4ai/1Zcd26dcI5/fUhdECtbXk="
   },
-  "org/jetbrains/compose/ui#ui-text/1.12.0-beta02": {
+  "org/jetbrains/compose/ui#ui-text/1.12.0-beta03": {
    "jar": "sha256-3eP5W0RVMybYYm4vdt2APUS0ZHKdRSy8onpRuP2Fz4k=",
-   "module": "sha256-maTQiAIdSKdRvjnYNmE3o2IH2R0i8nGeX4lJ4KgzPgk=",
-   "pom": "sha256-tWolbilkpmNwM/DI1OEBXD6lZrg0Tg2qRlqHNGeVhxQ="
+   "module": "sha256-E4Lm69yL0hwgmXvvazSRD1W3grJgRVLE5u3eA0jlee8=",
+   "pom": "sha256-dVYpB+sgXRFTOKKtgKrw7BURW+D9ZhCY/Nk9P8nBrGY="
   },
-  "org/jetbrains/compose/ui#ui-tooling-preview-desktop/1.12.0-beta02": {
+  "org/jetbrains/compose/ui#ui-tooling-preview-desktop/1.12.0-beta03": {
    "jar": "sha256-GfUAW6on378/Q1/u1E37qck4ujhqxnU9AKZ6JwzXIjE=",
-   "module": "sha256-xVIssDKt5Aw0clcl6kxtYLEMslhzKAJsfF5p7zm1+lU=",
-   "pom": "sha256-Zw5SpwY2erdT+BQvmPnGPUHeNp/PVR3L4vfNRH0T7b8="
+   "module": "sha256-DRobJVXmvGbh0LsMeOkr1YoXhXF/htzIGo0LkSJD2+c=",
+   "pom": "sha256-GGMNwmtVfASMt6S6zWyPg9g90Fjm/QsYAiNb9idqHQM="
   },
-  "org/jetbrains/compose/ui#ui-tooling-preview/1.12.0-beta02": {
+  "org/jetbrains/compose/ui#ui-tooling-preview/1.12.0-beta03": {
    "jar": "sha256-2aTqcrJIW80TSYOl/AtcoQ9sj0u3pC+dVWxoMlS/Egk=",
-   "module": "sha256-N6HrB5+FTIAOt2VjgKt0gXfp6hO/HiSiKxKrckLvSe4=",
-   "pom": "sha256-rm219KnmjcENTGA8gO/17dGJFdn8r5YWqs3GR7v1UBk="
+   "module": "sha256-rgoAwELrjVW9eLD1msQNA72xBVVR7mgmDsvGm3n3UsY=",
+   "pom": "sha256-jmXWhwjOsx3/wuNwBy4IIPhcFUorp7aGELeHnfkfTkE="
   },
   "org/jetbrains/compose/ui#ui-uikit/1.12.0-beta01": {
    "module": "sha256-Yzvk3sc5gf+RuIcTf8f6my6IOgubH5VQs1lgqOlcyyw=",
    "pom": "sha256-b1cPK7lGljKfZkr6hd8O9tswEkI9aqlop81IiMSnY48="
   },
-  "org/jetbrains/compose/ui#ui-uikit/1.12.0-beta02": {
+  "org/jetbrains/compose/ui#ui-uikit/1.12.0-beta03": {
    "jar": "sha256-axl+MetJAS/Qvc0HxVjrXVpXYkZoXpVBvD0rcTNa7ug=",
-   "module": "sha256-eQh7BA8LPNBsh1c6rC7SdMVq9PxolgbHpimHNlPxZ3Y=",
-   "pom": "sha256-GgHPUv0c/+T0Y9eT7SdJJOhbiELl/yKWxig7/vKrnto="
+   "module": "sha256-Am9Q8ObCngfWoYjE3p0MTgT580r/JLEK4JApMyFclGc=",
+   "pom": "sha256-QsrN3GFgG9W33gggb/+jfkHuf5mwWthva00A9d8oozM="
   },
   "org/jetbrains/compose/ui#ui-unit-desktop/1.12.0-beta01": {
    "module": "sha256-Zj6TGKv2xIlu/B5PA6A/bLF2xnd4d3wzrF+qBc+vAYw=",
    "pom": "sha256-OiwSj77Y7m8INI7PQE2lE5D1zAE/nh3v6li+sMx/6NI="
   },
-  "org/jetbrains/compose/ui#ui-unit-desktop/1.12.0-beta02": {
+  "org/jetbrains/compose/ui#ui-unit-desktop/1.12.0-beta03": {
    "jar": "sha256-fEmY8SJPJB2+iPpZcB1pfVmP6JeaSsrtcXuDZdTNkwA=",
-   "module": "sha256-NF+6R8Q0gl3UyeLFO3M2eReUQTCEM/NKayCbWmBawBw=",
-   "pom": "sha256-0wV2Mvxh0GWAfo3i23Pf9qt8PmvQYsO6H1mbkkzqxVc="
+   "module": "sha256-3aefsIrPCug49Xu/obdObQLh2P2tE3nJohefXA7jj2Q=",
+   "pom": "sha256-RnDdF6vzVgyrYQwjwyvfw+5qYM7FDUXXS4qXMLOsgag="
   },
   "org/jetbrains/compose/ui#ui-unit/1.10.0": {
    "module": "sha256-PODKlwhqnA3bqCKx7Q7M/n5AcNZCrQANU67aPbQWoPQ=",
@@ -2696,33 +2815,33 @@
    "module": "sha256-wMCx9bjzo8pK8AibCxQLKDoDsdMkdiJXKw6Ef6/IRmE=",
    "pom": "sha256-itG8VmgcM+0dKRRRP2Ewt3WB73BziPGUHEbBap8hEt0="
   },
-  "org/jetbrains/compose/ui#ui-unit/1.12.0-beta02": {
+  "org/jetbrains/compose/ui#ui-unit/1.12.0-beta03": {
    "jar": "sha256-KjsSDfox2/o9Pd8yfP9KHBXwUP8MGeZPacHiQdtqByo=",
-   "module": "sha256-F1dWTgKX7V5mCAMlQzU0UsYcVyaMxx4SozH0vuKdE2Q=",
-   "pom": "sha256-hiH663BoB6oaRnrt5vmoEbH9i0zUBDsYFVdxP7vOm0c="
+   "module": "sha256-LlaQGlgN3brQvXRT1hDbVUnPjhPvXy1Rp/iw42+Ri5g=",
+   "pom": "sha256-sGNb9BGSIPHouNLWQLQFQE6lPEAMhxUYLY45mfExaBk="
   },
-  "org/jetbrains/compose/ui#ui-util-desktop/1.12.0-beta02": {
+  "org/jetbrains/compose/ui#ui-util-desktop/1.12.0-beta03": {
    "jar": "sha256-u4HpdIybyt6uuZurZH4hRC5i4lOjpJeiE8aOBAyys4U=",
-   "module": "sha256-h9LjJz3SChbxJqeMh2fEyShsohlZkgySB4r7F1vaPAM=",
-   "pom": "sha256-p1OdlRmYqVBbmab7ewewx75Tt+qJIvAi+zx61CgH6Ss="
+   "module": "sha256-BeNmmHiUs1vcv1FWo8VjFtoCSIvF9S2Laai1AbIzKAc=",
+   "pom": "sha256-IHhRkKErcu2D99ogLf4nQkFfUf1j21lRx6Jb5zj5Pnk="
   },
   "org/jetbrains/compose/ui#ui-util/1.12.0-beta01": {
    "module": "sha256-rhZw/wJQBWGnKswB42vKd7OhBcJLNCgY9m2vbXqv7O0=",
    "pom": "sha256-qwvHRsIUcr0Zq6utorC9+HaP7W2BQFaMyYloPhiMLY4="
   },
-  "org/jetbrains/compose/ui#ui-util/1.12.0-beta02": {
+  "org/jetbrains/compose/ui#ui-util/1.12.0-beta03": {
    "jar": "sha256-NlCCj991HvX5VnN2a3cLrIeKsojeCDWASHxHIK9mkD0=",
-   "module": "sha256-ROAMejm2tEXr81GbYM/DUD9BJNIt2FugkZ5GaSlSDJM=",
-   "pom": "sha256-SxsfY0GdjKh7NkICr/v2R/6aU48mM/e213GipoqyqoM="
+   "module": "sha256-rqpb8fqUe3vkIy5Sl2AVLs2+WkiK9S4/L8gF8eGogiw=",
+   "pom": "sha256-wZih1REkQn1icDU/aoukTlEXQyUbHZQwG7BnKzuaGBk="
   },
   "org/jetbrains/compose/ui#ui/1.12.0-beta01": {
    "module": "sha256-1U5ydKZzOy3GIRllYHOaOLCaDKsxA240VDTMf37DrII=",
    "pom": "sha256-5tThIvP6CJX4mevRiYhWi+cNYQB1dL3SVg7Q03u1nx0="
   },
-  "org/jetbrains/compose/ui#ui/1.12.0-beta02": {
-   "jar": "sha256-KYAualG7WU1hiMNnFSRltsPdBRdiT3gAZDgGsqJfAHE=",
-   "module": "sha256-irSMNpWCnvIUacgq7lRL3ZdRP5a7HRoxgNSYNnME/F0=",
-   "pom": "sha256-rnuzS/VLRkiI8tjBCqRqxOKIHXmdbGhcVU37pDOy3Bc="
+  "org/jetbrains/compose/ui#ui/1.12.0-beta03": {
+   "jar": "sha256-1hDfgzCyyn3sL7O56vR2NUwfc4T8+doJ0PpowMa+cQ4=",
+   "module": "sha256-72vmPQh8t2oI0wvYT0rNulaAbxz42nyNnWGKI938zM4=",
+   "pom": "sha256-58FDik42VWYMLiSZ+VFXWrl2HytfAX9/umUhZ6JTwRw="
   },
   "org/jetbrains/kotlin#compose-compiler-gradle-plugin/2.4.10": {
    "module": "sha256-ex+asAI2BHlhjuCapscAWgKCw55wXlYSUPNYaoKDcpY=",
@@ -3104,10 +3223,20 @@
    "module": "sha256-0RrPnfTLjwsBXNARZici1ySQwIiZhCJOpW3+TCc0rqQ=",
    "pom": "sha256-jQD25Qd/O76Bod8yi+te79AIzI+B//5srNUm8BXcnoQ="
   },
+  "org/jetbrains/kotlinx#kotlinx-io-bytestring-jvm/0.9.1": {
+   "jar": "sha256-hYneC3xHa/3QKiRkFoX2Ca3nL15ZXPKQnBaKzbp+a6Q=",
+   "module": "sha256-bg1bxVGvKIRyg5eerohOnfGsSgldSM9nCQtpYe288uU=",
+   "pom": "sha256-xC9KI5StvopK5ViFKPX2Tl1O3ddDQkCMLyU8xslcI6U="
+  },
   "org/jetbrains/kotlinx#kotlinx-io-bytestring/0.9.0": {
    "jar": "sha256-Siu1X59CjfC/p3WsVAZAzA5tYz7Gb1IM0hV7/hC+L0g=",
    "module": "sha256-hhg+j506LZqCiIN4+tb5V1hhk1nkXfty7K9sCwcmOFA=",
    "pom": "sha256-1DAvY5qQe0AlwH89LuQ+3KC369+2rtWA2k0gdjQLIGc="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-bytestring/0.9.1": {
+   "jar": "sha256-Siu1X59CjfC/p3WsVAZAzA5tYz7Gb1IM0hV7/hC+L0g=",
+   "module": "sha256-ACtgq7Zief9ZVJz6LnnHLI2uKeGbDEZJjtlZsOcClYE=",
+   "pom": "sha256-kuCEpM0bw0w4gQNbC/dV9M44Tdg/2ddyZWCEuTEt3g8="
   },
   "org/jetbrains/kotlinx#kotlinx-io-core-jvm/0.6.0": {
    "module": "sha256-tZuXjCxEJJpnRkGmlONaKs7LqBLah9NlpRZzQqjKU0c=",
@@ -3118,6 +3247,11 @@
    "module": "sha256-GtjQ5PgKNhxWevWqkEYHYp5TAN7hU6RnPmUX+HayFDY=",
    "pom": "sha256-fLkR4mPRz0Lm1zY+1WAaYaxYgZdo1SB9+RsPaeIqbOg="
   },
+  "org/jetbrains/kotlinx#kotlinx-io-core-jvm/0.9.1": {
+   "jar": "sha256-dl2IUdjKaUcGkxMxuSOGhEgAhn4EG3IPHxk9vah003A=",
+   "module": "sha256-tToKE0wAD4MvTfJcRgRdaOYVMkkUHapOBs9VZCOH5R4=",
+   "pom": "sha256-aaAhOJ7iqClIQtPdHEAIxcXfIMJdcmprrWZD70IM3yA="
+  },
   "org/jetbrains/kotlinx#kotlinx-io-core/0.6.0": {
    "module": "sha256-FIX7aljyQWnRr3PEFDAiUKx4u0axpD4Csa4hILKhJPA=",
    "pom": "sha256-QIZ+EY9KW7uz291WZ3DY8Yu07w02MtyE+WyZ+2vD6oE="
@@ -3126,6 +3260,11 @@
    "jar": "sha256-7yi18O49Zm/1B49uGwjAjRCj/ioWkUHfx2PeluqvvK0=",
    "module": "sha256-+QJWEkHN4gRxfh6u368DBumKuZZ5rLemY6rqgfFaNiA=",
    "pom": "sha256-rYa7iYQNaLA2Wz0hnRACStrUxkZOBBNsakKeG7do/qY="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-core/0.9.1": {
+   "jar": "sha256-7yi18O49Zm/1B49uGwjAjRCj/ioWkUHfx2PeluqvvK0=",
+   "module": "sha256-kK017PfkovutRYa+tMcSQEgKB1ZPLCtcG773v3GJwb4=",
+   "pom": "sha256-VKzgH5zhflCIiKWTQ8ZCzNUpgA8SZIay7GYBjV49/UQ="
   },
   "org/jetbrains/kotlinx#kotlinx-io-okio/0.9.0": {
    "jar": "sha256-xapQ7H4/tmSRrRDEaim8sB/VZDEYFfdLKLZL41jb3EU=",

--- a/pkgs/by-name/ru/rush-lyrics/package.nix
+++ b/pkgs/by-name/ru/rush-lyrics/package.nix
@@ -6,7 +6,6 @@
   copyDesktopItems,
   makeDesktopItem,
   gradle_9,
-  openjdk21,
   nix-update-script,
   libGL,
   libx11,
@@ -19,8 +18,6 @@
 }:
 
 let
-  gradle = gradle_9.override { java = openjdk21; };
-
   runtimeLibs = [
     libGL
     libx11
@@ -37,13 +34,13 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   pname = "rush-lyrics";
-  version = "6.5.1";
+  version = "6.5.2";
 
   src = fetchFromGitHub {
     owner = "shub39";
     repo = "Rush";
     tag = finalAttrs.version;
-    hash = "sha256-6cIgClRAQg7yVLyr00Qg/VD7WybraLEraa47WPjvCZo=";
+    hash = "sha256-+x42qGw2mQdUxRSq4r5kiPD9feE0DMhjUPk+8vLfLzw=";
   };
 
   patches = [
@@ -51,12 +48,12 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   nativeBuildInputs = [
-    gradle
+    gradle_9
     makeWrapper
     copyDesktopItems
   ];
 
-  mitmCache = gradle.fetchDeps {
+  mitmCache = gradle_9.fetchDeps {
     inherit (finalAttrs) pname;
     data = ./deps.json;
   };


### PR DESCRIPTION
Bump rush-lyrics from [6.5.1 to 6.5.2](https://github.com/shub39/Rush/compare/6.5.1...6.5.2) and remove `gradle_9.override` for Java as upstream now requires Java 25.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
