### PR TITLE
fittrackee: 1.3.3 -> 1.3.4

### DIFF
--- a/pkgs/by-name/fi/fittrackee/0001-pytest-Parametrize-compatability-with-9.1.1.patch
+++ b/pkgs/by-name/fi/fittrackee/0001-pytest-Parametrize-compatability-with-9.1.1.patch
@@ -1,0 +1,34 @@
+From 4fa9323aa6c029049848bf619b11fc790d9cecc2 Mon Sep 17 00:00:00 2001
+From: Chris Moultrie <tebriel@frodux.in>
+Date: Sun, 9 Aug 2026 18:08:21 -0400
+Subject: [PATCH] pytest: Parametrize compatability with 9.1.1
+
+---
+ fittrackee/tests/workouts/test_workouts_model.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/fittrackee/tests/workouts/test_workouts_model.py b/fittrackee/tests/workouts/test_workouts_model.py
+index 077a8a86e..ca4175a6f 100644
+--- a/fittrackee/tests/workouts/test_workouts_model.py
++++ b/fittrackee/tests/workouts/test_workouts_model.py
+@@ -1199,7 +1199,7 @@ class TestWorkoutModelForOwner(WorkoutModelTestCase):
+         )
+ 
+     @pytest.mark.parametrize(
+-        "input_args,",
++        "input_args",
+         [
+             {"light": False},
+             {"light": False, "with_equipments": True},
+@@ -1226,7 +1226,7 @@ class TestWorkoutModelForOwner(WorkoutModelTestCase):
+             equipment_bike_user_1.serialize(current_user=user_1)
+         ]
+ 
+-    @pytest.mark.parametrize("input_args,", [{}, {"light": True}])
++    @pytest.mark.parametrize("input_args", [{}, {"light": True}])
+     def test_serializer_does_not_return_equipments(
+         self,
+         app: Flask,
+-- 
+2.54.0
+

--- a/pkgs/by-name/fi/fittrackee/package.nix
+++ b/pkgs/by-name/fi/fittrackee/package.nix
@@ -11,22 +11,27 @@
 }:
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "fittrackee";
-  version = "1.3.3";
+  version = "1.3.4";
   pyproject = true;
 
   src = fetchFromCodeberg {
     owner = "FitTrackee";
     repo = "FitTrackee";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-XWR9gg52pfg0lHoFikQ2wVhvkPCTjTTndBYqBzYPB8s=";
+    hash = "sha256-PN+YHRKvsAgTaSm4dl2t5voRxbgIo+yoieMfGEuE0oI=";
   };
+
+  patches = [
+    # https://codeberg.org/FitTrackee/FitTrackee/pulls/1205
+    ./0001-pytest-Parametrize-compatability-with-9.1.1.patch
+  ];
 
   makeCacheWritable = true;
   npmRoot = "fittrackee_client";
 
   npmDeps = fetchNpmDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-HEgof2ln+mBxM63Dv8Lc/bfx3ozoJCRYYyJOz6jh+Vs=";
+    hash = "sha256-kN/J7hIeEcnCKaramIPhoBsbBg32VgF372f9KOPi+nY=";
     sourceRoot = "${finalAttrs.src.name}/fittrackee_client";
   };
 


### PR DESCRIPTION
changelog: https://codeberg.org/FitTrackee/FitTrackee/releases/tag/v1.3.4


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
