### PR TITLE
gcc-arm-embedded: 15.2.rel1 -> 15.3.rel1

### DIFF
--- a/pkgs/by-name/gc/gcc-arm-embedded-15/package.nix
+++ b/pkgs/by-name/gc/gcc-arm-embedded-15/package.nix
@@ -8,10 +8,7 @@
   zstd,
 }:
 
-stdenv.mkDerivation rec {
-  pname = "gcc-arm-embedded";
-  version = "15.2.rel1";
-
+let
   platform =
     {
       aarch64-darwin = "darwin-arm64";
@@ -19,15 +16,19 @@ stdenv.mkDerivation rec {
       x86_64-linux = "x86_64";
     }
     .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gcc-arm-embedded";
+  version = "15.3.rel1";
 
   src = fetchurl {
-    url = "https://developer.arm.com/-/media/Files/downloads/gnu/${version}/binrel/arm-gnu-toolchain-${version}-${platform}-arm-none-eabi.tar.xz";
+    url = "https://gitlab.arm.com/api/v4/projects/tooling%2Fgnu-toolchains-for-arm/packages/generic/gnu-toolchain/${finalAttrs.version}/arm-gnu-toolchain-${finalAttrs.version}-${platform}-arm-none-eabi.tar.xz";
     # hashes obtained from location ${url}.sha256asc
     sha256 =
       {
-        aarch64-darwin = "1938a84b7105c192e3fb4fa5e893ba25f425f7ddab40515ae608cd40f68669a8";
-        aarch64-linux = "d061559d814b205ed30c5b7c577c03317ec447ca51cd5a159d26b12a5bbeb20c";
-        x86_64-linux = "597893282ac8c6ab1a4073977f2362990184599643b4c5ee34870a8215783a16";
+        aarch64-darwin = "376808a59ca209c1413236f1c6a509e33da4b29857ab28642b9927cf3048af55";
+        aarch64-linux = "06979e0c8171de58e5dc2a2b2019330a290f30930f27728af98a83e1a7369b3a";
+        x86_64-linux = "563bebb2b97d53382b956d6ee1fe61e2cae26699901417234a37df505ef9b5fa";
       }
       .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
   };
@@ -84,4 +85,4 @@ stdenv.mkDerivation rec {
     ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
