### PR TITLE
ayugram-desktop: 6.7.8 -> 7.0.9

### DIFF
--- a/pkgs/by-name/ay/ayugram-desktop/package.nix
+++ b/pkgs/by-name/ay/ayugram-desktop/package.nix
@@ -1,9 +1,7 @@
 {
   lib,
   fetchFromGitHub,
-  fetchpatch2,
   nix-update-script,
-  stdenvNoCC,
   telegram-desktop,
   withWebkit ? true,
 }:
@@ -14,22 +12,18 @@ telegram-desktop.override {
   unwrapped = telegram-desktop.unwrapped.overrideAttrs (
     finalAttrs: previousAttrs: {
       pname = "ayugram-desktop-unwrapped";
-      version = "6.7.8";
+      version = "7.0.9";
 
       src = fetchFromGitHub {
         owner = "AyuGram";
         repo = "AyuGramDesktop";
-        tag = "v${finalAttrs.version}";
-        hash = "sha256-X0g/zl5pJE8S5rkk7o81LiDNClLEMDyHVxmdoO4X9DE=";
+        # tag = "v${finalAttrs.version}";
+        # v7.0.9 tag contains a codegen bug due to an outdated submodule
+        # https://github.com/AyuGram/codegen/pull/3
+        rev = "db3b9891cb0b04ebb7d8c0e71ada3bcc669b910a";
+        hash = "sha256-JSx6qPpVul3NX8stNZzZX/ckNBQ3uXZP7lofb6eWauM=";
         fetchSubmodules = true;
       };
-
-      patches =
-        (previousAttrs.patches or [ ])
-        ++ (lib.optional stdenvNoCC.hostPlatform.isDarwin (fetchpatch2 {
-          url = "https://github.com/telegramdesktop/tdesktop/commit/923efd9e7ef8ff72d9b83973502e587682119e54.patch?full_index=1";
-          hash = "sha256-XcmH9SSI3K2SsFjHDEMnKA6YOyWF1kRVJJAWP2/vdf8=";
-        }));
 
       passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
Diff: https://github.com/AyuGram/AyuGramDesktop/compare/v6.7.8...v7.0.9

Changelog: https://github.com/AyuGram/AyuGramDesktop/releases/tag/v7.0.9


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
