### PR TITLE
top-level: fix package set variants inside NixOS configurations

### DIFF
--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -34,7 +34,15 @@ let
     ++ lib.optional (opt.localSystem.highestPrio < (lib.mkOptionDefault { }).priority) opt.localSystem
     ++ lib.optional (opt.crossSystem.highestPrio < (lib.mkOptionDefault { }).priority) opt.crossSystem;
 
-  _configDefinitions = opt.config.definitionsWithLocations;
+  # Forward the `nixpkgs.config` definitions unevaluated, so that Nixpkgs
+  # performs the single authoritative evaluation of `pkgs/top-level/config.nix`
+  # and merging follows the usual module system semantics.
+  #
+  # Passing this always, even when empty, also keeps `impure.nix` from falling
+  # back to the `NIXPKGS_CONFIG` environment variable.
+  configModules = map (
+    def: lib.modules.setDefaultModuleLocation def.file def.value
+  ) opt.config.definitionsWithLocations;
 
   defaultPkgs =
     if opt.hostPlatform.isDefined then
@@ -53,20 +61,14 @@ let
       in
       import ../../.. (
         {
-          inherit _configDefinitions;
+          config = configModules;
           inherit (cfg) overlays;
-          # Explicitly set config to prevent impure.nix from filling it
-          # from the NIXPKGS_CONFIG environment variable.
-          config = { };
         }
         // systemArgs
       )
     else
       import ../../.. {
-        inherit _configDefinitions;
-        # Explicitly set config to prevent impure.nix from filling it
-        # from the NIXPKGS_CONFIG environment variable.
-        config = { };
+        config = configModules;
         inherit (cfg)
           overlays
           localSystem

--- a/pkgs/test/config-nix-unit.nix
+++ b/pkgs/test/config-nix-unit.nix
@@ -93,6 +93,48 @@ in
     expected = true;
   };
 
+  # Package set variants that override `config` must keep working when Nixpkgs
+  # was instantiated by the NixOS module, which forwards the definitions via the
+  # internal `_configDefinitions` argument.
+  # Regression test for https://github.com/NixOS/nixpkgs/issues/550852
+  testVariantOverridingConfig = {
+    expr =
+      let
+        eval = evalNixos [
+          { nixpkgs.config.allowUnfree = true; }
+          { nixpkgs.config.allowBroken = true; }
+          { nixpkgs.config.allowBroken = lib.mkForce false; }
+        ];
+      in
+      {
+        inherit (eval.pkgs.pkgsRocm.config)
+          rocmSupport
+          cudaSupport
+          allowUnfree
+          allowBroken
+          ;
+      };
+    expected = {
+      # Set by the variant itself.
+      rocmSupport = true;
+      cudaSupport = false;
+      # Inherited from the NixOS modules, with properties already resolved.
+      allowUnfree = true;
+      allowBroken = false;
+    };
+  };
+
+  # Variants that do not override `config` keep receiving the definitions, so
+  # module system properties are still resolved by the new instance.
+  testVariantInheritingConfig = {
+    expr =
+      (evalNixos [
+        { nixpkgs.config.allowUnfree = true; }
+        { nixpkgs.config.allowUnfree = lib.mkForce false; }
+      ]).pkgs.pkgsCross.aarch64-multiplatform.config.allowUnfree;
+    expected = false;
+  };
+
   # Passing both config and _configDefinitions is not allowed
   testConfigAndDefinitionsMutuallyExclusive = {
     expr =

--- a/pkgs/test/config-nix-unit.nix
+++ b/pkgs/test/config-nix-unit.nix
@@ -135,25 +135,40 @@ in
     expected = false;
   };
 
-  # Passing both config and _configDefinitions is not allowed
-  testConfigAndDefinitionsMutuallyExclusive = {
+  # `config` also accepts a list of modules, which is how the NixOS module
+  # forwards its definitions. Merging and properties work across them.
+  testStandaloneConfigModules = {
+    expr =
+      let
+        pkgs' = import nixpkgsPath {
+          config = [
+            { allowUnfree = true; }
+            { allowBroken = true; }
+            { allowBroken = lib.mkForce false; }
+          ];
+        };
+      in
+      {
+        inherit (pkgs'.config) allowUnfree allowBroken;
+      };
+    expected = {
+      allowUnfree = true;
+      allowBroken = false;
+    };
+  };
+
+  # Module locations are preserved, so conflicts point at the defining file.
+  testConfigModuleLocations = {
     expr =
       (import nixpkgsPath {
-        config = {
-          allowUnfree = true;
-        };
-        _configDefinitions = [
-          {
-            file = "test";
-            value = {
-              allowBroken = true;
-            };
-          }
+        config = map (lib.modules.setDefaultModuleLocation "some-file.nix") [
+          { fetchedSourceNameDefault = "versioned"; }
+          { fetchedSourceNameDefault = "full"; }
         ];
-      }).config.allowUnfree;
+      }).config.fetchedSourceNameDefault;
     expectedError = {
       type = "ThrownError";
-      msg = ".*_configDefinitions.*internal.*must not be combined.*";
+      msg = ".*some-file.nix.*";
     };
   };
 }

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -28,6 +28,11 @@
   crossSystem ? null,
 
   # Allow a configuration attribute set to be passed in as an argument.
