### PR TITLE
libreoffice: set JAVA_HOME

### DIFF
--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -811,6 +811,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     inherit srcs;
+    inherit withJava;
     jdk = if withJava then jre' else null;
     python = python3; # for unoconv
     updateScript = [

--- a/pkgs/applications/office/libreoffice/wrapper.nix
+++ b/pkgs/applications/office/libreoffice/wrapper.nix
@@ -118,6 +118,11 @@ let
         fi
       '')
     ]
+    ++ lib.optionals unwrapped.withJava [
+      "--set"
+      "JAVA_HOME"
+      "${unwrapped.jdk.home}"
+    ]
     ++ [
       "--inherit-argv0"
     ]


### PR DESCRIPTION
Closes #344494; fixes issues with various plugins (e.g. [Zotero LibreOffice Integration](https://www.zotero.org/support/libreoffice_writer_plugin_usage)).

Currently, manual installation of plugins dependent on JRE fails without [`programs.java.enable`](https://github.com/NixOS/nixpkgs/blob/ee48b147c18c7de1e6ec97dc74792be42724bed1/nixos/modules/programs/java.nix#L20-L34); this is despite JRE being bundled with the package under `withJava`. Setting `JAVA_HOME` internally seems to facilitate JRE discovery and mitigate the issue.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test