### PR TITLE
nixos/udisks2: systemd hardening

### DIFF
--- a/nixos/modules/services/hardware/udisks2.nix
+++ b/nixos/modules/services/hardware/udisks2.nix
@@ -98,10 +98,7 @@ in
 
     services.dbus.packages = [ cfg.package ];
 
-    systemd.tmpfiles.rules = [
-      "d /var/lib/udisks2 0755 root root -"
-    ]
-    ++ lib.optional cfg.mountOnMedia "D! /media 0755 root root -";
+    systemd.tmpfiles.rules = lib.optional cfg.mountOnMedia "D! /media 0755 root root -";
 
     services.udev.packages = [ cfg.package ];
 
@@ -110,6 +107,49 @@ in
     '';
 
     systemd.packages = [ cfg.package ];
+
+    systemd.services.udisks2 = {
+      after = lib.optionals cfg.mountOnMedia [ "systemd-tmpfiles-setup.service" ];
+      requires = lib.optionals cfg.mountOnMedia [ "systemd-tmpfiles-setup.service" ];
+
+      serviceConfig = {
+        User = "root";
+        Group = "root";
+
+        StateDirectory = "udisks2";
+        StateDirectoryMode = "0700";
+        RuntimeDirectory = "udisks2";
+        RuntimeDirectoryMode = "0755";
+
+        # A lot of the omitted Private*/Protect* settings would imply
+        # this to be true, which would have the daemon only mount disks
+        # inside its own sandbox and so breaking the main functionality.
+        PrivateMounts = false;
+
+        CapabilityBoundingSet = [
+          "CAP_SYS_ADMIN" # Needed for mount(2) and umount(2)
+        ];
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged @resources"
+          "@chown @mount"
+        ];
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        ProtectClock = true;
+        ProtectHostname = true;
+        RestrictAddressFamilies = [
+          "AF_UNIX"
+          "AF_NETLINK" # Needed to talk to udev
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        UMask = "022";
+      };
+    };
   };
 
 }

--- a/nixos/tests/udisks2.nix
+++ b/nixos/tests/udisks2.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 
 let
 
@@ -12,9 +12,7 @@ in
 
 {
   name = "udisks2";
-  meta = {
-    maintainers = [ ];
-  };
+  meta.maintainers = [ lib.maintainers.h7x4 ];
 
   nodes = {
     machine = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add a variety of hardening options, and extend the nixos test to cover more functionality.

Ref https://github.com/NixOS/nixpkgs/issues/377827

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
