### PR TITLE
ci: also run config-nix-unit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,8 +35,8 @@ jobs:
         include:
           - runner: ubuntu-24.04
             system: x86_64-linux
-            builds: [shell, manual-nixos, lib-tests, tarball]
-            desc: shell, docs, lib, tarball
+            builds: [shell, manual-nixos, lib-tests, config-nix-unit, tarball]
+            desc: shell, docs, lib, config, tarball
           - runner: ubuntu-24.04-arm
             system: aarch64-linux
             builds: [shell, manual-nixos, manual-nixpkgs]
@@ -96,6 +96,10 @@ jobs:
       - name: Build lib tests
         if: contains(matrix.builds, 'lib-tests') && !cancelled()
         run: nix-build-uncached nixpkgs/untrusted/ci --arg nixpkgs ./nixpkgs/untrusted-pinned -A lib-tests
+
+      - name: Build Nixpkgs config tests
+        if: contains(matrix.builds, 'config-nix-unit') && !cancelled()
+        run: nix-build-uncached nixpkgs/untrusted/ci --arg nixpkgs ./nixpkgs/untrusted-pinned -A config-nix-unit
 
       - name: Build tarball
         if: contains(matrix.builds, 'tarball') && !cancelled()

--- a/ci/config-nix-unit/default.nix
+++ b/ci/config-nix-unit/default.nix
@@ -11,6 +11,15 @@ runCommand "config-nix-unit"
   }
   ''
     export HOME=$TMPDIR
+
+    # `pkgs/top-level/impure.nix` falls back to this file when Nixpkgs is
+    # imported without a `config` argument. The tests use it to tell apart
+    # "config was passed explicitly" from "config came from the environment",
+    # which is why they need a controlled environment and cannot run at
+    # evaluation time.
+    echo '{ allowUnfree = true; }' > "$TMPDIR/nixpkgs-config.nix"
+    export NIXPKGS_CONFIG="$TMPDIR/nixpkgs-config.nix"
+
     nix-unit --eval-store "$HOME" ${./tests.nix} \
       --arg nixpkgsPath "${lib.cleanSource nixpkgs}"
     touch $out

--- a/ci/config-nix-unit/default.nix
+++ b/ci/config-nix-unit/default.nix
@@ -1,0 +1,17 @@
+{
+  lib,
+  nix-unit,
+  runCommand,
+  nixpkgs,
+}:
+
+runCommand "config-nix-unit"
+  {
+    nativeBuildInputs = [ nix-unit ];
+  }
+  ''
+    export HOME=$TMPDIR
+    nix-unit --eval-store "$HOME" ${./tests.nix} \
+      --arg nixpkgsPath "${lib.cleanSource nixpkgs}"
+    touch $out
+  ''

--- a/ci/config-nix-unit/tests.nix
+++ b/ci/config-nix-unit/tests.nix
@@ -1,14 +1,15 @@
 # Tests for `nixpkgs.config` that inspect evaluation *error messages*.
 #
-# Everything that can be asserted on a value lives in `pkgs/test/config.nix`,
-# where it runs at evaluation time and costs no build. These cases remain here
-# because `builtins.tryEval` reports only whether an evaluation failed, never
-# why, so the message can only be matched by a runner such as nix-unit.
+# Everything that can be asserted on values instead lives in
+# `pkgs/test/top-level`, where it runs at evaluation time and costs no build.
+# These tests remain here because `builtins.tryEval` reports only whether an
+# evaluation failed, never why, so the message can only be matched by a runner
+# such as nix-unit.
 #
 # Run with:
-#   nix-unit pkgs/test/config-nix-unit.nix
+#   nix-unit ci/config-nix-unit/tests.nix
 # or
