### PR TITLE
python3Packages.xstatic-font-awesome: format to pyproject

### DIFF
--- a/pkgs/development/python-modules/xstatic-font-awesome/default.nix
+++ b/pkgs/development/python-modules/xstatic-font-awesome/default.nix
@@ -8,7 +8,7 @@
 buildPythonPackage rec {
   pname = "xstatic-font-awesome";
   version = "6.2.1.1";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     pname = "XStatic-Font-Awesome";

--- a/pkgs/development/python-modules/xstatic-font-awesome/default.nix
+++ b/pkgs/development/python-modules/xstatic-font-awesome/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = {
-    homepage = "https://github.com/python-xstatic/font-awesome";
+    homepage = "https://github.com/xstatic-py/xstatic-font-awesome";
     description = "Font Awesome packaged for python";
     license = lib.licenses.ofl;
     maintainers = with lib.maintainers; [ aither64 ];


### PR DESCRIPTION
Part of https://github.com/NixOS/nixpkgs/issues/515974


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
