### PR TITLE
python3Packages.openai: 2.41.1 -> 2.53.0

### DIFF
--- a/pkgs/development/python-modules/openai/default.nix
+++ b/pkgs/development/python-modules/openai/default.nix
@@ -49,10 +49,10 @@
   respx,
 
   # optional-dependencies toggle
-  withAiohttp ? true,
+  withAiohttp ? false,
   withDatalib ? false,
-  withRealtime ? true,
-  withVoiceHelpers ? true,
+  withRealtime ? false,
+  withVoiceHelpers ? false,
 }:
 
 buildPythonPackage (finalAttrs: {

--- a/pkgs/development/python-modules/openai/default.nix
+++ b/pkgs/development/python-modules/openai/default.nix
@@ -21,10 +21,16 @@
   aiohttp,
   httpx-aiohttp,
 
+  # optional-dependencies (bedock)
+  botocore,
+
   # optional-dependencies (datalib)
   numpy,
   pandas,
   pandas-stubs,
+
+  # optional-dependencies (httpx2)
+  httpx2,
 
   # optional-dependencies (realtime)
   websockets,
@@ -36,7 +42,7 @@
   pytestCheckHook,
   dirty-equals,
   inline-snapshot,
-  nest-asyncio,
+  jsonschema,
   pytest-asyncio,
   pytest-mock,
   pytest-xdist,
@@ -49,16 +55,16 @@
   withVoiceHelpers ? true,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "openai";
-  version = "2.41.1";
+  version = "2.53.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "openai";
     repo = "openai-python";
-    tag = "v${version}";
-    hash = "sha256-jSkBxZY5POlrznhBwFMR2NcL92uGRSYI6BDDC3C7RfU=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-XwiSIKjYD07zhx8uIO8wsPWdAASBCJ5KqFUgdk+uaUU=";
   };
 
   postPatch = ''substituteInPlace pyproject.toml --replace-fail "hatchling==1.26.3" "hatchling"'';
@@ -78,20 +84,28 @@ buildPythonPackage rec {
     tqdm
     typing-extensions
   ]
-  ++ lib.optionals withAiohttp optional-dependencies.aiohttp
-  ++ lib.optionals withDatalib optional-dependencies.datalib
-  ++ lib.optionals withRealtime optional-dependencies.realtime
-  ++ lib.optionals withVoiceHelpers optional-dependencies.voice-helpers;
+  ++ lib.optionals withAiohttp finalAttrs.passthru.optional-dependencies.aiohttp
+  ++ lib.optionals withDatalib finalAttrs.passthru.optional-dependencies.datalib
+  ++ lib.optionals withRealtime finalAttrs.passthru.optional-dependencies.realtime
+  ++ lib.optionals withVoiceHelpers finalAttrs.passthru.optional-dependencies.voice-helpers;
 
   optional-dependencies = {
     aiohttp = [
       aiohttp
       httpx-aiohttp
     ];
+    bedrock = [
+      botocore
+    ];
     datalib = [
       numpy
       pandas
       pandas-stubs
+    ];
+    httpx2 = [
+      anyio
+      httpx
+      httpx2
     ];
     realtime = [
       websockets
@@ -108,12 +122,14 @@ buildPythonPackage rec {
     pytestCheckHook
     dirty-equals
     inline-snapshot
-    nest-asyncio
+    jsonschema
     pytest-asyncio
     pytest-mock
     pytest-xdist
     respx
-  ];
+  ]
+  # including pandas-stubs would cause infinite recursion
+  ++ lib.concatAttrValues (lib.removeAttrs finalAttrs.passthru.optional-dependencies [ "datalib" ]);
 
   disabledTestPaths = [
     # Test makes network requests
@@ -126,8 +142,8 @@ buildPythonPackage rec {
   meta = {
     description = "Python client library for the OpenAI API";
     homepage = "https://github.com/openai/openai-python";
-    changelog = "https://github.com/openai/openai-python/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/openai/openai-python/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.malo ];
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/openai/openai-python/compare/v2.41.1...v2.53.0

Changelog: https://github.com/openai/openai-python/blob/v2.53.0/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
