### PR TITLE
python3Packages.mutagen: 1.47.0 -> 1.48.1

### DIFF
--- a/pkgs/development/python-modules/mediafile/default.nix
+++ b/pkgs/development/python-modules/mediafile/default.nix
@@ -29,6 +29,11 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  disabledTestPaths = [
+    # https://github.com/beetbox/mediafile/issues/109
+    "test/test_mediafile.py::OpusTest::test_read_audio_properties"
+  ];
+
   pythonImportsCheck = [ "mediafile" ];
 
   meta = {

--- a/pkgs/development/python-modules/mutagen/default.nix
+++ b/pkgs/development/python-modules/mutagen/default.nix
@@ -1,15 +1,13 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
-  fetchpatch,
+  fetchFromGitHub,
 
   # build-system
   setuptools,
 
   # docs
-  python,
-  sphinx,
+  sphinxHook,
   sphinx-rtd-theme,
 
   # tests
@@ -17,51 +15,35 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "mutagen";
-  version = "1.47.0";
+  version = "1.48.1";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-cZ+t7wqXjDG0zzyVYmGzxYtpSLMgIweKIRex3gnw/Jk=";
+  src = fetchFromGitHub {
+    owner = "quodlibet";
+    repo = "mutagen";
+    tag = "release-${finalAttrs.version}";
+    hash = "sha256-CasNC5oW59WOUr7WSu4lUnYYzs6ow8RuJAylqNW7geA=";
   };
-
-  patches = [
-    # fix compatibility with hypothesis CI profile
-    # (remove on next release)
-    (fetchpatch {
-      url = "https://github.com/quodlibet/mutagen/commit/967212631719de1aeccbd6855c5b6d03f271fdfe.patch";
-      hash = "sha256-jfCz8qTGZpnP6ICMB9K/Dgyp9TQeMuDq+V6kPFA3Q44=";
-    })
-  ];
 
   outputs = [
     "out"
     "doc"
   ];
 
-  nativeBuildInputs = [
+  build-system = [
     setuptools
-    sphinx
-    sphinx-rtd-theme
   ];
 
-  postInstall = ''
-    ${python.pythonOnBuildForHost.interpreter} setup.py build_sphinx --build-dir=$doc
-  '';
+  nativeBuildInputs = [
+    sphinxHook
+    sphinx-rtd-theme
+  ];
 
   nativeCheckInputs = [
     hypothesis
     pytestCheckHook
-  ];
-
-  disabledTests = [
-    # Hypothesis produces unreliable results: Falsified on the first call but did not on a subsequent one
-    "test_test_fileobj_save"
-    "test_test_fileobj_load"
-    "test_test_fileobj_delete"
-    "test_mock_fileobj"
   ];
 
   pythonImportsCheck = [ "mutagen" ];
@@ -80,9 +62,9 @@ buildPythonPackage rec {
     '';
     homepage = "https://mutagen.readthedocs.io";
     changelog = "https://mutagen.readthedocs.io/en/latest/changelog.html#release-${
-      lib.replaceStrings [ "." ] [ "-" ] version
+      lib.replaceString "." "-" finalAttrs.version
     }";
     license = lib.licenses.gpl2Plus;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.dotlambda ];
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/quodlibet/mutagen/compare/release-1.47.0...release-1.48.1

Changelog: https://mutagen.readthedocs.io/en/latest/changelog.html#release-1-48-1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
