### PR TITLE
openlogi: 0.3.4 -> 0.6.25, add Linux support

### DIFF
--- a/pkgs/by-name/op/openlogi/package.nix
+++ b/pkgs/by-name/op/openlogi/package.nix
@@ -4,15 +4,27 @@
   rustPlatform,
   fetchFromGitHub,
   cargo-bundle,
-  libicns,
-  resvg,
   nix-update-script,
   versionCheckHook,
 }:
 
+let
+  # crates/openlogi-gui/build.rs embeds gpui-component's themes, which live at
+  # that repo's root rather than inside the crate, so cargo vendoring drops them.
+  # Fetch the rev Cargo.lock pins and point build.rs's OPENLOGI_THEMES_DIR
+  # escape hatch at it. This pin follows Cargo.lock rather than openlogi's
+  # version, and nix-update does not maintain it.
+  gpuiComponentThemes = fetchFromGitHub {
+    owner = "longbridge";
+    repo = "gpui-component";
+    rev = "031555662e99a1b5a549990b47f246d475b8288a";
+    hash = "sha256-yOXdgxQgfvGN2/+OdDnl1pYti0DoGFvS3Tyqvj3Bkng=";
+  };
+in
+
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "openlogi";
-  version = "0.3.4";
+  version = "0.6.25";
 
   strictDeps = true;
   __structuredAttrs = true;
@@ -21,12 +33,17 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "AprilNEA";
     repo = "OpenLogi";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-04o/Ry65CdNtycgJfqhXwTD5InUwfkr88xQ+I/5Pe4o=";
+    hash = "sha256-JziSstP3TdPVuqpZHtStT5fEy431tdFW7nB6bZvMyVA=";
   };
 
-  cargoHash = "sha256-nKQRcRsEq5JJpn0DZIssS/wAwVsj4kq9J2WmQXJ3smY=";
+  cargoHash = "sha256-MVmPZ2IDss6+HmHKGdg4Q3g4W/fJgaQRGKoeUKDiEFU=";
 
   postPatch = ''
+    grep -q 'gpui-component?rev=${gpuiComponentThemes.rev}' Cargo.lock || {
+      echo "ERROR: gpui-component revision needs update (must match Cargo.lock)"
+      exit 1
+    }
+
     # gpui-component generates its IconName enum from a sibling assets directory,
     # but cargo vendoring stores gpui-component-assets as a separate package.
     for component in "$cargoDepsCopy"/source-git-*/gpui-component-[0-9]*; do
@@ -43,8 +60,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeBuildInputs = [
     cargo-bundle
-    libicns
-    resvg
     rustPlatform.bindgenHook
   ];
 
@@ -59,24 +74,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "gpui_platform/runtime_shaders"
   ];
 
