### PR TITLE
kde: enable darwin for frameworks

### DIFF
--- a/pkgs/kde/frameworks/baloo/default.nix
+++ b/pkgs/kde/frameworks/baloo/default.nix
@@ -1,5 +1,6 @@
 {
   mkKdeDerivation,
+  lib,
   qtdeclarative,
   lmdb,
 }:
@@ -15,4 +16,6 @@ mkKdeDerivation {
     qtdeclarative
     lmdb
   ];
+
+  meta.badPlatforms = lib.platforms.darwin;
 }

--- a/pkgs/kde/frameworks/bluez-qt/default.nix
+++ b/pkgs/kde/frameworks/bluez-qt/default.nix
@@ -1,9 +1,12 @@
 {
   mkKdeDerivation,
+  lib,
   qtdeclarative,
 }:
 mkKdeDerivation {
   pname = "bluez-qt";
 
   extraBuildInputs = [ qtdeclarative ];
+
+  meta.badPlatforms = lib.platforms.darwin;
 }

--- a/pkgs/kde/frameworks/extra-cmake-modules/ecm-hook.sh
+++ b/pkgs/kde/frameworks/extra-cmake-modules/ecm-hook.sh
@@ -15,7 +15,7 @@ ecmPostHook() {
     # Because we need to use absolute paths here, we must set *all* the paths.
     # Keep this in sync with https://github.com/KDE/extra-cmake-modules/blob/master/kde-modules/KDEInstallDirs6.cmake
     if [ "$(uname)" = "Darwin" ]; then
-        appendToVar cmakeFlags "-DKDE_INSTALL_BUNDLEDIR=${!outputBin}/Applications/KDE"
+        appendToVar cmakeFlags "-DKDE_INSTALL_BUNDLEDIR=${!outputBin}/Applications"
     fi
 
     appendToVar cmakeFlags "-DKDE_INSTALL_EXECROOTDIR=${!outputBin}"

--- a/pkgs/kde/frameworks/frameworkintegration/default.nix
+++ b/pkgs/kde/frameworks/frameworkintegration/default.nix
@@ -1,5 +1,6 @@
 {
   mkKdeDerivation,
+  lib,
   pkg-config,
   packagekit-qt,
 }:
@@ -8,4 +9,6 @@ mkKdeDerivation {
 
   extraNativeBuildInputs = [ pkg-config ];
   extraBuildInputs = [ packagekit-qt ];
+
+  meta.badPlatforms = lib.platforms.darwin;
 }

--- a/pkgs/kde/frameworks/karchive/default.nix
+++ b/pkgs/kde/frameworks/karchive/default.nix
@@ -3,6 +3,7 @@
   qttools,
   pkg-config,
   xz,
+  bzip2,
 }:
 mkKdeDerivation {
   pname = "karchive";
@@ -11,5 +12,8 @@ mkKdeDerivation {
     qttools
     pkg-config
   ];
-  extraBuildInputs = [ xz ];
+  extraBuildInputs = [
+    xz
+    bzip2
+  ];
 }

--- a/pkgs/kde/frameworks/kded/default.nix
+++ b/pkgs/kde/frameworks/kded/default.nix
@@ -1,5 +1,12 @@
-{ mkKdeDerivation }:
+{
+  mkKdeDerivation,
+  lib,
+}:
 mkKdeDerivation {
   pname = "kded";
-  meta.mainProgram = "kded6";
+
+  meta = {
+    mainProgram = "kded6";
+    badPlatforms = lib.platforms.darwin;
+  };
 }

--- a/pkgs/kde/frameworks/kdesu/default.nix
+++ b/pkgs/kde/frameworks/kdesu/default.nix
@@ -1,7 +1,12 @@
-{ mkKdeDerivation }:
+{
+  mkKdeDerivation,
+  lib,
+}:
 mkKdeDerivation {
   pname = "kdesu";
 
   # Look for NixOS SUID wrapper first
   patches = [ ./kdesu-search-for-wrapped-daemon-first.patch ];
+
+  meta.badPlatforms = lib.platforms.darwin;
 }

--- a/pkgs/kde/frameworks/kdoctools/datadir-absolute-path.patch
+++ b/pkgs/kde/frameworks/kdoctools/datadir-absolute-path.patch
@@ -1,0 +1,8 @@
+--- a/config-kdoctools.h.cmake
++++ b/config-kdoctools.h.cmake
+@@ -2,4 +2,4 @@
+ 
+ #define DOCBOOK_XML_CURRDTD "@DocBookXML4_DTD_DIR@"
+ 
+-#define KDOCTOOLS_INSTALL_DATADIR_KF "${CMAKE_INSTALL_PREFIX}/${KDE_INSTALL_DATADIR_KF}"
++#define KDOCTOOLS_INSTALL_DATADIR_KF "${KDE_INSTALL_FULL_DATADIR_KF}"