+  #
+  # This may also be a function returning one, or a list of modules for
+  # `pkgs/top-level/config.nix`. The NixOS `nixpkgs` module uses the latter to
+  # forward the `nixpkgs.config` definitions unevaluated, so that the module
+  # system merges them here with their priorities and locations intact.
   config ? { },
 
   # Temporary hack to let Nixpkgs forbid internal use of `lib.fileset`
@@ -44,11 +49,6 @@
   # environment. See below for the arguments given to that function, the type of
   # list it returns.
   stdenvStages ? import ../stdenv,
-
-  # Temporary parameter to unify nixpkgs/pkgs evaluation
-  # Internal, do not use this manually!
-  # Will be removed again within the next releases
-  _configDefinitions ? null,
 
   # Ignore unexpected args.
   ...
@@ -114,13 +114,11 @@ let
       (throwIfNot (lib.all lib.isFunction overlays) "All overlays passed to nixpkgs must be functions.")
       (throwIfNot (lib.isList crossOverlays) "The crossOverlays argument to nixpkgs must be a list.")
       (throwIfNot (lib.all lib.isFunction crossOverlays) "All crossOverlays passed to nixpkgs must be functions.")
-      (throwIf (
-        ((localSystem.isDarwin && localSystem.isx86) || (crossSystem.isDarwin && crossSystem.isx86))
-        && config.allowDeprecatedx86_64Darwin != "force"
-      ) x86_64DarwinDeprecationMessage)
       (
-        throwIfNot (_configDefinitions == null || config0 == { })
-          "The `_configDefinitions` argument is an internal interface and must not be combined with `config`."
+        throwIf (
+          ((localSystem.isDarwin && localSystem.isx86) || (crossSystem.isDarwin && crossSystem.isx86))
+          && config.allowDeprecatedx86_64Darwin != "force"
+        ) x86_64DarwinDeprecationMessage
       );
 
   localSystem = lib.systems.elaborate args.localSystem;
@@ -153,8 +151,8 @@ let
       ./config.nix
     ]
     ++ (
-      if _configDefinitions != null then
-        map (def: lib.modules.setDefaultModuleLocation def.file def.value) _configDefinitions
+      if lib.isList config0 then
+        config0
       else
         [
           {
@@ -203,20 +201,7 @@ let
   # via `evalModules` is not idempotent. In other words, if you add `config` to
   # `newArgs`, expect strange very hard to debug errors! (Yes, I'm speaking from
   # experience here.)
-  #
-  # `_configDefinitions` (only ever set by the NixOS `nixpkgs` module) and
-  # `config` are mutually exclusive, see `checked` above. A caller passing
-  # `config` supplies the complete configuration for the new package set —
-  # it is derived from the `config` variable above, which already contains
-  # everything `_configDefinitions` evaluated to — so the definitions must be
-  # dropped instead of being combined. Without this, package set variants
-  # overriding `config` (`pkgsRocm`, `pkgsCuda`, `pkgsChecked`, ...) would fail
-  # to evaluate inside a NixOS configuration.
-  nixpkgsFun =
-    newArgs:
-    import ./. (
-      (if newArgs ? config then removeAttrs args [ "_configDefinitions" ] else args) // newArgs
-    );
+  nixpkgsFun = newArgs: import ./. (args // newArgs);
 
   # Partially apply some arguments for building bootstrapping stage pkgs
   # sets. Only apply arguments which no stdenv would want to override.

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -203,7 +203,20 @@ let
   # via `evalModules` is not idempotent. In other words, if you add `config` to
   # `newArgs`, expect strange very hard to debug errors! (Yes, I'm speaking from
   # experience here.)
-  nixpkgsFun = newArgs: import ./. (args // newArgs);
+  #
+  # `_configDefinitions` (only ever set by the NixOS `nixpkgs` module) and
+  # `config` are mutually exclusive, see `checked` above. A caller passing
+  # `config` supplies the complete configuration for the new package set —
+  # it is derived from the `config` variable above, which already contains
+  # everything `_configDefinitions` evaluated to — so the definitions must be
+  # dropped instead of being combined. Without this, package set variants
+  # overriding `config` (`pkgsRocm`, `pkgsCuda`, `pkgsChecked`, ...) would fail
+  # to evaluate inside a NixOS configuration.
+  nixpkgsFun =
+    newArgs:
+    import ./. (
+      (if newArgs ? config then removeAttrs args [ "_configDefinitions" ] else args) // newArgs
+    );
 
   # Partially apply some arguments for building bootstrapping stage pkgs
   # sets. Only apply arguments which no stdenv would want to override.


### PR DESCRIPTION
See individual commits. First commit is immidiate fix for a problem, second commit proposes a better solution instead.

Alternative to #550876
Resolves #550852

Assisted-by: claude-code with claude-opus-5[1m]-high

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
