### PR TITLE
nixos/consul: avoid generating an empty /etc/consul-addrs.json file

### DIFF
--- a/nixos/modules/services/networking/consul.nix
+++ b/nixos/modules/services/networking/consul.nix
@@ -20,8 +20,8 @@ let
 
   configFiles = [
     "/etc/consul.json"
-    "/etc/consul-addrs.json"
   ]
+  ++ lib.optional (devices != [ ]) "/etc/consul-addrs.json"
   ++ cfg.extraConfigFiles;
 
   devices = lib.attrValues (lib.filterAttrs (_: i: i != null) cfg.interface);
@@ -234,41 +234,44 @@ in
             ''
               mkdir -m 0700 -p ${dataDir}
               chown -R consul ${dataDir}
-
-              # Determine interface addresses
-              getAddrOnce () {
-                ip ${family} addr show dev "$1" scope global \
-                  | awk -F '[ /\t]*' '/inet/ {print $3}' | head -n 1
-              }
-              getAddr () {
-                ADDR="$(getAddrOnce $1)"
-                LEFT=60 # Die after 1 minute
-                while [ -z "$ADDR" ]; do
-                  sleep 1
-                  LEFT=$(expr $LEFT - 1)
-                  if [ "$LEFT" -eq "0" ]; then
-                    echo "Address lookup timed out"
-                    exit 1
-                  fi
-                  ADDR="$(getAddrOnce $1)"
-                done
-                echo "$ADDR"
-              }
-              echo "{" > /etc/consul-addrs.json
-              delim=" "
             ''
-            + lib.concatStrings (
-              lib.flip lib.mapAttrsToList cfg.interface (
-                name: i:
-                lib.optionalString (i != null) ''
-                  echo "$delim \"${name}_addr\": \"$(getAddr "${i}")\"" >> /etc/consul-addrs.json
-                  delim=","
-                ''
+            + lib.optionalString (devices != [ ]) (
+              ''
+                # Determine interface addresses
+                getAddrOnce () {
+                  ip ${family} addr show dev "$1" scope global \
+                    | awk -F '[ /\t]*' '/inet/ {print $3}' | head -n 1
+                }
+                getAddr () {
+                  ADDR="$(getAddrOnce $1)"
+                  LEFT=60 # Die after 1 minute
+                  while [ -z "$ADDR" ]; do
+                    sleep 1
+                    LEFT=$(expr $LEFT - 1)
+                    if [ "$LEFT" -eq "0" ]; then
+                      echo "Address lookup timed out"
+                      exit 1
+                    fi
+                    ADDR="$(getAddrOnce $1)"
+                  done
+                  echo "$ADDR"
+                }
+                echo "{" > /etc/consul-addrs.json
+                delim=" "
+              ''
+              + lib.concatStrings (
+                lib.flip lib.mapAttrsToList cfg.interface (
+                  name: i:
+                  lib.optionalString (i != null) ''
+                    echo "$delim \"${name}_addr\": \"$(getAddr "${i}")\"" >> /etc/consul-addrs.json
+                    delim=","
+                  ''
+                )
               )
-            )
-            + ''
-              echo "}" >> /etc/consul-addrs.json
-            '';
+              + ''
+                echo "}" >> /etc/consul-addrs.json
+              ''
+            );
         };
       }
 

--- a/nixos/modules/services/networking/consul.nix
+++ b/nixos/modules/services/networking/consul.nix
@@ -20,8 +20,8 @@ let
 
   configFiles = [
     "/etc/consul.json"
-    "/etc/consul-addrs.json"
   ]
+  ++ lib.optional (devices != [ ]) "/etc/consul-addrs.json"
   ++ cfg.extraConfigFiles;
 
   devices = lib.attrValues (lib.filterAttrs (_: i: i != null) cfg.interface);
@@ -233,41 +233,43 @@ in
                 else
                   "";
             in
-            ''
-              # Determine interface addresses
-              getAddrOnce () {
-                ip ${family} addr show dev "$1" scope global \
-                  | awk -F '[ /\t]*' '/inet/ {print $3}' | head -n 1
-              }
-              getAddr () {
-                ADDR="$(getAddrOnce $1)"
-                LEFT=60 # Die after 1 minute
-                while [ -z "$ADDR" ]; do
-                  sleep 1
-                  LEFT=$(expr $LEFT - 1)
-                  if [ "$LEFT" -eq "0" ]; then
-                    echo "Address lookup timed out"
-                    exit 1
-                  fi
+            lib.optionalString (devices != [ ]) (
+              ''
+                # Determine interface addresses
+                getAddrOnce () {
+                  ip ${family} addr show dev "$1" scope global \
+                    | awk -F '[ /\t]*' '/inet/ {print $3}' | head -n 1
+                }
+                getAddr () {
                   ADDR="$(getAddrOnce $1)"
-                done
-                echo "$ADDR"
-              }
-              echo "{" > /etc/consul-addrs.json
-              delim=" "
-            ''
-            + lib.concatStrings (
-              lib.flip lib.mapAttrsToList cfg.interface (
-                name: i:
-                lib.optionalString (i != null) ''
-                  echo "$delim \"${name}_addr\": \"$(getAddr "${i}")\"" >> /etc/consul-addrs.json
-                  delim=","
-                ''
+                  LEFT=60 # Die after 1 minute
+                  while [ -z "$ADDR" ]; do
+                    sleep 1
+                    LEFT=$(expr $LEFT - 1)
+                    if [ "$LEFT" -eq "0" ]; then
+                      echo "Address lookup timed out"
+                      exit 1
+                    fi
+                    ADDR="$(getAddrOnce $1)"
+                  done
+                  echo "$ADDR"
+                }
+                echo "{" > /etc/consul-addrs.json
+                delim=" "
+              ''
+              + lib.concatStrings (
+                lib.flip lib.mapAttrsToList cfg.interface (
+                  name: i:
+                  lib.optionalString (i != null) ''
+                    echo "$delim \"${name}_addr\": \"$(getAddr "${i}")\"" >> /etc/consul-addrs.json
+                    delim=","
+                  ''
+                )
               )
-            )
-            + ''
-              echo "}" >> /etc/consul-addrs.json
-            '';
+              + ''
+                echo "}" >> /etc/consul-addrs.json
+              ''
+            );
         };
       }
 


### PR DESCRIPTION
Creating this file unconditionally, even when there is nothing in cfg.interface, gets in the way of using the immutable etc overlay.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
