### PR TITLE
libphidget22: 1.23.20250925 -> 1.25.20260512; libphidget22extra: 1.2320250925 -> 1.25.20260512

### DIFF
--- a/pkgs/by-name/li/libphidget22/package.nix
+++ b/pkgs/by-name/li/libphidget22/package.nix
@@ -7,7 +7,7 @@
 }:
 let
   # This package should be updated together with libphidget22extra
-  version = "1.23.20250925";
+  version = "1.25.20260512";
 in
 stdenv.mkDerivation {
   pname = "libphidget22";
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.phidgets.com/downloads/phidget22/libraries/linux/libphidget22/libphidget22-${version}.tar.gz";
-    hash = "sha256-/2OgjiuoK3+gJ95tSk809OfMABUtKPN9bb4pVH447Ik=";
+    hash = "sha256-wrLPP32gOjXsewdLUCe7lUUqfib3egrOONey9mcUfV8=";
   };
 
   nativeBuildInputs = [ automake ];

--- a/pkgs/by-name/li/libphidget22extra/package.nix
+++ b/pkgs/by-name/li/libphidget22extra/package.nix
@@ -9,7 +9,7 @@
 let
 
   # This package should be updated together with libphidget22
-  version = "1.23.20250925";
+  version = "1.25.20260512";
 in
 stdenv.mkDerivation {
   pname = "libphidget22extra";
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.phidgets.com/downloads/phidget22/libraries/linux/libphidget22extra/libphidget22extra-${version}.tar.gz";
-    hash = "sha256-eU/4tO9oa+/Cyy2Ro3zm2m3sAN4s3mCcRblicqSapxs=";
+    hash = "sha256-yN4g32Zx73A35yGAA5xnfEu72Nh8yH3KFmFKP5T3Pao=";
   };
 
   nativeBuildInputs = [ automake ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
