### PR TITLE
moshi: 0.2.5 -> 0.2.12

### DIFF
--- a/pkgs/by-name/mo/moshi/package.nix
+++ b/pkgs/by-name/mo/moshi/package.nix
@@ -43,18 +43,18 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "moshi";
-  version = "0.2.5";
+  version = "0.2.12";
 
   src = fetchFromGitHub {
     owner = "kyutai-labs";
     repo = "moshi";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-MkZsLRQE5Swdyp9l/cvPvznWxRfKuYecj+TTgb3ufKU=";
+    tag = "moshi-v${finalAttrs.version}";
+    hash = "sha256-Q+3amcF3T53z/ViCBmjpyfJmZVoRAGzP4yBsnorjxU8=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/rust";
 
-  cargoHash = "sha256-BxV8oZlN+6cVb3GwhY7TKWxHEpY3WVEhN6A6+5NMOyU=";
+  cargoHash = "sha256-C8q0WaDYrLopuuVNjtmXJaPSCojGHfPv+VwWGbY5VBU=";
 
   nativeBuildInputs = [
     pkg-config
@@ -97,6 +97,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   env = {
     # use system oniguruma
     RUSTONIG_SYSTEM_LIBONIG = true;
+
+    # Otherwise the build fails with python>=3.14
+    PYO3_USE_ABI3_FORWARD_COMPATIBILITY = true;
   }
   // lib.optionalAttrs config.cudaSupport {
     CUDA_COMPUTE_CAP = cudaCapability';
@@ -120,7 +123,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
       );
     };
     updateScript = nix-update-script {
-      extraArgs = [ "--generate-lockfile" ];
+      extraArgs = [
+        "--generate-lockfile"
+        "--version-regex=moshi-v(.*)"
+      ];
     };
   };
 
@@ -133,5 +139,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
     maintainers = with lib.maintainers; [ GaetanLepage ];
     platforms = lib.platforms.all;
     mainProgram = "moshi-cli";
+    problems = lib.optionalAttrs (config.cudaSupport && (cudaPackages.cudaAtLeast "12.9")) {
+      unsupported-cuda-version = {
+        message = ''
+          cudaPackages is too new (${cudaPackages.cudaMajorMinorVersion}).
+          Version 0.16.2 of the cudarc crate asks for a CUDA version older than 12.9.
+          Please override cudaPackages with an older version.
+        '';
+        kind = "broken";
+      };
+    };
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/kyutai-labs/moshi/compare/v0.2.5...moshi-v0.2.12

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
