### PR TITLE
python3Packages.pygame-ce: 2.5.7 -> 2.5.8

### DIFF
--- a/pkgs/development/python-modules/pygame-ce/default.nix
+++ b/pkgs/development/python-modules/pygame-ce/default.nix
@@ -42,7 +42,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pygame-ce";
-  version = "2.5.7";
+  version = "2.5.8";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -50,7 +50,7 @@ buildPythonPackage (finalAttrs: {
     owner = "pygame-community";
     repo = "pygame-ce";
     tag = finalAttrs.version;
-    hash = "sha256-Yjs2SLgPVMOy8DCS+Pfk0fs0G//sY20jfGQNJ5rN58Q=";
+    hash = "sha256-1aUrnTllhaMjsCd/vVQ6aPDgcUdjBTPTeLzfrI6YLCI=";
     # Unicode files cause different checksums on HFS+ vs. other filesystems
     postFetch = "rm -rf $out/docs/reST";
   };
@@ -78,10 +78,10 @@ buildPythonPackage (finalAttrs: {
     # cython was pinned to fix windows build hangs (pygame-community/pygame-ce/pull/3015)
     ''
       substituteInPlace pyproject.toml \
-        --replace-fail "meson-python<=0.18.0" "meson-python" \
-        --replace-fail "meson<=1.10.0" "meson" \
+        --replace-fail "meson-python<=0.20.0" "meson-python" \
+        --replace-fail "meson<=1.11.2" "meson" \
         --replace-fail "ninja<=1.13.0" "ninja" \
-        --replace-fail "cython<=3.2.4" "cython" \
+        --replace-fail "cython<=3.2.9" "cython" \
         --replace-fail "sphinx<=8.2.3" "sphinx" \
         --replace-fail "astroid<4.0.0" "astroid" \
         --replace-fail "sphinx-autoapi<=3.6.0" "sphinx-autoapi" \


### PR DESCRIPTION
Changelog: https://github.com/pygame-community/pygame-ce/releases/tag/2.5.8


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
