### PR TITLE
triton-llvm: re-enable BUILD_SHARED_LIBS to save 3GiB

### DIFF
--- a/pkgs/by-name/tr/triton-llvm/package.nix
+++ b/pkgs/by-name/tr/triton-llvm/package.nix
@@ -130,8 +130,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "LLVM_INCLUDE_DOCS" (buildDocs || buildMan))
     (lib.cmakeBool "MLIR_INCLUDE_DOCS" (buildDocs || buildMan))
     (lib.cmakeBool "LLVM_BUILD_DOCS" (buildDocs || buildMan))
-    # It's tempting to set BUILD_SHARED_LIBS, which saves far more space
-    # but currently segfaults in keras's test suite. More work needed.
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
     (lib.cmakeBool "LLVM_TOOL_LLVM_DRIVER_BUILD" true) # Save space by using busybox style tool binary
     # Way too slow, only uses one core
     # (lib.cmakeBool "LLVM_ENABLE_DOXYGEN" (buildDocs || buildMan))

--- a/pkgs/development/python-modules/tensorflow/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/bin.nix
@@ -107,6 +107,12 @@ buildPythonPackage (finalAttrs: {
   ]
   ++ lib.optional (!isPy3k) mock;
 
+  # Don't set RTLD_GLOBAL by removing file only meant to ship in static builds.
+  # https://github.com/tensorflow/tensorflow/commit/5720ab7845de0b2a2e2f5fdf547d2515d39a20b9
+  postInstall = ''
+    rm $out/${python.sitePackages}/tensorflow/python/pywrap_dlopen_global_flags.py
+  '';
+
   preConfigure = ''
     unset SOURCE_DATE_EPOCH
 

--- a/pkgs/development/python-modules/tensorflow/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/bin.nix
@@ -110,6 +110,12 @@ buildPythonPackage (finalAttrs: {
   ]
   ++ lib.optional (!isPy3k) mock;
 
+  # Don't set RTLD_GLOBAL by removing file only meant to ship in static builds.
+  # https://github.com/tensorflow/tensorflow/commit/5720ab7845de0b2a2e2f5fdf547d2515d39a20b9
+  postInstall = ''
+    rm $out/${python.sitePackages}/tensorflow/python/pywrap_dlopen_global_flags.py
+  '';
+
   preConfigure = ''
     unset SOURCE_DATE_EPOCH
 

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -628,13 +628,19 @@ buildPythonPackage {
       -e "s/'protobuf[^']*',/'protobuf',/"
   '';
 
-  # Upstream has a pip hack that results in bin/tensorboard being in both tensorflow
-  # and the propagated input tensorboard, which causes environment collisions.
-  # Another possibility would be to have tensorboard only in the buildInputs
-  # https://github.com/tensorflow/tensorflow/blob/v1.7.1/tensorflow/tools/pip_package/setup.py#L79
-  postInstall = ''
-    rm $out/bin/tensorboard
-  '';
+  postInstall =
+    # Upstream has a pip hack that results in bin/tensorboard being in both tensorflow
+    # and the propagated input tensorboard, which causes environment collisions.
+    # Another possibility would be to have tensorboard only in the buildInputs
+    # https://github.com/tensorflow/tensorflow/blob/v1.7.1/tensorflow/tools/pip_package/setup.py#L79
+    ''
+      rm $out/bin/tensorboard
+    ''
+    # Don't set RTLD_GLOBAL by removing file only meant to ship in static builds.
+    # https://github.com/tensorflow/tensorflow/commit/5720ab7845de0b2a2e2f5fdf547d2515d39a20b9
+    + ''
+      rm $out/${python.sitePackages}/tensorflow/python/pywrap_dlopen_global_flags.py
+    '';
 
   setupPyGlobalFlags = [
     "--project_name"

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -634,6 +634,10 @@ buildPythonPackage {
   # https://github.com/tensorflow/tensorflow/blob/v1.7.1/tensorflow/tools/pip_package/setup.py#L79
   postInstall = ''
     rm $out/bin/tensorboard
+
+    # Don't set RTLD_GLOBAL by removing file only meant to ship in static builds.
+    # https://github.com/tensorflow/tensorflow/commit/5720ab7845de0b2a2e2f5fdf547d2515d39a20b9
+    rm $out/${python.sitePackages}/tensorflow/python/pywrap_dlopen_global_flags.py
   '';
 
   setupPyGlobalFlags = [


### PR DESCRIPTION
Another attempt at #500596

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
