### PR TITLE
mdbook-rss-feed: init at 1.7.0

### DIFF
--- a/pkgs/by-name/md/mdbook-rss-feed/package.nix
+++ b/pkgs/by-name/md/mdbook-rss-feed/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "mdbook-rss-feed";
+  version = "1.7.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "saylesss88";
+    repo = "mdbook-rss-feed";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-uIEl9lHHsTMV+ft9Zn42zzL1A8HRV17zuf/FBh973/E=";
+  };
+
+  cargoHash = "sha256-/tm0rciW4Nif3nfAokZ1P2eDkC1hXY6owccyev+kVZ0=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "mdBook preprocessor that generates a full-content RSS 2.0 feed";
+    homepage = "https://github.com/saylesss88/mdbook-rss-feed";
+    changelog = "https://github.com/saylesss88/mdbook-rss-feed/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      matthiasbeyer
+      pinage404
+    ];
+    mainProgram = "mdbook-rss-feed";
+  };
+})


### PR DESCRIPTION
Package https://github.com/saylesss88/mdbook-rss-feed a plugin for mdBook to generate RSS feed

There are few others mdBook RSS generators

Why this project ?

* https://gitlab.com/albalitz/mdbook-rss

  but [seems unmaintained](https://gitlab.com/albalitz/mdbook-rss/-/work_items/2)

* https://github.com/theowenyoung/mdbook-rss

  a fork of the previous

  without activities since years

  not compatible with mdBook 0.5.0+

This one is newer and have more recent activities, the maintainer is reactive


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy]. no AI used

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


@matthiasbeyer i added you as co-maintainer because you do it for almost all `mdbook` packages, let me know if you want to be removed =)