### PR TITLE
python3Packages.wfuzz: fix build, other improvements

### DIFF
--- a/pkgs/development/python-modules/wfuzz/Drop-pkg_resources-from-filter-help-loader.patch
+++ b/pkgs/development/python-modules/wfuzz/Drop-pkg_resources-from-filter-help-loader.patch
@@ -1,0 +1,84 @@
+From 5e3d2b6377a920f6af40981651a1f829f138c2d7 Mon Sep 17 00:00:00 2001
+From: Miro <200482516+Mirochill@users.noreply.github.com>
+Date: Fri, 22 May 2026 23:03:09 +0200
+Subject: [PATCH] Drop pkg_resources from filter help loader
+
+---
+ src/wfuzz/helpers/file_func.py  | 18 +++++++++++-------
+ tests/helpers/test_file_func.py | 29 +++++++++++++++++++++++++++++
+ 2 files changed, 40 insertions(+), 7 deletions(-)
+ create mode 100644 tests/helpers/test_file_func.py
+
+diff --git a/src/wfuzz/helpers/file_func.py b/src/wfuzz/helpers/file_func.py
+index e5459faf82b940fa474d758f63b94d3768f958a2..ae8081bfac785339f4f59bffc3942ecf0ddc1949 100644
+--- a/src/wfuzz/helpers/file_func.py
++++ b/src/wfuzz/helpers/file_func.py
+@@ -1,7 +1,7 @@
+ import os
+ import sys
+ import re
+-import pkg_resources
++import pkgutil
+ 
+ from chardet.universaldetector import UniversalDetector
+ import chardet
+@@ -13,14 +13,18 @@ def get_filter_help_file():
+     FILTER_HELP_FILE = "advanced.rst"
+     FILTER_HELP_DEV_FILE = "../../../docs/user/advanced.rst"
+ 
+-    filter_help_text = None
+     try:
+-        fname = pkg_resources.resource_filename("wfuzz", FILTER_HELP_FILE)
+-        filter_help_text = open(fname).read()
+-    except IOError:
+-        filter_help_text = open(get_path(FILTER_HELP_DEV_FILE)).read()
++        filter_help_text = pkgutil.get_data("wfuzz", FILTER_HELP_FILE)
++    except (IOError, OSError):
++        filter_help_text = None
+ 
+-    return filter_help_text
++    if filter_help_text is not None:
++        if not isinstance(filter_help_text, str):
++            filter_help_text = filter_help_text.decode("utf-8")
++        return filter_help_text
++
++    with open(get_path(FILTER_HELP_DEV_FILE)) as filter_help:
++        return filter_help.read()
+ 
+ 
+ def create_dir(dir_path):
+diff --git a/tests/helpers/test_file_func.py b/tests/helpers/test_file_func.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..66c58b3dcc992d6a4afb3b1860b1cd3f944a7bf4
+--- /dev/null
++++ b/tests/helpers/test_file_func.py
+@@ -0,0 +1,29 @@
++try:
++    from unittest import mock
++except ImportError:
++    import mock
++
++from wfuzz.helpers import file_func
++
++
++def test_get_filter_help_file_uses_package_data():
++    with mock.patch(
++        "wfuzz.helpers.file_func.pkgutil.get_data",
++        return_value=b"Package help",
++    ):
++        assert file_func.get_filter_help_file() == "Package help"
++
++
++def test_get_filter_help_file_falls_back_to_development_file(tmpdir):
++    help_file = tmpdir.join("advanced.rst")
++    help_file.write("Development help")
++
++    with mock.patch(
++        "wfuzz.helpers.file_func.pkgutil.get_data",
++        return_value=None,
++    ):
++        with mock.patch(
++            "wfuzz.helpers.file_func.get_path",
++            return_value=str(help_file),
++        ):
++            assert file_func.get_filter_help_file() == "Development help"

