### PR TITLE
m4b-tool: init at 0.5.2

### DIFF
--- a/pkgs/by-name/m4/m4b-tool/package.nix
+++ b/pkgs/by-name/m4/m4b-tool/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  fetchFromGitHub,
+  php,
+  ffmpeg-headless,
+  mp4v2,
+  fdk-aac-encoder,
+  withFdkAac ? false,
+  makeWrapper,
+  testers,
+  nix-update-script,
+}:
+
+php.buildComposerProject (finalAttrs: {
+  pname = "m4b-tool";
+  version = "0.5.2";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "sandreas";
+    repo = "m4b-tool";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-g/qNKdrcZCPOsUn1bW0ow+35AG+rYAmqG/Kca96C86w=";
+  };
+
+  composerStrictValidation = false;
+
+  vendorHash = "sha256-6jkKVS1VwuD8uHxHA7KkLa+TQEL1ZuhSv7y2PYP9eFQ=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postPatch = ''
+    substituteInPlace bin/m4b-tool.php \
+      --replace-fail '@package_version@' '${finalAttrs.version}'
+  '';
+
+  postInstall = ''
+    find "$out/share/php/${finalAttrs.pname}" -mindepth 1 -maxdepth 1 \
+      ! -name bin \
+      ! -name src \
+      ! -name vendor \
+      ! -name composer.json \
+      ! -name composer.lock \
+      ! -name LICENSE \
+      -exec rm -rf {} +
+
+    rm -rf $out/bin
+    mkdir -p $out/bin
+
+    makeWrapper ${lib.getExe php} $out/bin/m4b-tool \
+      --add-flags "$out/share/php/${finalAttrs.pname}/bin/m4b-tool.php" \
+      --prefix PATH : ${
+        lib.makeBinPath (
+          [
+            ffmpeg-headless
+            mp4v2
+          ]
+          ++ (lib.optional withFdkAac fdk-aac-encoder)
+        )
+      } \
+      --set M4B_TOOL_DISABLE_TONE true
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+  };
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A command line utility to merge, split and chapterize audiobook files such as mp3, ogg, flac, m4a or m4b";
+    homepage = "https://github.com/sandreas/m4b-tool";
+    changelog = "https://github.com/sandreas/m4b-tool/releases/tag/${finalAttrs.src.tag}";
+    license = with lib.licenses; [ mit ] ++ lib.optional withFdkAac fraunhofer-fdk;
+    maintainers = with lib.maintainers; [ lnk3 ];
+    mainProgram = "m4b-tool";
+    platforms = php.meta.platforms;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
