### PR TITLE
python3Packages.fastmcp: 3.3.1 -> 3.4.7

### DIFF
--- a/pkgs/development/python-modules/fastmcp/default.nix
+++ b/pkgs/development/python-modules/fastmcp/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   writableTmpDirAsHomeHook,
 
   # build-system
@@ -29,7 +30,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "fastmcp";
-  version = "3.3.1";
+  version = "3.4.7";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -37,8 +38,18 @@ buildPythonPackage (finalAttrs: {
     owner = "PrefectHQ";
     repo = "fastmcp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-1W5NbWIULxFXGSozZEeITcPt1EbY6IsJLQdyevcn9BI=";
+    hash = "sha256-EysVbtFbop5ENupc9T5EmtUSZ8osVtQSzpwa6rea/OQ=";
   };
+
+  patches = [
+    # Fix python 3.14 compatibility (https://github.com/PrefectHQ/fastmcp/pull/4796)
+    # TODO: remove when updating to the next release
+    (fetchpatch {
+      url = "https://github.com/PrefectHQ/fastmcp/commit/6be0ac8e15d35ff8f5121266855bc34c1158c9a1.patch";
+      includes = [ "fastmcp_slim/fastmcp/tools/function_tool.py" ];
+      hash = "sha256-7N86b5sslWLgoB2dS2Xh3JfZX3oTHeXfeSJOaWKI5b0=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace pyproject.toml \
@@ -108,8 +119,11 @@ buildPythonPackage (finalAttrs: {
     "test_nested_streamable_http_server_resolves_correctly"
 
     # Requires prefab-ui (optional dependency)
+    # https://github.com/NixOS/nixpkgs/pull/510123 adds the prefab-ui package.
     "TestPrefabAppConfig"
     "test_doc_examples_quality"
+    "test_run_dev_apps_with_host"
+    "test_run_dev_apps_log_panel_propagation"
 
     # AssertionError: assert 'INFO' == 'DEBUG'
     "test_temporary_settings"
@@ -119,6 +133,14 @@ buildPythonPackage (finalAttrs: {
     "test_multi_server"
     "test_server_starts_without_auth"
     "test_canonical_multi_client_with_transforms"
+
+    # Server startup is flaky when the suite runs with pytest-xdist
+    "test_unauthorized_access"
+
+    # Timing-sensitive and flaky
+    "test_rate_limiting_recovery_over_time"
+    "test_rate_limiting_with_different_operations"
+    "test_timeout"
 
     # RuntimeError: Attempted to exit a cancel scope that isn't the current tasks's current cancel scope
     "test_stateful_proxy"


### PR DESCRIPTION
Diff: https://github.com/PrefectHQ/fastmcp/compare/v3.3.1...v3.4.7

Changelog: https://github.com/PrefectHQ/fastmcp/releases/tag/v3.4.7


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
