### PR TITLE
gccNGPackages: fix and enable quadmath

### DIFF
--- a/pkgs/development/compilers/gcc/ng/common/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/default.nix
@@ -131,6 +131,7 @@ makeScopeWithSplicing' {
           "-B${targetGccPackages.libssp}/lib"
           "-B${targetGccPackages.libatomic}/lib"
           "-B${targetGccPackages.libgomp}/lib"
+          "-B${targetGccPackages.libquadmath}/lib/"
           "-B${targetGccPackages.libgfortran}/lib/"
         ];
       };
@@ -148,6 +149,7 @@ makeScopeWithSplicing' {
           "-B${targetGccPackages.libatomic}/lib"
           "-B${targetGccPackages.libgomp}/lib"
           "-I${targetGccPackages.libgomp}/lib/gcc/${metadata.release_version}/include"
+          "-B${targetGccPackages.libquadmath}/lib/"
         ];
       };
 
@@ -164,6 +166,8 @@ makeScopeWithSplicing' {
           "-B${targetGccPackages.libatomic}/lib"
           "-B${targetGccPackages.libgomp}/lib"
           "-I${targetGccPackages.libgomp}/lib/gcc/${metadata.release_version}/include"
+          "-B${targetGccPackages.libquadmath}/lib/"
+          "-I${targetGccPackages.libquadmath}/lib/gcc/${metadata.release_version}/include"
         ];
       };
 

--- a/pkgs/development/compilers/gcc/ng/common/libquadmath/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/libquadmath/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
     cp gcc/BASE-VER "$out/gcc"
     cp gcc/DATESTAMP "$out/gcc"
 
+    cp -r include "$out"
     cp -r libquadmath "$out"
 
     cp config.guess "$out"


### PR DESCRIPTION
This fixes the broken build of libquadmath, and adds it to the include paths of gcc and gfortran.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