-#   nix-build -A tests.config-nix-unit
+#   nix-build ci -A config-nix-unit
 #
 {
   nixpkgsPath ? ../..,

--- a/ci/config-nix-unit/tests.nix
+++ b/ci/config-nix-unit/tests.nix
@@ -1,15 +1,15 @@
-# Tests for `nixpkgs.config` that inspect evaluation *error messages*.
+# Tests for `nixpkgs.config` that cannot run at evaluation time, either
+# because they match the text of an error, which `builtins.tryEval` never
+# exposes, or because they depend on the process environment.
 #
-# Everything that can be asserted on values instead lives in
-# `pkgs/test/top-level`, where it runs at evaluation time and costs no build.
-# These tests remain here because `builtins.tryEval` reports only whether an
-# evaluation failed, never why, so the message can only be matched by a runner
-# such as nix-unit.
+# Everything that can be asserted on a value lives in `pkgs/test/config.nix`,
+# where it runs at evaluation time and costs no build.
 #
 # Run with:
-#   nix-unit ci/config-nix-unit/tests.nix
-# or
 #   nix-build ci -A config-nix-unit
+#
+# Running `nix-unit` on this file directly requires `$NIXPKGS_CONFIG` to point
+# at a file containing `{ allowUnfree = true; }`, which `./default.nix` sets up.
 #
 {
   nixpkgsPath ? ../..,
@@ -53,5 +53,24 @@ in
       type = "ThrownError";
       msg = ".*my-nixos-module.nix.*";
     };
+  };
+
+  # Control for the test below: importing Nixpkgs without a `config` argument
+  # does read `$NIXPKGS_CONFIG`. Without this, a NixOS package set could look
+  # unaffected by the environment merely because the variable was never seen.
+  testEnvironmentConfigIsRead = {
+    expr = (import nixpkgsPath { }).config.allowUnfree;
+    expected = true;
+  };
+
+  # The NixOS module always passes `config`, so `$NIXPKGS_CONFIG` must not
+  # reach a package set it built. This is what the module's former explicit
+  # `config = { }` protected, before the definitions were passed as modules.
+  testNixosConfigIgnoresEnvironment = {
+    expr =
+      (import (nixpkgsPath + "/nixos/lib/eval-config.nix") {
+        modules = [ { nixpkgs.hostPlatform = "x86_64-linux"; } ];
+      }).pkgs.config.allowUnfree;
+    expected = false;
   };
 }

