### PR TITLE
archi: init at 5.10.0

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -239,6 +239,7 @@ in
   apparmor = runTest ./apparmor;
   appliance-repart-image = runTest ./appliance-repart-image.nix;
   appliance-repart-image-verity-store = runTest ./appliance-repart-image-verity-store.nix;
+  archi = runTest ./archi.nix;
   aria2 = runTest ./aria2.nix;
   armagetronad = runTest ./armagetronad.nix;
   artalk = runTest ./artalk.nix;

--- a/nixos/tests/archi.nix
+++ b/nixos/tests/archi.nix
@@ -1,0 +1,49 @@
+{ pkgs, ... }:
+{
+  name = "archi";
+  meta = { inherit (pkgs.archi.meta) maintainers platforms; };
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      imports = [
+        ./common/x11.nix
+      ];
+
+      environment.systemPackages = with pkgs; [ archi ];
+    };
+
+  testScript = ''
+    machine.wait_for_x()
+
+    with subtest("create a model from the command line"):
+        machine.succeed(
+            "archi -application com.archimatetool.commandline.app -consoleLog -nosplash"
+            " --createEmptyModel --saveModel smoke.archimate"
+        )
+        machine.succeed("grep -q 'archimate:model' smoke.archimate")
+
+    # Waiting for the welcome text with OCR would be preferable but it hangs
+    # indefinitely on this screen, see: https://github.com/NixOS/nixpkgs/issues/302965
+    with subtest("the workbench comes up"):
+        machine.succeed("DISPLAY=:0 archi >&2 &")
+        # The first window to appear is the splash screen, so it says nothing
+        # about the workbench.
+        machine.wait_for_window("Archi")
+
+        # SWT maps this native only when it brings up a display, so wait for
+        # that. The launcher forks a JVM and stays around, so match on the
+        # launcher jar to get the JVM rather than the launcher itself. The
+        # bracket stops pgrep from matching the shell running the check.
+        machine.wait_until_succeeds(
+            'grep -q "libswt-pi3-gtk" "/proc/$(pgrep -f "equinox[.]launcher_")/maps"'
+        )
+        machine.screenshot("archi")
+
+        # The welcome screen is drawn by an SWT Browser widget, which dlopens
+        # webkitgtk through appendRunpaths.
+        machine.wait_until_succeeds(
+            'grep -q "libwebkit2gtk" "/proc/$(pgrep -f "equinox[.]launcher_")/maps"'
+        )
+  '';
+}

--- a/pkgs/by-name/ar/archi/mime-info.xml
+++ b/pkgs/by-name/ar/archi/mime-info.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+  <mime-type type="application/x-archimate">
+    <comment>ArchiMate model</comment>
+    <sub-class-of type="application/xml"/>
+    <icon name="archi"/>
+    <glob pattern="*.archimate"/>
+    <root-XML namespaceURI="http://www.archimatetool.com/archimate" localName="model"/>
+  </mime-type>
+</mime-info>

