### PR TITLE
stdenv/darwin: move the libiconv alias assertion into tests.stdenv

### DIFF
--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -1177,9 +1177,6 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
     assert isFromNixpkgs prevStage.binutils-unwrapped.src;
     assert isBuiltByNixpkgsCompiler prevStage.curl;
 
-    # libiconv should be an alias for darwin.libiconv
-    assert prevStage.libiconv == prevStage.darwin.libiconv;
-
     {
       inherit (prevStage) config overlays stdenv;
     }

--- a/pkgs/test/stdenv/default.nix
+++ b/pkgs/test/stdenv/default.nix
@@ -249,6 +249,13 @@ in
     }
   );
 
+  # `libiconv` should be an alias for `darwin.libiconv`. Checked here and not in
+  # the Darwin stdenv because comparing derivations forces `outPath`, which is
+  # guarded behind validity, which reads `config` — a cycle during bootstrap.
+  darwin-libiconv-alias =
+    assert stdenv.hostPlatform.isDarwin -> pkgs.libiconv == pkgs.darwin.libiconv;
+    pkgs.emptyFile;
+
   outputs-no-out =
     runCommand "outputs-no-out-assert"
       {


### PR DESCRIPTION
Prefered alternative to #550905, #550880 and #550948
Closes #550879

The final stage asserted

    assert prevStage.libiconv == prevStage.darwin.libiconv;

On Darwin `libiconv` is `darwin.libiconv`, so this compares a value with itself. Nix does not notice: `eqValues` short-circuits only on pointer identity of the two value slots, and these are two slots that resolve to one attribute set. It therefore falls through to the derivation case, which compares `outPath`.

`lib.extendDerivation` guards `outPath` behind the derivation's validity, which reads `config.allowUnfree`, so the assertion demanded a `config` option while the package set was still being assembled. When `config` is a function it is passed `pkgs`, and the loop closes:

    (import <nixpkgs> {
      system = "aarch64-darwin";
      config = { pkgs, lib, ... }: { allowUnfree = lib.isAttrs pkgs; };
    }).config.allowUnfree

failed with an infinite recursion on Darwin while evaluating on Linux, whose stdenv never forces a derivation that early. It now evaluates on both.

Keep checking the invariant, from `tests.stdenv` instead. By then the package set is complete, so forcing `outPath` is just a read. The other twelve assertions in the stage read `passthru` and `stdenv.cc.cc`, which are ungated, and stay where they are.

Assisted-by: claude-code with claude-opus-5[1m]-high


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
