### PR TITLE
check-meta: do not force allowUnfree for every package

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -174,26 +174,31 @@ let
   # Defaults to allow all names defined in config.allowUnfreePackages, and all
   # packages that match the unfree predicate function
   hasDeniedUnfreeLicense =
-    if allowUnfree then
-      _: false
-    else
-      let
-        listPredicate = pkg: elem (getName pkg) config.allowUnfreePackages;
-        definedListPredicate = config.allowUnfreePackages or [ ] != [ ];
+    let
+      listPredicate = pkg: elem (getName pkg) config.allowUnfreePackages;
+      definedListPredicate = config.allowUnfreePackages or [ ] != [ ];
 
-        explicitPredicate = config.allowUnfreePredicate;
-        # Be robust against misconfigured allowUnfreePredicate values such as null
-        definedExplicitPredicate = isFunction (config.allowUnfreePredicate or null);
-      in
-      if definedListPredicate then
-        if definedExplicitPredicate then
-          attrs: hasUnfreeLicense attrs && !(listPredicate attrs || explicitPredicate attrs)
+      explicitPredicate = config.allowUnfreePredicate;
+      # Be robust against misconfigured allowUnfreePredicate values such as null
+      definedExplicitPredicate = isFunction (config.allowUnfreePredicate or null);
+
+      # Still selected once, rather than per package.
+      deniedByPredicates =
+        if definedListPredicate then
+          if definedExplicitPredicate then
+            attrs: !(listPredicate attrs || explicitPredicate attrs)
+          else
+            attrs: !listPredicate attrs
+        else if definedExplicitPredicate then
+          attrs: !explicitPredicate attrs
         else
-          attrs: hasUnfreeLicense attrs && !listPredicate attrs
-      else if definedExplicitPredicate then
-        attrs: hasUnfreeLicense attrs && !explicitPredicate attrs
-      else
-        hasUnfreeLicense;
+          _: true;
+    in
+    # `hasUnfreeLicense` has to be tested before `allowUnfree`: for a free
+    # package the `&&` short-circuits and `allowUnfree` is never forced. Reading
+    # `allowUnfree` first makes every package force `config`, which is a cycle
+    # whenever `config` is itself a function of `pkgs`.
+    attrs: hasUnfreeLicense attrs && !allowUnfree && deniedByPredicates attrs;
 
   allowInsecure = getEnv "NIXPKGS_ALLOW_INSECURE" == "1";
 


### PR DESCRIPTION
Fixes #550879.

`hasDeniedUnfreeLicense` currently reads `allowUnfree` before anything else, so **every** package forces Nixpkgs `config`. When `config` is itself a function of `pkgs` — the form `pkgs/test/config-nix-unit.nix` covers in `testStandaloneConfigFunctionPkgs` — that closes a cycle and evaluation fails with `infinite recursion`, currently on `aarch64-darwin`.

The original code tested `hasUnfreeLicense attrs` first, so for a free package the `&&` short-circuited and `allowUnfree` was never forced; every package consulted during stdenv bootstrap is free. This restores that ordering while keeping the predicate selection cached once, which is what 270c9c9792ee (#548898) set out to do:

```nix
attrs: hasUnfreeLicense attrs && !allowUnfree && deniedByPredicates attrs;
```

cc @llakala, as the author of the caching series — happy to take a different shape if you prefer one.

### Verification

Evaluating `(import ./. { system = …; config = { pkgs, lib, ... }: { allowUnfree = lib.isAttrs pkgs; }; }).config.allowUnfree`:

|                | `x86_64-linux` | `aarch64-darwin`   |
| -------------- | -------------- | ------------------ |
| before         | `true`         | infinite recursion |
| after          | `true`         | `true`             |

* `nix-build -A tests.config-nix-unit` → **8/8** (was 7/8 on `aarch64-darwin`).
* Unfree gating is unchanged. Evaluating `unrar` (unfree) and `hello` (free) against four configs gives identical results before and after:

  | config | `unrar` allowed |
  | --- | --- |
  | `{ }` | `false` |
  | `{ allowUnfree = true; }` | `true` |
  | `{ allowUnfreePredicate = p: true; }` | `true` |
  | `{ allowUnfreePackages = [ "unrar" ]; }` | `true` |

  `hello` is allowed under `{ }` in both.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Prepared with AI assistance (Claude Code, `claude-opus-5`), including this description; the commit carries an `Assisted-by:` trailer. I have reviewed the change and the reasoning above and am accountable for it.
