### PR TITLE
luajit_2_1: 2.1.1774638290 -> 2.1.1785577137

### DIFF
--- a/pkgs/development/interpreters/luajit/2.1.nix
+++ b/pkgs/development/interpreters/luajit/2.1.nix
@@ -8,13 +8,13 @@
 callPackage ./default.nix {
   # The patch version is the timestamp of the git commit,
   # obtain via `cat $(nix-build -A luajit_2_1.src)/.relver`
-  version = "2.1.1774638290";
+  version = "2.1.1785577137";
 
   src = fetchFromGitHub {
     owner = "LuaJIT";
     repo = "LuaJIT";
-    rev = "fbb36bb6bfa88716a47c58bcf9ce9f2ef752abac";
-    hash = "sha256-BqH66q38mJpIYJgPiSPt7I0B3VLBvuDRRTiMJ7ldkBI=";
+    rev = "4886b676a698acc4bbdf54adfabb3e33a8c020e8";
+    hash = "sha256-3nTyPcphBQN2segb5bxBgvrWHodN/ckRy4AGS8lDL44=";
   };
 
   inherit self passthruFun;

--- a/pkgs/development/interpreters/luajit/2.1.nix
+++ b/pkgs/development/interpreters/luajit/2.1.nix
@@ -8,13 +8,13 @@
 callPackage ./default.nix {
   # The patch version is the timestamp of the git commit,
   # obtain via `cat $(nix-build -A luajit_2_1.src)/.relver`
-  version = "2.1.1785577137";
+  version = "2.1.1785763465";
 
   src = fetchFromGitHub {
     owner = "LuaJIT";
     repo = "LuaJIT";
-    rev = "4886b676a698acc4bbdf54adfabb3e33a8c020e8";
-    hash = "sha256-3nTyPcphBQN2segb5bxBgvrWHodN/ckRy4AGS8lDL44=";
+    rev = "1edc3e52b67eaf6ce5f809be8e17d6862594b8bc";
+    hash = "sha256-mcOvVJ7AaoHrbEXxznpOkFoY7Kbd2aWMoOmyx5B4FIg=";
   };
 
   inherit self passthruFun;


### PR DESCRIPTION
closes https://github.com/NixOS/nixpkgs/issues/548383

newer upstream version includes v3 syntax backport.

uses https://github.com/LuaJIT/LuaJIT/commit/4886b676a698acc4bbdf54adfabb3e33a8c020e8 as specified by @vcunat

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
