### PR TITLE
spice-gtk: 0.42 -> 0.43; split into spice-glib and spice-gtk

### DIFF
--- a/pkgs/by-name/fi/field-monitor/package.nix
+++ b/pkgs/by-name/fi/field-monitor/package.nix
@@ -23,7 +23,7 @@
   libxml2,
   nix-update-script,
   spice-protocol,
-  spice-gtk,
+  spice-glib,
   vte-gtk4,
   gcr_4,
   gtk-vnc,
@@ -78,7 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
     libGL
     libvirt
     openssl
-    spice-gtk
+    spice-glib
     spice-protocol
     usbredir
     vte-gtk4

--- a/pkgs/by-name/sp/spice-glib/package.nix
+++ b/pkgs/by-name/sp/spice-glib/package.nix
@@ -15,7 +15,6 @@
   json-glib,
   libcacard,
   libcap_ng,
-  libdrm,
   libjpeg_turbo,
   libopus,
   libsoup_3,
@@ -38,9 +37,11 @@
   wayland-scanner,
   zlib,
   wrapGAppsHook3,
+  wrapGAppsNoGuiHook,
   withIntrospection ?
     lib.meta.availableOn stdenv.hostPlatform gobject-introspection
     && stdenv.hostPlatform.emulatorAvailable buildPackages,
+  withGtk ? false,
   withPolkit ? stdenv.hostPlatform.isLinux,
 }:
 
@@ -50,7 +51,7 @@
 # then adds a device acl entry for that user.
 # Example NixOS config to create a setuid wrapper for the helper:
 # security.wrappers.spice-client-glib-usb-acl-helper.source =
-#   "${pkgs.spice-gtk}/bin/spice-client-glib-usb-acl-helper";
+#   "${pkgs.spice-glib}/bin/spice-client-glib-usb-acl-helper";
 # On non-NixOS installations, make a setuid copy of the helper
 # outside the store and adjust PATH to find the setuid version.
 
