### PR TITLE
lightningstream: 0.4.3 -> 1.0.2

### DIFF
--- a/pkgs/by-name/li/lightningstream/package.nix
+++ b/pkgs/by-name/li/lightningstream/package.nix
@@ -7,27 +7,28 @@
   versionCheckHook,
   nix-update-script,
 }:
-let
-  version = "0.4.3";
-in
-buildGoModule {
+buildGoModule (finalAttrs: {
   pname = "lightningstream";
-  inherit version;
+  version = "1.0.2";
 
   src = fetchFromGitHub {
     owner = "PowerDNS";
     repo = "lightningstream";
-    tag = "v${version}";
-    hash = "sha256-gnLmqm35HHpQlglKjw57NBMs8jMAHDieWlnE3OAQR4I=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9RJOPNiso7RjjlzeRCjR6hl/er7g72oLvOqTAA+B4oc=";
   };
+
+  postPatch = ''
+    substituteInPlace cmd/lightningstream/commands/version.go \
+      --replace-fail 'bi.Main.Version' '"${finalAttrs.version}"'
+  '';
 
   ldflags = [
     "-s"
     "-w"
-    "-X main.version=${version}"
   ];
 
-  vendorHash = "sha256-wkLoaR46l+jCm3TJDflcuI2hDvluoH2o5lLIqtrVRqo=";
+  vendorHash = "sha256-19WrmUuUxkhvH8gLtGAghMUX9cjUpY4Go4KPGKwJjB0=";
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -62,7 +63,8 @@ buildGoModule {
     description = "LMDB sync via S3 buckets";
     mainProgram = "lightningstream";
     license = lib.licenses.mit;
+    changelog = "https://github.com/PowerDNS/lightningstream/releases/tag/v${finalAttrs.version}";
     homepage = "https://doc.powerdns.com/lightningstream/latest/index.html";
     maintainers = with lib.maintainers; [ samw ];
   };
-}
+})


### PR DESCRIPTION
Bump `lightningstream` from 0.4.3 to 1.0.2

Changed to `finalAttrs` pattern and added in `changelog`
`postPatch` added to inject version to `SetBuildInfo` fn used to infer version of the tool. Previously `SetVersion` was used, but has since been deprecated


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
