### PR TITLE
turnon: 2.9.3 -> 3.2.2

### DIFF
--- a/pkgs/by-name/tu/turnon/package.nix
+++ b/pkgs/by-name/tu/turnon/package.nix
@@ -14,7 +14,7 @@
 }:
 
 let
-  version = "2.9.3";
+  version = "3.2.2";
 in
 rustPlatform.buildRustPackage {
   pname = "turnon";
@@ -24,10 +24,10 @@ rustPlatform.buildRustPackage {
     owner = "swsnr";
     repo = "turnon";
     rev = "v${version}";
-    hash = "sha256-2dPvIuD7gVfhr/E5szJ5rqWL5yRJKZoj2lV+W9CyCjI=";
+    hash = "sha256-GccO6zwIR/JFdKE3uUQZ3RaBMm9tHumP7jpZRb6n5uU=";
   };
 
-  cargoHash = "sha256-e0Hds/y3qh7Th+ZTqHIfVleh3vmDlKKJ5Bwt64g5c60=";
+  cargoHash = "sha256-5FBVDNzmen/GnfN6JBmxU4et9gkxZt8RjSD12t/2THI=";
 
   doCheck = true;
 
@@ -56,7 +56,7 @@ rustPlatform.buildRustPackage {
 
   postPatch = ''
     substituteInPlace justfile \
-        --replace-fail "version := \`git describe\`" "version := \"${version}\"" \
+        --replace-fail "version := \`git describe --always\`" "version := \"${version}\"" \
         --replace-fail "DESTPREFIX := '/app'" "DESTPREFIX := '$out'" \
         --replace-fail "APPID := 'de.swsnr.turnon.Devel'" "APPID := 'de.swsnr.turnon'" \
         --replace-fail "just --list" "just compile" # Replacing the default recipe with the compile command as just-hook-buildPhase runs the default recipe to compile the package.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
