### PR TITLE
Proton-Drive-CLI

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29448,6 +29448,13 @@
     matrix = "@ty:tjll.net";
     name = "Tyler Langlois";
   };
+  TylerNilson = {
+    email = "tyler@nilsonintegrations.ca";
+    github = "TylerNilson";
+    githubId = "184452187";
+    matrix = "@tyler:matrix.nilsonintegrations.ca";
+    name = "Tyler Nilson";
+  };
   tylervick = {
     email = "nix@tylervick.com";
     github = "tylervick";

--- a/pkgs/by-name/pr/proton-drive-cli/package.nix
+++ b/pkgs/by-name/pr/proton-drive-cli/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  fetchurl,
+  buildFHSEnv,
+  pkgs,
+  stdenv,
+}:
+
+let
+  version = "0.7.0";
+  pname = "proton-drive";
+  system = "linux-x64";
+
+  protonSource = fetchurl {
+    url = "https://proton.me/download/drive/cli/${version}/${system}/${pname}";
+    hash = "sha256-Tjx0p6JdoA16DKnuIjqbewsjjaNXq2/P7gSlwxPd9NE=";
+  };
+
+  protonBinary = stdenv.mkDerivation {
+    name = "proton-drive-cli-binary";
+    src = protonSource;
+
+    dontUnpack = true;
+    dontStrip = true;
+    dontPatchELF = true;
+
+    installPhase = ''
+      mkdir -p $out/bin
+      cp $src $out/bin/proton-drive-cli
+      chmod +x $out/bin/proton-drive-cli
+    '';
+  };
+in
+buildFHSEnv {
+  name = "proton-drive-cli";
+
+  targetPkgs =
+    p: with p; [
+      stdenv.cc.cc.lib
+      zlib
+      libsecret
+      glib
+      dbus
+      pkg-config
+    ];
+
+  runScript = toString (
+    pkgs.writeScript "proton-drive-cli-wrapper" ''
+      exec ${protonBinary}/bin/proton-drive-cli "$@"
+    ''
+  );
+
+  meta = with lib; {
+    description = "Proton Drive Command Line Interface";
+    homepage = "https://proton.me/download/drive/cli";
+    license = licenses.unfree;
+    maintainers = "TylerNilson";
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