-  # Upstream intentionally fetches optional device images on first launch
-  # unless OPENLOGI_BUNDLE_ASSETS is set while bundling.
-  preBuild = ''
-    iconset=$(mktemp -d)
-    for size in 16 32 128 256 512; do
-      resvg \
-        --width "$size" \
-        --height "$size" \
-        design/icon/openlogi.svg \
-        "$iconset/icon_''${size}x''${size}.png"
-    done
-
-    mkdir -p crates/openlogi-gui/icon
-    png2icns crates/openlogi-gui/icon/AppIcon.icns "$iconset"/*.png
-
-    rm -rf crates/openlogi-gui/assets
-    mkdir -p crates/openlogi-gui/assets
-  '';
+  env.OPENLOGI_THEMES_DIR = "${gpuiComponentThemes}/themes";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/op/openlogi/package.nix
+++ b/pkgs/by-name/op/openlogi/package.nix
@@ -4,8 +4,18 @@
   rustPlatform,
   fetchFromGitHub,
   cargo-bundle,
+  fontconfig,
+  freetype,
+  libGL,
+  libxcb,
+  libxkbcommon,
+  makeBinaryWrapper,
   nix-update-script,
+  openssl,
+  pkg-config,
   versionCheckHook,
+  vulkan-loader,
+  wayland,
 }:
 
 let
@@ -59,13 +69,33 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   nativeBuildInputs = [
-    cargo-bundle
     rustPlatform.bindgenHook
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    cargo-bundle
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    makeBinaryWrapper
+    pkg-config
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    fontconfig
+    freetype
+    libGL
+    libxcb
+    libxkbcommon
+    openssl
+    vulkan-loader
+    wayland
   ];
 
   cargoBuildFlags = [
     "--package=openlogi"
     "--package=openlogi-gui"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    "--package=openlogi-agent"
   ];
 
   cargoTestFlags = [ "--workspace" ];
@@ -80,6 +110,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     runHook preInstall
 
     release_target="target/${stdenv.hostPlatform.rust.cargoShortTarget}/release"
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
     mv "$release_target/openlogi-gui" target/release/openlogi-gui
 
     pushd crates/openlogi-gui
@@ -90,8 +122,47 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mkdir -p "$out/Applications" "$out/bin"
     mv "$app_path" "$out/Applications/"
     install -Dm755 "$release_target/openlogi" "$out/bin/openlogi"
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    install -Dm755 "$release_target/openlogi" "$out/bin/openlogi"
+    install -Dm755 "$release_target/openlogi-gui" "$out/bin/openlogi-gui"
+    install -Dm755 "$release_target/openlogi-agent" "$out/bin/openlogi-agent"
 
+    # Upstream's own packaging inputs, installed verbatim rather than
+    # re-authored here (they are what the .deb/.rpm ship).
+    install -Dm644 packaging/linux/udev/70-openlogi.rules \
+      "$out/lib/udev/rules.d/70-openlogi.rules"
+    install -Dm644 packaging/linux/desktop/openlogi.desktop \
+      "$out/share/applications/openlogi.desktop"
+    install -Dm644 packaging/linux/systemd/openlogi-agent.service \
+      "$out/share/systemd/user/openlogi-agent.service"
+
+    # The unit hardcodes /usr/bin (upstream's install.sh rewrites it for a
+    # custom PREFIX); point it at the store path instead.
+    substituteInPlace "$out/share/systemd/user/openlogi-agent.service" \
+      --replace-fail "ExecStart=/usr/bin/openlogi-agent" \
+                     "ExecStart=$out/bin/openlogi-agent"
+
+    install -Dm644 design/icon/openlogi.png \
+      "$out/share/icons/hicolor/1024x1024/apps/openlogi.png"
+  ''
+  + ''
     runHook postInstall
+  '';
+
+  # GPUI (Blade) dlopen()s its Vulkan/Wayland/GL backends at runtime, so they
+  # are invisible to the linker and must be on the wrapper's search path.
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    wrapProgram "$out/bin/openlogi-gui" \
+      --suffix LD_LIBRARY_PATH : "${
+        lib.makeLibraryPath [
+          libGL
+          libxcb
+          libxkbcommon
+          vulkan-loader
+          wayland
+        ]
+      }"
   '';
 
   doInstallCheck = true;
@@ -110,6 +181,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     ];
     mainProgram = "openlogi";
     maintainers = with lib.maintainers; [ imcvampire ];
-    platforms = lib.platforms.darwin;
+    platforms = lib.platforms.darwin ++ [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
   };
 })


### PR DESCRIPTION
Bumps `openlogi` 0.3.4 -> 0.6.25 and adds `x86_64-linux` / `aarch64-linux` alongside the existing Darwin support.

Changelog: https://github.com/AprilNEA/OpenLogi/releases/tag/v0.6.25

Split into two commits: the version bump (which Darwin needs on its own — see below), then the Linux platform work.

### Why now

Upstream has shipped Linux `.deb`/`.rpm` artifacts since 0.6.19, but the GUI panicked on startup there (a `RefCell` double-borrow when the theme was applied from inside the XDG portal appearance callback, AprilNEA/OpenLogi#337). That was fixed in 0.6.20, and 0.6.21 added a Linux client-side titlebar. The build needs no patching — only the GPUI runtime dependencies and packaging.

### Packaging changes the version alone doesn't explain

* **`preBuild` is gone, and this bump requires that.** 0.6.x no longer ships `design/icon/openlogi.svg`, so rendering the icon there would fail on a missing file. Upstream has committed a prebuilt `crates/openlogi-gui/icon/AppIcon.icns` since 0.6.19, which `cargo-bundle` picks up directly — dropping both `resvg` and `libicns` from `nativeBuildInputs`. The rest of the hook scrubbed `crates/openlogi-gui/assets`, a directory the release tarball does not contain: `cargo-bundle` resolves the crate's `resources = ["assets/**/*"]` with a plain glob, and a glob matching nothing is not an error, so creating it empty changed no bundle either.
* **`OPENLOGI_THEMES_DIR` and the extra source.** `crates/openlogi-gui/build.rs` now embeds the upstream gpui-component themes at build time. Those JSON files live at the gpui-component repo *root*, next to rather than inside the crate, and cargo vendoring only takes crates — so `build.rs`'s `cargo metadata` walk finds no ancestor containing `themes/catppuccin.json` and panics. Fetching the exact rev `Cargo.lock` pins gpui-component 0.5.2 to, and setting the documented `OPENLOGI_THEMES_DIR` escape hatch, is the smallest fix I found. (It has to go through `env` because `__structuredAttrs` keeps plain attrs out of the build environment.) I looked for a way to avoid the second source and could not find one: `fetchCargoVendor` clones the whole repo but keeps only the crate subtree (`copy_and_patch_git_crate_subtree`), `rustPlatform.importCargoLock` does the same, and reading the rev out of `Cargo.lock` at eval time would be IFD. Since that leaves the rev duplicated with nothing keeping it in sync, `postPatch` asserts the two still agree — the same guard `pkgs/by-name/mo/moonshine` uses for `inputtino`. A stale pin then fails in `patchPhase` instead of silently embedding themes from the wrong revision.
* **Linux packaging comes from `$src`.** The udev rule, desktop entry and systemd user unit are installed from `packaging/linux/` rather than authored in the derivation — they are the same files upstream feeds to nfpm for the `.deb`. Only the unit is modified, to rewrite its hardcoded `/usr/bin` `ExecStart` to the store path (upstream's `install.sh` does the same for a custom `PREFIX`).
* **Three binaries on Linux, two on Darwin.** `openlogi-agent` is the daemon the GUI talks to over `agent.sock` for device control; it gained Linux support in 0.6.19. Darwin's build is otherwise untouched.
* **The GUI needs a wrapper on Linux.** GPUI (Blade) `dlopen()`s its Vulkan/Wayland/GL backends, so they are invisible to the linker.

### Platform coverage

I have no Darwin machine, so the Darwin builds come from `nixpkgs-review-gha`. On `99b6243` it built `openlogi` on `x86_64-linux`, `aarch64-linux` and `aarch64-darwin` (sandbox relaxed); `x86_64-darwin` reports no rebuilds. That covers the part of the bump I could not check myself — Darwin's `installPhase` now consumes the committed `.icns` instead of generating one, and `cargo-bundle` still produces a valid `.app` from it.

What is still unverified anywhere: nobody has **launched the GUI on macOS**. A successful build is not a smoke test, and `versionCheckHook` only exercises the CLI binary. cc @imcvampire as maintainer.

On Linux the upstream workspace test suite (`cargoTestFlags = [ "--workspace" ]`) runs in the sandbox and passes: 796 tests, 0 failures, so Linux is not getting weaker test coverage than Darwin.

### Disclosure

This contribution was prepared with AI assistance (Claude Code, `claude-opus-5`), including this pull request description. Each commit carries an `Assisted-by:` trailer. I have reviewed the derivation and the reasoning behind each packaging decision above, and am accountable for it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

