### PR TITLE
python3Packages.python-backoff: 2.3.1 -> 2.4.0

### DIFF
--- a/pkgs/development/python-modules/python-backoff/default.nix
+++ b/pkgs/development/python-modules/python-backoff/default.nix
@@ -1,5 +1,6 @@
 {
   buildPythonPackage,
+  dirty-equals,
   fetchFromGitHub,
   hatchling,
   lib,
@@ -11,14 +12,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "python-backoff";
-  version = "2.3.1";
+  version = "2.4.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "python-backoff";
     repo = "backoff";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Os20Gz+uWaEdUPPF9/tT7LNxbmN0W/tuzVZa3H+ZG2A=";
+    hash = "sha256-qrPlszLO5eSYjZi638yH2hUV5zASgzMmiGKsEKGlLEA=";
   };
 
   build-system = [ hatchling ];
@@ -26,14 +27,11 @@ buildPythonPackage (finalAttrs: {
   pythonImportsCheck = [ "backoff" ];
 
   nativeCheckInputs = [
+    dirty-equals
     pytest-asyncio
     pytestCheckHook
     requests
     responses
-  ];
-
-  pytestFlags = [
-    "-Wignore::pytest.PytestRemovedIn10Warning"
   ];
 
   meta = {


### PR DESCRIPTION
Diff: https://github.com/python-backoff/backoff/compare/v2.3.1...v2.4.0

Changelog: https://github.com/python-backoff/backoff/blob/v2.4.0/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