--- a/ci/default.nix
+++ b/ci/default.nix
@@ -63,6 +63,7 @@ rec {
 
   # CI jobs
   lib-tests = import ../lib/tests/release.nix { inherit pkgs; };
+  config-nix-unit = pkgs.callPackage ../ci/config-nix-unit { nixpkgs = nixpkgs'; };
   manual-nixos = (import ../nixos/release.nix { }).manual.${system} or null;
   manual-nixpkgs = (import ../doc { pkgs = docPkgs; });
   nixpkgs-vet = pkgs.callPackage ./nixpkgs-vet.nix {

--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -34,7 +34,15 @@ let
     ++ lib.optional (opt.localSystem.highestPrio < (lib.mkOptionDefault { }).priority) opt.localSystem
     ++ lib.optional (opt.crossSystem.highestPrio < (lib.mkOptionDefault { }).priority) opt.crossSystem;
 
-  _configDefinitions = opt.config.definitionsWithLocations;
+  # Forward the `nixpkgs.config` definitions unevaluated, so that Nixpkgs
+  # performs the single authoritative evaluation of `pkgs/top-level/config.nix`
+  # and merging follows the usual module system semantics.
+  #
+  # Passing this always, even when empty, also keeps `impure.nix` from falling
+  # back to the `NIXPKGS_CONFIG` environment variable.
+  configModules = map (
+    def: lib.modules.setDefaultModuleLocation def.file def.value
+  ) opt.config.definitionsWithLocations;
 
   defaultPkgs =
     if opt.hostPlatform.isDefined then
@@ -53,20 +61,14 @@ let
       in
       import ../../.. (
         {
-          inherit _configDefinitions;
+          config = configModules;
           inherit (cfg) overlays;
-          # Explicitly set config to prevent impure.nix from filling it
-          # from the NIXPKGS_CONFIG environment variable.
-          config = { };
         }
         // systemArgs
       )
     else
       import ../../.. {
-        inherit _configDefinitions;
-        # Explicitly set config to prevent impure.nix from filling it
-        # from the NIXPKGS_CONFIG environment variable.
-        config = { };
+        config = configModules;
         inherit (cfg)
           overlays
           localSystem

--- a/pkgs/test/config-nix-unit.nix
+++ b/pkgs/test/config-nix-unit.nix
@@ -1,4 +1,9 @@
-# Tests for nixpkgs config forwarding from NixOS modules.
+# Tests for `nixpkgs.config` that inspect evaluation *error messages*.
+#
+# Everything that can be asserted on a value lives in `pkgs/test/config.nix`,
+# where it runs at evaluation time and costs no build. These cases remain here
+# because `builtins.tryEval` reports only whether an evaluation failed, never
+# why, so the message can only be matched by a runner such as nix-unit.
 #
 # Run with:
 #   nix-unit pkgs/test/config-nix-unit.nix
@@ -12,156 +17,14 @@
 let
   lib = pkgs.lib;
 
-  # Test helper
-  evalNixos =
-    modules:
-    import (nixpkgsPath + "/nixos/lib/eval-config.nix") {
-      modules = [ { nixpkgs.hostPlatform = "x86_64-linux"; } ] ++ modules;
-    };
+  located = file: modules: map (lib.modules.setDefaultModuleLocation file) modules;
 in
 {
-  # Basic: a single config option is forwarded correctly.
-  testSingleConfigOption = {
-    expr = (evalNixos [ { nixpkgs.config.allowUnfree = true; } ]).config.nixpkgs.config.allowUnfree;
-    expected = true;
-  };
-
-  # Multiple config definitions from separate modules are merged.
-  testMultipleModulesMerge = {
-    expr =
-      let
-        eval = evalNixos [
-          { nixpkgs.config.allowUnfree = true; }
-          { nixpkgs.config.allowBroken = true; }
-        ];
-      in
-      {
-        inherit (eval.config.nixpkgs.config) allowUnfree allowBroken;
-      };
-    expected = {
-      allowUnfree = true;
-      allowBroken = true;
-    };
-  };
-
-  # mkForce works. Also covers other properties
-  testMkForce = {
-    expr =
-      (evalNixos [
-        { nixpkgs.config.allowUnfree = true; }
-        { nixpkgs.config.allowUnfree = lib.mkForce false; }
-      ]).config.nixpkgs.config.allowUnfree;
-    expected = false;
-  };
-
-  testDefaults = {
-    expr = (evalNixos [ ]).config.nixpkgs.config.allowUnfree;
-    expected = false;
-  };
-
-  # Standalone nixpkgs (i.e. import <nixpkgs> { ... })
-  testStandaloneConfig = {
-    expr = (import nixpkgsPath { config.allowUnfree = true; }).config.allowUnfree;
-    expected = true;
-  };
-
-  # Standalone nixpkgs with a function (i.e. import <nixpkgs> ({pkgs, lib, ...}: { ... })
-  testStandaloneConfigFunctionPkgs = {
-    expr =
-      (import nixpkgsPath {
-        config =
-          { pkgs, lib, ... }:
-          {
-            allowUnfree = lib.isAttrs pkgs;
-          };
-      }).config.allowUnfree;
-    expected = true;
-  };
-
-  # NixOS module sets nixpkgs.config as a function
-  testNixosConfigFunction = {
-    expr =
-      (evalNixos [
-        {
-          nixpkgs.config =
-            { lib, ... }:
-            {
-              allowUnfree = lib.isFunction lib.id;
-            };
-        }
-      ]).config.nixpkgs.config.allowUnfree;
-    expected = true;
-  };
-
-  # Package set variants that override `config` must keep working when Nixpkgs
-  # was instantiated by the NixOS module, which forwards the definitions via the
-  # internal `_configDefinitions` argument.
-  # Regression test for https://github.com/NixOS/nixpkgs/issues/550852
-  testVariantOverridingConfig = {
-    expr =
-      let
-        eval = evalNixos [
-          { nixpkgs.config.allowUnfree = true; }
-          { nixpkgs.config.allowBroken = true; }
-          { nixpkgs.config.allowBroken = lib.mkForce false; }
-        ];
-      in
-      {
-        inherit (eval.pkgs.pkgsRocm.config)
-          rocmSupport
-          cudaSupport
-          allowUnfree
-          allowBroken
-          ;
-      };
-    expected = {
-      # Set by the variant itself.
-      rocmSupport = true;
-      cudaSupport = false;
-      # Inherited from the NixOS modules, with properties already resolved.
-      allowUnfree = true;
-      allowBroken = false;
-    };
-  };
-
-  # Variants that do not override `config` keep receiving the definitions, so
-  # module system properties are still resolved by the new instance.
-  testVariantInheritingConfig = {
-    expr =
-      (evalNixos [
-        { nixpkgs.config.allowUnfree = true; }
-        { nixpkgs.config.allowUnfree = lib.mkForce false; }
-      ]).pkgs.pkgsCross.aarch64-multiplatform.config.allowUnfree;
-    expected = false;
-  };
-
-  # `config` also accepts a list of modules, which is how the NixOS module
-  # forwards its definitions. Merging and properties work across them.
-  testStandaloneConfigModules = {
-    expr =
-      let
-        pkgs' = import nixpkgsPath {
-          config = [
-            { allowUnfree = true; }
-            { allowBroken = true; }
-            { allowBroken = lib.mkForce false; }
-          ];
-        };
-      in
-      {
-        inherit (pkgs'.config) allowUnfree allowBroken;
-      };
-    expected = {
-      allowUnfree = true;
-      allowBroken = false;
-    };
-  };
-
-  # Module locations are preserved, so conflicts point at the defining file.
+  # Nixpkgs reports the file a conflicting `config` definition came from.
   testConfigModuleLocations = {
     expr =
       (import nixpkgsPath {
-        config = map (lib.modules.setDefaultModuleLocation "some-file.nix") [
+        config = located "some-file.nix" [
           { fetchedSourceNameDefault = "versioned"; }
           { fetchedSourceNameDefault = "full"; }
         ];
@@ -169,6 +32,25 @@ in
     expectedError = {
       type = "ThrownError";
       msg = ".*some-file.nix.*";
+    };
+  };
+
+  # The NixOS module forwards definitions unevaluated, so a conflict points at
+  # the NixOS module that defined it rather than at Nixpkgs internals.
+  testNixosConfigConflictLocation = {
+    expr =
+      (import (nixpkgsPath + "/nixos/lib/eval-config.nix") {
+        modules = [
+          { nixpkgs.hostPlatform = "x86_64-linux"; }
+        ]
+        ++ located "my-nixos-module.nix" [
+          { nixpkgs.config.fetchedSourceNameDefault = "versioned"; }
+          { nixpkgs.config.fetchedSourceNameDefault = "full"; }
+        ];
+      }).pkgs.config.fetchedSourceNameDefault;
+    expectedError = {
+      type = "ThrownError";
+      msg = ".*my-nixos-module.nix.*";
     };
   };
 }

--- a/pkgs/test/config-nix-unit.nix
+++ b/pkgs/test/config-nix-unit.nix
@@ -93,6 +93,48 @@ in
     expected = true;
   };
 
+  # Package set variants that override `config` must keep working when Nixpkgs
+  # was instantiated by the NixOS module, which forwards the definitions via the
+  # internal `_configDefinitions` argument.
+  # Regression test for https://github.com/NixOS/nixpkgs/issues/550852
+  testVariantOverridingConfig = {
+    expr =
+      let
+        eval = evalNixos [
+          { nixpkgs.config.allowUnfree = true; }
+          { nixpkgs.config.allowBroken = true; }
+          { nixpkgs.config.allowBroken = lib.mkForce false; }
+        ];
+      in
+      {
+        inherit (eval.pkgs.pkgsRocm.config)
+          rocmSupport
+          cudaSupport
+          allowUnfree
+          allowBroken
+          ;
+      };
+    expected = {
+      # Set by the variant itself.
+      rocmSupport = true;
+      cudaSupport = false;
+      # Inherited from the NixOS modules, with properties already resolved.
+      allowUnfree = true;
+      allowBroken = false;
+    };
+  };
+
+  # Variants that do not override `config` keep receiving the definitions, so
+  # module system properties are still resolved by the new instance.
+  testVariantInheritingConfig = {
+    expr =
+      (evalNixos [
+        { nixpkgs.config.allowUnfree = true; }
+        { nixpkgs.config.allowUnfree = lib.mkForce false; }
+      ]).pkgs.pkgsCross.aarch64-multiplatform.config.allowUnfree;
+    expected = false;
+  };
+
   # Passing both config and _configDefinitions is not allowed
   testConfigAndDefinitionsMutuallyExclusive = {
     expr =

--- a/pkgs/test/config-nix-unit.nix
+++ b/pkgs/test/config-nix-unit.nix
@@ -135,25 +135,40 @@ in
     expected = false;
   };
 
-  # Passing both config and _configDefinitions is not allowed
-  testConfigAndDefinitionsMutuallyExclusive = {
+  # `config` also accepts a list of modules, which is how the NixOS module
+  # forwards its definitions. Merging and properties work across them.
+  testStandaloneConfigModules = {
+    expr =
+      let
+        pkgs' = import nixpkgsPath {
+          config = [
+            { allowUnfree = true; }
+            { allowBroken = true; }
+            { allowBroken = lib.mkForce false; }
+          ];
+        };
+      in
+      {
+        inherit (pkgs'.config) allowUnfree allowBroken;
+      };
+    expected = {
+      allowUnfree = true;
+      allowBroken = false;
+    };
+  };
+
+  # Module locations are preserved, so conflicts point at the defining file.
+  testConfigModuleLocations = {
     expr =
       (import nixpkgsPath {
-        config = {
-          allowUnfree = true;
-        };
-        _configDefinitions = [
-          {
-            file = "test";
-            value = {
-              allowBroken = true;
-            };
-          }
+        config = map (lib.modules.setDefaultModuleLocation "some-file.nix") [
+          { fetchedSourceNameDefault = "versioned"; }
+          { fetchedSourceNameDefault = "full"; }
         ];
-      }).config.allowUnfree;
+      }).config.fetchedSourceNameDefault;
     expectedError = {
       type = "ThrownError";
-      msg = ".*_configDefinitions.*internal.*must not be combined.*";
+      msg = ".*some-file.nix.*";
     };
   };
 }

--- a/pkgs/test/config.nix
+++ b/pkgs/test/config.nix
@@ -4,7 +4,113 @@
   pkgs,
   ...
 }:
+let
+  nixpkgsFun = import ../top-level;
+
+  evalNixos =
+    modules:
+    import ../../nixos/lib/eval-config.nix {
+      modules = [ { nixpkgs.hostPlatform = "x86_64-linux"; } ] ++ modules;
+    };
+
+  localSystem = {
+    system = "x86_64-linux";
+  };
+in
 lib.recurseIntoAttrs {
+
+  # `nixpkgs.config` is merged by the module system, so definitions from
+  # separate modules combine and properties such as `mkForce` are resolved.
+  # The result reaches every package set variant, including the ones that
+  # override `config` themselves.
+  # Regression test for https://github.com/NixOS/nixpkgs/issues/550852
+  fromNixosModules =
+    let
+      nixosPkgs =
+        (evalNixos [
+          {
+            nixpkgs.config.allowUnfree = true;
+            nixpkgs.config.allowBroken = true;
+          }
+          { nixpkgs.config.allowBroken = lib.mkForce false; }
+        ]).pkgs;
+      cross = nixosPkgs.pkgsCross.aarch64-multiplatform;
+    in
+    assert nixosPkgs.config.allowUnfree;
+    assert !nixosPkgs.config.allowBroken;
+    # Variants overriding `config` keep the definitions and apply their own.
+    assert nixosPkgs.pkgsRocm.config.rocmSupport;
+    assert !nixosPkgs.pkgsRocm.config.cudaSupport;
+    assert nixosPkgs.pkgsRocm.config.allowUnfree;
+    assert !nixosPkgs.pkgsRocm.config.allowBroken;
+    # Variants not overriding `config` resolve the definitions themselves.
+    assert cross.config.allowUnfree;
+    assert !cross.config.allowBroken;
+    pkgs.emptyFile;
+
+  # `nixpkgs.config` may also be written as a module function, and options
+  # nobody defined keep the defaults declared in `pkgs/top-level/config.nix`.
+  fromNixosModuleFunction =
+    let
+      nixosPkgs =
+        (evalNixos [
+          {
+            nixpkgs.config =
+              { lib, ... }:
+              {
+                allowBroken = lib.isFunction lib.id;
+              };
+          }
+        ]).pkgs;
+    in
+    assert nixosPkgs.config.allowBroken;
+    assert !nixosPkgs.config.allowUnfree;
+    pkgs.emptyFile;
+
+  # Standalone, `config` accepts an attribute set, a function returning one,
+  # or a list of modules. The NixOS module uses the last form to forward its
+  # definitions unevaluated.
+  configForms =
+    let
+      fromAttrs = nixpkgsFun {
+        inherit localSystem;
+        config.allowUnfree = true;
+      };
+      fromFunction = nixpkgsFun {
+        inherit localSystem;
+        config =
+          { lib, pkgs }:
+          {
+            allowUnfree = lib.isAttrs pkgs;
+          };
+      };
+      fromModules = nixpkgsFun {
+        inherit localSystem;
+        config = [
+          { allowUnfree = true; }
+          { allowBroken = true; }
+          { allowBroken = lib.mkForce false; }
+        ];
+      };
+      conflicting = nixpkgsFun {
+        inherit localSystem;
+        config = [
+          { fetchedSourceNameDefault = "versioned"; }
+          { fetchedSourceNameDefault = "full"; }
+        ];
+      };
+      defaults = nixpkgsFun { inherit localSystem; };
+    in
+    assert fromAttrs.config.allowUnfree;
+    assert fromFunction.config.allowUnfree;
+    assert fromModules.config.allowUnfree;
+    assert !fromModules.config.allowBroken;
+    assert !defaults.config.allowUnfree;
+    # Conflicting definitions of a `uniq` option must fail loudly rather than
+    # silently picking one of them. The error text is checked in
+    # `ci/config-nix-unit`, which `builtins.tryEval` cannot do.
+    assert !(builtins.tryEval conflicting.config.fetchedSourceNameDefault).success;
+    pkgs.emptyFile;
 
   # https://github.com/NixOS/nixpkgs/issues/175196
   # This test has since been simplified to test the recursion without

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -128,26 +128,6 @@ in
 
   config = callPackage ./config.nix { };
 
-  # Technically nix-unit binds to a fixed nix version
-  # We have tests in lib to test the module system itself against different nix-versions
-  # Based on this assumption (transitivity of correctness) this test should therefore also cover all tested nix-versions
-  config-nix-unit =
-    pkgs.runCommand "config-nix-unit"
-      {
-        nativeBuildInputs = [ pkgs.nix-unit ];
-      }
-      ''
-        export HOME=$TMPDIR
-        nix-unit --eval-store "$HOME" ${./config-nix-unit.nix} \
-          --arg nixpkgsPath "${
-            builtins.path {
-              path = pkgs.path;
-              name = "source";
-            }
-          }"
-        mkdir $out
-      '';
-
   top-level = callPackage ./top-level { };
 
   haskell = callPackage ./haskell { };

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -28,6 +28,11 @@
   crossSystem ? null,
 
   # Allow a configuration attribute set to be passed in as an argument.
+  #
+  # This may also be a function returning one, or a list of modules for
+  # `pkgs/top-level/config.nix`. The NixOS `nixpkgs` module uses the latter to
+  # forward the `nixpkgs.config` definitions unevaluated, so that the module
+  # system merges them here with their priorities and locations intact.
   config ? { },
 
   # Temporary hack to let Nixpkgs forbid internal use of `lib.fileset`
@@ -44,11 +49,6 @@
   # environment. See below for the arguments given to that function, the type of
   # list it returns.
   stdenvStages ? import ../stdenv,
-
-  # Temporary parameter to unify nixpkgs/pkgs evaluation
-  # Internal, do not use this manually!
-  # Will be removed again within the next releases
-  _configDefinitions ? null,
 
   # Ignore unexpected args.
   ...
@@ -114,13 +114,11 @@ let
       (throwIfNot (lib.all lib.isFunction overlays) "All overlays passed to nixpkgs must be functions.")
       (throwIfNot (lib.isList crossOverlays) "The crossOverlays argument to nixpkgs must be a list.")
       (throwIfNot (lib.all lib.isFunction crossOverlays) "All crossOverlays passed to nixpkgs must be functions.")
-      (throwIf (
-        ((localSystem.isDarwin && localSystem.isx86) || (crossSystem.isDarwin && crossSystem.isx86))
-        && config.allowDeprecatedx86_64Darwin != "force"
-      ) x86_64DarwinDeprecationMessage)
       (
-        throwIfNot (_configDefinitions == null || config0 == { })
-          "The `_configDefinitions` argument is an internal interface and must not be combined with `config`."
+        throwIf (
+          ((localSystem.isDarwin && localSystem.isx86) || (crossSystem.isDarwin && crossSystem.isx86))
+          && config.allowDeprecatedx86_64Darwin != "force"
+        ) x86_64DarwinDeprecationMessage
       );
 
   localSystem = lib.systems.elaborate args.localSystem;
@@ -153,8 +151,8 @@ let
       ./config.nix
     ]
     ++ (
-      if _configDefinitions != null then
-        map (def: lib.modules.setDefaultModuleLocation def.file def.value) _configDefinitions
+      if lib.isList config0 then
+        config0
       else
         [
           {
@@ -203,20 +201,7 @@ let
   # via `evalModules` is not idempotent. In other words, if you add `config` to
   # `newArgs`, expect strange very hard to debug errors! (Yes, I'm speaking from
   # experience here.)
-  #
-  # `_configDefinitions` (only ever set by the NixOS `nixpkgs` module) and
-  # `config` are mutually exclusive, see `checked` above. A caller passing
-  # `config` supplies the complete configuration for the new package set —
-  # it is derived from the `config` variable above, which already contains
-  # everything `_configDefinitions` evaluated to — so the definitions must be
-  # dropped instead of being combined. Without this, package set variants
-  # overriding `config` (`pkgsRocm`, `pkgsCuda`, `pkgsChecked`, ...) would fail
-  # to evaluate inside a NixOS configuration.
-  nixpkgsFun =
-    newArgs:
-    import ./. (
-      (if newArgs ? config then removeAttrs args [ "_configDefinitions" ] else args) // newArgs
-    );
+  nixpkgsFun = newArgs: import ./. (args // newArgs);
 
   # Partially apply some arguments for building bootstrapping stage pkgs
   # sets. Only apply arguments which no stdenv would want to override.

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -203,7 +203,20 @@ let
   # via `evalModules` is not idempotent. In other words, if you add `config` to
   # `newArgs`, expect strange very hard to debug errors! (Yes, I'm speaking from
   # experience here.)
-  nixpkgsFun = newArgs: import ./. (args // newArgs);
+  #
+  # `_configDefinitions` (only ever set by the NixOS `nixpkgs` module) and
+  # `config` are mutually exclusive, see `checked` above. A caller passing
+  # `config` supplies the complete configuration for the new package set —
+  # it is derived from the `config` variable above, which already contains
+  # everything `_configDefinitions` evaluated to — so the definitions must be
+  # dropped instead of being combined. Without this, package set variants
+  # overriding `config` (`pkgsRocm`, `pkgsCuda`, `pkgsChecked`, ...) would fail
+  # to evaluate inside a NixOS configuration.
+  nixpkgsFun =
+    newArgs:
+    import ./. (
+      (if newArgs ? config then removeAttrs args [ "_configDefinitions" ] else args) // newArgs
+    );
 
   # Partially apply some arguments for building bootstrapping stage pkgs
   # sets. Only apply arguments which no stdenv would want to override.


### PR DESCRIPTION
Depends on #550890 (first 2 commits are from this pr), needs some more work. Putting here for reference and to not forget that config-nix-unit currently broken

Assisted-by: claude-code with claude-opus-5[1m]-high

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
