### PR TITLE
nixos-container: use `systemd-run` to provide `root-login` and `run`

### DIFF
--- a/pkgs/by-name/ni/nixos-container/nixos-container.pl
+++ b/pkgs/by-name/ni/nixos-container/nixos-container.pl
@@ -14,9 +14,6 @@ use IPC::Run 'run';
 # 25.11pre-git.
 my $nixpkgsLib = "@lib@";
 
-my $nsenter = "@util-linux@/bin/nsenter";
-my $su = "@su@";
-
 my $configurationDirectory = "@configurationDirectory@";
 my $stateDirectory = "@stateDirectory@";
 
@@ -383,9 +380,9 @@ sub restartContainer {
 # Run a command in the container.
 sub runInContainer {
     my @args = @_;
-    my $leader = getLeader;
-    exec($nsenter, "--all", "-t", $leader, "--", @args);
-    die "cannot run ‘nsenter’: $!\n";
+    exec("systemd-run", "--machine", "root\@$containerName",
+        "--quiet", "--wait", "--collect", "--pipe", "--pty", "--", @args);
+    die "cannot run ‘systemd-run’: $!\n";
 }
 
 sub evalAttribute {
@@ -520,14 +517,14 @@ elsif ($action eq "login") {
 }
 
 elsif ($action eq "root-login") {
-    runInContainer("@su@", "root", "-l");
+    runInContainer("/bin/sh", "-l");
 }
 
 elsif ($action eq "run") {
     shift @ARGV; shift @ARGV;
     # Escape command.
     my $s = join(' ', map { s/'/'\\''/g; "'$_'" } @ARGV);
-    runInContainer("@su@", "root", "-l", "-c", "exec " . $s);
+    runInContainer("/bin/sh", "-l", "-c", "exec " . $s);
 }
 
 elsif ($action eq "show-ip") {

--- a/pkgs/by-name/ni/nixos-container/package.nix
+++ b/pkgs/by-name/ni/nixos-container/package.nix
@@ -1,8 +1,6 @@
 {
   replaceVarsWith,
   perl,
-  shadow,
-  util-linux,
   installShellFiles,
   configurationDirectory ? "/etc/nixos-containers",
   stateDirectory ? "/var/lib/nixos-containers",
@@ -20,10 +18,9 @@ replaceVarsWith {
       p.FileSlurp
       p.IPCRun
     ]);
-    su = "${shadow.su}/bin/su";
     lib = "${path + "/lib"}";
 
-    inherit configurationDirectory stateDirectory util-linux;
+    inherit configurationDirectory stateDirectory;
   };
 
   passthru = {


### PR DESCRIPTION
Currently nixos-container uses `nsenter` to implement "root-login" and "run" command. This however does cause the `su` process launched to have the parent being the `nsenter` process. This means that the launched process has PPID of 0 (inside the namespace) and not in the process tree of the init process inside the container.

When the container is being teared down by `nixos-container stop`, the child process is killed but the nsenter'ed process is not, causing the tearing down process to freeze.

Use `systemd-run` to execute the shell so systemd is aware of the running process.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
