### PR TITLE
soapui: enable Java FX

### DIFF
--- a/pkgs/by-name/so/soapui/package.nix
+++ b/pkgs/by-name/so/soapui/package.nix
@@ -3,10 +3,18 @@
   lib,
   stdenv,
   writeText,
-  jdk,
+  openjdk21,
+  openjfx21,
   makeWrapper,
   nixosTests,
 }:
+let
+  openjfx_jdk = openjfx21.override { withWebKit = true; };
+  jdk = openjdk21.override {
+    enableJavaFX = true;
+    inherit openjfx_jdk;
+  };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "soapui";
   version = "5.9.1";


### PR DESCRIPTION

<details>
<summary>Current version of SoapUI does not launch without Java FX:</summary>
<pre>
$ nix run nixpkgs\#soapui
================================
=
= SOAPUI_HOME = /nix/store/qpa312rkbdjcdz2vcq5nqp0nw62y8msf-soapui-5.9.1/share/java
=
================================
Configuring log4j from [/nix/store/qpa312rkbdjcdz2vcq5nqp0nw62y8msf-soapui-5.9.1/share/java/bin/soapui-log4j.xml]
20:18:34,707 INFO  [DefaultSoapUICore] initialized soapui-settings from [/home/adomas/soapui-settings.xml]
20:18:35,056 INFO  [PluginManager] 0 plugins loaded in 1 ms
20:18:35,057 INFO  [DefaultSoapUICore] All plugins loaded
20:18:35,395 INFO  [WorkspaceImpl] Loading workspace from [/home/adomas/default-soapui-workspace.xml]
20:18:35,521 INFO  [SoapUI] Used java version: 21.0.12
rugp. 09, 2026 8:18:36 POPIET com.sun.javafx.application.PlatformImpl startup
WARNING: Unsupported JavaFX configuration: classes were loaded from 'unnamed module @3b2cf7ab'
Loading library prism_es2 from resource failed: java.lang.UnsatisfiedLinkError: /home/adomas/.openjfx/cache/17.0.12/libprism_es2.so: libXxf86vm.so.1: cannot open shared object file: No such file or directory
java.lang.UnsatisfiedLinkError: /home/adomas/.openjfx/cache/17.0.12/libprism_es2.so: libXxf86vm.so.1: cannot open shared object file: No such file or directory
	at java.base/jdk.internal.loader.NativeLibraries.load(Native Method)
	at java.base/jdk.internal.loader.NativeLibraries$NativeLibraryImpl.open(NativeLibraries.java:331)
	at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(NativeLibraries.java:197)
	at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(NativeLibraries.java:139)
	at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2418)
	at java.base/java.lang.Runtime.load0(Runtime.java:852)
	at java.base/java.lang.System.load(System.java:2026)
	at com.sun.glass.utils.NativeLibLoader.installLibraryFromResource(NativeLibLoader.java:217)
	at com.sun.glass.utils.NativeLibLoader.loadLibraryFromResource(NativeLibLoader.java:197)
	at com.sun.glass.utils.NativeLibLoader.loadLibraryInternal(NativeLibLoader.java:138)
	at com.sun.glass.utils.NativeLibLoader.loadLibrary(NativeLibLoader.java:54)
	at com.sun.prism.es2.ES2Pipeline.lambda$static$0(ES2Pipeline.java:63)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:319)
	at com.sun.prism.es2.ES2Pipeline.<clinit>(ES2Pipeline.java:52)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:423)
	at java.base/java.lang.Class.forName(Class.java:414)
	at com.sun.prism.GraphicsPipeline.createPipeline(GraphicsPipeline.java:218)
	at com.sun.javafx.tk.quantum.QuantumRenderer$PipelineRunnable.init(QuantumRenderer.java:92)
	at com.sun.javafx.tk.quantum.QuantumRenderer$PipelineRunnable.run(QuantumRenderer.java:125)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Loading library glassgtk3 from resource failed: java.lang.UnsatisfiedLinkError: /home/adomas/.openjfx/cache/17.0.12/libglassgtk3.so: libgthread-2.0.so.0: cannot open shared object file: No such file or directory
