### PR TITLE
beeper: 4.3.0 -> 4.3.20, harden update disabling

### DIFF
--- a/pkgs/by-name/be/beeper/package.nix
+++ b/pkgs/by-name/be/beeper/package.nix
@@ -50,14 +50,16 @@ let
       linuxConfigFilename=$appRoot/build/main/linux-*.mjs
       echo "export function registerLinuxConfig() {}" > $linuxConfigFilename
 
-      # disable auto update
-      sed -i 's/c=d??{},p=c.hw_acceleration??!0/c={...(d??{}),auto_update_disabled:true},p=c.hw_acceleration??!0/g' $appRoot/build/main/index-*.mjs
+      # Disable scheduled update checks.
+      autoUpdateConfigFilename=$(
+        grep -lF 'c=d??{},p=c.hw_acceleration??!0' $appRoot/build/main/index-*.mjs
+      )
+      substituteInPlace "$autoUpdateConfigFilename" \
+        --replace-fail 'c=d??{},p=c.hw_acceleration??!0' 'c={...(d??{}),auto_update_disabled:true},p=c.hw_acceleration??!0'
 
-      # prevent updates
-      sed -i -E 's/executeDownload\([^)]+\)\{/executeDownload(){return;/g' $appRoot/build/main/main-entry-*.mjs
-
-      # hide version status element on about page otherwise an error message is shown
-      sed -i '$ a\.subview-prefs-about > div:nth-child(2) {display: none;}' $appRoot/build-browser/*.css
+      # Disable user-triggered update checks, which ignore auto_update_disabled.
+      substituteInPlace $appRoot/build/main/main-entry-*.mjs \
+        --replace-fail 'async checkForUpdates(r=!1){' 'async checkForUpdates(r=!1){return;'
     '';
   };
 in
@@ -75,7 +77,7 @@ appimageTools.wrapAppImage {
 
     . ${makeWrapper}/nix-support/setup-hook
     wrapProgram $out/bin/beeper \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}} --no-update" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --set APPIMAGE beeper \
       --run 'exec >/dev/null' # as recommended in #486164
   '';

--- a/pkgs/by-name/be/beeper/package.nix
+++ b/pkgs/by-name/be/beeper/package.nix
@@ -12,18 +12,18 @@
 }:
 let
   pname = "beeper";
-  version = "4.3.0";
+  version = "4.3.20";
 
   inherit (stdenv.hostPlatform) system;
 
   sources = {
     x86_64-linux = fetchurl {
       url = "https://beeper-desktop.download.beeper.com/builds/Beeper-${version}-x86_64.AppImage";
-      hash = "sha256-/DJmQMQGzZFnONjQZ9fr9NDtGv9Kg8jF8aBzAOUyCUg=";
+      hash = "sha256-9xlsLhJ2Z0ICaAmdYSraNK11+YPbvgiXJDD2e+lJaQE=";
     };
     aarch64-linux = fetchurl {
       url = "https://beeper-desktop.download.beeper.com/builds/Beeper-${version}-arm64.AppImage";
-      hash = "sha256-zZIbcE78XcXremyWjs3jsiBRTwP24y45CfZHJym8MhQ=";
+      hash = "sha256-ukAZMw7XUQGpUY/QcV/JVZSN3PsTKFJskp7h1n9he6o=";
     };
   };
 


### PR DESCRIPTION
Updates Beeper from 4.3.0 to 4.3.20.

Beeper only honors `auto_update_disabled` for scheduled checks. Manual checks bypass it, so nixpkgs previously patched electron-updater's low-level download method. This blocks updates at Beeper's own `checkForUpdates()` entry point and makes both minified-source rewrites fail if upstream changes.

The old About-page CSS selector no longer matches Beeper's current UI, and Beeper does not consume the `--no-update` argument, so both ineffective workarounds are removed.

This follows up on #401086.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

The aarch64 AppImage was independently extracted, patched, and wrapped using x86_64 build tools. It was not executed on aarch64 hardware. Both architecture-specific outputs contain exactly one forced `auto_update_disabled` setting and one guarded `checkForUpdates()` entry point.

AI disclosure: The implementation and this pull request summary were drafted with OpenAI Codex (GPT-5.6 Sol) and manually reviewed by @zh4ngx before submission.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/tree/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/tree/master/pkgs/test
