### PR TITLE
wayvr: 26.7.1 -> 26.8.0, fix xwayland-satellite executable path, fix uidev

### DIFF
--- a/pkgs/by-name/wa/wayvr/package.nix
+++ b/pkgs/by-name/wa/wayvr/package.nix
@@ -134,7 +134,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
       gpl3Only
       mit # wayvr-ipc
     ];
-    maintainers = with lib.maintainers; [ Scrumplex ];
+    maintainers = with lib.maintainers; [
+      Scrumplex
+      ImSapphire
+    ];
     platforms = lib.platforms.linux;
     broken = stdenv.hostPlatform.isAarch64 && withOpenVR;
     mainProgram = "wayvr";

--- a/pkgs/by-name/wa/wayvr/package.nix
+++ b/pkgs/by-name/wa/wayvr/package.nix
@@ -18,11 +18,13 @@
   pkg-config,
   procps,
   pulseaudio,
+  replaceVars,
   rustPlatform,
   shaderc,
   stdenv,
   testers,
   wayvr,
+  xwayland-satellite,
   withOpenVR ? !stdenv.hostPlatform.isAarch64,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -35,6 +37,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-0llU19bFJJ4yJvA6eGzOzyW8TnnurTS9js3/r+UAVCQ=";
   };
+
+  patches = [
+    (replaceVars ./use-system-xwayland-satellite.patch {
+      xwayland-satellite = lib.getExe xwayland-satellite;
+    })
+  ];
 
   cargoHash = "sha256-yUHLtB3/cBEWVAN1vuGLLlLFqJ25ucIy6qqInTGaOvA=";
 

--- a/pkgs/by-name/wa/wayvr/package.nix
+++ b/pkgs/by-name/wa/wayvr/package.nix
@@ -4,6 +4,7 @@
   dbus,
   fetchFromGitHub,
   lib,
+  libinput,
   libx11,
   libxext,
   libxrandr,
@@ -26,16 +27,16 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "wayvr";
-  version = "26.7.1";
+  version = "26.8.0";
 
   src = fetchFromGitHub {
     owner = "wayvr-org";
     repo = "wayvr";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-SdHN3jDe2QJaRORy452RP7kTMxPOZOB/yjpApUOLhRU=";
+    hash = "sha256-0llU19bFJJ4yJvA6eGzOzyW8TnnurTS9js3/r+UAVCQ=";
   };
 
-  cargoHash = "sha256-eGmlFtlorKG7uygLer3UW6ERLQzdugoYyXVSC2sFh+k=";
+  cargoHash = "sha256-yUHLtB3/cBEWVAN1vuGLLlLFqJ25ucIy6qqInTGaOvA=";
 
   nativeBuildInputs = [
     pkg-config
@@ -46,6 +47,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     alsa-lib
     dav1d
     dbus
+    libinput
     libx11
     libxext
     libxrandr

--- a/pkgs/by-name/wa/wayvr/package.nix
+++ b/pkgs/by-name/wa/wayvr/package.nix
@@ -1,14 +1,17 @@
 {
   alsa-lib,
+  autoPatchelfHook,
   dav1d,
   dbus,
   fetchFromGitHub,
   lib,
   libinput,
   libx11,
+  libxcursor,
   libxext,
   libxrandr,
   libxcb,
+  libxi,
   libxkbcommon,
   nix-update-script,
   openssl,
@@ -23,6 +26,8 @@
   shaderc,
   stdenv,
   testers,
+  vulkan-loader,
+  wayland,
   wayvr,
   xwayland-satellite,
   withOpenVR ? !stdenv.hostPlatform.isAarch64,
@@ -49,6 +54,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeBuildInputs = [
     pkg-config
     rustPlatform.bindgenHook
+    autoPatchelfHook
   ];
 
   buildInputs = [
@@ -56,6 +62,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     dav1d
     dbus
     libinput
+    # X dependencies are dlopen'd at runtime by uidev
     libx11
     libxext
     libxrandr
@@ -64,6 +71,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
     openssl
     openxr-loader
     pipewire
+
+    # only dlopen'd at runtime by uidev
+    libxcursor
+    libxi
+    wayland
+    vulkan-loader
   ]
   ++ lib.optionals withOpenVR [ openvr ];
 
@@ -92,6 +105,20 @@ rustPlatform.buildRustPackage (finalAttrs: {
     install -D wayvr/wayvr.svg -t $out/share/icons/hicolor/scalable/apps
 
     rm $out/bin/prost_build
+  '';
+
+  preFixup = ''
+    patchelf \
+      --add-needed libwayland-client.so.0 \
+      --add-needed libwayland-cursor.so.0 \
+      --add-needed libwayland-egl.so.1 \
+      --add-needed libX11.so.6 \
+      --add-needed libxcb.so.1 \
+      --add-needed libXcursor.so.1 \
+      --add-needed libXi.so.6 \
+      --add-needed libvulkan.so.1 \
+      --add-needed libxkbcommon.so.0 \
+      $out/bin/uidev
   '';
 
   passthru = {

--- a/pkgs/by-name/wa/wayvr/use-system-xwayland-satellite.patch
+++ b/pkgs/by-name/wa/wayvr/use-system-xwayland-satellite.patch
@@ -1,0 +1,25 @@
+diff --git a/wayvr/src/backend/wayvr/client.rs b/wayvr/src/backend/wayvr/client.rs
+index 734e8b68..17058705 100644
+--- a/wayvr/src/backend/wayvr/client.rs
++++ b/wayvr/src/backend/wayvr/client.rs
+@@ -98,7 +98,7 @@ impl WayVRCompositor {
+     ) -> anyhow::Result<Self> {
+         let (wayland_env, listener) = create_wayland_listener()?;
+ 
+-        let xwayland_satellite = Command::new(bundled_executable("xwayland-satellite"))
++        let xwayland_satellite = Command::new("@xwayland-satellite@")
+             .arg(wayland_env.display_num_string())
+             .env("WAYLAND_DISPLAY", wayland_env.wayland_display_num_string())
+             .spawn()
+@@ -468,11 +468,3 @@ fn accumulate_discrete_scroll(acc: &mut f32, delta_v120: i32) -> i32 {
+ 
+     steps
+ }
+-
+-/// Runs executable from APPDIR, falling back to PATH
+-fn bundled_executable(name: impl AsRef<std::path::Path>) -> PathBuf {
+-    match std::env::var_os("APPDIR") {
+-        Some(appdir) => PathBuf::from(appdir).join("usr").join("bin").join(name),
+-        None => PathBuf::from(name.as_ref()),
+-    }
+-}


### PR DESCRIPTION
https://github.com/wayvr-org/wayvr/releases/tag/v26.8.0
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
