### PR TITLE
maven.buildMavenPackage: preserve Tycho metadata

### DIFF
--- a/pkgs/by-name/ma/maven/build-maven-package.nix
+++ b/pkgs/by-name/ma/maven/build-maven-package.nix
@@ -112,7 +112,8 @@ let
             runHook postBuild
           '';
 
-          # keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files with lastModified timestamps inside
+          # Preserve .meta because Tycho needs p2-artifacts.properties for offline builds.
+          # Maven Resolver's cached prefix indexes are volatile, so remove them and their checksums.
           installPhase = ''
             runHook preInstall
 
@@ -121,7 +122,7 @@ let
               -o -name resolver-status.properties \
               -o -name _remote.repositories \) \
               -delete
-            rm -rf $out/.m2/.meta
+            rm -f "$out"/.m2/.meta/prefixes-*.txt{,.*}
 
             runHook postInstall
           '';


### PR DESCRIPTION
`buildMavenPackage` currently deletes `$out/.m2/.meta` from its dependency fixed-output derivation. The directory-wide deletion was introduced (8b6cd28599b2b9add14ad7e066e65e24a0e4b824) for Maven Resolver 2.0.11+, which stores cached remote repository prefix indexes in `.meta`. These indexes change as their upstream repositories change, so retaining them would make the fixed-output derivation non-reproducible.

Eclipse Tycho also uses `.meta` but for unrelated state. It stores `p2-artifacts.properties` there and requires that file when resolving Eclipse artifacts during the offline build. Deleting the entire directory consequently makes Tycho builds fail offline.

Replace the directory-wide deletion with targeted removal of Maven Resolver's `prefixes-*.txt` files and their checksum sidecars. The existing cleanup already removes `resolver-status.properties`. This preserves the metadata needed by Tycho without retaining the known volatile Resolver files or adding a new builder option.

Tycho-generated files can require additional package-specific normalization. In particular, the motivating [Archi package](https://github.com/NixOS/nixpkgs/pull/550840) sorts `p2-artifacts.properties` and normalizes Tycho HTTP cache headers. Those steps remain the responsibility of the consuming package.

### Testing

- Rebuilt the dependency FODs for `checkstyle`, `cryptomator`, `dependency-track`, `fop`, `global-platform-pro`, `java-language-server`, `ninjabrain-bot`, `nzbhydra2` and `tuxguitar` with `--check`; their existing `mvnHash` values remain valid.
- `tika` did not reproduce its existing hash because live Maven metadata now resolves `bcutil-jdk18on` 1.80.2 instead of 1.80. Both outputs lack `.m2/.meta`, confirming that the mismatch is unrelated to this change.
- Rebuilt `archi`'s dependency FOD twice with `--check` after removing the previous `.meta` backup and restore workaround; both builds reproduced the existing `mvnHash`.
- Built `maven.tests` and `maven_4.tests`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
