### PR TITLE
django-celery-results: format to pyproject, enable tests

### DIFF
--- a/pkgs/development/python-modules/django-celery-results/default.nix
+++ b/pkgs/development/python-modules/django-celery-results/default.nix
@@ -1,15 +1,25 @@
 {
   lib,
+  stdenv,
   fetchPypi,
+  fetchpatch,
   buildPythonPackage,
+  setuptools,
   celery,
   django,
+  postgresqlTestHook,
+  postgresql,
+  pytestCheckHook,
+  pytest-django,
+  pytz,
+  psycopg,
+  psycopg2cffi,
 }:
 
 buildPythonPackage rec {
   pname = "django-celery-results";
   version = "2.6.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     pname = "django_celery_results";
@@ -17,18 +27,47 @@ buildPythonPackage rec {
     hash = "sha256-mrzYNq5rYQY3eSRNiIeoj+gLv6uhQ98208sHA0ZxJ3w=";
   };
 
+  patches = [
+    # Needed to fix some `AttributeError`s during tests
+    (fetchpatch {
+      name = "fix-attribute-error.patch";
+      url = "https://github.com/celery/django-celery-results/commit/067dfc9a857344c833e269f679047d48b938e60d.patch?full_index=1";
+      hash = "sha256-IHwzd91rAsgjJblnQ8lLMRVH3GZfPuK8phDAGYj6HUY=";
+    })
+  ];
+
   postPatch = ''
     # Drop malformatted tests_require specification
     sed -i '/tests_require=/d' setup.py
   '';
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     celery
     django
   ];
 
-  # Tests need access to a database.
-  doCheck = false;
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-django
+    pytz
+    psycopg
+    psycopg2cffi
+    postgresqlTestHook
+    postgresql
+  ];
+
+  disabledTestPaths = [
+    # Only benchmarks, which we don't care about
+    "t/integration"
+  ];
+
+  # Can't connect to the test db with a unix socket for some reason, so use TCP instead
+  postgresqlEnableTCP = true;
+
+  # postgresqlTestHook doesn't work on darwin.
+  doCheck = lib.meta.availableOn stdenv.buildPlatform postgresqlTestHook;
 
   meta = {
     description = "Celery result back end with django";


### PR DESCRIPTION
Part of https://github.com/NixOS/nixpkgs/issues/515974

Enables tests using `postgresqlTestHook`, needs a patch to fix errors, and disable benchmarks

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
