### PR TITLE
python3Packages.setuptools-git-versioning: 3.0.1 -> 3.1.0, modernize

### DIFF
--- a/pkgs/development/python-modules/setuptools-git-versioning/default.nix
+++ b/pkgs/development/python-modules/setuptools-git-versioning/default.nix
@@ -10,6 +10,7 @@
   pyprojectVersionPatchHook,
   pytestCheckHook,
   pytest-rerunfailures,
+  pytest-xdist,
   setuptools,
   tomli-w,
 }:
@@ -47,12 +48,8 @@ buildPythonPackage (finalAttrs: {
     git
     pytestCheckHook
     pytest-rerunfailures
+    pytest-xdist
     tomli-w
-  ];
-
-  # limit tests because the full suite takes several minutes to run
-  enabledTestMarks = [
-    "important"
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/setuptools-git-versioning/default.nix
+++ b/pkgs/development/python-modules/setuptools-git-versioning/default.nix
@@ -11,20 +11,21 @@
   pytestCheckHook,
   pytest-rerunfailures,
   pytest-xdist,
+  scikit-build-core,
   setuptools,
   tomli-w,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "setuptools-git-versioning";
-  version = "3.0.1";
+  version = "3.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "dolfinus";
     repo = "setuptools-git-versioning";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-rAJ9OvSKhQ3sMN5DlUg2tfR42Ae7jjz9en3gfRnXb3I=";
+    hash = "sha256-d6d8taSSAjvirivf1WaEICq0XbrYQzC2LB//LpGpHhI=";
   };
 
   nativeBuildInputs = [ pyprojectVersionPatchHook ];
@@ -49,6 +50,7 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
     pytest-rerunfailures
     pytest-xdist
+    scikit-build-core
     tomli-w
   ];
 

--- a/pkgs/development/python-modules/setuptools-git-versioning/default.nix
+++ b/pkgs/development/python-modules/setuptools-git-versioning/default.nix
@@ -64,7 +64,7 @@ buildPythonPackage (finalAttrs: {
     description = "Use git repo data (latest tag, current commit hash, etc) for building a version number according PEP-440";
     mainProgram = "setuptools-git-versioning";
     homepage = "https://github.com/dolfinus/setuptools-git-versioning";
-    changelog = "https://github.com/dolfinus/setuptools-git-versioning/blob/${finalAttrs.src.tag}/CHANGELOG.rst";
+    changelog = "https://setuptools-git-versioning.readthedocs.io/en/${finalAttrs.src.tag}/changelog.html";
     license = lib.licenses.mit;
   };
 })

--- a/pkgs/development/python-modules/setuptools-git-versioning/default.nix
+++ b/pkgs/development/python-modules/setuptools-git-versioning/default.nix
@@ -2,17 +2,19 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  addBinToPathHook,
   build,
   coverage,
   git,
   packaging,
+  pyprojectVersionPatchHook,
   pytestCheckHook,
   pytest-rerunfailures,
   setuptools,
   tomli-w,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "setuptools-git-versioning";
   version = "3.0.1";
   pyproject = true;
@@ -20,14 +22,11 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "dolfinus";
     repo = "setuptools-git-versioning";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-rAJ9OvSKhQ3sMN5DlUg2tfR42Ae7jjz9en3gfRnXb3I=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail 'dynamic = ["version"]' 'version = "${version}"'
-  '';
+  nativeBuildInputs = [ pyprojectVersionPatchHook ];
 
   build-system = [
     packaging
@@ -42,6 +41,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "setuptools_git_versioning" ];
 
   nativeCheckInputs = [
+    addBinToPathHook
     build
     coverage
     git
@@ -49,11 +49,6 @@ buildPythonPackage rec {
     pytest-rerunfailures
     tomli-w
   ];
-
-  preCheck = ''
-    # so that its built binary is accessible by tests
-    export PATH="$out/bin:$PATH"
-  '';
 
   # limit tests because the full suite takes several minutes to run
   enabledTestMarks = [
@@ -69,7 +64,7 @@ buildPythonPackage rec {
     description = "Use git repo data (latest tag, current commit hash, etc) for building a version number according PEP-440";
     mainProgram = "setuptools-git-versioning";
     homepage = "https://github.com/dolfinus/setuptools-git-versioning";
-    changelog = "https://github.com/dolfinus/setuptools-git-versioning/blob/${src.tag}/CHANGELOG.rst";
+    changelog = "https://github.com/dolfinus/setuptools-git-versioning/blob/${finalAttrs.src.tag}/CHANGELOG.rst";
     license = lib.licenses.mit;
   };
-}
+})


### PR DESCRIPTION
- **python3Packages.setuptools-git-versioning: modernize**
- **python3Packages.setuptools-git-versioning: correct meta.changelog**
- **python3Packages.setuptools-git-versioning: run full test suite**
  Only 1m30s on my 4 core/8 thread laptop now that it uses pytest-xdist.
- **python3Packages.setuptools-git-versioning: 3.0.1 -> 3.1.0**
  Diff: https://github.com/dolfinus/setuptools-git-versioning/compare/v3.0.1...v3.1.0
  Changelog: https://setuptools-git-versioning.readthedocs.io/en/stable/changelog/3.1.x.html

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
