### PR TITLE
qt6: fix cross for most modules, enable structuredAttrs, strictDeps

### DIFF
--- a/pkgs/development/libraries/qt-6/modules/qt3d.nix
+++ b/pkgs/development/libraries/qt-6/modules/qt3d.nix
@@ -5,6 +5,7 @@
   qtdeclarative,
   qtmultimedia,
   assimp,
+  pkgsBuildBuild,
 }:
 
 qtModule {
@@ -27,5 +28,8 @@ qtModule {
   cmakeFlags = [
     (lib.cmakeBool "FEATURE_qt3d_system_assimp" true) # use nix assimp
     (lib.cmakeBool "TEST_assimp" true) # required for internal cmake asserts
+    "-DQt6ShaderToolsTools_DIR=${pkgsBuildBuild.qt6.qtshadertools}/lib/cmake/Qt6ShaderToolsTools"
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
+    "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
   ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qt5compat.nix
+++ b/pkgs/development/libraries/qt-6/modules/qt5compat.nix
@@ -5,6 +5,7 @@
   libiconv,
   icu,
   openssl,
+  pkgsBuildBuild,
 }:
 
 qtModule {
@@ -17,5 +18,10 @@ qtModule {
     libiconv
     icu
     openssl
+  ];
+
+  cmakeFlags = [
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
+    "-DQt6ShaderToolsTools_DIR=${pkgsBuildBuild.qt6.qtshadertools}/lib/cmake/Qt6ShaderToolsTools"
   ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtbase/default.nix
@@ -377,6 +377,8 @@ stdenv.mkDerivation {
     inherit qtPluginPrefix qtQmlPrefix;
   };
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://www.qt.io/";
     description = "Cross-platform application framework for C++";

--- a/pkgs/development/libraries/qt-6/modules/qtcharts.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtcharts.nix
@@ -2,6 +2,7 @@
   qtModule,
   qtbase,
   qtdeclarative,
+  pkgsBuildBuild,
 }:
 
 qtModule {
@@ -9,5 +10,10 @@ qtModule {
   propagatedBuildInputs = [
     qtbase
     qtdeclarative
+  ];
+
+  cmakeFlags = [
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
+    "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
   ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtcharts.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtcharts.nix
@@ -2,6 +2,7 @@
   qtModule,
   qtbase,
   qtdeclarative,
+  qtmultimedia,
   pkgsBuildBuild,
 }:
 
@@ -10,6 +11,7 @@ qtModule {
   propagatedBuildInputs = [
     qtbase
     qtdeclarative
+    qtmultimedia
   ];
 
   cmakeFlags = [

--- a/pkgs/development/libraries/qt-6/modules/qtconnectivity.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtconnectivity.nix
@@ -6,6 +6,7 @@
   qtdeclarative,
   bluez,
   pcsclite,
+  pkgsBuildBuild,
 }:
 
 qtModule {
@@ -17,5 +18,9 @@ qtModule {
   propagatedBuildInputs = [
     qtbase
     qtdeclarative
+  ];
+
+  cmakeFlags = [
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
   ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtconnectivity.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtconnectivity.nix
@@ -6,12 +6,10 @@
   qtdeclarative,
   bluez,
   pcsclite,
-  pkg-config,
 }:
 
 qtModule {
   pname = "qtconnectivity";
-  nativeBuildInputs = [ pkg-config ];
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     pcsclite
     bluez

--- a/pkgs/development/libraries/qt-6/modules/qtdatavis3d.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtdatavis3d.nix
@@ -2,6 +2,7 @@
   qtModule,
   qtbase,
   qtdeclarative,
+  pkgsBuildBuild,
 }:
 
 qtModule {
@@ -9,5 +10,9 @@ qtModule {
   propagatedBuildInputs = [
     qtbase
     qtdeclarative
+  ];
+
+  cmakeFlags = [
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
   ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtdeclarative/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtdeclarative/default.nix
@@ -59,12 +59,13 @@ qtModule {
   ];
 
   cmakeFlags = [
-    "-DQt6ShaderToolsTools_DIR=${pkgsBuildBuild.qt6.qtshadertools}/lib/cmake/Qt6ShaderTools"
+    "-DQt6ShaderToolsTools_DIR=${pkgsBuildBuild.qt6.qtshadertools}/lib/cmake/Qt6ShaderToolsTools"
     # for some reason doesn't get found automatically on Darwin
     "-DPython_EXECUTABLE=${lib.getExe pkgsBuildBuild.python3}"
   ]
   # Conditional is required to prevent infinite recursion during a cross build
   ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
     "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
   ];
 

--- a/pkgs/development/libraries/qt-6/modules/qtdeclarative/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtdeclarative/default.nix
@@ -23,7 +23,6 @@ qtModule {
     qtsvg
     openssl
   ];
-  strictDeps = true;
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     darwin.sigtool

--- a/pkgs/development/libraries/qt-6/modules/qtdoc.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtdoc.nix
@@ -11,7 +11,7 @@ qtModule {
   postPatch = ''
     for file in $(grep -rl '$QT_INSTALL_DOCS'); do
       substituteInPlace $file \
-          --replace '$QT_INSTALL_DOCS' "${qtbase}/share/doc"
+          --replace-fail '$QT_INSTALL_DOCS' "${qtbase}/share/doc"
     done
   '';
   nativeBuildInputs = [ (qttools.override { withClang = true; }) ];

--- a/pkgs/development/libraries/qt-6/modules/qtgraphs.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtgraphs.nix
@@ -4,6 +4,7 @@
   qtdeclarative,
   qtquick3d,
   qtquicktimeline,
+  pkgsBuildBuild,
 }:
 
 qtModule {
@@ -13,5 +14,11 @@ qtModule {
     qtdeclarative
     qtquick3d
     qtquicktimeline
+  ];
+
+  cmakeFlags = [
+    "-DQt6ShaderToolsTools_DIR=${pkgsBuildBuild.qt6.qtshadertools}/lib/cmake/Qt6ShaderToolsTools"
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
+    "-DQt6Quick3DTools_DIR=${pkgsBuildBuild.qt6.qtquick3d}/lib/cmake/Qt6Quick3DTools"
   ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtgrpc.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtgrpc.nix
@@ -1,9 +1,12 @@
 {
   qtModule,
+  lib,
+  stdenv,
   qtbase,
   qtdeclarative,
   protobuf,
   grpc,
+  pkgsBuildBuild,
 }:
 
 qtModule {
@@ -17,4 +20,20 @@ qtModule {
     protobuf
     grpc
   ];
+
+  nativeBuildInputs = [
+    protobuf # for protoc executable
+  ];
+
+  # Conditional is required to prevent infinite recursion during a cross build
+  cmakeFlags =
+    lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+      "-DQt6GrpcTools_DIR=${pkgsBuildBuild.qt6.qtgrpc}/lib/cmake/Qt6GrpcTools"
+      "-DQt6ProtobufTools_DIR=${pkgsBuildBuild.qt6.qtgrpc}/lib/cmake/Qt6ProtobufTools"
+    ]
+    ++ [
+      "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
+      "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
+    ];
+
 }

--- a/pkgs/development/libraries/qt-6/modules/qtlocation.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtlocation.nix
@@ -3,6 +3,7 @@
   qtbase,
   qtdeclarative,
   qtpositioning,
+  pkgsBuildBuild,
 }:
 
 qtModule {
@@ -11,5 +12,11 @@ qtModule {
     qtbase
     qtdeclarative
     qtpositioning
+  ];
+
+  cmakeFlags = [
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
+    "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
+    "-DQt6ShaderToolsTools_DIR=${pkgsBuildBuild.qt6.qtshadertools}/lib/cmake/Qt6ShaderToolsTools"
   ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtlottie.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtlottie.nix
@@ -1,7 +1,10 @@
 {
   qtModule,
+  lib,
+  stdenv,
   qtbase,
   qtdeclarative,
+  pkgsBuildBuild,
 }:
 
 qtModule {
@@ -10,4 +13,14 @@ qtModule {
     qtbase
     qtdeclarative
   ];
+
+  # Conditional is required to prevent infinite recursion during a cross build
+  cmakeFlags =
+    lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+      "-DQt6LottieTools_DIR=${pkgsBuildBuild.qt6.qtlottie}/lib/cmake/Qt6LottieTools"
+    ]
+    ++ [
+      "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
+      "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
+    ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtmqtt.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtmqtt.nix
@@ -2,6 +2,9 @@
   qtModule,
   fetchFromGitHub,
   qtbase,
+  qtdeclarative,
+  qtwebsockets,
+  pkgsBuildBuild,
 }:
 
 qtModule rec {
@@ -15,5 +18,13 @@ qtModule rec {
     hash = "sha256-GWaF4iCPtATL1mJkPHVY0rom8R2FMNWGahE3KWBlfV8=";
   };
 
-  propagatedBuildInputs = [ qtbase ];
+  propagatedBuildInputs = [
+    qtbase
+    qtdeclarative
+    qtwebsockets
+  ];
+
+  cmakeFlags = [
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
+  ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtmultimedia/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtmultimedia/default.nix
@@ -7,7 +7,6 @@
   qtquick3d,
   qtshadertools,
   qtsvg,
-  pkg-config,
   alsa-lib,
   gstreamer,
   gst-plugins-bad,
@@ -28,7 +27,6 @@
 
 qtModule {
   pname = "qtmultimedia";
-  nativeBuildInputs = [ pkg-config ];
   buildInputs = [
     ffmpeg
   ]

--- a/pkgs/development/libraries/qt-6/modules/qtmultimedia/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtmultimedia/default.nix
@@ -64,12 +64,15 @@ qtModule {
   ];
 
   cmakeFlags = [
-    "-DENABLE_DYNAMIC_RESOLVE_VAAPI_SYMBOLS=0"
+    "-DENABLE_DYNAMIC_RESOLVE_VAAPI_SYMBOLS=0" # Manually-specified variables were not used by the project; drop?
     "-DQt6ShaderToolsTools_DIR=${pkgsBuildBuild.qt6.qtshadertools}/lib/cmake/Qt6ShaderToolsTools"
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
+    "-DQt6Quick3DTools_DIR=${pkgsBuildBuild.qt6.qtquick3d}/lib/cmake/Qt6Quick3DTools"
+    "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
   ];
 
-  env = {
-    NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-include AudioToolbox/AudioToolbox.h";
-    NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-framework AudioToolbox";
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    NIX_CFLAGS_COMPILE = "-include AudioToolbox/AudioToolbox.h";
+    NIX_LDFLAGS = "-framework AudioToolbox";
   };
 }

--- a/pkgs/development/libraries/qt-6/modules/qtpositioning.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtpositioning.nix
@@ -3,7 +3,6 @@
   qtbase,
   qtdeclarative,
   qtserialport,
-  pkg-config,
   openssl,
 }:
 
@@ -14,6 +13,5 @@ qtModule {
     qtdeclarative
     qtserialport
   ];
-  nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtpositioning.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtpositioning.nix
@@ -4,6 +4,7 @@
   qtdeclarative,
   qtserialport,
   openssl,
+  pkgsBuildBuild,
 }:
 
 qtModule {
@@ -14,4 +15,10 @@ qtModule {
     qtserialport
   ];
   buildInputs = [ openssl ];
+
+  cmakeFlags = [
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
+    "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
+    "-DQt6ShaderToolsTools_DIR=${pkgsBuildBuild.qt6.qtshadertools}/lib/cmake/Qt6ShaderToolsTools"
+  ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtquick3d.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtquick3d.nix
@@ -1,8 +1,11 @@
 {
   qtModule,
+  stdenv,
+  lib,
   qtbase,
   qtdeclarative,
   openssl,
+  pkgsBuildBuild,
 }:
 
 qtModule {
@@ -12,4 +15,14 @@ qtModule {
     qtdeclarative
   ];
   buildInputs = [ openssl ];
+
+  cmakeFlags = [
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
+    # "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
+    "-DQt6ShaderToolsTools_DIR=${pkgsBuildBuild.qt6.qtshadertools}/lib/cmake/Qt6ShaderToolsTools"
+  ]
+  # Conditional is required to prevent infinite recursion during a cross build
+  ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    "-DQt6Quick3DTools_DIR=${pkgsBuildBuild.qt6.qtquick3d}/lib/cmake/Qt6Quick3DTools"
+  ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtquick3d.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtquick3d.nix
@@ -4,6 +4,7 @@
   lib,
   qtbase,
   qtdeclarative,
+  qtquicktimeline,
   openssl,
   pkgsBuildBuild,
 }:
@@ -13,6 +14,7 @@ qtModule {
   propagatedBuildInputs = [
     qtbase
     qtdeclarative
+    qtquicktimeline
   ];
   buildInputs = [ openssl ];
 

--- a/pkgs/development/libraries/qt-6/modules/qtquick3dphysics.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtquick3dphysics.nix
@@ -1,9 +1,8 @@
 {
   qtModule,
-  lib,
-  stdenv,
   qtbase,
   qtquick3d,
+  pkgsBuildBuild,
 }:
 
 qtModule {
@@ -12,5 +11,12 @@ qtModule {
     qtbase
     qtquick3d
   ];
+
+  cmakeFlags = [
+    "-DQt6ShaderToolsTools_DIR=${pkgsBuildBuild.qt6.qtshadertools}/lib/cmake/Qt6ShaderToolsTools"
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
+    "-DQt6Quick3DTools_DIR=${pkgsBuildBuild.qt6.qtquick3d}/lib/cmake/Qt6Quick3DTools"
+  ];
+
   meta.mainProgram = "cooker";
 }

--- a/pkgs/development/libraries/qt-6/modules/qtquickeffectmaker.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtquickeffectmaker.nix
@@ -2,6 +2,7 @@
   qtModule,
   qtbase,
   qtquick3d,
+  pkgsBuildBuild,
 }:
 
 qtModule {
@@ -10,5 +11,13 @@ qtModule {
     qtbase
     qtquick3d
   ];
+
+  # Still doesn't cross-compile, because it's blocked explicitly:
+  # "Skipping the build as the condition "NOT CMAKE_CROSSCOMPILING" is not met."
+  cmakeFlags = [
+    "-DQt6ShaderToolsTools_DIR=${pkgsBuildBuild.qt6.qtshadertools}/lib/cmake/Qt6ShaderToolsTools"
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
+  ];
+
   meta.mainProgram = "qqem";
 }

--- a/pkgs/development/libraries/qt-6/modules/qtquicktimeline.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtquicktimeline.nix
@@ -2,6 +2,7 @@
   qtModule,
   qtbase,
   qtdeclarative,
+  pkgsBuildBuild,
 }:
 
 qtModule {
@@ -9,5 +10,9 @@ qtModule {
   propagatedBuildInputs = [
     qtbase
     qtdeclarative
+  ];
+
+  cmakeFlags = [
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
   ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtremoteobjects.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtremoteobjects.nix
@@ -3,7 +3,9 @@
   stdenv,
   qtModule,
   qtbase,
+  qtconnectivity,
   qtdeclarative,
+  qtwebsockets,
   pkgsBuildBuild,
 }:
 
@@ -11,7 +13,9 @@ qtModule {
   pname = "qtremoteobjects";
   propagatedBuildInputs = [
     qtbase
+    qtconnectivity
     qtdeclarative
+    qtwebsockets
   ];
 
   # Conditional is required to prevent infinite recursion during a cross build

--- a/pkgs/development/libraries/qt-6/modules/qtremoteobjects.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtremoteobjects.nix
@@ -1,7 +1,10 @@
 {
+  lib,
+  stdenv,
   qtModule,
   qtbase,
   qtdeclarative,
+  pkgsBuildBuild,
 }:
 
 qtModule {
@@ -10,4 +13,13 @@ qtModule {
     qtbase
     qtdeclarative
   ];
+
+  # Conditional is required to prevent infinite recursion during a cross build
+  cmakeFlags =
+    lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+      "-DQt6RemoteObjectsTools_DIR=${pkgsBuildBuild.qt6.qtremoteobjects}/lib/cmake/Qt6RemoteObjectsTools"
+    ]
+    ++ [
+      "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
+    ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtscxml.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtscxml.nix
@@ -1,7 +1,10 @@
 {
   qtModule,
+  lib,
+  stdenv,
   qtbase,
   qtdeclarative,
+  pkgsBuildBuild,
 }:
 
 qtModule {
@@ -10,4 +13,13 @@ qtModule {
     qtbase
     qtdeclarative
   ];
+  # Conditional is required to prevent infinite recursion during a cross build
+  cmakeFlags =
+    lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+      "-DQt6ScxmlTools_DIR=${pkgsBuildBuild.qt6.qtscxml}/lib/cmake/Qt6ScxmlTools"
+    ]
+    ++ [
+      "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
+      "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
+    ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtsensors.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtsensors.nix
@@ -3,6 +3,7 @@
   qtbase,
   qtdeclarative,
   qtsvg,
+  pkgsBuildBuild,
 }:
 
 qtModule {
@@ -12,4 +13,14 @@ qtModule {
     qtdeclarative
     qtsvg
   ];
+
+  buildInputs = [
+    # sensorfw # not available in nixpkgs
+  ];
+
+  cmakeFlags = [
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
+    "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
+  ];
+
 }

--- a/pkgs/development/libraries/qt-6/modules/qtserialport.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtserialport.nix
@@ -4,11 +4,9 @@
   lib,
   qtbase,
   udev,
-  pkg-config,
 }:
 
 qtModule {
   pname = "qtserialport";
-  nativeBuildInputs = [ pkg-config ];
   propagatedBuildInputs = [ qtbase ] ++ lib.optionals stdenv.hostPlatform.isLinux [ udev ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtshadertools.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtshadertools.nix
@@ -9,6 +9,7 @@
 qtModule {
   pname = "qtshadertools";
   propagatedBuildInputs = [ qtbase ];
+  # Conditional is required to prevent infinite recursion during a cross build
   cmakeFlags = lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
     "-DQt6ShaderToolsTools_DIR=${pkgsBuildBuild.qt6.qtshadertools}/lib/cmake/Qt6ShaderToolsTools"
   ];

--- a/pkgs/development/libraries/qt-6/modules/qtspeech.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtspeech.nix
@@ -4,7 +4,6 @@
   stdenv,
   qtbase,
   qtmultimedia,
-  pkg-config,
   flite,
   alsa-lib,
   speechd-minimal,
@@ -12,7 +11,6 @@
 
 qtModule {
   pname = "qtspeech";
-  nativeBuildInputs = [ pkg-config ];
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     flite
     alsa-lib

--- a/pkgs/development/libraries/qt-6/modules/qtspeech.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtspeech.nix
@@ -7,6 +7,7 @@
   flite,
   alsa-lib,
   speechd-minimal,
+  pkgsBuildBuild,
 }:
 
 qtModule {
@@ -19,5 +20,10 @@ qtModule {
   propagatedBuildInputs = [
     qtbase
     qtmultimedia
+  ];
+
+  cmakeFlags = [
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
+    "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
   ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtsvg.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtsvg.nix
@@ -5,7 +5,6 @@
   jasper,
   libmng,
   zlib,
-  pkg-config,
   lib,
   stdenv,
 }:
@@ -23,5 +22,4 @@ qtModule {
     libmng
     zlib
   ];
-  nativeBuildInputs = [ pkg-config ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qttools/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qttools/default.nix
@@ -37,13 +37,26 @@ qtModule {
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ cups ];
 
+  # Conditional is required to prevent infinite recursion during a cross build
+  # If we want to build withClang in cross, we need tools that are only built when clang is enabled for the native build
   cmakeFlags =
+    let
+      qttoolsBuildBuild =
+        if withClang then
+          pkgsBuildBuild.qt6.qttools.override { withClang = true; }
+        else
+          pkgsBuildBuild.qt6.qttools;
+    in
     lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
-      "-DQt6LinguistTools_DIR=${pkgsBuildBuild.qt6.qttools}/lib/cmake/Qt6LinguistTools"
-      "-DQt6ToolsTools_DIR=${pkgsBuildBuild.qt6.qttools}/lib/cmake/Qt6ToolsTools"
+      "-DQt6LinguistTools_DIR=${qttoolsBuildBuild}/lib/cmake/Qt6LinguistTools"
+      "-DQt6ToolsTools_DIR=${qttoolsBuildBuild}/lib/cmake/Qt6ToolsTools"
+    ]
+    ++ lib.optionals (qtdeclarative != null) [
+      "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
+      "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
     ]
     ++ lib.optionals withClang [
-      "-DFEATURE_clang=ON"
+      (lib.cmakeBool "DFEATURE_clang" true)
     ];
 
   postInstall = ''

--- a/pkgs/development/libraries/qt-6/modules/qttranslations.nix
+++ b/pkgs/development/libraries/qt-6/modules/qttranslations.nix
@@ -1,12 +1,24 @@
 {
   qtModule,
+  lib,
+  stdenv,
+  python3,
   qttools,
+  pkgsBuildBuild,
 }:
 
 qtModule {
   pname = "qttranslations";
-  nativeBuildInputs = [ qttools ];
+  nativeBuildInputs = [
+    qttools
+    python3
+  ];
   separateDebugInfo = false;
   outputs = [ "out" ];
   allowedReferences = [ "out" ];
+
+  # Conditional is required to prevent infinite recursion during a cross build
+  cmakeFlags = lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    "-DQt6LinguistTools_DIR=${pkgsBuildBuild.qt6.qttools}/lib/cmake/Qt6LinguistTools"
+  ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtvirtualkeyboard.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtvirtualkeyboard.nix
@@ -2,6 +2,7 @@
   qtModule,
   qtbase,
   qtdeclarative,
+  qtmultimedia,
   qtsvg,
   hunspell,
   pkgsBuildBuild,
@@ -12,6 +13,7 @@ qtModule {
   propagatedBuildInputs = [
     qtbase
     qtdeclarative
+    qtmultimedia
     qtsvg
     hunspell
   ];

--- a/pkgs/development/libraries/qt-6/modules/qtvirtualkeyboard.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtvirtualkeyboard.nix
@@ -4,6 +4,7 @@
   qtdeclarative,
   qtsvg,
   hunspell,
+  pkgsBuildBuild,
 }:
 
 qtModule {
@@ -13,5 +14,9 @@ qtModule {
     qtdeclarative
     qtsvg
     hunspell
+  ];
+
+  cmakeFlags = [
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
   ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtvirtualkeyboard.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtvirtualkeyboard.nix
@@ -4,7 +4,6 @@
   qtdeclarative,
   qtsvg,
   hunspell,
-  pkg-config,
 }:
 
 qtModule {
@@ -15,5 +14,4 @@ qtModule {
     qtsvg
     hunspell
   ];
-  nativeBuildInputs = [ pkg-config ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtwayland.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwayland.nix
@@ -5,7 +5,6 @@
   qtModule,
   qtbase,
   qtdeclarative,
-  pkg-config,
   libdrm,
 }:
 
@@ -17,7 +16,6 @@ qtModule {
     qtdeclarative
   ];
   buildInputs = [ libdrm ];
-  nativeBuildInputs = [ pkg-config ];
 
   cmakeFlags = lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
     "-DQt6WaylandScannerTools_DIR=${pkgsBuildBuild.qt6.qtbase}/lib/cmake/Qt6WaylandScannerTools"

--- a/pkgs/development/libraries/qt-6/modules/qtwayland.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwayland.nix
@@ -17,9 +17,14 @@ qtModule {
   ];
   buildInputs = [ libdrm ];
 
-  cmakeFlags = lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
-    "-DQt6WaylandScannerTools_DIR=${pkgsBuildBuild.qt6.qtbase}/lib/cmake/Qt6WaylandScannerTools"
-  ];
+  # Conditional is required to prevent infinite recursion during a cross build
+  cmakeFlags =
+    lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+      "-DQt6WaylandScannerTools_DIR=${pkgsBuildBuild.qt6.qtbase}/lib/cmake/Qt6WaylandScannerTools"
+    ]
+    ++ [
+      "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
+    ];
 
   meta = {
     platforms = lib.platforms.unix;

--- a/pkgs/development/libraries/qt-6/modules/qtwebchannel.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwebchannel.nix
@@ -4,6 +4,7 @@
   qtdeclarative,
   qtwebsockets,
   openssl,
+  pkgsBuildBuild,
 }:
 
 qtModule {
@@ -14,4 +15,8 @@ qtModule {
     qtwebsockets
   ];
   buildInputs = [ openssl ];
+
+  cmakeFlags = [
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
+  ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtwebengine/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwebengine/default.nix
@@ -70,6 +70,7 @@
   bootstrap_cmds,
   cctools,
   xcbuild,
+  pkgsBuildBuild,
 }:
 
 qtModule {
@@ -80,7 +81,7 @@ qtModule {
     flex
     gperf
     ninja
-    (python3.withPackages (ps: with ps; [ html5lib ]))
+    (pkgsBuildBuild.python3.withPackages (ps: with ps; [ html5lib ]))
     which
     gn
     nodejs
@@ -174,6 +175,9 @@ qtModule {
     # "-DQT_FEATURE_webengine_native_spellchecker=ON"
     "-DQT_FEATURE_webengine_sanitizer=ON"
     "-DQT_FEATURE_webengine_kerberos=ON"
+    # Cross build still fails: Could NOT find Gn
+    "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     "-DQT_FEATURE_webengine_system_libxml=ON"

--- a/pkgs/development/libraries/qt-6/modules/qtwebengine/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwebengine/default.nix
@@ -11,7 +11,6 @@
   flex,
   gperf,
   ninja,
-  pkg-config,
   python3,
   which,
   nodejs,
@@ -81,7 +80,6 @@ qtModule {
     flex
     gperf
     ninja
-    pkg-config
     (python3.withPackages (ps: with ps; [ html5lib ]))
     which
     gn

--- a/pkgs/development/libraries/qt-6/modules/qtwebsockets.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwebsockets.nix
@@ -3,6 +3,7 @@
   qtbase,
   qtdeclarative,
   openssl,
+  pkgsBuildBuild,
 }:
 
 qtModule {
@@ -12,4 +13,8 @@ qtModule {
     qtdeclarative
   ];
   buildInputs = [ openssl ];
+
+  cmakeFlags = [
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
+  ];
 }

--- a/pkgs/development/libraries/qt-6/qtModule.nix
+++ b/pkgs/development/libraries/qt-6/qtModule.nix
@@ -5,6 +5,7 @@
   cmake,
   ninja,
   perl,
+  pkg-config,
   moveBuildTree,
   srcs,
   patches ? [ ],
@@ -31,6 +32,7 @@ stdenv.mkDerivation (
         cmake
         ninja
         perl
+        pkg-config
       ]
       ++ lib.optionals stdenv.hostPlatform.isDarwin [ moveBuildTree ];
     propagatedBuildInputs =

--- a/pkgs/development/libraries/qt-6/qtModule.nix
+++ b/pkgs/development/libraries/qt-6/qtModule.nix
@@ -37,6 +37,8 @@ stdenv.mkDerivation (
       (lib.warnIf (args ? qtInputs) "qt6.qtModule's qtInputs argument is deprecated" args.qtInputs or [ ])
       ++ (args.propagatedBuildInputs or [ ]);
 
+    strictDeps = true;
+
     cmakeFlags = [
       # be more verbose
       "--log-level=STATUS"
@@ -63,6 +65,8 @@ stdenv.mkDerivation (
     separateDebugInfo = args.separateDebugInfo or true;
 
     dontWrapQtApps = args.dontWrapQtApps or true;
+
+    __structuredAttrs = true;
   }
 )
 // {


### PR DESCRIPTION
Some few modules already compiled in cross, by use of `-DQt6...DIR` in `cmakeFlags` to point to various tools needed at build time. This PR extends this to most other modules. It also adds some missing optional dependencies to modules that were reported in the logs.

Exceptions:
* `qtquickeffectmaker`: upstream code explicitly checks for cross builds and forbids it.
* `qtdoc`, `qtwebengine`: haven't been able to fix it, and especially the latter is a hell of a rebuild.
* `qtwebview`: depends on `qtwebengine`

Since we do enable the cross build of many other modules I think this is a reasonable place to end the scope of this PR.

Tested individually via:

```
for m in $(ls -1 pkgs/development/libraries/qt-6/modules/ | sed 's/\.nix$//'); do 
    echo $m
    nix-build -A "qt6Packages.${m}" >/dev/null 2>&1;
    echo $?
done
```

and the `pkgsCross.aarch64-multiplatform` variant of the same loop, with this branch on top of master.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
