### PR TITLE
conjure-tor: 0-unstable-2024-11-11 -> 0-unstable-2026-01-13

### DIFF
--- a/pkgs/by-name/co/conjure-tor/package.nix
+++ b/pkgs/by-name/co/conjure-tor/package.nix
@@ -6,17 +6,17 @@
 }:
 buildGoModule {
   pname = "conjure-tor";
-  version = "0-unstable-2024-11-11";
+  version = "0-unstable-2026-01-13";
 
   src = fetchFromGitLab {
     domain = "gitlab.torproject.org";
     owner = "tpo";
     repo = "anti-censorship/pluggable-transports/conjure";
-    rev = "a773daab19928f37caf2ec4181f0da2e0d20d35a";
-    hash = "sha256-WC9QEgwhu7ynf2p8SXzMf8JNp6ZzF4S9Lk2SjUWj2lU=";
+    rev = "0090962226b82aa4a8fc38506f9b98de67d0781e";
+    hash = "sha256-WGyzoc03QqPtLiZrUMCRMlPNm6JVSOnZv2a8KeZt7P4=";
   };
 
-  vendorHash = "sha256-vdcpNYa2gjacK0DMQ6VP9kX6f10JOHn8+Wr1Ql+lI7o=";
+  vendorHash = "sha256-6m/qNRrbWMREdDK/VpDAILynplyzbicdplxDrcTipSc=";
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
