### PR TITLE
fmtron: init at 0.3.0

### DIFF
--- a/pkgs/by-name/fm/fmtron/package.nix
+++ b/pkgs/by-name/fm/fmtron/package.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  fetchCrate,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "fmtron";
+  version = "0.6.0";
+  __structuredAttrs = true;
+
+  src = fetchCrate {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-yXDB/fN4cqGy+LNPOcgovZpyH1Z+B339iHuGywIgU9g=";
+  };
+
+  cargoHash = "sha256-/DFE5MqLBBMqsq/fSYGf3Sk4yJaSZRyvDCIuDthDeO8=";
+
+  meta = {
+    description = "CLI tool to format RON files";
+    homepage = "https://github.com/barafael/fmtron";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ yusufraji ];
+    mainProgram = "fmtron";
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
