### PR TITLE
check-meta: test the package before reading config

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -469,7 +469,14 @@ let
       }
 
     # --- Put checks that can be ignored here ---
-    else if hasDeniedUnfreeLicense attrs && !(nonEmptyAllowList && hasAllowlistedLicense attrs) then
+    # Testing the license first keeps `config` unforced for packages that are
+    # not unfree, which would otherwise be a cycle when `config` is a function,
+    # as those are passed `pkgs`.
+    else if
+      hasUnfreeLicense attrs
+      && hasDeniedUnfreeLicense attrs
+      && !(nonEmptyAllowList && hasAllowlistedLicense attrs)
+    then
       {
         reason = "unfree";
         msg = "has an unfree license (‘${showLicense attrs.meta.license}’)";

--- a/pkgs/stdenv/generic/problems.nix
+++ b/pkgs/stdenv/generic/problems.nix
@@ -111,13 +111,19 @@ rec {
               lib.warnIf (lib.oldestSupportedReleaseIsAtLeast 2605)
                 "config.allowBrokenPredicate is deprecated, use config.problems.handlers.myPackage.broken = \"warn\" for individual packages instead."
                 config.allowBrokenPredicate;
+
+            # Testing `meta.broken` first keeps `config` unforced for packages
+            # that are not broken, which would otherwise be a cycle when
+            # `config` is a function, as those are passed `pkgs`.
+            denied =
+              if allowBroken then
+                _: false
+              else if config ? allowBrokenPredicate then
+                attrs: !allowBrokenPredicate attrs
+              else
+                _: true;
           in
-          if allowBroken then
-            attrs: false
-          else if config ? allowBrokenPredicate then
-            attrs: attrs ? meta.broken && attrs.meta.broken && !allowBrokenPredicate attrs
-          else
-            attrs: attrs ? meta.broken && attrs.meta.broken;
+          attrs: attrs ? meta.broken && attrs.meta.broken && denied attrs;
         value.message = "This package is broken.";
       };
     };


### PR DESCRIPTION
Checking a derivation's validity read `config.allowUnfree` and `config.allowBroken` before looking at the package at all, so both were forced even for packages that are neither unfree nor broken.

That is a latent cycle. Nixpkgs accepts `config` as a function, and such a function is passed `pkgs`, so demanding a `config` option while `pkgs` is still being evaluated closes a loop. On Darwin the loop really does close, because the final stdenv stage asserts

    assert prevStage.libiconv == prevStage.darwin.libiconv;

and comparing two derivations forces `outPath`, which `lib.extendDerivation` guards behind the derivation's validity, which reads `config`. So

    (import <nixpkgs> {
      system = "aarch64-darwin";
      config = { lib, pkgs }: { allowUnfree = lib.isAttrs pkgs; };
    }).config.allowUnfree

fails with an infinite recursion, while the same expression evaluates on x86_64-linux, whose stdenv never forces a derivation while the package set is still being assembled.

Test `meta.license` and `meta.broken` before reaching for `config`. Both decisions stay hoisted out of the per-package lambdas, so nothing is specialised per call and no lookup moves into the hot path; the resulting derivations are unchanged.

`tests.config-nix-unit.testStandaloneConfigFunctionPkgs` covers the expression above. It has been failing on aarch64-darwin in every nixpkgs-review, since that derivation takes the whole tree as a build input and is rebuilt for every pull request.

Assisted-by: claude-code with claude-opus-5[1m]-high


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
