### PR TITLE
vimPlugins.jupynvim: init at 0.4.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1428,6 +1428,11 @@
     githubId = 30437811;
     name = "Alex Andrews";
   };
+  alikaansun = {
+    github = "alikaansun";
+    githubId = 77810345;
+    name = "Ali Kaan Sunnetcioglu";
+  };
   alikindsys = {
     email = "alice@blocovermelho.org";
     github = "alikindsys";

--- a/pkgs/applications/editors/vim/plugins/non-generated/jupynvim/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/jupynvim/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  rustPlatform,
+  vimUtils,
+}:
+let
+  version = "0.4.4";
+  src = fetchFromGitHub {
+    owner = "sheng-tse";
+    repo = "jupynvim";
+    tag = "v${version}";
+    hash = "sha256-DJinRfxOoSj8xnWUnpPd14mA8zMQmLhavmJsUz4h2XQ=";
+  };
+  jupynvim-core = rustPlatform.buildRustPackage {
+    pname = "jupynvim-core";
+    inherit version src;
+
+    sourceRoot = "${src.name}/core";
+
+    cargoHash = "sha256-cZKHYCFtzU1ULNp7TY/4/l6SrzGF3ghnBF5y5nvxuWw=";
+
+    meta.mainProgram = "jupynvim-core";
+  };
+in
+vimUtils.buildVimPlugin {
+  pname = "jupynvim";
+  inherit version src;
+
+  # Upstream resolves the backend from an in-tree build directory that only
+  # exists once its install hook has downloaded or built one.
+  postInstall = ''
+    rm -rf $out/core
+    substituteInPlace $out/lua/jupynvim/backend/connect.lua \
+      --replace-fail 'M._plugin_root() .. "/core/target/release/jupynvim-core"' \
+                     '"${lib.getExe jupynvim-core}"'
+  '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "vimPlugins.jupynvim.jupynvim-core";
+    };
+
+    # needed for the update script
+    inherit jupynvim-core;
+  };
+
+  meta = {
+    description = "Jupyter notebooks in Neovim with native cell rendering and kernel execution";
+    homepage = "https://github.com/sheng-tse/jupynvim";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ alikaansun ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds [jupynvim](https://github.com/sheng-tse/jupynvim) 0.4.4 (MIT): Jupyter notebook editing in Neovim, with cell execution against a live kernel and inline image output through the kitty graphics protocol. It reads and writes `.ipynb` natively rather than round-tripping through jupytext.

The plugin ships a Rust backend, `jupynvim-core`, which the Lua spawns and talks to over RPC. Upstream fetches a prebuilt binary from GitHub Releases on first use, which cannot work in a sandboxed build, so the backend is built from source here and the resolver in `lua/jupynvim/backend/connect.lua` is pointed at the store path with `--replace-fail`.

It is packaged under `non-generated/` rather than being added to `vim-plugin-names`, because the backend has to be built from the *same* `src` as the Lua — the two share an RPC protocol and must not drift apart. This follows the existing convention for plugins with native components (`blink-cmp`, `avante-nvim`, `sniprun`, `jupyter-api-nvim`), and `passthru.updateScript` handles updates in place of the generated-plugin updater.

Upstream's 25 Rust unit tests run in `checkPhase`, and all 26 Lua modules pass `neovimRequireCheckHook`, so no `nvimSkipModules` is needed.

### Automation disclosure

The package expression was written with the assist of Claude Code (Claude Opus 5); both commits carry `Assisted-by:` trailers. I reviewed the expression, built it locally on aarch64-darwin and x86_64-linux, and ran the plugin in my own configuration against a live Jupyter kernel before submitting.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
