### PR TITLE
lxgw-bright: init at 5.528

### DIFF
--- a/pkgs/by-name/lx/lxgw-bright/package.nix
+++ b/pkgs/by-name/lx/lxgw-bright/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  p7zip,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "lxgw-bright";
+  version = "5.528";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchurl {
+    url = "https://github.com/lxgw/LxgwBright/releases/download/v${finalAttrs.version}/LXGWBright.7z";
+    hash = "sha256-pHa6liDc4Pu6dSL+V47VzHuhRRg2NhKvWD/gfqM5c+o=";
+  };
+
+  nativeBuildInputs = [ p7zip ];
+  dontBuild = true;
+
+  unpackPhase = ''
+    runHook preUnpack
+    7z x $src
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/fonts/truetype
+    find . -name "*.ttf" -exec install -m644 {} $out/share/fonts/truetype/ \;
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/lxgw/LxgwBright";
+    description = "A merged font of Ysabeau and LXGW WenKai.";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
LXGW Bright is a merged font of Ysabeau and LXGW WenKai. See <https://github.com/lxgw/LxgwBright>.

---

Add via a mailinglist contributor from here: https://lists.sr.ht/~andir/nixpkgs-dev/patches/70903

The author is not added to maintainers-list because they do not have a github account.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