--- a/pkgs/kde/frameworks/kdoctools/default.nix
+++ b/pkgs/kde/frameworks/kdoctools/default.nix
@@ -9,6 +9,9 @@
 mkKdeDerivation {
   pname = "kdoctools";
 
+  # In nixpkgs KDE_INSTALL_DATADIR_KF is an absolute path, the below logic assumes it's a relative path.
+  patches = [ ./datadir-absolute-path.patch ];
+
   # Perl could be used both at build time and at runtime.
   extraNativeBuildInputs = [
     perl

--- a/pkgs/kde/frameworks/kfilemetadata/default.nix
+++ b/pkgs/kde/frameworks/kfilemetadata/default.nix
@@ -8,6 +8,8 @@
   kconfig,
   kdegraphics-mobipocket,
   libappimage,
+  lib,
+  stdenv,
 }:
 mkKdeDerivation {
   pname = "kfilemetadata";
@@ -18,12 +20,14 @@ mkKdeDerivation {
 
   extraNativeBuildInputs = [ pkg-config ];
   extraBuildInputs = [
-    attr
     ebook_tools
     exiv2
     ffmpeg
     kconfig
     kdegraphics-mobipocket
+  ]
+  ++ lib.filter (lib.meta.availableOn stdenv.hostPlatform) [
     libappimage
+    attr
   ];
 }

--- a/pkgs/kde/frameworks/kglobalaccel/default.nix
+++ b/pkgs/kde/frameworks/kglobalaccel/default.nix
@@ -1,9 +1,12 @@
 {
   mkKdeDerivation,
+  lib,
   qttools,
 }:
 mkKdeDerivation {
   pname = "kglobalaccel";
 
   extraNativeBuildInputs = [ qttools ];
+
+  meta.badPlatforms = lib.platforms.darwin;
 }

--- a/pkgs/kde/frameworks/kguiaddons/default.nix
+++ b/pkgs/kde/frameworks/kguiaddons/default.nix
@@ -2,6 +2,8 @@
   mkKdeDerivation,
   qtwayland,
   pkg-config,
+  lib,
+  stdenv,
 }:
 mkKdeDerivation {
   pname = "kguiaddons";
@@ -9,6 +11,9 @@ mkKdeDerivation {
   hasPythonBindings = true;
 
   extraNativeBuildInputs = [ pkg-config ];
-  extraBuildInputs = [ qtwayland ];
+  extraBuildInputs = lib.filter (lib.meta.availableOn stdenv.hostPlatform) [
+    qtwayland
+  ];
+
   meta.mainProgram = "kde-geo-uri-handler";
 }

--- a/pkgs/kde/frameworks/kidletime/default.nix
+++ b/pkgs/kde/frameworks/kidletime/default.nix
@@ -1,5 +1,6 @@
 {
   mkKdeDerivation,
+  lib,
   qtwayland,
   pkg-config,
   libxscrnsaver,
@@ -12,4 +13,6 @@ mkKdeDerivation {
     qtwayland
     libxscrnsaver
   ];
+
+  meta.badPlatforms = lib.platforms.darwin;
 }

--- a/pkgs/kde/frameworks/kio/default.nix
+++ b/pkgs/kde/frameworks/kio/default.nix
@@ -5,6 +5,8 @@
   kauth,
   acl,
   attr,
+  lib,
+  stdenv,
 }:
 mkKdeDerivation {
   pname = "kio";
@@ -18,6 +20,8 @@ mkKdeDerivation {
     qt5compat
     qttools
     kauth
+  ]
+  ++ lib.filter (lib.meta.availableOn stdenv.hostPlatform) [
     acl
     attr
   ];

--- a/pkgs/kde/frameworks/kirigami/default.nix
+++ b/pkgs/kde/frameworks/kirigami/default.nix
@@ -6,7 +6,6 @@
   qtdeclarative,
   qt5compat,
   qqc2-desktop-style,
-  fetchpatch,
 }:
 # Kirigami has a runtime dependency on qqc2-desktop-style,
 # which has a build time dependency on Kirigami.

--- a/pkgs/kde/frameworks/krunner/default.nix
+++ b/pkgs/kde/frameworks/krunner/default.nix
@@ -1,9 +1,12 @@
 {
   mkKdeDerivation,
+  lib,
   plasma-activities,
 }:
 mkKdeDerivation {
   pname = "krunner";
 
   extraBuildInputs = [ plasma-activities ];
+
+  meta.badPlatforms = lib.platforms.darwin;
 }

--- a/pkgs/kde/frameworks/kwindowsystem/default.nix
+++ b/pkgs/kde/frameworks/kwindowsystem/default.nix
@@ -4,6 +4,8 @@
   qtdeclarative,
   qtwayland,
   pkg-config,
+  lib,
+  stdenv,
 }:
 mkKdeDerivation {
   pname = "kwindowsystem";
@@ -14,6 +16,8 @@ mkKdeDerivation {
   ];
   extraBuildInputs = [
     qtdeclarative
+  ]
+  ++ lib.filter (lib.meta.availableOn stdenv.hostPlatform) [
     qtwayland
   ];
 }

