### PR TITLE
taskexplorer: init at 2.1.0

### DIFF
--- a/pkgs/by-name/ta/taskexplorer/package.nix
+++ b/pkgs/by-name/ta/taskexplorer/package.nix
@@ -1,0 +1,94 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  makeWrapper,
+  nix-update-script,
+  testers,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "taskexplorer";
+  version = "2.1.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchzip {
+    url = "https://github.com/objective-see/TaskExplorer/releases/download/v${finalAttrs.version}/TaskExplorer_${finalAttrs.version}.zip";
+    hash = "sha256-hwqV06vE3LyZW8AnnatTOcapCqEuHp/EM5dV+xhhvno=";
+
+    stripRoot = false;
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications"
+    cp -R TaskExplorer.app "$out/Applications/TaskExplorer.app"
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    mkdir -p $out/bin
+    makeWrapper $out/Applications/TaskExplorer.app/Contents/MacOS/TaskExplorer $out/bin/taskexplorer
+  '';
+
+  dontFixup = true; # Preserve upstream's notarized app bundle and system extension signature.
+
+  passthru = {
+    updateScript = nix-update-script { };
+
+    tests = {
+      help = testers.runCommand {
+        name = "taskexplorer-help-test";
+        buildInputs = [ finalAttrs.finalPackage ];
+        script = ''
+          # Capture both stdout and stderr, and use `|| true` to suppress the 255 exit code
+          # which occurs because of the wrong help exit code imlementation in taskexplorer
+          # Fix when this is merged: https://github.com/objective-see/TaskExplorer/pull/9
+          output=$(taskexplorer -h 2>&1 || true)
+
+          echo "$output" | grep -F "TASKEXPLORER USAGE:"
+
+          touch $out
+        '';
+      };
+    };
+  };
+
+  meta = {
+    mainProgram = "taskexplorer";
+    description = "Tool to explore all the running tasks (processes)";
+    longDescription = ''
+      Explore all the tasks (processes) running on your Mac with TaskExplorer.
+      Quickly see a task's signature status, loaded dylibs, open files, network connection, and much more!
+    '';
+    homepage = "https://objective-see.org/products/taskexplorer.html";
+    downloadPage = "https://github.com/objective-see/TaskExplorer/releases";
+    changelog = "https://github.com/objective-see/TaskExplorer/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    identifiers = {
+      cpeParts = {
+        vendor = "objective-see";
+        product = "taskexplorer";
+        version = finalAttrs.version;
+        target_sw = "macos";
+      };
+      purlParts = {
+        type = "github";
+        namespace = "objective-see";
+        name = "taskexplorer";
+        version = finalAttrs.version;
+      };
+    };
+    maintainers = with lib.maintainers; [
+      KristijanZic
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added taskexplorer at 2.1.0 from https://objective-see.org/products/taskexplorer.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