--- a/pkgs/by-name/ar/archi/package.nix
+++ b/pkgs/by-name/ar/archi/package.nix
@@ -1,0 +1,213 @@
+{
+  lib,
+  at-spi2-core,
+  autoPatchelfHook,
+  cairo,
+  copyDesktopItems,
+  fetchFromGitHub,
+  glib,
+  gtk3,
+  gtk4,
+  jdk21,
+  libsecret,
+  makeDesktopItem,
+  makeWrapper,
+  maven,
+  nix-update-script,
+  nixosTests,
+  stdenv,
+  stripJavaArchivesHook,
+  unzip,
+  webkitgtk_4_1,
+  wrapGAppsHook3,
+}:
+let
+  platform =
+    {
+      "x86_64-linux" = {
+        jna = "linux-x86-64";
+        product = "linux/gtk/x86_64";
+        swt = "linux.x86_64";
+      };
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+in
+
+maven.buildMavenPackage (finalAttrs: {
+  pname = "archi";
+  version = "5.10.0";
+
+  src = fetchFromGitHub {
+    owner = "archimatetool";
+    repo = "archi";
+    tag = "release_${finalAttrs.version}";
+    hash = "sha256-tm41GKf7QFLTyZQkLhSuSs0XELcrlEUYfcya2nNHv5g=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  mvnJdk = jdk21;
+
+  mvnParameters = lib.escapeShellArgs [
+    "-Dbuild.timestamp=198001010000" # application build timestamp
+    "-Dproject.build.outputTimestamp=1980-01-01T00:00:02Z" # JAR/ZIP archive timestamps
+    "-Pproduct"
+  ];
+
+  mvnHash = "sha256-f/qnIpkHDdnVYraTlOucgb1tehUBlTUSfN/Yck0jxeo=";
+
+  mvnFetchExtraArgs = {
+    postInstall = ''
+      # Tycho needs this metadata for offline dependency resolution.
+      # Sort it because entries are emitted in hash-map order.
+      sort -o $out/.m2/.meta/p2-artifacts.properties $out/.m2/.meta/p2-artifacts.properties
+
+      # Remove volatile response and fetch timestamps.
+      # Keep the cache files because Tycho requires their *.headers files.
+      find $out/.m2/.cache -type f -name '*.headers' \
+        -exec sed -i -e '/^date=/d' -e '/^FILE-LAST_UPDATED=/d' {} +
+    '';
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    copyDesktopItems
+    makeWrapper
+    stripJavaArchivesHook
+    unzip
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    at-spi2-core
+    cairo
+    glib
+    gtk3
+    gtk4
+  ];
+
+  # These are dlopen'd rather than being DT_NEEDED entries, so autoPatchelfHook
+  # cannot infer them.
+  appendRunpaths = [
+    "${lib.getLib libsecret}/lib" # reached through JNA by Equinox's keyring provider
+    "${lib.getLib webkitgtk_4_1}/lib" # dlopen'd by libswt-webkit-gtk for the browser widget
+  ];
+
+  postPatch = ''
+    # Source tarballs lack the Git history required by the jgit timestamp provider.
+    substituteInPlace pom.xml \
+      --replace-fail '<timestampProvider>jgit</timestampProvider>' '<timestampProvider>default</timestampProvider>'
+  '';
+
+  # Upstream's tests would need extra work to run at all and still fail in the
+  # build environment.
+  doCheck = false;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/libexec
+
+    # Upstream declares icon.xpm as the Linux launcher icon in archi.product
+    # but these PNGs are the same artwork at different sizes, which suits the
+    # hicolor theme better than a single size XPM.
+    for icon in com.archimatetool.editor/img/app-*.png; do
+      name=''${icon##*/app-}; name=''${name%.png} # 16, or 16@2x
+      size=''${name%%@*}                          # 16
+      scale=''${name#"$size"}                     # empty, or @2x
+      install -Dm444 "$icon" \
+        "$out/share/icons/hicolor/''${size}x''${size}''${scale%x}/apps/archi.png"
+    done
+
+    install -Dm444 ${./mime-info.xml} $out/share/mime/packages/archi.xml
+
+    pushd com.archimatetool.editor.product/target/products/com.archimatetool.editor.product/${platform.product}/Archi
+
+    # Copy everything except what is not needed:
+    # - icon.xpm, superseded by the PNGs installed above
+    # - artifacts.xml, p2's index for provisioning and self-update
+    # - p2/, provisioning metadata for unsupported self-update; the profile
+    # snapshots also contain wall-clock times and unordered entries
+    cp -r . $out/libexec
+    rm $out/libexec/{artifacts.xml,icon.xpm}
+    rm -r $out/libexec/p2/
+
+    # Tycho writes the wall clock into otherwise stable generated metadata.
+    sed -i '/^#.* UTC [0-9]\{4\}$/d' $out/libexec/configuration/config.ini
+    sed -i 's/<config date="[0-9]\+"/<config date="0"/' $out/libexec/configuration/org.eclipse.update/platform.xml
+
+    # Keep only the JNA native for the target platform.
+    find $out/libexec/plugins/com.sun.jna_* -type f -name libjnidispatch.so \
+      ! -path "*/com/sun/jna/${platform.jna}/*" -delete
+    chmod 755 $out/libexec/Archi
+
+    # SWT would otherwise unpack its JNI natives at runtime, bypassing
+    # autoPatchelfHook. Unpack them here and point swt.library.path at them
+    # instead. The glx and awt natives are excluded because Archi uses neither.
+    mkdir -p $out/lib/swt
+    unzip -q -o -d $out/lib/swt plugins/org.eclipse.swt.gtk.${platform.swt}_*.jar '*.so' \
+      -x '*-glx-*' '*-awt-*'
+    substituteInPlace $out/libexec/Archi.ini \
+      --replace-fail '-vmargs' "-vmargs
+    -Dswt.library.path=$out/lib/swt"
+
+    # Simulate the upstream release layout, where the launcher finds a JVM
+    # beside itself, so the wrapper does not have to put a JDK on PATH.
+    ln -s ${jdk21.home} $out/libexec/jre
+
+    popd
+
+    runHook postInstall
+  '';
+
+  # Wrap manually to keep the hook from also wrapping $out/libexec/Archi, which
+  # breaks Eclipse's argv[0]-derived lookup of Archi.ini.
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapper $out/libexec/Archi $out/bin/archi "''${gappsWrapperArgs[@]}"
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = finalAttrs.pname;
+      desktopName = "Archi";
+      comment = finalAttrs.meta.description;
+      exec = "${finalAttrs.meta.mainProgram} %f";
+      icon = "archi";
+      categories = [ "Development" ];
+      startupWMClass = "Archi";
+      mimeTypes = [ "application/x-archimate" ];
+    })
+  ];
+
+  passthru = {
+    tests.archi = nixosTests.archi;
+
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version-regex"
+        "release_(.*)"
+      ];
+    };
+  };
+
+  meta = {
+    description = "ArchiMate modelling tool";
+    homepage = "https://www.archimatetool.com/";
+    changelog = "https://github.com/archimatetool/archi/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    # Archi itself is built from source but Tycho resolves the Eclipse platform
+    # it is assembled onto from a p2 repository, which ships prebuilt bundles
+    # and prebuilt SWT/Equinox JNI libraries.
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode
+      binaryNativeCode
+    ];
+    mainProgram = "archi";
+    maintainers = with lib.maintainers; [ ilkecan ];
+    platforms = [ "x86_64-linux" ];
+  };
+})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -335,7 +335,6 @@ mapAliases {
   arc-browser = throw "arc-browser was removed due to being unmaintained"; # Added 2025-09-03
   arc-unpacker = throw "'arc-unpacker' has been removed because upstream archived the project in April 2022."; # Added 2026-09-02
   arc_unpacker = throw "'arc_unpacker' has been removed because upstream archived the project in April 2022."; # Added 2026-09-02
-  archi = throw "'archi' has been removed, since its upstream maintainers do not want it packaged"; # Added 2025-11-18
   archipelago-minecraft = throw "archipelago-minecraft has been removed, as upstream no longer ships minecraft as a default APWorld."; # Added 2025-07-15
   ArchiSteamFarm = warnAlias "ArchiSteamFarm has been renamed to/replaced by 'archisteamfarm'" archisteamfarm; # Added 2026-01-31
   archivebox = throw "archivebox has been removed, since the packaged version was stuck on django 3."; # Added 2025-08-01


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/archimatetool/archi

supersedes: #360270
resolves: #549873
related: #462964

Note that this package was previously dropped due to friction with upstream, but I don't think there is anything preventing us from adding it back. The main reason for its removal was the instability of upstream releases; this PR works around that issue by building the package from source instead.
 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