--- a/pkgs/kde/frameworks/modemmanager-qt/default.nix
+++ b/pkgs/kde/frameworks/modemmanager-qt/default.nix
@@ -1,5 +1,6 @@
 {
   mkKdeDerivation,
+  lib,
   pkg-config,
   modemmanager,
 }:
@@ -8,4 +9,6 @@ mkKdeDerivation {
 
   extraNativeBuildInputs = [ pkg-config ];
   extraPropagatedBuildInputs = [ modemmanager ];
+
+  meta.badPlatforms = lib.platforms.darwin;
 }

--- a/pkgs/kde/frameworks/networkmanager-qt/default.nix
+++ b/pkgs/kde/frameworks/networkmanager-qt/default.nix
@@ -1,5 +1,6 @@
 {
   mkKdeDerivation,
+  lib,
   qtdeclarative,
   pkg-config,
   networkmanager,
@@ -10,4 +11,6 @@ mkKdeDerivation {
   extraNativeBuildInputs = [ pkg-config ];
   extraBuildInputs = [ qtdeclarative ];
   extraPropagatedBuildInputs = [ networkmanager ];
+
+  meta.badPlatforms = lib.platforms.darwin;
 }

--- a/pkgs/kde/frameworks/syntax-highlighting/default.nix
+++ b/pkgs/kde/frameworks/syntax-highlighting/default.nix
@@ -1,5 +1,4 @@
 {
-  lib,
   mkKdeDerivation,
   qtdeclarative,
   qttools,
@@ -13,8 +12,5 @@ mkKdeDerivation {
     qttools
     perl
   ];
-  meta = {
-    mainProgram = "ksyntaxhighlighter6";
-    platforms = lib.platforms.linux ++ lib.platforms.freebsd ++ lib.platforms.darwin;
-  };
+  meta.mainProgram = "ksyntaxhighlighter6";
 }

--- a/pkgs/kde/lib/darwin-bundle-hook.sh
+++ b/pkgs/kde/lib/darwin-bundle-hook.sh
@@ -1,0 +1,43 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2154
+
+fixDarwinBundles() {
+    # Just in case it doesn't work with all of them
+    if [ -n "${dontFixupDarwinBundle-}" ]; then
+        return
+    fi
+
+    local prefix="${!outputBin}"
+    local app name f
+
+    for app in "$prefix"/bin/*.app; do
+        [ -e "$app" ] || continue
+        mkdir -p "$prefix/Applications"
+        mv "$app" "$prefix/Applications/"
+    done
+
+    for app in "$prefix"/Applications/*.app; do
+        [ -e "$app" ] || continue
+        name="$(basename "$app" .app)"
+
+        mkdir -p "$app/Contents/Resources"
+        for f in "$prefix"/share/*; do
+            if [ ! -e "$app/Contents/Resources/$(basename "$f")" ]; then
+                ln -s "$f" "$app/Contents/Resources/"
+            fi
+        done
+
+        for f in "$prefix"/bin/*; do
+            if [ -f "$f" ] && [ -x "$f" ] && [ ! -e "$app/Contents/MacOS/$(basename "$f")" ]; then
+                ln -s "$f" "$app/Contents/MacOS/"
+            fi
+        done
+
+        if [ -e "$app/Contents/MacOS/$name" ] && [ ! -e "$prefix/bin/$name" ]; then
+            mkdir -p "$prefix/bin"
+            ln -s "$app/Contents/MacOS/$name" "$prefix/bin/$name"
+        fi
+    done
+}
+
+postInstallHooks+=('fixDarwinBundles')

--- a/pkgs/kde/lib/iconutil-compat.py
+++ b/pkgs/kde/lib/iconutil-compat.py
@@ -1,0 +1,25 @@
+import argparse
+import os
+import shutil
+import sys
+from pathlib import Path
+
+# https://manp.gs/mac/1/iconutil
+parser = argparse.ArgumentParser(
+    description="iconutil compatibility shim"
+)
+parser.add_argument("-c", "--convert", required=True, choices=["icns"])
+parser.add_argument("-o", "--output", type=Path)
+parser.add_argument("iconset", type=Path)
+args = parser.parse_args()
+
+output = args.output or args.iconset.with_suffix(".icns")
+icons = sorted(str(f) for f in args.iconset.glob("icon_*.png"))
+if not icons:
+    sys.exit(f"no usable icons in {args.iconset}")
+
+icnsutil = shutil.which("icnsutil")
+if icnsutil is None:
+    sys.exit("icnsutil not found in PATH")
+
+os.execv(icnsutil, [icnsutil, "compose", "--toc", "-f", str(output), *icons])

--- a/pkgs/kde/lib/mk-kde-derivation.nix
+++ b/pkgs/kde/lib/mk-kde-derivation.nix
@@ -162,6 +162,11 @@ let
     "meta"
   ];
 
+  repoPath = projectInfo.${pname}.repo_path or null;
+  # Enable darwin by default only for framework scope atm
+  # In other folders most of them tend to not work
+  isFramework = repoPath != null && lib.hasPrefix "frameworks/" repoPath;
+
   meta = {
     description = projectInfo.${pname}.description;
     homepage = "https://invent.kde.org/${projectInfo.${pname}.repo_path}";
@@ -169,7 +174,8 @@ let
     license = lib.filter (l: l != null) (map (l: licensesBySpdxId.${l}) licenseInfo.${pname});
     teams = [ lib.teams.qt-kde ];
     # Platforms are currently limited to what upstream tests in CI, but can be extended if there's interest.
-    platforms = lib.platforms.linux ++ lib.platforms.freebsd;
+    platforms =
+      lib.platforms.linux ++ lib.platforms.freebsd ++ lib.optionals isFramework lib.platforms.darwin;
   }
   // (args.meta or { });
 

--- a/pkgs/kde/lib/mk-kde-derivation.nix
+++ b/pkgs/kde/lib/mk-kde-derivation.nix
@@ -9,6 +9,7 @@ self:
   python3,
   python3Packages,
   jq,
+  writers,
 }:
 let
   dependencies = (lib.importJSON ../generated/dependencies.json).dependencies;
@@ -54,6 +55,14 @@ let
     name = "kf6-move-outputs-hook";
     meta.license = lib.licenses.mit;
   } ./move-outputs-hook.sh;
+
+  darwinBundleHook = makeSetupHook {
+    name = "kf6-darwin-bundle-hook";
+    meta.license = lib.licenses.mit;
+  } ./darwin-bundle-hook.sh;
+
+  # Compatibility layer for getting past iconutil not being in the nix sandbox.
+  iconutilCompat = writers.writePython3Bin "iconutil" { } ./iconutil-compat.py;
 
   qmllintHook = makeSetupHook {
     name = "qmllint-validate-hook";
@@ -121,6 +130,11 @@ let
       qt6.wrapQtAppsHook
       moveOutputsHook
       qmllintHook
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      darwinBundleHook
+      iconutilCompat
+      python3Packages.icnsutil
     ]
     ++ lib.optionals hasPythonBindings [
       python3Packages.shiboken6

--- a/pkgs/kde/lib/mk-kde-derivation.nix
+++ b/pkgs/kde/lib/mk-kde-derivation.nix
@@ -79,10 +79,13 @@ in
 let
   depNames = dependencies.${pname} or [ ];
   filteredDepNames = builtins.filter (dep: !(builtins.elem dep excludeDependencies)) depNames;
+  availableDepNames = builtins.filter (
+    dep: lib.meta.availableOn stdenv.hostPlatform self.${dep}
+  ) filteredDepNames;
 
   # FIXME(later): this is wrong for cross, some of these things really need to go into nativeBuildInputs,
   # but cross is currently very broken anyway, so we can figure this out later.
-  deps = map (dep: self.${dep}) filteredDepNames;
+  deps = map (dep: self.${dep}) availableDepNames;
 
   traceDuplicateDeps =
     attrName: attrValue:


### PR DESCRIPTION
Continues on from https://github.com/NixOS/nixpkgs/pull/550592

Splits up darwin hooks and framework enablement since it causes too many rebuilds. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