java.lang.UnsatisfiedLinkError: /home/adomas/.openjfx/cache/17.0.12/libglassgtk3.so: libgthread-2.0.so.0: cannot open shared object file: No such file or directory
	at java.base/jdk.internal.loader.NativeLibraries.load(Native Method)
	at java.base/jdk.internal.loader.NativeLibraries$NativeLibraryImpl.open(NativeLibraries.java:331)
	at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(NativeLibraries.java:197)
	at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(NativeLibraries.java:139)
	at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2418)
	at java.base/java.lang.Runtime.load0(Runtime.java:852)
	at java.base/java.lang.System.load(System.java:2026)
	at com.sun.glass.utils.NativeLibLoader.installLibraryFromResource(NativeLibLoader.java:217)
	at com.sun.glass.utils.NativeLibLoader.loadLibraryFromResource(NativeLibLoader.java:197)
	at com.sun.glass.utils.NativeLibLoader.loadLibraryInternal(NativeLibLoader.java:138)
	at com.sun.glass.utils.NativeLibLoader.loadLibrary(NativeLibLoader.java:54)
	at com.sun.glass.ui.gtk.GtkApplication.lambda$new$6(GtkApplication.java:195)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:319)
	at com.sun.glass.ui.gtk.GtkApplication.<init>(GtkApplication.java:179)
	at com.sun.glass.ui.gtk.GtkPlatformFactory.createApplication(GtkPlatformFactory.java:41)
	at com.sun.glass.ui.Application.run(Application.java:146)
	at com.sun.javafx.tk.quantum.QuantumToolkit.startup(QuantumToolkit.java:290)
	at com.sun.javafx.application.PlatformImpl.startup(PlatformImpl.java:293)
	at com.sun.javafx.application.PlatformImpl.startup(PlatformImpl.java:163)
	at javafx.embed.swing.JFXPanel.lambda$initFx$1(JFXPanel.java:230)
	at java.base/java.lang.Thread.run(Thread.java:1583)
java.lang.RuntimeException: java.lang.UnsatisfiedLinkError: no glassgtk3 in java.library.path: /nix/store/qpa312rkbdjcdz2vcq5nqp0nw62y8msf-soapui-5.9.1/share/java/bin
	at com.sun.javafx.tk.quantum.QuantumToolkit.startup(QuantumToolkit.java:300)
	at com.sun.javafx.application.PlatformImpl.startup(PlatformImpl.java:293)
	at com.sun.javafx.application.PlatformImpl.startup(PlatformImpl.java:163)
	at javafx.embed.swing.JFXPanel.lambda$initFx$1(JFXPanel.java:230)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.UnsatisfiedLinkError: no glassgtk3 in java.library.path: /nix/store/qpa312rkbdjcdz2vcq5nqp0nw62y8msf-soapui-5.9.1/share/java/bin
	at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2458)
	at java.base/java.lang.Runtime.loadLibrary0(Runtime.java:916)
	at java.base/java.lang.System.loadLibrary(System.java:2064)
	at com.sun.glass.utils.NativeLibLoader.loadLibraryInternal(NativeLibLoader.java:166)
	at com.sun.glass.utils.NativeLibLoader.loadLibrary(NativeLibLoader.java:54)
	at com.sun.glass.ui.gtk.GtkApplication.lambda$new$6(GtkApplication.java:195)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:319)
	at com.sun.glass.ui.gtk.GtkApplication.<init>(GtkApplication.java:179)
	at com.sun.glass.ui.gtk.GtkPlatformFactory.createApplication(GtkPlatformFactory.java:41)
	at com.sun.glass.ui.Application.run(Application.java:146)
	at com.sun.javafx.tk.quantum.QuantumToolkit.startup(QuantumToolkit.java:290)
	... 4 more
</pre>
</details>
I have also enabled Webkit because the startup dialog contains HTML and it is blank otherwise.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
