### PR TITLE
nixos/papra: Improve module definition; Harden systemd service

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -193,6 +193,8 @@
 
 - Package `overseerr` has been removed as the `overseerr` and `jellyseerr` projects were merged under `seerr`.
 
+- The papra NixOS module is now hardening the systemd unit by default. If this breaks any of the configured directories, please reconfigure them through `services.papra.environment` to enable sandbox passthrough.
+
 - `slskd` has been updated to v0.25.0, which renames the `global` option to `transfers`. Please review the [changelog](https://github.com/slskd/slskd/releases#release-0.25.0).
 
 - [firefox-syncserver.database.type](#opt-services.firefox-syncserver.database.type) no longer defaults to `"mysql"`. You must now explicitly choose between `"mysql"` and `"postgresql"`. New deployments should prefer PostgreSQL.

--- a/nixos/modules/services/web-apps/papra.nix
+++ b/nixos/modules/services/web-apps/papra.nix
@@ -8,14 +8,22 @@ let
   cfg = config.services.papra;
   defaultUser = "papra";
   defaultGroup = "papra";
-  defaultEnv = {
-    SERVER_SERVE_PUBLIC_DIR = true;
-    PORT = 1221;
-    DATABASE_URL = "file:/var/lib/papra/db.sqlite";
-    DOCUMENT_STORAGE_FILESYSTEM_ROOT = "/var/lib/papra/local-documents";
-  };
 in
 {
+  imports = [
+    (lib.mkChangedOptionModule
+      [ "services" "papra" "environmentFile" ]
+      [ "services" "papra" "environmentFiles" ]
+      (
+        config:
+        let
+          value = lib.getAttrFromPath [ "services" "papra" "environmentFile" ] config;
+        in
+        if value == null then [ ] else [ value ]
+      )
+    )
+  ];
+
   options = {
     services.papra = {
       enable = lib.mkEnableOption "Papra";
@@ -37,31 +45,103 @@ in
 
       package = lib.mkPackageOption pkgs "papra" { };
 
-      environment = lib.mkOption {
-        type =
-          with lib.types;
-          attrsOf (oneOf [
-            str
-            int
-            float
-            bool
-            path
-            package
-          ]);
-        default = defaultEnv;
-        example = {
-          PORT = 1221;
-        };
-        description = "Environment variables to set for the service.";
+      openFirewall = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Whether to open the firewall for Papra.
+        '';
       };
 
-      environmentFile = lib.mkOption {
-        type = with lib.types; nullOr path;
-        default = null;
-        description = "Environment file, usefult to provide secrets to the service";
+      environment = lib.mkOption {
+        type = lib.types.submodule {
+          freeformType =
+            with lib.types;
+            attrsOf (oneOf [
+              str
+              int
+              float
+              bool
+              path
+              package
+            ]);
+
+          options = {
+            PORT = lib.mkOption {
+              type = lib.types.port;
+              default = 1221;
+              description = ''
+                The port on which Papra listens.
+                See <https://docs.papra.app/self-hosting/configuration/#port> for more information.
+              '';
+            };
+
+            DATABASE_URL = lib.mkOption {
+              type = lib.types.str;
+              default = "file:/var/lib/papra/db.sqlite";
+              description = ''
+                The URL of the database.
+                See <https://docs.papra.app/self-hosting/configuration/#database_url> for more information.
+
+                ::: {.note}
+                When specifying a `file:` URL with an absolute path through this option,
+                the database's parent directory is automatically added to the systemd
+                service's `ReadWritePaths`. Other local database paths, including paths
+                specified through `environmentFiles`, may need to be added to `ReadWritePaths` manually.
+                :::
+              '';
+            };
+
+            INGESTION_FOLDER_ROOT_PATH = lib.mkOption {
+              type = lib.types.path;
+              default = "/var/lib/papra/ingestion";
+              description = ''
+                The root directory in which ingestion folders for each organization are stored.
+                The parent directory must already exist if using a custom path.
+                See <https://docs.papra.app/self-hosting/configuration/#ingestion_folder_root_path> for more information.
+              '';
+            };
+
+            DOCUMENT_STORAGE_FILESYSTEM_ROOT = lib.mkOption {
+              type = lib.types.path;
+              default = "/var/lib/papra/local-documents";
+              description = ''
+                The root directory to store documents in.
+                The parent directory must already exist if using a custom path.
+                See <https://docs.papra.app/self-hosting/configuration/#document_storage_filesystem_root> for more information.
+              '';
+            };
+
+            SERVER_SERVE_PUBLIC_DIR = lib.mkOption {
+              type = lib.types.bool;
+              default = true;
+              description = ''
+                Whether to serve the public directory.
+                See <https://docs.papra.app/self-hosting/configuration/#server_serve_public_dir> for more information.
+              '';
+            };
+          };
+        };
+        default = { };
+        description = ''
+          Environment variables to pass to Papra.
+          See <https://docs.papra.app/self-hosting/configuration/#configuration-variables> for more information.
+        '';
+      };
+
+      environmentFiles = lib.mkOption {
+        type = with lib.types; listOf path;
+        default = [ ];
+        example = [ "/run/secrets/papra.env" ];
+        description = ''
+          Files to load environment variables from in addition to [](#opt-services.papra.environment).
+          This is useful to avoid putting secrets into the nix store.
+          See <https://docs.papra.app/self-hosting/configuration/#configuration-variables> for more information.
+        '';
       };
     };
   };
+
   config = lib.mkIf cfg.enable {
     users = {
       users = lib.optionalAttrs (cfg.user == defaultUser) {
@@ -76,6 +156,18 @@ in
       };
     };
 
+    systemd.tmpfiles.settings."10-papra" = {
+      "${cfg.environment.DOCUMENT_STORAGE_FILESYSTEM_ROOT}".d = {
+        mode = "0700";
+        inherit (cfg) user group;
+      };
+
+      "${cfg.environment.INGESTION_FOLDER_ROOT_PATH}".d = {
+        mode = "0770";
+        inherit (cfg) user group;
+      };
+    };
+
     systemd.services.papra = {
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
@@ -85,15 +177,58 @@ in
         User = cfg.user;
         Group = cfg.group;
         StateDirectory = "papra";
-        EnvironmentFile = cfg.environmentFile;
+        StateDirectoryMode = "0700";
+        EnvironmentFile = cfg.environmentFiles;
+        ReadWritePaths = lib.unique (
+          [
+            cfg.environment.DOCUMENT_STORAGE_FILESYSTEM_ROOT
+            cfg.environment.INGESTION_FOLDER_ROOT_PATH
+          ]
+          ++ lib.optional (lib.hasPrefix "file:/" cfg.environment.DATABASE_URL) (
+            dirOf (lib.removePrefix "file:" cfg.environment.DATABASE_URL)
+          )
+        );
+
+        # Hardening
+        CapabilityBoundingSet = "";
+        NoNewPrivileges = true;
+        LockPersonality = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_UNIX"
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+          "~@resources"
+        ];
+        UMask = "0007";
       };
-      environment =
-        let
-          environmentwithDefaults = defaultEnv // cfg.environment;
-        in
-        (lib.mapAttrs (
-          _: s: if lib.isBool s then lib.boolToString s else toString s
-        ) environmentwithDefaults);
+      environment = lib.mapAttrs (
+        _: s: if lib.isBool s then lib.boolToString s else toString s
+      ) cfg.environment;
+    };
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.environment.PORT ];
     };
   };
 


### PR DESCRIPTION

- Replaced `environmentFile` with `environmentFiles`, since systemd allows for multiple definitions of `EnvironmentFile` keys. In my case, I have two files I need to pass, which is impossible to do right now. 
- Added `openFirewall` option
- Updated description of `environment` to be a freeform module with some default values and include links to the upstream documentation
- Added systemd hardening. This should block the service from accessing any critical system resources while still allowing it to work normally without extra configuration. **PLEASE TEST WITH YOUR SETUP**. 


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
