### PR TITLE
tildefriends: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10042,6 +10042,12 @@
     githubId = 34658064;
     name = "Grace Dinh";
   };
+  GearKite = {
+    email = "onyx-commute-quit@duck.com";
+    github = "GearKite";
+    githubId = 29222413;
+    name = "GearKite";
+  };
   geekiot-hub = {
     email = "geekiot@proton.me";
     github = "geekiot-hub";

--- a/pkgs/by-name/ti/tildefriends/package.nix
+++ b/pkgs/by-name/ti/tildefriends/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  gnumake,
+  openssl,
+  which,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tildefriends";
+  version = "0.2026.7";
+
+  __structuredAttrs = true;
+
+  src = fetchgit {
+    url = "https://dev.tildefriends.net/cory/tildefriends.git";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-VK1hSnhw1v8kX6zxt4zrknS2MA1Qphtf71CC1IL75EQ=";
+  };
+
+  nativeBuildInputs = [
+    gnumake
+    openssl
+    which
+  ];
+
+  buildPhase = ''
+    make -j $NIX_BUILD_CORES release
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r out/release/* $out/bin
+  '';
+
+  doCheck = false;
+
+  meta = {
+    homepage = "https://tildefriends.net";
+    description = "A Secure Scuttlebutt decentralized social network client.";
+    mainProgram = "tildefriends";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ GearKite ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Add Tilde Friends: _a Secure Scuttlebutt decentralized social network client_.
https://www.tildefriends.net/

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