@@ -66,7 +67,10 @@
 #  '';
 
 stdenv.mkDerivation (finalAttrs: {
-  pname = "spice-gtk";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  pname = if withGtk then "spice-gtk" else "spice-glib";
   version = "0.43";
 
   outputs = [
@@ -100,26 +104,33 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     python3
     python3.pkgs.pyparsing
-    wrapGAppsHook3
   ]
   ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
     mesonEmulatorHook
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
-    wayland-scanner
   ]
   ++ lib.optionals withIntrospection [
     gi-docgen
     gobject-introspection
     vala
-  ];
+  ]
+  ++ (
+    if withGtk then
+      [
+        wrapGAppsHook3
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isLinux [
+        wayland-scanner
+      ]
+    else
+      [
+        wrapGAppsNoGuiHook
+      ]
+  );
 
   buildInputs = [
     gst_all_1.gst-plugins-base
     gst_all_1.gst-plugins-good
     cyrus_sasl
-    libepoxy
-    gtk3
     json-glib
     libcacard
     libjpeg_turbo
@@ -140,7 +151,12 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     libcap_ng
-    libdrm
+    libepoxy
+  ]
+  ++ lib.optionals withGtk [
+    gtk3
+  ]
+  ++ lib.optionals (withGtk && stdenv.hostPlatform.isLinux) [
     wayland-protocols
   ];
 
@@ -151,13 +167,10 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dusb-ids-path=${hwdata}/share/hwdata/usb.ids"
     (lib.mesonEnable "introspection" withIntrospection)
     (lib.mesonEnable "vapi" withIntrospection)
-  ]
-  ++ lib.optionals (!withPolkit) [
-    "-Dpolkit=disabled"
-  ]
-  ++ lib.optionals (!stdenv.hostPlatform.isLinux) [
-    "-Dlibcap-ng=disabled"
-    "-Degl=disabled"
+    (lib.mesonEnable "polkit" withPolkit)
+    (lib.mesonEnable "libcap-ng" stdenv.hostPlatform.isLinux)
+    (lib.mesonEnable "egl" stdenv.hostPlatform.isLinux)
+    (lib.mesonEnable "gtk" withGtk)
   ]
   ++ lib.optionals stdenv.hostPlatform.isMusl [
     "-Dcoroutine=gthread" # Fixes "Function missing:makecontext"
@@ -182,14 +195,24 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "GTK 3 SPICE widget";
-    longDescription = ''
-      spice-gtk is a GTK 3 SPICE widget. It features glib-based
-      objects for SPICE protocol parsing and a gtk widget for embedding
-      the SPICE display into other applications such as virt-manager.
-      Python bindings are available too.
-    '';
-
+    description = "SPICE Glib client library" + lib.optionalString withGtk " with GTK+3 widget";
+    longDescription =
+      if withGtk then
+        ''
+          spice-glib provides support for Glib apps to interact with the SPICE
+          protocol and spice-gtk itself provides a GTK 3 SPICE widget.
+          The package features glib-based objects for SPICE protocol parsing and a GTK widget
+          for embedding the SPICE display into other applications such as virt-manager.
+          Python bindings are available too.
+          This package is also available without the GTK+3 widget, use 'spice-glib' for this.
+        ''
+      else
+        ''
+          spice-glib provides support for Glib apps to interact with the SPICE
+          protocol. It features glib-based objects for SPICE protocol parsing.
+          Python bindings are available too.
+          This package is also available with a GTK+3 widget, use 'spice-gtk' for this.
+        '';
     homepage = "https://www.spice-space.org/";
     license = lib.licenses.lgpl21;
     maintainers = [

--- a/pkgs/by-name/sp/spice-glib/package.nix
+++ b/pkgs/by-name/sp/spice-glib/package.nix
@@ -188,10 +188,10 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs subprojects/keycodemapdb/tools/keymap-gen
   ''
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    # don't use version script and don't export symbols
-    substituteInPlace src/meson.build \
-      --replace-fail "spice_gtk_version_script = [" "# spice_gtk_version_script = [" \
-      --replace-fail ",--version-script=@0@'.format(spice_client_glib_syms_path)" "'"
+    # drm/drm_fourcc.h is a Linux kernel uAPI header; only one constant is used
+    substituteInPlace src/channel-display.c --replace-fail \
+      '#include <drm/drm_fourcc.h>' \
+      '#define DRM_FORMAT_MOD_INVALID 0x00ffffffffffffffULL'
   '';
 
   meta = {

--- a/pkgs/by-name/sp/spice-gtk/package.nix
+++ b/pkgs/by-name/sp/spice-gtk/package.nix
@@ -1,15 +1,15 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitLab,
   acl,
+  buildPackages,
   cyrus_sasl,
-  docbook_xsl,
   libepoxy,
   gettext,
+  gi-docgen,
   gobject-introspection,
   gst_all_1,
-  gtk-doc,
   gtk3,
   hwdata,
   json-glib,
@@ -38,6 +38,9 @@
   wayland-scanner,
   zlib,
   wrapGAppsHook3,
+  withIntrospection ?
+    lib.meta.availableOn stdenv.hostPlatform gobject-introspection
+    && stdenv.hostPlatform.emulatorAvailable buildPackages,
   withPolkit ? stdenv.hostPlatform.isLinux,
 }:
 
@@ -64,37 +67,39 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "spice-gtk";
-  version = "0.42";
+  version = "0.43";
 
   outputs = [
     "out"
     "dev"
-    "devdoc"
     "man"
   ];
 
-  src = fetchurl {
-    url = "https://www.spice-space.org/download/gtk/spice-gtk-${finalAttrs.version}.tar.xz";
-    sha256 = "sha256-k4ARfxgRrR+qGBLLZgJHm2KQ1KDYzEQtREJ/f2wOelg=";
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "spice";
+    repo = "spice-gtk";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-e0B3shnXDwKMPvy1nyz/iNPPRGJbnygh0bqIufq/93g=";
+    fetchSubmodules = true;
   };
+  # Required since we strip .git
+  postUnpack = ''
+    echo "${finalAttrs.version}" > source/.tarball-version
+  '';
 
   depsBuildBuild = [
     pkg-config
   ];
 
   nativeBuildInputs = [
-    docbook_xsl
     gettext
-    gobject-introspection
-    gtk-doc
     meson
     ninja
     perl
     pkg-config
     python3
     python3.pkgs.pyparsing
-    python3.pkgs.six
-    vala
     wrapGAppsHook3
   ]
   ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
@@ -102,6 +107,11 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     wayland-scanner
+  ]
+  ++ lib.optionals withIntrospection [
+    gi-docgen
+    gobject-introspection
+    vala
   ];
 
   buildInputs = [
@@ -122,7 +132,6 @@ stdenv.mkDerivation (finalAttrs: {
     pixman
     spice-protocol
     usbredir
-    vala
     zlib
   ]
   ++ lib.optionals withPolkit [
@@ -140,6 +149,8 @@ stdenv.mkDerivation (finalAttrs: {
   mesonFlags = [
     "-Dusb-acl-helper-dir=${placeholder "out"}/bin"
     "-Dusb-ids-path=${hwdata}/share/hwdata/usb.ids"
+    (lib.mesonEnable "introspection" withIntrospection)
+    (lib.mesonEnable "vapi" withIntrospection)
   ]
   ++ lib.optionals (!withPolkit) [
     "-Dpolkit=disabled"

--- a/pkgs/by-name/sp/spice-gtk/package.nix
+++ b/pkgs/by-name/sp/spice-gtk/package.nix
@@ -192,7 +192,10 @@ stdenv.mkDerivation (finalAttrs: {
 
     homepage = "https://www.spice-space.org/";
     license = lib.licenses.lgpl21;
-    maintainers = [ lib.maintainers.xeji ];
+    maintainers = [
+      lib.maintainers.xeji
+      lib.maintainers.theCapypara
+    ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2861,6 +2861,8 @@ with pkgs;
     inherit (llvmPackages) openmp;
   };
 
+  spice-gtk = callPackage ../by-name/sp/spice-glib/package.nix { withGtk = true; };
+
   # to match naming of other package repositories
   spire-agent = spire.agent;
   spire-server = spire.server;


### PR DESCRIPTION
This updates spice-gtk to 0.43 and splits it into two packages.

- Unfortunately upstream has not published a tarball yet. I reached out to them a while ago but haven't gotten a response yet, so I think we should just switch to gitlab pull for now.
- I decided to split the package into a variant without the GTK 3 widget and one with GTK 3. For all new apps the GTK 3 widgets are useless, as GTK 3 is legacy. The Glib components on their own are still useful to implement a GTK 4 SPICE display on top of them, like [rdw](https://gitlab.gnome.org/malureau/rdw) does. My app Field Monitor uses that and I'm pretty sure all other current consumers of spice-gtk will either do the same in their GTK 4 migration or switch to something else entirely.
  - This is consistent with what Fedora and Debian do (though it's possible those also ship spice-gtk without spice-glib, haven't checked that)
- The package switched to gi-docgen for docs. The `withIntrospection` is compatibility for cross-compilation, I took this approach from other places where we use gi-docgen.
- added myself as maintainer

edit: No idea why GitHub is being silly and not displaying the move properly on the "Files" tab, but it is recorded correctly in d6d9df203da9a61ac913c9e4eccfd9478815b42e. Sorry about that.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