--- a/pkgs/development/python-modules/wfuzz/Update-loader.py.patch
+++ b/pkgs/development/python-modules/wfuzz/Update-loader.py.patch
@@ -1,0 +1,67 @@
+From 4f5148dc85d06ca934d571d1401f6e69b8ad07de Mon Sep 17 00:00:00 2001
+From: R0ttCyph3r <146866845+R0ttCyph3r@users.noreply.github.com>
+Date: Mon, 3 Jun 2024 16:48:25 +0530
+Subject: [PATCH] Update loader.py
+
+As of python 3.12 imp module is depreciated and removed so wfuzz gives error for that
+
+### Summary of Changes:
+- Replaced `imp.find_module` and `imp.load_module` with `importlib.util.spec_from_file_location` and `importlib.util.module_from_spec`.
+- Updated the `_load_py_from_file` method to use `importlib` for loading the modules.
+---
+ src/wfuzz/externals/moduleman/loader.py | 26 +++++++++----------------
+ 1 file changed, 9 insertions(+), 17 deletions(-)
+
+diff --git a/src/wfuzz/externals/moduleman/loader.py b/src/wfuzz/externals/moduleman/loader.py
+index 4e7d81c8ebc683f97ba1f9c953cf1e69eb5bbac7..26e7f581895e531cbb754e61e31753a72ca2e7e2 100644
+--- a/src/wfuzz/externals/moduleman/loader.py
++++ b/src/wfuzz/externals/moduleman/loader.py
+@@ -1,6 +1,6 @@
+ import inspect
+ import logging
+-import imp
++import importlib.util
+ import os.path
+ 
+ 
+@@ -52,32 +52,24 @@ class FileLoader(IModuleLoader):
+         """
+         self.__logger.debug("__load_py_from_file. START, file=%s" % (filename,))
+ 
+-        dirname, filename = os.path.split(filename)
+-        fn = os.path.splitext(filename)[0]
+-        exten_file = None
+-        module = None
++        module_name = os.path.splitext(os.path.basename(filename))[0]
+ 
+         try:
+-            exten_file, filename, description = imp.find_module(fn, [dirname])
+-            module = imp.load_module(fn, exten_file, filename, description)
++            spec = importlib.util.spec_from_file_location(module_name, filename)
++            if spec and spec.loader:
++                module = importlib.util.module_from_spec(spec)
++                spec.loader.exec_module(module)
++            else:
++                raise ImportError(f"Could not load spec for {filename}")
+         except ImportError as msg:
+             self.__logger.critical(
+                 "__load_py_from_file. Filename: %s Exception, msg=%s" % (filename, msg)
+             )
+-            # raise msg
+-            pass
++            return
+         except SyntaxError as msg:
+-            # incorrect python syntax in file
+             self.__logger.critical(
+                 "__load_py_from_file. Filename: %s Exception, msg=%s" % (filename, msg)
+             )
+-            # raise msg
+-            pass
+-        finally:
+-            if exten_file:
+-                exten_file.close()
+-
+-        if module is None:
+             return
+ 
+         for objname in dir(module):

--- a/pkgs/development/python-modules/wfuzz/default.nix
+++ b/pkgs/development/python-modules/wfuzz/default.nix
@@ -38,7 +38,16 @@ buildPythonPackage (finalAttrs: {
     # replace removed `pipes` stdlib module with `shlex` for Python >= 3.13
     # https://github.com/xmendez/wfuzz/issues/380
     ./python-313-shlex.patch
+    # https://github.com/xmendez/wfuzz/pull/382
+    ./Drop-pkg_resources-from-filter-help-loader.patch
   ];
+
+  postPatch = ''
+    substituteInPlace src/wfuzz/__init__.py \
+      --replace-fail \
+        '__version__ = "3.1.0"' \
+        '__version__ = "${finalAttrs.version}"'
+  '';
 
   build-system = [ setuptools ];
 
@@ -49,7 +58,6 @@ buildPythonPackage (finalAttrs: {
     netaddr # src/wfuzz/plugins/payloads/{iprange,ipnet}.py
     pycurl
     pyparsing
-    setuptools
     six
   ]
   ++ lib.optionals stdenv.hostPlatform.isWindows [ colorama ];

--- a/pkgs/development/python-modules/wfuzz/default.nix
+++ b/pkgs/development/python-modules/wfuzz/default.nix
@@ -13,6 +13,7 @@
   setuptools,
   six,
   legacy-cgi,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -61,11 +62,8 @@ buildPythonPackage (finalAttrs: {
   nativeCheckInputs = [
     netaddr
     pytestCheckHook
+    writableTmpDirAsHomeHook
   ];
-
-  preCheck = ''
-    export HOME=$(mktemp -d)
-  '';
 
   disabledTestPaths = [
     # The tests are requiring a local web server

--- a/pkgs/development/python-modules/wfuzz/default.nix
+++ b/pkgs/development/python-modules/wfuzz/default.nix
@@ -12,7 +12,6 @@
   pytestCheckHook,
   setuptools,
   six,
-  fetchpatch2,
   legacy-cgi,
 }:
 
@@ -31,10 +30,7 @@ buildPythonPackage (finalAttrs: {
   patches = [
     # replace use of imp module for Python >= 3.12
     # https://github.com/xmendez/wfuzz/pull/365
-    (fetchpatch2 {
-      url = "https://github.com/xmendez/wfuzz/commit/f4c028b9ada4c36dabf3bc752f69f6ddc110920f.patch?full_index=1";
-      hash = "sha256-t7pUMcdFmwAsGUNBRdZr+Jje/yR0yzeGIgeYNEq4hFE=";
-    })
+    ./Update-loader.py.patch
     # replace removed `pipes` stdlib module with `shlex` for Python >= 3.13
     # https://github.com/xmendez/wfuzz/issues/380
     ./python-313-shlex.patch


### PR DESCRIPTION
## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 550786`
Commit: `2eb3a7c9b6d81f60af696649ae33420d2e45e152`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 5 packages built:</summary>
  <ul>
    <li>python313Packages.wfuzz</li>
    <li>python314Packages.wfuzz</li>
    <li>tests.config-nix-unit</li>
    <li>wfuzz</li>
    <li>wordlists</li>
  </ul>
</details>


---
### `aarch64-linux`
<details>
  <summary>:white_check_mark: 5 packages built:</summary>
  <ul>
    <li>python313Packages.wfuzz</li>
    <li>python314Packages.wfuzz</li>
    <li>tests.config-nix-unit</li>
    <li>wfuzz</li>
    <li>wordlists</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test