### PR TITLE
glci: init at 0.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16212,6 +16212,11 @@
     githubId = 263230236;
     name = "Lila Hummel";
   };
+  lildojd = {
+    github = "LilDojd";
+    githubId = 37330594;
+    name = "George";
+  };
   lilioid = {
     name = "Lilly";
     email = "li@lly.sh";

--- a/pkgs/by-name/gl/glci/package.nix
+++ b/pkgs/by-name/gl/glci/package.nix
@@ -1,0 +1,110 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitLab,
+  fetchurl,
+  gitMinimal,
+  makeWrapper,
+  nix-update-script,
+  runCommand,
+  runtimeShell,
+  writableTmpDirAsHomeHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "glci";
+  version = "0.7.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitLab {
+    group = "gitlab-org/ci-cd";
+    owner = "runner-tools";
+    repo = "glci";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-S6MvJIAQmRqrME+sl/2MUiQ2FsStbcn6lclxRY8s+X4=";
+  };
+
+  vendorHash = "sha256-XOpUoZGQy6eZxHIfi52Bfpwg5GKj0DUSPDG+vx02Hs4=";
+
+  env.CGO_ENABLED = 0;
+
+  subPackages = [ "cmd/glci" ];
+
+  ldflags = [
+    "-X gitlab.com/gitlab-org/ci-cd/runner-tools/glci/pkg/version.Commit=${finalAttrs.src.rev}"
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  nativeCheckInputs = [
+    gitMinimal
+    writableTmpDirAsHomeHook
+  ];
+
+  postPatch = ''
+    substituteInPlace pkg/daemon/endpoint_test.go \
+      --replace-fail "#!/bin/sh" "#!${runtimeShell}" \
+      --replace-fail "/usr/bin/env" "env" \
+      --replace-fail "/bin/cat" "cat"
+
+    # The sandbox blocks the remote include used by this test fixture.
+    cp ${
+      fetchurl {
+        url = "https://gitlab.com/gitlab-org/frontend/untamper-my-lockfile/-/raw/bea592e045f9f97ae4929f7de592834aa6c8e306/templates/merge_request_pipelines.yml";
+        hash = "sha256-BozLjE+uzwZJEC5jBWZoJ+ZfvcTiBlj80d0CsVi+ZsI=";
+      }
+    } pkg/config/testdata/gitlab/raw/.gitlab/ci/untamper-my-lockfile.yml
+    substituteInPlace pkg/config/testdata/gitlab/raw/.gitlab-ci.yml \
+      --replace-fail \
+        "remote: 'https://gitlab.com/gitlab-org/frontend/untamper-my-lockfile/-/raw/main/templates/merge_request_pipelines.yml'" \
+        "local: .gitlab/ci/untamper-my-lockfile.yml"
+  '';
+
+  # Source archives lack the Git metadata required by pkg/variables tests.
+  preCheck = ''
+    git init --quiet --initial-branch=main
+    git config user.email glci-tests@example.invalid
+    git config user.name "glci tests"
+    git add .
+    git commit --quiet --message "Test fixture"
+    git remote add origin https://gitlab.com/gitlab-org/ci-cd/runner-tools/glci.git
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    # We do not set trimpath for tests, in case they reference test assets
+    export GOFLAGS=''${GOFLAGS//-trimpath/}
+
+    go test ./...
+
+    runHook postCheck
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/glci --prefix PATH : ${lib.makeBinPath [ gitMinimal ]}
+  '';
+
+  passthru.tests.version = runCommand "glci-version-test" { } ''
+    ${finalAttrs.finalPackage}/bin/glci version 2>&1 \
+      | grep -F ${finalAttrs.src.rev}
+    touch $out
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Run GitLab CI/CD pipelines locally";
+    homepage = "https://gitlab.com/gitlab-org/ci-cd/runner-tools/glci";
+    changelog = "https://glci-e20136.gitlab.io/changelog/v${finalAttrs.version}/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ lildojd ];
+    mainProgram = "glci";
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds glci 0.7.0, a tool for running GitLab CI/CD pipelines locally.

OpenCode (`openai/gpt-5.6-sol`) assisted with the package implementation and this pull request summary.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
